### PR TITLE
Fix continuation leaks in JetpackConnectionStore and PushNotificationsManager

### DIFF
--- a/Modules/Sources/Yosemite/Stores/JetpackConnectionStore.swift
+++ b/Modules/Sources/Yosemite/Stores/JetpackConnectionStore.swift
@@ -64,11 +64,19 @@ private extension JetpackConnectionStore {
     }
 
     func retrieveJetpackPluginDetails(siteID: Int64, completion: @escaping (Result<SitePlugin, Error>) -> Void) {
-        jetpackConnectionRemote?.retrieveJetpackPluginDetails(siteID: siteID, completion: completion)
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
+        jetpackConnectionRemote.retrieveJetpackPluginDetails(siteID: siteID, completion: completion)
     }
 
     func installJetpackPlugin(siteID: Int64, completion: @escaping (Result<Void, Error>) -> Void) {
-        jetpackConnectionRemote?.installJetpackPlugin(siteID: siteID, completion: { result in
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
+        jetpackConnectionRemote.installJetpackPlugin(siteID: siteID, completion: { result in
             switch result {
             case .success:
                 completion(.success(()))
@@ -79,7 +87,11 @@ private extension JetpackConnectionStore {
     }
 
     func activateJetpackPlugin(siteID: Int64, completion: @escaping (Result<Void, Error>) -> Void) {
-        jetpackConnectionRemote?.activateJetpackPlugin(siteID: siteID, completion: { result in
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
+        jetpackConnectionRemote.activateJetpackPlugin(siteID: siteID, completion: { result in
             switch result {
             case .success:
                 completion(.success(()))
@@ -91,11 +103,15 @@ private extension JetpackConnectionStore {
 
     func fetchJetpackConnectionURL(authenticatedWithWPCom: Bool,
                                    completion: @escaping (Result<URL, Error>) -> Void) {
-        guard authenticatedWithWPCom else {
-            jetpackConnectionRemote?.fetchJetpackConnectionURL(completion: completion)
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
             return
         }
-        jetpackConnectionRemote?.fetchJetpackConnectionURL { [weak self] result in
+        guard authenticatedWithWPCom else {
+            jetpackConnectionRemote.fetchJetpackConnectionURL(completion: completion)
+            return
+        }
+        jetpackConnectionRemote.fetchJetpackConnectionURL { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let url):
@@ -112,11 +128,18 @@ private extension JetpackConnectionStore {
     }
 
     func fetchJetpackConnectionData(siteID: Int64, completion: @escaping (Result<JetpackConnectionData, Error>) -> Void) {
-        jetpackConnectionRemote?.fetchJetpackConnectionData(siteID: siteID, completion: completion)
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
+        jetpackConnectionRemote.fetchJetpackConnectionData(siteID: siteID, completion: completion)
     }
 
     func registerSite(completion: @escaping (Result<Int64, Error>) -> Void) {
-        guard let jetpackConnectionRemote else { return }
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
         Task { @MainActor in
             do {
                 let blogID = try await jetpackConnectionRemote.registerSite()
@@ -128,7 +151,10 @@ private extension JetpackConnectionStore {
     }
 
     func provisionConnection(completion: @escaping (Result<JetpackConnectionProvisionResponse, Error>) -> Void) {
-        guard let jetpackConnectionRemote else { return }
+        guard let jetpackConnectionRemote else {
+            completion(.failure(JetpackConnectionStoreError.remoteNotConfigured))
+            return
+        }
         Task { @MainActor in
             do {
                 let response = try await jetpackConnectionRemote.provisionConnection()
@@ -175,5 +201,9 @@ private extension JetpackConnectionStore {
 private extension JetpackConnectionStore {
     enum Constants {
         static let jetpackAccountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
+    }
+
+    enum JetpackConnectionStoreError: Error {
+        case remoteNotConfigured
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -741,6 +741,7 @@ private extension PushNotificationsManager {
     func registerSelfDrivenPushNotificationFlow(with deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         guard let siteID else {
             DDLogError("⛔️ Unable to register self-driven push token: missing siteID")
+            onCompletion(.failure(PushNotificationError.missingSiteID))
             return
         }
 
@@ -930,6 +931,7 @@ private enum AnalyticKey {
 
 private enum PushNotificationError: Error {
     case deviceTokenTimeout
+    case missingSiteID
 }
 
 private enum PushType {


### PR DESCRIPTION
## Description
Several methods in `JetpackConnectionStore` silently returned without calling their completion handler when `jetpackConnectionRemote` was nil. When these methods were invoked through `withCheckedThrowingContinuation` (via the `dispatch` helper in `JetpackConnectionService`), the leaked completion caused the continuation to never resume — suspending the calling task forever and logging:

> SWIFT TASK CONTINUATION MISUSE: dispatch(_:) leaked its continuation without resuming it.

The most visible symptom was tapping the "Never miss a new order" dashboard banner, which triggered `fetchConnectionData()` → `JetpackConnectionStore.fetchJetpackConnectionData()` with a nil remote.

Similarly, `PushNotificationsManager.registerSelfDrivenPushNotificationFlow` returned without calling `onCompletion` when `siteID` was nil, leaking the continuation in `registerDeviceAndWaitForTokenAcceptance()`.

**Fix:** All `guard`-let early returns now call the completion with a `.failure` result instead of silently returning.

**Affected methods in `JetpackConnectionStore`:**
- `retrieveJetpackPluginDetails`
- `installJetpackPlugin`
- `activateJetpackPlugin`
- `fetchJetpackConnectionURL`
- `fetchJetpackConnectionData`
- `registerSite`
- `provisionConnection`

**Affected method in `PushNotificationsManager`:**
- `registerSelfDrivenPushNotificationFlow`

## Repro Steps 
If helps - the JN site used for testing: https://mandolin-of-falcons.jurassic.ninja
- Create a JN store with JP
- Connect WooCommerce site to WP.com account
- Connect Jetpack
- Deactivate Jetpack, don't delete.
- Run the app from trunk before fix
- In the app enable self-driven notifications related FFs in FF debug panel (logged out state).
- Login to the site with WP.com account.
- Tap on "Never miss a new order" banner to start self driven notifications registering process.
- Check out Xcode debug console log for leaked continuation issue.
- Go to settings -> Debug Panel -> Present WPComConnectionSetupView. The "Connect store to Wordpress.com" will get stuck and Xcode console log will surface leaked continuation issue.

## Testing steps
- Repeat steps above from fix branch
- Self-driven PNs flows shouldn't get stuck
- No leaked continuation issues logged in Xcode debug console

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.