### PR TITLE
Remove `pointOfSaleOnlyProducts` flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -103,8 +103,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .selfDrivenPushTokenAppPasswords:
             return false
-        case .pointOfSaleOnlyProducts:
-            return true
         case .clientSideDashboardBanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ageRangeRequirementsCompliance:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -217,10 +217,6 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case selfDrivenPushTokenAppPasswords
 
-    /// Enables POS-only products filtering
-    ///
-    case pointOfSaleOnlyProducts
-
     /// Enables client-side promotional banners for non-Jetpack stores on the dashboard
     ///
     case clientSideDashboardBanner

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -10,11 +10,10 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - includeStatus: Optional status to include (e.g., "trash" to fetch trashed products).
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
     // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
     // periphery:ignore
-    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String?, posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
+    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String?) async throws -> PagedItems<POSProduct>
 
     /// Loads POS product variations modified after the specified date for incremental sync.
     ///
@@ -22,11 +21,10 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - modifiedAfter: Only variations modified after this date will be returned.
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
-    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
     // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
     // periphery:ignore
-    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int, posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation>
+    func loadProductVariations(modifiedAfter: Date, siteID: Int64, pageNumber: Int) async throws -> PagedItems<POSProductVariation>
 
     /// Starts generation of a POS catalog.
     /// The catalog is generated asynchronously and a download URL may be returned when the file is ready.
@@ -64,9 +62,8 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
-    func loadProducts(siteID: Int64, pageNumber: Int, allowCellular: Bool, posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
+    func loadProducts(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProduct>
 
     /// Loads POS product variations for full sync.
     ///
@@ -74,25 +71,22 @@ public protocol POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
-    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
-    func loadProductVariations(siteID: Int64, pageNumber: Int, allowCellular: Bool, posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation>
+    func loadProductVariations(siteID: Int64, pageNumber: Int, allowCellular: Bool) async throws -> PagedItems<POSProductVariation>
 
     /// Gets the total count of products for the specified site.
     ///
     /// - Parameters:
     ///   - siteID: Site ID to get product count for.
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Total number of products.
-    func getProductCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int
+    func getProductCount(siteID: Int64) async throws -> Int
 
     /// Gets the total count of product variations for the specified site.
     ///
     /// - Parameters:
     ///   - siteID: Site ID to get variation count for.
-    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Total number of variations.
-    func getProductVariationCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int
+    func getProductVariationCount(siteID: Int64) async throws -> Int
 }
 
 /// POS Catalog Sync: Remote Endpoints
@@ -119,14 +113,12 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - includeStatus: Optional status to include (e.g., "trash" to fetch trashed products).
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
     ///
     public func loadProducts(modifiedAfter: Date,
                              siteID: Int64,
                              pageNumber: Int,
-                             includeStatus: String? = nil,
-                             posProductsOnly: Bool = false)
+                             includeStatus: String? = nil)
     async throws -> PagedItems<POSProduct> {
         let path = Path.products
         var parameters: [String: String] = [
@@ -134,7 +126,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         if let includeStatus = includeStatus {
@@ -161,20 +153,18 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - modifiedAfter: Only variations modified after this date will be returned.
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
-    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
     ///
     public func loadProductVariations(modifiedAfter: Date,
                                       siteID: Int64,
-                                      pageNumber: Int,
-                                      posProductsOnly: Bool = false) async throws -> PagedItems<POSProductVariation> {
+                                      pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         let path = Path.variations
         let parameters = [
             ParameterKey.modifiedAfter: dateFormatter.string(from: modifiedAfter),
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
             ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let request = JetpackRequest(
@@ -313,19 +303,17 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load products from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Paginated list of POS products.
     ///
     public func loadProducts(siteID: Int64,
                              pageNumber: Int,
-                             allowCellular: Bool,
-                             posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
+                             allowCellular: Bool) async throws -> PagedItems<POSProduct> {
         let path = Path.products
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let request = JetpackRequest(
@@ -349,19 +337,17 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///   - siteID: Site ID to load variations from.
     ///   - pageNumber: Page number for pagination.
     ///   - allowCellular: Should cellular data be used if required.
-    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Paginated list of POS product variations.
     ///
     public func loadProductVariations(siteID: Int64,
                                       pageNumber: Int,
-                                      allowCellular: Bool,
-                                      posProductsOnly: Bool = false) async throws -> PagedItems<POSProductVariation> {
+                                      allowCellular: Bool) async throws -> PagedItems<POSProductVariation> {
         let path = Path.variations
         let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
             ParameterKey.fields: POSProductVariation.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let request = JetpackRequest(
@@ -385,15 +371,14 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///
     /// - Parameters:
     ///   - siteID: Site ID to get product count for.
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: Total number of products.
-    public func getProductCount(siteID: Int64, posProductsOnly: Bool = false) async throws -> Int {
+    public func getProductCount(siteID: Int64) async throws -> Int {
         let path = Path.products
         let parameters = [
             ParameterKey.page: String(1),
             ParameterKey.perPage: String(1),
             ParameterKey.fields: POSProductVariation.requestFields.first ?? "",
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let request = JetpackRequest(
@@ -413,15 +398,14 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     ///
     /// - Parameters:
     ///   - siteID: Site ID to get variation count for.
-    ///   - posProductsOnly: Whether to filter to POS-eligible variations only.
     /// - Returns: Total number of variations.
-    public func getProductVariationCount(siteID: Int64, posProductsOnly: Bool = false) async throws -> Int {
+    public func getProductVariationCount(siteID: Int64) async throws -> Int {
         let path = Path.variations
         let parameters = [
             ParameterKey.page: String(1),
             ParameterKey.perPage: String(1),
             ParameterKey.fields: POSProductVariation.requestFields.first ?? "",
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let request = JetpackRequest(

--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -14,8 +14,7 @@ public protocol ProductVariationsRemoteProtocol {
                                   completion: @escaping ([ProductVariation]?, Error?) -> Void)
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
-                                      pageNumber: Int,
-                                      posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation>
+                                      pageNumber: Int) async throws -> PagedItems<POSProductVariation>
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void)
     func createProductVariation(for siteID: Int64,
                                 productID: Int64,
@@ -80,8 +79,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
     /// - Returns: Variations for the provided parent product.
     public func loadVariationsForPointOfSale(for siteID: Int64,
                                              parentProductID: Int64,
-                                             pageNumber: Int = Default.pageNumber,
-                                             posProductsOnly: Bool = false) async throws -> PagedItems<POSProductVariation> {
+                                             pageNumber: Int = Default.pageNumber) async throws -> PagedItems<POSProductVariation> {
         let request = productVariationsRequest(for: siteID,
                                                productID: parentProductID,
                                                variationIDs: [],
@@ -93,7 +91,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                                context: nil,
                                                pageNumber: pageNumber,
                                                pageSize: POSConstants.variationsPerPage,
-                                               posProductsOnly: posProductsOnly)
+                                               posProductsOnly: true)
         // N.B. POS is only available for WC 9.6 and later.
         // `parent_id` was added in WC 8.3, so we don't need to pass the parent product ID to the decoder.
         // https://github.com/woocommerce/woocommerce/pull/40606

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -82,26 +82,22 @@ public protocol ProductsRemoteProtocol {
 
     func loadProductsForPointOfSale(for siteID: Int64,
                                     productTypes: [ProductType],
-                                    pageNumber: Int,
-                                    posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
+                                    pageNumber: Int) async throws -> PagedItems<POSProduct>
 
     func searchProductsForPointOfSale(for siteID: Int64,
                                       query: String,
                                       productTypes: [ProductType],
-                                      pageNumber: Int,
-                                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
+                                      pageNumber: Int) async throws -> PagedItems<POSProduct>
 
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
                                            pageNumber: Int,
-                                           perPage: Int,
-                                           posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
+                                           perPage: Int) async throws -> PagedItems<POSProduct>
 
     func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
-                                                   globalUniqueID: String,
-                                                   posProductsOnly: Bool) async throws -> POSProduct
+                                                   globalUniqueID: String) async throws -> POSProduct
 
-    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool) async throws -> POSProduct
+    func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct
 }
 
 extension ProductsRemoteProtocol {
@@ -226,12 +222,10 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     ///
     public func loadProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType] = [.simple],
-                                           pageNumber: Int = 1,
-                                           posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
+                                           pageNumber: Int = 1) async throws -> PagedItems<POSProduct> {
         let parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
-            productTypes: productTypes,
-            posProductsOnly: posProductsOnly)
+            productTypes: productTypes)
 
         return try await makePagedPointOfSaleProductsRequest(
             for: siteID,
@@ -249,15 +243,13 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func loadPopularProductsForPointOfSale(for siteID: Int64,
                                                   productTypes: [ProductType] = [.simple],
                                                   pageNumber: Int = 1,
-                                                  perPage: Int = Default.pageSize,
-                                                  posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
+                                                  perPage: Int = Default.pageSize) async throws -> PagedItems<POSProduct> {
         let parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
             productsPerPage: String(perPage),
             productTypes: productTypes,
             orderBy: .popularity,
-            order: .descending,
-            posProductsOnly: posProductsOnly
+            order: .descending
         )
 
         return try await makePagedPointOfSaleProductsRequest(
@@ -270,8 +262,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
                                                    productsPerPage: String = POSConstants.productsPerPage,
                                                    productTypes: [ProductType],
                                                    orderBy: OrderKey = .name,
-                                                   order: Order = .ascending,
-                                                   posProductsOnly: Bool = false) -> [String: any Hashable] {
+                                                   order: Order = .ascending) -> [String: any Hashable] {
         let parameters: [String: any Hashable] = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: productsPerPage,
@@ -283,7 +274,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.productStatus: POSConstants.productStatus,
             ParameterKey.downloadable: String(false),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         return parameters
@@ -316,12 +307,10 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     public func searchProductsForPointOfSale(for siteID: Int64,
                                              query: String,
                                              productTypes: [ProductType] = [.simple],
-                                             pageNumber: Int = 1,
-                                             posProductsOnly: Bool = false) async throws -> PagedItems<POSProduct> {
+                                             pageNumber: Int = 1) async throws -> PagedItems<POSProduct> {
         var parameters = pointOfSaleProductFetchParameters(
             pageNumber: pageNumber,
-            productTypes: productTypes,
-            posProductsOnly: posProductsOnly
+            productTypes: productTypes
         )
 
         parameters.updateValue(query, forKey: ParameterKey.search)
@@ -352,15 +341,14 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Throws: Error if the product is not found or if there's a network error
     ///
     public func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64,
-                                                       globalUniqueID: String,
-                                                       posProductsOnly: Bool = false) async throws -> POSProduct {
+                                                       globalUniqueID: String) async throws -> POSProduct {
         let parameters: [String: Any] = [
             ParameterKey.globalUniqueID: globalUniqueID,
             ParameterKey.page: "1",
             ParameterKey.perPage: "1",
             ParameterKey.contextKey: Default.context,
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let path = Path.products
@@ -381,10 +369,10 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     /// - Returns: A POSProduct if found
     /// - Throws: Error if the product is not found or if there's a network error
     ///
-    public func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool = false) async throws -> POSProduct {
+    public func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
         let parameters: [String: Any] = [
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(posProductsOnly)
+            ParameterKey.posProductsOnly: String(true)
         ]
 
         let path = "\(Path.products)/\(productID)"

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -5,15 +5,12 @@ import class WooFoundation.CurrencySettings
 struct POSProductOrVariationResolver {
     private let productsRemote: ProductsRemoteProtocol
     private let itemMapper: PointOfSaleItemMapperProtocol
-    private let posProductsOnly: Bool
 
     init (productsRemote: ProductsRemoteProtocol,
           currencySettings: CurrencySettings,
-          itemMapper: PointOfSaleItemMapperProtocol? = nil,
-          posProductsOnly: Bool = false) {
+          itemMapper: PointOfSaleItemMapperProtocol? = nil) {
         self.productsRemote = productsRemote
         self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
-        self.posProductsOnly = posProductsOnly
     }
 
     func itemForProductOrVariation(_ productOrVariation: POSProduct,
@@ -64,8 +61,7 @@ struct POSProductOrVariationResolver {
                                    scannedCode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
             return try await productsRemote.loadPOSProduct(for: variation.siteID,
-                                                           productID: variation.productID,
-                                                           posProductsOnly: posProductsOnly)
+                                                           productID: variation.productID)
         } catch {
             switch ProductLoadError(underlyingError: error) {
             case .notFound:

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleBarcodeScanService.swift
@@ -31,33 +31,27 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     private let productsRemote: ProductsRemoteProtocol
     private let siteID: Int64
     private let itemResolver: POSProductOrVariationResolver
-    private let posProductsOnly: Bool
 
     init (siteID: Int64,
           productsRemote: ProductsRemoteProtocol,
-          currencySettings: CurrencySettings,
-          posProductsOnly: Bool = false) {
+          currencySettings: CurrencySettings) {
         self.siteID = siteID
         self.productsRemote = productsRemote
-        self.posProductsOnly = posProductsOnly
         self.itemResolver = POSProductOrVariationResolver(productsRemote: productsRemote,
-                                                          currencySettings: currencySettings,
-                                                          posProductsOnly: posProductsOnly)
+                                                          currencySettings: currencySettings)
     }
 
     public convenience init(siteID: Int64,
                             credentials: Credentials?,
                             selectedSite: AnyPublisher<JetpackSite?, Never>,
                             appPasswordSupportState: AnyPublisher<Bool, Never>,
-                            currencySettings: CurrencySettings,
-                            posProductsOnly: Bool = false) {
+                            currencySettings: CurrencySettings) {
         let network = AlamofireNetwork(credentials: credentials,
                                        selectedSite: selectedSite,
                                        appPasswordSupportState: appPasswordSupportState)
         self.init(siteID: siteID,
                   productsRemote: ProductsRemote(network: network),
-                  currencySettings: currencySettings,
-                  posProductsOnly: posProductsOnly)
+                  currencySettings: currencySettings)
     }
 
     /// Looks up a POSItem using a barcode scan string
@@ -75,8 +69,7 @@ public final class PointOfSaleBarcodeScanService: PointOfSaleBarcodeScanServiceP
     private func loadPOSProduct(barcode: String) async throws(PointOfSaleBarcodeScanError) -> POSProduct {
         do {
             return try await productsRemote.loadPOSProductByGlobalUniqueIdentifier(for: siteID,
-                                                                                   globalUniqueID: barcode,
-                                                                                   posProductsOnly: posProductsOnly)
+                                                                                   globalUniqueID: barcode)
         } catch NetworkError.notFound {
             throw .notFound(scannedCode: barcode)
         } catch {

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
@@ -22,7 +22,6 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
     private let itemMapper: PointOfSaleItemMapperProtocol?
     private let isLocalCatalogEnabled: Bool
     private let isFTSSearchEnabled: Bool
-    private let posProductsOnlyEnabled: Bool
 
     public init(siteID: Int64,
                 credentials: Credentials?,
@@ -32,8 +31,7 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                 currencySettings: CurrencySettings,
                 itemMapper: PointOfSaleItemMapperProtocol? = nil,
                 isLocalCatalogEnabled: Bool = false,
-                isFTSSearchEnabled: Bool = false,
-                posProductsOnlyEnabled: Bool = false) {
+                isFTSSearchEnabled: Bool = false) {
         self.siteID = siteID
         let network = AlamofireNetwork(credentials: credentials,
                                        selectedSite: selectedSite,
@@ -44,15 +42,13 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
         self.itemMapper = itemMapper ?? PointOfSaleItemMapper(currencySettings: currencySettings)
         self.isLocalCatalogEnabled = isLocalCatalogEnabled
         self.isFTSSearchEnabled = isFTSSearchEnabled
-        self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
 
     public func defaultStrategy(analytics: POSItemFetchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
         PointOfSaleDefaultPurchasableItemFetchStrategy(siteID: siteID,
                                                        productsRemote: productsRemote,
                                                        variationsRemote: variationsRemote,
-                                                       analytics: analytics,
-                                                       posProductsOnly: posProductsOnlyEnabled)
+                                                       analytics: analytics)
     }
     public func searchStrategy(searchTerm: String,
                                analytics: POSItemFetchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
@@ -65,7 +61,6 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                                                                       variationsRemote: variationsRemote,
                                                                       itemMapper: itemMapper,
                                                                       analytics: analytics,
-                                                                      posProductsOnly: posProductsOnlyEnabled,
                                                                       isFTSSearchEnabled: isFTSSearchEnabled)
         }
         // Fall back to remote API search
@@ -73,16 +68,14 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                                                             searchTerm: searchTerm,
                                                             productsRemote: productsRemote,
                                                             variationsRemote: variationsRemote,
-                                                            analytics: analytics,
-                                                            posProductsOnly: posProductsOnlyEnabled)
+                                                            analytics: analytics)
     }
 
     public func popularStrategy(pageSize: Int = 10) -> PointOfSalePurchasableItemFetchStrategy {
         PointOfSalePopularPurchasableItemFetchStrategy(siteID: siteID,
                                                        pageSize: pageSize,
                                                        productsRemote: productsRemote,
-                                                       variationsRemote: variationsRemote,
-                                                       posProductsOnly: posProductsOnlyEnabled)
+                                                       variationsRemote: variationsRemote)
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleLocalSearchPurchasableItemFetchStrategy.swift
@@ -17,7 +17,6 @@ struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasabl
     private let itemMapper: PointOfSaleItemMapperProtocol
     private let analytics: POSItemFetchAnalyticsTracking
     private let pageSize: Int
-    private let posProductsOnly: Bool
     private let isFTSSearchEnabled: Bool
 
     init(siteID: Int64,
@@ -27,7 +26,6 @@ struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasabl
          itemMapper: PointOfSaleItemMapperProtocol,
          analytics: POSItemFetchAnalyticsTracking,
          pageSize: Int = 25,
-         posProductsOnly: Bool = false,
          isFTSSearchEnabled: Bool = true) {
         self.siteID = siteID
         self.searchTerm = searchTerm
@@ -36,7 +34,6 @@ struct PointOfSaleLocalSearchPurchasableItemFetchStrategy: PointOfSalePurchasabl
         self.itemMapper = itemMapper
         self.analytics = analytics
         self.pageSize = pageSize
-        self.posProductsOnly = posProductsOnly
         self.isFTSSearchEnabled = isFTSSearchEnabled
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSalePurchasableItemFetchStrategy.swift
@@ -34,28 +34,24 @@ public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchas
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
-    private let posProductsOnly: Bool
 
     static var defaultProductTypes: [ProductType] { [.simple, .variable] }
 
     init(siteID: Int64,
          productsRemote: ProductsRemoteProtocol,
          variationsRemote: ProductVariationsRemoteProtocol,
-         analytics: POSItemFetchAnalyticsTracking,
-         posProductsOnly: Bool = false) {
+         analytics: POSItemFetchAnalyticsTracking) {
         self.siteID = siteID
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.analytics = analytics
-        self.posProductsOnly = posProductsOnly
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
         let pagedProducts = try await productsRemote.loadProductsForPointOfSale(
             for: siteID,
             productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
-            pageNumber: pageNumber,
-            posProductsOnly: posProductsOnly
+            pageNumber: pageNumber
         )
 
         if pageNumber == 1 {
@@ -69,8 +65,7 @@ public struct PointOfSaleDefaultPurchasableItemFetchStrategy: PointOfSalePurchas
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
-                                          pageNumber: pageNumber,
-                                          posProductsOnly: posProductsOnly)
+                                          pageNumber: pageNumber)
     }
 }
 
@@ -82,20 +77,17 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let analytics: POSItemFetchAnalyticsTracking
-    private let posProductsOnly: Bool
 
     init(siteID: Int64,
          searchTerm: String,
          productsRemote: ProductsRemoteProtocol,
          variationsRemote: ProductVariationsRemoteProtocol,
-         analytics: POSItemFetchAnalyticsTracking,
-         posProductsOnly: Bool = false) {
+         analytics: POSItemFetchAnalyticsTracking) {
         self.siteID = siteID
         self.searchTerm = searchTerm
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.analytics = analytics
-        self.posProductsOnly = posProductsOnly
     }
 
     // periphery:ignore - Protocol requirement, used via protocol
@@ -112,8 +104,7 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
             for: siteID,
             query: searchTerm,
             productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
-            pageNumber: pageNumber,
-            posProductsOnly: posProductsOnly
+            pageNumber: pageNumber
         )
         if pageNumber == 1 {
             let milliseconds = Int(Date().timeIntervalSince(startTime) * Double(MSEC_PER_SEC))
@@ -127,8 +118,7 @@ public struct PointOfSaleSearchPurchasableItemFetchStrategy: PointOfSalePurchasa
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
-                                          pageNumber: pageNumber,
-                                          posProductsOnly: posProductsOnly)
+                                          pageNumber: pageNumber)
     }
 }
 
@@ -137,18 +127,15 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
     private let productsRemote: ProductsRemoteProtocol
     private let variationsRemote: ProductVariationsRemoteProtocol
     private let pageSize: Int
-    private let posProductsOnly: Bool
 
     init(siteID: Int64,
          pageSize: Int,
          productsRemote: ProductsRemoteProtocol,
-         variationsRemote: ProductVariationsRemoteProtocol,
-         posProductsOnly: Bool = false) {
+         variationsRemote: ProductVariationsRemoteProtocol) {
         self.siteID = siteID
         self.productsRemote = productsRemote
         self.variationsRemote = variationsRemote
         self.pageSize = pageSize
-        self.posProductsOnly = posProductsOnly
     }
 
     public func fetchProducts(pageNumber: Int) async throws -> PagedItems<POSProduct> {
@@ -156,8 +143,7 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
             for: siteID,
             productTypes: PointOfSaleDefaultPurchasableItemFetchStrategy.defaultProductTypes,
             pageNumber: pageNumber,
-            perPage: pageSize,
-            posProductsOnly: posProductsOnly
+            perPage: pageSize
         )
         let modifiedItems = PagedItems<POSProduct>(items: receivedItems.items,
                                                    hasMorePages: false,
@@ -169,7 +155,6 @@ public struct PointOfSalePopularPurchasableItemFetchStrategy: PointOfSalePurchas
         try await variationsRemote
             .loadVariationsForPointOfSale(for: siteID,
                                           parentProductID: parentProductID,
-                                          pageNumber: pageNumber,
-                                          posProductsOnly: posProductsOnly)
+                                          pageNumber: pageNumber)
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogFullSyncService.swift
@@ -15,9 +15,8 @@ public protocol POSCatalogFullSyncServiceProtocol {
     ///   - siteID: The site ID to sync catalog for
     ///   - regenerateCatalog: Whether to force the catalog generation
     ///   - allowCellular: Should cellular data be used if required.
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: The synced catalog containing products and variations
-    func startFullSync(for siteID: Int64, regenerateCatalog: Bool, allowCellular: Bool, posProductsOnly: Bool) async throws -> POSCatalog
+    func startFullSync(for siteID: Int64, regenerateCatalog: Bool, allowCellular: Bool) async throws -> POSCatalog
 
     /// Parses and persists a downloaded catalog file from a background download.
     /// - Parameters:
@@ -95,10 +94,9 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
 
     public func startFullSync(for siteID: Int64,
                               regenerateCatalog: Bool = false,
-                              allowCellular: Bool,
-                              posProductsOnly: Bool = false) async throws -> POSCatalog {
+                              allowCellular: Bool) async throws -> POSCatalog {
         DDLogInfo("🔄 Starting full catalog sync for site ID: \(siteID) with regenerateCatalog: \(regenerateCatalog), " +
-                  "allowCellular: \(allowCellular), posProductsOnly: \(posProductsOnly)")
+                  "allowCellular: \(allowCellular)")
 
         do {
             // Sync from network
@@ -109,7 +107,7 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
                                                               regenerateCatalog: regenerateCatalog,
                                                               allowCellular: allowCellular)
             } else {
-                catalog = try await loadCatalog(for: siteID, syncRemote: syncRemote, allowCellular: allowCellular, posProductsOnly: posProductsOnly)
+                catalog = try await loadCatalog(for: siteID, syncRemote: syncRemote, allowCellular: allowCellular)
             }
             DDLogInfo("✅ Loaded \(catalog.products.count) products and \(catalog.variations.count) variations for siteID \(siteID)")
 
@@ -151,24 +149,21 @@ public final class POSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol 
 private extension POSCatalogFullSyncService {
     func loadCatalog(for siteID: Int64,
                      syncRemote: POSCatalogSyncRemoteProtocol,
-                     allowCellular: Bool,
-                     posProductsOnly: Bool) async throws -> POSCatalog {
+                     allowCellular: Bool) async throws -> POSCatalog {
         let syncStartDate = Date.now
         // Loads products and variations in batches in parallel.
         async let productsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProducts(siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  allowCellular: allowCellular,
-                                                  posProductsOnly: posProductsOnly)
+                                                  allowCellular: allowCellular)
             }
         )
         async let variationsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProductVariations(siteID: siteID,
                                                            pageNumber: pageNumber,
-                                                           allowCellular: allowCellular,
-                                                           posProductsOnly: posProductsOnly)
+                                                           allowCellular: allowCellular)
             }
         )
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -14,13 +14,11 @@ public protocol POSCatalogIncrementalSyncServiceProtocol {
     ///   - siteID: The site ID to sync catalog for.
     ///   - lastFullSyncDate: The date of the last full sync to use if no incremental sync date exists.
     ///   - lastIncrementalSyncDate: The date of the last incremental sync.
-    ///   - posProductsOnly: Whether to filter to POS-eligible products only.
     /// - Returns: The synced catalog containing updated products and variations
     @discardableResult
     func startIncrementalSync(for siteID: Int64,
                               lastFullSyncDate: Date,
-                              lastIncrementalSyncDate: Date?,
-                              posProductsOnly: Bool) async throws -> POSCatalog
+                              lastIncrementalSyncDate: Date?) async throws -> POSCatalog
 }
 
 // TODO - remove the periphery ignore comment when the service is integrated with POS.
@@ -62,14 +60,13 @@ public final class POSCatalogIncrementalSyncService: POSCatalogIncrementalSyncSe
     @discardableResult
     public func startIncrementalSync(for siteID: Int64,
                                      lastFullSyncDate: Date,
-                                     lastIncrementalSyncDate: Date?,
-                                     posProductsOnly: Bool = false) async throws -> POSCatalog {
+                                     lastIncrementalSyncDate: Date?) async throws -> POSCatalog {
         let modifiedAfter = latestSyncDate(fullSyncDate: lastFullSyncDate, incrementalSyncDate: lastIncrementalSyncDate)
 
-        DDLogInfo("🔄 Starting incremental catalog sync for site ID: \(siteID), modifiedAfter: \(modifiedAfter), posProductsOnly: \(posProductsOnly)")
+        DDLogInfo("🔄 Starting incremental catalog sync for site ID: \(siteID), modifiedAfter: \(modifiedAfter)")
 
         do {
-            let catalog = try await loadCatalog(for: siteID, modifiedAfter: modifiedAfter, syncRemote: syncRemote, posProductsOnly: posProductsOnly)
+            let catalog = try await loadCatalog(for: siteID, modifiedAfter: modifiedAfter, syncRemote: syncRemote)
             DDLogInfo("✅ Loaded \(catalog.products.count) updated products and \(catalog.variations.count) updated variations for siteID \(siteID)")
 
             try await persistenceService.persistIncrementalCatalogData(catalog, siteID: siteID)
@@ -88,42 +85,22 @@ public final class POSCatalogIncrementalSyncService: POSCatalogIncrementalSyncSe
 private extension POSCatalogIncrementalSyncService {
     func loadCatalog(for siteID: Int64,
                      modifiedAfter: Date,
-                     syncRemote: POSCatalogSyncRemoteProtocol,
-                     posProductsOnly: Bool) async throws -> POSCatalog {
+                     syncRemote: POSCatalogSyncRemoteProtocol) async throws -> POSCatalog {
         let syncStartDate = Date.now
 
-        if posProductsOnly {
-            // Dual-request: Detect products/variations hidden from POS
-            return try await loadCatalogWithHiddenDetection(for: siteID,
-                                                            modifiedAfter: modifiedAfter,
-                                                            syncRemote: syncRemote,
-                                                            syncStartDate: syncStartDate)
-        } else {
-            // Single-request: No hidden detection needed
-            return try await loadCatalogWithoutFiltering(for: siteID,
-                                                         modifiedAfter: modifiedAfter,
-                                                         syncRemote: syncRemote,
-                                                         syncStartDate: syncStartDate,
-                                                         posProductsOnly: posProductsOnly)
-        }
-    }
+        // Dual-request: Detect products/variations hidden from POS.
+        // Products hidden from POS don't appear in the pos_products_only=true response (hardcoded in the remote),
+        // they're simply omitted. To detect these, we compare against a second request without the flag:
+        // products present there but missing from the filtered response have been hidden and should be removed
+        // from the local DB.
 
-    /// Loads catalog with dual requests to detect products hidden from POS.
-    /// Products hidden from POS don't appear in the `posProductsOnly=true` response, they're simply omitted.
-    /// To detect these, we compare against a second request without the flag: products present there but
-    /// missing from the `posProductsOnly=true` response have been hidden and should be removed from the local DB.
-    func loadCatalogWithHiddenDetection(for siteID: Int64,
-                                        modifiedAfter: Date,
-                                        syncRemote: POSCatalogSyncRemoteProtocol,
-                                        syncStartDate: Date) async throws -> POSCatalog {
-        // Fetch POS-filtered products (excluding trash)
+        // Fetch POS-filtered products (excluding trash) — the remote always sends pos_products_only=true
         async let posProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: nil,
-                                                  posProductsOnly: true)
+                                                  includeStatus: nil)
             }
         )
 
@@ -133,19 +110,17 @@ private extension POSCatalogIncrementalSyncService {
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: nil,
-                                                  posProductsOnly: false)
+                                                  includeStatus: nil)
             }
         )
 
-        // Fetch trashed products (POS-filtered) to detect products moved to trash
+        // Fetch trashed products to detect products moved to trash
         async let trashedProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: ProductStatus.trash.rawValue,
-                                                  posProductsOnly: true)
+                                                  includeStatus: ProductStatus.trash.rawValue)
             }
         )
 
@@ -154,8 +129,7 @@ private extension POSCatalogIncrementalSyncService {
             makeRequest: { pageNumber in
                 try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter,
                                                            siteID: siteID,
-                                                           pageNumber: pageNumber,
-                                                           posProductsOnly: true)
+                                                           pageNumber: pageNumber)
             }
         )
 
@@ -173,51 +147,6 @@ private extension POSCatalogIncrementalSyncService {
                           variations: posVariations,
                           syncDate: syncStartDate,
                           productsToRemove: hiddenProductIDs)
-    }
-
-    /// Loads catalog without hidden detection - single request mode.
-    func loadCatalogWithoutFiltering(for siteID: Int64,
-                                     modifiedAfter: Date,
-                                     syncRemote: POSCatalogSyncRemoteProtocol,
-                                     syncStartDate: Date,
-                                     posProductsOnly: Bool) async throws -> POSCatalog {
-        // Fetch regular products (excluding trash)
-        async let regularProductsTask = batchedLoader.loadAll(
-            makeRequest: { pageNumber in
-                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
-                                                  siteID: siteID,
-                                                  pageNumber: pageNumber,
-                                                  includeStatus: nil,
-                                                  posProductsOnly: posProductsOnly)
-            }
-        )
-
-        // Fetch trashed products separately to detect products moved to trash
-        async let trashedProductsTask = batchedLoader.loadAll(
-            makeRequest: { pageNumber in
-                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
-                                                  siteID: siteID,
-                                                  pageNumber: pageNumber,
-                                                  includeStatus: ProductStatus.trash.rawValue,
-                                                  posProductsOnly: posProductsOnly)
-            }
-        )
-
-        async let variationsTask = batchedLoader.loadAll(
-            makeRequest: { pageNumber in
-                try await syncRemote.loadProductVariations(modifiedAfter: modifiedAfter,
-                                                           siteID: siteID,
-                                                           pageNumber: pageNumber,
-                                                           posProductsOnly: posProductsOnly)
-            }
-        )
-
-        let (regularProducts, trashedProducts, variations) = try await (regularProductsTask, trashedProductsTask, variationsTask)
-
-        // Union regular and trashed products before persistence
-        let allProducts = regularProducts + trashedProducts
-
-        return POSCatalog(products: allProducts, variations: variations, syncDate: syncStartDate)
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -88,24 +88,8 @@ private extension POSCatalogIncrementalSyncService {
                      syncRemote: POSCatalogSyncRemoteProtocol) async throws -> POSCatalog {
         let syncStartDate = Date.now
 
-        // Dual-request: Detect products/variations hidden from POS.
-        // Products hidden from POS don't appear in the pos_products_only=true response (hardcoded in the remote),
-        // they're simply omitted. To detect these, we compare against a second request without the flag:
-        // products present there but missing from the filtered response have been hidden and should be removed
-        // from the local DB.
-
         // Fetch POS-filtered products (excluding trash) — the remote always sends pos_products_only=true
         async let posProductsTask = batchedLoader.loadAll(
-            makeRequest: { pageNumber in
-                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
-                                                  siteID: siteID,
-                                                  pageNumber: pageNumber,
-                                                  includeStatus: nil)
-            }
-        )
-
-        // Fetch ALL products (excluding trash) to compare and find hidden ones
-        async let allProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
@@ -133,31 +117,16 @@ private extension POSCatalogIncrementalSyncService {
             }
         )
 
-        let (posProducts, allProducts, trashedProducts, posVariations) = try await (
-            posProductsTask, allProductsTask, trashedProductsTask, posVariationsTask
+        let (posProducts, trashedProducts, posVariations) = try await (
+            posProductsTask, trashedProductsTask, posVariationsTask
         )
 
-        // Find products hidden from POS: present in "all" but missing from "POS"
-        let hiddenProductIDs = findHiddenProductIDs(posProducts: posProducts, allProducts: allProducts)
-
-        // Aggregate regular and trashed products before persist them
+        // Aggregate regular and trashed products before persisting
         let productsToSync = posProducts + trashedProducts
 
         return POSCatalog(products: productsToSync,
                           variations: posVariations,
-                          syncDate: syncStartDate,
-                          productsToRemove: hiddenProductIDs)
-    }
-}
-
-private extension POSCatalogIncrementalSyncService {
-    /// Finds product IDs that are present in the unfiltered response but missing from the POS-filtered response.
-    /// These products have been hidden from POS and should be removed from the local catalog.
-    func findHiddenProductIDs(posProducts: [POSProduct], allProducts: [POSProduct]) -> [Int64] {
-        let posProductIDs = Set(posProducts.map { $0.productID })
-        return allProducts
-            .filter { !posProductIDs.contains($0.productID) }
-            .map { $0.productID }
+                          syncDate: syncStartDate)
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSizeChecker.swift
@@ -14,28 +14,24 @@ public protocol POSCatalogSizeCheckerProtocol {
 /// Implementation of catalog size checker that uses the sync remote to get counts
 public struct POSCatalogSizeChecker: POSCatalogSizeCheckerProtocol {
     private let syncRemote: POSCatalogSyncRemoteProtocol
-    private let posProductsOnlyEnabled: Bool
 
-    public init(syncRemote: POSCatalogSyncRemoteProtocol,
-                posProductsOnlyEnabled: Bool) {
+    public init(syncRemote: POSCatalogSyncRemoteProtocol) {
         self.syncRemote = syncRemote
-        self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
 
     public init(credentials: Credentials?,
                 selectedSite: AnyPublisher<JetpackSite?, Never>,
-                appPasswordSupportState: AnyPublisher<Bool, Never>,
-                posProductsOnlyEnabled: Bool) {
+                appPasswordSupportState: AnyPublisher<Bool, Never>) {
         let syncRemote = POSCatalogSyncRemote(network: AlamofireNetwork(credentials: credentials,
                                                                         selectedSite: selectedSite,
                                                                         appPasswordSupportState: appPasswordSupportState))
-        self.init(syncRemote: syncRemote, posProductsOnlyEnabled: posProductsOnlyEnabled)
+        self.init(syncRemote: syncRemote)
     }
 
     public func checkCatalogSize(for siteID: Int64) async throws -> POSCatalogSize {
         // Make concurrent requests to get both counts
-        async let productCount = syncRemote.getProductCount(siteID: siteID, posProductsOnly: posProductsOnlyEnabled)
-        async let variationCount = syncRemote.getProductVariationCount(siteID: siteID, posProductsOnly: posProductsOnlyEnabled)
+        async let productCount = syncRemote.getProductCount(siteID: siteID)
+        async let variationCount = syncRemote.getProductVariationCount(siteID: siteID)
 
         do {
             return try await POSCatalogSize(

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -116,7 +116,6 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     private let siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol
     private let analytics: Analytics?
     private let connectivityObserver: ConnectivityObserver?
-    private let posProductsOnlyEnabled: Bool
 
     /// Tracks ongoing incremental syncs by site ID to prevent duplicates
     private var ongoingIncrementalSyncs: Set<Int64> = []
@@ -139,8 +138,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
                 catalogEligibilityChecker: POSLocalCatalogEligibilityServiceProtocol,
                 siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol? = nil,
                 analytics: Analytics? = nil,
-                connectivityObserver: ConnectivityObserver? = nil,
-                posProductsOnlyEnabled: Bool = false) {
+                connectivityObserver: ConnectivityObserver? = nil) {
         self.fullSyncService = fullSyncService
         self.incrementalSyncService = incrementalSyncService
         self.grdbManager = grdbManager
@@ -148,7 +146,6 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         self.siteSettings = siteSettings ?? SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
         self.analytics = analytics
         self.connectivityObserver = connectivityObserver
-        self.posProductsOnlyEnabled = posProductsOnlyEnabled
     }
 
     public func performFullSyncIfApplicable(for siteID: Int64, maxAge: TimeInterval, regenerateCatalog: Bool) async throws {
@@ -185,8 +182,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let syncTask = Task<POSCatalog, Error> {
             try await fullSyncService.startFullSync(for: siteID,
                                                     regenerateCatalog: regenerateCatalog,
-                                                    allowCellular: allowCellular,
-                                                    posProductsOnly: posProductsOnlyEnabled)
+                                                    allowCellular: allowCellular)
         }
 
         // Store the task for potential cancellation
@@ -363,8 +359,7 @@ public actor POSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         let syncTask = Task<POSCatalog, Error> {
             try await incrementalSyncService.startIncrementalSync(for: siteID,
                                                                   lastFullSyncDate: lastFullSyncDate,
-                                                                  lastIncrementalSyncDate: await lastIncrementalSyncDate(for: siteID),
-                                                                  posProductsOnly: posProductsOnlyEnabled)
+                                                                  lastIncrementalSyncDate: await lastIncrementalSyncDate(for: siteID))
         }
 
         // Store the task for potential cancellation

--- a/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -284,36 +284,21 @@ struct POSProductsNetworkingTests {
         #expect(request.parameters["_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
     }
 
-    @Test func loadProductsForPointOfSale_includes_posProductsOnly_false_when_default() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
-                                                         productTypes: [.simple],
-                                                         pageNumber: 1,
-                                                         posProductsOnly: false)
-
-        // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
-    }
-
-    @Test func loadProductsForPointOfSale_includes_posProductsOnly_when_true() async throws {
+    @Test func loadProductsForPointOfSale_always_includes_posProductsOnly_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
         // When
         _ = try? await remote.loadProductsForPointOfSale(for: sampleSiteID,
                                                          productTypes: [.simple],
-                                                         pageNumber: 1,
-                                                         posProductsOnly: true)
+                                                         pageNumber: 1)
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
         #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
     }
 
-    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_false_when_false() async throws {
+    @Test func loadPopularProductsForPointOfSale_always_includes_posProductsOnly_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -321,31 +306,14 @@ struct POSProductsNetworkingTests {
         _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
                                                                  productTypes: [.simple],
                                                                  pageNumber: 1,
-                                                                 perPage: 25,
-                                                                 posProductsOnly: false)
-
-        // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
-    }
-
-    @Test func loadPopularProductsForPointOfSale_includes_posProductsOnly_when_true() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When
-        _ = try? await remote.loadPopularProductsForPointOfSale(for: sampleSiteID,
-                                                                 productTypes: [.simple],
-                                                                 pageNumber: 1,
-                                                                 perPage: 25,
-                                                                 posProductsOnly: true)
+                                                                 perPage: 25)
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
         #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
     }
 
-    @Test func searchProductsForPointOfSale_includes_posProductsOnly_false_when_default() async throws {
+    @Test func searchProductsForPointOfSale_always_includes_posProductsOnly_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
@@ -353,82 +321,34 @@ struct POSProductsNetworkingTests {
         _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
                                                             query: "test",
                                                             productTypes: [.simple],
-                                                            pageNumber: 1,
-                                                            posProductsOnly: false)
-
-        // Then
-        let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["pos_products_only"] as? String == "false")
-    }
-
-    @Test func searchProductsForPointOfSale_includes_posProductsOnly_when_true() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When
-        _ = try? await remote.searchProductsForPointOfSale(for: sampleSiteID,
-                                                            query: "test",
-                                                            productTypes: [.simple],
-                                                            pageNumber: 1,
-                                                            posProductsOnly: true)
+                                                            pageNumber: 1)
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
         #expect(queryParametersDictionary["pos_products_only"] as? String == "true")
     }
 
-    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_false_when_default() async throws {
+    @Test func loadPOSProductByGlobalUniqueIdentifier_always_includes_posProductsOnly_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
 
         // When
         _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
-                                                                      globalUniqueID: "123456789",
-                                                                      posProductsOnly: false)
-
-        // Then
-        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
-        #expect(request.parameters["pos_products_only"] as? String == "false")
-    }
-
-    @Test func loadPOSProductByGlobalUniqueIdentifier_includes_posProductsOnly_when_true() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "products", filename: "pos-products")
-
-        // When
-        _ = try? await remote.loadPOSProductByGlobalUniqueIdentifier(for: sampleSiteID,
-                                                                      globalUniqueID: "123456789",
-                                                                      posProductsOnly: true)
+                                                                      globalUniqueID: "123456789")
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
         #expect(request.parameters["pos_products_only"] as? String == "true")
     }
 
-    @Test func loadPOSProduct_includes_posProductsOnly_false_when_default() async throws {
+    @Test func loadPOSProduct_always_includes_posProductsOnly_true() async throws {
         // Given
         let remote = ProductsRemote(network: network)
 
         // When
         _ = try? await remote.loadPOSProduct(for: sampleSiteID,
-                                              productID: 123,
-                                              posProductsOnly: false)
-
-        // Then
-        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
-        #expect(request.parameters["pos_products_only"] as? String == "false")
-    }
-
-    @Test func loadPOSProduct_includes_posProductsOnly_when_true() async throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-
-        // When
-        _ = try? await remote.loadPOSProduct(for: sampleSiteID,
-                                              productID: 123,
-                                              posProductsOnly: true)
+                                              productID: 123)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)

--- a/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -604,30 +604,14 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(queryParametersDictionary["per_page"] as? String, "25")
     }
 
-    func test_loadVariationsForPointOfSale_includes_posProductsOnly_false_when_default() async throws {
+    func test_loadVariationsForPointOfSale_always_includes_posProductsOnly_true() async throws {
         // Given
         let remote = ProductVariationsRemote(network: network)
 
         // When
         _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
                                                            parentProductID: sampleProductID,
-                                                           pageNumber: 1,
-                                                           posProductsOnly: false)
-
-        // Then
-        let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)
-        XCTAssertEqual(queryParametersDictionary["pos_products_only"] as? String, "false")
-    }
-
-    func test_loadVariationsForPointOfSale_includes_posProductsOnly_when_true() async throws {
-        // Given
-        let remote = ProductVariationsRemote(network: network)
-
-        // When
-        _ = try? await remote.loadVariationsForPointOfSale(for: sampleSiteID,
-                                                           parentProductID: sampleProductID,
-                                                           pageNumber: 1,
-                                                           posProductsOnly: true)
+                                                           pageNumber: 1)
 
         // Then
         let queryParametersDictionary = try XCTUnwrap(network.queryParametersDictionary)

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogIncrementalSyncService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogIncrementalSyncService.swift
@@ -16,8 +16,7 @@ final class MockPOSCatalogIncrementalSyncService: POSCatalogIncrementalSyncServi
     @discardableResult
     func startIncrementalSync(for siteID: Int64,
                               lastFullSyncDate: Date,
-                              lastIncrementalSyncDate: Date?,
-                              posProductsOnly: Bool) async throws -> POSCatalog {
+                              lastIncrementalSyncDate: Date?) async throws -> POSCatalog {
         startIncrementalSyncCallCount += 1
         lastSyncSiteID = siteID
         self.lastFullSyncDate = lastFullSyncDate

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -9,7 +9,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     private(set) var incrementalVariationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
     private(set) var trashedProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
 
-    // Results returned when posProductsOnly=false (used during dual-request hidden product detection)
+    // Results returned for the unfiltered request (used during dual-request hidden product detection)
     private(set) var allProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
 
     var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
@@ -86,13 +86,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         }
     }
 
-    /* MARK: - Setup Methods for posProductsOnly=false requests
-     Dual-request mode is triggered when the feature flag posProductsOnly=true
-     Within that mode, we make requests with both values:
-        - posProductsOnly=true returns POS-eligible products (uses incrementalProductResults)
-        - posProductsOnly=false returns all products (uses allProductResults)
-     We compare the two to find hidden products (present in "all" but missing from "POS")
-     */
+    // MARK: - Setup Methods for unfiltered product requests (hidden product detection)
     func setAllProductResult(pageNumber: Int, result: Result<PagedItems<POSProduct>, Error>) {
         allProductResults[pageNumber] = result
     }
@@ -102,11 +96,10 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     func loadProducts(modifiedAfter: Date,
                       siteID: Int64,
                       pageNumber: Int,
-                      includeStatus: String?,
-                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
+                      includeStatus: String?) async throws -> PagedItems<POSProduct> {
         await includeStatusTracker.append(includeStatus)
 
-        // Route to appropriate results based on includeStatus and posProductsOnly
+        // Route to appropriate results based on includeStatus
         if includeStatus == "trash" {
             await loadTrashedProductsCallCount.increment()
             lastTrashedProductsModifiedAfter = modifiedAfter
@@ -118,17 +111,6 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
                 case .failure(let error):
                     throw error
                 }
-            }
-        } else if !posProductsOnly, let result = allProductResults[pageNumber] {
-            // Use all-products results when posProductsOnly=false and results are configured
-            await loadIncrementalProductsCallCount.increment()
-            lastIncrementalProductsModifiedAfter = modifiedAfter
-
-            switch result {
-            case .success(let pagedItems):
-                return pagedItems
-            case .failure(let error):
-                throw error
             }
         } else {
             await loadIncrementalProductsCallCount.increment()
@@ -148,8 +130,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
 
     func loadProductVariations(modifiedAfter: Date,
                                 siteID: Int64,
-                                pageNumber: Int,
-                                posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
+                                pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         await loadIncrementalProductVariationsCallCount.increment()
         lastIncrementalVariationsModifiedAfter = modifiedAfter
 
@@ -168,8 +149,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
 
     func loadProducts(siteID: Int64,
                       pageNumber: Int,
-                      allowCellular: Bool,
-                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
+                      allowCellular: Bool) async throws -> PagedItems<POSProduct> {
         await loadProductsCallCount.increment()
 
         if let result = productResults[pageNumber] {
@@ -185,8 +165,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
 
     func loadProductVariations(siteID: Int64,
                                 pageNumber: Int,
-                                allowCellular: Bool,
-                                posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
+                                allowCellular: Bool) async throws -> PagedItems<POSProductVariation> {
         await loadProductVariationsCallCount.increment()
 
         if let result = variationResults[pageNumber] {
@@ -255,7 +234,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     var getProductVariationCountResult: Result<Int, Error> = .success(0)
     var variationCountDelay: UInt64 = 0
 
-    func getProductCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int {
+    func getProductCount(siteID: Int64) async throws -> Int {
         getProductCountCallCount += 1
         lastProductCountSiteID = siteID
 
@@ -271,7 +250,7 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         }
     }
 
-    func getProductVariationCount(siteID: Int64, posProductsOnly: Bool) async throws -> Int {
+    func getProductVariationCount(siteID: Int64) async throws -> Int {
         getProductVariationCountCallCount += 1
         lastVariationCountSiteID = siteID
 

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -9,9 +9,6 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     private(set) var incrementalVariationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
     private(set) var trashedProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
 
-    // Results returned for the unfiltered request (used during dual-request hidden product detection)
-    private(set) var allProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
-
     var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
     var catalogDownloadResult: Result<POSCatalogResponse, Error> = .success(.init(products: [], variations: []))
 
@@ -84,11 +81,6 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         for (index, pagedItems) in results.enumerated() {
             trashedProductResults[index + 1] = .success(pagedItems)
         }
-    }
-
-    // MARK: - Setup Methods for unfiltered product requests (hidden product detection)
-    func setAllProductResult(pageNumber: Int, result: Result<PagedItems<POSProduct>, Error>) {
-        allProductResults[pageNumber] = result
     }
 
     // MARK: - Protocol Methods - Incremental Sync

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -102,8 +102,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
 
     func loadVariationsForPointOfSale(for siteID: Int64,
                                       parentProductID: Int64,
-                                      pageNumber: Int,
-                                      posProductsOnly: Bool) async throws -> PagedItems<POSProductVariation> {
+                                      pageNumber: Int) async throws -> PagedItems<POSProductVariation> {
         let key = ResultKey(siteID: siteID, productID: parentProductID, productVariationIDs: [])
         guard let result = variationsForPointOfSaleResults[key] else {
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -447,8 +447,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
 
     func loadProductsForPointOfSale(for siteID: Int64,
                                     productTypes: [ProductType],
-                                    pageNumber: Int,
-                                    posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
+                                    pageNumber: Int) async throws -> PagedItems<POSProduct> {
         guard let result = posProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()
         }
@@ -463,8 +462,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func searchProductsForPointOfSale(for siteID: Int64,
                                       query: String,
                                       productTypes: [ProductType],
-                                      pageNumber: Int,
-                                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
+                                      pageNumber: Int) async throws -> PagedItems<POSProduct> {
         guard let result = posSearchResultsByQuery[query] else {
             throw NetworkError.notFound()
         }
@@ -476,7 +474,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String, posProductsOnly: Bool) async throws -> POSProduct {
+    func loadPOSProductByGlobalUniqueIdentifier(for siteID: Int64, globalUniqueID: String) async throws -> POSProduct {
             return POSProduct.fake().copy(siteID: siteID,
                                           globalUniqueID: globalUniqueID)
     }
@@ -484,8 +482,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
     func loadPopularProductsForPointOfSale(for siteID: Int64,
                                            productTypes: [ProductType],
                                            pageNumber: Int,
-                                           perPage: Int,
-                                           posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
+                                           perPage: Int) async throws -> PagedItems<POSProduct> {
         lastRequestedPageSize = perPage
         guard let result = posPopularProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()
@@ -498,7 +495,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         }
     }
 
-    func loadPOSProduct(for siteID: Int64, productID: Int64, posProductsOnly: Bool) async throws -> POSProduct {
+    func loadPOSProduct(for siteID: Int64, productID: Int64) async throws -> POSProduct {
         invocationCountOfLoadPOSProduct += 1
         requestedProductIDsForFetchingPOSProduct.append(productID)
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
@@ -308,27 +308,18 @@ struct POSCatalogIncrementalSyncServiceTests {
 
     // MARK: - Hidden Product Detection Tests (Dual-Request)
 
-    @Test func startIncrementalSync_detects_products_hidden_from_POS_when_posProductsOnly_is_true() async throws {
+    @Test func startIncrementalSync_detects_products_hidden_from_POS() async throws {
         // Given
         let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
 
-        // Products visible in POS (posProductsOnly=true response)
+        // Products visible in POS (filtered response)
         let posProduct1 = POSProduct.fake().copy(productID: 1)
         let posProduct2 = POSProduct.fake().copy(productID: 2)
-
-        // All products (posProductsOnly=false response) - includes a product hidden from POS
-        let allProduct1 = POSProduct.fake().copy(productID: 1)
-        let allProduct2 = POSProduct.fake().copy(productID: 2)
-        let hiddenProduct = POSProduct.fake().copy(productID: 3) // Hidden from POS
 
         mockSyncRemote.setIncrementalProductResult(
             pageNumber: 1,
             result: .success(PagedItems(items: [posProduct1, posProduct2], hasMorePages: false, totalItems: 2))
         )
-        mockSyncRemote.setAllProductResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [allProduct1, allProduct2, hiddenProduct], hasMorePages: false, totalItems: 3))
-        )
         mockSyncRemote.setTrashedProductResult(
             pageNumber: 1,
             result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
@@ -338,46 +329,14 @@ struct POSCatalogIncrementalSyncServiceTests {
             result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
         )
 
-        // When - Sync with posProductsOnly=true (enables dual-request)
+        // When
         try await sut.startIncrementalSync(for: sampleSiteID,
                                            lastFullSyncDate: lastFullSyncDate,
-                                           lastIncrementalSyncDate: nil,
-                                           posProductsOnly: true)
+                                           lastIncrementalSyncDate: nil)
 
-        // Then - Hidden product ID should be in productsToRemove
+        // Then
         let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
         #expect(persistedCatalog.products.count == 2)
-        #expect(persistedCatalog.productsToRemove.contains(3))
-        #expect(persistedCatalog.productsToRemove.count == 1)
-    }
-
-    @Test func startIncrementalSync_does_not_detect_hidden_products_when_posProductsOnly_is_false() async throws {
-        // Given
-        let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
-        let products = [POSProduct.fake().copy(productID: 1)]
-
-        mockSyncRemote.setIncrementalProductResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: products, hasMorePages: false, totalItems: 1))
-        )
-        mockSyncRemote.setTrashedProductResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
-        )
-        mockSyncRemote.setIncrementalVariationResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [], hasMorePages: false, totalItems: 0))
-        )
-
-        // When - Sync with posProductsOnly=false (single-request, no hidden product detection)
-        try await sut.startIncrementalSync(for: sampleSiteID,
-                                           lastFullSyncDate: lastFullSyncDate,
-                                           lastIncrementalSyncDate: nil,
-                                           posProductsOnly: false)
-
-        // Then - No products should be marked for removal
-        let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
-        #expect(persistedCatalog.productsToRemove.isEmpty)
     }
 
     @Test func startIncrementalSync_handles_no_hidden_products_when_all_products_are_in_POS() async throws {
@@ -389,10 +348,6 @@ struct POSCatalogIncrementalSyncServiceTests {
         let product2 = POSProduct.fake().copy(productID: 2)
 
         mockSyncRemote.setIncrementalProductResult(
-            pageNumber: 1,
-            result: .success(PagedItems(items: [product1, product2], hasMorePages: false, totalItems: 2))
-        )
-        mockSyncRemote.setAllProductResult(
             pageNumber: 1,
             result: .success(PagedItems(items: [product1, product2], hasMorePages: false, totalItems: 2))
         )
@@ -408,8 +363,7 @@ struct POSCatalogIncrementalSyncServiceTests {
         // When
         try await sut.startIncrementalSync(for: sampleSiteID,
                                            lastFullSyncDate: lastFullSyncDate,
-                                           lastIncrementalSyncDate: nil,
-                                           posProductsOnly: true)
+                                           lastIncrementalSyncDate: nil)
 
         // Then, no products marked for removal
         let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSizeCheckerTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSizeCheckerTests.swift
@@ -9,7 +9,7 @@ struct POSCatalogSizeCheckerTests {
 
     init() throws {
         self.mockSyncRemote = MockPOSCatalogSyncRemote()
-        self.sut = POSCatalogSizeChecker(syncRemote: mockSyncRemote, posProductsOnlyEnabled: false)
+        self.sut = POSCatalogSizeChecker(syncRemote: mockSyncRemote)
     }
 
     @Test func checkCatalogSize_returns_combined_count_from_remote() async throws {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogSyncCoordinatorTests.swift
@@ -595,8 +595,7 @@ final class MockPOSCatalogFullSyncService: POSCatalogFullSyncServiceProtocol {
 
     func startFullSync(for siteID: Int64,
                         regenerateCatalog: Bool,
-                        allowCellular: Bool,
-                        posProductsOnly: Bool) async throws -> POSCatalog {
+                        allowCellular: Bool) async throws -> POSCatalog {
         startFullSyncCallCount += 1
         lastSyncSiteID = siteID
         lastAllowCellular = allowCellular

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -50,7 +50,6 @@ final class POSTabCoordinator {
 
     /// Creates item fetch strategy factory with current local catalog eligibility
     private func createItemFetchStrategyFactory(isLocalCatalogEnabled: Bool) -> PointOfSaleItemFetchStrategyFactory {
-        let posProductsOnlyEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOnlyProducts)
         let isFTSSearchEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleFTSSearch)
         return PointOfSaleItemFetchStrategyFactory(siteID: siteID,
                                                    credentials: credentials,
@@ -59,8 +58,7 @@ final class POSTabCoordinator {
                                                    grdbManager: isLocalCatalogEnabled ? ServiceLocator.grdbManager : nil,
                                                    currencySettings: currencySettings,
                                                    isLocalCatalogEnabled: isLocalCatalogEnabled,
-                                                   isFTSSearchEnabled: isFTSSearchEnabled,
-                                                   posProductsOnlyEnabled: posProductsOnlyEnabled)
+                                                   isFTSSearchEnabled: isFTSSearchEnabled)
     }
 
     /// Creates popular item fetch strategy factory with current local catalog eligibility
@@ -108,13 +106,11 @@ final class POSTabCoordinator {
                                                      currencySettings: currencySettings)
         } else {
             // Fall back to remote barcode scanning
-            let posProductsOnlyEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOnlyProducts)
             return PointOfSaleBarcodeScanService(siteID: siteID,
                                                 credentials: credentials,
                                                 selectedSite: defaultSitePublisher,
                                                 appPasswordSupportState: isAppPasswordSupported,
-                                                currencySettings: currencySettings,
-                                                posProductsOnly: posProductsOnlyEnabled)
+                                                currencySettings: currencySettings)
         }
     }
 

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -181,15 +181,12 @@ class AuthenticatedState: StoresManagerState {
             appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher(),
             grdbManager: ServiceLocator.grdbManager
            ) {
-            let posProductsOnlyEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOnlyProducts)
-
             // Create eligibility service
             let eligibilityService = POSLocalCatalogEligibilityService(
                 catalogSizeChecker: POSCatalogSizeChecker(
                     credentials: credentials,
                     selectedSite: site,
-                    appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher(),
-                    posProductsOnlyEnabled: posProductsOnlyEnabled
+                    appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher()
                 ),
                 systemStatusService: POSSystemStatusService(
                     credentials: credentials,
@@ -214,8 +211,7 @@ class AuthenticatedState: StoresManagerState {
                 grdbManager: ServiceLocator.grdbManager,
                 catalogEligibilityChecker: eligibilityService,
                 analytics: ServiceLocator.analytics,
-                connectivityObserver: ServiceLocator.connectivityObserver,
-                posProductsOnlyEnabled: posProductsOnlyEnabled
+                connectivityObserver: ServiceLocator.connectivityObserver
             )
 
             // Note: POS eligibility will be set later by POSTabCoordinator.updatePOSEligibility


### PR DESCRIPTION
Closes WOOMOB-2012

## Description

This flag has been on in production for a couple of months now, so we clean it up. This flag threaded through many layers, as was used to pass a single API param to the network. Where the query param expects `pos_products_only=true`, now we directly pass the value where needed:

- `ProductsRemote`
- `ProductVariationsRemote`
- `POSCatalogSyncRemote`

And remove the flag from everywhere else.

## Test Steps
- CI should pass
- POS should behave normally:
  - Product list loads correctly: Open POS, verify the product list loads and shows only POS-eligible products (same behavior as before)
  - Search works: Search for a product in POS, verify results return correctly
  - Barcode scanning works: Scan a barcode, verify the product is found
  - Popular products load: Verify the popular products section loads