### PR TITLE
Tag CIAB support tickets with commerce_in_a_box

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 24.6
 -----
 - [*] Add troubleshooting tool for login [https://github.com/woocommerce/woocommerce-ios/pull/16890]
+- [Internal] Tag CIAB support tickets with commerce_in_a_box for proper routing [https://github.com/woocommerce/woocommerce-ios/pull/16910]
 
 
 24.5

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -57,7 +57,8 @@ class SupportFormMetadataProvider {
             site.isWordPressComStore ? Constants.wpComTag : nil,
             site.plan.isNotEmpty ? site.plan : nil,
             stores.isAuthenticatedWithoutWPCom ? Constants.authenticatedWithApplicationPasswordTag : nil,
-            stores.requestAuthenticationMode == .appPasswordsWithJetpack ? Constants.jetpackSiteUsingAppPasswords : nil
+            stores.requestAuthenticationMode == .appPasswordsWithJetpack ? Constants.jetpackSiteUsingAppPasswords : nil,
+            site.isCIAB ? Constants.ciabTag : nil
         ].compactMap { $0 } + getIPPTags()
     }
 
@@ -210,6 +211,7 @@ private extension SupportFormMetadataProvider {
         static let networkWWAN = "Mobile"
         static let sourcePlatform = "mobile_-_woo_ios"
         static let jetpackSiteUsingAppPasswords = "jetpack_site_using_app_passwords"
+        static let ciabTag = "commerce_in_a_box"
     }
 
     /// Payments extensions Slugs

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormMetadataProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormMetadataProviderTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+struct SupportFormMetadataProviderTests {
+
+    // MARK: - CIAB Tag
+
+    @Test
+    func systemTags_when_site_is_CIAB_then_includes_commerce_in_a_box_tag() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(
+            authenticated: true,
+            defaultSite: Site.fake().copy(isGarden: true, gardenName: "commerce")
+        )
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let provider = SupportFormMetadataProvider(
+            stores: stores,
+            sessionManager: sessionManager
+        )
+
+        // When
+        let tags = provider.systemTags()
+
+        // Then
+        #expect(tags.contains("commerce_in_a_box"))
+    }
+
+    @Test
+    func systemTags_when_site_is_not_CIAB_then_does_not_include_commerce_in_a_box_tag() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(
+            authenticated: true,
+            defaultSite: Site.fake().copy(isGarden: false)
+        )
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let provider = SupportFormMetadataProvider(
+            stores: stores,
+            sessionManager: sessionManager
+        )
+
+        // When
+        let tags = provider.systemTags()
+
+        // Then
+        #expect(!tags.contains("commerce_in_a_box"))
+    }
+
+    @Test
+    func systemTags_when_site_is_garden_but_not_commerce_then_does_not_include_commerce_in_a_box_tag() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(
+            authenticated: true,
+            defaultSite: Site.fake().copy(isGarden: true, gardenName: "not-commerce")
+        )
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let provider = SupportFormMetadataProvider(
+            stores: stores,
+            sessionManager: sessionManager
+        )
+
+        // When
+        let tags = provider.systemTags()
+
+        // Then
+        #expect(!tags.contains("commerce_in_a_box"))
+    }
+
+    @Test
+    func systemTags_when_no_default_site_then_does_not_include_commerce_in_a_box_tag() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let provider = SupportFormMetadataProvider(
+            stores: stores,
+            sessionManager: sessionManager
+        )
+
+        // When
+        let tags = provider.systemTags()
+
+        // Then
+        #expect(!tags.contains("commerce_in_a_box"))
+    }
+}


### PR DESCRIPTION
Part of: WOOMOB-2551
For more context also check linked parent issue

## Description

When a CIAB site user submits a support ticket via Help & Feedback, the ticket now includes the `commerce_in_a_box` Zendesk tag. This enables proper routing and tier 1 treatment for all CIAB users (including free trials) as requested by the support team.

### Changes

- Added CIAB detection to `SupportFormMetadataProvider.systemTags()` using the existing `Site.isCIAB(isGarden:gardenName:)` check
- Added `commerce_in_a_box` tag constant
- The tag is appended to **all** support areas (Mobile App, Card Reader, WooPayments, etc.)

## Test Steps

1. Log in with a CIAB site (garden site with `gardenName == "commerce"`)
2. Go to Menu → Settings → Help & Feedback → Contact Support
3. Fill in and submit a support ticket
4. Verify the ticket in Zendesk includes the `commerce_in_a_box` tag
5. Repeat with a non-CIAB site and verify the tag is **not** present

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.