### PR TITLE
Fix Connectivity Tool Jetpack check for shop manager users

### DIFF
--- a/.claude/rules/swift-style.md
+++ b/.claude/rules/swift-style.md
@@ -17,6 +17,7 @@ These rules are enforced by SwiftLint (see `.swiftlint.yml` for the full configu
 - Use the most restrictive access level possible
 - Mark classes `final` unless designed for subclassing
 - Prefer `private` over `fileprivate`
+- Prefer immutable properties for external access — use `private(set)` for properties that need to be mutable internally but read-only externally, and `let` over `var` whenever possible
 
 ## Naming
 - Protocols for a single type: append `Protocol` (e.g., `ProductsRemoteProtocol`)

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/system-status-with-jetpack-active.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/system-status-with-jetpack-active.json
@@ -1,0 +1,69 @@
+{
+  "data": {
+    "inactive_plugins": [],
+    "active_plugins":[
+      {
+        "plugin": "woocommerce/woocommerce.php",
+        "name": "WooCommerce",
+        "version": "10.0.0-dev",
+        "version_latest": "10.0.0-dev",
+        "url": "https://woocommerce.com/",
+        "author_name": "Automattic",
+        "author_url": "https://woocommerce.com",
+        "network_activated": false
+      },
+      {
+        "plugin": "jetpack/jetpack.php",
+        "name": "Jetpack",
+        "version": "14.0",
+        "version_latest": "14.0",
+        "url": "https://jetpack.com/",
+        "author_name": "Automattic",
+        "author_url": "https://automattic.com",
+        "network_activated": false
+      }
+    ],
+    "settings": {
+      "api_enabled": false,
+      "force_ssl": false,
+      "currency": "USD",
+      "currency_symbol": "&#36;",
+      "currency_position": "left",
+      "thousand_separator": ",",
+      "decimal_separator": ".",
+      "number_of_decimals": 2,
+      "geolocation_enabled": false,
+      "taxonomies": {
+        "external": "external",
+        "grouped": "grouped",
+        "simple": "simple",
+        "variable": "variable"
+      },
+      "product_visibility_terms": {
+        "exclude-from-catalog": "exclude-from-catalog",
+        "exclude-from-search": "exclude-from-search",
+        "featured": "featured",
+        "outofstock": "outofstock",
+        "rated-1": "rated-1",
+        "rated-2": "rated-2",
+        "rated-3": "rated-3",
+        "rated-4": "rated-4",
+        "rated-5": "rated-5"
+      },
+      "woocommerce_com_connected": "no",
+      "enforce_approved_download_dirs": true,
+      "order_datastore": "Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\OrdersTableDataStore",
+      "HPOS_enabled": true,
+      "HPOS_sync_enabled": false,
+      "enabled_features": [
+        "analytics",
+        "marketplace",
+        "order_attribution",
+        "site_visibility_badge",
+        "remote_logging",
+        "email_improvements",
+        "custom_order_tables"
+      ]
+    }
+  }
+}

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -12,7 +12,7 @@ extension ConnectivityToolViewModel {
     @MainActor
     func testNotifications() async -> ConnectivityToolCard.ConnectivityState {
         // Sub-check 1: Jetpack plugin is active.
-        let jetpackResult = await checkJetpackPluginActiveIfNeeded()
+        let jetpackResult = checkJetpackPluginActiveIfNeeded()
         if case .failure = jetpackResult {
             DDLogError("Connectivity Tool: ❌ Jetpack plugin not found in active plugins")
             let setupJetpackAction = makeNotificationAction(.setupJetpack) { [weak self] in
@@ -68,22 +68,10 @@ extension ConnectivityToolViewModel {
         }
     }
 
-    /// Checks whether Jetpack is active using the active plugins from the system status report
-    /// (cached during the site connectivity test). This avoids calling `/wp/v2/plugins`,
-    /// which requires administrator-level permissions and fails for shop manager users.
+    /// Checks whether Jetpack is active using the cached system status report plugins.
     ///
-    @MainActor
-    func checkJetpackPluginActiveIfNeeded() async -> Result<Void, JetpackCheckError> {
-        /// WPCom and CIAB sites have Jetpack by default so skip this check
-        guard stores.sessionManager.defaultSite?.isWordPressComStore == false,
-              stores.sessionManager.defaultSite?.isCIAB == false else {
-            return .success(())
-        }
-
-        let jetpackSlug = "jetpack/"
-        let isJetpackActive = activeSystemPlugins.contains { $0.plugin.hasPrefix(jetpackSlug) }
-
-        if isJetpackActive {
+    func checkJetpackPluginActiveIfNeeded() -> Result<Void, JetpackCheckError> {
+        if isJetpackPluginActive {
             return .success(())
         } else {
             return .failure(.pluginNotActive)

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -32,7 +32,14 @@ extension ConnectivityToolViewModel {
             return .error(Localization.ErrorMessage.notificationsNotAuthorized, [openSettingsAction, retryAction(for: .notifications)])
         }
 
-        // Sub-check 3: Notification config — device registered and order notifications enabled.
+        // Sub-check 3: Notification config — only needed when the device is not registered
+        // for self-driven push notifications, which bypass WPCom notification settings.
+        let isRegisteredForSelfDrivenPN = pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID)
+        if isRegisteredForSelfDrivenPN {
+            DDLogInfo("Connectivity Tool: ✅ Site registered for self-driven push notifications, skipping WPCom config check")
+            return .success
+        }
+
         let configResult = await checkNotificationConfig()
         switch configResult {
         case .success:

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 import Yosemite
-import enum Networking.SitePluginStatusEnum
 import UserNotifications
 
 // MARK: - Notifications Check
@@ -14,21 +13,13 @@ extension ConnectivityToolViewModel {
     func testNotifications() async -> ConnectivityToolCard.ConnectivityState {
         // Sub-check 1: Jetpack plugin is active.
         let jetpackResult = await checkJetpackPluginActiveIfNeeded()
-        if case .failure(let error) = jetpackResult {
-            DDLogError("Connectivity Tool: ❌ Jetpack plugin check failed\n\(error)")
-            switch error {
-            case .pluginNotActive:
-                let setupJetpackAction = makeNotificationAction(.setupJetpack) { [weak self] in
-                    self?.shouldStartJetpackSetup = true
-                }
-                return .error(Localization.ErrorMessage.jetpackPluginNotActive,
-                              [setupJetpackAction, retryAction(for: .notifications)])
-            case .requestFailed(let underlyingError):
-                let technicalDetails = String(describing: underlyingError)
-                let viewDetailsAction = makeNotificationAction(.viewDetails, technicalDetails: technicalDetails)
-                return .error(Localization.ErrorMessage.notificationConfigCheckFailed,
-                              [viewDetailsAction, retryAction(for: .notifications)])
+        if case .failure = jetpackResult {
+            DDLogError("Connectivity Tool: ❌ Jetpack plugin not found in active plugins")
+            let setupJetpackAction = makeNotificationAction(.setupJetpack) { [weak self] in
+                self?.shouldStartJetpackSetup = true
             }
+            return .error(Localization.ErrorMessage.jetpackPluginNotActive,
+                          [setupJetpackAction, retryAction(for: .notifications)])
         }
 
         // Sub-check 2: iOS notification permission is authorized.
@@ -70,7 +61,9 @@ extension ConnectivityToolViewModel {
         }
     }
 
-    /// Authenticates and retrieves the Jetpack plugin details to verify it's active.
+    /// Checks whether Jetpack is active using the active plugins from the system status report
+    /// (cached during the site connectivity test). This avoids calling `/wp/v2/plugins`,
+    /// which requires administrator-level permissions and fails for shop manager users.
     ///
     @MainActor
     func checkJetpackPluginActiveIfNeeded() async -> Result<Void, JetpackCheckError> {
@@ -80,25 +73,13 @@ extension ConnectivityToolViewModel {
             return .success(())
         }
 
-        /// Authenticate the JetpackConnectionStore with current network.
-        if let siteURL {
-            stores.dispatch(JetpackConnectionAction.authenticate(siteURL: siteURL, network: network))
-        }
+        let jetpackSlug = "jetpack/"
+        let isJetpackActive = activeSystemPlugins.contains { $0.plugin.hasPrefix(jetpackSlug) }
 
-        return await withCheckedContinuation { continuation in
-            let action = JetpackConnectionAction.retrieveJetpackPluginDetails(siteID: siteID) { result in
-                switch result {
-                case .success(let plugin):
-                    if plugin.status == .active || plugin.status == .networkActive {
-                        continuation.resume(returning: .success(()))
-                    } else {
-                        continuation.resume(returning: .failure(.pluginNotActive(status: plugin.status)))
-                    }
-                case .failure(let error):
-                    continuation.resume(returning: .failure(.requestFailed(error)))
-                }
-            }
-            stores.dispatch(action)
+        if isJetpackActive {
+            return .success(())
+        } else {
+            return .failure(.pluginNotActive)
         }
     }
 
@@ -271,8 +252,7 @@ extension ConnectivityToolViewModel {
     /// Error types for the Jetpack plugin check.
     ///
     enum JetpackCheckError: Error {
-        case pluginNotActive(status: SitePluginStatusEnum)
-        case requestFailed(Error)
+        case pluginNotActive
     }
 
     /// Error types for the notification permission check.
@@ -308,9 +288,8 @@ private extension ConnectivityToolViewModel {
                 comment: "Message when iOS notification permission is denied in the connectivity tool"
             )
             static let deviceNotRegistered = NSLocalizedString(
-                "connectivityToolViewModel.errorMessage.deviceNotRegistered",
-                value: "Your device doesn't appear to be registered for push notifications.\n\n" +
-                "Try logging out and back in to re-register.",
+                "connectivityToolViewModel.errorMessage.deviceNotRegisteredForPN",
+                value: "Your device doesn't appear to be registered for push notifications.",
                 comment: "Message when the device is not registered for push notifications in the connectivity tool"
             )
             static let orderNotificationsDisabled = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -4,6 +4,7 @@ import UIKit
 import Yosemite
 import enum Networking.DotcomError
 import class Networking.AlamofireNetwork
+import protocol NetworkingCore.Network
 import class Networking.AnnouncementsRemote
 import class Networking.SystemStatusRemote
 import class Networking.OrdersRemote
@@ -68,21 +69,28 @@ final class ConnectivityToolViewModel {
 
     /// Active plugins from the system status report, cached after the site connectivity test.
     /// Used by the notification check to verify Jetpack is active without calling `/wp/v2/plugins`.
-    /// Internal for testability via `@testable import`.
     ///
-    var activeSystemPlugins: [SystemPlugin] = []
+    private var activeSystemPlugins: [SystemPlugin] = []
+
+    /// Whether Jetpack is among the active plugins from the system status report.
+    /// Populated after the site connectivity test. Internal for testability.
+    ///
+    var isJetpackPluginActive: Bool {
+        activeSystemPlugins.contains { $0.plugin.hasPrefix(Constants.jetpackPluginSlug) }
+    }
 
     private var latestTestResult: [ConnectivityTestResult] = []
 
-    let network: AlamofireNetwork
+    private let network: Network
 
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          userNotificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
-         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         network: Network? = nil) {
 
-        let network = AlamofireNetwork(credentials: session.defaultCredentials, selectedSite: nil, appPasswordSupportState: nil)
+        let network = network ?? AlamofireNetwork(credentials: session.defaultCredentials, selectedSite: nil, appPasswordSupportState: nil)
         self.network = network
         self.announcementsRemote = AnnouncementsRemote(network: network)
         self.systemStatusRemote = SystemStatusRemote(network: network)
@@ -668,6 +676,10 @@ private extension ConnectivityToolViewModel {
 }
 
 private extension ConnectivityToolViewModel {
+    enum Constants {
+        static let jetpackPluginSlug = "jetpack/"
+    }
+
     enum SystemImages: String {
         case retry = "arrow.clockwise"
         case readMore = "arrow.up.forward.app"

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -9,6 +9,7 @@ import class Networking.SystemStatusRemote
 import class Networking.OrdersRemote
 import class Networking.ProductsRemote
 import class Networking.UserAgent
+import struct Networking.SystemPlugin
 import protocol WooFoundation.Analytics
 
 final class ConnectivityToolViewModel {
@@ -64,6 +65,12 @@ final class ConnectivityToolViewModel {
     /// Site to be tested.
     ///
     let siteID: Int64
+
+    /// Active plugins from the system status report, cached after the site connectivity test.
+    /// Used by the notification check to verify Jetpack is active without calling `/wp/v2/plugins`.
+    /// Internal for testability via `@testable import`.
+    ///
+    var activeSystemPlugins: [SystemPlugin] = []
 
     private var latestTestResult: [ConnectivityTestResult] = []
 
@@ -242,8 +249,9 @@ final class ConnectivityToolViewModel {
                 guard let self else { return }
 
                 switch result {
-                case .success:
+                case .success(let report):
                     DDLogInfo("Connectivity Tool: ✅ Site connection")
+                    self.activeSystemPlugins = report.activePlugins
                 case .failure(let error):
                     DDLogError("Connectivity Tool: ❌ Site connection\n\(error)")
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -216,8 +216,7 @@ private extension SettingsViewModel {
         let configureSection: Section? = {
             var rows: [Row] = []
 
-            if stores.isAuthenticated,
-               stores.sessionManager.defaultSite?.isWordPressComStore == false {
+            if stores.isAuthenticated {
                 rows.append(.connectivity)
             }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -187,9 +187,9 @@ struct ConnectivityToolViewModelTests {
 
     // MARK: - testNotifications
 
-    @Test func test_testNotifications_when_wpcom_site_authorized_and_config_ok_then_returns_success() async {
+    @Test func test_testNotifications_when_jetpack_active_authorized_and_config_ok_then_returns_success() async {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake()
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
@@ -210,9 +210,16 @@ struct ConnectivityToolViewModelTests {
             }
         }
 
+        let mockNetwork = MockNetwork()
+        mockNetwork.simulateResponse(requestUrlSuffix: "system_status",
+                                     filename: "system-status-with-jetpack-active")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            pushNotesManager: mockPushNotesManager)
+                                            pushNotesManager: mockPushNotesManager,
+                                            network: mockNetwork)
+
+        // Populate activeSystemPlugins with Jetpack by running the site connectivity test.
+        _ = await sut.testSiteConnectivity()
 
         // When
         let result = await sut.testNotifications()
@@ -222,8 +229,8 @@ struct ConnectivityToolViewModelTests {
     }
 
     @Test func test_testNotifications_when_jetpack_not_active_then_returns_error_with_setup_jetpack_action() async {
-        // Given — self-hosted site (isWordPressComStore: false) with no Jetpack in active plugins
-        let site = Site.fake().copy(isWordPressComStore: false)
+        // Given — active plugins do not include Jetpack
+        let site = Site.fake()
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
@@ -255,17 +262,24 @@ struct ConnectivityToolViewModelTests {
     }
 
     @Test func test_testNotifications_when_permission_denied_then_returns_error_with_open_settings() async {
-        // Given — WPCom site to skip Jetpack check
-        let site = Site.fake().copy(isWordPressComStore: true)
+        // Given
+        let site = Site.fake()
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .denied
 
+        let mockNetwork = MockNetwork()
+        mockNetwork.simulateResponse(requestUrlSuffix: "system_status",
+                                     filename: "system-status-with-jetpack-active")
         let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            pushNotesManager: mockPushNotesManager)
+                                            pushNotesManager: mockPushNotesManager,
+                                            network: mockNetwork)
+
+        // Populate activeSystemPlugins with Jetpack by running the site connectivity test.
+        _ = await sut.testSiteConnectivity()
 
         // When
         let result = await sut.testNotifications()
@@ -280,16 +294,23 @@ struct ConnectivityToolViewModelTests {
 
     @Test func test_testNotifications_when_no_device_id_then_returns_device_not_registered_error() async {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake()
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .authorized
 
+        let mockNetwork = MockNetwork()
+        mockNetwork.simulateResponse(requestUrlSuffix: "system_status",
+                                     filename: "system-status-with-jetpack-active")
         let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: nil)
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            pushNotesManager: mockPushNotesManager)
+                                            pushNotesManager: mockPushNotesManager,
+                                            network: mockNetwork)
+
+        // Populate activeSystemPlugins with Jetpack by running the site connectivity test.
+        _ = await sut.testSiteConnectivity()
 
         // When
         let result = await sut.testNotifications()
@@ -304,7 +325,7 @@ struct ConnectivityToolViewModelTests {
 
     @Test func test_testNotifications_when_order_notifications_disabled_then_returns_error_with_enable_action() async {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake()
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
@@ -325,9 +346,16 @@ struct ConnectivityToolViewModelTests {
             }
         }
 
+        let mockNetwork = MockNetwork()
+        mockNetwork.simulateResponse(requestUrlSuffix: "system_status",
+                                     filename: "system-status-with-jetpack-active")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            pushNotesManager: mockPushNotesManager)
+                                            pushNotesManager: mockPushNotesManager,
+                                            network: mockNetwork)
+
+        // Populate activeSystemPlugins with Jetpack by running the site connectivity test.
+        _ = await sut.testSiteConnectivity()
 
         // When
         let result = await sut.testNotifications()
@@ -342,7 +370,7 @@ struct ConnectivityToolViewModelTests {
 
     @Test func test_testNotifications_when_config_request_fails_then_returns_error_with_technical_details() async {
         // Given
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let site = Site.fake()
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
@@ -358,10 +386,17 @@ struct ConnectivityToolViewModelTests {
             }
         }
 
+        let mockNetwork = MockNetwork()
+        mockNetwork.simulateResponse(requestUrlSuffix: "system_status",
+                                     filename: "system-status-with-jetpack-active")
         let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "789")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            pushNotesManager: mockPushNotesManager)
+                                            pushNotesManager: mockPushNotesManager,
+                                            network: mockNetwork)
+
+        // Populate activeSystemPlugins with Jetpack by running the site connectivity test.
+        _ = await sut.testSiteConnectivity()
 
         // When
         let result = await sut.testNotifications()

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -1,7 +1,6 @@
 import Testing
 import Foundation
 import Yosemite
-import enum Networking.SitePluginStatusEnum
 @testable import WooCommerce
 
 @MainActor
@@ -222,41 +221,20 @@ struct ConnectivityToolViewModelTests {
     }
 
     @Test func test_testNotifications_when_jetpack_not_active_then_returns_error_with_setup_jetpack_action() async {
-        // Given — self-hosted site (isWordPressComStore: false)
+        // Given — self-hosted site (isWordPressComStore: false) with no Jetpack in active plugins
         let site = Site.fake().copy(isWordPressComStore: false)
         let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
         let stores = MockStoresManager(sessionManager: session)
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .authorized
 
-        let inactivePlugin = SitePlugin(siteID: site.siteID,
-                                        plugin: "jetpack/jetpack",
-                                        status: .inactive,
-                                        name: "Jetpack",
-                                        pluginUri: "",
-                                        author: "",
-                                        authorUri: "",
-                                        descriptionRaw: "",
-                                        descriptionRendered: "",
-                                        version: "1.0",
-                                        networkOnly: false,
-                                        requiresWPVersion: "",
-                                        requiresPHPVersion: "",
-                                        textDomain: "")
-
-        stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
-            switch action {
-            case let .retrieveJetpackPluginDetails(_, completion):
-                completion(.success(inactivePlugin))
-            default:
-                break
-            }
-        }
-
         let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
                                             pushNotesManager: mockPushNotesManager)
+
+        // Simulate system status report with no Jetpack plugin in active plugins.
+        sut.activeSystemPlugins = []
 
         // When
         let result = await sut.testNotifications()

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import Yosemite
+@testable import Networking
 @testable import WooCommerce
 
 @MainActor
@@ -228,13 +229,19 @@ struct ConnectivityToolViewModelTests {
         let mockNotificationCenter = MockUserNotificationsCenterAdapter()
         mockNotificationCenter.authorizationStatus = .authorized
 
+        // Mock system status response with active plugins that don't include Jetpack.
+        let mockNetwork = MockNetwork()
+        mockNetwork.simulateResponse(requestUrlSuffix: "system_status",
+                                     filename: "system-status-wc-plugin-and-pos-feature-enabled")
+
         let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123")
         let sut = ConnectivityToolViewModel(session: session, stores: stores,
                                             userNotificationCenter: mockNotificationCenter,
-                                            pushNotesManager: mockPushNotesManager)
+                                            pushNotesManager: mockPushNotesManager,
+                                            network: mockNetwork)
 
-        // Simulate system status report with no Jetpack plugin in active plugins.
-        sut.activeSystemPlugins = []
+        // Populate activeSystemPlugins by running the site connectivity test.
+        _ = await sut.testSiteConnectivity()
 
         // When
         let result = await sut.testNotifications()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -341,18 +341,6 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.enablePushNotifications) })
     }
 
-    func test_sections_does_not_contain_connectivity_row_for_wpcom_site() {
-        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: true)
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
-        let viewModel = SettingsViewModel(stores: stores)
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
-    }
-
     func test_sections_contains_connectivity_row_if_user_authenticated_without_wpcom() {
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: false)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
@@ -365,7 +353,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
     }
 
-    func test_sections_contains_connectivity_row_if_user_authenticated_with_wpcom_to_non_wpcom_site() {
+    func test_sections_contains_connectivity_row_if_user_authenticated_with_wpcom() {
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true, isWordPressComStore: false)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores)


### PR DESCRIPTION
## Description

Fixes WOOMOB-2676

The notification check in the Connectivity Tool fails for "shop manager" users because `checkJetpackPluginActiveIfNeeded()` calls `/wp/v2/plugins` (via `JetpackConnectionAction.retrieveJetpackPluginDetails`), which requires administrator permissions.

This PR makes two changes:

1. **Use system status active plugins instead of `/wp/v2/plugins`**: The site connectivity test already fetches `/wc/v3/system_status` which includes active plugins as `SystemPlugin` objects. We now cache these and check for the Jetpack plugin prefix (`jetpack/`) instead of making a separate admin-only API call.

2. **Skip WPCom notification config check for self-driven push notifications**: If the site is already registered for self-driven push notifications (`siteIDsRegisteredForWooPNs`), the WPCom device registration and order notification settings check is unnecessary and is now skipped.

## Test Steps

1. Log in with a **shop manager** account on a self-hosted WooCommerce site with Jetpack active.
2. Navigate to **Settings > Troubleshooting > Connectivity Tool**.
3. Verify all checks pass, including the notification settings check.
4. Repeat with a site where Jetpack is **not** active — confirm the "Setup Jetpack" error action appears.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.