### PR TITLE
Add CoreData relationship between Order and OrderFulfillment

### DIFF
--- a/Modules/Sources/Fakes/NetworkingCore.generated.swift
+++ b/Modules/Sources/Fakes/NetworkingCore.generated.swift
@@ -190,6 +190,7 @@ extension NetworkingCore.Order {
             appliedGiftCards: .fake(),
             attributionInfo: .fake(),
             shippingLabels: .fake(),
+            fulfillments: .fake(),
             createdVia: .fake()
         )
     }

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -244,6 +244,7 @@ extension NetworkingCore.Order {
         appliedGiftCards: CopiableProp<[OrderGiftCard]> = .copy,
         attributionInfo: NullableCopiableProp<OrderAttributionInfo> = .copy,
         shippingLabels: CopiableProp<[ShippingLabel]> = .copy,
+        fulfillments: CopiableProp<[OrderFulfillment]> = .copy,
         createdVia: NullableCopiableProp<String> = .copy
     ) -> NetworkingCore.Order {
         let siteID = siteID ?? self.siteID
@@ -287,6 +288,7 @@ extension NetworkingCore.Order {
         let appliedGiftCards = appliedGiftCards ?? self.appliedGiftCards
         let attributionInfo = attributionInfo ?? self.attributionInfo
         let shippingLabels = shippingLabels ?? self.shippingLabels
+        let fulfillments = fulfillments ?? self.fulfillments
         let createdVia = createdVia ?? self.createdVia
 
         return NetworkingCore.Order(
@@ -331,6 +333,7 @@ extension NetworkingCore.Order {
             appliedGiftCards: appliedGiftCards,
             attributionInfo: attributionInfo,
             shippingLabels: shippingLabels,
+            fulfillments: fulfillments,
             createdVia: createdVia
         )
     }

--- a/Modules/Sources/NetworkingCore/Model/Order.swift
+++ b/Modules/Sources/NetworkingCore/Model/Order.swift
@@ -74,6 +74,10 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
     ///
     public let shippingLabels: [ShippingLabel]
 
+    /// Fulfillments associated with the order (fetched from a separate endpoint, populated via CoreData relationship).
+    ///
+    public let fulfillments: [OrderFulfillment]
+
     /// Set to orders created via specific sources (e.g. checkout, store-api, Point of Sale, ...)
     ///
     public let createdVia: String?
@@ -126,6 +130,7 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
                 appliedGiftCards: [OrderGiftCard],
                 attributionInfo: OrderAttributionInfo?,
                 shippingLabels: [ShippingLabel],
+                fulfillments: [OrderFulfillment] = [],
                 createdVia: String?) {
 
         self.siteID = siteID
@@ -175,6 +180,7 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
         self.appliedGiftCards = appliedGiftCards
         self.attributionInfo = attributionInfo
         self.shippingLabels = shippingLabels
+        self.fulfillments = fulfillments
         self.createdVia = createdVia
     }
 
@@ -378,6 +384,7 @@ public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
                   appliedGiftCards: [],
                   attributionInfo: nil,
                   shippingLabels: [],
+                  fulfillments: [],
                   createdVia: nil)
     }
 }
@@ -472,7 +479,8 @@ extension Order: Equatable {
             lhs.customerNote == rhs.customerNote &&
             lhs.attributionInfo == rhs.attributionInfo &&
             lhs.shippingLabels == rhs.shippingLabels &&
-            lhs.fulfillmentStatus == rhs.fulfillmentStatus
+            lhs.fulfillmentStatus == rhs.fulfillmentStatus &&
+            lhs.fulfillments == rhs.fulfillments
     }
 }
 

--- a/Modules/Sources/NetworkingCore/Model/OrderFulfillment.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderFulfillment.swift
@@ -6,7 +6,7 @@ import Codegen
 /// Fulfillments contain shipment details — tracking number, shipping provider, tracking URL, and fulfillment date —
 /// stored as private metadata on the fulfillment entity.
 ///
-public struct OrderFulfillment: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderFulfillment: Decodable, Sendable, Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// Site Identifier.
     ///

--- a/Modules/Sources/Storage/Model/Order+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/Order+CoreDataProperties.swift
@@ -68,6 +68,7 @@ extension Order {
     @NSManaged public var notes: Set<OrderNote>?
     @NSManaged public var searchResults: Set<OrderSearchResults>?
     @NSManaged public var refunds: Set<OrderRefundCondensed>?
+    @NSManaged public var fulfillments: Set<OrderFulfillment>?
     @NSManaged public var shippingLabels: Set<ShippingLabel>?
     @NSManaged public var shippingLabelSettings: ShippingLabelSettings?
     @NSManaged public var taxes: Set<OrderTaxLine>?

--- a/Modules/Sources/Storage/Model/OrderFulfillment+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/OrderFulfillment+CoreDataProperties.swift
@@ -19,5 +19,6 @@ extension OrderFulfillment {
     @NSManaged public var providerName: String?
     @NSManaged public var shipmentProvider: String?
     @NSManaged public var trackingURL: String?
+    @NSManaged public var order: Order?
 
 }

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 136.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 136.xcdatamodel/contents
@@ -325,6 +325,7 @@
         <relationship name="refunds" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderRefundCondensed" inverseName="order" inverseEntity="OrderRefundCondensed"/>
         <relationship name="searchResults" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderSearchResults" inverseName="orders" inverseEntity="OrderSearchResults"/>
         <relationship name="shipments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WooShippingShipment" inverseName="order" inverseEntity="WooShippingShipment"/>
+        <relationship name="fulfillments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrderFulfillment" inverseName="order" inverseEntity="OrderFulfillment"/>
         <relationship name="shippingLabels" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLabel" inverseName="order" inverseEntity="ShippingLabel"/>
         <relationship name="shippingLabelSettings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ShippingLabelSettings" inverseName="order" inverseEntity="ShippingLabelSettings"/>
         <relationship name="shippingLines" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ShippingLine" inverseName="order" inverseEntity="ShippingLine"/>
@@ -358,6 +359,7 @@
         <attribute name="statusKey" optional="YES" attributeType="String"/>
         <attribute name="trackingNumber" optional="YES" attributeType="String"/>
         <attribute name="trackingURL" optional="YES" attributeType="String"/>
+        <relationship name="order" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Order" inverseName="fulfillments" inverseEntity="Order"/>
     </entity>
     <entity name="OrderFeeLine" representedClassName="OrderFeeLine" syncable="YES">
         <attribute name="feeID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Modules/Sources/Yosemite/Model/Extensions/Order+Fulfillment.swift
+++ b/Modules/Sources/Yosemite/Model/Extensions/Order+Fulfillment.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Networking
+
+// MARK: - Fulfillment Helpers
+
+public extension Order {
+    /// The most recent fulfillment date across all fulfilled entries, if any.
+    var latestDateFulfilled: Date? {
+        fulfillments
+            .filter { $0.isFulfilled }
+            .compactMap { $0.dateFulfilled }
+            .max()
+    }
+}

--- a/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -83,6 +83,7 @@ extension Storage.Order: ReadOnlyConvertible {
         let orderCustomFields = customFields?.map { $0.toReadOnly() } ?? [Yosemite.MetaData]()
         let orderGiftCards = appliedGiftCards?.map { $0.toReadOnly() } ?? [Yosemite.OrderGiftCard]()
         let orderShippingLabels = shippingLabels?.map { $0.toReadOnly() } ?? [Yosemite.ShippingLabel]()
+        let orderFulfillments = fulfillments?.map { $0.toReadOnly() } ?? [Yosemite.OrderFulfillment]()
 
         return Order(siteID: siteID,
                      orderID: orderID,
@@ -124,6 +125,7 @@ extension Storage.Order: ReadOnlyConvertible {
                      appliedGiftCards: orderGiftCards,
                      attributionInfo: attributionInfo?.toReadOnly(),
                      shippingLabels: orderShippingLabels,
+                     fulfillments: orderFulfillments,
                      createdVia: createdVia)
 
     }

--- a/Modules/Sources/Yosemite/Stores/OrderFulfillmentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderFulfillmentStore.swift
@@ -70,6 +70,10 @@ extension OrderFulfillmentStore {
                                              readOnlyFulfillments: [Networking.OrderFulfillment],
                                              onCompletion: @escaping () -> Void) {
         storageManager.performAndSave({ storage in
+            guard let storageOrder = storage.loadOrder(siteID: siteID, orderID: orderID) else {
+                return
+            }
+
             let storageFulfillments = storage.loadOrderFulfillmentList(
                 siteID: siteID,
                 orderID: orderID
@@ -85,6 +89,7 @@ extension OrderFulfillmentStore {
                     ofType: Storage.OrderFulfillment.self
                 )
                 storageFulfillment.update(with: readOnlyFulfillment)
+                storageFulfillment.order = storageOrder
             }
 
             // Remove stale entries not present in the remote response

--- a/Modules/Tests/YosemiteTests/Stores/OrderFulfillmentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderFulfillmentStoreTests.swift
@@ -58,6 +58,8 @@ final class OrderFulfillmentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Synchronize order fulfillments")
         let store = OrderFulfillmentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
+        insertOrder(siteID: sampleSiteID, orderID: sampleOrderID)
+
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/fulfillments", filename: "order_fulfillment_list")
 
         // When
@@ -99,6 +101,8 @@ final class OrderFulfillmentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Synchronize order fulfillments error")
         let store = OrderFulfillmentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
+        insertOrder(siteID: sampleSiteID, orderID: sampleOrderID)
+
         network.simulateError(requestUrlSuffix: "orders/\(sampleOrderID)/fulfillments", error: NetworkError.notFound())
 
         // When
@@ -120,14 +124,20 @@ final class OrderFulfillmentStoreTests: XCTestCase {
         // Given
         let store = OrderFulfillmentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        // Insert a stale fulfillment that won't be in the response
-        let insertExpectation = expectation(description: "Insert stale fulfillment")
+        // Insert an order and a stale fulfillment that won't be in the response
+        let insertExpectation = expectation(description: "Insert order and stale fulfillment")
         storageManager.performAndSave({ storage in
+            let order = storage.insertNewObject(ofType: Storage.Order.self)
+            order.siteID = self.sampleSiteID
+            order.orderID = self.sampleOrderID
+            order.statusKey = "processing"
+
             let staleFulfillment = storage.insertNewObject(ofType: Storage.OrderFulfillment.self)
             staleFulfillment.siteID = self.sampleSiteID
             staleFulfillment.orderID = self.sampleOrderID
             staleFulfillment.fulfillmentID = 999
             staleFulfillment.statusKey = "stale"
+            staleFulfillment.order = order
         }, completion: { insertExpectation.fulfill() }, on: .main)
         await fulfillment(of: [insertExpectation], timeout: Constants.expectationTimeout)
 
@@ -149,6 +159,18 @@ final class OrderFulfillmentStoreTests: XCTestCase {
     }
 }
 
+
+// MARK: - Helpers
+//
+private extension OrderFulfillmentStoreTests {
+    func insertOrder(siteID: Int64, orderID: Int64) {
+        let storage = viewStorage
+        let order = storage.insertNewObject(ofType: Storage.Order.self)
+        order.siteID = siteID
+        order.orderID = orderID
+        order.statusKey = "processing"
+    }
+}
 
 // MARK: - Constants
 //

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -104,10 +104,6 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var orderTracking: [ShipmentTracking] = []
 
-    /// Order fulfillments list
-    ///
-    var orderFulfillments: [OrderFulfillment] = []
-
     /// Order statuses list
     ///
     var currentSiteStatuses: [OrderStatus] = []
@@ -1178,7 +1174,6 @@ extension OrderDetailsDataSource {
         refunds = resultsControllers.refunds
         customAmounts = resultsControllers.feeLines
         orderTracking = resultsControllers.orderTracking
-        orderFulfillments = resultsControllers.orderFulfillments
         currentSiteStatuses = resultsControllers.currentSiteStatuses
         products = resultsControllers.products
         addOnGroups = resultsControllers.addOnGroups

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -70,16 +70,6 @@ final class OrderDetailsResultsControllers {
         return ResultsController<StorageShippingMethod>(storageManager: storageManager, matching: predicate, sortedBy: [])
     }()
 
-    /// Order Fulfillment ResultsController.
-    ///
-    private lazy var fulfillmentResultsController: ResultsController<StorageOrderFulfillment> = {
-        let predicate = NSPredicate(format: "siteID = %ld AND orderID = %ld",
-                                    self.order.siteID,
-                                    self.order.orderID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageOrderFulfillment.fulfillmentID, ascending: true)
-
-        return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
-    }()
 
     /// Shipments Results Controller.
     ///
@@ -96,12 +86,6 @@ final class OrderDetailsResultsControllers {
     ///
     var orderTracking: [ShipmentTracking] {
         return trackingResultsController.fetchedObjects
-    }
-
-    /// Order fulfillments list
-    ///
-    var orderFulfillments: [OrderFulfillment] {
-        return fulfillmentResultsController.fetchedObjects
     }
 
     /// Order statuses list
@@ -187,7 +171,6 @@ final class OrderDetailsResultsControllers {
         configureSitePluginsResultsController(onReload: onReload)
         configureShippingMethodsResultsController(onReload: onReload)
         configureShipmentResultsController(onReload: onReload)
-        configureFulfillmentResultsController(onReload: onReload)
     }
 
     func update(order: Order) {
@@ -212,26 +195,6 @@ private extension OrderDetailsResultsControllers {
         let predicate = NSPredicate(format: "siteID == %lld AND productVariationID in %@", siteID, variationIDs)
 
         return ResultsController<StorageProductVariation>(storageManager: storageManager, matching: predicate, sortedBy: [])
-    }
-
-    func configureFulfillmentResultsController(onReload: @escaping () -> Void) {
-        fulfillmentResultsController.onDidChangeContent = {
-            onReload()
-        }
-
-        fulfillmentResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
-                return
-            }
-            self.refetchAllResultsControllers()
-            onReload()
-        }
-
-        do {
-            try fulfillmentResultsController.performFetch()
-        } catch {
-            DDLogError("⛔️ Unable to fetch order fulfillments: \(error)")
-        }
     }
 
     func configureShipmentResultsController(onReload: @escaping () -> Void) {
@@ -410,7 +373,6 @@ private extension OrderDetailsResultsControllers {
         try? addOnGroupResultsController.performFetch()
         try? sitePluginsResultsController.performFetch()
         try? shippingMethodsResultsController.performFetch()
-        try? fulfillmentResultsController.performFetch()
     }
 
     func createProductResultsController() -> GenericResultsController<StorageProduct, OrderDetailsProduct> {


### PR DESCRIPTION
Part of WOOMOB-2636 (split: data layer only, UI changes in a follow-up PR).

## Description
Migrates `OrderFulfillment` to use a CoreData relationship with `Order`, following the same pattern as `ShippingLabel`. This removes the need for a dedicated `ResultsController` and makes fulfillments accessible directly from the `Order` model via `order.fulfillments`.

**Changes:**
- Add bidirectional `Order ↔ OrderFulfillment` relationship to CoreData Model 136
- Update `OrderFulfillmentStore` upsert to load parent Order and assign the relationship
- Add `fulfillments` property to Networking `Order` struct, populated via `toReadOnly()`
- Move `OrderFulfillment.swift` from `Networking` to `NetworkingCore` (so `Order` can reference it)
- Add `Order.latestDateFulfilled` computed property in Yosemite
- Remove `fulfillmentResultsController` from `OrderDetailsResultsControllers`
- Remove `orderFulfillments` property from `OrderDetailsDataSource`

## Test Steps
- Verify the app builds and runs on a CIAB site
- Navigate to order details — fulfillment data should still load correctly
- Confirm no regressions in order detail sections that depend on other ResultsControllers

## Screenshots
N/A (data layer refactor, no visual changes)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.