### PR TITLE
Mitigate crashes from MockActionHandler and warn of missing actions in mocks

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -37,9 +37,9 @@ mock_handler_files = git.modified_files.select { |f| f.start_with?('Modules/Sour
 if action_files.any? && mock_handler_files.empty?
   warn(
     "Action enum(s) modified (`#{action_files.map { |f| File.basename(f) }.join('`, `')}`) " \
-    "without updating mock handlers. If new action cases were added, update the corresponding " \
-    "MockActionHandler in `Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/` to avoid " \
-    "breaking screenshot tests."
+    'without updating mock handlers. If new action cases were added, update the corresponding ' \
+    'MockActionHandler in `Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/` to avoid ' \
+    'breaking screenshot tests.'
   )
 end
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -30,6 +30,19 @@ tracks_checker.check_tracks_changes(
   tracks_label: 'category: tracks'
 )
 
+# Warn when Action enums are modified without updating mock handlers
+action_files = git.modified_files.select { |f| f.start_with?('Modules/Sources/Yosemite/Actions/') }
+mock_handler_files = git.modified_files.select { |f| f.start_with?('Modules/Sources/Yosemite/Model/Mocks/') }
+
+if action_files.any? && mock_handler_files.empty?
+  warn(
+    "Action enum(s) modified (`#{action_files.map { |f| File.basename(f) }.join('`, `')}`) " \
+    "without updating mock handlers. If new action cases were added, update the corresponding " \
+    "MockActionHandler in `Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/` to avoid " \
+    "breaking screenshot tests."
+  )
+end
+
 view_changes_checker.check
 
 pr_size_checker.check_diff_size(

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockActionHandler.swift
@@ -14,7 +14,9 @@ extension MockActionHandler {
 
     /// A helper method to keep ActionHandler switch statements clean
     func unimplementedAction<T>(action: T) where T: Action {
-        fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")
+        let message = "⚠️ [MockActionHandler] Unhandled action: \(action.identifier) \(String(describing: action))"
+        DDLogWarn(message)
+        assertionFailure(message)
     }
 
     /// A helper that immediately returns a success for `Result<Void>` closure patterns

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
@@ -28,7 +28,7 @@ struct MockCardPresentPaymentActionHandler: MockActionHandler {
             // `WooCommerceScreenshots` to display it for screenshotting purpose.
             onCardReaderMessage(.waitingForInput([.tap, .swipe, .insert]))
         default:
-            break
+            unimplementedAction(action: action)
         }
     }
 

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockPaymentActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockPaymentActionHandler.swift
@@ -28,7 +28,7 @@ struct MockPaymentActionHandler: MockActionHandler {
             completion(.success(mockPlan))
 
         default:
-            break
+            unimplementedAction(action: action)
         }
     }
 }

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -169,7 +169,9 @@ public class MockStoresManager: StoresManager {
                 completion(true)
             }
         default:
-            fatalError("Unable to handle action: \(action.identifier) \(String(describing: action))")
+            let message = "⚠️ [MockStoresManager] Unhandled action type: \(action.identifier) \(String(describing: action))"
+            DDLogWarn(message)
+            assertionFailure(message)
         }
     }
 


### PR DESCRIPTION
Closes WOOMOB-2043

## Description

Adding new actions to the dispatcher can silently break screenshot tests because the mock infrastructure (MockActionHandler, MockStoresManager) used `fatalError` for unhandled actions. Since screenshot tests aren't run on every build, this is easy to miss until the release pipeline fails when we run screenshots jobs for example.

Exhaustive switches perhaps is the way to go, but this means 23 handlers with 95 cases to be added, so instead we add a Danger check to help act as a reminder going forward.

##  Changes:                                                                                                                                                                                     
- Replace `fatalError` for `assertionFailure` in mocks. This logs a warning and crashes in debug instead of unconditionally terminating. Helpful so screenshots tests don't full crash the job when triggered.
- Add a Danger check that warns when Action enums are modified without updating the corresponding mock handlers.

## Test Steps
- Tested via https://github.com/woocommerce/woocommerce-ios/pull/16879 , when adding new actions that compile for the app target, it will still build normally but log a danger check as a reminder.

## Screenshots

<img width="838" height="355" alt="Screenshot 2026-04-02 at 11 22 39" src="https://github.com/user-attachments/assets/296283f1-1997-4095-aaec-86b0d67c0f00" />
