### PR TITLE
Preserve error message on DotcomError.requestFailed and log role check failures

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/DotcomError.swift
+++ b/Modules/Sources/NetworkingCore/Model/DotcomError.swift
@@ -19,7 +19,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
 
     /// Remote Request Failed
     ///
-    case requestFailed(data: [String: AnyDecodable]? = nil)
+    case requestFailed(message: String? = nil, data: [String: AnyDecodable]? = nil)
 
     /// No route was found matching the URL and request method
     ///
@@ -61,7 +61,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
         case Constants.invalidToken:
             self = .invalidToken(data: data)
         case Constants.requestFailed:
-            self = .requestFailed(data: data)
+            self = .requestFailed(message: message, data: data)
         case Constants.unauthorized where message == ErrorMessages.noStatsPermission:
             self = .noStatsPermission(data: data)
         case Constants.unauthorized:
@@ -121,7 +121,10 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Response Empty", comment: "WordPress.com Error thrown when the response body is empty")
         case .invalidToken:
             return NSLocalizedString("Dotcom Token Invalid", comment: "WordPress.com Invalid Token")
-        case .requestFailed:
+        case .requestFailed(let message, _):
+            if let message {
+                return "Dotcom Request Failed: \(message)"
+            }
             return NSLocalizedString("Dotcom Request Failed", comment: "WordPress.com Request Failure")
         case .unauthorized:
             return NSLocalizedString("Dotcom Missing Token", comment: "WordPress.com Missing Token")

--- a/Modules/Sources/NetworkingCore/Model/DotcomError.swift
+++ b/Modules/Sources/NetworkingCore/Model/DotcomError.swift
@@ -121,11 +121,7 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Response Empty", comment: "WordPress.com Error thrown when the response body is empty")
         case .invalidToken:
             return NSLocalizedString("Dotcom Token Invalid", comment: "WordPress.com Invalid Token")
-        case .requestFailed(let message, _):
-            if let message {
-                let format = NSLocalizedString("Dotcom Request Failed: %1$@", comment: "WordPress.com Request Failure with details. Parameter: %1$@ - error message")
-                return String.localizedStringWithFormat(format, message)
-            }
+        case .requestFailed:
             return NSLocalizedString("Dotcom Request Failed", comment: "WordPress.com Request Failure")
         case .unauthorized:
             return NSLocalizedString("Dotcom Missing Token", comment: "WordPress.com Missing Token")

--- a/Modules/Sources/NetworkingCore/Model/DotcomError.swift
+++ b/Modules/Sources/NetworkingCore/Model/DotcomError.swift
@@ -123,7 +123,8 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Token Invalid", comment: "WordPress.com Invalid Token")
         case .requestFailed(let message, _):
             if let message {
-                return "Dotcom Request Failed: \(message)"
+                let format = NSLocalizedString("Dotcom Request Failed: %1$@", comment: "WordPress.com Request Failure with details. Parameter: %1$@ - error message")
+                return String.localizedStringWithFormat(format, message)
             }
             return NSLocalizedString("Dotcom Request Failed", comment: "WordPress.com Request Failure")
         case .unauthorized:

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerError.swift
@@ -7,8 +7,9 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
 
     /// Creates an `StorePickerErrorHostingController` with preconfigured button actions.
     ///
-    static func createWithActions(presenting: UIViewController) -> StorePickerErrorHostingController {
-        let viewController = StorePickerErrorHostingController()
+    static func createWithActions(presenting: UIViewController,
+                                  isPermissionError: Bool = false) -> StorePickerErrorHostingController {
+        let viewController = StorePickerErrorHostingController(isPermissionError: isPermissionError)
         viewController.setActions(troubleshootingAction: {
             WebviewHelper.launch(WooConstants.URLs.troubleshootErrorLoadingData.asURL(), with: viewController)
         },
@@ -24,8 +25,8 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
         return viewController
     }
 
-    init() {
-        super.init(rootView: StorePickerError())
+    init(isPermissionError: Bool = false) {
+        super.init(rootView: StorePickerError(isPermissionError: isPermissionError))
     }
 
     override func viewDidLoad() {
@@ -52,6 +53,10 @@ final class StorePickerErrorHostingController: UIHostingController<StorePickerEr
 ///
 struct StorePickerError: View {
 
+    /// Whether this error is a permission verification failure.
+    ///
+    let isPermissionError: Bool
+
     /// Closure invoked when the "Troubleshooting" button is pressed
     ///
     var troubleshootingAction: () -> Void = {}
@@ -76,7 +81,7 @@ struct StorePickerError: View {
                 Image(uiImage: .errorImage)
 
                 // Body text
-                Text(Localization.body)
+                Text(isPermissionError ? Localization.permissionErrorBody : Localization.body)
                     .multilineTextAlignment(.center)
                     .bodyStyle()
 
@@ -116,6 +121,11 @@ private extension StorePickerError {
         static let title = NSLocalizedString("We couldn't load your site", comment: "Title for the default store picker error screen")
         static let body = NSLocalizedString("Please try again or reach out to us and we'll be happy to assist you!",
                                             comment: "Body text for the default store picker error screen")
+        static let permissionErrorBody = NSLocalizedString(
+            "storePickerError.permissionErrorBody",
+            value: "There was a problem verifying your permissions. " +
+                "Please try again or reach out to us and we'll be happy to assist you!",
+            comment: "Body text for the store picker error screen when the permission check fails")
         static let troubleshoot = NSLocalizedString("Read our Troubleshooting Tips",
                                                     comment: "Text for the button to navigate to troubleshooting tips from the store picker error screen")
         static let contact = NSLocalizedString("Contact Support",
@@ -139,18 +149,19 @@ private extension StorePickerError {
 struct StorePickerError_Preview: PreviewProvider {
     static var previews: some View {
         VStack {
-            StorePickerError()
+            StorePickerError(isPermissionError: false)
         }
         .padding()
         .background(Color.gray)
         .previewLayout(.sizeThatFits)
+        .previewDisplayName("Generic Error")
 
         VStack {
-            StorePickerError()
+            StorePickerError(isPermissionError: true)
         }
         .padding()
         .background(Color.gray)
-        .environment(\.colorScheme, .dark)
         .previewLayout(.sizeThatFits)
+        .previewDisplayName("Permission Error")
     }
 }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -6,6 +6,7 @@ import WordPressAuthenticator
 import WordPressUI
 import Yosemite
 import Experiments
+import enum NetworkingCore.DotcomError
 
 
 typealias SelectStoreClosure = () -> Void
@@ -610,10 +611,10 @@ private extension StorePickerViewController {
         actionButton.showActivityIndicator(false)
     }
 
-    /// Displays a generic error view as a modal with options to see troubleshooting tips and to contact support.
+    /// Displays an error view as a modal with options to see troubleshooting tips and to contact support.
     ///
-    func displayUnknownErrorModal() {
-        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self)
+    func displayUnknownErrorModal(isPermissionError: Bool = false) {
+        let viewController = StorePickerErrorHostingController.createWithActions(presenting: self, isPermissionError: isPermissionError)
         viewController.modalPresentationStyle = .custom
         viewController.transitioningDelegate = self
         present(viewController, animated: true)
@@ -840,7 +841,9 @@ private extension StorePickerViewController {
                         self?.dismiss()
                     }
                 } else {
-                    self.displayUnknownErrorModal()
+                    let underlyingError = (error as? RoleEligibilityError)?.underlyingError ?? error
+                    let isPermissionError = underlyingError is DotcomError
+                    self.displayUnknownErrorModal(isPermissionError: isPermissionError)
                 }
             }
         }

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -1,4 +1,5 @@
 import Yosemite
+import enum NetworkingCore.DotcomError
 
 /// Encapsulates the logic for checking the eligibility of user roles.
 protocol RoleEligibilityUseCaseProtocol {
@@ -80,7 +81,11 @@ extension RoleEligibilityUseCase: RoleEligibilityUseCaseProtocol {
                 completion(.success(()))
 
             case .failure(let error):
-                DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(error)")
+                if case .requestFailed(let message, _) = error as? DotcomError {
+                    DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(message ?? error.localizedDescription)")
+                } else {
+                    DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(error)")
+                }
                 completion(.failure(.unknown(error: error)))
             }
         }

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -109,4 +109,12 @@ enum RoleEligibilityError: Error {
 
     /// An unknown error caused from other sources.
     case unknown(error: Error)
+
+    /// Returns the underlying error for the `.unknown` case, or `nil` for other cases.
+    var underlyingError: Error? {
+        if case .unknown(let error) = self {
+            return error
+        }
+        return nil
+    }
 }

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -80,6 +80,7 @@ extension RoleEligibilityUseCase: RoleEligibilityUseCaseProtocol {
                 completion(.success(()))
 
             case .failure(let error):
+                DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(error)")
                 completion(.failure(.unknown(error: error)))
             }
         }

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -82,7 +82,7 @@ extension RoleEligibilityUseCase: RoleEligibilityUseCaseProtocol {
 
             case .failure(let error):
                 if case .requestFailed(let message, _) = error as? DotcomError {
-                    DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(message ?? error.localizedDescription)")
+                    DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(message ?? String(describing: error))")
                 } else {
                     DDLogError("⛔️ Role eligibility check failed for site \(storeID): \(error)")
                 }


### PR DESCRIPTION
Fixes: WOOMOB-2509

## Summary

- Preserve the `message` field on `DotcomError.requestFailed` so it appears in logs instead of the vague "Dotcom Request Failed"
- Add `DDLogError` in `RoleEligibilityUseCase` when the role eligibility check fails, so support can see the error details in customer logs

## Test Steps

1. In Proxyman, mock the Jetpack tunnel request for `wp/v2/users/me` to return HTTP 200 with body:
```json
{"error": "http_request_failed", "message": "A very very bad error", "data": {"status": 500}}
```
2. Log in with any store
3. Turn off applicaiton password in Setting/Experimental Features
2. Reach the store picker, tap Continue on any site.
4. Verify the error modal appears.
5. Check the console logs for:
```
⛔️ Role eligibility check failed for site <site-id>: A very very bad error
```

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.