### PR TITLE
Display total sales instead of net revenue on dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 24.5
 -----
+- [*] Fix dashboard showing total sales instead of net sales to match what merchants expect [https://github.com/woocommerce/woocommerce-ios/pull/16942]
 - [*] Add analytics setting check to troubleshooting tool [https://github.com/woocommerce/woocommerce-ios/pull/16871]
 - [*] Add notification check to troubleshooting tool [https://github.com/woocommerce/woocommerce-ios/pull/16875]
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/OrderStatsV4Interval+Chart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/OrderStatsV4Interval+Chart.swift
@@ -2,8 +2,8 @@ import Foundation
 import Yosemite
 
 extension OrderStatsV4Interval {
-    /// Value of the net revenue during a stats interval.
+    /// Value of the total sales during a stats interval.
     var revenueValue: Decimal {
-        return subtotals.netRevenue
+        return subtotals.grossRevenue
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -348,9 +348,9 @@ private extension StorePerformanceView {
             comment: "Title of the custom time range on the store performance card on the Dashboard screen"
         )
         static let revenue = NSLocalizedString(
-            "storePerformanceView.netSales",
-            value: "Net sales",
-            comment: "Net sales stat label on dashboard — shows revenue excluding taxes, shipping, and fees."
+            "storePerformanceView.totalSales",
+            value: "Total sales",
+            comment: "Total sales stat label on dashboard — shows revenue including taxes and shipping."
         )
         static let noRevenueText = NSLocalizedString(
             "storePerformanceView.noRevenueText",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -139,8 +139,8 @@ private extension StoreStatsChart {
             comment: "Value for the x-Axis of the store stats chart on the Dashboard screen"
         )
         static let yValue = NSLocalizedString(
-            "storeStatsChart.yValueNetSales",
-            value: "Net sales",
+            "storeStatsChart.yValueTotalSales",
+            value: "Total sales",
             comment: "Value for the y-Axis of the store stats chart on the Dashboard screen"
         )
         static let zeroRevenue = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -28,10 +28,10 @@ final class StoreStatsPeriodViewModel {
     private(set) lazy var revenueStatsText: AnyPublisher<String, Never> = $orderStatsData.combineLatest($selectedIntervalIndex, currencySettings.$currencyCode)
         .compactMap { [weak self] orderStatsData, selectedIntervalIndex, currencyCode in
             guard let self else { return "-" }
-            return StatsDataTextFormatter.createNetSalesText(orderStats: orderStatsData.stats,
-                                                              selectedIntervalIndex: selectedIntervalIndex,
-                                                              currencyFormatter: self.currencyFormatter,
-                                                              currencyCode: currencyCode.rawValue)
+            return StatsDataTextFormatter.createTotalRevenueText(orderStats: orderStatsData.stats,
+                                                                selectedIntervalIndex: selectedIntervalIndex,
+                                                                currencyFormatter: self.currencyFormatter,
+                                                                currencyCode: currencyCode.rawValue)
         }
         .removeDuplicates()
         .eraseToAnyPublisher()

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -187,9 +187,9 @@ private struct UnableToFetchView: View {
 private extension StoreInfoView {
     enum Localization {
         static let revenue = AppLocalizedString(
-            "storeWidgets.infoView.netSales",
-            value: "Net sales",
-            comment: "Net sales title label for the store info widget — shows revenue excluding taxes, shipping, and fees."
+            "storeWidgets.infoView.totalSales",
+            value: "Total sales",
+            comment: "Total sales title label for the store info widget — shows revenue including taxes and shipping."
         )
         static let visitors = AppLocalizedString(
             "storeWidgets.infoView.visitors",

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
@@ -55,9 +55,9 @@ private struct UnableToFetchView: View {
 private extension StoreInfoRectangularView {
     enum Localization {
         static let revenue = AppLocalizedString(
-            "storeWidgets.storeInfoRectangularWidget.netSales",
-            value: "Net sales",
-            comment: "Net sales title label for the store info widget — shows revenue excluding taxes, shipping, and fees."
+            "storeWidgets.storeInfoRectangularWidget.totalSales",
+            value: "Total sales",
+            comment: "Total sales title label for the store info widget — shows revenue including taxes and shipping."
         )
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -67,7 +67,7 @@ final class StoreInfoDataService {
 
             // Assemble stats data
             let conversion = siteStats.visitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(siteStats.visitors) : 0
-            return Stats(revenue: revenueAndOrders.totals.netRevenue,
+            return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                          totalOrders: revenueAndOrders.totals.totalOrders,
                          totalVisitors: siteStats.visitors,
                          conversion: min(conversion, 1))
@@ -85,7 +85,7 @@ final class StoreInfoDataService {
     ///
     private func todayStatsWithoutVisitors(for storeID: Int64) async throws -> Stats {
         let revenueAndOrders = try await fetchTodaysRevenueAndOrders(for: storeID)
-        return Stats(revenue: revenueAndOrders.totals.netRevenue,
+        return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
                      totalVisitors: nil,
                      conversion: nil)

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -188,9 +188,9 @@ fileprivate extension MyStoreView {
 
     enum Localization {
         static let revenue = AppLocalizedString(
-            "watch.mystore.netSales.title",
-            value: "Net sales",
-            comment: "Net sales title on the watch store stats screen."
+            "watch.mystore.totalSales.title",
+            value: "Total sales",
+            comment: "Total sales title on the watch store stats screen."
         )
         static let today = AppLocalizedString(
             "watch.mystore.today.title",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -57,7 +57,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         // When
         let orderStats = OrderStatsV4(siteID: siteID,
                                       granularity: timeRange.intervalGranularity,
-                                      totals: .fake().copy(totalOrders: 3, netRevenue: 6220.7),
+                                      totals: .fake().copy(totalOrders: 3, grossRevenue: 6220.7),
                                       intervals: [.fake()])
         insertOrderStats(orderStats, timeRange: timeRange)
 


### PR DESCRIPTION
Closes: WOOMOB-2718

## Description

After #16814 switched the dashboard from `total_sales` to `net_revenue` to match wp-admin, merchants reported confusion because the revenue figure they were used to seeing (which includes taxes and shipping) dropped unexpectedly, leading to negative app reviews.

This PR reverts the data source from `netRevenue` back to `grossRevenue` (which maps to the API's `total_sales`) across:
- Dashboard performance card and chart
- Homescreen and lockscreen widgets
- Watch app

Labels are updated from "Net sales" to "Total sales" with new localization keys so translations fall back to English until retranslated via GlotPress.

The `date_type` fix from #15493 (removing the hardcoded `date_created` override) is preserved — only the metric and label are changed.

Android counterpart: woocommerce/woocommerce-android#15668

## Test Steps

1. Open the app and navigate to the **My Store** dashboard
2. Verify the performance card shows **"Total sales"** as the revenue label
3. Confirm the revenue value includes taxes and shipping (higher than net revenue)
4. Tap into different time ranges (Today, This Week, This Month, This Year) and verify the chart and values are consistent
5. Check the **homescreen widget** — should show "Total sales" label
6. Check the **lockscreen widget** — should show "Total sales" label
7. If available, check the **Watch app** — should show "Total sales" label

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.