### PR TITLE
Optimize API requests after login to avoid rate limiting

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -15,6 +15,10 @@ final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
     private let stores: StoresManager
     private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
 
+    /// In-flight eligibility checks keyed by siteID, shared across all instances.
+    /// Thread-safe because all access is on @MainActor.
+    private static var inFlightChecks: [Int64: Task<Bool, Never>] = [:]
+
     init(
         stores: StoresManager = ServiceLocator.stores,
         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()
@@ -25,23 +29,42 @@ final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
 
     /// Checks if the site is eligible for Blaze.
     /// - Returns: Whether the site is eligible for Blaze.
+    @MainActor
     func isSiteEligible(_ site: Site) async -> Bool {
-        await checkSiteEligibility(site)
+        await deduplicatedCheckSiteEligibility(site)
     }
 
     /// Checks if the product is eligible for Blaze.
     /// - Parameter product: The product to check for Blaze eligibility.
     /// - Parameter isPasswordProtected: Whether the product is password protected.
     /// - Returns: Whether the product is eligible for Blaze.
+    @MainActor
     func isProductEligible(site: Site, product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
         guard product.status == .published && isPasswordProtected == false else {
             return false
         }
-        return await checkSiteEligibility(site)
+        return await deduplicatedCheckSiteEligibility(site)
     }
 }
 
 private extension BlazeEligibilityChecker {
+    @MainActor
+    func deduplicatedCheckSiteEligibility(_ site: Site) async -> Bool {
+        let siteID = site.siteID
+        if let existingTask = Self.inFlightChecks[siteID] {
+            return await existingTask.value
+        }
+
+        let task = Task { @MainActor [weak self] () -> Bool in
+            guard let self else { return false }
+            return await self.checkSiteEligibility(site)
+        }
+        Self.inFlightChecks[siteID] = task
+        let result = await task.value
+        Self.inFlightChecks.removeValue(forKey: siteID)
+        return result
+    }
+
     @MainActor
     func checkSiteEligibility(_ site: Site) async -> Bool {
         guard

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -15,13 +15,34 @@ final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
 
+    /// In-flight eligibility checks keyed by siteID, shared across all instances.
+    /// Thread-safe because all access is on @MainActor.
+    private static var inFlightChecks: [Int64: Task<Bool, Never>] = [:]
+
     init(stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
         self.featureFlagService = featureFlagService
     }
 
+    @MainActor
     func isSiteEligible(siteID: Int64) async -> Bool {
+        if let existingTask = Self.inFlightChecks[siteID] {
+            return await existingTask.value
+        }
+
+        let task = Task { @MainActor [weak self] () -> Bool in
+            guard let self else { return false }
+            return await self.performEligibilityCheck(siteID: siteID)
+        }
+        Self.inFlightChecks[siteID] = task
+        let result = await task.value
+        Self.inFlightChecks.removeValue(forKey: siteID)
+        return result
+    }
+
+    @MainActor
+    private func performEligibilityCheck(siteID: Int64) async -> Bool {
         guard featureFlagService.isFeatureFlagEnabled(.googleAdsCampaignCreationOnWebView) else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -222,6 +222,8 @@ final class DashboardViewModel: ObservableObject {
         observeStoreSetupEligibility()
         configureOrdersResultController()
         setupDashboardCards()
+        observeValuesForDashboardCards()
+        observeDashboardCardsAndReload()
         observeWPCOMSiteSuspendedState()
         observeSelfDrivenPushTokenPersistence()
         bindClientSideBannerWebViewSheet()
@@ -385,8 +387,6 @@ private extension DashboardViewModel {
             }))
         }
         savedCards = storageCards ?? []
-        observeValuesForDashboardCards()
-        observeDashboardCardsAndReload()
     }
 
     func saveDashboardCards(cards: [DashboardCard]) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -398,10 +398,32 @@ private extension DashboardViewModel {
 // MARK: Reload cards
 
 private extension DashboardViewModel {
-    /// Sync essential data to construct the dashboard
+    /// Sync essential data to construct the dashboard.
+    ///
+    /// Split into two phases to reduce the initial request burst and avoid
+    /// rate limiting (429 errors) on self-hosted sites. Phase 1 handles data
+    /// needed for the initial dashboard render; phase 2 handles card availability
+    /// checks that only toggle visibility and can appear slightly later.
     ///
     @MainActor
     func syncDashboardEssentialData() async {
+        // Phase 1: Data needed for initial dashboard render.
+        // Local checks (no network) + hasOrders check (1 request).
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { [weak self] in
+                await self?.updateJetpackBannerVisibilityFromAppSettings()
+            }
+            group.addTask { [weak self] in
+                await self?.updateHasOrdersStatus()
+            }
+            group.addTask { [weak self] in
+                await self?.updateSelfDrivenPushRegistrationStatus()
+            }
+        }
+
+        // Phase 2: Card availability checks and announcements.
+        // These toggle card visibility and load banners — not needed for initial render.
+        // Deferred to reduce the concurrent request count in the initial burst.
         await withTaskGroup(of: Void.self) { group in
             group.addTask { [weak self] in
                 guard let self else { return }
@@ -411,16 +433,7 @@ private extension DashboardViewModel {
                 await self?.blazeCampaignDashboardViewModel.checkAvailability()
             }
             group.addTask { [weak self] in
-                await self?.updateJetpackBannerVisibilityFromAppSettings()
-            }
-            group.addTask { [weak self] in
-                await self?.updateHasOrdersStatus()
-            }
-            group.addTask { [weak self] in
                 await self?.googleAdsDashboardCardViewModel.checkAvailability()
-            }
-            group.addTask { [weak self] in
-                await self?.updateSelfDrivenPushRegistrationStatus()
             }
         }
     }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -768,26 +768,31 @@ private extension DefaultStoresManager {
             restoreJetpackSiteAndSynchronizeIfNeeded(with: siteID)
         }
 
-        // Essential requests — needed for dashboard rendering.
-        // Fire these first, then defer non-essential requests to avoid rate limiting.
-        synchronizeSettings(with: siteID) {
-            ServiceLocator.shippingSettingsService.update(siteID: siteID)
-        }
+        // Requests are split into three batches to avoid rate limiting (429 errors)
+        // on self-hosted sites. The dashboard also fires its own requests concurrently
+        // (via syncDashboardEssentialData), so keeping each batch small is important.
+        //
+        // Batch 1 (immediate): Site settings — needed for dashboard rendering.
         loadStoreUUID(siteID: siteID)
+        synchronizeSettings(with: siteID) { [weak self] in
+            guard let self else { return }
+            ServiceLocator.shippingSettingsService.update(siteID: siteID)
 
-        Task { @MainActor in
-            // Order statuses and system plugins syncing are required outside of snapshot tracking.
-            async let orderStatuses = retrieveOrderStatus(with: siteID)
-            async let systemInformation = fetchSystemInformationAndRetryIfFails(siteID: siteID)
+            // Batch 2 (after settings complete): Order statuses and system info for snapshot tracking.
+            // Sequenced after batch 1 so these don't overlap with the initial burst.
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                async let orderStatuses = retrieveOrderStatus(with: siteID)
+                async let systemInformation = fetchSystemInformationAndRetryIfFails(siteID: siteID)
 
-            trackSnapshotIfNeeded(siteID: siteID, orderStatuses: await orderStatuses, systemPlugins: await systemInformation?.systemPlugins)
+                trackSnapshotIfNeeded(siteID: siteID, orderStatuses: await orderStatuses, systemPlugins: await systemInformation?.systemPlugins)
 
-            // Non-essential requests — deferred until essential requests have completed
-            // to spread the request burst and avoid 429 rate limiting.
-            synchronizePaymentGateways(siteID: siteID)
-            synchronizeAddOnsGroups(siteID: siteID)
-            synchronizeSitePlugins(siteID: siteID)
-            sendTelemetryIfNeeded(siteID: siteID)
+                // Batch 3 (after batch 2 completes): Non-essential data.
+                synchronizePaymentGateways(siteID: siteID)
+                synchronizeAddOnsGroups(siteID: siteID)
+                synchronizeSitePlugins(siteID: siteID)
+                sendTelemetryIfNeeded(siteID: siteID)
+            }
         }
     }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -768,15 +768,12 @@ private extension DefaultStoresManager {
             restoreJetpackSiteAndSynchronizeIfNeeded(with: siteID)
         }
 
+        // Essential requests — needed for dashboard rendering.
+        // Fire these first, then defer non-essential requests to avoid rate limiting.
         synchronizeSettings(with: siteID) {
             ServiceLocator.shippingSettingsService.update(siteID: siteID)
         }
-        synchronizePaymentGateways(siteID: siteID)
-        synchronizeAddOnsGroups(siteID: siteID)
-        synchronizeSitePlugins(siteID: siteID)
         loadStoreUUID(siteID: siteID)
-
-        sendTelemetryIfNeeded(siteID: siteID)
 
         Task { @MainActor in
             // Order statuses and system plugins syncing are required outside of snapshot tracking.
@@ -784,6 +781,13 @@ private extension DefaultStoresManager {
             async let systemInformation = fetchSystemInformationAndRetryIfFails(siteID: siteID)
 
             trackSnapshotIfNeeded(siteID: siteID, orderStatuses: await orderStatuses, systemPlugins: await systemInformation?.systemPlugins)
+
+            // Non-essential requests — deferred until essential requests have completed
+            // to spread the request burst and avoid 429 rate limiting.
+            synchronizePaymentGateways(siteID: siteID)
+            synchronizeAddOnsGroups(siteID: siteID)
+            synchronizeSitePlugins(siteID: siteID)
+            sendTelemetryIfNeeded(siteID: siteID)
         }
     }
 


### PR DESCRIPTION
## Description

After logging in to a self-hosted site with application passwords, the app fires ~32 requests to the site within ~5 seconds, with ~14 concentrated in a single 300ms window. This triggers 8 rate-limited (429) responses, causing failed data loads on the dashboard.

This PR applies four fixes that together **eliminate all 429 errors (8→0)** and reduce total requests by ~40% (32→19):

### 1. Fix duplicated Combine subscriptions on dashboard ([WOOMOB-2699](https://linear.app/a8c/issue/WOOMOB-2699))

`DashboardViewModel.loadDashboardCardsFromStorage()` called `observeValuesForDashboardCards()` and `observeDashboardCardsAndReload()` on every invocation, accumulating duplicate Combine subscriptions (2→5→8). This caused `updateDashboardCards` to fire ~20 times instead of ~7, multiplying card reload requests. Fixed by moving subscription setup to `init`.

### 2. Deduplicate eligibility checker requests ([WOOMOB-2700](https://linear.app/a8c/issue/WOOMOB-2700))

`DefaultGoogleAdsEligibilityChecker` and `BlazeEligibilityChecker` are independently instantiated by `DashboardViewModel` and `HubMenuViewModel`, each making their own network calls. Added static in-flight `Task` deduplication — first caller creates the Task, subsequent callers for the same `siteID` await the same result. Thread-safe because all access is on `@MainActor`.

### 3. Split DefaultStoresManager startup requests into 3 sequenced batches ([WOOMOB-2702](https://linear.app/a8c/issue/WOOMOB-2702))

`DefaultStoresManager.restoreSessionSiteIfPossible()` fired all requests at once. Now split into three batches:

- **Batch 1 (immediate):** Site settings — needed for dashboard rendering
- **Batch 2 (after settings complete):** Order statuses + system info — for snapshot tracking
- **Batch 3 (after batch 2 completes):** Payment gateways, add-ons, plugins, telemetry

Batches are sequenced using the existing `synchronizeSettings` completion handler, so batch 2 genuinely waits for batch 1 to return before firing.

### 4. Split dashboard essential data sync into 2 phases

`DashboardViewModel.syncDashboardEssentialData()` fired all checks concurrently. Now split into:

- **Phase 1 (immediate):** Local checks + `updateHasOrdersStatus` (1 network request)
- **Phase 2 (after phase 1 completes):** Announcements (JITM), Blaze eligibility, Google Ads eligibility

This removes 3 network requests (JITM, Google Ads connection, Blaze check) from the initial burst.

### Results

| Metric | Before | After |
|--------|:---:|:---:|
| Total site requests | ~32 | **~19** |
| 429 errors | **8** | **0** |
| Request pattern | 300ms burst | 4 waves over ~4s |

```
Wave 1 (immediate):     settings x2, orders/totals, products, orders x2    (7 reqs)
Wave 2 (~1.5s later):   orders/totals, analytics x2                        (3 reqs)
Wave 3 (~2.5s later):   gla/ads, system_status, products, onboarding       (4 reqs)
Wave 4 (~4s later):     payment_gateways, plugins, product-add-ons         (3 reqs)
```

Closes: [WOOMOB-2697](https://linear.app/a8c/issue/WOOMOB-2697)

## Test Steps

1. Log in to a self-hosted WooCommerce site using application passwords (site credentials)
2. Monitor network requests using a proxy tool (e.g., Proxyman)
3. Verify that requests are spread across four waves instead of one burst
4. Verify no 429 errors appear
5. Verify the dashboard loads correctly with no missing data — cards may appear progressively as waves complete
6. Navigate to Hub Menu → verify Google Ads and Blaze eligibility checks still work
7. Pull to refresh on dashboard → verify all cards reload correctly

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.