### PR TITLE
Move ApiCredentials to per-target DerivedSources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,9 @@
 ## Build generated
 build/
 DerivedData/
-# Any folder named DerivedSources, regardless of the location, so that if we move it, we won't risk accidentally committing it
-DerivedSources/
-# But allow .gitkeep so the folders exist on clone for Xcode synchronized groups
-!DerivedSources/.gitkeep
+# Ignore contents of any DerivedSources folder, except README.md
+**/DerivedSources/*
+!**/DerivedSources/README.md
 # Any file named ApiCredentials.swift, regardless of the location, so that if we move it, we won't risk accidentally committing it
 ApiCredentials.swift
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 ## Build generated
 build/
 DerivedData/
-# Ignore contents of any DerivedSources folder, except README.md
+# Ignore contents of any DerivedSources folder (except README.md) so that if we move it, we won't risk accidentally committing it
 **/DerivedSources/*
 !**/DerivedSources/README.md
 # Any file named ApiCredentials.swift, regardless of the location, so that if we move it, we won't risk accidentally committing it

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ build/
 DerivedData/
 # Any folder named DerivedSources, regardless of the location, so that if we move it, we won't risk accidentally committing it
 DerivedSources/
+# But allow .gitkeep so the folders exist on clone for Xcode synchronized groups
+!DerivedSources/.gitkeep
 # Any file named ApiCredentials.swift, regardless of the location, so that if we move it, we won't risk accidentally committing it
 ApiCredentials.swift
 

--- a/Scripts/build-phases/generate-credentials-outputs.xcfilelist
+++ b/Scripts/build-phases/generate-credentials-outputs.xcfilelist
@@ -1,5 +1,5 @@
 # Output files for the script generating the app's credentials.
 # The script is currently run via a build phase in the GenerateCredentials
 # aggregate target.
-$(SRCROOT)/Classes/DerivedSources/ApiCredentials.swift
-$(SRCROOT)/Woo Watch App/DerivedSources/ApiCredentials.swift
+$(SRCROOT)/DerivedSources/WooCommerce/ApiCredentials.swift
+$(SRCROOT)/DerivedSources/WatchApp/ApiCredentials.swift

--- a/Scripts/build-phases/generate-credentials-outputs.xcfilelist
+++ b/Scripts/build-phases/generate-credentials-outputs.xcfilelist
@@ -1,4 +1,5 @@
 # Output files for the script generating the app's credentials.
 # The script is currently run via a build phase in the GenerateCredentials
 # aggregate target.
-$(SRCROOT)/DerivedSources/ApiCredentials.swift
+$(SRCROOT)/Classes/DerivedSources/ApiCredentials.swift
+$(SRCROOT)/Woo Watch App/DerivedSources/ApiCredentials.swift

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -6,8 +6,8 @@ if [[ $ACTION == 'indexbuild' ]]; then
 fi
 
 DERIVED_PATH=${SOURCE_ROOT}/DerivedSources
-CLASSES_DERIVED_PATH=${SOURCE_ROOT}/Classes/DerivedSources
-WATCH_DERIVED_PATH="${SOURCE_ROOT}/Woo Watch App/DerivedSources"
+CLASSES_DERIVED_PATH=${SOURCE_ROOT}/DerivedSources/WooCommerce
+WATCH_DERIVED_PATH=${SOURCE_ROOT}/DerivedSources/WatchApp
 SCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb
 
 CREDS_INPUT_PATH=${SOURCE_ROOT}/Credentials/ApiCredentials.tpl
@@ -30,11 +30,11 @@ if [ ! -f $SECRETS_PATH ]; then
     ##
     mkdir -p ${DERIVED_PATH}
     mkdir -p ${CLASSES_DERIVED_PATH}
-    mkdir -p "${WATCH_DERIVED_PATH}"
+    mkdir -p ${WATCH_DERIVED_PATH}
 
     ## Create credentials files from the template (if needed)
     ##
-    for TARGET_PATH in ${CLASSES_DERIVED_PATH} "${WATCH_DERIVED_PATH}"; do
+    for TARGET_PATH in ${CLASSES_DERIVED_PATH} ${WATCH_DERIVED_PATH}; do
         if [ ! -f "${TARGET_PATH}/ApiCredentials.swift" ]; then
             echo ">> Creating Credentials File from Template: ${CREDS_TEMPLATE_PATH} -> ${TARGET_PATH}"
             cp ${CREDS_TEMPLATE_PATH} "${TARGET_PATH}/ApiCredentials.swift"
@@ -56,7 +56,7 @@ else
     ##
     mkdir -p ${DERIVED_PATH}
     mkdir -p ${CLASSES_DERIVED_PATH}
-    mkdir -p "${WATCH_DERIVED_PATH}"
+    mkdir -p ${WATCH_DERIVED_PATH}
 
     if which rbenv; then
       # Fix an issue where, depending on the shell you are using on your machine and your rbenv setup,
@@ -70,7 +70,7 @@ else
 
     ## Generate ApiCredentials.swift into per-target DerivedSources folders
     ##
-    for TARGET_PATH in ${CLASSES_DERIVED_PATH} "${WATCH_DERIVED_PATH}"; do
+    for TARGET_PATH in ${CLASSES_DERIVED_PATH} ${WATCH_DERIVED_PATH}; do
         echo ">> Generating Credentials ${TARGET_PATH}/ApiCredentials.swift"
         ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > "${TARGET_PATH}/ApiCredentials.swift"
     done

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -22,7 +22,7 @@ SECRETS_PATH="${HOME}/.configure/woocommerce-ios/secrets/woo_app_credentials.jso
 
 ## Validate Secrets!
 ##
-if [ ! -f $SECRETS_PATH ]; then
+if [ ! -f "$SECRETS_PATH" ]; then
 
     echo "warning: Could not find secrets at $SECRETS_PATH. This is likely due to the secrets folder being missing. Falling back to templated secrets. If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
 
@@ -30,24 +30,24 @@ if [ ! -f $SECRETS_PATH ]; then
 
     ## Generate the Derived folders, if needed
     ##
-    mkdir -p ${DERIVED_PATH}
-    mkdir -p ${CLASSES_DERIVED_PATH}
-    mkdir -p ${WATCH_DERIVED_PATH}
+    mkdir -p "${DERIVED_PATH}"
+    mkdir -p "${CLASSES_DERIVED_PATH}"
+    mkdir -p "${WATCH_DERIVED_PATH}"
 
     ## Create credentials files from the template (if needed)
     ##
     for TARGET_PATH in ${CLASSES_DERIVED_PATH} ${WATCH_DERIVED_PATH}; do
         if [ ! -f "${TARGET_PATH}/ApiCredentials.swift" ]; then
             echo ">> Creating Credentials File from Template: ${CREDS_TEMPLATE_PATH} -> ${TARGET_PATH}"
-            cp ${CREDS_TEMPLATE_PATH} "${TARGET_PATH}/ApiCredentials.swift"
+            cp "${CREDS_TEMPLATE_PATH}" "${TARGET_PATH}/ApiCredentials.swift"
         fi
     done
 
     ## Create a bash secrets file from the template (if needed)
     ##
-    if [ ! -f $BASH_OUTPUT_PATH ]; then
+    if [ ! -f "$BASH_OUTPUT_PATH" ]; then
         echo ">> Creating Bash Secrets File from Template: ${BASH_INPUT_PATH}"
-        cp ${BASH_INPUT_PATH} ${BASH_OUTPUT_PATH}
+        cp "${BASH_INPUT_PATH}" "${BASH_OUTPUT_PATH}"
     fi
 
 else
@@ -56,9 +56,9 @@ else
 
     ## Generate the Derived folders, if needed
     ##
-    mkdir -p ${DERIVED_PATH}
-    mkdir -p ${CLASSES_DERIVED_PATH}
-    mkdir -p ${WATCH_DERIVED_PATH}
+    mkdir -p "${DERIVED_PATH}"
+    mkdir -p "${CLASSES_DERIVED_PATH}"
+    mkdir -p "${WATCH_DERIVED_PATH}"
 
     if which rbenv; then
       # Fix an issue where, depending on the shell you are using on your machine and your rbenv setup,
@@ -74,12 +74,12 @@ else
     ##
     for TARGET_PATH in ${CLASSES_DERIVED_PATH} ${WATCH_DERIVED_PATH}; do
         echo ">> Generating Credentials ${TARGET_PATH}/ApiCredentials.swift"
-        ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > "${TARGET_PATH}/ApiCredentials.swift"
+        ruby "${SCRIPT_PATH}" -i "${CREDS_INPUT_PATH}" -s "${SECRETS_PATH}" > "${TARGET_PATH}/ApiCredentials.swift"
     done
 
     ## Generate bash_secrets
     ##
     echo ">> Generating Credentials ${BASH_OUTPUT_PATH}"
-    ruby ${SCRIPT_PATH} -i ${BASH_INPUT_PATH} -s ${SECRETS_PATH} > ${BASH_OUTPUT_PATH}
+    ruby "${SCRIPT_PATH}" -i "${BASH_INPUT_PATH}" -s "${SECRETS_PATH}" > "${BASH_OUTPUT_PATH}"
 
 fi

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -euo pipefail
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 if [[ $ACTION == 'indexbuild' ]]; then
   echo "ℹ️: Skipping code generation in 'indexbuild' build. See https://github.com/mac-cain13/R.swift/issues/719#issuecomment-937733804 for more info."

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -11,8 +11,6 @@ WATCH_DERIVED_PATH="${SOURCE_ROOT}/Woo Watch App/DerivedSources"
 SCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb
 
 CREDS_INPUT_PATH=${SOURCE_ROOT}/Credentials/ApiCredentials.tpl
-CREDS_OUTPUT_PATH=${DERIVED_PATH}/ApiCredentials.swift
-
 CREDS_TEMPLATE_PATH=${SOURCE_ROOT}/Credentials/Templates/ApiCredentials-Template.swift
 
 BASH_INPUT_PATH=${SOURCE_ROOT}/Credentials/bash_secrets.tpl
@@ -34,26 +32,21 @@ if [ ! -f $SECRETS_PATH ]; then
     mkdir -p ${CLASSES_DERIVED_PATH}
     mkdir -p "${WATCH_DERIVED_PATH}"
 
-    ## Create a credentials file from the template (if needed)
-    ## then copy it into place for the build.
+    ## Create credentials files from the template (if needed)
     ##
-    if [ ! -f $CREDS_OUTPUT_PATH ]; then
-        echo ">> Creating Credentials File from Template: ${CREDS_TEMPLATE_PATH}"
-        cp ${CREDS_TEMPLATE_PATH} ${CREDS_OUTPUT_PATH}
-    fi
+    for TARGET_PATH in ${CLASSES_DERIVED_PATH} "${WATCH_DERIVED_PATH}"; do
+        if [ ! -f "${TARGET_PATH}/ApiCredentials.swift" ]; then
+            echo ">> Creating Credentials File from Template: ${CREDS_TEMPLATE_PATH} -> ${TARGET_PATH}"
+            cp ${CREDS_TEMPLATE_PATH} "${TARGET_PATH}/ApiCredentials.swift"
+        fi
+    done
 
     ## Create a bash secrets file from the template (if needed)
-    ## then copy it into place for the build.
     ##
     if [ ! -f $BASH_OUTPUT_PATH ]; then
         echo ">> Creating Bash Secrets File from Template: ${BASH_INPUT_PATH}"
         cp ${BASH_INPUT_PATH} ${BASH_OUTPUT_PATH}
     fi
-
-    ## Copy credentials to per-target DerivedSources folders
-    ##
-    cp ${CREDS_OUTPUT_PATH} ${CLASSES_DERIVED_PATH}/ApiCredentials.swift
-    cp ${CREDS_OUTPUT_PATH} "${WATCH_DERIVED_PATH}/ApiCredentials.swift"
 
 else
 
@@ -75,19 +68,16 @@ else
       rbenv rehash
     fi
 
-    ## Generate ApiCredentials.swift
+    ## Generate ApiCredentials.swift into per-target DerivedSources folders
     ##
-    echo ">> Generating Credentials ${CREDS_OUTPUT_PATH}"
-    ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > ${CREDS_OUTPUT_PATH}
+    for TARGET_PATH in ${CLASSES_DERIVED_PATH} "${WATCH_DERIVED_PATH}"; do
+        echo ">> Generating Credentials ${TARGET_PATH}/ApiCredentials.swift"
+        ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > "${TARGET_PATH}/ApiCredentials.swift"
+    done
 
     ## Generate bash_secrets
     ##
     echo ">> Generating Credentials ${BASH_OUTPUT_PATH}"
     ruby ${SCRIPT_PATH} -i ${BASH_INPUT_PATH} -s ${SECRETS_PATH} > ${BASH_OUTPUT_PATH}
-
-    ## Copy credentials to per-target DerivedSources folders
-    ##
-    cp ${CREDS_OUTPUT_PATH} ${CLASSES_DERIVED_PATH}/ApiCredentials.swift
-    cp ${CREDS_OUTPUT_PATH} "${WATCH_DERIVED_PATH}/ApiCredentials.swift"
 
 fi

--- a/Scripts/build-phases/generate-credentials.sh
+++ b/Scripts/build-phases/generate-credentials.sh
@@ -6,6 +6,8 @@ if [[ $ACTION == 'indexbuild' ]]; then
 fi
 
 DERIVED_PATH=${SOURCE_ROOT}/DerivedSources
+CLASSES_DERIVED_PATH=${SOURCE_ROOT}/Classes/DerivedSources
+WATCH_DERIVED_PATH="${SOURCE_ROOT}/Woo Watch App/DerivedSources"
 SCRIPT_PATH=${SOURCE_ROOT}/Credentials/replace_secrets.rb
 
 CREDS_INPUT_PATH=${SOURCE_ROOT}/Credentials/ApiCredentials.tpl
@@ -26,9 +28,11 @@ if [ ! -f $SECRETS_PATH ]; then
 
     echo ">> Using Templated Secrets"
 
-    ## Generate the Derived Folder. If needed
+    ## Generate the Derived folders, if needed
     ##
     mkdir -p ${DERIVED_PATH}
+    mkdir -p ${CLASSES_DERIVED_PATH}
+    mkdir -p "${WATCH_DERIVED_PATH}"
 
     ## Create a credentials file from the template (if needed)
     ## then copy it into place for the build.
@@ -46,13 +50,20 @@ if [ ! -f $SECRETS_PATH ]; then
         cp ${BASH_INPUT_PATH} ${BASH_OUTPUT_PATH}
     fi
 
+    ## Copy credentials to per-target DerivedSources folders
+    ##
+    cp ${CREDS_OUTPUT_PATH} ${CLASSES_DERIVED_PATH}/ApiCredentials.swift
+    cp ${CREDS_OUTPUT_PATH} "${WATCH_DERIVED_PATH}/ApiCredentials.swift"
+
 else
 
     echo ">> Loading Secrets ${SECRETS_PATH}"
 
-    ## Generate the Derived Folder. If needed
+    ## Generate the Derived folders, if needed
     ##
     mkdir -p ${DERIVED_PATH}
+    mkdir -p ${CLASSES_DERIVED_PATH}
+    mkdir -p "${WATCH_DERIVED_PATH}"
 
     if which rbenv; then
       # Fix an issue where, depending on the shell you are using on your machine and your rbenv setup,
@@ -73,5 +84,10 @@ else
     ##
     echo ">> Generating Credentials ${BASH_OUTPUT_PATH}"
     ruby ${SCRIPT_PATH} -i ${BASH_INPUT_PATH} -s ${SECRETS_PATH} > ${BASH_OUTPUT_PATH}
+
+    ## Copy credentials to per-target DerivedSources folders
+    ##
+    cp ${CREDS_OUTPUT_PATH} ${CLASSES_DERIVED_PATH}/ApiCredentials.swift
+    cp ${CREDS_OUTPUT_PATH} "${WATCH_DERIVED_PATH}/ApiCredentials.swift"
 
 fi

--- a/WooCommerce/DerivedSources/README.md
+++ b/WooCommerce/DerivedSources/README.md
@@ -1,0 +1,14 @@
+# Derived Sources
+
+This folder contains files generated at build time by the `GenerateCredentials` aggregate target.
+
+The generation script (`Scripts/build-phases/generate-credentials.sh`) creates `ApiCredentials.swift` in each subfolder:
+
+- `WooCommerce/` — compiled by the WooCommerce app target
+- `WatchApp/` — compiled by the Woo Watch App target
+
+These files are **gitignored** and must not be committed.
+They are recreated on every build from either the secrets file (`~/.configure/woocommerce-ios/secrets/woo_app_credentials.json`) or a placeholder template.
+
+The subfolders use explicit Xcode groups (not synchronized folders) because synchronized folders determine their file list at project-load time, before build phases run.
+Generated files that don't exist on disk yet would be invisible to a synchronized group.

--- a/WooCommerce/DerivedSources/README.md
+++ b/WooCommerce/DerivedSources/README.md
@@ -1,9 +1,9 @@
 # Derived Sources
 
 This folder contains files generated at build time by the `GenerateCredentials` aggregate target.
-You'll notice the setup derived sources are set up differently in the Xcode project, that is, as a group rather than the superior synchronized folder.
+In the Xcode project, these derived sources are added as a group rather than as a synchronized folder.
 This is because synchronized folders determine their file list at project-load time, before build phases run.
-Generated files that don't exist on disk yet would be invisible to a synchronized group.
+Generated files that do not yet exist on disk would not appear in a synchronized folder.
 
 The generation script (`Scripts/build-phases/generate-credentials.sh`) creates `ApiCredentials.swift` in each subfolder:
 

--- a/WooCommerce/DerivedSources/README.md
+++ b/WooCommerce/DerivedSources/README.md
@@ -1,6 +1,9 @@
 # Derived Sources
 
 This folder contains files generated at build time by the `GenerateCredentials` aggregate target.
+You'll notice the setup derived sources are set up differently in the Xcode project, that is, as a group rather than the superior synchronized folder.
+This is because synchronized folders determine their file list at project-load time, before build phases run.
+Generated files that don't exist on disk yet would be invisible to a synchronized group.
 
 The generation script (`Scripts/build-phases/generate-credentials.sh`) creates `ApiCredentials.swift` in each subfolder:
 
@@ -9,6 +12,3 @@ The generation script (`Scripts/build-phases/generate-credentials.sh`) creates `
 
 These files are **gitignored** and must not be committed.
 They are recreated on every build from either the secrets file (`~/.configure/woocommerce-ios/secrets/woo_app_credentials.json`) or a placeholder template.
-
-The subfolders use explicit Xcode groups (not synchronized folders) because synchronized folders determine their file list at project-load time, before build phases run.
-Generated files that don't exist on disk yet would be invisible to a synchronized group.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -27,7 +27,6 @@
 		267A04862C051C5200C91CB4 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F1FA84128B60125009E246C /* WidgetKit.framework */; };
 		267A04872C051C5200C91CB4 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */; };
 		267A04902C051C5300C91CB4 /* WatchWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 267A04852C051C5200C91CB4 /* WatchWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		26A52EF12C69B947000B1CFB /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A8F8A720B84D3F00D211DE /* ApiCredentials.swift */; };
 		26CA2BC72AAA17A2003B16C2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */; };
 		26F81B222BE433A3009EC58E /* Woo Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 26F81B152BE433A2009EC58E /* Woo Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 315E14F32698DA24000AD5FF /* PassKit.framework */; };
@@ -52,7 +51,6 @@
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
 		B559EBAF20A0BF8F00836CD4 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B559EBAD20A0BF8E00836CD4 /* README.md */; };
 		B559EBB020A0BF8F00836CD4 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = B559EBAE20A0BF8F00836CD4 /* LICENSE */; };
-		B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A8F8A720B84D3F00D211DE /* ApiCredentials.swift */; };
 		DE158D252F31BC8200161712 /* NotificationServiceExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DE158D1E2F31BC8200161712 /* NotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -112,6 +110,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = B56DB3C52049BFAA00D4AA8E;
 			remoteInfo = WooCommerce;
+		};
+		BA3A98EF567948209638343C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B56DB3BE2049BFAA00D4AA8E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B55D4C0F20B612F300D7A50F;
+			remoteInfo = GenerateCredentials;
 		};
 		CCDC49CF23FFFFF4003166BA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -235,7 +240,6 @@
 		B559EBAE20A0BF8F00836CD4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WooCommerce.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B56DB3DD2049BFAA00D4AA8E /* WooCommerceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		B5A8F8A720B84D3F00D211DE /* ApiCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ApiCredentials.swift; path = DerivedSources/ApiCredentials.swift; sourceTree = SOURCE_ROOT; };
 		CCDC49CA23FFFFF4003166BA /* WooCommerceUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE158D1E2F31BC8200161712 /* NotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F997170223DBB97500592D8E /* WooCommerceScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommerceScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -657,7 +661,6 @@
 				3FDA4E362F440D3900CC3259 /* docs */,
 				8CA4F6DC220B24EB00A47B5D /* config */,
 				3F9DC43D2F7A39590039E4FB /* Credentials */,
-				B5A8F8A620B84CF600D211DE /* DerivedSources */,
 				3F39E9372F624A4A00B68326 /* Classes */,
 				3FA6FD902F2C941500F48C4E /* Resources */,
 				3F64CB3C2F593477002672A3 /* WooCommerceTests */,
@@ -695,14 +698,6 @@
 				DE158D1E2F31BC8200161712 /* NotificationServiceExtension.appex */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		B5A8F8A620B84CF600D211DE /* DerivedSources */ = {
-			isa = PBXGroup;
-			children = (
-				B5A8F8A720B84D3F00D211DE /* ApiCredentials.swift */,
-			);
-			path = DerivedSources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -770,6 +765,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6E989DC1086243CA8E3AB379 /* PBXTargetDependency */,
 				267A048F2C051C5300C91CB4 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
@@ -1256,7 +1252,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26A52EF12C69B947000B1CFB /* ApiCredentials.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1285,7 +1280,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B5A8F8A920B84D3F00D211DE /* ApiCredentials.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1349,6 +1343,11 @@
 			isa = PBXTargetDependency;
 			target = 3F1FA83F28B60125009E246C /* StoreWidgetsExtension */;
 			targetProxy = 3F1FA84D28B60126009E246C /* PBXContainerItemProxy */;
+		};
+		6E989DC1086243CA8E3AB379 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B55D4C0F20B612F300D7A50F /* GenerateCredentials */;
+			targetProxy = BA3A98EF567948209638343C /* PBXContainerItemProxy */;
 		};
 		B55D4C1520B6131400D7A50F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		3F0904152D26A40800D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */; };
 		3F09A3FE2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3F0BFD682F85E1CD001182F9 /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0BFD642F85E1C4001182F9 /* ApiCredentials.swift */; };
+		3F0BFD692F85E1D4001182F9 /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0BFD662F85E1C4001182F9 /* ApiCredentials.swift */; };
 		3F1FA84228B60125009E246C /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F1FA84128B60125009E246C /* WidgetKit.framework */; };
 		3F1FA84328B60125009E246C /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */; };
 		3F1FA84F28B60126009E246C /* StoreWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3F1FA84028B60125009E246C /* StoreWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -225,6 +227,9 @@
 		3F0904082D26A40800D8ACCE /* WordPressAuthenticatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressAuthenticatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F096E462D23F50800D8ACCE /* WooCommerce.common.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WooCommerce.common.xcconfig; sourceTree = "<group>"; };
 		3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F0BFD622F85DF6E001182F9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		3F0BFD642F85E1C4001182F9 /* ApiCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiCredentials.swift; sourceTree = "<group>"; };
+		3F0BFD662F85E1C4001182F9 /* ApiCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiCredentials.swift; sourceTree = "<group>"; };
 		3F1FA84028B60125009E246C /* StoreWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = StoreWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F1FA84128B60125009E246C /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		3F3689E22DCB1B470065B48F /* Modules */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Modules; path = ../Modules; sourceTree = SOURCE_ROOT; };
@@ -623,6 +628,32 @@
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
+		3F0BFD632F85DF6E001182F9 /* DerivedSources */ = {
+			isa = PBXGroup;
+			children = (
+				3F0BFD652F85E1C4001182F9 /* WatchApp */,
+				3F0BFD672F85E1C4001182F9 /* WooCommerce */,
+				3F0BFD622F85DF6E001182F9 /* README.md */,
+			);
+			path = DerivedSources;
+			sourceTree = "<group>";
+		};
+		3F0BFD652F85E1C4001182F9 /* WatchApp */ = {
+			isa = PBXGroup;
+			children = (
+				3F0BFD642F85E1C4001182F9 /* ApiCredentials.swift */,
+			);
+			path = WatchApp;
+			sourceTree = "<group>";
+		};
+		3F0BFD672F85E1C4001182F9 /* WooCommerce */ = {
+			isa = PBXGroup;
+			children = (
+				3F0BFD662F85E1C4001182F9 /* ApiCredentials.swift */,
+			);
+			path = WooCommerce;
+			sourceTree = "<group>";
+		};
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -662,6 +693,7 @@
 				8CA4F6DC220B24EB00A47B5D /* config */,
 				3F9DC43D2F7A39590039E4FB /* Credentials */,
 				3F39E9372F624A4A00B68326 /* Classes */,
+				3F0BFD632F85DF6E001182F9 /* DerivedSources */,
 				3FA6FD902F2C941500F48C4E /* Resources */,
 				3F64CB3C2F593477002672A3 /* WooCommerceTests */,
 				3FD9BFBE2E0A2533004A8DC8 /* WooCommerceScreenshots */,
@@ -1252,6 +1284,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F0BFD682F85E1CD001182F9 /* ApiCredentials.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1280,6 +1313,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F0BFD692F85E1D4001182F9 /* ApiCredentials.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Description

Moves `ApiCredentials.swift` generation from the shared `DerivedSources/` folder into per-target synchronized subfolders (`DerivedSources/WooCommerce` and `DerivedSources/WatchApp`).

This is part of the ongoing effort to convert legacy Xcode groups to synchronized folders (AINFRA-1907) even though we are still left with a group in this case because of how Xcode works (see the new `README` in the `DerivedSources` folder). 

The shared `DerivedSources` group and its file references are removed from the project.
The watch app now has `GenerateCredentials` as a build dependency so credentials are generated for watch-only builds too.

I consider this a setup improvement because it clarifies that both the mobile and the watch app require an `ApiCredentials` instance.

## Test Steps

- Build the WooCommerce scheme — verify it succeeds and `ApiCredentials` is available
- Build the Woo Watch App scheme — verify it succeeds (credentials now generated via its own dependency on `GenerateCredentials`)
- Delete `WooCommerce/Classes/DerivedSources/` and `WooCommerce/Woo Watch App/DerivedSources/` then rebuild — verify the folders and files are recreated by the build phase

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.  — N.A.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*