### PR TITLE
Fix POS cart items misaligned when no coupons in cart

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -278,7 +278,9 @@ private struct CartScrollViewContent: View {
         ScrollViewReader { proxy in
             ScrollView {
                 VStack(spacing: Constants.cartItemSpacing) {
-                    CouponsCartSection(shouldShowItemImages: $shouldShowItemImages)
+                    if posModel.cart.coupons.isNotEmpty {
+                        CouponsCartSection(shouldShowItemImages: $shouldShowItemImages)
+                    }
 
                     PurchasableItemsCartSection(shouldShowItemImages: $shouldShowItemImages)
                 }


### PR DESCRIPTION
## Description
This PR fixes the alignment between the top of the first cart item, and the top of the product/coupon list.

When no coupons are applied, the empty `CouponsCartSection` was still rendered in the cart's `VStack`, causing alignment issues with the product items below it. To fix, we just wrap the section in an `isNotEmpty` check so it's only included when there are coupons to display.

Fixes WOOMOB-2558.

## Test Steps
1. Open POS and add items to the cart
2. Without any coupons applied, verify the top cart item is properly aligned with products/coupons
3. Apply a coupon and verify the coupon is also properly aligned

## Screenshots
![aligned-pos](https://github.com/user-attachments/assets/087ba109-9aab-420a-ad52-20ec996e0d24)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.