### PR TITLE
Avoid logout when application password generation fails

### DIFF
--- a/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -23,6 +23,9 @@ public protocol ApplicationPasswordUseCase {
     ///
     var applicationPassword: ApplicationPassword? { get }
 
+    /// Whether the use case is capable of re-generating password
+    var canRegenerateApplicationPassword: Bool { get }
+
     /// Generates new ApplicationPassword
     ///
     /// - Returns: Generated `ApplicationPassword` instance
@@ -126,6 +129,9 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
     public var applicationPassword: ApplicationPassword? {
         storage.applicationPassword
     }
+
+    /// Whether the use case is capable of re-generating password
+    public var canRegenerateApplicationPassword: Bool { true }
 
     /// Generates new ApplicationPassword
     ///

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/OneTimeApplicationPasswordUseCase.swift
@@ -13,6 +13,9 @@ extension URLSession: URLSessionProtocol {}
 final public class OneTimeApplicationPasswordUseCase: ApplicationPasswordUseCase {
     public let applicationPassword: ApplicationPassword?
 
+    /// Whether the use case is capable of re-generating password
+    public var canRegenerateApplicationPassword: Bool { false }
+
     private let siteAddress: String
     private let session: URLSessionProtocol
     private let storage: ApplicationPasswordStorageType

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestAuthenticator.swift
@@ -117,7 +117,7 @@ public struct DefaultRequestAuthenticator: RequestAuthenticator {
         guard let applicationPasswordUseCase else {
             return false
         }
-        return applicationPasswordUseCase is DefaultApplicationPasswordUseCase
+        return applicationPasswordUseCase.canRegenerateApplicationPassword
     }
 
     /// Generates application password

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestAuthenticator.swift
@@ -19,6 +19,9 @@ protocol RequestAuthenticator {
     ///
     func authenticate(_ urlRequest: URLRequest) throws -> URLRequest
 
+    /// Checks whether app password generation is possible
+    func canGenerateApplicationPassword() -> Bool
+
     /// Generates application password
     ///
     func generateApplicationPassword() async throws
@@ -107,6 +110,14 @@ public struct DefaultRequestAuthenticator: RequestAuthenticator {
         } else {
             return try authenticateUsingWPCOMTokenIfPossible(urlRequest)
         }
+    }
+
+    /// Checks whether app password generation is possible
+    func canGenerateApplicationPassword() -> Bool {
+        guard let applicationPasswordUseCase else {
+            return false
+        }
+        return applicationPasswordUseCase is DefaultApplicationPasswordUseCase
     }
 
     /// Generates application password

--- a/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
+++ b/Modules/Sources/NetworkingCore/ApplicationPassword/RequestProcessor.swift
@@ -55,7 +55,7 @@ extension RequestProcessor: RequestRetrier {
 
         let shouldRetryRequest = state.shouldRetry(urlRequest)
 
-        guard shouldRetryRequest else {
+        guard shouldRetryRequest, state.authenticator.canGenerateApplicationPassword() else {
             completion(.doNotRetry)
             return
         }

--- a/Modules/Sources/Yosemite/Base/StoresManager.swift
+++ b/Modules/Sources/Yosemite/Base/StoresManager.swift
@@ -94,10 +94,6 @@ public protocol StoresManager {
     ///
     func updateDefaultRoles(_ roles: [User.Role])
 
-    /// Deauthenticates upon receiving `ApplicationPasswordsGenerationFailed` notification
-    ///
-    func listenToApplicationPasswordGenerationFailureNotification()
-
     /// De-authenticates upon receiving `RemoteDidReceiveInvalidTokenError` notification
     ///
     func listenToWPCOMInvalidWPCOMTokenNotification()

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -558,6 +558,10 @@ private class MockRequestAuthenticator: RequestAuthenticator {
         return urlRequest
     }
 
+    func canGenerateApplicationPassword() -> Bool {
+        return true
+    }
+
     func generateApplicationPassword() async throws {
         generateApplicationPasswordCalled = true
         if let mockErrorWhileGeneratingPassword {

--- a/Modules/Tests/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/DefaultRequestAuthenticatorTests.swift
@@ -226,6 +226,8 @@ private final class MockApplicationPasswordUseCase: ApplicationPasswordUseCase {
         mockApplicationPassword
     }
 
+    var canRegenerateApplicationPassword: Bool { true }
+
     func generateNewPassword() async throws -> Networking.ApplicationPassword {
         if let mockGeneratedPassword {
             // Store the newly generated password

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -408,9 +408,7 @@ extension AppDelegate {
     ///
     private func listenToAuthenticationFailureNotifications() {
         let stores = ServiceLocator.stores
-        if stores.isAuthenticatedWithoutWPCom {
-            stores.listenToApplicationPasswordGenerationFailureNotification()
-        } else {
+        if stores.isAuthenticatedWithoutWPCom == false {
             stores.listenToWPCOMInvalidWPCOMTokenNotification()
         }
     }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -30,10 +30,6 @@ class DefaultStoresManager: StoresManager {
     ///
     private lazy var keychain = Keychain(service: WooConstants.keychainServiceName)
 
-    /// Observes application password generation failure notification
-    ///
-    private var applicationPasswordGenerationFailureObserver: NSObjectProtocol?
-
     /// Observes invalid WPCOM token notification
     ///
     private var invalidWPCOMTokenNotificationObserver: NSObjectProtocol?
@@ -206,25 +202,13 @@ class DefaultStoresManager: StoresManager {
 
         if case .wpcom = credentials {
             listenToWPCOMInvalidWPCOMTokenNotification()
-            applicationPasswordGenerationFailureObserver = nil
             startObservingNetworkNotifications()
         } else {
-            listenToApplicationPasswordGenerationFailureNotification()
             invalidWPCOMTokenNotificationObserver = nil
             stopObservingNetworkNotifications()
         }
 
         return self
-    }
-
-    /// De-authenticates upon receiving `ApplicationPasswordsGenerationFailed` notification
-    ///
-    func listenToApplicationPasswordGenerationFailureNotification() {
-        applicationPasswordGenerationFailureObserver = notificationCenter.addObserver(forName: .ApplicationPasswordsGenerationFailed,
-                                                                                      object: nil,
-                                                                                      queue: .main) { [weak self] note in
-            _ = self?.deauthenticate()
-        }
     }
 
     /// De-authenticates upon receiving `RemoteDidReceiveInvalidTokenError` notification
@@ -303,7 +287,6 @@ class DefaultStoresManager: StoresManager {
             _ = currentState
         }
 
-        applicationPasswordGenerationFailureObserver = nil
         invalidWPCOMTokenNotificationObserver = nil
         stopObservingNetworkNotifications()
         trackedEligibleSites.removeAll()

--- a/WooCommerce/WooCommerceTests/Authentication/PostSiteCredentialLoginCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/PostSiteCredentialLoginCheckerTests.swift
@@ -244,6 +244,8 @@ private final class MockApplicationPasswordUseCase: ApplicationPasswordUseCase {
         mockApplicationPassword
     }
 
+    var canRegenerateApplicationPassword: Bool { true }
+
     func generateNewPassword() async throws -> Networking.ApplicationPassword {
         if let mockGeneratedPassword {
             // Store the newly generated password

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -459,26 +459,6 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.numberOfTimesWriteWithAITooltipIsShown])
     }
 
-    /// Verifies that user is logged out when application password regeneration fails if authenticated with wpcom
-    ///
-    func test_it_does_not_deauthenticate_upon_receiving_application_password_generation_failure_notification_when_authenticated_with_wpcom() {
-        // Given
-        let manager = DefaultStoresManager.testingInstance
-        var isLoggedInValues = [Bool]()
-        cancellable = manager.isLoggedInPublisher.sink { isLoggedIn in
-            isLoggedInValues.append(isLoggedIn)
-        }
-        manager.authenticate(credentials: SessionSettings.wpcomCredentials)
-
-        // When
-        let error = ApplicationPasswordUseCaseError.unauthorizedRequest
-        MockNotificationCenter.testingInstance.post(name: .ApplicationPasswordsGenerationFailed, object: error, userInfo: nil)
-
-        // Assert
-        XCTAssertTrue(manager.isAuthenticated)
-        XCTAssertEqual(isLoggedInValues, [false, true])
-    }
-
     /// Verifies that user is logged out when WPCOM token expires
     ///
     func test_it_deauthenticates_upon_receiving_invalid_token_error_notification() {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -459,27 +459,6 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.numberOfTimesWriteWithAITooltipIsShown])
     }
 
-    /// Verifies that user is logged out when application password regeneration fails if authenticated with wporg
-    ///
-    @MainActor
-    func test_it_deauthenticates_upon_receiving_application_password_generation_failure_notification_when_authenticated_without_wpcom() {
-        // Given
-        let manager = DefaultStoresManager.testingInstance
-        var isLoggedInValues = [Bool]()
-        cancellable = manager.isLoggedInPublisher.sink { isLoggedIn in
-            isLoggedInValues.append(isLoggedIn)
-        }
-        manager.authenticate(credentials: SessionSettings.wporgCredentials)
-
-        // When
-        let error = ApplicationPasswordUseCaseError.unauthorizedRequest
-        MockNotificationCenter.testingInstance.post(name: .ApplicationPasswordsGenerationFailed, object: error, userInfo: nil)
-
-        // Assert
-        XCTAssertFalse(manager.isAuthenticated)
-        XCTAssertEqual(isLoggedInValues, [false, true, false])
-    }
-
     /// Verifies that user is logged out when application password regeneration fails if authenticated with wpcom
     ///
     func test_it_does_not_deauthenticate_upon_receiving_application_password_generation_failure_notification_when_authenticated_with_wpcom() {


### PR DESCRIPTION
Closes WOOMOB-2653

## Description

When a user logs in via web view application password authorization, a later 401 from a plugin (e.g. Google Ads `GOOGLE_DISCONNECTED`) triggers the app to regenerate the application password. Since regeneration is not supported for web view–created passwords, this fails and automatically logs the user out.

This PR fixes the issue in two ways:

1. **Skip password regeneration when unsupported** — `RequestProcessor` now checks `canGenerateApplicationPassword()` before retrying. This returns `false` when the password was obtained through web view authorization (i.e., not via `DefaultApplicationPasswordUseCase`).

2. **Remove automatic logout on generation failure** — The `ApplicationPasswordsGenerationFailed` notification observer that called `deauthenticate()` has been removed entirely. Instead of silently logging users out, the failed request simply won't be retried.

## Test Steps

1. Log in with a site that uses web view application password authorization. You can force this by adding a captcha to your site's login page.
2. Trigger a 401 from a plugin response (or simulate one). 
3. Verify the app does **not** log the user out.
4. Verify the app continues to function normally.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.