### PR TITLE
POS: NavigationStack push for cash payment and email receipt

### DIFF
--- a/Modules/Sources/PointOfSale/Models/POSNavigationDestination.swift
+++ b/Modules/Sources/PointOfSale/Models/POSNavigationDestination.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum POSNavigationDestination: Hashable {
+    case cashPayment(orderTotal: String)
+    case emailReceipt
+}

--- a/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingPaymentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Bookings/POSBookingPaymentView.swift
@@ -8,19 +8,42 @@ struct POSBookingPaymentView: View {
     let paymentModel: POSPaymentModel
     let onDismiss: () -> Void
 
+    @State private var navigationPath: [POSNavigationDestination] = []
+
+    private var navigationRouter: POSNavigationRouter {
+        POSNavigationRouter(navigationPath: $navigationPath)
+    }
+
     var body: some View {
-        POSPaymentContentView(
-            formattedSubtotal: booking.order.formattedSubtotal,
-            formattedTax: booking.order.formattedTotalTax,
-            formattedTotal: booking.order.formattedTotal,
-            onDismiss: onDismiss)
-            .environment(paymentModel)
-            .background(Color.posSurface)
-            .task {
-                await paymentModel.startPayment()
+        NavigationStack(path: $navigationPath) {
+            POSPaymentContentView(
+                formattedSubtotal: booking.order.formattedSubtotal,
+                formattedTax: booking.order.formattedTotalTax,
+                formattedTotal: booking.order.formattedTotal,
+                onDismiss: onDismiss)
+            .navigationDestination(for: POSNavigationDestination.self) { destination in
+                switch destination {
+                case .cashPayment(let orderTotal):
+                    POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
+                case .emailReceipt:
+                    POSNavigationDestinationEmailReceiptView()
+                }
             }
-            .onDisappear {
-                paymentModel.tearDown()
+        }
+        .scrollContentBackground(.hidden)
+        .environment(paymentModel)
+        .environment(\.posNavigationRouter, navigationRouter)
+        .background(Color.posSurface)
+        .onChange(of: paymentModel.paymentState.cash) { _, newValue in
+            if newValue == .collectingCash {
+                navigationRouter.pushCash(orderTotal: booking.order.formattedTotal)
             }
+        }
+        .task {
+            await paymentModel.startPayment()
+        }
+        .onDisappear {
+            paymentModel.tearDown()
+        }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -28,7 +28,6 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
             PointOfSalePaymentSuccessView(
                 viewModel: viewModel,
                 customerEmail: paymentModel.customerBillingEmail,
-                onSendReceipt: { email in try await paymentModel.sendReceipt(to: email) },
                 successAction: paymentModel.configuration.successAction,
                 onSuccessScreenBarcodeScanned: paymentModel.configuration.onSuccessScreenBarcodeScanned)
         case .paymentError(let viewModel):

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -28,7 +28,7 @@ struct PointOfSalePaymentSuccessView: View {
         .accessibilityIdentifier("pos-payment-success-view")
         .onAppear {
             Task { @MainActor in
-                withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.8).delay(0.1)) {
                     isViewLoaded = true
                 }
             }

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -3,43 +3,36 @@ import SwiftUI
 struct PointOfSalePaymentSuccessView: View {
     let viewModel: PointOfSalePaymentSuccessViewModel
     let customerEmail: String?
-    let onSendReceipt: (String) async throws -> Void
     let successAction: PaymentFlowAction
     let onSuccessScreenBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
-    @State private var isShowingSendReceiptView: Bool = false
     @State private var isViewLoaded: Bool = false
+    @Environment(\.posNavigationRouter) private var router
+
+    private var isBarcodeScanningEnabled: Bool {
+        onSuccessScreenBarcodeScanned != nil && !router.isNavigated
+    }
 
     var body: some View {
-        VStack {
-            if isShowingSendReceiptView {
-                POSSendReceiptView(isShowingSendReceiptView: $isShowingSendReceiptView) { email in
-                    try await onSendReceipt(email)
-                }
-                .transition(.asymmetric(
-                    insertion: .move(edge: .trailing).combined(with: .opacity),
-                    removal: .move(edge: .trailing).combined(with: .opacity)))
-            } else {
-                HStack(alignment: .center) {
-                    Spacer()
-                    successView
-                    Spacer()
-                }
-                .padding([.leading, .trailing], dynamicTypeSize.isAccessibilitySize ? nil : POSPadding.small)
-                .background(Color.posSurfaceBright)
-            }
+        HStack(alignment: .center) {
+            Spacer()
+            successView
+            Spacer()
         }
-        .barcodeScanning(enabled: .constant(onSuccessScreenBarcodeScanned != nil && !isShowingSendReceiptView)) { barcode in
+        .padding([.leading, .trailing], dynamicTypeSize.isAccessibilitySize ? nil : POSPadding.small)
+        .background(Color.posSurfaceBright)
+        .barcodeScanning(enabled: .constant(isBarcodeScanningEnabled)) { barcode in
             onSuccessScreenBarcodeScanned?(barcode)
         }
         .accessibilityIdentifier("pos-payment-success-view")
         .onAppear {
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
-                isViewLoaded = true
+            Task { @MainActor in
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                    isViewLoaded = true
+                }
             }
         }
-        .animation(.default, value: isShowingSendReceiptView)
     }
 
     private var successView: some View {
@@ -83,8 +76,7 @@ struct PointOfSalePaymentSuccessView: View {
 
                 Spacer().frame(height: POSSpacing.xxLarge)
 
-                PaymentsActionButtons(successAction: successAction,
-                                      isShowingSendReceiptView: $isShowingSendReceiptView)
+                PaymentsActionButtons(successAction: successAction)
                     .containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
@@ -121,7 +113,6 @@ private extension PointOfSalePaymentSuccessView {
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
                                                       paymentMethod: .card),
         customerEmail: "test@example.com",
-        onSendReceipt: { _ in },
         successAction: PaymentFlowAction(title: "New order", action: {}, analyticsEvent: nil),
         onSuccessScreenBarcodeScanned: nil
     )

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -34,6 +34,7 @@ struct POSNavigationDestinationCashPaymentView: View {
     var body: some View {
         PointOfSaleCollectCashView(orderTotal: orderTotal,
                                    currencySettings: currencyProvider.currencySettings)
+        .environment(\.floatingControlAreaSize, .zero)
         .navigationBarHidden(true)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -34,7 +34,6 @@ struct POSNavigationDestinationCashPaymentView: View {
     var body: some View {
         PointOfSaleCollectCashView(orderTotal: orderTotal,
                                    currencySettings: currencyProvider.currencySettings)
-        .environment(\.floatingControlAreaSize, .zero)
         .navigationBarHidden(true)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -24,24 +24,31 @@ struct POSNavigationRouter {
     }
 }
 
-// MARK: - View Modifiers
+// MARK: - Navigation Destination Wrappers
 
-private struct OnNewOrderClearNavigationModifier: ViewModifier {
-    let orderStage: PointOfSaleOrderStage
-    @Binding var navigationPath: [POSNavigationDestination]
+/// Thin wrapper that resolves environment dependencies for the cash payment NavigationStack destination.
+struct POSNavigationDestinationCashPaymentView: View {
+    let orderTotal: String
+    @Environment(\.posCurrencyProvider) private var currencyProvider
 
-    func body(content: Content) -> some View {
-        content
-            .onChange(of: orderStage) { _, newValue in
-                guard newValue == .building, !navigationPath.isEmpty else { return }
-                navigationPath.removeAll()
-            }
+    var body: some View {
+        PointOfSaleCollectCashView(orderTotal: orderTotal,
+                                   currencySettings: currencyProvider.currencySettings)
+        .navigationBarHidden(true)
     }
 }
 
-extension View {
-    func onNewOrderClearNavigation(orderStage: PointOfSaleOrderStage,
-                                   navigationPath: Binding<[POSNavigationDestination]>) -> some View {
-        modifier(OnNewOrderClearNavigationModifier(orderStage: orderStage, navigationPath: navigationPath))
+/// Thin wrapper that resolves environment dependencies for the email receipt NavigationStack destination.
+struct POSNavigationDestinationEmailReceiptView: View {
+    @Environment(POSPaymentModel.self) private var paymentModel
+    @Environment(\.posNavigationRouter) private var router
+
+    var body: some View {
+        POSSendReceiptView(onDismiss: {
+            router.pop()
+        }) { email in
+            try await paymentModel.sendReceipt(to: email)
+        }
+        .navigationBarHidden(true)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct POSNavigationRouter {
+    @Binding var navigationPath: [POSNavigationDestination]
+
+    var isNavigated: Bool { !navigationPath.isEmpty }
+
+    func pushCash(orderTotal: String) {
+        guard navigationPath.isEmpty else { return }
+        navigationPath.append(.cashPayment(orderTotal: orderTotal))
+    }
+
+    func pushEmailReceipt() {
+        navigationPath.append(.emailReceipt)
+    }
+
+    func pop() {
+        guard !navigationPath.isEmpty else { return }
+        navigationPath.removeLast()
+    }
+
+    func popToRoot() {
+        navigationPath.removeAll()
+    }
+}
+
+// MARK: - View Modifiers
+
+private struct OnNewOrderClearNavigationModifier: ViewModifier {
+    let orderStage: PointOfSaleOrderStage
+    @Binding var navigationPath: [POSNavigationDestination]
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: orderStage) { _, newValue in
+                guard newValue == .building, !navigationPath.isEmpty else { return }
+                navigationPath.removeAll()
+            }
+    }
+}
+
+extension View {
+    func onNewOrderClearNavigation(orderStage: PointOfSaleOrderStage,
+                                   navigationPath: Binding<[POSNavigationDestination]>) -> some View {
+        modifier(OnNewOrderClearNavigationModifier(orderStage: orderStage, navigationPath: navigationPath))
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -93,9 +93,10 @@ struct POSPaymentContentView: View {
     private var paymentContentView: some View {
         switch displayPaymentState.activePaymentMethod {
         case .cash:
-            POSCashPaymentContentView(
-                cashPaymentState: displayPaymentState.cash,
-                formattedOrderTotal: formattedTotal)
+            PointOfSaleCardPresentPaymentInLineMessage(
+                messageType: .paymentSuccess(
+                    viewModel: .init(formattedOrderTotal: formattedTotal,
+                                     paymentMethod: .cash)))
         case .card:
             POSCardPaymentContentView(
                 cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
@@ -259,31 +260,6 @@ struct POSCardPaymentContentView: View {
                   case .idle = paymentState.card,
                   case .connected = cardReaderConnectionStatus {
             POSPaymentLoadingView()
-        }
-    }
-}
-
-// MARK: - Shared Cash Payment Content
-
-/// Shared cash payment content rendering used by both cart and bookings flows.
-struct POSCashPaymentContentView: View {
-    let cashPaymentState: PointOfSaleCashPaymentState
-    let formattedOrderTotal: String
-    @Environment(\.posCurrencyProvider) private var currencyProvider
-
-    var body: some View {
-        switch cashPaymentState {
-        case .collectingCash:
-            PointOfSaleCollectCashView(orderTotal: formattedOrderTotal,
-                                       currencySettings: currencyProvider.currencySettings)
-                .transition(.move(edge: .trailing))
-        case .paymentSuccess:
-            PointOfSaleCardPresentPaymentInLineMessage(
-                messageType: .paymentSuccess(
-                    viewModel: .init(formattedOrderTotal: formattedOrderTotal,
-                                     paymentMethod: .cash)))
-        case .idle:
-            EmptyView()
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -19,6 +19,7 @@ struct POSPaymentContentView: View {
 
     /// Payment state with cash collection neutralized. Only `.collectingCash` is handled
     /// by NavigationStack push. Success and idle are visible to this view.
+    /// TODO: Consider removing cash state entirely - it no longer drives the cash view.
     private var displayPaymentState: PointOfSalePaymentState {
         let cash: PointOfSaleCashPaymentState = paymentModel.paymentState.cash == .collectingCash
             ? .idle : paymentModel.paymentState.cash

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -17,6 +17,14 @@ struct POSPaymentContentView: View {
     @Environment(POSPaymentModel.self) private var paymentModel
     private let viewHelper = POSPaymentViewHelper()
 
+    /// Payment state with cash collection neutralized. Only `.collectingCash` is handled
+    /// by NavigationStack push. Success and idle are visible to this view.
+    private var displayPaymentState: PointOfSalePaymentState {
+        let cash: PointOfSaleCashPaymentState = paymentModel.paymentState.cash == .collectingCash
+            ? .idle : paymentModel.paymentState.cash
+        return PointOfSalePaymentState(card: paymentModel.paymentState.card, cash: cash)
+    }
+
     var body: some View {
         @Bindable var paymentModel = paymentModel
 
@@ -31,12 +39,12 @@ struct POSPaymentContentView: View {
             }
 
             Spacer()
-                .renderedIf(viewHelper.shouldApplyPadding(paymentState: paymentModel.paymentState))
+                .renderedIf(viewHelper.shouldApplyPadding(paymentState: displayPaymentState))
 
             cashPaymentButtonView
         }
-        .background(viewHelper.paymentBackgroundColor(for: paymentModel.paymentState))
-        .animation(.default, value: paymentModel.paymentState)
+        .background(viewHelper.paymentBackgroundColor(for: displayPaymentState))
+        .animation(.default, value: displayPaymentState.card)
         .overlay(alignment: .topTrailing) {
             closeButton
         }
@@ -66,7 +74,7 @@ struct POSPaymentContentView: View {
     private var closeButton: some View {
         if let onDismiss,
            paymentModel.configuration.showInitialCloseButton,
-           !paymentModel.paymentState.shownFullScreen {
+           !displayPaymentState.shownFullScreen {
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
                     .font(.posBodyLargeBold)
@@ -82,15 +90,15 @@ struct POSPaymentContentView: View {
 
     @ViewBuilder
     private var paymentContentView: some View {
-        switch paymentModel.paymentState.activePaymentMethod {
+        switch displayPaymentState.activePaymentMethod {
         case .cash:
             POSCashPaymentContentView(
-                cashPaymentState: paymentModel.paymentState.cash,
+                cashPaymentState: displayPaymentState.cash,
                 formattedOrderTotal: formattedTotal)
         case .card:
             POSCardPaymentContentView(
                 cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
-                paymentState: paymentModel.paymentState,
+                paymentState: displayPaymentState,
                 cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
                 connectCardReaderAction: paymentModel.connectCardReader,
                 showLoadingWhenIdle: !paymentModel.isZeroTotal)
@@ -100,7 +108,7 @@ struct POSPaymentContentView: View {
     // MARK: - Totals Fields
 
     private var shouldShowTotalsFields: Bool {
-        viewHelper.shouldShowTotalsFields(for: paymentModel.paymentState)
+        viewHelper.shouldShowTotalsFields(for: displayPaymentState)
     }
 
     @ViewBuilder
@@ -169,7 +177,7 @@ struct POSPaymentContentView: View {
     @ViewBuilder
     private var cashPaymentButtonView: some View {
         if viewHelper.shouldShowCashPaymentButton(
-            paymentState: paymentModel.paymentState,
+            paymentState: displayPaymentState,
             cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
             isZeroTotal: paymentModel.isZeroTotal) {
             Button(action: {

--- a/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct PaymentsActionButtons: View {
     let successAction: PaymentFlowAction
     @Environment(\.posAnalytics) private var analytics
-    @Binding var isShowingSendReceiptView: Bool
+    @Environment(\.posNavigationRouter) private var router
 
     var body: some View {
         ZStack {
@@ -19,7 +19,7 @@ private extension PaymentsActionButtons {
     var sendReceiptButton: some View {
         Button(action: {
             analytics.track(.receiptEmailTapped)
-            isShowingSendReceiptView = true
+            router.pushEmailReceipt()
         }, label: {
             HStack(spacing: Constants.buttonSpacing) {
                 Text(Localization.sendReceipt)
@@ -63,7 +63,6 @@ private extension PaymentsActionButtons {
         successAction: PaymentFlowAction(
             title: "New order",
             action: {},
-            analyticsEvent: nil),
-        isShowingSendReceiptView: .constant(false))
+            analyticsEvent: nil))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -44,8 +44,14 @@ struct PointOfSaleCollectCashView: View {
     var body: some View {
         collectCashContent
             .onChange(of: paymentModel.paymentState.cash) { _, newValue in
-                if newValue == .paymentSuccess {
+                switch newValue {
+                case .paymentSuccess:
                     popToSuccess()
+                case .idle:
+                    // Card event forced exit from cash (e.g. card tapped during cash flow).
+                    router.popToRoot()
+                case .collectingCash:
+                    break
                 }
             }
     }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -28,6 +28,12 @@ struct PointOfSaleCollectCashView: View {
         String.localizedStringWithFormat(Localization.backNavigationSubtitle, orderTotal)
     }
 
+    private var bottomPadding: CGFloat {
+        keyboardObserver.isKeyboardVisible
+            ? Constants.bottomPadding
+            : floatingControlAreaSize.height + Constants.bottomPadding
+    }
+
     private var isButtonEnabled: Bool {
         viewHelper.isPaymentButtonEnabled(orderTotal: orderTotal,
                                           textFieldAmountInput: textFieldAmountInput,
@@ -119,9 +125,7 @@ struct PointOfSaleCollectCashView: View {
                         .disabled(!isButtonEnabled)
                     }
                     .padding([.horizontal])
-                    .padding(.bottom, keyboardObserver.isKeyboardVisible
-                             ? Constants.bottomPadding
-                             : floatingControlAreaSize.height + Constants.bottomPadding)
+                    .padding(.bottom, bottomPadding)
                 }
                 .frame(minHeight: geometry.size.height)
                 .animation(.easeInOut, value: errorMessage)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -5,6 +5,7 @@ import WooFoundation
 struct PointOfSaleCollectCashView: View {
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
+    @Environment(\.posNavigationRouter) private var router
     @Environment(POSPaymentModel.self) private var paymentModel
     @FocusState private var isTextFieldFocused: Bool
 
@@ -41,6 +42,25 @@ struct PointOfSaleCollectCashView: View {
     }
 
     var body: some View {
+        collectCashContent
+            .onChange(of: paymentModel.paymentState.cash) { _, newValue in
+                if newValue == .paymentSuccess {
+                    popToSuccess()
+                }
+            }
+    }
+
+    /// Pops the cash view without animation so TotalsView's success screen
+    /// appears immediately in place, with no visible transition.
+    private func popToSuccess() {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            router.popToRoot()
+        }
+    }
+
+    private var collectCashContent: some View {
         GeometryReader { geometry in
             ScrollView {
                 VStack(alignment: .center, spacing: conditionalPadding(POSSpacing.medium)) {
@@ -51,6 +71,7 @@ struct PointOfSaleCollectCashView: View {
                         isTextFieldFocused = false
                         Task { @MainActor in
                             await paymentModel.cancelCashPayment()
+                            router.popToRoot()
                         }
                     }))
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -7,6 +7,7 @@ struct PointOfSaleCollectCashView: View {
     @Environment(\.floatingControlAreaSize) private var floatingControlAreaSize: CGSize
     @Environment(\.posNavigationRouter) private var router
     @Environment(POSPaymentModel.self) private var paymentModel
+    @Environment(\.keyboardObserver) private var keyboardObserver
     @FocusState private var isTextFieldFocused: Bool
 
     private let viewHelper: CollectCashViewHelper
@@ -21,7 +22,6 @@ struct PointOfSaleCollectCashView: View {
     private let orderTotal: String
 
     @State private var buttonFrame: CGRect = .zero
-    @State private var keyboardFrame: CGRect = .zero
     @State private var shouldMinimizePadding: Bool = false
 
     private var formattedOrderTotal: String {
@@ -119,9 +119,9 @@ struct PointOfSaleCollectCashView: View {
                         .disabled(!isButtonEnabled)
                     }
                     .padding([.horizontal])
-                    .padding(.bottom, max(keyboardFrame.height - geometry.safeAreaInsets.bottom,
-                                          floatingControlAreaSize.height) + Constants.bottomPadding
-                    )
+                    .padding(.bottom, keyboardObserver.isKeyboardVisible
+                             ? Constants.bottomPadding
+                             : floatingControlAreaSize.height + Constants.bottomPadding)
                 }
                 .frame(minHeight: geometry.size.height)
                 .animation(.easeInOut, value: errorMessage)
@@ -131,13 +131,13 @@ struct PointOfSaleCollectCashView: View {
                     updateChangeDueMessage()
                 }
                 .onReceive(Publishers.keyboardFrame) {
-                    keyboardFrame = $0
                     shouldMinimizePadding = $0.intersects(buttonFrame)
                 }
                 .animation(.default, value: shouldMinimizePadding)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea([])
     }
 
     private func markComplete() async throws {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -46,7 +46,7 @@ struct PointOfSaleCollectCashView: View {
             .onChange(of: paymentModel.paymentState.cash) { _, newValue in
                 switch newValue {
                 case .paymentSuccess:
-                    popToSuccess()
+                    router.popToRoot()
                 case .idle:
                     // Card event forced exit from cash (e.g. card tapped during cash flow).
                     router.popToRoot()
@@ -54,16 +54,6 @@ struct PointOfSaleCollectCashView: View {
                     break
                 }
             }
-    }
-
-    /// Pops the cash view without animation so TotalsView's success screen
-    /// appears immediately in place, with no visible transition.
-    private func popToSuccess() {
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            router.popToRoot()
-        }
     }
 
     private var collectCashContent: some View {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -158,7 +158,6 @@ struct PointOfSaleDashboardView: View {
             guard case .eligible = newValue, oldValue != newValue else { return }
             loadItemsWhenEligible()
         }
-        .onNewOrderClearNavigation(orderStage: posModel.orderStage, navigationPath: $navigationPath)
         .ignoresSafeArea(.keyboard)
         .onAppear {
             trackTimeForInitialLoadingState()
@@ -332,35 +331,6 @@ private extension PointOfSaleDashboardView {
             value: "Cancel",
             comment: "Button to dismiss the support form from the POS dashboard."
         )
-    }
-}
-
-// MARK: - Navigation Destination Wrappers
-
-/// Thin wrapper that resolves environment dependencies for the cash payment NavigationStack destination.
-private struct POSNavigationDestinationCashPaymentView: View {
-    let orderTotal: String
-    @Environment(\.posCurrencyProvider) private var currencyProvider
-
-    var body: some View {
-        PointOfSaleCollectCashView(orderTotal: orderTotal,
-                                   currencySettings: currencyProvider.currencySettings)
-        .navigationBarHidden(true)
-    }
-}
-
-/// Thin wrapper that resolves environment dependencies for the email receipt NavigationStack destination.
-private struct POSNavigationDestinationEmailReceiptView: View {
-    @Environment(POSPaymentModel.self) private var paymentModel
-    @Environment(\.posNavigationRouter) private var router
-
-    var body: some View {
-        POSSendReceiptView(onDismiss: {
-            router.pop()
-        }) { email in
-            try await paymentModel.sendReceipt(to: email)
-        }
-        .navigationBarHidden(true)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -200,12 +200,14 @@ struct PointOfSaleDashboardView: View {
                                 .accessibilitySortPriority(1)
                         }
 
+                        let totalsWidth = posModel.paymentState.card.shownFullScreen
+                            || posModel.paymentState.cash == .paymentSuccess
+                            ? cartWidth + checkoutWidth
+                            : checkoutWidth
+
                         TotalsView()
                             .background(Color.posSurface)
-                            .frame(width: posModel.paymentState.card.shownFullScreen
-                                    || posModel.paymentState.cash == .paymentSuccess
-                                   ? cartWidth + checkoutWidth
-                                   : checkoutWidth)
+                            .frame(width: totalsWidth)
                             .accessibilitySortPriority(posModel.orderStage == .finalizing ? 2 : 0)
                             .allowsHitTesting(posModel.orderStage == .finalizing)
                     }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -226,9 +226,8 @@ struct PointOfSaleDashboardView: View {
             .offset(x: dashboardOffset)
             .onChange(of: posModel.paymentState.cash) { _, newValue in
                 if newValue == .collectingCash,
-                   navigationPath.isEmpty,
                    case .loaded(let totals) = posModel.orderState {
-                    navigationPath.append(.cashPayment(orderTotal: totals.orderTotal))
+                    navigationRouter.pushCash(orderTotal: totals.orderTotal)
                 }
             }
             .animation(.default, value: posModel.orderStage)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -14,6 +14,7 @@ struct PointOfSaleDashboardView: View {
     @State private var showSettings: Bool = false
     @State private var waitingTimeTracker: WaitingTimeTracker?
 
+    @State private var navigationPath: [POSNavigationDestination] = []
     @State private var floatingSize: CGSize = .zero
 
     private var viewStateCoordinator: PointOfSaleViewStateCoordinator {
@@ -157,6 +158,7 @@ struct PointOfSaleDashboardView: View {
             guard case .eligible = newValue, oldValue != newValue else { return }
             loadItemsWhenEligible()
         }
+        .onNewOrderClearNavigation(orderStage: posModel.orderStage, navigationPath: $navigationPath)
         .ignoresSafeArea(.keyboard)
         .onAppear {
             trackTimeForInitialLoadingState()
@@ -169,32 +171,73 @@ struct PointOfSaleDashboardView: View {
         }
     }
 
+    private var navigationRouter: POSNavigationRouter {
+        POSNavigationRouter(navigationPath: $navigationPath)
+    }
+
     private var contentView: some View {
         @Bindable var viewStateCoordinator = viewStateCoordinator
         return GeometryReader { geometry in
+            // Fixed widths ensure views don't resize during offset-based transitions.
+            let productsWidth = geometry.size.width * (1 - Constants.cartWidth)
+            let cartWidth = geometry.size.width * Constants.cartWidth
+            let checkoutWidth = geometry.size.width * (1 - Constants.cartWidth)
+            let dashboardWidth = productsWidth + cartWidth + checkoutWidth
+            let dashboardOffset: CGFloat = posModel.orderStage == .building ? 0 : -productsWidth
+
             HStack(spacing: POSSpacing.none) {
-                if posModel.orderStage == .building {
-                    ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
-                                 searchTerm: $viewStateCoordinator.searchTerm)
-                        .accessibilitySortPriority(2)
-                        .transition(.move(edge: .leading))
-                }
+                ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
+                             searchTerm: $viewStateCoordinator.searchTerm)
+                    .frame(width: productsWidth)
+                    .accessibilitySortPriority(posModel.orderStage == .building ? 2 : 0)
+                    .allowsHitTesting(posModel.orderStage == .building)
 
-                if !posModel.paymentState.shownFullScreen {
-                    CartView()
-                        .accessibilitySortPriority(1)
-                        .frame(width: geometry.size.width * Constants.cartWidth)
-                }
+                NavigationStack(path: $navigationPath) {
+                    HStack(spacing: POSSpacing.none) {
+                        if !posModel.paymentState.card.shownFullScreen
+                            && posModel.paymentState.cash != .paymentSuccess {
+                            CartView()
+                                .frame(width: cartWidth)
+                                .accessibilitySortPriority(1)
+                        }
 
-                if posModel.orderStage == .finalizing {
-                    TotalsView()
-                        .accessibilitySortPriority(2)
-                        .transition(.move(edge: .trailing))
+                        TotalsView()
+                            .background(Color.posSurface)
+                            .frame(width: posModel.paymentState.card.shownFullScreen
+                                    || posModel.paymentState.cash == .paymentSuccess
+                                   ? cartWidth + checkoutWidth
+                                   : checkoutWidth)
+                            .accessibilitySortPriority(posModel.orderStage == .finalizing ? 2 : 0)
+                            .allowsHitTesting(posModel.orderStage == .finalizing)
+                    }
+                    .navigationDestination(for: POSNavigationDestination.self) { destination in
+                        switch destination {
+                        case .cashPayment(let orderTotal):
+                            POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
+                        case .emailReceipt:
+                            POSNavigationDestinationEmailReceiptView()
+                        }
+                    }
+                }
+                .scrollContentBackground(.hidden)
+                .background(Color.posSurface)
+                .frame(width: cartWidth + checkoutWidth)
+            }
+            .frame(width: dashboardWidth, alignment: .leading)
+            .offset(x: dashboardOffset)
+            .onChange(of: posModel.paymentState.cash) { _, newValue in
+                if newValue == .collectingCash,
+                   navigationPath.isEmpty,
+                   case .loaded(let totals) = posModel.orderState {
+                    navigationPath.append(.cashPayment(orderTotal: totals.orderTotal))
                 }
             }
             .animation(.default, value: posModel.orderStage)
-            .animation(.default, value: posModel.paymentState.shownFullScreen)
+            .animation(.default, value: posModel.paymentState.card.shownFullScreen)
         }
+        .ignoresSafeArea()
+        .background(Color.posSurface.ignoresSafeArea())
+        .environment(\.posNavigationRouter, navigationRouter)
     }
 
     private var backgroundAppearance: POSBackgroundAppearanceKey.Appearance {
@@ -289,6 +332,35 @@ private extension PointOfSaleDashboardView {
             value: "Cancel",
             comment: "Button to dismiss the support form from the POS dashboard."
         )
+    }
+}
+
+// MARK: - Navigation Destination Wrappers
+
+/// Thin wrapper that resolves environment dependencies for the cash payment NavigationStack destination.
+private struct POSNavigationDestinationCashPaymentView: View {
+    let orderTotal: String
+    @Environment(\.posCurrencyProvider) private var currencyProvider
+
+    var body: some View {
+        PointOfSaleCollectCashView(orderTotal: orderTotal,
+                                   currencySettings: currencyProvider.currencySettings)
+        .navigationBarHidden(true)
+    }
+}
+
+/// Thin wrapper that resolves environment dependencies for the email receipt NavigationStack destination.
+private struct POSNavigationDestinationEmailReceiptView: View {
+    @Environment(POSPaymentModel.self) private var paymentModel
+    @Environment(\.posNavigationRouter) private var router
+
+    var body: some View {
+        POSSendReceiptView(onDismiss: {
+            router.pop()
+        }) { email in
+            try await paymentModel.sendReceipt(to: email)
+        }
+        .navigationBarHidden(true)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -8,11 +8,16 @@ struct POSSendReceiptView: View {
     @State private var errorMessage: String?
     @Environment(\.posAnalytics) private var analytics
 
-    @Binding private(set) var isShowingSendReceiptView: Bool
+    private let onDismiss: () -> Void
     private let onSendReceipt: (String) async throws -> Void
 
     init(isShowingSendReceiptView: Binding<Bool>, onSendReceipt: @escaping (String) async throws -> Void) {
-        self._isShowingSendReceiptView = isShowingSendReceiptView
+        self.onDismiss = { isShowingSendReceiptView.wrappedValue = false }
+        self.onSendReceipt = onSendReceipt
+    }
+
+    init(onDismiss: @escaping () -> Void = {}, onSendReceipt: @escaping (String) async throws -> Void) {
+        self.onDismiss = onDismiss
         self.onSendReceipt = onSendReceipt
     }
 
@@ -31,7 +36,7 @@ struct POSSendReceiptView: View {
             isButtonEnabled: true,
             onSubmit: { sendReceipt() },
             onClose: {
-                isShowingSendReceiptView = false
+                onDismiss()
             },
             keyboardType: .emailAddress,
             autocapitalization: .never,
@@ -54,7 +59,7 @@ struct POSSendReceiptView: View {
                 withAnimation {
                     buttonState = .success
                 } completion: {
-                    isShowingSendReceiptView = false
+                    onDismiss()
                 }
             } catch {
                 errorMessage = Localization.sendReceiptErrorText

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -16,8 +16,16 @@ struct TotalsView: View {
     // _should be_ showing, so that we can animate the change.
     // Default true so totals fields would be included in the view hiearchy on first render and animate with TotalsView
     @State private var isShowingTotalsFields: Bool = true
+
+    /// Payment state with cash collection neutralized. Only `.collectingCash` is handled
+    /// by NavigationStack push. Success and idle are visible to TotalsView.
+    private var displayPaymentState: PointOfSalePaymentState {
+        let cash: PointOfSaleCashPaymentState = paymentModel.paymentState.cash == .collectingCash ? .idle : paymentModel.paymentState.cash
+        return PointOfSalePaymentState(card: paymentModel.paymentState.card, cash: cash)
+    }
+
     private var shouldShowTotalsFields: Bool {
-        viewHelper.shouldShowTotalsFields(for: paymentModel.paymentState)
+        viewHelper.shouldShowTotalsFields(for: displayPaymentState)
     }
 
     var body: some View {
@@ -29,7 +37,7 @@ struct TotalsView: View {
 
                     if isShowingPaymentView {
                         PaymentViewContent(
-                            paymentState: paymentModel.paymentState,
+                            paymentState: displayPaymentState,
                             cardReaderViewLayout: cardReaderViewLayout,
                             isShowingTotalsFields: isShowingTotalsFields,
                             backgroundColor: backgroundColor,
@@ -47,7 +55,7 @@ struct TotalsView: View {
                     if isShowingTotalsFields {
                         TotalsFieldsContent(
                             orderState: posModel.orderState,
-                            paymentState: paymentModel.paymentState,
+                            paymentState: displayPaymentState,
                             cart: posModel.cart,
                             totalsFieldAnimation: totalsFieldAnimation
                         )
@@ -58,7 +66,7 @@ struct TotalsView: View {
 
                     CashPaymentButton(
                         orderState: posModel.orderState,
-                        paymentState: paymentModel.paymentState,
+                        paymentState: displayPaymentState,
                         cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
                         startCashPaymentAction: { paymentModel.startCashPayment() }
                     )
@@ -78,7 +86,7 @@ struct TotalsView: View {
             }
         }
         .background(backgroundColor)
-        .animation(.default, value: paymentModel.paymentState)
+        .animation(.default, value: displayPaymentState.card)
         .animation(.default, value: posModel.orderState.isError)
         .onAppear {
             isShowingTotalsFields = shouldShowTotalsFields
@@ -90,7 +98,7 @@ struct TotalsView: View {
     }
 
     private var backgroundColor: Color {
-        viewHelper.paymentBackgroundColor(for: paymentModel.paymentState)
+        viewHelper.paymentBackgroundColor(for: displayPaymentState)
     }
 }
 
@@ -132,26 +140,7 @@ private extension TotalsView {
     }
 
     private var isShowingPaymentView: Bool {
-        guard posModel.orderState.isLoaded else {
-            // When the order's being created or synced, we only show the shimmering totals.
-            // Before the order exists, we don't want to show the card payment status, as it will
-            // show for a second initially, then disappear the moment we start syncing the order.
-            return false
-        }
-
-        switch paymentModel.cardReaderConnectionStatus {
-        case .connected, .disconnecting, .cancellingConnection:
-            // Show card payment UI if there's a message, or cash payment UI when not idle
-            switch paymentModel.paymentState.activePaymentMethod {
-            case .cash:
-                return true
-            case .card:
-                return paymentModel.cardPresentPaymentInlineMessage != nil
-            }
-        case .disconnected:
-            // Since the reader is disconnected, this will show the "Connect your reader" CTA button view.
-            return true
-        }
+        posModel.orderState.isLoaded
     }
 
     private var cardReaderViewLayout: PaymentViewLayout {
@@ -159,13 +148,13 @@ private extension TotalsView {
             return .primary
         }
 
-        switch paymentModel.paymentState.activePaymentMethod {
+        switch displayPaymentState.activePaymentMethod {
         case .cash:
             return PaymentViewLayout(topPadding: POSPadding.none,
-                                     bottomPadding: paymentModel.paymentState.cash == .collectingCash ? nil : POSPadding.none,
+                                     bottomPadding: POSPadding.none,
                                      sidePadding: POSPadding.none)
         case .card:
-            switch paymentModel.paymentState.card {
+            switch displayPaymentState.card {
             case .validatingOrderError,
                     .paymentIntentCreationError:
                 return .outlined
@@ -184,7 +173,7 @@ private extension TotalsView {
                     .preparingReader,
                     .processingPayment:
                 if POSPaymentViewHelper().shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
-                                                                    paymentState: paymentModel.paymentState) {
+                                                                        paymentState: displayPaymentState) {
                     return .primary
                 }
             }
@@ -445,14 +434,11 @@ private struct PaymentViewContent: View {
     }
 
     @ViewBuilder private var paymentView: some View {
-        switch paymentState.activePaymentMethod {
-        case .cash:
-            if case .loaded(let total) = orderState {
-                POSCashPaymentContentView(
-                    cashPaymentState: paymentState.cash,
-                    formattedOrderTotal: total.orderTotal)
-            }
-        case .card:
+        if paymentState.cash == .paymentSuccess, case .loaded(let total) = orderState {
+            POSCashPaymentContentView(
+                cashPaymentState: .paymentSuccess,
+                formattedOrderTotal: total.orderTotal)
+        } else {
             POSCardPaymentContentView(
                 cardReaderConnectionStatus: cardReaderConnectionStatus,
                 paymentState: paymentState,

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -436,9 +436,10 @@ private struct PaymentViewContent: View {
 
     @ViewBuilder private var paymentView: some View {
         if paymentState.cash == .paymentSuccess, case .loaded(let total) = orderState {
-            POSCashPaymentContentView(
-                cashPaymentState: .paymentSuccess,
-                formattedOrderTotal: total.orderTotal)
+            PointOfSaleCardPresentPaymentInLineMessage(
+                messageType: .paymentSuccess(
+                    viewModel: .init(formattedOrderTotal: total.orderTotal,
+                                     paymentMethod: .cash)))
         } else {
             POSCardPaymentContentView(
                 cardReaderConnectionStatus: cardReaderConnectionStatus,

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -19,6 +19,7 @@ struct TotalsView: View {
 
     /// Payment state with cash collection neutralized. Only `.collectingCash` is handled
     /// by NavigationStack push. Success and idle are visible to TotalsView.
+    /// TODO: Consider removing cash state entirely - it no longer drives the cash view.
     private var displayPaymentState: PointOfSalePaymentState {
         let cash: PointOfSaleCashPaymentState = paymentModel.paymentState.cash == .collectingCash ? .idle : paymentModel.paymentState.cash
         return PointOfSalePaymentState(card: paymentModel.paymentState.card, cash: cash)

--- a/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
@@ -53,6 +53,11 @@ struct POSExternalViewKey: EnvironmentKey {
     static let defaultValue: POSExternalViewProviding = EmptyPOSExternalView()
 }
 
+/// Environment key for POS payment navigation router
+struct POSNavigationRouterKey: EnvironmentKey {
+    static let defaultValue: POSNavigationRouter = POSNavigationRouter(navigationPath: .constant([]))
+}
+
 /// Environment key for POS search text field unfocused border color
 struct POSSearchTextFieldUnfocusedBorderColorKey: EnvironmentKey {
     static let defaultValue: Color = .posSurfaceBright
@@ -92,6 +97,11 @@ extension EnvironmentValues {
     var posExternalViews: POSExternalViewProviding {
         get { self[POSExternalViewKey.self] }
         set { self[POSExternalViewKey.self] = newValue }
+    }
+
+    var posNavigationRouter: POSNavigationRouter {
+        get { self[POSNavigationRouterKey.self] }
+        set { self[POSNavigationRouterKey.self] = newValue }
     }
 
     var posSearchTextFieldUnfocusedBorderColor: Color {


### PR DESCRIPTION
## Description

Replaces inline content-swap transitions for cash payment and email receipt with NavigationStack push navigation in both the cart flow (PointOfSaleDashboardView) and the bookings flow (POSBookingPaymentView).

Built on top of https://github.com/woocommerce/woocommerce-ios/pull/16813. I don't want to merge the first one to give as much time as possible to find issues with payment cancellation, etc. This is one of those tasks that took more time to test and refine rather than do an initial implementation. 

### Other issues

I'm also irritated by the general sluggishness of TotalsView, Instruments show only 30 fps. I worked all day today, and I cannot quite pinpoint that single culprit yet, looks like a combination of complex view structure,too many updates, shimmering view, matched geometry, and complex animations. Looking forward to making PR on at least some improvements tomorrow. 

### Why NavigationStack push

The previous approach swapped content inline within TotalsView/POSPaymentContentView, which caused competing animations, layout resizing, and visual glitches. NavigationStack push solves these by giving cash/email its own screen with clean transitions. It also:

- Improves performance by avoiding unnecessary layout recalculations during state changes
- Fixes unreliable keyboard appearance on the cash payment text field - native `.focused()` modifiers are tied to the view lifecycle which NavigationStack push properly enforces, unlike inline content swaps
- Makes future additions of new payment methods and transitions straightforward - just add a new destination case
- Simplifies TotalsView and POSPaymentContentView since they can focus on card payment, with cash handled as a pushed screen
- Eventually allows removing cash state from the view layer entirely, as it no longer drives inline content

### How it works

**Cart flow:** Uses an offset-based dashboard layout with a NavigationStack wrapping Cart + Totals. Cash and email receipt are pushed as navigation destinations.

**Bookings flow:** NavigationStack lives inside the `.posFullScreenCover` modal. Same destination wrappers are reused.

Both flows use a `displayPaymentState` pattern to neutralize `.collectingCash` so the underlying views stay in card mode while the cash form is pushed on screen. Later we could likely move `.cash` out of the paymentState enum, since it was largely needed to drive those swaps within the TotalsView. 

## Test Steps

Conditions::
- Normal flow and bookings
- Connected and disconnected reader

1, Check out tap Cash Payment - verify push transition
2. Navigate back and forth multiple times
3. Complete cash payment - verify success shows, "New Order" slides back to products
4. On the success screen, tap "Email receipt" - verify push transition, dismiss returns to success
5. Cancel cash payment (back button) - verify return to checkout
6. Try making cash payment and card payment at the same time and catch some issues

## TODOs
- [x] Test with different iOS versions (iOS 17, iOS 18)
- [x] Test with different card readers (BBPOS Chipper, Stripe M2, WisePad 3)

## Video

### Before - messy, sluggish, custom transitions

https://github.com/user-attachments/assets/6c70392c-2883-45dc-bcd3-747dd05683d5

| | |
|--------|--------|
| <img width="1457" height="1004" alt="bad 1" src="https://github.com/user-attachments/assets/b8c4ed38-da5d-4d64-8610-d47da019a707" />  |  <img width="1455" height="1011" alt="bad 4" src="https://github.com/user-attachments/assets/02704062-ba3a-44c2-8575-b11d89cba9c3" /> |
|  <img width="1457" height="1008" alt="bad 3" src="https://github.com/user-attachments/assets/a5372ec3-85a4-492d-915d-1e71a9ad21cf" /> |  <img width="1456" height="1013" alt="bad 2" src="https://github.com/user-attachments/assets/1e3797dc-7bf6-4548-a456-80015197929e" /> | 

### After - quick, clean, native, reusable transitions

https://github.com/user-attachments/assets/6230f666-6891-494f-917a-daedf63044e0

| Header | Header |
|--------|--------|
| <img width="1465" height="1010" alt="image" src="https://github.com/user-attachments/assets/62beadf2-f42d-4ba3-bfc2-5f6dd19a95b4" /> | <img width="1466" height="1008" alt="image" src="https://github.com/user-attachments/assets/cfcba2b4-36d2-4a6f-9940-35bb3c9dfd13" /> |
| <img width="1466" height="1011" alt="image" src="https://github.com/user-attachments/assets/8c8e644c-b2d5-4dfb-9d12-75a4903d8468" /> | <img width="1461" height="1007" alt="image" src="https://github.com/user-attachments/assets/d7625a41-fc71-4799-a15c-473d42b5f4a3" /> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.