### PR TITLE
Harden `gitignore` rules for derived sources and credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@
 ## Build generated
 build/
 DerivedData/
-WooCommerce/DerivedSources/
+# Any folder named DerivedSources, regardless of the location, so that if we move it, we won't risk accidentally committing it
+DerivedSources/
+# Any file named ApiCredentials.swift, regardless of the location, so that if we move it, we won't risk accidentally committing it
+ApiCredentials.swift
 
 ## Various settings
 *.pbxuser


### PR DESCRIPTION
Harden `.gitignore` rule to ignore `DerivedSources` and `ApiCredentials.swift` regardless of their location.

Some tests I run. Notice the first `g check-ignore` prints the file path and returns 0 (green arrow in my prompt) confirming the file is indeed ignored.

<img width="2468" height="1856" alt="image" src="https://github.com/user-attachments/assets/75578c16-16de-4dc0-a116-0d9cf7e447ab" />

<img width="1126" height="997" alt="image" src="https://github.com/user-attachments/assets/15cbb715-5616-4201-b30d-ef5aeb4e1ca3" />
