### PR TITLE
Fix empty_string SwiftLint violations

### DIFF
--- a/Modules/Tests/NetworkingTests/Encoder/OrderItemRefundEncoderTests.swift
+++ b/Modules/Tests/NetworkingTests/Encoder/OrderItemRefundEncoderTests.swift
@@ -23,16 +23,16 @@ struct OrderItemRefundEncoderTests {
         #expect(item.taxes == [])
 
         // Defaulted fields
-        #expect(item.name == "")
+        #expect(item.name.isEmpty)
         #expect(item.productID == 0)
         #expect(item.variationID == 0)
         #expect(item.refundedItemID == nil)
         #expect(item.price == .zero)
         #expect(item.sku == nil)
-        #expect(item.subtotal == "")
-        #expect(item.subtotalTax == "")
-        #expect(item.taxClass == "")
-        #expect(item.totalTax == "")
+        #expect(item.subtotal.isEmpty)
+        #expect(item.subtotalTax.isEmpty)
+        #expect(item.taxClass.isEmpty)
+        #expect(item.totalTax.isEmpty)
     }
 
     @Test func init_with_explicit_values_then_overrides_defaults() {

--- a/WooCommerce/WooCommerceTests/Analytics/BookingAnalyticsMappingsTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/BookingAnalyticsMappingsTests.swift
@@ -18,7 +18,7 @@ struct BookingAnalyticsMappingsTests {
         )
 
         // Then
-        #expect(noFilters.analyticsFilterString == "")
+        #expect(noFilters.analyticsFilterString.isEmpty)
         #expect(allFilters.analyticsFilterString == "attendance_status,customer,date_time,service_events,team_member")
     }
 }


### PR DESCRIPTION
## Description

Fix `empty_string` SwiftLint violations by replacing `== ""` comparisons with `.isEmpty`.

The PR that enabled the `empty_string` rule, #16860 , had no violations when it was merged, but new code landed on `trunk` while it was in review, introducing these violations.

## Test Steps

The modified tests should continue to pass — the assertions are logically equivalent.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

---

Generated with the help of Claude Code, https://claude.ai/code

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>