### PR TITLE
Add custom provider name support to OrderFulfillment

### DIFF
--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -775,6 +775,7 @@ extension Networking.OrderFulfillment {
             dateFulfilled: .fake(),
             trackingNumber: .fake(),
             shipmentProvider: .fake(),
+            providerName: .fake(),
             trackingURL: .fake()
         )
     }

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1315,6 +1315,7 @@ extension Networking.OrderFulfillment {
         dateFulfilled: NullableCopiableProp<Date> = .copy,
         trackingNumber: NullableCopiableProp<String> = .copy,
         shipmentProvider: NullableCopiableProp<String> = .copy,
+        providerName: NullableCopiableProp<String> = .copy,
         trackingURL: NullableCopiableProp<String> = .copy
     ) -> Networking.OrderFulfillment {
         let siteID = siteID ?? self.siteID
@@ -1326,6 +1327,7 @@ extension Networking.OrderFulfillment {
         let dateFulfilled = dateFulfilled ?? self.dateFulfilled
         let trackingNumber = trackingNumber ?? self.trackingNumber
         let shipmentProvider = shipmentProvider ?? self.shipmentProvider
+        let providerName = providerName ?? self.providerName
         let trackingURL = trackingURL ?? self.trackingURL
 
         return Networking.OrderFulfillment(
@@ -1338,6 +1340,7 @@ extension Networking.OrderFulfillment {
             dateFulfilled: dateFulfilled,
             trackingNumber: trackingNumber,
             shipmentProvider: shipmentProvider,
+            providerName: providerName,
             trackingURL: trackingURL
         )
     }

--- a/Modules/Sources/Networking/Model/OrderFulfillment.swift
+++ b/Modules/Sources/Networking/Model/OrderFulfillment.swift
@@ -44,6 +44,11 @@ public struct OrderFulfillment: Decodable, Equatable, GeneratedFakeable, Generat
     ///
     public let shipmentProvider: String?
 
+    /// Custom provider name (from `_provider_name` meta).
+    /// When the user selects "other" as the shipping provider, they can specify a custom provider name.
+    ///
+    public let providerName: String?
+
     /// External tracking URL (from `_tracking_url` meta).
     ///
     public let trackingURL: String?
@@ -59,6 +64,7 @@ public struct OrderFulfillment: Decodable, Equatable, GeneratedFakeable, Generat
                 dateFulfilled: Date?,
                 trackingNumber: String?,
                 shipmentProvider: String?,
+                providerName: String?,
                 trackingURL: String?) {
         self.siteID = siteID
         self.orderID = orderID
@@ -69,6 +75,7 @@ public struct OrderFulfillment: Decodable, Equatable, GeneratedFakeable, Generat
         self.dateFulfilled = dateFulfilled
         self.trackingNumber = trackingNumber
         self.shipmentProvider = shipmentProvider
+        self.providerName = providerName
         self.trackingURL = trackingURL
     }
 
@@ -95,6 +102,7 @@ public struct OrderFulfillment: Decodable, Equatable, GeneratedFakeable, Generat
 
         let trackingNumber = metaData.first(where: { $0.key == MetaKeys.trackingNumber })?.value.stringValue
         let shipmentProvider = metaData.first(where: { $0.key == MetaKeys.shipmentProvider })?.value.stringValue
+        let providerName = metaData.first(where: { $0.key == MetaKeys.providerName })?.value.stringValue
         let trackingURL = metaData.first(where: { $0.key == MetaKeys.trackingURL })?.value.stringValue
         let dateFulfilledString = metaData.first(where: { $0.key == MetaKeys.dateFulfilled })?.value.stringValue
         let dateFulfilled = dateFulfilledString.flatMap { DateFormatter.Stats.dateTimeFormatter.date(from: $0) }
@@ -108,6 +116,7 @@ public struct OrderFulfillment: Decodable, Equatable, GeneratedFakeable, Generat
                   dateFulfilled: dateFulfilled,
                   trackingNumber: trackingNumber,
                   shipmentProvider: shipmentProvider,
+                  providerName: providerName,
                   trackingURL: trackingURL)
     }
 }
@@ -129,6 +138,7 @@ private extension OrderFulfillment {
         static let dateFulfilled = "_date_fulfilled"
         static let trackingNumber = "_tracking_number"
         static let shipmentProvider = "_shipment_provider"
+        static let providerName = "_provider_name"
         static let trackingURL = "_tracking_url"
     }
 }

--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -4,7 +4,7 @@ This file documents changes in the WCiOS Storage data model. Please explain any 
 
 ## Model 136 (Release 24.6.0.0)
 - @rafaelkayumov 2026-04-06
-  - Added `OrderFulfillment` entity with attributes: `siteID`, `orderID`, `fulfillmentID`, `statusKey`, `isFulfilled`, `dateUpdated`, `dateFulfilled`, `trackingNumber`, `shipmentProvider`, `trackingURL`.
+  - Added `OrderFulfillment` entity with attributes: `siteID`, `orderID`, `fulfillmentID`, `statusKey`, `isFulfilled`, `dateUpdated`, `dateFulfilled`, `trackingNumber`, `shipmentProvider`, `providerName`, `trackingURL`.
 - @itsmeichigo 2026-04-07
   - Added `bookingDuration` attribute to `Product` entity.
   - Added `bookingDurationUnit` attribute to `Product` entity.

--- a/Modules/Sources/Storage/Model/OrderFulfillment+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/OrderFulfillment+CoreDataProperties.swift
@@ -16,6 +16,7 @@ extension OrderFulfillment {
     @NSManaged public var dateUpdated: Date?
     @NSManaged public var dateFulfilled: Date?
     @NSManaged public var trackingNumber: String?
+    @NSManaged public var providerName: String?
     @NSManaged public var shipmentProvider: String?
     @NSManaged public var trackingURL: String?
 

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 136.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 136.xcdatamodel/contents
@@ -352,6 +352,7 @@
         <attribute name="fulfillmentID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="isFulfilled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="orderID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="providerName" optional="YES" attributeType="String"/>
         <attribute name="shipmentProvider" optional="YES" attributeType="String"/>
         <attribute name="siteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="statusKey" optional="YES" attributeType="String"/>

--- a/Modules/Sources/Yosemite/Model/Storage/OrderFulfillment+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/OrderFulfillment+ReadOnlyConvertible.swift
@@ -18,6 +18,7 @@ extension Storage.OrderFulfillment: ReadOnlyConvertible {
         dateFulfilled = orderFulfillment.dateFulfilled
         trackingNumber = orderFulfillment.trackingNumber
         shipmentProvider = orderFulfillment.shipmentProvider
+        providerName = orderFulfillment.providerName
         trackingURL = orderFulfillment.trackingURL
     }
 
@@ -33,6 +34,7 @@ extension Storage.OrderFulfillment: ReadOnlyConvertible {
                                 dateFulfilled: dateFulfilled,
                                 trackingNumber: trackingNumber,
                                 shipmentProvider: shipmentProvider,
+                                providerName: providerName,
                                 trackingURL: trackingURL)
     }
 }

--- a/Modules/Tests/NetworkingTests/Mapper/OrderFulfillmentListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/OrderFulfillmentListMapperTests.swift
@@ -35,6 +35,7 @@ struct OrderFulfillmentListMapperTests {
         #expect(first.dateFulfilled == expectedDateFulfilled)
         #expect(first.trackingNumber == "1Z999AA10123456784")
         #expect(first.shipmentProvider == "ups")
+        #expect(first.providerName?.isEmpty != false)
         #expect(first.trackingURL == "https://www.ups.com/track?tracknum=1Z999AA10123456784")
 
         let second = try #require(fulfillments.last)
@@ -45,6 +46,7 @@ struct OrderFulfillmentListMapperTests {
         #expect(second.dateFulfilled == nil)
         #expect(second.trackingNumber == nil)
         #expect(second.shipmentProvider == nil)
+        #expect(second.providerName == nil)
         #expect(second.trackingURL == nil)
     }
 
@@ -62,6 +64,19 @@ struct OrderFulfillmentListMapperTests {
         #expect(first.status == "fulfilled")
         #expect(first.trackingNumber == "1Z999AA10123456784")
         #expect(first.shipmentProvider == "ups")
+    }
+
+    @Test func test_fulfillment_fields_are_properly_parsed_for_custom_provider() throws {
+        // Given
+        let fulfillments = try mapFulfillments(from: "order_fulfillment_list_custom_provider")
+
+        // Then
+        #expect(fulfillments.count == 1)
+
+        let first = try #require(fulfillments.first)
+        #expect(first.shipmentProvider == "other")
+        #expect(first.providerName == "Test custom provider name")
+        #expect(first.trackingNumber == "CUSTOM-12345")
     }
 
     @Test func test_fulfillment_fields_are_properly_parsed_for_empty_response() throws {

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/order_fulfillment_list.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/order_fulfillment_list.json
@@ -11,8 +11,9 @@
       { "id": 1, "key": "_date_fulfilled", "value": "2026-03-18 14:30:00" },
       { "id": 2, "key": "_tracking_number", "value": "1Z999AA10123456784" },
       { "id": 3, "key": "_shipment_provider", "value": "ups" },
-      { "id": 4, "key": "_tracking_url", "value": "https://www.ups.com/track?tracknum=1Z999AA10123456784" },
-      { "id": 5, "key": "_items", "value": [{"item_id": 456, "qty": 2}] }
+      { "id": 4, "key": "_provider_name", "value": "" },
+      { "id": 5, "key": "_tracking_url", "value": "https://www.ups.com/track?tracknum=1Z999AA10123456784" },
+      { "id": 6, "key": "_items", "value": [{"item_id": 456, "qty": 2}] }
     ]
   },
   {

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/order_fulfillment_list_custom_provider.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/order_fulfillment_list_custom_provider.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 42,
+    "entity_type": "WC_Order",
+    "entity_id": "123",
+    "status": "fulfilled",
+    "is_fulfilled": true,
+    "date_updated": "2026-03-18 21:00:00",
+    "date_deleted": null,
+    "meta_data": [
+      { "id": 1, "key": "_date_fulfilled", "value": "2026-03-18 14:30:00" },
+      { "id": 2, "key": "_tracking_number", "value": "CUSTOM-12345" },
+      { "id": 3, "key": "_shipment_provider", "value": "other" },
+      { "id": 4, "key": "_provider_name", "value": "Test custom provider name" },
+      { "id": 5, "key": "_tracking_url", "value": "https://example.com/track/CUSTOM-12345" }
+    ]
+  }
+]

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -2579,6 +2579,7 @@ final class MigrationTests: XCTestCase {
         fulfillment.setValue(true, forKey: "isFulfilled")
         fulfillment.setValue("1Z999AA10123456784", forKey: "trackingNumber")
         fulfillment.setValue("ups", forKey: "shipmentProvider")
+        fulfillment.setValue("Custom Provider", forKey: "providerName")
         fulfillment.setValue("https://ups.com/track", forKey: "trackingURL")
         fulfillment.setValue(Date(), forKey: "dateUpdated")
         fulfillment.setValue(Date(), forKey: "dateFulfilled")

--- a/Modules/Tests/YosemiteTests/Stores/OrderFulfillmentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderFulfillmentStoreTests.swift
@@ -74,6 +74,7 @@ final class OrderFulfillmentStoreTests: XCTestCase {
             XCTAssertEqual(storedFulfillment?.isFulfilled, true)
             XCTAssertEqual(storedFulfillment?.trackingNumber, "1Z999AA10123456784")
             XCTAssertEqual(storedFulfillment?.shipmentProvider, "ups")
+            XCTAssertEqual(storedFulfillment?.providerName, "")
             XCTAssertNotNil(storedFulfillment?.dateUpdated)
             XCTAssertNotNil(storedFulfillment?.dateFulfilled)
 


### PR DESCRIPTION
## Description
Add support for the `_provider_name` metadata field in `OrderFulfillment`.

When a user selects a shipping provider from the predefined list, `_shipment_provider` contains the provider slug and `_provider_name` is empty. However, when the user selects "other" and specifies a custom provider name, `_shipment_provider` is set to `"other"` and `_provider_name` contains the user-provided name.

This PR adds the `providerName` field across all layers (Networking model, CoreData entity, Yosemite mapping) so the custom provider name is properly parsed, persisted, and available to the UI.

Builds on top of #16896.

## Test Steps
1. Verify the app builds successfully
2. Run `OrderFulfillmentListMapperTests` — all tests should pass including the new custom provider test
3. Run `OrderFulfillmentStoreTests` — all tests should pass
4. Run `MigrationTests/test_migrating_from_135_to_136_adds_OrderFulfillment_entity` — should pass

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.