### PR TITLE
[WOOMOB-2617] Handle invalid destination name errors in shipping rates

### DIFF
--- a/Modules/Sources/Networking/Mapper/ShippingLabelCarriersAndRatesMapper.swift
+++ b/Modules/Sources/Networking/Mapper/ShippingLabelCarriersAndRatesMapper.swift
@@ -48,6 +48,7 @@ private struct ShippingLabelDefaultBoxEnvelope: Decodable {
         boxes = dictionary.map { key, value in
             return ShippingLabelCarriersAndRates(packageID: key,
                                                  defaultRates: value.defaultRates,
+                                                 defaultErrors: value.defaultErrors,
                                                  signatureRequired: value.signatureRequired,
                                                  adultSignatureRequired: value.adultSignatureRequired,
                                                  carbonNeutral: value.carbonNeutral,

--- a/Modules/Sources/Networking/Mapper/WooShippingLabelRatesMapper.swift
+++ b/Modules/Sources/Networking/Mapper/WooShippingLabelRatesMapper.swift
@@ -40,6 +40,7 @@ private struct ShippingLabelDefaultBoxEnvelope: Decodable {
         boxes = dictionary.map { key, value in
             return ShippingLabelCarriersAndRates(packageID: key,
                                                  defaultRates: value.defaultRates,
+                                                 defaultErrors: value.defaultErrors,
                                                  signatureRequired: value.signatureRequired,
                                                  adultSignatureRequired: value.adultSignatureRequired,
                                                  carbonNeutral: value.carbonNeutral,

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/ShippingLabelCarriersAndRates.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/ShippingLabelCarriersAndRates.swift
@@ -6,6 +6,7 @@ public struct ShippingLabelCarriersAndRates: Equatable {
 
     public var packageID: String?
     public let defaultRates: [ShippingLabelCarrierRate]
+    public let defaultErrors: [ShippingLabelRateError]
     public let signatureRequired: [ShippingLabelCarrierRate]
     public let adultSignatureRequired: [ShippingLabelCarrierRate]
     public let carbonNeutral: [ShippingLabelCarrierRate]
@@ -14,6 +15,7 @@ public struct ShippingLabelCarriersAndRates: Equatable {
 
     public init(packageID: String?,
                 defaultRates: [ShippingLabelCarrierRate],
+                defaultErrors: [ShippingLabelRateError] = [],
                 signatureRequired: [ShippingLabelCarrierRate],
                 adultSignatureRequired: [ShippingLabelCarrierRate],
                 carbonNeutral: [ShippingLabelCarrierRate],
@@ -21,6 +23,7 @@ public struct ShippingLabelCarriersAndRates: Equatable {
                 additionalHandling: [ShippingLabelCarrierRate]) {
         self.packageID = packageID
         self.defaultRates = defaultRates
+        self.defaultErrors = defaultErrors
         self.signatureRequired = signatureRequired
         self.adultSignatureRequired = adultSignatureRequired
         self.carbonNeutral = carbonNeutral
@@ -36,7 +39,9 @@ extension ShippingLabelCarriersAndRates: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let packageID = try container.decodeIfPresent(String.self, forKey: .packageID)
-        let defaultRates = try container.decode(ShippingLabelRatesEnvelope.self, forKey: .defaultRates).rates
+        let defaultOption = try container.decode(ShippingLabelRatesEnvelope.self, forKey: .defaultRates)
+        let defaultRates = defaultOption.rates
+        let defaultErrors = defaultOption.errors
         let signatureRequired = try container.decode(ShippingLabelRatesEnvelope.self, forKey: .signatureRequired).rates
         let adultSignatureRequired = try container.decode(ShippingLabelRatesEnvelope.self, forKey: .adultSignatureRequired).rates
         let carbonNeutral = try container.decodeIfPresent(ShippingLabelRatesEnvelope.self, forKey: .carbonNeutral)?.rates ?? []
@@ -45,6 +50,7 @@ extension ShippingLabelCarriersAndRates: Decodable {
 
         self.init(packageID: packageID,
                   defaultRates: defaultRates,
+                  defaultErrors: defaultErrors,
                   signatureRequired: signatureRequired,
                   adultSignatureRequired: adultSignatureRequired,
                   carbonNeutral: carbonNeutral,
@@ -66,8 +72,26 @@ extension ShippingLabelCarriersAndRates: Decodable {
 
 private struct ShippingLabelRatesEnvelope: Decodable {
     let rates: [ShippingLabelCarrierRate]
+    let errors: [ShippingLabelRateError]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        rates = try container.decodeIfPresent([ShippingLabelCarrierRate].self, forKey: .rates) ?? []
+        errors = try container.decodeIfPresent([ShippingLabelRateError].self, forKey: .errors) ?? []
+    }
 
     private enum CodingKeys: String, CodingKey {
         case rates
+        case errors
+    }
+}
+
+public struct ShippingLabelRateError: Equatable, Codable {
+    public let code: String?
+    public let message: String?
+
+    public init(code: String? = nil, message: String? = nil) {
+        self.code = code
+        self.message = message
     }
 }

--- a/Modules/Sources/Yosemite/Stores/WooShippingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/WooShippingStore.swift
@@ -174,7 +174,12 @@ private extension WooShippingStore {
                               destinationAddress: destinationAddress,
                               packages: packages,
                               completion: { result in
-            completion(packages, result)
+            switch result {
+            case let .success(rates) where rates.contains(where: \.hasInvalidDestinationNameRateError):
+                completion(packages, .failure(WooShippingLoadLabelRatesError.invalidDestinationName))
+            default:
+                completion(packages, result)
+            }
         })
     }
 
@@ -908,4 +913,17 @@ public enum WooShippingLabelPurchaseError: Error {
     case purchaseMissingLabels
     case failedToRefreshSelectedPackage
     case failedToRefreshSelectedRate
+}
+
+public enum WooShippingLoadLabelRatesError: Error {
+    case invalidDestinationName
+}
+
+private extension ShippingLabelCarriersAndRates {
+    var hasInvalidDestinationNameRateError: Bool {
+        defaultErrors.contains { error in
+            error.code == "rate_error" &&
+            error.message?.localizedCaseInsensitiveContains("shipment.to_address: invalid name") == true
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -201,6 +201,30 @@ final class WooShippingRemoteTests: XCTestCase {
         XCTAssertEqual(successResponse.first?.additionalHandling.count, 2)
     }
 
+    func test_loadLabelRates_parses_invalid_destination_name_rate_error() throws {
+        // Given
+        let remote = WooShippingRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "label/rate",
+                                 filename: "wooshipping-get-label-rates-invalid-destination-name")
+
+        // When
+        let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
+            remote.loadLabelRates(siteID: self.sampleSiteID,
+                                  orderID: self.sampleOrderID,
+                                  originAddress: WooShippingAddress.fake(),
+                                  destinationAddress: WooShippingAddress.fake(),
+                                  packages: [ShippingLabelPackageSelected.fake()]) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        let response = try XCTUnwrap(result.get())
+        XCTAssertEqual(response.first?.defaultErrors.first?.code, "rate_error")
+        XCTAssertEqual(response.first?.defaultErrors.first?.message,
+                       "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character")
+    }
+
     func test_loadLabelRates_returns_error_on_failure() throws {
         // Given
         let remote = WooShippingRemote(network: network)

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/wooshipping-get-label-rates-invalid-destination-name.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/wooshipping-get-label-rates-invalid-destination-name.json
@@ -1,0 +1,61 @@
+{
+  "default_package": {
+    "default": {
+      "rates": [],
+      "errors": [
+        {
+          "code": "rate_error",
+          "message": "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character",
+          "errors": [
+            {
+              "carrier": "UspsShip",
+              "carrier_account_id": "ca_bf7f1fb0afe248ebbef7e457a04322a9"
+            }
+          ]
+        }
+      ]
+    },
+    "signature_required": {
+      "rates": [],
+      "errors": [
+        {
+          "code": "rate_error",
+          "message": "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character",
+          "errors": [
+            {
+              "carrier": "UspsShip",
+              "carrier_account_id": "ca_bf7f1fb0afe248ebbef7e457a04322a9"
+            }
+          ]
+        }
+      ]
+    },
+    "adult_signature_required": {
+      "rates": [],
+      "errors": [
+        {
+          "code": "rate_error",
+          "message": "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character",
+          "errors": [
+            {
+              "carrier": "UspsShip",
+              "carrier_account_id": "ca_bf7f1fb0afe248ebbef7e457a04322a9"
+            }
+          ]
+        }
+      ]
+    },
+    "carbon_neutral": {
+      "rates": [],
+      "errors": []
+    },
+    "additional_handling": {
+      "rates": [],
+      "errors": []
+    },
+    "saturday_delivery": {
+      "rates": [],
+      "errors": []
+    }
+  }
+}

--- a/Modules/Tests/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -315,8 +315,12 @@ final class WooShippingStoreTests: XCTestCase {
         let remote = MockWooShippingRemote()
         let ratesWithError = [ShippingLabelCarriersAndRates(packageID: "123",
                                                             defaultRates: [],
-                                                            defaultErrors: [ShippingLabelRateError(code: "rate_error",
-                                                                                                  message: "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character")],
+                                                            defaultErrors: [ShippingLabelRateError(
+                                                                code: "rate_error",
+                                                                message: "shipment.to_address: invalid name; " +
+                                                                "A first and last name is required if passed in: " +
+                                                                "input name needs at least 1 space character"
+                                                            )],
                                                             signatureRequired: [],
                                                             adultSignatureRequired: [],
                                                             carbonNeutral: [],

--- a/Modules/Tests/YosemiteTests/Stores/WooShippingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/WooShippingStoreTests.swift
@@ -310,6 +310,37 @@ final class WooShippingStoreTests: XCTestCase {
         XCTAssertEqual(error as? NetworkError, expectedError)
     }
 
+    func test_loadLabelRates_maps_invalid_destination_name_rate_error() throws {
+        // Given
+        let remote = MockWooShippingRemote()
+        let ratesWithError = [ShippingLabelCarriersAndRates(packageID: "123",
+                                                            defaultRates: [],
+                                                            defaultErrors: [ShippingLabelRateError(code: "rate_error",
+                                                                                                  message: "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character")],
+                                                            signatureRequired: [],
+                                                            adultSignatureRequired: [],
+                                                            carbonNeutral: [],
+                                                            saturdayDelivery: [],
+                                                            additionalHandling: [])]
+        remote.whenLoadLabelRates(siteID: sampleSiteID, thenReturn: .success(ratesWithError))
+        let store = WooShippingStore(dispatcher: dispatcher, storageManager: storageManager, network: network, remote: remote)
+
+        // When
+        let result: Result<[ShippingLabelCarriersAndRates], Error> = waitFor { promise in
+            let action = WooShippingAction.loadLabelRates(siteID: self.sampleSiteID,
+                                                          orderID: self.sampleOrderID,
+                                                          originAddress: WooShippingAddress.fake(),
+                                                          destinationAddress: WooShippingAddress.fake(),
+                                                          packages: [ShippingLabelPackageSelected.fake()]) { _, result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertNotNil(result.failure as? WooShippingLoadLabelRatesError)
+    }
+
     func test_loadLabelRates_returns_sent_packages_on_success() throws {
         // Given
         let remote = MockWooShippingRemote()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceView.swift
@@ -39,6 +39,8 @@ struct WooShippingServiceView: View {
                             viewModel.loadLabelRates(for: package)
                         }
                     }
+                case .invalidDestinationName:
+                    ErrorState(message: Localization.invalidDestinationNameError)
                 case .noRatesAvailable(let isHAZMAT):
                     ErrorState(message: isHAZMAT ?
                                Localization.noRatesAvailableWithHAZMAT :
@@ -213,6 +215,11 @@ private extension WooShippingServiceView {
                                                               value: "We are unable to load shipping rates",
                                                               comment: "Error message when loading shipping label rates "
                                                               + "failed on the shipping label creation screen")
+        static let invalidDestinationNameError = NSLocalizedString(
+            "wooShipping.createLabels.rates.invalidDestinationNameError",
+            value: "We couldn't load shipping rates. Please add a first and last name to the destination address and try again.",
+            comment: "Error message when shipping rates fail to load because the destination address name is invalid."
+        )
         static let noRatesAvailableNoHAZMAT = NSLocalizedString(
             "wooShipping.createLabels.rates.noRatesAvailableNoHAZMAT",
             value: "We couldn't find a shipping service for the combination of the selected package "

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -189,9 +189,16 @@ final class WooShippingServiceViewModel: ObservableObject {
                 onLoadingCompletion(.success(()))
             case let .failure(error):
                 DDLogError("⛔️ Error loading shipping label rates for Woo Shipping: \(error)")
-                updateLoadingState(to: .error(Error.failedLoadingLabelRates))
+                let loadingError: Error
+                switch error {
+                case WooShippingLoadLabelRatesError.invalidDestinationName:
+                    loadingError = .invalidDestinationName
+                default:
+                    loadingError = .failedLoadingLabelRates
+                }
+                updateLoadingState(to: .error(loadingError))
                 analytics.track(event: .WooShipping.rateSelectionStep(state: .loadingFailed, error: error))
-                onLoadingCompletion(.failure(Error.failedLoadingLabelRates))
+                onLoadingCompletion(.failure(loadingError))
             }
         }
         stores.dispatch(action)
@@ -232,6 +239,7 @@ extension WooShippingServiceViewModel {
         case missingDestinationAddress
         case missingShipmentWeight
         case failedLoadingLabelRates
+        case invalidDestinationName
         case noRatesAvailable(isHAZMAT: Bool)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -354,6 +354,38 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.loadingState, .error(.noRatesAvailable(isHAZMAT: true)))
     }
 
+    func test_when_loadLabelRates_receives_invalid_destination_name_rate_error_it_sets_error_state() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let ratesWithError = [ShippingLabelCarriersAndRates(packageID: Self.samplePackageID,
+                                                            defaultRates: [],
+                                                            defaultErrors: [ShippingLabelRateError(code: "rate_error",
+                                                                                                  message: "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character")],
+                                                            signatureRequired: [],
+                                                            adultSignatureRequired: [],
+                                                            carbonNeutral: [],
+                                                            saturdayDelivery: [],
+                                                            additionalHandling: [])]
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .loadLabelRates(_, _, _, _, packages, completion):
+                completion(packages, .success(ratesWithError))
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+        let viewModel = WooShippingServiceViewModel(order: Order.fake(),
+                                                    originAddress: WooShippingAddress.fake(),
+                                                    destinationAddress: sampleDestinationAddress(),
+                                                    stores: stores)
+
+        // When
+        viewModel.loadLabelRates(for: samplePackage)
+
+        // Then
+        XCTAssertEqual(viewModel.loadingState, .error(.invalidDestinationName))
+    }
+
     func test_switching_tab_updates_the_card_list() {
         // Given
         let viewModel = WooShippingServiceViewModel(order: Order.fake(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -359,8 +359,12 @@ final class WooShippingServiceViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let ratesWithError = [ShippingLabelCarriersAndRates(packageID: Self.samplePackageID,
                                                             defaultRates: [],
-                                                            defaultErrors: [ShippingLabelRateError(code: "rate_error",
-                                                                                                  message: "shipment.to_address: invalid name; A first and last name is required if passed in: input name needs at least 1 space character")],
+                                                            defaultErrors: [ShippingLabelRateError(
+                                                                code: "rate_error",
+                                                                message: "shipment.to_address: invalid name; " +
+                                                                "A first and last name is required if passed in: " +
+                                                                "input name needs at least 1 space character"
+                                                            )],
                                                             signatureRequired: [],
                                                             adultSignatureRequired: [],
                                                             carbonNeutral: [],

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import enum Networking.NetworkError
+import struct Networking.ShippingLabelRateError
 
 final class WooShippingServiceViewModelTests: XCTestCase {
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingServiceViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import WooCommerce
 import Yosemite
 import enum Networking.NetworkError
-import struct Networking.ShippingLabelRateError
 
 final class WooShippingServiceViewModelTests: XCTestCase {
 
@@ -358,23 +357,10 @@ final class WooShippingServiceViewModelTests: XCTestCase {
     func test_when_loadLabelRates_receives_invalid_destination_name_rate_error_it_sets_error_state() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let ratesWithError = [ShippingLabelCarriersAndRates(packageID: Self.samplePackageID,
-                                                            defaultRates: [],
-                                                            defaultErrors: [ShippingLabelRateError(
-                                                                code: "rate_error",
-                                                                message: "shipment.to_address: invalid name; " +
-                                                                "A first and last name is required if passed in: " +
-                                                                "input name needs at least 1 space character"
-                                                            )],
-                                                            signatureRequired: [],
-                                                            adultSignatureRequired: [],
-                                                            carbonNeutral: [],
-                                                            saturdayDelivery: [],
-                                                            additionalHandling: [])]
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case let .loadLabelRates(_, _, _, _, packages, completion):
-                completion(packages, .success(ratesWithError))
+                completion(packages, .failure(WooShippingLoadLabelRatesError.invalidDestinationName))
             default:
                 XCTFail("Received unexpected action: \(action)")
             }


### PR DESCRIPTION
Part of: WOOMOB-2617

## Description
This updates the Woo Shipping rate loading flow to handle the `rate_error` returned by `/label/rate` when the destination name is invalid.

It parses rate errors from the response, maps the invalid destination name case in the store layer, and shows a more specific message in the shipping service step instead of falling back to the generic rates error state.

## Test Steps
1. Open an order that supports shipping labels.
2. Edit the destination address and enter a single-word value in the name field.
3. Return to the shipping label flow and select a package for the shipment.
4. Enter a shipment weight and wait for the Shipping service section to load rates.
5. Reproduce a `/label/rate` response where `default.errors` contains the invalid destination name error.
6. Verify the Shipping service section shows the destination-name-specific error message.
7. Update the destination name field to include both a first and last name.
8. Return to the Shipping service step and verify the destination-name-specific error no longer appears.

## Screenshots
|Before|After|
|-|-|
|<img width="350" alt="before" src="https://github.com/user-attachments/assets/568af1a6-ded3-4942-b30b-964d23815cc3" />|<img width="350"  alt="after" src="https://github.com/user-attachments/assets/4e0a47df-9189-4947-a307-d6bd8f47766d" />|

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
