### PR TITLE
Add sunset warning banner for WooCommerce versions below 10.5.0

### DIFF
--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -74,6 +74,12 @@ protocol PointOfSaleAggregateModelProtocol {
     /// Indicates whether the local catalog feature is enabled for this store
     let isLocalCatalogEligible: Bool
 
+    /// Indicates whether the store needs a POS sunset warning (WC < 10.5)
+    let needsSunsetWarning: Bool
+
+    /// Closure called when the sunset warning is dismissed, to persist the dismissal date
+    private let onSunsetWarningDismissed: (() -> Void)?
+
     private var cancellables: Set<AnyCancellable> = []
 
     // Private storage of the concrete coordinator
@@ -101,6 +107,12 @@ protocol PointOfSaleAggregateModelProtocol {
         return isSyncStale && !isStaleSyncWarningDismissed
     }
 
+    var isSunsetWarningDismissed: Bool = false
+
+    var showSunsetWarning: Bool {
+        needsSunsetWarning && !isSunsetWarningDismissed
+    }
+
     @MainActor
     init(entryPointController: POSEntryPointController,
          itemsController: PointOfSaleItemsControllerProtocol,
@@ -120,7 +132,9 @@ protocol PointOfSaleAggregateModelProtocol {
          paymentState: PointOfSalePaymentState = .idle,
          siteID: Int64,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
-         isLocalCatalogEligible: Bool = false) {
+         isLocalCatalogEligible: Bool = false,
+         needsSunsetWarning: Bool = false,
+         onSunsetWarningDismissed: (() -> Void)? = nil) {
         self.entryPointController = entryPointController
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -138,6 +152,8 @@ protocol PointOfSaleAggregateModelProtocol {
         self.siteID = siteID
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
+        self.needsSunsetWarning = needsSunsetWarning
+        self.onSunsetWarningDismissed = onSunsetWarningDismissed
 
         // Payment controller is created with cart-specific dependencies.
         // The weak self captures below are safe because paymentModel is owned by self.
@@ -541,6 +557,13 @@ extension PointOfSaleAggregateModel {
     func hoursSinceLastSync() async -> Int? {
         guard let catalogSyncCoordinator else { return nil }
         return await catalogSyncCoordinator.hoursSinceLastSync(for: siteID)
+    }
+}
+
+extension PointOfSaleAggregateModel {
+    func dismissSunsetWarning() {
+        isSunsetWarningDismissed = true
+        onSunsetWarningDismissed?()
     }
 }
 

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -74,11 +74,8 @@ protocol PointOfSaleAggregateModelProtocol {
     /// Indicates whether the local catalog feature is enabled for this store
     let isLocalCatalogEligible: Bool
 
-    /// Indicates whether the store needs a POS sunset warning (WC < 10.5)
-    let needsSunsetWarning: Bool
-
-    /// Closure called when the sunset warning is dismissed, to persist the dismissal date
-    private let onSunsetWarningDismissed: (() -> Void)?
+    /// Checker for whether the store needs a POS sunset warning (WC < 10.5)
+    private let sunsetWarningChecker: POSSunsetWarningChecking?
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -107,11 +104,7 @@ protocol PointOfSaleAggregateModelProtocol {
         return isSyncStale && !isStaleSyncWarningDismissed
     }
 
-    var isSunsetWarningDismissed: Bool = false
-
-    var showSunsetWarning: Bool {
-        needsSunsetWarning && !isSunsetWarningDismissed
-    }
+    var showSunsetWarning: Bool = false
 
     @MainActor
     init(entryPointController: POSEntryPointController,
@@ -133,8 +126,7 @@ protocol PointOfSaleAggregateModelProtocol {
          siteID: Int64,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
          isLocalCatalogEligible: Bool = false,
-         needsSunsetWarning: Bool = false,
-         onSunsetWarningDismissed: (() -> Void)? = nil) {
+         sunsetWarningChecker: POSSunsetWarningChecking? = nil) {
         self.entryPointController = entryPointController
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -152,8 +144,7 @@ protocol PointOfSaleAggregateModelProtocol {
         self.siteID = siteID
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
-        self.needsSunsetWarning = needsSunsetWarning
-        self.onSunsetWarningDismissed = onSunsetWarningDismissed
+        self.sunsetWarningChecker = sunsetWarningChecker
 
         // Payment controller is created with cart-specific dependencies.
         // The weak self captures below are safe because paymentModel is owned by self.
@@ -562,8 +553,13 @@ extension PointOfSaleAggregateModel {
 
 extension PointOfSaleAggregateModel {
     func dismissSunsetWarning() {
-        isSunsetWarningDismissed = true
-        onSunsetWarningDismissed?()
+        showSunsetWarning = false
+        sunsetWarningChecker?.recordDismissal(siteID: siteID)
+    }
+
+    func checkSunsetWarningStatus() async {
+        guard let sunsetWarningChecker else { return }
+        showSunsetWarning = await sunsetWarningChecker.shouldShowSunsetWarning(siteID: siteID)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -206,8 +206,8 @@ struct ItemListView: View {
             }
         }
         .task {
-            // Check stale sync status when view appears
             await posModel.checkStaleSyncStatus()
+            await posModel.checkSunsetWarningStatus()
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -166,7 +166,7 @@ struct ItemListView: View {
             if posModel.showSunsetWarning {
                 sunsetWarningBanner
                     .padding(.horizontal, POSPadding.medium)
-                    .padding(.vertical, POSPadding.small)
+                    .padding(.vertical, POSPadding.medium)
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
 

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -471,7 +471,7 @@ private extension ItemListView {
         static let productsTitle = NSLocalizedString(
             "pos.itemlistview.title",
             value: "Products",
-            comment: "Title at the top of the Point of Sale product selector screen."
+            comment: "Title at the top of the point of sale product selector screen."
         )
 
         static let couponsTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -163,6 +163,13 @@ struct ItemListView: View {
     @ViewBuilder
     private func listView(itemListType: ItemListType) -> some View {
         VStack(spacing: 0) {
+            if posModel.showSunsetWarning {
+                sunsetWarningBanner
+                    .padding(.horizontal, POSPadding.medium)
+                    .padding(.vertical, POSPadding.small)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             // Stale sync warning banner
             if posModel.showStaleSyncWarning {
                 staleSyncWarningBanner
@@ -202,6 +209,27 @@ struct ItemListView: View {
             // Check stale sync status when view appears
             await posModel.checkStaleSyncStatus()
         }
+    }
+
+    @ViewBuilder
+    private var sunsetWarningBanner: some View {
+        POSNoticeView(
+            title: Localization.sunsetWarningTitle,
+            icon: Image(systemName: "info.circle"),
+            onDismiss: {
+                // TODO: WOOMOB-2057
+                //analytics.track(event: WooAnalyticsEvent.LocalCatalog.sunsetWarningDismissed())
+                withAnimation {
+                    posModel.dismissSunsetWarning()
+                }
+            }, content: {
+                Text(Localization.sunsetWarningDescription)
+                    .font(POSFontStyle.posBodyMediumRegular())
+            })
+            .task {
+                // TODO: WOOMOB-2057
+                //analytics.track(event: WooAnalyticsEvent.LocalCatalog.sunsetWarningShown())
+            }
     }
 
     @ViewBuilder
@@ -450,6 +478,18 @@ private extension ItemListView {
             "pos.itemlistview.couponsTitle",
             value: "Coupons",
             comment: "Title of the button at the top of Point of Sale to switch to Coupons list."
+        )
+
+        static let sunsetWarningTitle = NSLocalizedString(
+            "pos.itemlistview.sunsetWarning.title",
+            value: "Update WooCommerce Soon",
+            comment: "Warning title shown when the store's WooCommerce version is below 10.5 and POS will soon require it"
+        )
+
+        static let sunsetWarningDescription = NSLocalizedString(
+            "pos.itemlistview.sunsetWarning.description",
+            value: "Starting August 1st, Point of Sale will require WooCommerce 10.5.0 or later. Update to ensure uninterrupted access.",
+            comment: "Message shown when the store's WooCommerce version is below 10.5 and POS will soon require it"
         )
 
         static let staleSyncWarningTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -488,7 +488,7 @@ private extension ItemListView {
 
         static let sunsetWarningDescription = NSLocalizedString(
             "pos.itemlistview.sunsetWarning.description",
-            value: "Starting August 1st, Point of Sale will require WooCommerce 10.5.0 or later. Update to ensure uninterrupted access.",
+            value: "Starting August 1st, point of sale will require WooCommerce 10.5.0 or later. Update to ensure uninterrupted access.",
             comment: "Message shown when the store's WooCommerce version is below 10.5 and POS will soon require it"
         )
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -50,6 +50,8 @@ public struct PointOfSaleEntryPointView: View {
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
     private let isLocalCatalogEligible: Bool
     private let isBookingsEligible: Bool
+    private let needsSunsetWarning: Bool
+    private let onSunsetWarningDismissed: (() -> Void)?
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -77,6 +79,8 @@ public struct PointOfSaleEntryPointView: View {
          grdbManager: GRDBManagerProtocol?,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?,
          isLocalCatalogEligible: Bool,
+         needsSunsetWarning: Bool = false,
+         onSunsetWarningDismissed: (() -> Void)? = nil,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
@@ -164,6 +168,8 @@ public struct PointOfSaleEntryPointView: View {
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
         self.isBookingsEligible = isBookingsEligible
+        self.needsSunsetWarning = needsSunsetWarning
+        self.onSunsetWarningDismissed = onSunsetWarningDismissed
     }
 
     public var body: some View {
@@ -197,7 +203,9 @@ public struct PointOfSaleEntryPointView: View {
                 receiptSender: receiptSender,
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
-                isLocalCatalogEligible: isLocalCatalogEligible)
+                isLocalCatalogEligible: isLocalCatalogEligible,
+                needsSunsetWarning: needsSunsetWarning,
+                onSunsetWarningDismissed: onSunsetWarningDismissed)
         }
         .environment(\.posAnalytics, services.analytics)
         .environment(\.posCurrencyProvider, services.currency)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -50,8 +50,7 @@ public struct PointOfSaleEntryPointView: View {
     private let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?
     private let isLocalCatalogEligible: Bool
     private let isBookingsEligible: Bool
-    private let needsSunsetWarning: Bool
-    private let onSunsetWarningDismissed: (() -> Void)?
+    private let sunsetWarningChecker: POSSunsetWarningChecking?
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -79,8 +78,7 @@ public struct PointOfSaleEntryPointView: View {
          grdbManager: GRDBManagerProtocol?,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?,
          isLocalCatalogEligible: Bool,
-         needsSunsetWarning: Bool = false,
-         onSunsetWarningDismissed: (() -> Void)? = nil,
+         sunsetWarningChecker: POSSunsetWarningChecking? = nil,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
@@ -168,8 +166,7 @@ public struct PointOfSaleEntryPointView: View {
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
         self.isBookingsEligible = isBookingsEligible
-        self.needsSunsetWarning = needsSunsetWarning
-        self.onSunsetWarningDismissed = onSunsetWarningDismissed
+        self.sunsetWarningChecker = sunsetWarningChecker
     }
 
     public var body: some View {
@@ -204,8 +201,7 @@ public struct PointOfSaleEntryPointView: View {
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
                 isLocalCatalogEligible: isLocalCatalogEligible,
-                needsSunsetWarning: needsSunsetWarning,
-                onSunsetWarningDismissed: onSunsetWarningDismissed)
+                sunsetWarningChecker: sunsetWarningChecker)
         }
         .environment(\.posAnalytics, services.analytics)
         .environment(\.posCurrencyProvider, services.currency)

--- a/Modules/Sources/PointOfSale/Protocols/POSSunsetWarningChecking.swift
+++ b/Modules/Sources/PointOfSale/Protocols/POSSunsetWarningChecking.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Determines whether the POS sunset warning banner should be shown
+/// and records when the user dismisses it.
+///
+public protocol POSSunsetWarningChecking {
+    func shouldShowSunsetWarning(siteID: Int64) async -> Bool
+    func recordDismissal(siteID: Int64)
+}

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -239,7 +239,8 @@ struct POSPreviewHelpers {
         analytics: POSAnalyticsProviding = EmptyPOSAnalytics(),
         siteID: Int64 = 1,
         catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
-        isLocalCatalogEligible: Bool = false
+        isLocalCatalogEligible: Bool = false,
+        needsSunsetWarning: Bool = false
     ) -> PointOfSaleAggregateModel {
         return PointOfSaleAggregateModel(
             entryPointController: POSEntryPointController(eligibilityChecker: PointOfSalePreviewTabEligibilityChecker()),
@@ -258,7 +259,8 @@ struct POSPreviewHelpers {
             receiptSender: receiptSender,
             siteID: siteID,
             catalogSyncCoordinator: catalogSyncCoordinator,
-            isLocalCatalogEligible: isLocalCatalogEligible
+            isLocalCatalogEligible: isLocalCatalogEligible,
+            needsSunsetWarning: needsSunsetWarning
         )
     }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -240,7 +240,7 @@ struct POSPreviewHelpers {
         siteID: Int64 = 1,
         catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
         isLocalCatalogEligible: Bool = false,
-        needsSunsetWarning: Bool = false
+        sunsetWarningChecker: POSSunsetWarningChecking? = nil
     ) -> PointOfSaleAggregateModel {
         return PointOfSaleAggregateModel(
             entryPointController: POSEntryPointController(eligibilityChecker: PointOfSalePreviewTabEligibilityChecker()),
@@ -260,7 +260,7 @@ struct POSPreviewHelpers {
             siteID: siteID,
             catalogSyncCoordinator: catalogSyncCoordinator,
             isLocalCatalogEligible: isLocalCatalogEligible,
-            needsSunsetWarning: needsSunsetWarning
+            sunsetWarningChecker: sunsetWarningChecker
         )
     }
 

--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -131,7 +131,8 @@ extension Storage.GeneralStoreSettings {
         isPOSTabVisible: NullableCopiableProp<Bool> = .copy,
         lastPOSOpenedDate: NullableCopiableProp<Date> = .copy,
         firstPOSCatalogSyncDate: NullableCopiableProp<Date> = .copy,
-        syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy
+        syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy,
+        lastSunsetWarningShownDate: NullableCopiableProp<Date> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -156,6 +157,7 @@ extension Storage.GeneralStoreSettings {
         let lastPOSOpenedDate = lastPOSOpenedDate ?? self.lastPOSOpenedDate
         let firstPOSCatalogSyncDate = firstPOSCatalogSyncDate ?? self.firstPOSCatalogSyncDate
         let syncPOSCatalogOverCellular = syncPOSCatalogOverCellular ?? self.syncPOSCatalogOverCellular
+        let lastSunsetWarningShownDate = lastSunsetWarningShownDate ?? self.lastSunsetWarningShownDate
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -180,7 +182,8 @@ extension Storage.GeneralStoreSettings {
             isPOSTabVisible: isPOSTabVisible,
             lastPOSOpenedDate: lastPOSOpenedDate,
             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
-            syncPOSCatalogOverCellular: syncPOSCatalogOverCellular
+            syncPOSCatalogOverCellular: syncPOSCatalogOverCellular,
+            lastSunsetWarningShownDate: lastSunsetWarningShownDate
         )
     }
 }

--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -132,7 +132,7 @@ extension Storage.GeneralStoreSettings {
         lastPOSOpenedDate: NullableCopiableProp<Date> = .copy,
         firstPOSCatalogSyncDate: NullableCopiableProp<Date> = .copy,
         syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy,
-        lastSunsetWarningShownDate: NullableCopiableProp<Date> = .copy
+        lastSunsetWarningDismissedDate: NullableCopiableProp<Date> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -157,7 +157,7 @@ extension Storage.GeneralStoreSettings {
         let lastPOSOpenedDate = lastPOSOpenedDate ?? self.lastPOSOpenedDate
         let firstPOSCatalogSyncDate = firstPOSCatalogSyncDate ?? self.firstPOSCatalogSyncDate
         let syncPOSCatalogOverCellular = syncPOSCatalogOverCellular ?? self.syncPOSCatalogOverCellular
-        let lastSunsetWarningShownDate = lastSunsetWarningShownDate ?? self.lastSunsetWarningShownDate
+        let lastSunsetWarningDismissedDate = lastSunsetWarningDismissedDate ?? self.lastSunsetWarningDismissedDate
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -183,7 +183,7 @@ extension Storage.GeneralStoreSettings {
             lastPOSOpenedDate: lastPOSOpenedDate,
             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
             syncPOSCatalogOverCellular: syncPOSCatalogOverCellular,
-            lastSunsetWarningShownDate: lastSunsetWarningShownDate
+            lastSunsetWarningDismissedDate: lastSunsetWarningDismissedDate
         )
     }
 }

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -98,6 +98,11 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var syncPOSCatalogOverCellular: Bool
 
+    /// The last time the sunset warning banner was shown for this store.
+    /// Used to throttle the banner to once every 14 days.
+    ///
+    public var lastSunsetWarningShownDate: Date?
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -120,7 +125,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 isPOSTabVisible: Bool? = nil,
                 lastPOSOpenedDate: Date? = nil,
                 firstPOSCatalogSyncDate: Date? = nil,
-                syncPOSCatalogOverCellular: Bool = true) {
+                syncPOSCatalogOverCellular: Bool = true,
+                lastSunsetWarningShownDate: Date? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -144,6 +150,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastPOSOpenedDate = lastPOSOpenedDate
         self.firstPOSCatalogSyncDate = firstPOSCatalogSyncDate
         self.syncPOSCatalogOverCellular = syncPOSCatalogOverCellular
+        self.lastSunsetWarningShownDate = lastSunsetWarningShownDate
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -167,7 +174,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              searchTermsByKey: searchTermsByKey,
                              isPOSTabVisible: isPOSTabVisible,
                              lastPOSOpenedDate: lastPOSOpenedDate,
-                             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate)
+                             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
+                             lastSunsetWarningShownDate: lastSunsetWarningShownDate)
     }
 }
 
@@ -205,6 +213,7 @@ extension GeneralStoreSettings {
         self.lastPOSOpenedDate = try container.decodeIfPresent(Date.self, forKey: .lastPOSOpenedDate)
         self.firstPOSCatalogSyncDate = try container.decodeIfPresent(Date.self, forKey: .firstPOSCatalogSyncDate)
         self.syncPOSCatalogOverCellular = try container.decodeIfPresent(Bool.self, forKey: .syncPOSCatalogOverCellular) ?? true
+        self.lastSunsetWarningShownDate = try container.decodeIfPresent(Date.self, forKey: .lastSunsetWarningShownDate)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -98,10 +98,10 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var syncPOSCatalogOverCellular: Bool
 
-    /// The last time the sunset warning banner was shown for this store.
+    /// The last time the sunset warning banner was dismissed for this store.
     /// Used to throttle the banner to once every 14 days.
     ///
-    public var lastSunsetWarningShownDate: Date?
+    public var lastSunsetWarningDismissedDate: Date?
 
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
@@ -126,7 +126,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastPOSOpenedDate: Date? = nil,
                 firstPOSCatalogSyncDate: Date? = nil,
                 syncPOSCatalogOverCellular: Bool = true,
-                lastSunsetWarningShownDate: Date? = nil) {
+                lastSunsetWarningDismissedDate: Date? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -150,7 +150,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastPOSOpenedDate = lastPOSOpenedDate
         self.firstPOSCatalogSyncDate = firstPOSCatalogSyncDate
         self.syncPOSCatalogOverCellular = syncPOSCatalogOverCellular
-        self.lastSunsetWarningShownDate = lastSunsetWarningShownDate
+        self.lastSunsetWarningDismissedDate = lastSunsetWarningDismissedDate
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -175,7 +175,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              isPOSTabVisible: isPOSTabVisible,
                              lastPOSOpenedDate: lastPOSOpenedDate,
                              firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
-                             lastSunsetWarningShownDate: lastSunsetWarningShownDate)
+                             lastSunsetWarningDismissedDate: lastSunsetWarningDismissedDate)
     }
 }
 
@@ -213,7 +213,7 @@ extension GeneralStoreSettings {
         self.lastPOSOpenedDate = try container.decodeIfPresent(Date.self, forKey: .lastPOSOpenedDate)
         self.firstPOSCatalogSyncDate = try container.decodeIfPresent(Date.self, forKey: .firstPOSCatalogSyncDate)
         self.syncPOSCatalogOverCellular = try container.decodeIfPresent(Bool.self, forKey: .syncPOSCatalogOverCellular) ?? true
-        self.lastSunsetWarningShownDate = try container.decodeIfPresent(Date.self, forKey: .lastSunsetWarningShownDate)
+        self.lastSunsetWarningDismissedDate = try container.decodeIfPresent(Date.self, forKey: .lastSunsetWarningDismissedDate)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsEvent.swift
@@ -96,6 +96,11 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .pointOfSaleLocalCatalogStaleWarningDismissed, properties: [:])
         }
 
+        // MARK: - Sunset Warning Events
+        // TODO: WOOMOB-2057
+        // public static func sunsetWarningShown() -> WooAnalyticsEvent { }
+        // public static func sunsetWarningDismissed() -> WooAnalyticsEvent { }
+
         // MARK: - Core Sync Events
 
         public static func syncStarted(syncType: String, connectionType: String) -> WooAnalyticsEvent {

--- a/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -23,8 +23,8 @@ public protocol SiteSpecificAppSettingsStoreMethodsProtocol {
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64) -> Bool
 
     // POS sunset warning
-    func getSunsetWarningLastShownDate(siteID: Int64) -> Date?
-    func setSunsetWarningLastShownDate(siteID: Int64, date: Date)
+    func getSunsetWarningLastDismissedDate(siteID: Int64) -> Date?
+    func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date)
 }
 
 /// Methods for managing site-specific app settings
@@ -149,13 +149,13 @@ extension SiteSpecificAppSettingsStoreMethods {
 }
 
 extension SiteSpecificAppSettingsStoreMethods {
-    public func getSunsetWarningLastShownDate(siteID: Int64) -> Date? {
-        getStoreSettings(for: siteID).lastSunsetWarningShownDate
+    public func getSunsetWarningLastDismissedDate(siteID: Int64) -> Date? {
+        getStoreSettings(for: siteID).lastSunsetWarningDismissedDate
     }
 
-    public func setSunsetWarningLastShownDate(siteID: Int64, date: Date) {
+    public func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {
         let storeSettings = getStoreSettings(for: siteID)
-        let updatedSettings = storeSettings.copy(lastSunsetWarningShownDate: date)
+        let updatedSettings = storeSettings.copy(lastSunsetWarningDismissedDate: date)
         setStoreSettings(settings: updatedSettings, for: siteID)
     }
 }

--- a/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -21,6 +21,10 @@ public protocol SiteSpecificAppSettingsStoreMethodsProtocol {
     // POS local catalog cellular data
     func setPOSLocalCatalogCellularDataAllowed(siteID: Int64, allowed: Bool)
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64) -> Bool
+
+    // POS sunset warning
+    func getSunsetWarningLastShownDate(siteID: Int64) -> Date?
+    func setSunsetWarningLastShownDate(siteID: Int64, date: Date)
 }
 
 /// Methods for managing site-specific app settings
@@ -141,6 +145,18 @@ extension SiteSpecificAppSettingsStoreMethods {
 
     public func getPOSLocalCatalogCellularDataAllowed(siteID: Int64) -> Bool {
         getStoreSettings(for: siteID).syncPOSCatalogOverCellular
+    }
+}
+
+extension SiteSpecificAppSettingsStoreMethods {
+    public func getSunsetWarningLastShownDate(siteID: Int64) -> Date? {
+        getStoreSettings(for: siteID).lastSunsetWarningShownDate
+    }
+
+    public func setSunsetWarningLastShownDate(siteID: Int64, date: Date) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(lastSunsetWarningShownDate: date)
+        setStoreSettings(settings: updatedSettings, for: siteID)
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSSunsetWarningChecker.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSSunsetWarningChecker.swift
@@ -1,0 +1,18 @@
+@testable import PointOfSale
+
+final class MockPOSSunsetWarningChecker: POSSunsetWarningChecking {
+    var shouldShow: Bool
+    var recordDismissalCalled = false
+
+    init(shouldShow: Bool = false) {
+        self.shouldShow = shouldShow
+    }
+
+    func shouldShowSunsetWarning(siteID: Int64) async -> Bool {
+        shouldShow
+    }
+
+    func recordDismissal(siteID: Int64) {
+        recordDismissalCalled = true
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -57,4 +57,10 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     }
 
     func setFirstPOSCatalogSyncDate(siteID: Int64, date: Date) {}
+
+    func getSunsetWarningLastShownDate(siteID: Int64) -> Date? {
+        nil
+    }
+
+    func setSunsetWarningLastShownDate(siteID: Int64, date: Date) {}
 }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -58,9 +58,9 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
 
     func setFirstPOSCatalogSyncDate(siteID: Int64, date: Date) {}
 
-    func getSunsetWarningLastShownDate(siteID: Int64) -> Date? {
+    func getSunsetWarningLastDismissedDate(siteID: Int64) -> Date? {
         nil
     }
 
-    func setSunsetWarningLastShownDate(siteID: Int64, date: Date) {}
+    func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {}
 }

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -1046,46 +1046,51 @@ struct PointOfSaleAggregateModelTests {
     }
 
     @MainActor struct SunsetWarningTests {
-        @Test func showSunsetWarning_when_needsSunsetWarning_is_false_then_returns_false() {
+        @Test func showSunsetWarning_defaults_to_false() {
             // Given
-            let sut = makePointOfSaleAggregateModel(needsSunsetWarning: false)
+            let sut = makePointOfSaleAggregateModel()
 
             // Then
             #expect(sut.showSunsetWarning == false)
         }
 
-        @Test func showSunsetWarning_when_needsSunsetWarning_is_true_then_returns_true() {
+        @Test func checkSunsetWarningStatus_when_checker_returns_true_then_showSunsetWarning_is_true() async {
             // Given
-            let sut = makePointOfSaleAggregateModel(needsSunsetWarning: true)
+            let checker = MockPOSSunsetWarningChecker(shouldShow: true)
+            let sut = makePointOfSaleAggregateModel(sunsetWarningChecker: checker)
+
+            // When
+            await sut.checkSunsetWarningStatus()
 
             // Then
             #expect(sut.showSunsetWarning == true)
         }
 
-        @Test func showSunsetWarning_when_dismissed_then_returns_false() {
+        @Test func checkSunsetWarningStatus_when_checker_returns_false_then_showSunsetWarning_is_false() async {
             // Given
-            let sut = makePointOfSaleAggregateModel(needsSunsetWarning: true)
+            let checker = MockPOSSunsetWarningChecker(shouldShow: false)
+            let sut = makePointOfSaleAggregateModel(sunsetWarningChecker: checker)
+
+            // When
+            await sut.checkSunsetWarningStatus()
+
+            // Then
+            #expect(sut.showSunsetWarning == false)
+        }
+
+        @Test func dismissSunsetWarning_sets_showSunsetWarning_to_false_and_records_dismissal() async {
+            // Given
+            let checker = MockPOSSunsetWarningChecker(shouldShow: true)
+            let sut = makePointOfSaleAggregateModel(sunsetWarningChecker: checker)
+            await sut.checkSunsetWarningStatus()
+            #expect(sut.showSunsetWarning == true)
 
             // When
             sut.dismissSunsetWarning()
 
             // Then
             #expect(sut.showSunsetWarning == false)
-        }
-
-        @Test func dismissSunsetWarning_calls_onSunsetWarningDismissed_closure() {
-            // Given
-            var dismissCalled = false
-            let sut = makePointOfSaleAggregateModel(
-                needsSunsetWarning: true,
-                onSunsetWarningDismissed: { dismissCalled = true }
-            )
-
-            // When
-            sut.dismissSunsetWarning()
-
-            // Then
-            #expect(dismissCalled == true)
+            #expect(checker.recordDismissalCalled == true)
         }
     }
 }
@@ -1137,8 +1142,7 @@ private func makePointOfSaleAggregateModel(
     paymentState: PointOfSalePaymentState = .idle,
     siteID: Int64 = 123,
     catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
-    needsSunsetWarning: Bool = false,
-    onSunsetWarningDismissed: (() -> Void)? = nil
+    sunsetWarningChecker: POSSunsetWarningChecking? = nil
 ) -> PointOfSaleAggregateModel {
     PointOfSaleAggregateModel(
         entryPointController: entryPointController,
@@ -1159,7 +1163,6 @@ private func makePointOfSaleAggregateModel(
         paymentState: paymentState,
         siteID: siteID,
         catalogSyncCoordinator: catalogSyncCoordinator,
-        needsSunsetWarning: needsSunsetWarning,
-        onSunsetWarningDismissed: onSunsetWarningDismissed
+        sunsetWarningChecker: sunsetWarningChecker
     )
 }

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -1044,6 +1044,50 @@ struct PointOfSaleAggregateModelTests {
             }
         }
     }
+
+    @MainActor struct SunsetWarningTests {
+        @Test func showSunsetWarning_when_needsSunsetWarning_is_false_then_returns_false() {
+            // Given
+            let sut = makePointOfSaleAggregateModel(needsSunsetWarning: false)
+
+            // Then
+            #expect(sut.showSunsetWarning == false)
+        }
+
+        @Test func showSunsetWarning_when_needsSunsetWarning_is_true_then_returns_true() {
+            // Given
+            let sut = makePointOfSaleAggregateModel(needsSunsetWarning: true)
+
+            // Then
+            #expect(sut.showSunsetWarning == true)
+        }
+
+        @Test func showSunsetWarning_when_dismissed_then_returns_false() {
+            // Given
+            let sut = makePointOfSaleAggregateModel(needsSunsetWarning: true)
+
+            // When
+            sut.dismissSunsetWarning()
+
+            // Then
+            #expect(sut.showSunsetWarning == false)
+        }
+
+        @Test func dismissSunsetWarning_calls_onSunsetWarningDismissed_closure() {
+            // Given
+            var dismissCalled = false
+            let sut = makePointOfSaleAggregateModel(
+                needsSunsetWarning: true,
+                onSunsetWarningDismissed: { dismissCalled = true }
+            )
+
+            // When
+            sut.dismissSunsetWarning()
+
+            // Then
+            #expect(dismissCalled == true)
+        }
+    }
 }
 
 private func makePurchasableItem(name: String = "") -> POSItem {
@@ -1092,7 +1136,9 @@ private func makePointOfSaleAggregateModel(
     soundPlayer: PointOfSaleSoundPlayerProtocol = MockPointOfSaleSoundPlayer(),
     paymentState: PointOfSalePaymentState = .idle,
     siteID: Int64 = 123,
-    catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil
+    catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
+    needsSunsetWarning: Bool = false,
+    onSunsetWarningDismissed: (() -> Void)? = nil
 ) -> PointOfSaleAggregateModel {
     PointOfSaleAggregateModel(
         entryPointController: entryPointController,
@@ -1112,6 +1158,8 @@ private func makePointOfSaleAggregateModel(
         soundPlayer: soundPlayer,
         paymentState: paymentState,
         siteID: siteID,
-        catalogSyncCoordinator: catalogSyncCoordinator
+        catalogSyncCoordinator: catalogSyncCoordinator,
+        needsSunsetWarning: needsSunsetWarning,
+        onSunsetWarningDismissed: onSunsetWarningDismissed
     )
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -40,9 +40,9 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     var mockPOSLocalCatalogCellularDataAllowed: Bool?
 
     // POS sunset warning properties
-    var getSunsetWarningLastShownDateCalled = false
-    var setSunsetWarningLastShownDateCalled = false
-    var mockSunsetWarningLastShownDate: Date?
+    var getSunsetWarningLastDismissedDateCalled = false
+    var setSunsetWarningLastDismissedDateCalled = false
+    var mockSunsetWarningLastDismissedDate: Date?
 
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
@@ -132,13 +132,13 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
         return mockPOSLocalCatalogCellularDataAllowed ?? false
     }
 
-    func getSunsetWarningLastShownDate(siteID: Int64) -> Date? {
-        getSunsetWarningLastShownDateCalled = true
-        return mockSunsetWarningLastShownDate
+    func getSunsetWarningLastDismissedDate(siteID: Int64) -> Date? {
+        getSunsetWarningLastDismissedDateCalled = true
+        return mockSunsetWarningLastDismissedDate
     }
 
-    func setSunsetWarningLastShownDate(siteID: Int64, date: Date) {
-        setSunsetWarningLastShownDateCalled = true
-        mockSunsetWarningLastShownDate = date
+    func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {
+        setSunsetWarningLastDismissedDateCalled = true
+        mockSunsetWarningLastDismissedDate = date
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -39,6 +39,10 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     var setPOSLocalCatalogCellularDataAllowedCalled = false
     var mockPOSLocalCatalogCellularDataAllowed: Bool?
 
+    // POS sunset warning properties
+    var getSunsetWarningLastShownDateCalled = false
+    var setSunsetWarningLastShownDateCalled = false
+    var mockSunsetWarningLastShownDate: Date?
 
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
@@ -126,5 +130,15 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64) -> Bool {
         getPOSLocalCatalogCellularDataAllowedCalled = true
         return mockPOSLocalCatalogCellularDataAllowed ?? false
+    }
+
+    func getSunsetWarningLastShownDate(siteID: Int64) -> Date? {
+        getSunsetWarningLastShownDateCalled = true
+        return mockSunsetWarningLastShownDate
+    }
+
+    func setSunsetWarningLastShownDate(siteID: Int64, date: Date) {
+        setSunsetWarningLastShownDateCalled = true
+        mockSunsetWarningLastShownDate = date
     }
 }

--- a/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -298,6 +298,40 @@ struct SiteSpecificAppSettingsStoreMethodsTests {
         #expect(savedData.storeSettingsBySite[otherSiteID]?.syncPOSCatalogOverCellular == true)
     }
 
+    // MARK: - Sunset Warning Tests
+
+    @Test func getSunsetWarningLastShownDate_returns_nil_when_no_date_set() {
+        // When
+        let date = sut.getSunsetWarningLastShownDate(siteID: siteID)
+
+        // Then
+        #expect(date == nil)
+    }
+
+    @Test func setSunsetWarningLastShownDate_persists_date() throws {
+        // Given
+        let expectedDate = Date()
+
+        // When
+        sut.setSunsetWarningLastShownDate(siteID: siteID, date: expectedDate)
+
+        // Then
+        let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
+        #expect(savedData.storeSettingsBySite[siteID]?.lastSunsetWarningShownDate == expectedDate)
+    }
+
+    @Test func getSunsetWarningLastShownDate_returns_persisted_date() {
+        // Given
+        let expectedDate = Date()
+        sut.setSunsetWarningLastShownDate(siteID: siteID, date: expectedDate)
+
+        // When
+        let date = sut.getSunsetWarningLastShownDate(siteID: siteID)
+
+        // Then
+        #expect(date == expectedDate)
+    }
+
 }
 
 // MARK: - Mock FileStorage

--- a/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/Helpers/SiteSpecificAppSettingsStoreMethodsTests.swift
@@ -300,33 +300,33 @@ struct SiteSpecificAppSettingsStoreMethodsTests {
 
     // MARK: - Sunset Warning Tests
 
-    @Test func getSunsetWarningLastShownDate_returns_nil_when_no_date_set() {
+    @Test func getSunsetWarningLastDismissedDate_returns_nil_when_no_date_set() {
         // When
-        let date = sut.getSunsetWarningLastShownDate(siteID: siteID)
+        let date = sut.getSunsetWarningLastDismissedDate(siteID: siteID)
 
         // Then
         #expect(date == nil)
     }
 
-    @Test func setSunsetWarningLastShownDate_persists_date() throws {
+    @Test func setSunsetWarningLastDismissedDate_persists_date() throws {
         // Given
         let expectedDate = Date()
 
         // When
-        sut.setSunsetWarningLastShownDate(siteID: siteID, date: expectedDate)
+        sut.setSunsetWarningLastDismissedDate(siteID: siteID, date: expectedDate)
 
         // Then
         let savedData: GeneralStoreSettingsBySite = try fileStorage.data(for: SiteSpecificAppSettingsStoreMethods.defaultGeneralStoreSettingsFileURL)
-        #expect(savedData.storeSettingsBySite[siteID]?.lastSunsetWarningShownDate == expectedDate)
+        #expect(savedData.storeSettingsBySite[siteID]?.lastSunsetWarningDismissedDate == expectedDate)
     }
 
-    @Test func getSunsetWarningLastShownDate_returns_persisted_date() {
+    @Test func getSunsetWarningLastDismissedDate_returns_persisted_date() {
         // Given
         let expectedDate = Date()
-        sut.setSunsetWarningLastShownDate(siteID: siteID, date: expectedDate)
+        sut.setSunsetWarningLastDismissedDate(siteID: siteID, date: expectedDate)
 
         // When
-        let date = sut.getSunsetWarningLastShownDate(siteID: siteID)
+        let date = sut.getSunsetWarningLastDismissedDate(siteID: siteID)
 
         // Then
         #expect(date == expectedDate)

--- a/WooCommerce/Classes/POS/TabBar/POSSunsetWarningChecker.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSSunsetWarningChecker.swift
@@ -2,14 +2,8 @@ import Foundation
 import Yosemite
 import Storage
 import Experiments
+import PointOfSale
 import class WooFoundation.VersionHelpers
-
-/// Determines whether the POS sunset warning banner should be shown.
-///
-protocol POSSunsetWarningChecking {
-    func shouldShowSunsetWarning(siteID: Int64) async -> Bool
-    func recordDismissal(siteID: Int64)
-}
 
 struct POSSunsetWarningChecker: POSSunsetWarningChecking {
     private let featureFlagService: FeatureFlagService

--- a/WooCommerce/Classes/POS/TabBar/POSSunsetWarningChecker.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSSunsetWarningChecker.swift
@@ -26,7 +26,7 @@ struct POSSunsetWarningChecker: POSSunsetWarningChecking {
             return false
         }
 
-        if let lastDismissedDate = siteSettings.getSunsetWarningLastShownDate(siteID: siteID) {
+        if let lastDismissedDate = siteSettings.getSunsetWarningLastDismissedDate(siteID: siteID) {
             let daysSinceDismissal = Calendar.current.dateComponents([.day], from: lastDismissedDate, to: currentDate()).day ?? 0
             if daysSinceDismissal < Constants.dismissalThresholdDays {
                 return false
@@ -48,7 +48,7 @@ struct POSSunsetWarningChecker: POSSunsetWarningChecking {
     }
 
     func recordDismissal(siteID: Int64) {
-        siteSettings.setSunsetWarningLastShownDate(siteID: siteID, date: currentDate())
+        siteSettings.setSunsetWarningLastDismissedDate(siteID: siteID, date: currentDate())
     }
 }
 

--- a/WooCommerce/Classes/POS/TabBar/POSSunsetWarningChecker.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSSunsetWarningChecker.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Yosemite
+import Storage
+import Experiments
+import class WooFoundation.VersionHelpers
+
+/// Determines whether the POS sunset warning banner should be shown.
+///
+protocol POSSunsetWarningChecking {
+    func shouldShowSunsetWarning(siteID: Int64) async -> Bool
+    func recordDismissal(siteID: Int64)
+}
+
+struct POSSunsetWarningChecker: POSSunsetWarningChecking {
+    private let featureFlagService: FeatureFlagService
+    private let systemStatusService: POSSystemStatusServiceProtocol
+    private let siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol
+    private let currentDate: () -> Date
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         systemStatusService: POSSystemStatusServiceProtocol,
+         siteSettings: SiteSpecificAppSettingsStoreMethodsProtocol = SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage()),
+         currentDate: @escaping () -> Date = { Date() }) {
+        self.featureFlagService = featureFlagService
+        self.systemStatusService = systemStatusService
+        self.siteSettings = siteSettings
+        self.currentDate = currentDate
+    }
+
+    func shouldShowSunsetWarning(siteID: Int64) async -> Bool {
+        guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI) else {
+            return false
+        }
+
+        if let lastDismissedDate = siteSettings.getSunsetWarningLastShownDate(siteID: siteID) {
+            let daysSinceDismissal = Calendar.current.dateComponents([.day], from: lastDismissedDate, to: currentDate()).day ?? 0
+            if daysSinceDismissal < Constants.dismissalThresholdDays {
+                return false
+            }
+        }
+
+        do {
+            let pluginInfo = try await systemStatusService.loadWooCommercePluginAndPOSFeatureSwitch(siteID: siteID)
+            guard let wcPlugin = pluginInfo.wcPlugin, wcPlugin.active else {
+                return false
+            }
+            return !VersionHelpers.isVersionSupported(
+                version: wcPlugin.version,
+                minimumRequired: Constants.minimumWCVersion
+            )
+        } catch {
+            return false
+        }
+    }
+
+    func recordDismissal(siteID: Int64) {
+        siteSettings.setSunsetWarningLastShownDate(siteID: siteID, date: currentDate())
+    }
+}
+
+private extension POSSunsetWarningChecker {
+    enum Constants {
+        static let dismissalThresholdDays = 14
+        static let minimumWCVersion = "10.5.0"
+    }
+}

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -7,6 +7,7 @@ import class WooFoundation.CurrencySettings
 import WooFoundationCore
 import protocol Storage.GRDBManagerProtocol
 import protocol Storage.StorageManagerType
+import class Storage.PListFileStorage
 import struct NetworkingCore.JetpackSite
 import struct NetworkingCore.OrderItem
 import PointOfSale
@@ -216,6 +217,9 @@ private extension POSTabCoordinator {
                 isLocalCatalogEligible = false
             }
 
+            // Check if sunset warning should be shown (WC < 10.5, throttled to once every 14 days)
+            let needsSunsetWarning = await self.shouldShowSunsetWarning(siteID: siteID)
+
             let serviceAdaptor = POSServiceLocatorAdaptor()
             let collectPaymentAnalyticsAdaptor = POSCollectOrderPaymentAnalyticsAdaptor(analytics: serviceAdaptor.analytics)
 
@@ -311,6 +315,12 @@ private extension POSTabCoordinator {
                     grdbManager: grdbManager,
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
+                    needsSunsetWarning: needsSunsetWarning,
+                    onSunsetWarningDismissed: { [weak self] in
+                        guard let self else { return }
+                        let siteSettings = SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
+                        siteSettings.setSunsetWarningLastShownDate(siteID: siteID, date: Date())
+                    },
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )
@@ -320,6 +330,47 @@ private extension POSTabCoordinator {
                 viewControllerToPresent.present(hostingController, animated: true)
             }
         }
+    }
+}
+
+// MARK: - Sunset Warning
+private extension POSTabCoordinator {
+    /// Determines whether the sunset warning banner should be shown.
+    /// Returns true if the store is on WC < 10.5 and the banner hasn't been shown in the last 14 days.
+    func shouldShowSunsetWarning(siteID: Int64) async -> Bool {
+        let siteSettings = SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
+        if let lastShownDate = siteSettings.getSunsetWarningLastShownDate(siteID: siteID) {
+            let daysSinceShown = Calendar.current.dateComponents([.day], from: lastShownDate, to: Date()).day ?? 0
+            if daysSinceShown < Constants.sunsetWarningThresholdDays {
+                return false
+            }
+        }
+
+        // Check WC version via system status service
+        do {
+            let systemStatusService = POSSystemStatusService(
+                credentials: credentials,
+                selectedSite: defaultSitePublisher,
+                appPasswordSupportState: isAppPasswordSupported,
+                storageManager: storageManager
+            )
+            let pluginInfo = try await systemStatusService.loadWooCommercePluginAndPOSFeatureSwitch(siteID: siteID)
+            guard let wcPlugin = pluginInfo.wcPlugin, wcPlugin.active else {
+                return false
+            }
+            let isVersionSupported = VersionHelpers.isVersionSupported(
+                version: wcPlugin.version,
+                minimumRequired: Constants.sunsetWarningMinimumWCVersion
+            )
+            return !isVersionSupported
+        } catch {
+            return false
+        }
+    }
+
+    enum Constants {
+        static let sunsetWarningThresholdDays = 14
+        static let sunsetWarningMinimumWCVersion = "10.5.0"
     }
 }
 

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -7,7 +7,6 @@ import class WooFoundation.CurrencySettings
 import WooFoundationCore
 import protocol Storage.GRDBManagerProtocol
 import protocol Storage.StorageManagerType
-import class Storage.PListFileStorage
 import struct NetworkingCore.JetpackSite
 import struct NetworkingCore.OrderItem
 import PointOfSale
@@ -218,7 +217,15 @@ private extension POSTabCoordinator {
             }
 
             // Check if sunset warning should be shown (WC < 10.5, throttled to once every 14 days)
-            let needsSunsetWarning = await self.shouldShowSunsetWarning(siteID: siteID)
+            let sunsetWarningChecker = POSSunsetWarningChecker(
+                systemStatusService: POSSystemStatusService(
+                    credentials: credentials,
+                    selectedSite: defaultSitePublisher,
+                    appPasswordSupportState: isAppPasswordSupported,
+                    storageManager: storageManager
+                )
+            )
+            let needsSunsetWarning = await sunsetWarningChecker.shouldShowSunsetWarning(siteID: siteID)
 
             let serviceAdaptor = POSServiceLocatorAdaptor()
             let collectPaymentAnalyticsAdaptor = POSCollectOrderPaymentAnalyticsAdaptor(analytics: serviceAdaptor.analytics)
@@ -316,10 +323,8 @@ private extension POSTabCoordinator {
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
                     needsSunsetWarning: needsSunsetWarning,
-                    onSunsetWarningDismissed: { [weak self] in
-                        guard let self else { return }
-                        let siteSettings = SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
-                        siteSettings.setSunsetWarningLastShownDate(siteID: siteID, date: Date())
+                    onSunsetWarningDismissed: {
+                        sunsetWarningChecker.recordDismissal(siteID: siteID)
                     },
                     services: serviceAdaptor,
                     itemProvider: itemProvider
@@ -333,52 +338,6 @@ private extension POSTabCoordinator {
     }
 }
 
-// MARK: - Sunset Warning
-private extension POSTabCoordinator {
-    /// Determines whether the sunset warning banner should be shown.
-    /// Returns true if the catalog API feature flag is enabled, the store is on WC < 10.5,
-    /// and the banner hasn't been dismissed in the last 14 days.
-    func shouldShowSunsetWarning(siteID: Int64) async -> Bool {
-        // Only show when catalog API flag is on — without it, i1 still works for WC 10.3+ users
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI) else {
-            return false
-        }
-
-        let siteSettings = SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
-        if let lastShownDate = siteSettings.getSunsetWarningLastShownDate(siteID: siteID) {
-            let daysSinceShown = Calendar.current.dateComponents([.day], from: lastShownDate, to: Date()).day ?? 0
-            if daysSinceShown < Constants.sunsetWarningThresholdDays {
-                return false
-            }
-        }
-
-        // Check WC version via system status service
-        do {
-            let systemStatusService = POSSystemStatusService(
-                credentials: credentials,
-                selectedSite: defaultSitePublisher,
-                appPasswordSupportState: isAppPasswordSupported,
-                storageManager: storageManager
-            )
-            let pluginInfo = try await systemStatusService.loadWooCommercePluginAndPOSFeatureSwitch(siteID: siteID)
-            guard let wcPlugin = pluginInfo.wcPlugin, wcPlugin.active else {
-                return false
-            }
-            let isVersionSupported = VersionHelpers.isVersionSupported(
-                version: wcPlugin.version,
-                minimumRequired: Constants.sunsetWarningMinimumWCVersion
-            )
-            return !isVersionSupported
-        } catch {
-            return false
-        }
-    }
-
-    enum Constants {
-        static let sunsetWarningThresholdDays = 14
-        static let sunsetWarningMinimumWCVersion = "10.5.0"
-    }
-}
 
 private extension POSTabCoordinator {
     func updateDefaultConfigurationForPointOfSale(_ isPointOfSaleActive: Bool) {

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -216,7 +216,6 @@ private extension POSTabCoordinator {
                 isLocalCatalogEligible = false
             }
 
-            // Check if sunset warning should be shown (WC < 10.5, throttled to once every 14 days)
             let sunsetWarningChecker = POSSunsetWarningChecker(
                 systemStatusService: POSSystemStatusService(
                     credentials: credentials,
@@ -225,7 +224,6 @@ private extension POSTabCoordinator {
                     storageManager: storageManager
                 )
             )
-            let needsSunsetWarning = await sunsetWarningChecker.shouldShowSunsetWarning(siteID: siteID)
 
             let serviceAdaptor = POSServiceLocatorAdaptor()
             let collectPaymentAnalyticsAdaptor = POSCollectOrderPaymentAnalyticsAdaptor(analytics: serviceAdaptor.analytics)
@@ -322,10 +320,7 @@ private extension POSTabCoordinator {
                     grdbManager: grdbManager,
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
-                    needsSunsetWarning: needsSunsetWarning,
-                    onSunsetWarningDismissed: {
-                        sunsetWarningChecker.recordDismissal(siteID: siteID)
-                    },
+                    sunsetWarningChecker: sunsetWarningChecker,
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )
@@ -337,7 +332,6 @@ private extension POSTabCoordinator {
         }
     }
 }
-
 
 private extension POSTabCoordinator {
     func updateDefaultConfigurationForPointOfSale(_ isPointOfSaleActive: Bool) {

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -336,8 +336,14 @@ private extension POSTabCoordinator {
 // MARK: - Sunset Warning
 private extension POSTabCoordinator {
     /// Determines whether the sunset warning banner should be shown.
-    /// Returns true if the store is on WC < 10.5 and the banner hasn't been shown in the last 14 days.
+    /// Returns true if the catalog API feature flag is enabled, the store is on WC < 10.5,
+    /// and the banner hasn't been dismissed in the last 14 days.
     func shouldShowSunsetWarning(siteID: Int64) async -> Bool {
+        // Only show when catalog API flag is on — without it, i1 still works for WC 10.3+ users
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI) else {
+            return false
+        }
+
         let siteSettings = SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage())
         if let lastShownDate = siteSettings.getSunsetWarningLastShownDate(siteID: siteID) {
             let daysSinceShown = Calendar.current.dateComponents([.day], from: lastShownDate, to: Date()).day ?? 0

--- a/WooCommerce/WooCommerceTests/POS/POSSunsetWarningCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSSunsetWarningCheckerTests.swift
@@ -1,0 +1,236 @@
+import Testing
+import Foundation
+@testable import WooCommerce
+import Yosemite
+import Storage
+import Experiments
+
+struct POSSunsetWarningCheckerTests {
+
+    private let siteID: Int64 = 123
+
+    // MARK: - Feature Flag
+
+    @Test func shouldShowSunsetWarning_when_featureFlag_disabled_then_returns_false() async {
+        // Given
+        let featureFlags = MockFeatureFlagService()
+        featureFlags.isFeatureFlagEnabledReturnValue[.pointOfSaleCatalogAPI] = false
+        let sut = makeSUT(featureFlagService: featureFlags)
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    // MARK: - Version Checks
+
+    @Test func shouldShowSunsetWarning_when_version_below_minimum_then_returns_true() async {
+        // Given
+        let sut = makeSUT(wcVersion: "10.4.0")
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func shouldShowSunsetWarning_when_version_meets_minimum_then_returns_false() async {
+        // Given
+        let sut = makeSUT(wcVersion: "10.5.0")
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func shouldShowSunsetWarning_when_version_above_minimum_then_returns_false() async {
+        // Given
+        let sut = makeSUT(wcVersion: "11.0.0")
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func shouldShowSunsetWarning_when_plugin_inactive_then_returns_false() async {
+        // Given
+        let sut = makeSUT(wcVersion: "10.4.0", pluginActive: false)
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func shouldShowSunsetWarning_when_plugin_nil_then_returns_false() async {
+        // Given
+        let systemStatusService = MockPOSSystemStatusService()
+        systemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil))
+        let sut = makeSUT(systemStatusService: systemStatusService)
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func shouldShowSunsetWarning_when_service_throws_then_returns_false() async {
+        // Given
+        let systemStatusService = MockPOSSystemStatusService()
+        systemStatusService.resultToReturn = .failure(NSError(domain: "test", code: 1))
+        let sut = makeSUT(systemStatusService: systemStatusService)
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    // MARK: - Dismissal Throttling
+
+    @Test func shouldShowSunsetWarning_when_dismissed_within_14_days_then_returns_false() async {
+        // Given
+        let now = Date()
+        let dismissedDate = Calendar.current.date(byAdding: .day, value: -10, to: now)!
+        let siteSettings = MockSunsetSiteSettings(lastDismissedDate: dismissedDate)
+        let sut = makeSUT(wcVersion: "10.4.0", siteSettings: siteSettings, currentDate: { now })
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func shouldShowSunsetWarning_when_dismissed_over_14_days_ago_then_returns_true() async {
+        // Given
+        let now = Date()
+        let dismissedDate = Calendar.current.date(byAdding: .day, value: -15, to: now)!
+        let siteSettings = MockSunsetSiteSettings(lastDismissedDate: dismissedDate)
+        let sut = makeSUT(wcVersion: "10.4.0", siteSettings: siteSettings, currentDate: { now })
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func shouldShowSunsetWarning_when_never_dismissed_then_returns_true() async {
+        // Given
+        let siteSettings = MockSunsetSiteSettings(lastDismissedDate: nil)
+        let sut = makeSUT(wcVersion: "10.4.0", siteSettings: siteSettings)
+
+        // When
+        let result = await sut.shouldShowSunsetWarning(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+    }
+
+    // MARK: - Record Dismissal
+
+    @Test func recordDismissal_persists_current_date() {
+        // Given
+        let now = Date()
+        let siteSettings = MockSunsetSiteSettings()
+        let sut = makeSUT(siteSettings: siteSettings, currentDate: { now })
+
+        // When
+        sut.recordDismissal(siteID: siteID)
+
+        // Then
+        #expect(siteSettings.lastDismissedDate == now)
+        #expect(siteSettings.lastDismissedSiteID == siteID)
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSSunsetWarningCheckerTests {
+    func makeSUT(
+        featureFlagService: MockFeatureFlagService? = nil,
+        wcVersion: String = "10.4.0",
+        pluginActive: Bool = true,
+        systemStatusService: MockPOSSystemStatusService? = nil,
+        siteSettings: MockSunsetSiteSettings = MockSunsetSiteSettings(),
+        currentDate: @escaping () -> Date = { Date() }
+    ) -> POSSunsetWarningChecker {
+        let flags = featureFlagService ?? {
+            let service = MockFeatureFlagService()
+            service.isFeatureFlagEnabledReturnValue[.pointOfSaleCatalogAPI] = true
+            return service
+        }()
+
+        let statusService = systemStatusService ?? {
+            let service = MockPOSSystemStatusService()
+            let plugin = SystemPlugin.fake().copy(version: wcVersion, active: pluginActive)
+            service.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: plugin, featureValue: nil))
+            return service
+        }()
+
+        return POSSunsetWarningChecker(
+            featureFlagService: flags,
+            systemStatusService: statusService,
+            siteSettings: siteSettings,
+            currentDate: currentDate
+        )
+    }
+}
+
+// MARK: - Mocks
+
+private final class MockPOSSystemStatusService: POSSystemStatusServiceProtocol {
+    var resultToReturn: Result<POSPluginAndFeatureInfo, Error> = .success(POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil))
+
+    func loadWooCommercePluginAndPOSFeatureSwitch(siteID: Int64) async throws -> POSPluginAndFeatureInfo {
+        switch resultToReturn {
+        case .success(let info):
+            return info
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+private final class MockSunsetSiteSettings: SiteSpecificAppSettingsStoreMethodsProtocol {
+    var lastDismissedDate: Date?
+    var lastDismissedSiteID: Int64?
+
+    init(lastDismissedDate: Date? = nil) {
+        self.lastDismissedDate = lastDismissedDate
+    }
+
+    func getSunsetWarningLastDismissedDate(siteID: Int64) -> Date? {
+        lastDismissedDate
+    }
+
+    func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {
+        lastDismissedSiteID = siteID
+        lastDismissedDate = date
+    }
+
+    func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings { .init() }
+    func setStoreSettings(settings: GeneralStoreSettings, for siteID: Int64, onCompletion: ((Result<Void, Error>) -> Void)?) {}
+    func resetStoreSettings() {}
+    func setStoreID(siteID: Int64, id: String?) {}
+    func getStoreID(siteID: Int64, onCompletion: (String?) -> Void) {}
+    func getSearchTerms(for itemType: POSItemType, siteID: Int64) -> [String] { [] }
+    func setSearchTerms(_ terms: [String], for itemType: POSItemType, siteID: Int64) {}
+    func getPOSLastOpenedDate(siteID: Int64) -> Date? { nil }
+    func setPOSLastOpenedDate(siteID: Int64, date: Date) {}
+    func getFirstPOSCatalogSyncDate(siteID: Int64) -> Date? { nil }
+    func setFirstPOSCatalogSyncDate(siteID: Int64, date: Date) {}
+    func setPOSLocalCatalogCellularDataAllowed(siteID: Int64, allowed: Bool) {}
+    func getPOSLocalCatalogCellularDataAllowed(siteID: Int64) -> Bool { false }
+}


### PR DESCRIPTION
Closes WOOMOB-2054

## Description

Adds a warning banner to the POS items screen that informs users when their WooCommerce version is below 10.5.0. Starting August 1st, POS will require WooCommerce 10.5.0 or later. The banner can be dismissed and will reappear after a 14-day cooldown period. 

## Test Steps
- Enable `pointOfSaleCatalogAPI`
- Connect a site running WooCommerce < 10.5.0 or update `sunsetWarningMinimumWCVersion` to be 11.0 or similar
- Open POS and navigate to the items screen
- Verify the sunset warning banner appears with the title "Update WooCommerce Soon"
- Dismiss the banner and verify it disappears
- Exit and re-enter POS. Banner should remain hidden (14-day cooldown)
- Connect a site running WooCommerce 10.5.0 or later
- Open POS and navigate to the items screen
- Verify the sunset warning banner does NOT appear

**Testing the 14 days trigger**
If you want to test the 14 day recurrent notice:
- Update `POSSunsetWarningChecker. Constants.minimumWCVersion` to `11.0` or so
- Add breakpoint to line 33 `POSSunsetWarningChecker.shouldShowSunsetWarning`
- Run the app, ignore breakpoint, see the banner, dismiss it
- Exit POS
- Enter POS, ignore breakpoint, see there is no banner
- Exit POS
- Enter POS, when breakpoint hits, `po` the following, then continue execution:
```
po siteSettings.setSunsetWarningLastShownDate(siteID: siteID, date: Calendar.current.date(byAdding: .day, value: -14, to: Date())!)
```
- Observe the sunset banner appears again

## Screenshots

<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-04-08 at 10 01 52" src="https://github.com/user-attachments/assets/6b63401b-5183-4894-81dc-70127b3d57c6" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
