### PR TITLE
Add optional include parameter to team members fetch

### DIFF
--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -29,7 +29,8 @@ public protocol BookingsRemoteProtocol {
 
     func fetchResources(for siteID: Int64,
                         pageNumber: Int,
-                        pageSize: Int) async throws -> [BookingResource]
+                        pageSize: Int,
+                        include: [Int64]?) async throws -> [BookingResource]
 
     func fetchBookingLocationResponse(for siteID: Int64,
                                      productID: Int64) async throws -> BookingLocationResponse
@@ -264,12 +265,16 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
     public func fetchResources(
         for siteID: Int64,
         pageNumber: Int = Default.pageNumber,
-        pageSize: Int = Default.pageSize
+        pageSize: Int = Default.pageSize,
+        include: [Int64]? = nil
     ) async throws -> [BookingResource] {
-        let parameters = [
+        var parameters = [
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize)
         ]
+        if let include, !include.isEmpty {
+            parameters[ParameterKey.include] = include.map { String($0) }.joined(separator: ",")
+        }
 
         let path = Path.resources
         let request = JetpackRequest(
@@ -348,6 +353,7 @@ public extension BookingsRemote {
         static let bookingStatusExclude    = "booking_status_exclude"
         static let status: String          = "status"
         static let note: String            = "note"
+        static let include: String         = "include"
         static let fields: String          = "_fields"
     }
 

--- a/Modules/Sources/Yosemite/Actions/BookingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/BookingAction.swift
@@ -58,6 +58,7 @@ public enum BookingAction: Action {
     case synchronizeResources(siteID: Int64,
                              pageNumber: Int,
                              pageSize: Int = BookingsRemote.Default.pageSize,
+                             include: [Int64]? = nil,
                              onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Updates a booking attendance status.

--- a/Modules/Sources/Yosemite/Stores/BookingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/BookingStore.swift
@@ -61,8 +61,8 @@ public class BookingStore: Store {
                            onCompletion: onCompletion)
         case let .fetchResource(siteID, resourceID, onCompletion):
             fetchResource(siteID: siteID, resourceID: resourceID, onCompletion: onCompletion)
-        case let .synchronizeResources(siteID, pageNumber, pageSize, onCompletion):
-            synchronizeResources(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case let .synchronizeResources(siteID, pageNumber, pageSize, include, onCompletion):
+            synchronizeResources(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, include: include, onCompletion: onCompletion)
         case .updateBookingAttendanceStatus(let siteID, let bookingID, let status, let onCompletion):
             performUpdateBookingAttendanceStatus(
                 siteID: siteID,
@@ -277,13 +277,15 @@ private extension BookingStore {
     func synchronizeResources(siteID: Int64,
                               pageNumber: Int,
                               pageSize: Int,
+                              include: [Int64]?,
                               onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         Task { @MainActor in
             do {
                 let resources = try await remote.fetchResources(
                     for: siteID,
                     pageNumber: pageNumber,
-                    pageSize: pageSize
+                    pageSize: pageSize,
+                    include: include
                 )
 
                 await upsertBookingResourcesInBackground(siteID: siteID,

--- a/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/BookingsRemoteTests.swift
@@ -263,6 +263,32 @@ struct BookingsRemoteTests {
         #expect((parameters["per_page"] as? String) == "100")
     }
 
+    @Test func test_fetchResources_sends_include_parameter_when_provided() async throws {
+        // Given
+        let remote = BookingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "resources/team-members", filename: "booking-resource-list")
+
+        // When
+        _ = try await remote.fetchResources(for: sampleSiteID, pageNumber: 1, pageSize: 25, include: [10, 20, 30])
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect((request.parameters["include"] as? String) == "10,20,30")
+    }
+
+    @Test func test_fetchResources_does_not_send_include_parameter_when_nil() async throws {
+        // Given
+        let remote = BookingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "resources/team-members", filename: "booking-resource-list")
+
+        // When
+        _ = try await remote.fetchResources(for: sampleSiteID, pageNumber: 1, pageSize: 25)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.parameters["include"] == nil)
+    }
+
     @Test func test_updateBookingNote_sends_correct_parameters_for_booking_note() async throws {
         // Given
         let remote = BookingsRemote(network: network)

--- a/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockBookingsRemote.swift
@@ -73,7 +73,7 @@ final class MockBookingsRemote: BookingsRemoteProtocol {
         return try result.get()
     }
 
-    func fetchResources(for siteID: Int64, pageNumber: Int, pageSize: Int) async throws -> [BookingResource] {
+    func fetchResources(for siteID: Int64, pageNumber: Int, pageSize: Int, include: [Int64]?) async throws -> [BookingResource] {
         guard let result = fetchResourcesResult else {
             throw NetworkError.timeout()
         }


### PR DESCRIPTION
Closes: WOOMOB-2609

## Description
Add an optional `include` parameter to the team members fetch request (`GET wc-bookings/v2/resources/team-members`). This allows filtering team members to only those with specific IDs, which is needed for the team member picker in the upcoming booking rescheduling screen.

Changes:
- **Networking**: Added `include: [Int64]?` parameter to `BookingsRemoteProtocol.fetchResources()` and its implementation. When provided, sends a comma-separated list of IDs as the `include` query parameter.
- **Yosemite**: Threaded the parameter through `BookingAction.synchronizeResources` and `BookingStore`.
- **Tests**: Added two tests verifying the parameter is sent when provided and omitted when nil.

All parameters default to `nil`, so existing callers are unaffected.

## Test Steps
1. Build the app, verify no compilation errors.
2. CI should pass.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.