### PR TITLE
Add feature flag override panel to Help screen for logged-out state

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -112,7 +112,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .wooShippingFedEx:
             return false
         case .loggedOutFFPanel:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return !buildConfig.isProduction
         default:
             return true
         }

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -111,6 +111,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .wooShippingFedEx:
             return false
+        case .loggedOutFFPanel:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -233,4 +233,8 @@ public enum FeatureFlag: Int, CaseIterable {
     /// Enables FedEx as a carrier option in WooShipping label creation
     ///
     case wooShippingFedEx
+
+    /// Enables the feature flag override panel in the Help screen during the login flow
+    ///
+    case loggedOutFFPanel
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -70,7 +70,7 @@ final class HelpAndSupportViewController: UIViewController {
         isAuthenticated: ServiceLocator.stores.isAuthenticated,
         isZendeskEnabled: ZendeskProvider.shared.zendeskEnabled,
         isMacCatalyst: isMacCatalyst,
-        isLoggedOutFFPanelEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
+        developerFFPanelEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
     )
 
     private var isMacCatalyst: Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -70,7 +70,8 @@ final class HelpAndSupportViewController: UIViewController {
         isAuthenticated: ServiceLocator.stores.isAuthenticated,
         isZendeskEnabled: ZendeskProvider.shared.zendeskEnabled,
         isMacCatalyst: isMacCatalyst,
-        developerFFPanelEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
+        developerFFPanelEnabled: !ServiceLocator.stores.isAuthenticated
+            && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
     )
 
     private var isMacCatalyst: Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 import Yosemite
 
@@ -68,7 +69,8 @@ final class HelpAndSupportViewController: UIViewController {
     private lazy var viewModel = HelpAndSupportViewModel(
         isAuthenticated: ServiceLocator.stores.isAuthenticated,
         isZendeskEnabled: ZendeskProvider.shared.zendeskEnabled,
-        isMacCatalyst: isMacCatalyst
+        isMacCatalyst: isMacCatalyst,
+        isLoggedOutFFPanelEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
     )
 
     private var isMacCatalyst: Bool {
@@ -169,7 +171,15 @@ private extension HelpAndSupportViewController {
     ///
     func configureSections() {
         let helpAndSupportTitle = NSLocalizedString("HOW CAN WE HELP?", comment: "My Store > Settings > Help & Support section title")
-        sections = [Section(title: helpAndSupportTitle, rows: viewModel.getRows())]
+        var result = [Section(title: helpAndSupportTitle, rows: viewModel.getRows())]
+
+        let developerRows = viewModel.getDeveloperRows()
+        if !developerRows.isEmpty {
+            let developerTitle = "DEVELOPER"
+            result.append(Section(title: developerTitle, rows: developerRows))
+        }
+
+        sections = result
     }
 
     /// Register table cells.
@@ -211,6 +221,8 @@ private extension HelpAndSupportViewController {
             configureApplicationLog(cell: cell)
         case let cell as ValueOneTableViewCell where row == .systemStatusReport:
             configureSystemStatusReport(cell: cell)
+        case let cell as ValueOneTableViewCell where row == .featureFlags:
+            configureFeatureFlags(cell: cell)
         default:
             fatalError()
         }
@@ -268,6 +280,15 @@ private extension HelpAndSupportViewController {
             "Various system information about your site",
             comment: "Description of the system status report on Help screen"
         )
+    }
+
+    /// Override Feature Flags cell
+    ///
+    func configureFeatureFlags(cell: ValueOneTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = "Override Feature Flags"
+        cell.detailTextLabel?.text = "Toggle local feature flags"
     }
 
     func refreshViewContent() {
@@ -365,6 +386,13 @@ private extension HelpAndSupportViewController {
         ServiceLocator.analytics.track(.supportSSROpened)
     }
 
+    /// Override Feature Flags action
+    ///
+    func featureFlagsWasPressed() {
+        let controller = UIHostingController(rootView: OverrideFeatureFlagsView(loadsRemoteValues: false))
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     @objc func dismissWasPressed() {
         dismiss(animated: true, completion: nil)
     }
@@ -417,6 +445,8 @@ extension HelpAndSupportViewController: UITableViewDelegate {
             applicationLogWasPressed()
         case .systemStatusReport:
             systemStatusReportWasPressed()
+        case .featureFlags:
+            featureFlagsWasPressed()
         }
     }
 }
@@ -441,10 +471,11 @@ enum HelpAndSupportRow: CaseIterable {
     case contactEmail
     case applicationLog
     case systemStatusReport
+    case featureFlags
 
     var type: UITableViewCell.Type {
         switch self {
-        case .helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport:
+        case .helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport, .featureFlags:
             return ValueOneTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -5,11 +5,16 @@ struct HelpAndSupportViewModel {
     private let isAuthenticated: Bool
     private let isZendeskEnabled: Bool
     private let isMacCatalyst: Bool
+    private let isLoggedOutFFPanelEnabled: Bool
 
-    init(isAuthenticated: Bool, isZendeskEnabled: Bool, isMacCatalyst: Bool) {
+    init(isAuthenticated: Bool,
+         isZendeskEnabled: Bool,
+         isMacCatalyst: Bool,
+         isLoggedOutFFPanelEnabled: Bool = false) {
         self.isAuthenticated = isAuthenticated
         self.isZendeskEnabled = isZendeskEnabled
         self.isMacCatalyst = isMacCatalyst
+        self.isLoggedOutFFPanelEnabled = isLoggedOutFFPanelEnabled
     }
 
     func getRows() -> [HelpAndSupportRow] {
@@ -26,5 +31,12 @@ struct HelpAndSupportViewModel {
             rows.append(.systemStatusReport)
         }
         return rows
+    }
+
+    func getDeveloperRows() -> [HelpAndSupportRow] {
+        guard isLoggedOutFFPanelEnabled else {
+            return []
+        }
+        return [.featureFlags]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -5,16 +5,16 @@ struct HelpAndSupportViewModel {
     private let isAuthenticated: Bool
     private let isZendeskEnabled: Bool
     private let isMacCatalyst: Bool
-    private let isLoggedOutFFPanelEnabled: Bool
+    private let developerFFPanelEnabled: Bool
 
     init(isAuthenticated: Bool,
          isZendeskEnabled: Bool,
          isMacCatalyst: Bool,
-         isLoggedOutFFPanelEnabled: Bool = false) {
+         developerFFPanelEnabled: Bool = false) {
         self.isAuthenticated = isAuthenticated
         self.isZendeskEnabled = isZendeskEnabled
         self.isMacCatalyst = isMacCatalyst
-        self.isLoggedOutFFPanelEnabled = isLoggedOutFFPanelEnabled
+        self.developerFFPanelEnabled = developerFFPanelEnabled
     }
 
     func getRows() -> [HelpAndSupportRow] {
@@ -34,7 +34,7 @@ struct HelpAndSupportViewModel {
     }
 
     func getDeveloperRows() -> [HelpAndSupportRow] {
-        guard isLoggedOutFFPanelEnabled else {
+        guard developerFFPanelEnabled else {
             return []
         }
         return [.featureFlags]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
@@ -9,6 +9,15 @@ struct OverrideFeatureFlagsView: View {
     @State private var searchText = ""
     private let defaultFeatureFlagService = DefaultFeatureFlagService()
 
+    /// Whether to fetch and display remote feature flag values.
+    /// When `false`, the remote section is still shown but rows skip the network
+    /// fetch and hide the "Remote: ..." status line. Useful in logged-out context.
+    private let loadsRemoteValues: Bool
+
+    init(loadsRemoteValues: Bool = true) {
+        self.loadsRemoteValues = loadsRemoteValues
+    }
+
     private var filteredFeatureFlags: [FeatureFlag] {
         let allFlags = FeatureFlag.allCases
         guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -33,7 +42,7 @@ struct OverrideFeatureFlagsView: View {
         List {
             Section("Remote Feature Flags") {
                 ForEach(filteredRemoteFeatureFlags, id: \.self) { flag in
-                    RemoteFeatureFlagRow(featureFlag: flag)
+                    RemoteFeatureFlagRow(featureFlag: flag, loadsRemoteValue: loadsRemoteValues)
                 }
             }
 
@@ -138,10 +147,13 @@ fileprivate struct FeatureFlagRow: View {
 fileprivate struct RemoteFeatureFlagRow: View {
     let featureFlag: RemoteFeatureFlag
     let stores: StoresManager
+    let loadsRemoteValue: Bool
 
     init(featureFlag: RemoteFeatureFlag,
+         loadsRemoteValue: Bool = true,
          stores: StoresManager = ServiceLocator.stores) {
         self.featureFlag = featureFlag
+        self.loadsRemoteValue = loadsRemoteValue
         self.stores = stores
         _overrideValue = State(initialValue: ServiceLocator.remoteFeatureFlagOverrideStore?.overrideValue(for: featureFlag))
     }
@@ -173,7 +185,7 @@ fileprivate struct RemoteFeatureFlagRow: View {
                     Text("Remote: \(remoteValue ? "Enabled" : "Disabled")")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                } else {
+                } else if loadsRemoteValue {
                     Text("Remote: Loading...")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -198,7 +210,9 @@ fileprivate struct RemoteFeatureFlagRow: View {
             )) { EmptyView() }
         }
         .onAppear {
-            fetchRemoteValueIfNeeded()
+            if loadsRemoteValue {
+                fetchRemoteValueIfNeeded()
+            }
         }
     }
 
@@ -215,8 +229,9 @@ fileprivate struct RemoteFeatureFlagRow: View {
     private func resetValue() {
         overrideValue = nil
         ServiceLocator.remoteFeatureFlagOverrideStore?.setOverrideValue(nil, for: featureFlag)
-        // Fetch remote value now that override is cleared
-        fetchRemoteValueIfNeeded()
+        if loadsRemoteValue {
+            fetchRemoteValueIfNeeded()
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -62,7 +62,7 @@ final class HelpAndSupportViewModelTests: XCTestCase {
 
     func test_getDeveloperRows_when_loggedOutFFPanel_enabled_then_returns_featureFlags() {
         // Given
-        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false, isLoggedOutFFPanelEnabled: true)
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false, developerFFPanelEnabled: true)
 
         // When
         let rows = viewModel.getDeveloperRows()
@@ -73,7 +73,7 @@ final class HelpAndSupportViewModelTests: XCTestCase {
 
     func test_getDeveloperRows_when_loggedOutFFPanel_disabled_then_returns_empty() {
         // Given
-        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false, isLoggedOutFFPanelEnabled: false)
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false, developerFFPanelEnabled: false)
 
         // When
         let rows = viewModel.getDeveloperRows()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -57,4 +57,39 @@ final class HelpAndSupportViewModelTests: XCTestCase {
         XCTAssertEqual(rows.first, .helpCenter)
         XCTAssertEqual(rows.last, .systemStatusReport)
     }
+
+    // MARK: - Developer rows
+
+    func test_getDeveloperRows_when_loggedOutFFPanel_enabled_then_returns_featureFlags() {
+        // Given
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false, isLoggedOutFFPanelEnabled: true)
+
+        // When
+        let rows = viewModel.getDeveloperRows()
+
+        // Then
+        XCTAssertEqual(rows, [.featureFlags])
+    }
+
+    func test_getDeveloperRows_when_loggedOutFFPanel_disabled_then_returns_empty() {
+        // Given
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false, isLoggedOutFFPanelEnabled: false)
+
+        // When
+        let rows = viewModel.getDeveloperRows()
+
+        // Then
+        XCTAssertTrue(rows.isEmpty)
+    }
+
+    func test_getDeveloperRows_when_default_then_returns_empty() {
+        // Given
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
+
+        // When
+        let rows = viewModel.getDeveloperRows()
+
+        // Then
+        XCTAssertTrue(rows.isEmpty)
+    }
 }


### PR DESCRIPTION
## Description

Adds a "Developer" section to the Help & Support screen (accessible during the login flow) that lets developers override feature flags **before logging in**. This avoids the painful restart cycle for flags that are read once at app launch (e.g., POS catalog flags baked into `AuthenticatedState.init`, push notification registration in `PushNotificationsManager.init`).

**What changed:**
- New `loggedOutFFPanel` local feature flag (enabled for local dev + alpha builds)
- `OverrideFeatureFlagsView` gains a `loadsRemoteValues` parameter — when `false`, rows skip the network fetch and hide the "Remote: ..." status line
- `HelpAndSupportViewController` gets a conditional "DEVELOPER" section with an "Override Feature Flags" row

**Behavior details:**
- The developer section **only appears in logged-out state** — when logged in, the FF panel is already accessible via Settings → Debug Panel
- Both local and remote feature flag sections are shown, but **remote value loading is skipped** in logged-out state (no network fetch, no "Remote: Loading..." text) — rows just show the flag name and override toggle
- Remote flag overrides are stored locally and checked before any network fetch, so they work without authentication context

## Demo

https://github.com/user-attachments/assets/dc38d4dc-63b8-432c-901e-41ac8d17711d

## Test Steps

1. Run a local dev or alpha build
2. Tap "Log In" on the prologue screen
3. Tap "Help" button (top-right corner)
4. Verify a "DEVELOPER" section appears with "Override Feature Flags" row
5. Tap it → verify both "Remote Feature Flags" and "Local Feature Flags" sections are shown
6. Verify remote flags show just the flag name and toggle (no "Remote: Loading..." text)
7. Toggle a flag, proceed with log in → verify the flag took effect OR navigate to settings debug panel and verify that FF override state is the same as in pre-login state.
8. Open Help from a logged-in state → verify the "DEVELOPER" section is **not** shown
9. Verify the developer section does **not** appear in production builds

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.