### PR TITLE
[Woo POS][Local Catalog i2] Update eligibility checker to account for catalog API WC 10.5+

### DIFF
--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -7,7 +7,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     private let systemStatusService: POSSystemStatusServiceProtocol
     private let catalogSizeLimit: Int
     private let isLocalCatalogFeatureFlagEnabled: Bool
-    private let usesCatalogAPI: Bool
+    private let isCatalogAPIFeatureFlagEnabled: Bool
     private let remoteFeatureFlagProvider: @Sendable () async -> Bool
     private let betaFeatureToggleProvider: @Sendable () async -> Bool
 
@@ -32,7 +32,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         catalogSizeChecker: POSCatalogSizeCheckerProtocol,
         systemStatusService: POSSystemStatusServiceProtocol,
         isLocalCatalogFeatureFlagEnabled: Bool,
-        usesCatalogAPI: Bool = false,
+        isCatalogAPIFeatureFlagEnabled: Bool = false,
         remoteFeatureFlagProvider: @escaping @Sendable () async -> Bool,
         betaFeatureToggleProvider: @escaping @Sendable () async -> Bool,
         catalogSizeLimit: Int? = nil
@@ -40,7 +40,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         self.catalogSizeChecker = catalogSizeChecker
         self.systemStatusService = systemStatusService
         self.isLocalCatalogFeatureFlagEnabled = isLocalCatalogFeatureFlagEnabled
-        self.usesCatalogAPI = usesCatalogAPI
+        self.isCatalogAPIFeatureFlagEnabled = isCatalogAPIFeatureFlagEnabled
         self.remoteFeatureFlagProvider = remoteFeatureFlagProvider
         self.betaFeatureToggleProvider = betaFeatureToggleProvider
         self.catalogSizeLimit = catalogSizeLimit ?? Constants.defaultCatalogSizeLimit
@@ -122,7 +122,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         // Check WooCommerce version:
         // - Paginated sync requires 10.3.0+
         // - Catalog API requires 10.5.0+,
-        let minimumVersion = usesCatalogAPI ? Constants.wcPluginMinimumVersionForCatalogAPI : Constants.wcPluginMinimumVersionForLocalCatalog
+        let minimumVersion = isCatalogAPIFeatureFlagEnabled ? Constants.wcPluginMinimumVersionForCatalogAPI : Constants.wcPluginMinimumVersionForLocalCatalog
         do {
             let pluginInfo = try await systemStatusService.loadWooCommercePluginAndPOSFeatureSwitch(siteID: siteID)
 
@@ -158,13 +158,14 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         }
 
         // Catalog API supports stores of any size, so we skip the size check
-        if usesCatalogAPI {
+        if isCatalogAPIFeatureFlagEnabled {
             DDLogInfo("📋 POSLocalCatalogEligibilityService: Using catalog API, skipping size check for site \(siteID)")
             eligibilityStates[siteID] = .eligible
             return .eligible
         }
 
         // Fetch remote catalog size and check against limit (paginated sync only)
+        // Once pointOfSaleCatalogAPI is enabled and file approach is working, catalog size won't apply
         do {
             let size = try await catalogSizeChecker.checkCatalogSize(for: siteID)
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSLocalCatalogEligibilityService.swift
@@ -7,6 +7,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
     private let systemStatusService: POSSystemStatusServiceProtocol
     private let catalogSizeLimit: Int
     private let isLocalCatalogFeatureFlagEnabled: Bool
+    private let usesCatalogAPI: Bool
     private let remoteFeatureFlagProvider: @Sendable () async -> Bool
     private let betaFeatureToggleProvider: @Sendable () async -> Bool
 
@@ -31,6 +32,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         catalogSizeChecker: POSCatalogSizeCheckerProtocol,
         systemStatusService: POSSystemStatusServiceProtocol,
         isLocalCatalogFeatureFlagEnabled: Bool,
+        usesCatalogAPI: Bool = false,
         remoteFeatureFlagProvider: @escaping @Sendable () async -> Bool,
         betaFeatureToggleProvider: @escaping @Sendable () async -> Bool,
         catalogSizeLimit: Int? = nil
@@ -38,6 +40,7 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
         self.catalogSizeChecker = catalogSizeChecker
         self.systemStatusService = systemStatusService
         self.isLocalCatalogFeatureFlagEnabled = isLocalCatalogFeatureFlagEnabled
+        self.usesCatalogAPI = usesCatalogAPI
         self.remoteFeatureFlagProvider = remoteFeatureFlagProvider
         self.betaFeatureToggleProvider = betaFeatureToggleProvider
         self.catalogSizeLimit = catalogSizeLimit ?? Constants.defaultCatalogSizeLimit
@@ -116,7 +119,10 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
             return state
         }
 
-        // Check WooCommerce version - local catalog requires 10.3.0 or higher
+        // Check WooCommerce version:
+        // - Paginated sync requires 10.3.0+
+        // - Catalog API requires 10.5.0+,
+        let minimumVersion = usesCatalogAPI ? Constants.wcPluginMinimumVersionForCatalogAPI : Constants.wcPluginMinimumVersionForLocalCatalog
         do {
             let pluginInfo = try await systemStatusService.loadWooCommercePluginAndPOSFeatureSwitch(siteID: siteID)
 
@@ -128,13 +134,13 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
             }
 
             guard VersionHelpers.isVersionSupported(version: wcPlugin.version,
-                                                    minimumRequired: Constants.wcPluginMinimumVersionForLocalCatalog) else {
+                                                    minimumRequired: minimumVersion) else {
                 let state = POSLocalCatalogEligibilityState.ineligible(
-                    reason: .unsupportedWooCommerceVersion(minimumVersion: Constants.wcPluginMinimumVersionForLocalCatalog)
+                    reason: .unsupportedWooCommerceVersion(minimumVersion: minimumVersion)
                 )
                 eligibilityStates[siteID] = state
-                DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce version \(wcPlugin.version) below minimum" +
-                          "\(Constants.wcPluginMinimumVersionForLocalCatalog) for site \(siteID)")
+                DDLogInfo("📋 POSLocalCatalogEligibilityService: WooCommerce version \(wcPlugin.version) below minimum " +
+                          "\(minimumVersion) for site \(siteID)")
                 return state
             }
 
@@ -151,7 +157,14 @@ public actor POSLocalCatalogEligibilityService: POSLocalCatalogEligibilityServic
             return state
         }
 
-        // Fetch remote catalog size and check against limit
+        // Catalog API supports stores of any size, so we skip the size check
+        if usesCatalogAPI {
+            DDLogInfo("📋 POSLocalCatalogEligibilityService: Using catalog API, skipping size check for site \(siteID)")
+            eligibilityStates[siteID] = .eligible
+            return .eligible
+        }
+
+        // Fetch remote catalog size and check against limit (paginated sync only)
         do {
             let size = try await catalogSizeChecker.checkCatalogSize(for: siteID)
 
@@ -215,5 +228,6 @@ private extension POSLocalCatalogEligibilityService {
     enum Constants {
         static let defaultCatalogSizeLimit = 1000
         static let wcPluginMinimumVersionForLocalCatalog = "10.3.0-beta"
+        static let wcPluginMinimumVersionForCatalogAPI = "10.5.0"
     }
 }

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
@@ -610,7 +610,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
-            usesCatalogAPI: true,
+            isCatalogAPIFeatureFlagEnabled: true,
             remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
             catalogSizeLimit: 1000
@@ -652,7 +652,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
-            usesCatalogAPI: true,
+            isCatalogAPIFeatureFlagEnabled: true,
             remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
             catalogSizeLimit: 1000
@@ -689,7 +689,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
-            usesCatalogAPI: false,
+            isCatalogAPIFeatureFlagEnabled: false,
             remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
             catalogSizeLimit: 1000
@@ -731,7 +731,7 @@ struct POSLocalCatalogEligibilityServiceTests {
             catalogSizeChecker: sizeChecker,
             systemStatusService: systemStatusService,
             isLocalCatalogFeatureFlagEnabled: true,
-            usesCatalogAPI: false,
+            isCatalogAPIFeatureFlagEnabled: false,
             remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
             betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
             catalogSizeLimit: 1000

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSLocalCatalogEligibilityServiceTests.swift
@@ -590,6 +590,170 @@ struct POSLocalCatalogEligibilityServiceTests {
         #expect(sizeChecker.checkCatalogSizeCallCount == 0)
     }
 
+    // MARK: - Catalog API (usesCatalogAPI = true)
+
+    @Test("Catalog API skips size check for large catalogs")
+    func test_usesCatalogAPI_when_large_catalog_then_skips_size_check() async throws {
+        // Given
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 3000, variationCount: 2000))
+        )
+        let systemStatusService = MockPOSSystemStatusService(
+            pluginInfoToReturn: .success(
+                POSPluginAndFeatureInfo(
+                    wcPlugin: makeSystemPlugin(version: "10.5.0"),
+                    featureValue: true
+                )
+            )
+        )
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            usesCatalogAPI: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
+            betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        // When
+        let state = try await service.catalogEligibility(for: siteID)
+
+        // Then
+        #expect(state == .eligible)
+        #expect(sizeChecker.checkCatalogSizeCallCount == 0)
+    }
+
+    @Test("Catalog API requires WC 10.5+",
+          arguments: [
+            ("10.3.0", false),
+            ("10.4.0", false),
+            ("10.5.0", true),
+            ("11.0.0", true),
+          ])
+    func test_usesCatalogAPI_when_version_then_checks_minimum_10_5(
+        version: String,
+        expectEligible: Bool
+    ) async throws {
+        // Given
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
+        )
+        let systemStatusService = MockPOSSystemStatusService(
+            pluginInfoToReturn: .success(
+                POSPluginAndFeatureInfo(
+                    wcPlugin: makeSystemPlugin(version: version),
+                    featureValue: true
+                )
+            )
+        )
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            usesCatalogAPI: true,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
+            betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        // When
+        let state = try await service.catalogEligibility(for: siteID)
+
+        // Then
+        if expectEligible {
+            #expect(state == .eligible)
+        } else {
+            guard case .ineligible(let reason) = state else {
+                Issue.record("Expected ineligible state for version \(version)")
+                return
+            }
+            guard case .unsupportedWooCommerceVersion(let minimumVersion) = reason else {
+                Issue.record("Expected unsupportedWooCommerceVersion reason for version \(version)")
+                return
+            }
+            #expect(minimumVersion == "10.5.0")
+        }
+    }
+
+    @Test("Paginated sync enforces size limit")
+    func test_usesCatalogAPI_false_when_over_limit_then_ineligible() async throws {
+        // Given
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 501, variationCount: 500))
+        )
+        let systemStatusService = MockPOSSystemStatusService()
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            usesCatalogAPI: false,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
+            betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        // When
+        let state = try await service.catalogEligibility(for: siteID)
+
+        // Then
+        guard case .ineligible(let reason) = state else {
+            Issue.record("Expected ineligible state")
+            return
+        }
+        guard case .catalogSizeTooLarge(let totalCount, let limit) = reason else {
+            Issue.record("Expected catalogSizeTooLarge reason")
+            return
+        }
+        #expect(totalCount == 1001)
+        #expect(limit == 1000)
+        #expect(sizeChecker.checkCatalogSizeCallCount == 1)
+    }
+
+    @Test("Paginated sync requires WC 10.3+")
+    func test_usesCatalogAPI_false_when_version_below_10_3_then_ineligible() async throws {
+        // Given
+        let sizeChecker = MockPOSCatalogSizeChecker(
+            sizeToReturn: .success(POSCatalogSize(productCount: 500, variationCount: 400))
+        )
+        let systemStatusService = MockPOSSystemStatusService(
+            pluginInfoToReturn: .success(
+                POSPluginAndFeatureInfo(
+                    wcPlugin: makeSystemPlugin(version: "10.2.0"),
+                    featureValue: true
+                )
+            )
+        )
+        let service = POSLocalCatalogEligibilityService(
+            catalogSizeChecker: sizeChecker,
+            systemStatusService: systemStatusService,
+            isLocalCatalogFeatureFlagEnabled: true,
+            usesCatalogAPI: false,
+            remoteFeatureFlagProvider: makeRemoteFeatureFlagProvider(),
+            betaFeatureToggleProvider: makeBetaFeatureToggleProvider(),
+            catalogSizeLimit: 1000
+        )
+        try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+        // When
+        let state = try await service.catalogEligibility(for: siteID)
+
+        // Then
+        guard case .ineligible(let reason) = state else {
+            Issue.record("Expected ineligible state")
+            return
+        }
+        guard case .unsupportedWooCommerceVersion(let minimumVersion) = reason else {
+            Issue.record("Expected unsupportedWooCommerceVersion reason")
+            return
+        }
+        #expect(minimumVersion == "10.3.0-beta")
+        #expect(sizeChecker.checkCatalogSizeCallCount == 0)
+    }
+
     // MARK: - Skip Reason Analytics
 
     @Test("POSLocalCatalogIneligibleReason skipReason returns correct analytics string")
@@ -615,5 +779,22 @@ struct POSLocalCatalogEligibilityServiceTests {
         let checkFailed1 = POSLocalCatalogIneligibleReason.catalogSizeCheckFailed(underlyingError: "error1")
         let checkFailed2 = POSLocalCatalogIneligibleReason.catalogSizeCheckFailed(underlyingError: "error2")
         #expect(checkFailed1.skipReason == checkFailed2.skipReason)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSystemPlugin(version: String, active: Bool = true) -> SystemPlugin {
+        SystemPlugin(
+            siteID: siteID,
+            plugin: "woocommerce/woocommerce.php",
+            name: "WooCommerce",
+            version: version,
+            versionLatest: "11.0.0",
+            url: "https://woocommerce.com",
+            authorName: "WooCommerce",
+            authorUrl: "https://woocommerce.com",
+            networkActivated: false,
+            active: active
+        )
     }
 }

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -195,7 +195,7 @@ class AuthenticatedState: StoresManagerState {
                     storageManager: ServiceLocator.storageManager
                 ),
                 isLocalCatalogFeatureFlagEnabled: isLocalCatalogFeatureFlagEnabled,
-                usesCatalogAPI: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI),
+                isCatalogAPIFeatureFlagEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI),
                 remoteFeatureFlagProvider: POSLocalCatalogEligibilityService.makeRemoteFeatureFlagProvider(dispatcher: dispatcher),
                 betaFeatureToggleProvider: {
                     await MainActor.run {

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -195,6 +195,7 @@ class AuthenticatedState: StoresManagerState {
                     storageManager: ServiceLocator.storageManager
                 ),
                 isLocalCatalogFeatureFlagEnabled: isLocalCatalogFeatureFlagEnabled,
+                usesCatalogAPI: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI),
                 remoteFeatureFlagProvider: POSLocalCatalogEligibilityService.makeRemoteFeatureFlagProvider(dispatcher: dispatcher),
                 betaFeatureToggleProvider: {
                     await MainActor.run {


### PR DESCRIPTION
Closes WOOMOB-2051

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
This PR expands the local catalog eligibility checks to account for the catalog API, which is only available from WC 10.5+

- Pre-existing: If a site is 10.3, they'll use remote-only search (no local catalog) 
- Pre-existing: If a site is 10.3-10.5, they'll use paginated sync (i1 bridge) with the 1,000 product limit
- New: If a site is 10.5+, they'll use file-based sync (i2 catalog API) with no product limit

Once i2 ships and i1 is sunset, stores on 10.3–10.4 will lose local catalog access (downgraded to remote-only). This has been discussed and we're ok with it.

## Test Steps
1. Verify i2 path requires WC 10.5+                                                                                                                                                          
    - In `POSLocalCatalogEligibilityService`, temporarily change `wcPluginMinimumVersionForCatalogAPI` to "12.0.0" or similar
    - Set `pointOfSaleCatalogAPI` to `true`
    - In the app, enable the POS Local Catalog beta toggle if it isn't active.
    - Open POS. Local catalog should be ineligible (store WC version < 12.0):
```
📋 POSLocalCatalogEligibilityService: WooCommerce version 10.5.3 below minimum 12.0 for site 215063064
```
2. Verify i2 path skips size limit
    - With `pointOfSaleCatalogAPI` set to `true` and a store with any number of products
    - Confirm local catalog is eligible regardless of product count:
```
📋 POSLocalCatalogEligibilityService: Using catalog API..`
```
