### PR TITLE
Fix continuation leak in waitForDeviceToken() during push notification registration

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -118,9 +118,15 @@ final class PushNotificationsManager: PushNotesManager {
     private var selfDrivenPushNotificationEnabled: Bool?
     private var pendingTokenData: Data?
 
-    /// Continuation used by `registerDeviceAndWaitForTokenAcceptance()` to wait for the device token
-    /// delivered asynchronously via `registerDeviceToken(with:)`.
-    private var deviceTokenContinuation: CheckedContinuation<String, Error>?
+    /// Holds the latest device token result, delivered asynchronously via `registerDeviceToken(with:)` or `registrationDidFail(with:)`.
+    /// Starts as `nil` (no result yet). `waitForDeviceToken()` reads `.value` for an immediate result
+    /// or subscribes for the first non-nil emission.
+    private let deviceTokenResult = CurrentValueSubject<Result<String, Error>?, Never>(nil)
+
+    /// Whether `registerDeviceAndWaitForTokenAcceptance()` is actively waiting for a token.
+    /// When true, `registerDeviceToken(with:)` skips its own registration path
+    /// because the awaited flow handles it.
+    private var isAwaitingTokenForRegistration = false
 
     /// Initializes the PushNotificationsManager.
     ///
@@ -196,6 +202,10 @@ extension PushNotificationsManager {
             return mockTokenID
         }
         #endif
+
+        // Reset any previous token result before starting a new registration
+        deviceTokenResult.send(nil)
+
         // 1. Register with iOS for remote notifications
         registerForRemoteNotifications()
 
@@ -218,14 +228,30 @@ extension PushNotificationsManager {
     }
 
     /// Waits for the device token to arrive via `registerDeviceToken(with:)`.
-    /// Returns immediately if a token is already available.
+    /// Returns immediately if a result is already available, otherwise subscribes
+    /// to `deviceTokenResult` with a 10-second timeout.
     private func waitForDeviceToken() async throws -> String {
-        if let existingToken = registrationState.deviceToken {
-            return existingToken
+        isAwaitingTokenForRegistration = true
+
+        defer {
+            isAwaitingTokenForRegistration = false
         }
-        return try await withCheckedThrowingContinuation { continuation in
-            deviceTokenContinuation = continuation
+
+        if let existing = deviceTokenResult.value {
+            return try existing.get()
         }
+
+        guard
+            let result = await deviceTokenResult
+                .compactMap({ $0 })
+                .timeout(.seconds(10), scheduler: DispatchQueue.main)
+                .values
+                .first(where: { _ in true })
+        else {
+            throw PushNotificationError.deviceTokenTimeout
+        }
+
+        return try result.get()
     }
 
 
@@ -305,6 +331,10 @@ extension PushNotificationsManager {
     ///     - defaultStoreID: Default WooCommerce Store ID
     ///
     func registerDeviceToken(with tokenData: Data) {
+        // Always publish the token so `waitForDeviceToken()` can pick it up,
+        // even when eligibility is not yet determined.
+        deviceTokenResult.send(.success(tokenData.hexString))
+
         guard let selfDrivenPushNotificationEnabled else {
             pendingTokenData = tokenData
             return
@@ -313,12 +343,9 @@ extension PushNotificationsManager {
 
         registrationState.applyNewDeviceToken(newToken)
 
-        // Resume any pending continuation waiting for the device token
-        // (from registerDeviceAndWaitForTokenAcceptance). The caller handles
-        // the self-driven registration flow, so we skip the existing path.
-        if let continuation = deviceTokenContinuation {
-            deviceTokenContinuation = nil
-            continuation.resume(returning: newToken)
+        // The awaited flow handles its own registration,
+        // so skip the existing path below.
+        if isAwaitingTokenForRegistration {
             return
         }
 
@@ -371,10 +398,9 @@ extension PushNotificationsManager {
     func registrationDidFail(with error: Error) {
         DDLogError("⛔️ Push Notifications Registration Failure: \(error)")
 
-        // Resume any pending continuation so the awaiting caller gets the error
-        if let continuation = deviceTokenContinuation {
-            deviceTokenContinuation = nil
-            continuation.resume(throwing: error)
+        // Notify any pending `waitForDeviceToken()` subscriber so the awaiting caller gets the error
+        if isAwaitingTokenForRegistration {
+            deviceTokenResult.send(.failure(error))
             return
         }
 
@@ -897,6 +923,10 @@ private enum AnalyticKey {
     static let token = "push_notification_token"
     static let fromSelectedSite = "is_from_selected_site"
     static let appState = "app_state"
+}
+
+private enum PushNotificationError: Error {
+    case deviceTokenTimeout
 }
 
 private enum PushType {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -230,6 +230,7 @@ extension PushNotificationsManager {
     /// Waits for the device token to arrive via `registerDeviceToken(with:)`.
     /// Returns immediately if a result is already available, otherwise subscribes
     /// to `deviceTokenResult` with a 10-second timeout.
+    @MainActor
     private func waitForDeviceToken() async throws -> String {
         isAwaitingTokenForRegistration = true
 
@@ -398,9 +399,11 @@ extension PushNotificationsManager {
     func registrationDidFail(with error: Error) {
         DDLogError("⛔️ Push Notifications Registration Failure: \(error)")
 
-        // Notify any pending `waitForDeviceToken()` subscriber so the awaiting caller gets the error
-        if isAwaitingTokenForRegistration {
-            deviceTokenResult.send(.failure(error))
+        // Always publish the failure so `waitForDeviceToken()` can pick it up,
+        // matching the symmetric behavior in `registerDeviceToken(with:)`.
+        deviceTokenResult.send(.failure(error))
+
+        guard !isAwaitingTokenForRegistration else {
             return
         }
 


### PR DESCRIPTION
Closes WOOMOB-2704

## Description

Fixes a race condition where `waitForDeviceToken()` could hang indefinitely during push notification registration.

**Root cause:** `registerDeviceAndWaitForTokenAcceptance()` calls `registerForRemoteNotifications()` first, then suspends for authorization. iOS can deliver the device token callback during that suspension — before `waitForDeviceToken()` runs. When `selfDrivenPushNotificationEnabled` is still `nil` at that point, the token gets stashed in `pendingTokenData` and `registrationState.deviceToken` is never set. So when `waitForDeviceToken()` finally runs, it stores a `CheckedContinuation` that nothing will ever resume.

**Fix:** Replace the stored `CheckedContinuation` with a `CurrentValueSubject<Result<String, Error>?, Never>` that:
- Is created once as a `let` property (no recreation needed)
- Retains the latest value, so tokens that arrive early are not lost
- Is published through in **all** paths of `registerDeviceToken(with:)`, including the early return when eligibility is undetermined
- Propagates errors from `registrationDidFail(with:)` immediately
- Includes a 10-second timeout via Combine `.timeout()` to prevent indefinite suspension

## Test Steps

To reproduce the race condition, temporarily replace the `#if targetEnvironment(simulator)` block in `registerDeviceAndWaitForTokenAcceptance()` with:

```swift
#if targetEnvironment(simulator)
if !isRunningTests {
    registrationState.deviceToken = nil
    pendingTokenData = nil
    let savedEligibility = selfDrivenPushNotificationEnabled
    selfDrivenPushNotificationEnabled = nil

    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
        self.registerDeviceToken(with: Data("simulated-token".utf8))
        self.selfDrivenPushNotificationEnabled = savedEligibility
    }

    try await Task.sleep(for: .seconds(2))
    let deviceToken = try await waitForDeviceToken()
    return 0
}
#endif
```

- Use a JN WooCommerce site.
- Make sure to enable self-driven push notifications flags in logged out FF console.
- Log into the store
- Navigate to self-driven PNs setup flow from dashboard and press "Continue"

**Before fix** (on `trunk`): the push notification setup flow hangs — the token was delivered while eligibility was `nil` (goes to `pendingTokenData`), so neither `registrationState.deviceToken` nor the continuation receives it. The continuation is never resumed.

**After fix** (on this branch): `waitForDeviceToken()` completes — the `CurrentValueSubject` already has the token because `registerDeviceToken(with:)` publishes through it in all paths, including the early return when eligibility is `nil`.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.