### PR TITLE
WOOMOB-1837: Update

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -9,7 +9,9 @@ import struct Yosemite.Order
 import struct Yosemite.POSCart
 import struct Yosemite.POSCartItem
 import struct Yosemite.POSCoupon
+import struct Yosemite.POSSimpleProduct
 import struct Yosemite.POSVariation
+import protocol Yosemite.POSOrderableItem
 import struct Yosemite.CouponsError
 import enum Yosemite.OrderAction
 import enum Yosemite.OrderUpdateField
@@ -32,6 +34,14 @@ enum SyncOrderStateError: Error {
     case syncFailure
 }
 
+/// Represents a cart item whose price was updated by the server during order sync.
+struct CartItemPriceUpdate {
+    /// The UUID of the cart's `PurchasableItem` whose price changed.
+    let cartItemID: UUID
+    /// The updated orderable item with the corrected price.
+    let updatedItem: POSOrderableItem
+}
+
 protocol PointOfSaleOrderControllerProtocol {
     var orderState: PointOfSaleInternalOrderState { get }
 
@@ -40,6 +50,10 @@ protocol PointOfSaleOrderControllerProtocol {
     func sendReceipt(recipientEmail: String) async throws
     func clearOrder()
     func collectCashPayment(changeDueAmount: String?) async throws
+
+    /// Compares cart item prices with the synced order's line items.
+    /// Returns updates for items whose server-side price differs from the local price.
+    func priceUpdates(for cart: Cart) -> [CartItemPriceUpdate]
 }
 
 @Observable final class PointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
@@ -129,6 +143,42 @@ protocol PointOfSaleOrderControllerProtocol {
         } catch {
             analytics.track(.pointOfSaleCashPaymentFailed)
             throw error
+        }
+    }
+
+    func priceUpdates(for cart: Cart) -> [CartItemPriceUpdate] {
+        guard let order else { return [] }
+
+        return cart.purchasableItems.compactMap { purchasableItem -> CartItemPriceUpdate? in
+            guard case .loaded(let orderableItem) = purchasableItem.state else { return nil }
+
+            // Find the matching order line item
+            guard let orderItem = order.items.first(where: { orderableItem.matches(orderItem: $0) }) else { return nil }
+
+            let orderPriceDecimal = orderItem.price
+            let orderPriceString = orderPriceDecimal.stringValue
+
+            // Update if the server price differs from the local price (compare as decimals to avoid string format mismatches)
+            if let simpleProduct = orderableItem as? POSSimpleProduct,
+               NSDecimalNumber(string: simpleProduct.price) != orderPriceDecimal {
+                let formattedPrice = currencyFormatter.formatAmount(orderPriceString, with: order.currency) ?? simpleProduct.formattedPrice
+                let updated = simpleProduct.copy(formattedPrice: formattedPrice, price: orderPriceString)
+                return CartItemPriceUpdate(cartItemID: purchasableItem.id, updatedItem: updated)
+            } else if let variation = orderableItem as? POSVariation,
+                      NSDecimalNumber(string: variation.price) != orderPriceDecimal {
+                let formattedPrice = currencyFormatter.formatAmount(orderPriceString, with: order.currency) ?? variation.formattedPrice
+                let updated = POSVariation(id: variation.id,
+                                           name: variation.name,
+                                           formattedPrice: formattedPrice,
+                                           price: orderPriceString,
+                                           productImageSource: variation.productImageSource,
+                                           productID: variation.productID,
+                                           variationID: variation.productVariationID,
+                                           parentProductName: variation.parentProductName)
+                return CartItemPriceUpdate(cartItemID: purchasableItem.id, updatedItem: updated)
+            }
+
+            return nil
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Models/Cart.swift
+++ b/Modules/Sources/PointOfSale/Models/Cart.swift
@@ -145,6 +145,21 @@ extension Cart {
         purchasableItems.removeAll(where: { $0.id == id })
     }
 
+    /// Updates cart item prices using server-provided corrections.
+    mutating func applyPriceUpdates(_ updates: [CartItemPriceUpdate]) {
+        for update in updates {
+            guard let index = purchasableItems.firstIndex(where: { $0.id == update.cartItemID }) else { continue }
+            let existing = purchasableItems[index]
+            purchasableItems[index] = PurchasableItem(
+                id: existing.id,
+                item: update.updatedItem,
+                title: existing.title,
+                subtitle: existing.subtitle,
+                quantity: existing.quantity
+            )
+        }
+    }
+
     var isEmpty: Bool {
         purchasableItems.isEmpty && coupons.isEmpty
     }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -453,7 +453,25 @@ extension PointOfSaleAggregateModel {
         })
         trackOrderSyncState(syncOrderResult)
         await removeMissingProductsFromCatalogAfterSync()
+        updateCartPricesFromOrderIfNeeded()
         await paymentModel.startPayment()
+    }
+
+    /// Updates cart item prices if the server returned different prices during order sync,
+    /// and triggers an incremental catalog sync so the catalog reflects the corrected prices.
+    private func updateCartPricesFromOrderIfNeeded() {
+        let updates = orderController.priceUpdates(for: cart)
+        guard !updates.isEmpty else { return }
+
+        cart.applyPriceUpdates(updates)
+        DDLogInfo("💰 Updated \(updates.count) cart item price(s) from order response")
+
+        // Prices changed — the local catalog is stale, trigger an incremental sync
+        guard let catalogSyncCoordinator else { return }
+        let siteID = siteID
+        Task {
+            try? await catalogSyncCoordinator.performIncrementalSync(for: siteID)
+        }
     }
 
     /// Removes unavailable products from the local catalog after detecting them during order sync

--- a/Modules/Sources/PointOfSale/Utils/PointOfSalePreviewOrderController.swift
+++ b/Modules/Sources/PointOfSale/Utils/PointOfSalePreviewOrderController.swift
@@ -25,5 +25,7 @@ class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
     func clearOrder() { }
 
     func collectCashPayment(changeDueAmount: String?) async throws {}
+
+    func priceUpdates(for cart: Cart) -> [CartItemPriceUpdate] { [] }
 }
 #endif

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -749,7 +749,7 @@ struct PointOfSaleOrderControllerTests {
     }
 
     @MainActor
-    @Test func priceUpdates_when_simple_product_price_changed_returns_update() async {
+    @Test func priceUpdates_when_simple_product_price_changed_returns_update() async throws {
         // Given
         let orderService = MockPOSOrderService()
         let sut = PointOfSaleOrderController(orderService: orderService,
@@ -769,12 +769,12 @@ struct PointOfSaleOrderControllerTests {
         // Then
         #expect(updates.count == 1)
         #expect(updates.first?.cartItemID == cartItemID)
-        let updatedProduct = try? #require(updates.first?.updatedItem as? POSSimpleProduct)
-        #expect(updatedProduct?.price == "15")
+        let updatedProduct = try #require(updates.first?.updatedItem as? POSSimpleProduct)
+        #expect(updatedProduct.price == "15")
     }
 
     @MainActor
-    @Test func priceUpdates_when_variation_price_changed_returns_update() async {
+    @Test func priceUpdates_when_variation_price_changed_returns_update() async throws {
         // Given
         let orderService = MockPOSOrderService()
         let sut = PointOfSaleOrderController(orderService: orderService,
@@ -794,8 +794,8 @@ struct PointOfSaleOrderControllerTests {
         // Then
         #expect(updates.count == 1)
         #expect(updates.first?.cartItemID == cartItemID)
-        let updatedVariation = try? #require(updates.first?.updatedItem as? POSVariation)
-        #expect(updatedVariation?.price == "8")
+        let updatedVariation = try #require(updates.first?.updatedItem as? POSVariation)
+        #expect(updatedVariation.price == "8")
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -14,6 +14,8 @@ import protocol WooFoundation.Analytics
 import enum Networking.DotcomError
 import enum Networking.NetworkError
 import struct Yosemite.POSItemIdentifier
+import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
 
 struct PointOfSaleOrderControllerTests {
     let mockOrderService = MockPOSOrderService()
@@ -706,6 +708,95 @@ struct PointOfSaleOrderControllerTests {
             #expect(analytics.events.first(where: { $0.eventName == "cash_payment_failed" }) != nil)
         }
     }
+
+    // MARK: - Price Updates
+
+    @MainActor
+    @Test func priceUpdates_when_no_order_returns_empty() {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: MockPOSOrderService(),
+                                             receiptSender: MockPOSReceiptSender(),
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+        let cart = Cart(purchasableItems: [makeSimpleProductCartItem(price: "10.00", productID: 1)])
+
+        // When
+        let updates = sut.priceUpdates(for: cart)
+
+        // Then
+        #expect(updates.isEmpty)
+    }
+
+    @MainActor
+    @Test func priceUpdates_when_prices_match_returns_empty() async {
+        // Given
+        let orderService = MockPOSOrderService()
+        let sut = PointOfSaleOrderController(orderService: orderService,
+                                             receiptSender: MockPOSReceiptSender(),
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+        let product = makeSimpleProduct(price: "10.00", productID: 1)
+        let cartItem = Cart.PurchasableItem(id: UUID(), item: product, title: product.name, subtitle: nil, quantity: 1)
+        let orderItem = OrderItem.fake().copy(productID: 1, quantity: 1, price: NSDecimalNumber(string: "10.00"))
+        orderService.orderToReturn = Order.fake().copy(items: [orderItem])
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem]), retryHandler: {})
+
+        // When
+        let updates = sut.priceUpdates(for: Cart(purchasableItems: [cartItem]))
+
+        // Then
+        #expect(updates.isEmpty)
+    }
+
+    @MainActor
+    @Test func priceUpdates_when_simple_product_price_changed_returns_update() async {
+        // Given
+        let orderService = MockPOSOrderService()
+        let sut = PointOfSaleOrderController(orderService: orderService,
+                                             receiptSender: MockPOSReceiptSender(),
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+        let product = makeSimpleProduct(price: "10.00", productID: 42)
+        let cartItemID = UUID()
+        let cartItem = Cart.PurchasableItem(id: cartItemID, item: product, title: product.name, subtitle: nil, quantity: 1)
+        let orderItem = OrderItem.fake().copy(productID: 42, quantity: 1, price: NSDecimalNumber(string: "15.00"))
+        orderService.orderToReturn = Order.fake().copy(currency: "USD", items: [orderItem])
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem]), retryHandler: {})
+
+        // When
+        let updates = sut.priceUpdates(for: Cart(purchasableItems: [cartItem]))
+
+        // Then
+        #expect(updates.count == 1)
+        #expect(updates.first?.cartItemID == cartItemID)
+        let updatedProduct = try? #require(updates.first?.updatedItem as? POSSimpleProduct)
+        #expect(updatedProduct?.price == "15")
+    }
+
+    @MainActor
+    @Test func priceUpdates_when_variation_price_changed_returns_update() async {
+        // Given
+        let orderService = MockPOSOrderService()
+        let sut = PointOfSaleOrderController(orderService: orderService,
+                                             receiptSender: MockPOSReceiptSender(),
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+        let variation = makeVariation(price: "5.00", productID: 10, variationID: 20)
+        let cartItemID = UUID()
+        let cartItem = Cart.PurchasableItem(id: cartItemID, item: variation, title: variation.parentProductName, subtitle: variation.name, quantity: 1)
+        let orderItem = OrderItem.fake().copy(productID: 10, variationID: 20, quantity: 1, price: NSDecimalNumber(string: "8.00"))
+        orderService.orderToReturn = Order.fake().copy(currency: "USD", items: [orderItem])
+        await sut.syncOrder(for: Cart(purchasableItems: [cartItem]), retryHandler: {})
+
+        // When
+        let updates = sut.priceUpdates(for: Cart(purchasableItems: [cartItem]))
+
+        // Then
+        #expect(updates.count == 1)
+        #expect(updates.first?.cartItemID == cartItemID)
+        let updatedVariation = try? #require(updates.first?.updatedItem as? POSVariation)
+        #expect(updatedVariation?.price == "8")
+    }
 }
 
 private func makeItem(name: String = "",
@@ -719,6 +810,36 @@ private func makeItem(name: String = "",
                  title: name,
                  subtitle: nil,
                  quantity: quantity)
+}
+
+private func makeSimpleProduct(price: String, productID: Int64) -> POSSimpleProduct {
+    POSSimpleProduct(
+        id: POSItemIdentifier(underlyingType: .product, itemID: productID),
+        name: "Product \(productID)",
+        formattedPrice: "$\(price)",
+        productID: productID,
+        price: price,
+        manageStock: false,
+        stockQuantity: nil,
+        stockStatusKey: "instock"
+    )
+}
+
+private func makeSimpleProductCartItem(price: String, productID: Int64) -> Cart.PurchasableItem {
+    let product = makeSimpleProduct(price: price, productID: productID)
+    return Cart.PurchasableItem(id: UUID(), item: product, title: product.name, subtitle: nil, quantity: 1)
+}
+
+private func makeVariation(price: String, productID: Int64, variationID: Int64) -> POSVariation {
+    POSVariation(
+        id: POSItemIdentifier(underlyingType: .variation, itemID: variationID),
+        name: "Variation \(variationID)",
+        formattedPrice: "$\(price)",
+        price: price,
+        productID: productID,
+        variationID: variationID,
+        parentProductName: "Parent \(productID)"
+    )
 }
 
 // MARK: - Mock Currency Settings Provider

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleOrderController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleOrderController.swift
@@ -45,4 +45,9 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
             throw sendReceiptErrorToThrow
         }
     }
+
+    var priceUpdatesToReturn: [CartItemPriceUpdate] = []
+    func priceUpdates(for cart: Cart) -> [CartItemPriceUpdate] {
+        priceUpdatesToReturn
+    }
 }

--- a/Modules/Tests/PointOfSaleTests/Models/CartTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/CartTests.swift
@@ -1,0 +1,104 @@
+import Testing
+import Foundation
+
+@testable import PointOfSale
+import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
+import struct Yosemite.POSItemIdentifier
+
+struct CartTests {
+    @Test func applyPriceUpdates_when_price_changed_then_updates_cart_item() {
+        // Given
+        let product = POSSimpleProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Widget",
+            formattedPrice: "$10.00",
+            productID: 1,
+            price: "10.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock"
+        )
+        let cartItemID = UUID()
+        var cart = Cart(purchasableItems: [
+            Cart.PurchasableItem(id: cartItemID, item: product, title: "Widget", subtitle: nil, quantity: 2)
+        ])
+
+        let updatedProduct = POSSimpleProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Widget",
+            formattedPrice: "$15.00",
+            productID: 1,
+            price: "15.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock"
+        )
+
+        // When
+        cart.applyPriceUpdates([CartItemPriceUpdate(cartItemID: cartItemID, updatedItem: updatedProduct)])
+
+        // Then
+        let item = cart.purchasableItems.first
+        #expect(item?.formattedPrice == "$15.00")
+        #expect(item?.quantity == 2)
+        #expect(item?.title == "Widget")
+    }
+
+    @Test func applyPriceUpdates_when_no_matching_id_then_cart_unchanged() {
+        // Given
+        let product = POSSimpleProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Widget",
+            formattedPrice: "$10.00",
+            productID: 1,
+            price: "10.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock"
+        )
+        var cart = Cart(purchasableItems: [
+            Cart.PurchasableItem(id: UUID(), item: product, title: "Widget", subtitle: nil, quantity: 1)
+        ])
+
+        let updatedProduct = POSSimpleProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Widget",
+            formattedPrice: "$15.00",
+            productID: 1,
+            price: "15.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock"
+        )
+
+        // When — update targets a non-existent cart item ID
+        cart.applyPriceUpdates([CartItemPriceUpdate(cartItemID: UUID(), updatedItem: updatedProduct)])
+
+        // Then
+        #expect(cart.purchasableItems.first?.formattedPrice == "$10.00")
+    }
+
+    @Test func applyPriceUpdates_when_empty_updates_then_cart_unchanged() {
+        // Given
+        let product = POSSimpleProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+            name: "Widget",
+            formattedPrice: "$10.00",
+            productID: 1,
+            price: "10.00",
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "instock"
+        )
+        var cart = Cart(purchasableItems: [
+            Cart.PurchasableItem(id: UUID(), item: product, title: "Widget", subtitle: nil, quantity: 1)
+        ])
+
+        // When
+        cart.applyPriceUpdates([])
+
+        // Then
+        #expect(cart.purchasableItems.first?.formattedPrice == "$10.00")
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -884,6 +884,137 @@ struct PointOfSaleAggregateModelTests {
         }
     }
 
+    @MainActor struct PriceUpdateTests {
+        private let cardPresentPaymentService = MockCardPresentPaymentService()
+        private let orderController = MockPointOfSaleOrderController()
+
+        init() {
+            orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$15.00", orderTotalDecimal: 15)
+        }
+
+        @Test func checkOut_when_prices_changed_then_updates_cart_items() async {
+            // Given
+            let product = POSSimpleProduct(
+                id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+                name: "Test Product",
+                formattedPrice: "$10.00",
+                productID: 1,
+                price: "10.00",
+                manageStock: false,
+                stockQuantity: nil,
+                stockStatusKey: "instock"
+            )
+            let updatedProduct = POSSimpleProduct(
+                id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+                name: "Test Product",
+                formattedPrice: "$15.00",
+                productID: 1,
+                price: "15.00",
+                manageStock: false,
+                stockQuantity: nil,
+                stockStatusKey: "instock"
+            )
+
+            let sut = makePointOfSaleAggregateModel(
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController)
+            sut.addToCart(.simpleProduct(product))
+
+            let cartItemID = sut.cart.purchasableItems.first!.id
+            orderController.priceUpdatesToReturn = [
+                CartItemPriceUpdate(cartItemID: cartItemID, updatedItem: updatedProduct)
+            ]
+
+            // When
+            await sut.checkOut()
+
+            // Then
+            let updatedItem = sut.cart.purchasableItems.first
+            #expect(updatedItem?.formattedPrice == "$15.00")
+        }
+
+        @Test func checkOut_when_prices_changed_then_triggers_incremental_sync() async {
+            // Given
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            let product = POSSimpleProduct(
+                id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+                name: "Test Product",
+                formattedPrice: "$10.00",
+                productID: 1,
+                price: "10.00",
+                manageStock: false,
+                stockQuantity: nil,
+                stockStatusKey: "instock"
+            )
+            let updatedProduct = POSSimpleProduct(
+                id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+                name: "Test Product",
+                formattedPrice: "$15.00",
+                productID: 1,
+                price: "15.00",
+                manageStock: false,
+                stockQuantity: nil,
+                stockStatusKey: "instock"
+            )
+
+            let sut = makePointOfSaleAggregateModel(
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController,
+                siteID: 789,
+                catalogSyncCoordinator: coordinator)
+            sut.addToCart(.simpleProduct(product))
+
+            let cartItemID = sut.cart.purchasableItems.first!.id
+            orderController.priceUpdatesToReturn = [
+                CartItemPriceUpdate(cartItemID: cartItemID, updatedItem: updatedProduct)
+            ]
+
+            // When
+            await withCheckedContinuation { continuation in
+                var resumed = false
+                coordinator.onPerformIncrementalSyncCalled = {
+                    if !resumed {
+                        continuation.resume()
+                        resumed = true
+                    }
+                }
+
+                Task {
+                    await sut.checkOut()
+                }
+            }
+
+            // Then
+            #expect(coordinator.performIncrementalSyncSiteID == 789)
+        }
+
+        @Test func checkOut_when_prices_unchanged_then_does_not_trigger_incremental_sync() async {
+            // Given
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            let sut = makePointOfSaleAggregateModel(
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController,
+                siteID: 789,
+                catalogSyncCoordinator: coordinator)
+            sut.addToCart(makePurchasableItem())
+
+            // priceUpdatesToReturn defaults to empty
+            orderController.priceUpdatesToReturn = []
+
+            // When
+            await sut.checkOut()
+
+            // Allow any pending tasks to complete
+            try? await Task.sleep(nanoseconds: 100_000_000)
+
+            // Then — incremental sync count should only reflect the payment-success observation, not order creation
+            // Since payment hasn't succeeded yet, the count from checkOut price updates should be 0
+            // The initial smart sync may fire, so we check the site ID wasn't set by our price-change path
+            // by verifying the invocation count is 0 (no price-triggered sync)
+            #expect(coordinator.performIncrementalSyncInvocationCount == 0)
+        }
+    }
+
     @MainActor struct AnalyticsTests {
         private let analytics: MockPOSAnalytics
         private let cardPresentPaymentService = MockCardPresentPaymentService()

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,27 @@
+Closes WOOMOB-1837
+
+## Description
+When a POS order is created and a product's price has changed since the last catalog sync, the API returns the correct totals but the cart UI still shows the old price. This PR fixes the stale price display by:
+
+1. **Updating cart item prices from the order response** — After order creation, compares each cart item's price with the corresponding order line item's price (using decimal comparison to avoid string format mismatches). If the server returned a different price, the cart item is updated with the corrected price and formatted amount.
+
+2. **Triggering an incremental catalog sync when prices differ** — Only when a price mismatch is detected, an incremental catalog sync is kicked off so the local catalog reflects the corrected prices. This ensures consistency if the merchant edits the order or starts a new one.
+
+### Key changes
+- `PointOfSaleOrderController.priceUpdates(for:)` — new method that compares cart item prices with the synced order's line items and returns updates for items whose server-side price differs
+- `Cart.applyPriceUpdates(_:)` — new mutation that applies price corrections to cart items
+- `PointOfSaleAggregateModel.checkOut()` — wired up to apply price updates after order sync, with conditional incremental sync
+
+## Test Steps
+1. Set up a WooCommerce store with POS enabled and a product priced at $10
+2. Open POS, add the product to the cart, and check out
+3. While the POS is open, change the product price to $15 in wp-admin
+4. Go back to POS, start a new order, add the same product
+5. Check out — verify the cart updates to show $15 after order creation
+6. Verify the catalog also reflects the new price for subsequent orders
+
+## Screenshots
+N/A — no visual UI changes, behavior-only fix.
+
+---
+- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


### PR DESCRIPTION
Closes WOOMOB-1837

## Description
When a POS order is created and a product's price has changed since the last catalog sync, the API returns the correct totals but the cart UI still shows the old price. This PR fixes the stale price display by:

1. **Updating cart item prices from the order response** — After order creation, compares each cart item's price with the corresponding order line item's price (using decimal comparison to avoid string format mismatches). If the server returned a different price, the cart item is updated with the corrected price and formatted amount.

2. **Triggering an incremental catalog sync when prices differ** — Only when a price mismatch is detected, an incremental catalog sync is kicked off so the local catalog reflects the corrected prices. This ensures consistency if the merchant edits the order or starts a new one.

### Key changes
- `PointOfSaleOrderController.priceUpdates(for:)` — new method that compares cart item prices with the synced order's line items and returns updates for items whose server-side price differs
- `Cart.applyPriceUpdates(_:)` — new mutation that applies price corrections to cart items
- `PointOfSaleAggregateModel.checkOut()` — wired up to apply price updates after order sync, with conditional incremental sync

## Test Steps
1. Set up a WooCommerce store with POS enabled and a product priced at $10
2. Open POS, add the product to the cart, and check out
3. While the POS is open, change the product price to $15 in wp-admin
4. Go back to POS, start a new order, add the same product
5. Check out — verify the cart updates to show $15 after order creation
6. Verify the catalog also reflects the new price for subsequent orders

## Screenshots
N/A — no visual UI changes, behavior-only fix.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.