### PR TITLE
Skip role eligibility gate for WP.com authenticated users

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -820,6 +820,17 @@ private extension StorePickerViewController {
             return
         }
 
+        // For WP.com authenticated users, skip the role check gate.
+        // Role eligibility is verified in the background on relaunch.
+        if case .wpcom = ServiceLocator.stores.sessionManager.defaultCredentials {
+            delegate.didSelectStore(with: site.siteID) { [weak self] in
+                self?.dismiss()
+            }
+            return
+        }
+
+        // For non-WP.com auth (site credentials, application passwords),
+        // keep the hard gate — role verification is critical.
         updateActionButtonAndTableState(animating: true, enabled: false)
 
         viewModel.checkEligibility(for: site.siteID) { [weak self] result in


### PR DESCRIPTION
## Description

Fixes WOOMOB-2509

For users authenticated via WP.com OAuth (Jetpack tunnel), the `wp/v2/users/me` role eligibility check at store selection was a hard gate. When this endpoint returns HTTP 500 (e.g. due to a server-side misconfiguration like GoDaddy blocking the endpoint), the user gets stuck in a loop:

1. Store picker → tap Continue → role check fails with 500 → "We couldn't load your site" error modal
2. Dismiss → tap Continue → same 500 → same error
3. Force-close → reopen → store picker again (store was never saved, since it's only persisted after a successful role check)

For WP.com authenticated users, this role check is supplementary — the user is already authenticated via WP.com OAuth, and all `/wc/v3/*` endpoints work through the Jetpack tunnel. The role check is primarily needed for Application Passwords flows where the app authenticates directly against the site.

**Fix:** Skip the blocking role check for `.wpcom` credentials at store selection time. The existing background check in `AppCoordinator.validateRoleEligibility` (which runs on every cold launch) catches insufficient roles on relaunch. For non-WP.com auth (`.wporg`, `.applicationPassword`), the hard gate is preserved.

## Test Steps

**Verify WP.com auth skips the role check gate:**
1. Log in with a WP.com account
2. Clear default store to trigger the store picker:
   ```
   xcrun simctl spawn <booted-device-id> defaults delete <bundle-id> defaultStoreID
   ```
3. Relaunch the app → store picker appears
4. Select a store and tap **Continue**
5. The app proceeds **immediately** — no loading spinner on the Continue button

**Verify the fix handles the 500 scenario (requires temporary code change):**
1. In `RoleEligibilityUseCase.swift`, temporarily add at the top of `checkEligibility(for:completion:)`:
   ```swift
   completion(.failure(.unknown(error: NSError(domain: "test", code: 500))))
   return
   ```
2. Repeat steps 2–4 above
3. **Before this PR:** "We couldn't load your site" error modal, user is stuck
4. **After this PR:** app proceeds to the main UI
5. Revert the temporary change

**Verify non-WP.com auth still checks roles:**
No code change on this path — the existing role check gate remains for `.wporg` and `.applicationPassword` credentials.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)