### PR TITLE
Fix TracksProvider thread-safety crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 - [*] Update Tap to Pay requirement to iOS 18.0.1 [https://github.com/woocommerce/woocommerce-ios/pull/16914]
 - [*] Add clear button to search fields [https://github.com/woocommerce/woocommerce-ios/pull/16913]
 - [Internal] Tag CIAB support tickets with commerce_in_a_box for proper routing [https://github.com/woocommerce/woocommerce-ios/pull/16910]
-- [*] Fix analytics crash caused by concurrent access to TracksService
+- [Internal] Fix analytics crash caused by concurrent access to TracksService [https://github.com/woocommerce/woocommerce-ios/pull/16944]
 
 
 24.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Update Tap to Pay requirement to iOS 18.0.1 [https://github.com/woocommerce/woocommerce-ios/pull/16914]
 - [*] Add clear button to search fields [https://github.com/woocommerce/woocommerce-ios/pull/16913]
 - [Internal] Tag CIAB support tickets with commerce_in_a_box for proper routing [https://github.com/woocommerce/woocommerce-ios/pull/16910]
+- [*] Fix analytics crash caused by concurrent access to TracksService
 
 
 24.5

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -14,6 +14,8 @@ public class TracksProvider: NSObject, AnalyticsProvider {
         return tracksService
     }()
 
+    private static let tracksQueue = DispatchQueue(label: "com.woocommerce.TracksProvider")
+
     private static var isPOSModeActive: Bool = false
 
     public static func setPOSMode(_ active: Bool) {
@@ -36,26 +38,30 @@ public extension TracksProvider {
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         let eventName = decorateEventNameForPOSIfNeeded(eventName)
-        if let properties {
-            guard Self.tracksService.trackEventName(eventName, withCustomProperties: properties) else {
-                return DDLogError("🔴 Error tracking \(eventName) with properties: \(properties)")
-            }
-
-            let keyValuePairs = properties
-                .map { key, value in
-                    "\(key): \(value)"
+        Self.tracksQueue.async {
+            if let properties {
+                guard Self.tracksService.trackEventName(eventName, withCustomProperties: properties) else {
+                    return DDLogError("🔴 Error tracking \(eventName) with properties: \(properties)")
                 }
-                .joined(separator: ", ")
 
-            DDLogInfo("🔵 Tracked \(eventName), properties: [\(keyValuePairs)]")
-        } else {
-            Self.tracksService.trackEventName(eventName)
-            DDLogInfo("🔵 Tracked \(eventName)")
+                let keyValuePairs = properties
+                    .map { key, value in
+                        "\(key): \(value)"
+                    }
+                    .joined(separator: ", ")
+
+                DDLogInfo("🔵 Tracked \(eventName), properties: [\(keyValuePairs)]")
+            } else {
+                Self.tracksService.trackEventName(eventName)
+                DDLogInfo("🔵 Tracked \(eventName)")
+            }
         }
     }
 
     func clearEvents() {
-        Self.tracksService.clearQueuedEvents()
+        Self.tracksQueue.async {
+            Self.tracksService.clearQueuedEvents()
+        }
     }
 
     /// When a user opts-out, wipe data
@@ -65,7 +71,10 @@ public extension TracksProvider {
             // To be safe, nil out the anonymousUserID guid so a fresh one is regenerated
             UserDefaults.standard[.defaultAnonymousID] = nil
             UserDefaults.standard[.analyticsUsername] = nil
-            Self.tracksService.switchToAnonymousUser(withAnonymousID: ServiceLocator.stores.sessionManager.anonymousUserID)
+            let anonymousUserID = ServiceLocator.stores.sessionManager.anonymousUserID
+            Self.tracksQueue.async {
+                Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousUserID)
+            }
             return
         }
 
@@ -86,27 +95,35 @@ private extension TracksProvider {
             if currentAnalyticsUsername.isEmpty {
                 // No previous username logged
                 UserDefaults.standard[.analyticsUsername] = account.username
-                Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
-                                                             userID: String(account.userID),
-                                                             wpComToken: authToken,
-                                                             skipAliasEventCreation: false)
+                Self.tracksQueue.async {
+                    Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
+                                                                 userID: String(account.userID),
+                                                                 wpComToken: authToken,
+                                                                 skipAliasEventCreation: false)
+                }
             } else if currentAnalyticsUsername == account.username {
                 // Username did not change - just make sure Tracks client has it
-                Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
-                                                             userID: String(account.userID),
-                                                             wpComToken: authToken,
-                                                             skipAliasEventCreation: true)
+                Self.tracksQueue.async {
+                    Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
+                                                                 userID: String(account.userID),
+                                                                 wpComToken: authToken,
+                                                                 skipAliasEventCreation: true)
+                }
             } else {
                 // Username changed for some reason - switch back to anonymous first
-                Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
-                Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
-                                                             userID: String(account.userID),
-                                                             wpComToken: authToken,
-                                                             skipAliasEventCreation: false)
+                Self.tracksQueue.async {
+                    Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
+                    Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
+                                                                 userID: String(account.userID),
+                                                                 wpComToken: authToken,
+                                                                 skipAliasEventCreation: false)
+                }
             }
         } else {
             UserDefaults.standard[.analyticsUsername] = nil
-            Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
+            Self.tracksQueue.async {
+                Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
+            }
         }
     }
 
@@ -293,12 +310,23 @@ private extension TracksProvider {
 
     func refreshTracksMetadata() {
         DDLogInfo("♻️ Refreshing tracks metadata...")
-        var userProperties = [String: Any]()
-        userProperties[UserProperties.platformKey] = "iOS"
-        userProperties[UserProperties.voiceOverKey] = UIAccessibility.isVoiceOverRunning
-        userProperties[UserProperties.rtlKey] = (UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft)
-        Self.tracksService.userProperties.removeAllObjects()
-        Self.tracksService.userProperties.addEntries(from: userProperties)
+        let readUIKitAndApply = {
+            let voiceOver = UIAccessibility.isVoiceOverRunning
+            let isRTL = UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
+            Self.tracksQueue.async {
+                Self.tracksService.userProperties.removeAllObjects()
+                Self.tracksService.userProperties.addEntries(from: [
+                    UserProperties.platformKey: "iOS",
+                    UserProperties.voiceOverKey: voiceOver,
+                    UserProperties.rtlKey: isRTL
+                ])
+            }
+        }
+        if Thread.isMainThread {
+            readUIKitAndApply()
+        } else {
+            DispatchQueue.main.async { readUIKitAndApply() }
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderThreadSafetyTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderThreadSafetyTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import WooCommerce
+
+/// Verifies that concurrent access to TracksProvider does not crash.
+/// This covers the fix for WOOMOB-2668 where concurrent `track()` and
+/// `refreshUserData()` calls raced on TracksService's NSMutableDictionary.
+final class TracksProviderThreadSafetyTests: XCTestCase {
+
+    func test_concurrent_track_and_refreshUserData_does_not_crash() {
+        // Given
+        let provider = TracksProvider()
+        let iterations = 50
+        let allDone = expectation(description: "All concurrent operations completed")
+        allDone.expectedFulfillmentCount = iterations * 2
+
+        // When
+        for _ in 0..<iterations {
+            DispatchQueue.global().async {
+                provider.track("thread_safety_test_event")
+                allDone.fulfill()
+            }
+            DispatchQueue.global().async {
+                provider.refreshUserData()
+                allDone.fulfill()
+            }
+        }
+
+        // Then — reaching here without EXC_BAD_ACCESS or NSGenericException means the fix works
+        wait(for: [allDone], timeout: 30.0)
+    }
+}


### PR DESCRIPTION
Fixes WOOMOB-2668

## Description

Fixes a crash caused by concurrent access to `TracksService`'s `NSMutableDictionary` (`userProperties`). When `track()` and `refreshUserData()` were called concurrently from different threads, the unsynchronized dictionary mutations caused `EXC_BAD_ACCESS` / `NSGenericException`.

## Test Steps

- CI should be 🟢 
- Validate that events are loged and sent as expected.

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.