### PR TITLE
Improve store picker error message for server errors

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/DotcomError.swift
+++ b/Modules/Sources/NetworkingCore/Model/DotcomError.swift
@@ -19,7 +19,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
 
     /// Remote Request Failed
     ///
-    case requestFailed(data: [String: AnyDecodable]? = nil)
+    case requestFailed(message: String? = nil, data: [String: AnyDecodable]? = nil)
 
     /// No route was found matching the URL and request method
     ///
@@ -61,7 +61,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
         case Constants.invalidToken:
             self = .invalidToken(data: data)
         case Constants.requestFailed:
-            self = .requestFailed(data: data)
+            self = .requestFailed(message: message, data: data)
         case Constants.unauthorized where message == ErrorMessages.noStatsPermission:
             self = .noStatsPermission(data: data)
         case Constants.unauthorized:
@@ -121,7 +121,10 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Response Empty", comment: "WordPress.com Error thrown when the response body is empty")
         case .invalidToken:
             return NSLocalizedString("Dotcom Token Invalid", comment: "WordPress.com Invalid Token")
-        case .requestFailed:
+        case .requestFailed(let message, _):
+            if let message {
+                return "Dotcom Request Failed: \(message)"
+            }
             return NSLocalizedString("Dotcom Request Failed", comment: "WordPress.com Request Failure")
         case .unauthorized:
             return NSLocalizedString("Dotcom Missing Token", comment: "WordPress.com Missing Token")

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -193,7 +193,8 @@ struct StorePickerError_Preview: PreviewProvider {
 
         VStack {
             StorePickerError(errorType: .serverError,
-                             technicalDetails: "Status: 500\nError: http_request_failed\ncURL error 28: Operation timed out after 3001 milliseconds with 0 bytes received")
+                             technicalDetails: "Status: 500\nError: http_request_failed\n"
+                                + "cURL error 28: Operation timed out after 3001 milliseconds")
         }
         .padding()
         .background(Color.gray)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SafariServices
+import enum NetworkingCore.DotcomError
 
 /// Hosting controller wrapper for `StorePickerError`
 ///
@@ -7,8 +8,9 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
 
     /// Creates an `StorePickerErrorHostingController` with preconfigured button actions.
     ///
-    static func createWithActions(presenting: UIViewController) -> StorePickerErrorHostingController {
-        let viewController = StorePickerErrorHostingController()
+    static func createWithActions(presenting: UIViewController,
+                                  errorType: StorePickerErrorType = .generic) -> StorePickerErrorHostingController {
+        let viewController = StorePickerErrorHostingController(errorType: errorType)
         viewController.setActions(troubleshootingAction: {
             WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController)
         },
@@ -24,8 +26,8 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
         return viewController
     }
 
-    init() {
-        super.init(rootView: StorePickerError())
+    init(errorType: StorePickerErrorType = .generic) {
+        super.init(rootView: StorePickerError(errorType: errorType))
     }
 
     override func viewDidLoad() {
@@ -48,9 +50,55 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
     }
 }
 
+/// Categorizes the error shown in the store picker error screen.
+/// Extracted as a standalone type for testability.
+///
+enum StorePickerErrorType: Equatable {
+    /// The remote site returned a server error (HTTP 500) when verifying user permissions.
+    case serverError
+    /// Any other error (network issues, unknown errors, etc.)
+    case generic
+
+    /// Creates an error type from the underlying error returned by the role eligibility check.
+    ///
+    static func from(_ error: Error) -> StorePickerErrorType {
+        if let dotcomError = error as? DotcomError,
+           case .requestFailed = dotcomError {
+            return .serverError
+        }
+        return .generic
+    }
+
+    var bodyText: String {
+        switch self {
+        case .serverError:
+            return Localization.serverErrorBody
+        case .generic:
+            return Localization.genericBody
+        }
+    }
+
+    private enum Localization {
+        static let serverErrorBody = NSLocalizedString(
+            "storePickerError.serverErrorBody",
+            value: "There was a problem verifying your permissions. " +
+                "This is usually caused by a server or hosting configuration issue on your site. " +
+                "Please contact your hosting provider for assistance, or reach out to us.",
+            comment: "Body text for the store picker error screen when the site returns a server error (HTTP 500)")
+        static let genericBody = NSLocalizedString(
+            "storePickerError.genericBody",
+            value: "Please try again or reach out to us and we'll be happy to assist you!",
+            comment: "Body text for the default store picker error screen")
+    }
+}
+
 /// Generic Store Picker error view that allows the user to contact support.
 ///
 struct StorePickerError: View {
+
+    /// The type of error to display.
+    ///
+    let errorType: StorePickerErrorType
 
     /// Closure invoked when the "Troubleshooting" button is pressed
     ///
@@ -64,6 +112,10 @@ struct StorePickerError: View {
     ///
     var dismissAction: () -> Void = {}
 
+    init(errorType: StorePickerErrorType = .generic) {
+        self.errorType = errorType
+    }
+
     var body: some View {
         // Adds an outer transparent padding and constraints the view max width
         Group {
@@ -76,7 +128,7 @@ struct StorePickerError: View {
                 Image(uiImage: .errorImage)
 
                 // Body text
-                Text(Localization.body)
+                Text(errorType.bodyText)
                     .multilineTextAlignment(.center)
                     .bodyStyle()
 
@@ -114,8 +166,6 @@ struct StorePickerError: View {
 private extension StorePickerError {
     enum Localization {
         static let title = NSLocalizedString("We couldn't load your site", comment: "Title for the default store picker error screen")
-        static let body = NSLocalizedString("Please try again or reach out to us and we'll be happy to assist you!",
-                                            comment: "Body text for the default store picker error screen")
         static let troubleshoot = NSLocalizedString("Read our Troubleshooting Tips",
                                                     comment: "Text for the button to navigate to troubleshooting tips from the store picker error screen")
         static let contact = NSLocalizedString("Contact Support",
@@ -139,18 +189,19 @@ private extension StorePickerError {
 struct StorePickerError_Preview: PreviewProvider {
     static var previews: some View {
         VStack {
-            StorePickerError()
+            StorePickerError(errorType: .generic)
         }
         .padding()
         .background(Color.gray)
         .previewLayout(.sizeThatFits)
+        .previewDisplayName("Generic Error")
 
         VStack {
-            StorePickerError()
+            StorePickerError(errorType: .serverError)
         }
         .padding()
         .background(Color.gray)
-        .environment(\.colorScheme, .dark)
         .previewLayout(.sizeThatFits)
+        .previewDisplayName("Server Error")
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -130,23 +130,19 @@ struct StorePickerError: View {
         Group {
             VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
 
-                // Title with optional close button
+                // Title with close button
                 HStack {
-                    if technicalDetails != nil {
-                        Button(action: dismissAction) {
-                            Image(uiImage: .closeButton)
-                                .secondaryBodyStyle()
-                        }
+                    Button(action: dismissAction) {
+                        Image(uiImage: .closeButton)
+                            .secondaryBodyStyle()
                     }
                     Spacer()
                     Text(Localization.title)
                         .headlineStyle()
                     Spacer()
-                    if technicalDetails != nil {
-                        // Invisible spacer to balance the close button
-                        Image(uiImage: .closeButton)
-                            .hidden()
-                    }
+                    // Invisible spacer to balance the close button
+                    Image(uiImage: .closeButton)
+                        .hidden()
                 }
 
                 // Main image

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -9,8 +9,9 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
     /// Creates an `StorePickerErrorHostingController` with preconfigured button actions.
     ///
     static func createWithActions(presenting: UIViewController,
-                                  errorType: StorePickerErrorType = .generic) -> StorePickerErrorHostingController {
-        let viewController = StorePickerErrorHostingController(errorType: errorType)
+                                  errorType: StorePickerErrorType = .generic,
+                                  technicalDetails: String? = nil) -> StorePickerErrorHostingController {
+        let viewController = StorePickerErrorHostingController(errorType: errorType, technicalDetails: technicalDetails)
         viewController.setActions(troubleshootingAction: {
             WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController)
         },
@@ -26,8 +27,8 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
         return viewController
     }
 
-    init(errorType: StorePickerErrorType = .generic) {
-        super.init(rootView: StorePickerError(errorType: errorType))
+    init(errorType: StorePickerErrorType = .generic, technicalDetails: String? = nil) {
+        super.init(rootView: StorePickerError(errorType: errorType, technicalDetails: technicalDetails))
     }
 
     override func viewDidLoad() {
@@ -82,7 +83,6 @@ enum StorePickerErrorType: Equatable {
         static let serverErrorBody = NSLocalizedString(
             "storePickerError.serverErrorBody",
             value: "There was a problem verifying your permissions. " +
-                "This is usually caused by a server or hosting configuration issue on your site. " +
                 "Please contact your hosting provider for assistance, or reach out to us.",
             comment: "Body text for the store picker error screen when the site returns a server error (HTTP 500)")
         static let genericBody = NSLocalizedString(
@@ -100,6 +100,10 @@ struct StorePickerError: View {
     ///
     let errorType: StorePickerErrorType
 
+    /// Technical details string to show in a detail sheet, if available.
+    ///
+    let technicalDetails: String?
+
     /// Closure invoked when the "Troubleshooting" button is pressed
     ///
     var troubleshootingAction: () -> Void = {}
@@ -112,17 +116,38 @@ struct StorePickerError: View {
     ///
     var dismissAction: () -> Void = {}
 
-    init(errorType: StorePickerErrorType = .generic) {
+    /// Item used to present the technical details sheet.
+    ///
+    @State private var technicalDetailsItem: TechnicalDetailsItem?
+
+    init(errorType: StorePickerErrorType = .generic, technicalDetails: String? = nil) {
         self.errorType = errorType
+        self.technicalDetails = technicalDetails
     }
 
     var body: some View {
         // Adds an outer transparent padding and constraints the view max width
         Group {
             VStack(alignment: .center, spacing: Layout.mainVerticalSpacing) {
-                // Title
-                Text(Localization.title)
-                    .headlineStyle()
+
+                // Title with optional close button
+                HStack {
+                    if technicalDetails != nil {
+                        Button(action: dismissAction) {
+                            Image(uiImage: .closeButton)
+                                .secondaryBodyStyle()
+                        }
+                    }
+                    Spacer()
+                    Text(Localization.title)
+                        .headlineStyle()
+                    Spacer()
+                    if technicalDetails != nil {
+                        // Invisible spacer to balance the close button
+                        Image(uiImage: .closeButton)
+                            .hidden()
+                    }
+                }
 
                 // Main image
                 Image(uiImage: .errorImage)
@@ -143,10 +168,19 @@ struct StorePickerError: View {
                         .buttonStyle(SecondaryButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
 
-                    // Dismiss button
-                    Button(Localization.back, action: dismissAction)
+                    if let technicalDetails {
+                        // Technical details button (close is handled by the header button)
+                        Button(Localization.viewTechnicalDetails) {
+                            technicalDetailsItem = TechnicalDetailsItem(details: technicalDetails)
+                        }
                         .buttonStyle(LinkButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        // Dismiss button
+                        Button(Localization.back, action: dismissAction)
+                            .buttonStyle(LinkButtonStyle())
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
             }
             .padding([.leading, .trailing, .bottom])
@@ -158,6 +192,9 @@ struct StorePickerError: View {
         .background(Color.clear)
         .scrollVerticallyIfNeeded()
         .frame(maxWidth: Layout.maxModalWidth)
+        .sheet(item: $technicalDetailsItem) { item in
+            TechnicalDetailsView(technicalDetails: item.details)
+        }
     }
 }
 
@@ -172,6 +209,10 @@ private extension StorePickerError {
                                                comment: "Text for the button to contact support from the store picker error screen")
         static let back = NSLocalizedString("Back to sites",
                                             comment: "Text for the button to dismiss the store picker error screen")
+        static let viewTechnicalDetails = NSLocalizedString(
+            "storePickerError.viewTechnicalDetails",
+            value: "View Technical Details",
+            comment: "Text for the button to view technical error details from the store picker error screen")
     }
 
     enum Layout {
@@ -197,7 +238,8 @@ struct StorePickerError_Preview: PreviewProvider {
         .previewDisplayName("Generic Error")
 
         VStack {
-            StorePickerError(errorType: .serverError)
+            StorePickerError(errorType: .serverError,
+                             technicalDetails: String(describing: DotcomError.requestFailed()))
         }
         .padding()
         .background(Color.gray)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import SafariServices
-import enum NetworkingCore.DotcomError
 
 /// Hosting controller wrapper for `StorePickerError`
 ///
@@ -48,47 +47,6 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
         rootView.troubleshootingAction = troubleshootingAction
         rootView.contactSupportAction = contactSupportAction
         rootView.dismissAction = dismissAction
-    }
-}
-
-/// Categorizes the error shown in the store picker error screen.
-/// Extracted as a standalone type for testability.
-///
-enum StorePickerErrorType: Equatable {
-    /// The remote site returned a server error (HTTP 500) when verifying user permissions.
-    case serverError
-    /// Any other error (network issues, unknown errors, etc.)
-    case generic
-
-    /// Creates an error type from the underlying error returned by the role eligibility check.
-    ///
-    static func from(_ error: Error) -> StorePickerErrorType {
-        if let dotcomError = error as? DotcomError,
-           case .requestFailed = dotcomError {
-            return .serverError
-        }
-        return .generic
-    }
-
-    var bodyText: String {
-        switch self {
-        case .serverError:
-            return Localization.serverErrorBody
-        case .generic:
-            return Localization.genericBody
-        }
-    }
-
-    private enum Localization {
-        static let serverErrorBody = NSLocalizedString(
-            "storePickerError.serverErrorBody",
-            value: "There was a problem verifying your permissions. " +
-                "Please contact your hosting provider for assistance, or reach out to us.",
-            comment: "Body text for the store picker error screen when the site returns a server error (HTTP 500)")
-        static let genericBody = NSLocalizedString(
-            "storePickerError.genericBody",
-            value: "Please try again or reach out to us and we'll be happy to assist you!",
-            comment: "Body text for the default store picker error screen")
     }
 }
 
@@ -235,7 +193,7 @@ struct StorePickerError_Preview: PreviewProvider {
 
         VStack {
             StorePickerError(errorType: .serverError,
-                             technicalDetails: String(describing: DotcomError.requestFailed()))
+                             technicalDetails: "requestFailed: http_request_failed")
         }
         .padding()
         .background(Color.gray)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -8,9 +8,8 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
     /// Creates an `StorePickerErrorHostingController` with preconfigured button actions.
     ///
     static func createWithActions(presenting: UIViewController,
-                                  errorType: StorePickerErrorType = .generic,
-                                  technicalDetails: String? = nil) -> StorePickerErrorHostingController {
-        let viewController = StorePickerErrorHostingController(errorType: errorType, technicalDetails: technicalDetails)
+                                  errorType: StorePickerErrorType = .generic) -> StorePickerErrorHostingController {
+        let viewController = StorePickerErrorHostingController(errorType: errorType)
         viewController.setActions(troubleshootingAction: {
             WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController)
         },
@@ -26,8 +25,8 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
         return viewController
     }
 
-    init(errorType: StorePickerErrorType = .generic, technicalDetails: String? = nil) {
-        super.init(rootView: StorePickerError(errorType: errorType, technicalDetails: technicalDetails))
+    init(errorType: StorePickerErrorType = .generic) {
+        super.init(rootView: StorePickerError(errorType: errorType))
     }
 
     override func viewDidLoad() {
@@ -58,10 +57,6 @@ struct StorePickerError: View {
     ///
     let errorType: StorePickerErrorType
 
-    /// Technical details string to show in a detail sheet, if available.
-    ///
-    let technicalDetails: String?
-
     /// Closure invoked when the "Troubleshooting" button is pressed
     ///
     var troubleshootingAction: () -> Void = {}
@@ -73,15 +68,6 @@ struct StorePickerError: View {
     /// Closure invoked when the "Back To Sites" button is pressed
     ///
     var dismissAction: () -> Void = {}
-
-    /// Item used to present the technical details sheet.
-    ///
-    @State private var technicalDetailsItem: TechnicalDetailsItem?
-
-    init(errorType: StorePickerErrorType = .generic, technicalDetails: String? = nil) {
-        self.errorType = errorType
-        self.technicalDetails = technicalDetails
-    }
 
     var body: some View {
         // Adds an outer transparent padding and constraints the view max width
@@ -122,19 +108,10 @@ struct StorePickerError: View {
                         .buttonStyle(SecondaryButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
 
-                    if let technicalDetails {
-                        // Technical details button (close is handled by the header button)
-                        Button(Localization.viewTechnicalDetails) {
-                            technicalDetailsItem = TechnicalDetailsItem(details: technicalDetails)
-                        }
+                    // Dismiss button
+                    Button(Localization.back, action: dismissAction)
                         .buttonStyle(LinkButtonStyle())
                         .fixedSize(horizontal: false, vertical: true)
-                    } else {
-                        // Dismiss button
-                        Button(Localization.back, action: dismissAction)
-                            .buttonStyle(LinkButtonStyle())
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
                 }
             }
             .padding([.leading, .trailing, .bottom])
@@ -146,9 +123,6 @@ struct StorePickerError: View {
         .background(Color.clear)
         .scrollVerticallyIfNeeded()
         .frame(maxWidth: Layout.maxModalWidth)
-        .sheet(item: $technicalDetailsItem) { item in
-            TechnicalDetailsView(technicalDetails: item.details)
-        }
     }
 }
 
@@ -163,10 +137,6 @@ private extension StorePickerError {
                                                comment: "Text for the button to contact support from the store picker error screen")
         static let back = NSLocalizedString("Back to sites",
                                             comment: "Text for the button to dismiss the store picker error screen")
-        static let viewTechnicalDetails = NSLocalizedString(
-            "storePickerError.viewTechnicalDetails",
-            value: "View Technical Details",
-            comment: "Text for the button to view technical error details from the store picker error screen")
     }
 
     enum Layout {
@@ -192,9 +162,7 @@ struct StorePickerError_Preview: PreviewProvider {
         .previewDisplayName("Generic Error")
 
         VStack {
-            StorePickerError(errorType: .serverError,
-                             technicalDetails: "Status: 500\nError: http_request_failed\n"
-                                + "cURL error 28: Operation timed out after 3001 milliseconds")
+            StorePickerError(errorType: .serverError)
         }
         .padding()
         .background(Color.gray)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -193,7 +193,7 @@ struct StorePickerError_Preview: PreviewProvider {
 
         VStack {
             StorePickerError(errorType: .serverError,
-                             technicalDetails: "requestFailed: http_request_failed")
+                             technicalDetails: "Status: 500\nError: http_request_failed\ncURL error 28: Operation timed out after 3001 milliseconds with 0 bytes received")
         }
         .padding()
         .background(Color.gray)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
@@ -31,9 +31,9 @@ enum StorePickerErrorType: Equatable {
 
     private enum Localization {
         static let serverErrorBody = NSLocalizedString(
-            "storePickerError.serverErrorBody",
+            "storePickerError.serverErrorBody.v2",
             value: "There was a problem verifying your permissions. " +
-                "Please contact your hosting provider for assistance, or reach out to us.",
+                "Please try again or reach out to us and we'll be happy to assist you!",
             comment: "Body text for the store picker error screen when the site returns a server error")
         static let genericBody = NSLocalizedString(
             "storePickerError.genericBody",

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
@@ -20,31 +20,6 @@ enum StorePickerErrorType: Equatable {
         return .generic
     }
 
-    /// Extracts a compact technical summary from a `DotcomError.requestFailed` data dictionary.
-    /// Returns `nil` for non-DotcomError errors or when no useful data is available.
-    ///
-    static func technicalDetails(from error: Error) -> String? {
-        guard let dotcomError = error as? DotcomError,
-              case .requestFailed(let data) = dotcomError,
-              let data else {
-            return nil
-        }
-
-        var parts: [String] = []
-        if let status = data["status"]?.value {
-            parts.append("Status: \(status)")
-        }
-        if let errors = data["errors"]?.value as? [String: Any] {
-            if let code = errors["code"] {
-                parts.append("Error: \(code)")
-            }
-            if let message = errors["message"] {
-                parts.append("\(message)")
-            }
-        }
-        return parts.isEmpty ? nil : parts.joined(separator: "\n")
-    }
-
     var bodyText: String {
         switch self {
         case .serverError:

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
@@ -1,0 +1,43 @@
+import Foundation
+import enum NetworkingCore.DotcomError
+
+/// Categorizes the error shown in the store picker error screen.
+/// Extracted as a standalone type for testability.
+///
+enum StorePickerErrorType: Equatable {
+    /// The remote site returned a server error when verifying user permissions.
+    case serverError
+    /// Any other error (network issues, unknown errors, etc.)
+    case generic
+
+    /// Creates an error type from the underlying error returned by the role eligibility check.
+    ///
+    static func from(_ error: Error) -> StorePickerErrorType {
+        if let dotcomError = error as? DotcomError,
+           case .requestFailed = dotcomError {
+            return .serverError
+        }
+        return .generic
+    }
+
+    var bodyText: String {
+        switch self {
+        case .serverError:
+            return Localization.serverErrorBody
+        case .generic:
+            return Localization.genericBody
+        }
+    }
+
+    private enum Localization {
+        static let serverErrorBody = NSLocalizedString(
+            "storePickerError.serverErrorBody",
+            value: "There was a problem verifying your permissions. " +
+                "Please contact your hosting provider for assistance, or reach out to us.",
+            comment: "Body text for the store picker error screen when the site returns a server error")
+        static let genericBody = NSLocalizedString(
+            "storePickerError.genericBody",
+            value: "Please try again or reach out to us and we'll be happy to assist you!",
+            comment: "Body text for the default store picker error screen")
+    }
+}

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerErrorType.swift
@@ -20,6 +20,31 @@ enum StorePickerErrorType: Equatable {
         return .generic
     }
 
+    /// Extracts a compact technical summary from a `DotcomError.requestFailed` data dictionary.
+    /// Returns `nil` for non-DotcomError errors or when no useful data is available.
+    ///
+    static func technicalDetails(from error: Error) -> String? {
+        guard let dotcomError = error as? DotcomError,
+              case .requestFailed(let data) = dotcomError,
+              let data else {
+            return nil
+        }
+
+        var parts: [String] = []
+        if let status = data["status"]?.value {
+            parts.append("Status: \(status)")
+        }
+        if let errors = data["errors"]?.value as? [String: Any] {
+            if let code = errors["code"] {
+                parts.append("Error: \(code)")
+            }
+            if let message = errors["message"] {
+                parts.append("\(message)")
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: "\n")
+    }
+
     var bodyText: String {
         switch self {
         case .serverError:

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -615,8 +615,7 @@ private extension StorePickerViewController {
     ///
     func displayUnknownErrorModal(error: Error? = nil) {
         let errorType = error.map(StorePickerErrorType.from) ?? .generic
-        let technicalDetails = error.flatMap { StorePickerErrorType.technicalDetails(from: $0) }
-        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, errorType: errorType, technicalDetails: technicalDetails)
+        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, errorType: errorType)
         viewController.modalPresentationStyle = .custom
         viewController.transitioningDelegate = self
         present(viewController, animated: true)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -610,10 +610,12 @@ private extension StorePickerViewController {
         actionButton.showActivityIndicator(false)
     }
 
-    /// Displays a generic error view as a modal with options to see troubleshooting tips and to contact support.
+    /// Displays an error view as a modal with options to see troubleshooting tips and to contact support.
+    /// Shows a specific message for server errors (HTTP 500) to help users identify hosting configuration issues.
     ///
-    func displayUnknownErrorModal() {
-        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self)
+    func displayUnknownErrorModal(error: Error) {
+        let errorType = StorePickerErrorType.from(error)
+        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, errorType: errorType)
         viewController.modalPresentationStyle = .custom
         viewController.transitioningDelegate = self
         present(viewController, animated: true)
@@ -840,7 +842,8 @@ private extension StorePickerViewController {
                         self?.dismiss()
                     }
                 } else {
-                    self.displayUnknownErrorModal()
+                    let underlyingError = (error as? RoleEligibilityError)?.underlyingError ?? error
+                    self.displayUnknownErrorModal(error: underlyingError)
                 }
             }
         }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -613,9 +613,10 @@ private extension StorePickerViewController {
     /// Displays an error view as a modal with options to see troubleshooting tips and to contact support.
     /// Shows a specific message for server errors (HTTP 500) to help users identify hosting configuration issues.
     ///
-    func displayUnknownErrorModal(error: Error) {
-        let errorType = StorePickerErrorType.from(error)
-        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, errorType: errorType)
+    func displayUnknownErrorModal(error: Error? = nil) {
+        let errorType = error.map(StorePickerErrorType.from) ?? .generic
+        let technicalDetails = error.map { String(describing: $0) }
+        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, errorType: errorType, technicalDetails: technicalDetails)
         viewController.modalPresentationStyle = .custom
         viewController.transitioningDelegate = self
         present(viewController, animated: true)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -615,7 +615,7 @@ private extension StorePickerViewController {
     ///
     func displayUnknownErrorModal(error: Error? = nil) {
         let errorType = error.map(StorePickerErrorType.from) ?? .generic
-        let technicalDetails = error.map { String(describing: $0) }
+        let technicalDetails = error.flatMap { StorePickerErrorType.technicalDetails(from: $0) }
         let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, errorType: errorType, technicalDetails: technicalDetails)
         viewController.modalPresentationStyle = .custom
         viewController.transitioningDelegate = self

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -103,4 +103,12 @@ enum RoleEligibilityError: Error {
 
     /// An unknown error caused from other sources.
     case unknown(error: Error)
+
+    /// Returns the underlying error for the `.unknown` case, or `nil` for other cases.
+    var underlyingError: Error? {
+        if case .unknown(let error) = self {
+            return error
+        }
+        return nil
+    }
 }

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -80,6 +80,7 @@ extension RoleEligibilityUseCase: RoleEligibilityUseCaseProtocol {
                 completion(.success(()))
 
             case .failure(let error):
+                DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(error)")
                 completion(.failure(.unknown(error: error)))
             }
         }

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import enum NetworkingCore.DotcomError
+@testable import WooCommerce
+
+@Suite("StorePickerErrorType")
+struct StorePickerErrorTypeTests {
+
+    @Test func from_when_DotcomError_requestFailed_then_returns_serverError() {
+        // Given
+        let error: Error = DotcomError.requestFailed()
+
+        // When
+        let errorType = StorePickerErrorType.from(error)
+
+        // Then
+        #expect(errorType == .serverError)
+    }
+
+    @Test func from_when_other_error_then_returns_generic() {
+        // Given
+        let error: Error = URLError(.notConnectedToInternet)
+
+        // When
+        let errorType = StorePickerErrorType.from(error)
+
+        // Then
+        #expect(errorType == .generic)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import enum NetworkingCore.DotcomError
 @testable import WooCommerce

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import enum NetworkingCore.DotcomError
+import struct NetworkingCore.AnyDecodable
 @testable import WooCommerce
 
 @Suite("StorePickerErrorType")
@@ -26,5 +27,34 @@ struct StorePickerErrorTypeTests {
 
         // Then
         #expect(errorType == .generic)
+    }
+
+    @Test func technicalDetails_when_requestFailed_with_data_then_returns_compact_summary() {
+        // Given
+        let data: [String: AnyDecodable] = [
+            "status": AnyDecodable(500),
+            "errors": AnyDecodable([
+                "code": "http_request_failed",
+                "message": "cURL error 28: Operation timed out"
+            ] as [String: String])
+        ]
+        let error: Error = DotcomError.requestFailed(data: data)
+
+        // When
+        let details = StorePickerErrorType.technicalDetails(from: error)
+
+        // Then
+        #expect(details == "Status: 500\nError: http_request_failed\ncURL error 28: Operation timed out")
+    }
+
+    @Test func technicalDetails_when_non_DotcomError_then_returns_nil() {
+        // Given
+        let error: Error = URLError(.notConnectedToInternet)
+
+        // When
+        let details = StorePickerErrorType.technicalDetails(from: error)
+
+        // Then
+        #expect(details == nil)
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/StorePickerErrorTypeTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Testing
 import enum NetworkingCore.DotcomError
-import struct NetworkingCore.AnyDecodable
 @testable import WooCommerce
 
 @Suite("StorePickerErrorType")
@@ -27,34 +26,5 @@ struct StorePickerErrorTypeTests {
 
         // Then
         #expect(errorType == .generic)
-    }
-
-    @Test func technicalDetails_when_requestFailed_with_data_then_returns_compact_summary() {
-        // Given
-        let data: [String: AnyDecodable] = [
-            "status": AnyDecodable(500),
-            "errors": AnyDecodable([
-                "code": "http_request_failed",
-                "message": "cURL error 28: Operation timed out"
-            ] as [String: String])
-        ]
-        let error: Error = DotcomError.requestFailed(data: data)
-
-        // When
-        let details = StorePickerErrorType.technicalDetails(from: error)
-
-        // Then
-        #expect(details == "Status: 500\nError: http_request_failed\ncURL error 28: Operation timed out")
-    }
-
-    @Test func technicalDetails_when_non_DotcomError_then_returns_nil() {
-        // Given
-        let error: Error = URLError(.notConnectedToInternet)
-
-        // When
-        let details = StorePickerErrorType.technicalDetails(from: error)
-
-        // Then
-        #expect(details == nil)
     }
 }


### PR DESCRIPTION
Fixes: WOOMOB-2509

## Description

When the role eligibility check (`wp/v2/users/me`) fails with a server error (HTTP 500 / `DotcomError.requestFailed`), the store picker error modal now shows a specific message pointing the user to their hosting provider instead of the generic fallback. A "View Technical Details" CTA presents the raw error in a copyable sheet for support diagnostics. A close button was also added to the modal header for all error variants.

## Test Steps

1. In `RoleEligibilityUseCase.checkEligibility`, add a stub at the top of the method:
   ```swift
   completion(.failure(.unknown(error: DotcomError.requestFailed())))
   return
   ```
   (requires `import enum NetworkingCore.DotcomError`)
2. Log in and reach the store picker, tap Continue on any site.
3. Verify the error modal shows "There was a problem verifying your permissions..." with a close button and "View Technical Details" link.
4. Tap "View Technical Details" and verify the error details sheet appears with a copy button.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-10 at 13 15 48" src="https://github.com/user-attachments/assets/c2f7b130-69d1-4f8b-b403-dd474f65e127" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-13 at 12 13 11" src="https://github.com/user-attachments/assets/a3bc961f-ff78-40b4-b7ac-c844b9e47aac" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.