### PR TITLE
Enable SwiftLint rule: contains_over_filter_is_empty

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over using `filter(where:).isEmpty`.
+  - contains_over_filter_is_empty
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -130,7 +130,7 @@ extension ShippingLabelCustomsFormInputViewModel {
               !missingITNForDestination,
               !missingITNForClassesAbove2500usd,
               !invalidITN,
-              itemViewModels.filter({ $0.validatedItem == nil }).isEmpty else {
+              !itemViewModels.contains(where: { $0.validatedItem == nil }) else {
             return nil
         }
         return ShippingLabelCustomsForm(packageID: packageID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -226,7 +226,7 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         await sut.reloadTasks()
 
         // Then
-        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.isComplete}).isEmpty)
+        XCTAssertFalse(sut.tasksForDisplay.contains(where: { $0.task.isComplete }))
     }
 
     // MARK: - shouldShowViewAllButton


### PR DESCRIPTION
## Summary

- Enables the `contains_over_filter_is_empty` SwiftLint rule, which prefers `.contains(where:)` over `.filter { ... }.isEmpty`
- 0 auto-fixed violations, 2 manual fixes
- Part of the Orchard SwiftLint rollout campaign

## Test plan

- [x] SwiftLint passes clean
- [x] Build verification: Swift compilation succeeds (only pre-existing Watch App asset catalog failure unrelated to this change)
- [x] CI passes

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*