### PR TITLE
Add fulfillment status badge to dashboard recent orders

### DIFF
--- a/WooCommerce/Classes/CIAB/OrderFulfillmentStatusDisplay.swift
+++ b/WooCommerce/Classes/CIAB/OrderFulfillmentStatusDisplay.swift
@@ -1,0 +1,71 @@
+import UIKit
+import SwiftUI
+import NetworkingCore
+
+/// Centralizes the display properties (text and color) for `OrderFulfillmentStatus` badges.
+///
+/// Used by order list, dashboard, order details, and search screens to render
+/// a consistent fulfillment badge for CIAB orders.
+extension OrderFulfillmentStatus {
+
+    /// Localized badge text, or `nil` if the status should not be displayed.
+    ///
+    /// - Parameter dateFulfilled: When provided and the status is `.fulfilled`,
+    ///   the text includes the date (e.g., "Fulfilled on Jan 28, 2025").
+    ///   Used in order details; pass `nil` for list/dashboard contexts.
+    func badgeText(dateFulfilled: Date? = nil) -> String? {
+        switch self {
+        case .fulfilled:
+            if let dateFulfilled {
+                let formatter = DateFormatter.mediumLengthLocalizedDateFormatter
+                formatter.timeZone = .siteTimezone
+                let dateString = formatter.string(from: dateFulfilled)
+                return String(format: Localization.fulfilledWithDate, dateString)
+            }
+            return Localization.fulfilled
+        case .unfulfilled:
+            return Localization.unfulfilled
+        case .partiallyFulfilled, .noFulfillments, .unknown:
+            return nil
+        }
+    }
+
+    /// Background color for the fulfillment badge (UIKit).
+    var badgeBackgroundColor: UIColor {
+        switch self {
+        case .fulfilled:
+            return .withColorStudio(.green, shade: .shade5)
+        case .unfulfilled:
+            return .withColorStudio(.orange, shade: .shade5)
+        case .partiallyFulfilled, .noFulfillments, .unknown:
+            return .clear
+        }
+    }
+
+    /// Background color for the fulfillment badge (SwiftUI).
+    var badgeBackgroundSwiftUIColor: Color {
+        Color(uiColor: badgeBackgroundColor)
+    }
+}
+
+// MARK: - Localization
+
+private extension OrderFulfillmentStatus {
+    enum Localization {
+        static let fulfilled = NSLocalizedString(
+            "orderFulfillmentStatus.badge.fulfilled",
+            value: "Fulfilled",
+            comment: "Fulfillment status badge text shown on CIAB order rows when the order has been fulfilled."
+        )
+        static let fulfilledWithDate = NSLocalizedString(
+            "orderFulfillmentStatus.badge.fulfilledWithDate",
+            value: "Fulfilled on %1$@",
+            comment: "Fulfillment status badge text with date, shown on the CIAB order details screen. %1$@ is the formatted date."
+        )
+        static let unfulfilled = NSLocalizedString(
+            "orderFulfillmentStatus.badge.unfulfilled",
+            value: "Unfulfilled",
+            comment: "Fulfillment status badge text shown on CIAB order rows when the order has not been fulfilled."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
@@ -39,6 +39,16 @@ struct LastOrderDashboardRow: View {
                                 .padding(.vertical, Layout.Status.vPadding)
                                 .background(viewModel.statusBackgroundColor)
                                 .cornerRadius(Layout.Status.cornerRadius)
+                                if let fulfillmentText = viewModel.fulfillmentBadgeText,
+                                   viewModel.isFulfillmentStatusRequired {
+                                    Text(fulfillmentText)
+                                        .foregroundStyle(.black)
+                                        .footnoteStyle()
+                                        .padding(.horizontal, Layout.Status.hPadding)
+                                        .padding(.vertical, Layout.Status.vPadding)
+                                        .background(viewModel.fulfillmentBadgeBackgroundColor)
+                                        .cornerRadius(Layout.Status.cornerRadius)
+                                }
                             if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleOrdersi1),
                                viewModel.isPOSOrder {
                                 Text(viewModel.salesChannelText)
@@ -96,6 +106,11 @@ struct LastOrderDashboardRowViewModel {
         order.salesChannel == .pointOfSale
     }
 
+    var isFulfillmentStatusRequired: Bool {
+        /// isCIAB gating is pending a planned refactoring
+        isCIAB && order.fulfillmentStatus != .unknown
+    }
+
     var salesChannelText: String {
         order.salesChannel?.description ?? ""
     }
@@ -135,6 +150,16 @@ struct LastOrderDashboardRowViewModel {
     var statusBackgroundColor: Color {
         let displayStatus = isCIAB ? CIABOrderStatusMapper.displayStatus(for: order.status) : order.status
         return Color(uiColor: displayStatus.backgroundColor)
+    }
+
+    /// Returns the fulfillment badge text for CIAB orders, or `nil` if the badge should not be shown.
+    var fulfillmentBadgeText: String? {
+        order.fulfillmentStatus.badgeText()
+    }
+
+    /// Background color for the fulfillment badge.
+    var fulfillmentBadgeBackgroundColor: Color {
+        order.fulfillmentStatus.badgeBackgroundSwiftUIColor
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrderDashboardRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrderDashboardRowViewModelTests.swift
@@ -1,0 +1,120 @@
+import Testing
+import Yosemite
+import NetworkingCore
+@testable import WooCommerce
+
+@Suite
+struct LastOrderDashboardRowViewModelTests {
+
+    // MARK: - Fulfillment badge text
+
+    @Test
+    func test_fulfillmentBadgeText_when_fulfilled_then_returns_fulfilled_text() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .fulfilled)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.fulfillmentBadgeText == "Fulfilled")
+    }
+
+    @Test
+    func test_fulfillmentBadgeText_when_unfulfilled_then_returns_unfulfilled_text() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .unfulfilled)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.fulfillmentBadgeText == "Unfulfilled")
+    }
+
+    @Test
+    func test_fulfillmentBadgeText_when_unknown_then_returns_nil() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .unknown)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.fulfillmentBadgeText == nil)
+    }
+
+    @Test
+    func test_fulfillmentBadgeText_when_partiallyFulfilled_then_returns_nil() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .partiallyFulfilled)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.fulfillmentBadgeText == nil)
+    }
+
+    @Test
+    func test_fulfillmentBadgeText_when_noFulfillments_then_returns_nil() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .noFulfillments)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.fulfillmentBadgeText == nil)
+    }
+
+    // MARK: - isFulfillmentStatusRequired
+
+    @Test
+    func test_isFulfillmentStatusRequired_when_CIAB_and_fulfilled_then_returns_true() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .fulfilled)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order, isCIAB: true)
+
+        // Then
+        #expect(viewModel.isFulfillmentStatusRequired == true)
+    }
+
+    @Test
+    func test_isFulfillmentStatusRequired_when_CIAB_and_unfulfilled_then_returns_true() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .unfulfilled)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order, isCIAB: true)
+
+        // Then
+        #expect(viewModel.isFulfillmentStatusRequired == true)
+    }
+
+    @Test
+    func test_isFulfillmentStatusRequired_when_CIAB_and_unknown_then_returns_false() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .unknown)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order, isCIAB: true)
+
+        // Then
+        #expect(viewModel.isFulfillmentStatusRequired == false)
+    }
+
+    @Test
+    func test_isFulfillmentStatusRequired_when_not_CIAB_and_fulfilled_then_returns_false() {
+        // Given
+        let order = Order.fake().copy(fulfillmentStatus: .fulfilled)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order, isCIAB: false)
+
+        // Then
+        #expect(viewModel.isFulfillmentStatusRequired == false)
+    }
+}


### PR DESCRIPTION
Part of: WOOMOB-2636

## Description
Adds a fulfillment status badge (Fulfilled / Unfulfilled) to the dashboard recent orders card for CIAB sites.

**What's included:**
- `OrderFulfillmentStatusDisplay` — centralized extension on `OrderFulfillmentStatus` providing `badgeText(dateFulfilled:)` and `badgeBackgroundColor`. Reusable across all order screens (list, details, search). Supports an optional date parameter for the order details screen.
- `LastOrderDashboardRow` — renders the fulfillment badge in the existing badge HStack, gated by `isFulfillmentStatusRequired` (CIAB + known fulfillment status).
- Unit tests for badge text and CIAB gating logic.

## Test Steps
1. Log in to a CIAB site with orders that have fulfillment status metadata
2. Navigate to the Dashboard tab
3. Verify recent orders show "Fulfilled" (green) or "Unfulfilled" (orange) badges next to the order status badge
4. Log in to a non-CIAB site and verify no fulfillment badges appear

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.