### PR TITLE
Optimize script phases and SwiftLint for faster builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -99,7 +99,7 @@ def dependency_failed(component)
 end
 
 def swiftlint(additional_args: [])
-  run_package_plugin(cmd: "swiftlint --working-directory .. --quiet #{additional_args.join(' ')}")
+  run_package_plugin(cmd: "swiftlint --working-directory .. --quiet --use-alternative-excluding #{additional_args.join(' ')}")
 end
 
 def run_package_plugin(cmd:)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -850,14 +850,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = B56DB3E62049BFAA00D4AA8E /* Build configuration list for PBXNativeTarget "WooCommerce" */;
 			buildPhases = (
-				57CCFFD4249D2A5700825FCF /* SwiftLint */,
-				3F50FE4528CAEE9F00C89201 /* Enforce AppLocalizedString usages */,
 				B56DB3C22049BFAA00D4AA8E /* Sources */,
 				B56DB3C32049BFAA00D4AA8E /* Frameworks */,
 				B56DB3C42049BFAA00D4AA8E /* Resources */,
 				B5650B1020A4CD7F009702D0 /* Embed Frameworks */,
 				3F1FA85028B60126009E246C /* Embed Foundation Extensions */,
 				26F81B232BE433A4009EC58E /* Embed Watch Content */,
+				57CCFFD4249D2A5700825FCF /* SwiftLint */,
+				3F50FE4528CAEE9F00C89201 /* Enforce AppLocalizedString usages */,
 			);
 			buildRules = (
 			);
@@ -1179,22 +1179,25 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3F50FE4528CAEE9F00C89201 /* Enforce AppLocalizedString usages */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../Scripts/build-phases/LintAppLocalizedStringsUsage.sh",
+				"$(SRCROOT)/../Scripts/build-phases/LintAppLocalizedStringsUsage.swift",
+				"$(PROJECT_FILE_PATH)/project.pbxproj",
 			);
 			name = "Enforce AppLocalizedString usages";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/lint-app-localized-strings-stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$SRCROOT/../Scripts/build-phases/LintAppLocalizedStringsUsage.sh\"\n";
+			shellScript = "\"$SRCROOT/../Scripts/build-phases/LintAppLocalizedStringsUsage.sh\" && touch \"${DERIVED_FILE_DIR}/lint-app-localized-strings-stamp\"\n";
 			showEnvVarsInLog = 0;
 		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {
@@ -1205,15 +1208,17 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/../.swiftlint.yml",
 			);
 			name = SwiftLint;
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swiftlint-stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "$SRCROOT/../Scripts/build-phases/swiftlint.sh\n";
+			shellScript = "$SRCROOT/../Scripts/build-phases/swiftlint.sh && touch \"${DERIVED_FILE_DIR}/swiftlint-stamp\"\n";
 		};
 		B55D4C1320B612FE00D7A50F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Description

Investigated Xcode build optimization opportunities for WooCommerce iOS using the [Xcode Build Optimization Agent Skill](https://github.com/AvdLee/Xcode-Build-Optimization-Agent-Skill).

### Result: No meaningful improvement found

After iterative benchmarking (median of 3 runs each, Apple Silicon MacBook Pro, Xcode 26.3, iPhone 16 Simulator), none of the tested changes reduced developer wait time.

### What was tested

| Change | Incremental (touch file) | Zero-change | Verdict |
|--------|--------------------------|-------------|---------|
| **Trunk baseline** | **52.3s** | **29.1s** | - |
| Move script phases after Sources | 55.0s | 30.6s | No improvement - serial work moves from before to after compilation, same total |
| + `--use-alternative-excluding` for SwiftLint | 55.0s | 30.6s | Negligible - SwiftLint traversal is not the bottleneck |
| + AppLocalizedString input/output caching | 55.0s | 30.6s | Negligible - the linter was already fast (~1s) |
| `EAGER_LINKING = YES` (target-level) | 42.8s* | 18.6s* | No improvement once SwiftLint runs properly |
| Remove `-fprofile-instr-generate` | 40.7s* | 17.9s* | No improvement once SwiftLint runs properly |
| `COMPILATION_CACHE_ENABLE_CACHING = YES` | N/A | N/A | Breaks incremental builds - prevents SwiftDriver Compilation from being tracked in build.db |

*These numbers were measured while SwiftLint was silently disabled by input/output declarations that only listed `.swiftlint.yml` as input. Xcode skipped the phase entirely on incremental builds since the config never changed. Once SwiftLint ran properly on every build, improvements vanished.

### Why the improvements were illusory

The dominant cost in incremental builds is `PhaseScriptExecution` (SwiftLint) at ~10-11s. This is serial work within the WooCommerce target. Moving it from before Sources to after Sources just shifts the wait from the beginning to the end of the build - total wall time is unchanged.

Adding input/output declarations to SwiftLint with only `.swiftlint.yml` as input effectively disabled it on incremental builds (Xcode skipped the phase since the config never changed). This produced impressive-looking numbers (40s incremental, 18s zero-change) that were actually caused by no longer linting source files.

### Approaches that could actually help

These require behavioral changes and team discussion:

1. **Lint only changed files via git diff** - run SwiftLint only on files modified since last commit. Saves ~10s per build. Tradeoff: pre-existing violations in untouched files are not shown locally (CI still catches everything).

2. **Move SwiftLint out of the build entirely** - run it as a git pre-commit hook or CI-only step. Removes ~10s from every build. Tradeoff: no immediate feedback in Xcode.

3. **Skip SwiftLint locally, rely on CI** - the script already skips in CI environments. Could add a user-level opt-out for local builds too.

### Settings investigated

- **`COMPILATION_CACHE_ENABLE_CACHING = YES`**: Breaks incremental build tracking for native Xcode targets. The cache prevents `SwiftDriver Compilation` from being recorded in `build.db`, causing all 1,744 `.o` files to be re-materialized on every incremental build (70 SwiftCompile tasks instead of 1). SPM targets are not cacheable in Xcode 26.
- **`EAGER_LINKING = YES`**: No measurable improvement when set on the WooCommerce target only. Setting it project-wide caused CI link failures for WordPressAuthenticator due to undeclared transitive dependencies.
- **`-fprofile-instr-generate` removal**: No measurable improvement on link time.
- **Unused SPM dependencies in Yosemite**: 5 unused deps identified (Aztec, WordPressEditor, KeychainAccess, StripeTerminal, WordPressShared) - would reduce link time but requires code-level Package.swift changes.

---
Closing as no changes in this PR provide real build time improvement. The findings above are documented for future reference.