### PR TITLE
Fix warnings and improve thread safety

### DIFF
--- a/Modules/Sources/Networking/Internal/Queue.swift
+++ b/Modules/Sources/Networking/Internal/Queue.swift
@@ -11,7 +11,7 @@ struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return isEmpty
+        return array.count - head == 0 // swiftlint:disable:this empty_count
     }
 
     public var count: Int {

--- a/Modules/Sources/Networking/Internal/Queue.swift
+++ b/Modules/Sources/Networking/Internal/Queue.swift
@@ -11,7 +11,7 @@ struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return array.count - head == 0 // swiftlint:disable:this empty_count
+        return count == 0 // swiftlint:disable:this empty_count
     }
 
     public var count: Int {

--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -117,7 +117,7 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
         let stringOfVariationIDs = variationIDs.map { String($0) }
             .joined(separator: ",")
         let stringOfRequiredFields = fields.joined(separator: ",")
-        var parameters = [
+        let parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.downloadable: downloadable.map { String($0) },

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
@@ -12,12 +12,15 @@ final class RequestProcessor: RequestInterceptor {
 
     private let state: RequestProcessorState
 
-    weak var delegate: RequestProcessorDelegate?
-
     init(requestAuthenticator: RequestAuthenticator,
          notificationCenter: NotificationCenter = .default) {
         self.notificationCenter = notificationCenter
         self.state = RequestProcessorState(requestAuthenticator: requestAuthenticator)
+    }
+
+    weak var delegate: RequestProcessorDelegate? {
+        get { state.delegate }
+        set { state.delegate = newValue }
     }
 
     func updateAuthenticator(_ authenticator: RequestAuthenticator) {
@@ -195,6 +198,7 @@ private extension RequestProcessor {
         private var isAuthenticating: Bool
         private var requestAuthenticator: RequestAuthenticator
         private var siteID: Int64?
+        private weak var _delegate: RequestProcessorDelegate?
 
         private let queue = DispatchQueue(
             label: "com.woocommerce.networking.request-processor.state-queue",
@@ -206,6 +210,11 @@ private extension RequestProcessor {
             self.isAuthenticating = false
             self.requestAuthenticator = requestAuthenticator
             self.siteID = requestAuthenticator.jetpackSiteID
+        }
+
+        var delegate: RequestProcessorDelegate? {
+            get { queue.sync { _delegate } }
+            set { queue.sync { _delegate = newValue } }
         }
 
         var authenticator: RequestAuthenticator {

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -13,11 +13,7 @@ final class CookieNonceAuthenticator: RequestInterceptor {
     private let password: String
     private let loginURL: URL
     private let adminURL: URL
-    private var nonce: String?
-
-    private var canRetry = true
-    private var isAuthenticating = false
-    private var requestsToRetry = [(RetryResult) -> Void]()
+    private let state = CookieNonceAuthenticatorState()
 
     init(configuration: CookieNonceAuthenticatorConfiguration) {
         self.username = configuration.username
@@ -28,7 +24,7 @@ final class CookieNonceAuthenticator: RequestInterceptor {
 
     // MARK: Request Adapter
     func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Swift.Error>) -> Void) {
-        guard let nonce else {
+        guard let nonce = state.nonce else {
             return completion(.success(urlRequest))
         }
         var adaptedRequest = urlRequest
@@ -39,7 +35,7 @@ final class CookieNonceAuthenticator: RequestInterceptor {
     // MARK: Retrier
     func retry(_ request: Alamofire.Request, for session: Alamofire.Session, dueTo error: Swift.Error, completion: @escaping (RetryResult) -> Void) {
         guard
-            canRetry,
+            state.canRetry,
             // Only retry once
             request.retryCount == 0,
             // And don't retry the login request
@@ -50,8 +46,8 @@ final class CookieNonceAuthenticator: RequestInterceptor {
             return completion(.doNotRetry)
         }
 
-        requestsToRetry.append(completion)
-        if !isAuthenticating {
+        let shouldStartAuthentication = state.enqueueRetry(completion)
+        if shouldStartAuthentication {
             startLoginSequence(session: session)
         }
     }
@@ -80,7 +76,7 @@ private extension CookieNonceAuthenticator {
                 guard let nonce = readNonceFromAjaxAction(html: page) else {
                     throw CookieNonceAuthenticator.Error.missingNonce
                 }
-                self.nonce = nonce
+                self.state.nonce = nonce
                 successfulLoginSequence()
             } catch let error as CookieNonceAuthenticator.Error {
                 invalidateLoginSequence(error: error)
@@ -130,24 +126,24 @@ private extension CookieNonceAuthenticator {
     }
 
     func invalidateLoginSequence(error: Error) {
-        canRetry = false
+        var allowRetry = false
         if case .postLoginFailed(let originalError) = error {
             let nsError = originalError as NSError
             if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorNotConnectedToInternet {
-                canRetry = true
+                allowRetry = true
             }
         }
+        state.invalidate(canRetry: allowRetry)
         DDLogInfo("Aborting Cookie+Nonce login sequence for \(loginURL)")
         completeRequests(false)
-        isAuthenticating = false
     }
 
     func completeRequests(_ shouldRetry: Bool) {
         let result: RetryResult = shouldRetry ? .retryWithDelay(0) : .doNotRetry
-        requestsToRetry.forEach { (completion) in
+        let pendingCompletions = state.drainPendingRetries()
+        pendingCompletions.forEach { completion in
             completion(result)
         }
-        requestsToRetry.removeAll()
     }
 
     func readNonceFromAjaxAction(html: String) -> String? {
@@ -156,6 +152,57 @@ private extension CookieNonceAuthenticator {
 
     func buildNonceRequestURL(base: URL) -> URL? {
         URL(string: "admin-ajax.php?action=rest-nonce", relativeTo: base)
+    }
+}
+
+// MARK: State
+private extension CookieNonceAuthenticator {
+    final class CookieNonceAuthenticatorState: @unchecked Sendable {
+        private var _nonce: String?
+        private var _canRetry = true
+        private var _isAuthenticating = false
+        private var _requestsToRetry = [(RetryResult) -> Void]()
+
+        private let queue = DispatchQueue(
+            label: "com.woocommerce.networking.cookie-nonce-authenticator.state-queue",
+            qos: .userInitiated
+        )
+
+        var nonce: String? {
+            get { queue.sync { _nonce } }
+            set { queue.sync { _nonce = newValue } }
+        }
+
+        var canRetry: Bool {
+            queue.sync { _canRetry }
+        }
+
+        /// Enqueues a retry completion and returns `true` if authentication should start.
+        func enqueueRetry(_ completion: @escaping (RetryResult) -> Void) -> Bool {
+            queue.sync {
+                _requestsToRetry.append(completion)
+                if _isAuthenticating {
+                    return false
+                }
+                _isAuthenticating = true
+                return true
+            }
+        }
+
+        func invalidate(canRetry: Bool) {
+            queue.sync {
+                _canRetry = canRetry
+                _isAuthenticating = false
+            }
+        }
+
+        func drainPendingRetries() -> [(RetryResult) -> Void] {
+            queue.sync {
+                let completions = _requestsToRetry
+                _requestsToRetry.removeAll()
+                return completions
+            }
+        }
     }
 }
 

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -157,7 +157,7 @@ private extension CookieNonceAuthenticator {
 }
 
 // MARK: State
-private extension CookieNonceAuthenticator {
+fileprivate extension CookieNonceAuthenticator {
     final class CookieNonceAuthenticatorState: @unchecked Sendable {
         private var _nonce: String?
         private var _canRetry = true

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -122,6 +122,7 @@ private extension CookieNonceAuthenticator {
 
     func successfulLoginSequence() {
         DDLogInfo("Completed Cookie+Nonce login sequence for \(loginURL)")
+        state.resetAfterSuccess()
         completeRequests(true)
     }
 
@@ -133,7 +134,7 @@ private extension CookieNonceAuthenticator {
                 allowRetry = true
             }
         }
-        state.invalidate(canRetry: allowRetry)
+        state.invalidate(allowRetry: allowRetry)
         DDLogInfo("Aborting Cookie+Nonce login sequence for \(loginURL)")
         completeRequests(false)
     }
@@ -189,9 +190,15 @@ private extension CookieNonceAuthenticator {
             }
         }
 
-        func invalidate(canRetry: Bool) {
+        func resetAfterSuccess() {
             queue.sync {
-                _canRetry = canRetry
+                _isAuthenticating = false
+            }
+        }
+
+        func invalidate(allowRetry: Bool) {
+            queue.sync {
+                _canRetry = allowRetry
                 _isAuthenticating = false
             }
         }

--- a/Modules/Sources/Yosemite/Internal/Queue.swift
+++ b/Modules/Sources/Yosemite/Internal/Queue.swift
@@ -10,7 +10,7 @@ public struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return array.count - head == 0 // swiftlint:disable:this empty_count
+        return count == 0 // swiftlint:disable:this empty_count
     }
 
     public var count: Int {

--- a/Modules/Sources/Yosemite/Internal/Queue.swift
+++ b/Modules/Sources/Yosemite/Internal/Queue.swift
@@ -10,7 +10,7 @@ public struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return array.count == 0 // swiftlint:disable:this empty_count
+        return array.count - head == 0 // swiftlint:disable:this empty_count
     }
 
     public var count: Int {

--- a/Modules/Sources/Yosemite/Internal/Queue.swift
+++ b/Modules/Sources/Yosemite/Internal/Queue.swift
@@ -10,7 +10,7 @@ public struct Queue<T> {
     fileprivate var head = 0
 
     public var isEmpty: Bool {
-        return isEmpty
+        return array.count == 0 // swiftlint:disable:this empty_count
     }
 
     public var count: Int {

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -449,11 +449,11 @@ final class RequestProcessorTests: XCTestCase {
     /// Simulates race condition of concurrent `delegate` reads and writes from different threads.
     /// Verifies the synchronized implementation does not crash. Best run with Thread Sanitizer enabled.
     func test_concurrent_delegate_access_does_not_trigger_race_condition() {
+        // Given
         let sut = RequestProcessor(
             requestAuthenticator: MockRequestAuthenticator(),
             notificationCenter: MockNotificationCenter()
         )
-
         let iterations = 20000
         let queue = DispatchQueue(
             label: "com.woocommerce.tests.requestProcessor.delegate-race",
@@ -461,9 +461,9 @@ final class RequestProcessorTests: XCTestCase {
             attributes: .concurrent
         )
         let group = DispatchGroup()
-
         let delegates = (0..<iterations / 2).map { _ in MockRequestProcessorDelegate() }
 
+        // When
         for index in 0..<iterations {
             queue.async(group: group) {
                 if index.isMultiple(of: 2) {
@@ -474,6 +474,7 @@ final class RequestProcessorTests: XCTestCase {
             }
         }
 
+        // Then
         let result = group.wait(timeout: .now() + 20)
         XCTAssertEqual(result, .success)
     }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -446,7 +446,38 @@ final class RequestProcessorTests: XCTestCase {
         XCTAssertFalse(shouldRetry.retryRequired)
     }
 
-    /// The test is designed for manual local run. It must be excluded from CI pipelines.
+    /// Simulates race condition of concurrent `delegate` reads and writes from different threads.
+    /// Verifies the synchronized implementation does not crash. Best run with Thread Sanitizer enabled.
+    func test_concurrent_delegate_access_does_not_trigger_race_condition() {
+        let sut = RequestProcessor(
+            requestAuthenticator: MockRequestAuthenticator(),
+            notificationCenter: MockNotificationCenter()
+        )
+
+        let iterations = 20000
+        let queue = DispatchQueue(
+            label: "com.woocommerce.tests.requestProcessor.delegate-race",
+            qos: .userInitiated,
+            attributes: .concurrent
+        )
+        let group = DispatchGroup()
+
+        let delegates = (0..<iterations / 2).map { _ in MockRequestProcessorDelegate() }
+
+        for index in 0..<iterations {
+            queue.async(group: group) {
+                if index.isMultiple(of: 2) {
+                    sut.delegate = delegates[index / 2]
+                } else {
+                    _ = sut.delegate
+                }
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 20)
+        XCTAssertEqual(result, .success)
+    }
+
     /// Simulates race condition of multiple `updateAuthenticator` calls from different threads
     /// Should cause a crash on old/non-synchronized `RequestProcessor` implementatoin
     /// Should work fine on synchronized version of `RequestProcessor`


### PR DESCRIPTION
## Description
Fixes several warnings and bugs:

- **Fix infinite recursion in `Queue.isEmpty`** (Networking & Yosemite): The property was calling itself instead of checking the underlying array. Fixed to use `array.count - head == 0`.
- **Make `RequestProcessor.delegate` thread-safe**: Moved the `delegate` property behind the existing synchronized `RequestProcessorState` dispatch queue, matching the pattern used for other state properties.
- **Make `CookieNonceAuthenticator` thread-safe**: Extracted mutable state (`nonce`, `canRetry`, `isAuthenticating`, `requestsToRetry`) into a new `CookieNonceAuthenticatorState` class with `DispatchQueue` synchronization, mirroring the `RequestProcessorState` pattern.
- **Change unused `var` to `let`** in `ProductVariationsRemote` to fix a warning.
- **Add concurrent access test** for `RequestProcessor.delegate` thread safety.

## Test Steps
1. Build and run the app to smoke test features to ensure that network requests work properly.
2. Run `RequestProcessorTests` — all tests should pass, including the new `test_concurrent_delegate_access_does_not_trigger_race_condition`.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.