### PR TITLE
Restore `posProductsOnly` filtering for incremental catalog sync

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -13,7 +13,7 @@ public protocol POSCatalogSyncRemoteProtocol {
     /// - Returns: Paginated list of POS products.
     // TODO - remove the periphery ignore comment when the incremental sync is integrated with POS.
     // periphery:ignore
-    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String?) async throws -> PagedItems<POSProduct>
+    func loadProducts(modifiedAfter: Date, siteID: Int64, pageNumber: Int, includeStatus: String?, posProductsOnly: Bool) async throws -> PagedItems<POSProduct>
 
     /// Loads POS product variations modified after the specified date for incremental sync.
     ///
@@ -118,7 +118,8 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
     public func loadProducts(modifiedAfter: Date,
                              siteID: Int64,
                              pageNumber: Int,
-                             includeStatus: String? = nil)
+                             includeStatus: String? = nil,
+                             posProductsOnly: Bool = true)
     async throws -> PagedItems<POSProduct> {
         let path = Path.products
         var parameters: [String: String] = [
@@ -126,7 +127,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(Constants.defaultPageSize),
             ParameterKey.fields: POSProduct.requestFields.joined(separator: ","),
-            ParameterKey.posProductsOnly: String(true)
+            ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
         if let includeStatus = includeStatus {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -88,19 +88,20 @@ private extension POSCatalogIncrementalSyncService {
                      syncRemote: POSCatalogSyncRemoteProtocol) async throws -> POSCatalog {
         let syncStartDate = Date.now
 
-        // Dual-request: Detect products/variations hidden from POS.
-        // Products hidden from POS don't appear in the pos_products_only=true response (hardcoded in the remote),
-        // they're simply omitted. To detect these, we compare against a second request without the flag:
-        // products present there but missing from the filtered response have been hidden and should be removed
-        // from the local DB.
+        // Dual-request: Detect products hidden from POS.
+        // Products hidden from POS don't appear in the pos_products_only=true response,
+        // they're simply omitted. To detect these, we compare against a second request
+        // with pos_products_only=false: products present there but missing from the
+        // filtered response have been hidden and should be removed from the local DB.
 
-        // Fetch POS-filtered products (excluding trash) — the remote always sends pos_products_only=true
+        // Fetch POS-filtered products (excluding trash)
         async let posProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: nil)
+                                                  includeStatus: nil,
+                                                  posProductsOnly: true)
             }
         )
 
@@ -110,7 +111,8 @@ private extension POSCatalogIncrementalSyncService {
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: nil)
+                                                  includeStatus: nil,
+                                                  posProductsOnly: false)
             }
         )
 
@@ -120,7 +122,8 @@ private extension POSCatalogIncrementalSyncService {
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
                                                   pageNumber: pageNumber,
-                                                  includeStatus: ProductStatus.trash.rawValue)
+                                                  includeStatus: ProductStatus.trash.rawValue,
+                                                  posProductsOnly: true)
             }
         )
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogIncrementalSyncService.swift
@@ -88,8 +88,24 @@ private extension POSCatalogIncrementalSyncService {
                      syncRemote: POSCatalogSyncRemoteProtocol) async throws -> POSCatalog {
         let syncStartDate = Date.now
 
+        // Dual-request: Detect products/variations hidden from POS.
+        // Products hidden from POS don't appear in the pos_products_only=true response (hardcoded in the remote),
+        // they're simply omitted. To detect these, we compare against a second request without the flag:
+        // products present there but missing from the filtered response have been hidden and should be removed
+        // from the local DB.
+
         // Fetch POS-filtered products (excluding trash) — the remote always sends pos_products_only=true
         async let posProductsTask = batchedLoader.loadAll(
+            makeRequest: { pageNumber in
+                try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
+                                                  siteID: siteID,
+                                                  pageNumber: pageNumber,
+                                                  includeStatus: nil)
+            }
+        )
+
+        // Fetch ALL products (excluding trash) to compare and find hidden ones
+        async let allProductsTask = batchedLoader.loadAll(
             makeRequest: { pageNumber in
                 try await syncRemote.loadProducts(modifiedAfter: modifiedAfter,
                                                   siteID: siteID,
@@ -117,16 +133,31 @@ private extension POSCatalogIncrementalSyncService {
             }
         )
 
-        let (posProducts, trashedProducts, posVariations) = try await (
-            posProductsTask, trashedProductsTask, posVariationsTask
+        let (posProducts, allProducts, trashedProducts, posVariations) = try await (
+            posProductsTask, allProductsTask, trashedProductsTask, posVariationsTask
         )
 
-        // Aggregate regular and trashed products before persisting
+        // Find products hidden from POS: present in "all" but missing from "POS"
+        let hiddenProductIDs = findHiddenProductIDs(posProducts: posProducts, allProducts: allProducts)
+
+        // Aggregate regular and trashed products before persist them
         let productsToSync = posProducts + trashedProducts
 
         return POSCatalog(products: productsToSync,
                           variations: posVariations,
-                          syncDate: syncStartDate)
+                          syncDate: syncStartDate,
+                          productsToRemove: hiddenProductIDs)
+    }
+}
+
+private extension POSCatalogIncrementalSyncService {
+    /// Finds product IDs that are present in the unfiltered response but missing from the POS-filtered response.
+    /// These products have been hidden from POS and should be removed from the local catalog.
+    func findHiddenProductIDs(posProducts: [POSProduct], allProducts: [POSProduct]) -> [Int64] {
+        let posProductIDs = Set(posProducts.map { $0.productID })
+        return allProducts
+            .filter { !posProductIDs.contains($0.productID) }
+            .map { $0.productID }
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -9,6 +9,9 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     private(set) var incrementalVariationResults: [Int: Result<PagedItems<POSProductVariation>, Error>] = [:]
     private(set) var trashedProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
 
+    // Results returned for the unfiltered request (used during dual-request hidden product detection)
+    private(set) var allProductResults: [Int: Result<PagedItems<POSProduct>, Error>] = [:]
+
     var catalogRequestResult: Result<POSCatalogRequestResponse, Error> = .success(.init(status: .completed, downloadURL: "https://example.com/catalog.json"))
     var catalogDownloadResult: Result<POSCatalogResponse, Error> = .success(.init(products: [], variations: []))
 
@@ -81,6 +84,11 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
         for (index, pagedItems) in results.enumerated() {
             trashedProductResults[index + 1] = .success(pagedItems)
         }
+    }
+
+    // MARK: - Setup Methods for unfiltered product requests (hidden product detection)
+    func setAllProductResult(pageNumber: Int, result: Result<PagedItems<POSProduct>, Error>) {
+        allProductResults[pageNumber] = result
     }
 
     // MARK: - Protocol Methods - Incremental Sync

--- a/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockPOSCatalogSyncRemote.swift
@@ -96,10 +96,11 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
     func loadProducts(modifiedAfter: Date,
                       siteID: Int64,
                       pageNumber: Int,
-                      includeStatus: String?) async throws -> PagedItems<POSProduct> {
+                      includeStatus: String?,
+                      posProductsOnly: Bool) async throws -> PagedItems<POSProduct> {
         await includeStatusTracker.append(includeStatus)
 
-        // Route to appropriate results based on includeStatus
+        // Route to appropriate results based on includeStatus and posProductsOnly
         if includeStatus == "trash" {
             await loadTrashedProductsCallCount.increment()
             lastTrashedProductsModifiedAfter = modifiedAfter
@@ -112,6 +113,18 @@ final class MockPOSCatalogSyncRemote: POSCatalogSyncRemoteProtocol {
                     throw error
                 }
             }
+        } else if !posProductsOnly {
+            // Unfiltered request (posProductsOnly=false) — used for hidden product detection.
+            // Uses allProductResults if configured, otherwise returns fallback.
+            if let result = allProductResults[pageNumber] {
+                switch result {
+                case .success(let pagedItems):
+                    return pagedItems
+                case .failure(let error):
+                    throw error
+                }
+            }
+            return fallbackResult
         } else {
             await loadIncrementalProductsCallCount.increment()
             lastIncrementalProductsModifiedAfter = modifiedAfter

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCatalogIncrementalSyncServiceTests.swift
@@ -312,13 +312,22 @@ struct POSCatalogIncrementalSyncServiceTests {
         // Given
         let lastFullSyncDate = Date(timeIntervalSince1970: 1000)
 
-        // Products visible in POS (filtered response)
+        // Products visible in POS (posProductsOnly=true response)
         let posProduct1 = POSProduct.fake().copy(productID: 1)
         let posProduct2 = POSProduct.fake().copy(productID: 2)
+
+        // All products (posProductsOnly=false response) - includes a product hidden from POS
+        let allProduct1 = POSProduct.fake().copy(productID: 1)
+        let allProduct2 = POSProduct.fake().copy(productID: 2)
+        let hiddenProduct = POSProduct.fake().copy(productID: 3) // Hidden from POS
 
         mockSyncRemote.setIncrementalProductResult(
             pageNumber: 1,
             result: .success(PagedItems(items: [posProduct1, posProduct2], hasMorePages: false, totalItems: 2))
+        )
+        mockSyncRemote.setAllProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [allProduct1, allProduct2, hiddenProduct], hasMorePages: false, totalItems: 3))
         )
         mockSyncRemote.setTrashedProductResult(
             pageNumber: 1,
@@ -334,9 +343,11 @@ struct POSCatalogIncrementalSyncServiceTests {
                                            lastFullSyncDate: lastFullSyncDate,
                                            lastIncrementalSyncDate: nil)
 
-        // Then
+        // Then - Hidden product ID should be in productsToRemove
         let persistedCatalog = try #require(mockPersistenceService.persistIncrementalCatalogDataLastPersistedCatalog)
         #expect(persistedCatalog.products.count == 2)
+        #expect(persistedCatalog.productsToRemove.contains(3))
+        #expect(persistedCatalog.productsToRemove.count == 1)
     }
 
     @Test func startIncrementalSync_handles_no_hidden_products_when_all_products_are_in_POS() async throws {
@@ -348,6 +359,10 @@ struct POSCatalogIncrementalSyncServiceTests {
         let product2 = POSProduct.fake().copy(productID: 2)
 
         mockSyncRemote.setIncrementalProductResult(
+            pageNumber: 1,
+            result: .success(PagedItems(items: [product1, product2], hasMorePages: false, totalItems: 2))
+        )
+        mockSyncRemote.setAllProductResult(
             pageNumber: 1,
             result: .success(PagedItems(items: [product1, product2], hasMorePages: false, totalItems: 2))
         )


### PR DESCRIPTION
Continuation of 16876

## Description

On #16876 we removed the `pointOfSaleOnlyProducts` feature flag but we also removed the `posProductsOnly` parameter from the incremental sync remote method. This broke the dual-request pattern introduced in #16510 that detects products hidden from POS during incremental sync (those marked as not available for POS in wp-admin)
                                                                                                                                                                                               
When a merchant marks a product as "not available for POS" in wp-admin, the `pos_products_only=true` API response simply omits it, there's no "deleted" signal. The dual-request compares a filtered response (pos_products_only=true) against an unfiltered one (pos_products_only=false) to find and remove those hidden products from the local catalog. Without the parameter, both requests were identical and hidden detection was a no-op.

The base PR got incorrectly merged before being fully addressed when I pushed an intermediate commit trying to fix the tests by removing the dual-request thinking was no longer needed, and auto-merge triggered when tests passed.

## Changes

This PR restores `posProductsOnly: Bool` on the incremental `loadProducts(modifiedAfter:...)` remote method only, the minimum needed for the dual-request to work. All other removals from #16876 (feature flag, full sync methods, count methods, PointOfSale module flag reads) remain removed.

## Test Steps
- Run the app and make a full POS sync if needed, just to have fresh data
- For one or more of your products, disable available for POS in wp-admin > products > edit > advanced.
- Re-run the app, and observe the product is deleted from the local catalog upon incremental sync

```
🗑️ Deleting 1 products and 0 variations from catalog
Deleted 1 products from catalog
✅ Catalog deletion complete
✅ Incremental catalog persistence complete
✅ POSCatalogSyncCoordinator completed incremental sync for site 215063064
```

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
