### PR TITLE
Fix thread-safety crash in MockAnalyticsProvider

### DIFF
--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -6,8 +6,22 @@ import XCTest
 import Testing
 
 public class MockAnalyticsProvider: NSObject, AnalyticsProvider, WPAnalyticsTracker {
-    var receivedEvents = [String]()
-    var receivedProperties = [[AnyHashable: Any]]()
+    private let lock = NSLock()
+
+    private var _receivedEvents = [String]()
+    var receivedEvents: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _receivedEvents
+    }
+
+    private var _receivedProperties = [[AnyHashable: Any]]()
+    var receivedProperties: [[AnyHashable: Any]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _receivedProperties
+    }
+
     var userID: String?
     var userOptedIn = true
 }
@@ -25,15 +39,19 @@ public extension MockAnalyticsProvider {
     }
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
-        receivedEvents.append(eventName)
+        lock.lock()
+        _receivedEvents.append(eventName)
         if let properties = properties {
-            receivedProperties.append(properties)
+            _receivedProperties.append(properties)
         }
+        lock.unlock()
     }
 
     func clearEvents() {
-        receivedEvents.removeAll()
-        receivedProperties.removeAll()
+        lock.lock()
+        _receivedEvents.removeAll()
+        _receivedProperties.removeAll()
+        lock.unlock()
     }
 
     func clearUsers() {


### PR DESCRIPTION
## Description
`MockAnalyticsProvider`'s `receivedEvents` and `receivedProperties` arrays were being mutated from multiple threads without synchronization, causing crashes on CI (e.g., `test_no_announcement_to_display_when_no_announcements_are_synced` crashing at `MockAnalyticsProvider.track(_:withProperties:)`).

This happens because `DashboardViewModel.init` creates many child view models that fire off async `Task` blocks during initialization, and those tasks track analytics events concurrently from different threads. The unsynchronized `append` calls on plain Swift arrays cause `EXC_BAD_ACCESS`.

The fix adds an `NSLock` to synchronize all reads and writes to the mutable arrays.

## Test Steps
1. Run `DashboardViewModelTests` — all tests should pass without crashes.
2. Run the full test suite — no crashes at `MockAnalyticsProvider.track`.
3. CI should pass.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.