### PR TITLE
Add fulfillment eligibility check for CIAB order details

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -45,6 +45,10 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var isEligibleForWooShipping: Bool = false
 
+    /// Whether the order is eligible for order fulfillment (CIAB sites only).
+    ///
+    var isEligibleForOrderFulfillment: Bool = false
+
     /// Whether the order is eligible for card present payment.
     ///
     var isEligibleForPayment: Bool {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -342,7 +342,11 @@ extension OrderDetailsViewModel {
                 defer {
                     group.leave()
                 }
-                await syncOrderFulfillments()
+                let isEligible = await checkOrderFulfillmentEligibility()
+                dataSource.isEligibleForOrderFulfillment = isEligible
+                if isEligible {
+                    await syncOrderFulfillments()
+                }
             }
         }
 
@@ -843,6 +847,19 @@ extension OrderDetailsViewModel {
             return await checkShippingLabelCreationEligibilityForLegacyPlugin(isRevampedFlow: isRevampedFlow)
         } else {
             return false
+        }
+    }
+
+    /// Checks whether the order is eligible for fulfillment on CIAB sites.
+    /// Reuses the WooShipping eligibility endpoint which determines if an order can be fulfilled.
+    /// Returns `false` on error to degrade gracefully without blocking order detail loading.
+    @MainActor
+    func checkOrderFulfillmentEligibility() async -> Bool {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(WooShippingAction.checkCreationEligibility(siteID: order.siteID,
+                                                                         orderID: order.orderID) { isEligible in
+                continuation.resume(returning: isEligible)
+            })
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -819,3 +819,29 @@ private extension OrderDetailsViewModelTests {
         }
     }
 }
+
+// MARK: - Order Fulfillment Eligibility (CIAB)
+extension OrderDetailsViewModelTests {
+
+    func test_checkOrderFulfillmentEligibility_when_eligible_then_returns_true() async {
+        // Given
+        whenCheckingShippingLabelCreationEligibility(thenReturn: true)
+
+        // When
+        let result = await viewModel.checkOrderFulfillmentEligibility()
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func test_checkOrderFulfillmentEligibility_when_not_eligible_then_returns_false() async {
+        // Given
+        whenCheckingShippingLabelCreationEligibility(thenReturn: false)
+
+        // When
+        let result = await viewModel.checkOrderFulfillmentEligibility()
+
+        // Then
+        XCTAssertFalse(result)
+    }
+}


### PR DESCRIPTION
Closes WOOMOB-2626

## Description

Adds an order fulfillment eligibility gate for CIAB sites. Before syncing fulfillment data on the order detail screen, we now call the existing WooShipping eligibility API (`/wcshipping/v1/eligibility/{orderId}`) to determine if the order is eligible for fulfillment. If the order is not eligible (or the check fails), we skip syncing fulfillment data and don't show the fulfillment UI.

This reuses the existing networking infrastructure (`WooShippingRemote.checkCreationEligibility`, `WooShippingAction`, `WooShippingStore`) — no new Networking or Yosemite layer changes needed.

**Changes:**
- `OrderDetailsDataSource`: Added `isEligibleForOrderFulfillment` property
- `OrderDetailsViewModel`: Added `checkOrderFulfillmentEligibility()` method and gated the existing CIAB fulfillment sync block on the eligibility result
- Tests for eligible and not-eligible scenarios

## Test Steps

1. Connect to a CIAB site with orders
2. Open an order that is eligible for fulfillment
3. Verify the fulfillment section appears
4. Open an order that is not eligible (e.g., all virtual products)
5. Verify the fulfillment section does not appear
6. Simulate a network error — verify the order detail still loads without the fulfillment section

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.