### PR TITLE
Fix Xcode 26.4 build: rename DecodingError.debugDescription extension

### DIFF
--- a/Modules/Sources/NetworkingCore/Extensions/DecodingError+CodingPath.swift
+++ b/Modules/Sources/NetworkingCore/Extensions/DecodingError+CodingPath.swift
@@ -21,7 +21,12 @@ public extension DecodingError {
     /// A description of what went wrong, for debugging purposes.
     ///
     /// Outputs: `Expected to decode a Number but found a String instead`
-    var debugDescription: String {
+    ///
+    /// Named `contextDebugDescription` rather than `debugDescription` to avoid colliding with the
+    /// `CustomDebugStringConvertible` conformance Swift 6.3 added to `DecodingError` via SE-0489.
+    /// That conformance is gated to iOS 26.4+, so shadowing it from an extension breaks builds
+    /// targeting lower deployment versions on Xcode 26.4.
+    var contextDebugDescription: String {
         context.debugDescription
     }
 }

--- a/Modules/Tests/NetworkingTests/Extensions/DecodingError+CodingPathTests.swift
+++ b/Modules/Tests/NetworkingTests/Extensions/DecodingError+CodingPathTests.swift
@@ -18,7 +18,7 @@ final class DecodingError_CodingPathTests: XCTestCase {
 
         // Then
         assertEqual("name", error.debugPath)
-        assertEqual(mockDebugDescription, error.debugDescription)
+        assertEqual(mockDebugDescription, error.contextDebugDescription)
     }
 
     func test_keyNotFound_decoding_error_has_expected_properties() {
@@ -27,7 +27,7 @@ final class DecodingError_CodingPathTests: XCTestCase {
 
         // Then
         assertEqual("name", error.debugPath)
-        assertEqual(mockDebugDescription, error.debugDescription)
+        assertEqual(mockDebugDescription, error.contextDebugDescription)
     }
 
     func test_typeMismatch_decoding_error_has_expected_properties() {
@@ -36,7 +36,7 @@ final class DecodingError_CodingPathTests: XCTestCase {
 
         // Then
         assertEqual("name", error.debugPath)
-        assertEqual(mockDebugDescription, error.debugDescription)
+        assertEqual(mockDebugDescription, error.contextDebugDescription)
     }
 
     func test_valueNotFound_decoding_error_has_expected_properties() {
@@ -45,7 +45,7 @@ final class DecodingError_CodingPathTests: XCTestCase {
 
         // Then
         assertEqual("name", error.debugPath)
-        assertEqual(mockDebugDescription, error.debugDescription)
+        assertEqual(mockDebugDescription, error.contextDebugDescription)
     }
 
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -3078,7 +3078,7 @@ extension WooAnalyticsEvent {
                                 Keys.path.rawValue: path,
                                 Keys.entityName.rawValue: entityName,
                                 Keys.debugDecodingPath.rawValue: (error as? DecodingError)?.debugPath,
-                                Keys.debugDecodingDescription.rawValue: (error as? DecodingError)?.debugDescription
+                                Keys.debugDecodingDescription.rawValue: (error as? DecodingError)?.contextDebugDescription
                               ].compactMapValues { $0 },
                               error: error)
         }


### PR DESCRIPTION
## Description

> **⚠️ AI-generated PR.** Research, diagnosis, patches, and verification were produced autonomously by Claude Code (Opus 4.6, 1M context, via Claude Code CLI). The human author's involvement was limited to a single prompt describing the symptom and asking to search for prior reports. All root-cause analysis, code changes, build verification, and PR authoring were performed by the agent. Please review accordingly.

### Root cause

Swift 6.3, which ships with Xcode 26.4, adds `CustomDebugStringConvertible` conformance to `DecodingError` and `EncodingError` via [SE-0489](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0489-codable-error-printing.md) (implemented in [swiftlang/swift#80941](https://github.com/swiftlang/swift/pull/80941)). The new `debugDescription` members are gated `@available(SwiftStdlib 6.3, *)`, which resolves to iOS 26.4 / macOS 26.4 / tvOS 26.4 / watchOS 26.4 / visionOS 26.4.

`NetworkingCore` already defined a custom `public extension DecodingError { var debugDescription: String }` that returned the underlying `Context.debugDescription`. That extension now collides with the new stdlib member and the compiler rejects it when the deployment target is below iOS 26.4.

### Fix

Rename the custom extension member from `debugDescription` to `contextDebugDescription`, preserving the exact same semantics. Update the single in-tree consumer (`WooAnalyticsEvent+WooApp.swift`) and the unit tests in `DecodingError+CodingPathTests.swift`.

### Why rename rather than delete

The custom extension is a simple shortcut to `Context.debugDescription`. Deleting it and using `String(reflecting:)` or the stdlib member directly would either change the output format on older OSes or require raising the deployment target. A rename is the minimal, fully back-deployable fix.

## Test Steps

1. Confirm the project builds on Xcode 26.4 without the original `'debugDescription' is only available in iOS 26.4 or newer` error.
2. Run the unit tests that exercise the renamed property:
   ```
   xcodebuild -workspace WooCommerce.xcworkspace -scheme Networking \
     -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
     -sdk iphonesimulator test \
     -only-testing:"NetworkingTests/DecodingError_CodingPathTests"
   ```
   Locally verified by the agent: 5 tests, 0 failures.
3. Verified that both `NetworkingCore` and the `WooCommerce` app target build clean on Xcode 26.4 / iPhone 17 Pro simulator.

## Screenshots

N/A — build-compatibility fix, no runtime or UI change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not needed: build-system fix, no behavior change.)