### PR TITLE
Check Woo plugin version before push notification registration

### DIFF
--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/PluginCompatibilityChecker.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComConnectionSetup/PluginCompatibilityChecker.swift
@@ -77,3 +77,15 @@ private extension PluginVersionChecker {
 enum PluginVersionError: Error {
     case pluginNotFound
 }
+
+// MARK: - Plugin Version Checker Factory
+
+protocol PluginVersionCheckerFactoryProtocol {
+    func makeChecker(siteID: Int64, pluginPath: String, minimumVersion: String) -> PluginVersionCheckerProtocol
+}
+
+final class PluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol {
+    func makeChecker(siteID: Int64, pluginPath: String, minimumVersion: String) -> PluginVersionCheckerProtocol {
+        PluginVersionChecker(siteID: siteID, pluginPath: pluginPath, minimumVersion: minimumVersion)
+    }
+}

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -117,6 +117,7 @@ final class PushNotificationsManager: PushNotesManager {
 
     private let backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol
     private let selfDriventPNEligiblityChecker: WooPushNotificationEligibilityCheck
+    private let pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol
     private var selfDrivenPushNotificationEnabled: Bool?
     private var pendingTokenData: Data?
 
@@ -138,12 +139,14 @@ final class PushNotificationsManager: PushNotesManager {
          backgroundSynchronizerFactory: PushNotificationBackgroundSynchronizerFactoryProtocol = PushNotificationBackgroundSynchronizerFactory(),
          analytics: Analytics = ServiceLocator.analytics,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol = PluginVersionCheckerFactory()) {
         self.configuration = configuration
         self.registrationState = PushNotificationRegistrationState(defaults: configuration.defaults, log: { DDLogInfo($0) })
         self.backgroundSynchronizerFactory = backgroundSynchronizerFactory
         self.analytics = analytics
         self.storageManager = storageManager
+        self.pluginVersionCheckerFactory = pluginVersionCheckerFactory
         self.selfDriventPNEligiblityChecker = WooPushNotificationEligibilityCheck(
             featureFlagService: featureFlagService,
             stores: configuration.storesManager
@@ -816,6 +819,37 @@ private extension PushNotificationsManager {
                                                 onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         DDLogInfo("📱 Registering self-driven push notification token for site \(siteID)")
 
+        // Check plugin version before attempting registration
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let minimumVersion = WooPluginRequirements.minimumVersion
+            let pluginVersionChecker = pluginVersionCheckerFactory.makeChecker(
+                siteID: siteID,
+                pluginPath: WooPluginRequirements.pluginPath,
+                minimumVersion: minimumVersion
+            )
+            do {
+                let result = try await pluginVersionChecker.checkCompatibility()
+                if case .incompatible(let currentVersion, _) = result {
+                    DDLogError("⛔️ Unable to register self-driven push token: WooCommerce plugin version \(currentVersion) is below required \(minimumVersion)")
+                    registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
+                    onCompletion(.failure(PushNotificationError.pluginVersionIncompatible(
+                        currentVersion: currentVersion,
+                        requiredVersion: minimumVersion
+                    )))
+                    return
+                }
+            } catch {
+                DDLogError("⛔️ Failed to check plugin version: \(error)")
+                // Continue with registration even if version check fails - the server will validate
+            }
+
+            // Plugin version is compatible (or check failed), proceed with registration
+            performDeviceRegistration(siteID: siteID, deviceToken: deviceToken, onCompletion: onCompletion)
+        }
+    }
+
+    private func performDeviceRegistration(siteID: Int64, deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         let device = APNSDevice(deviceToken: deviceToken)
         let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(
             siteID: siteID,
@@ -998,6 +1032,7 @@ private enum PushNotificationError: Error {
     case deviceTokenTimeout
     case missingSiteID
     case siteRegistrationFailed(siteIDs: [Int64])
+    case pluginVersionIncompatible(currentVersion: String, requiredVersion: String)
 }
 
 private enum PushType {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -67,7 +67,7 @@ final class WooPushNotificationSetupCoordinator {
 
 enum WooPluginRequirements {
     static let pluginPath = "woocommerce/woocommerce.php"
-    static let minimumVersion = "10.5.3" // This is for testing
+    static let minimumVersion = "10.8.0" // This is for testing
 }
 
 private extension WooPushNotificationSetupCoordinator {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPluginVersionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPluginVersionChecker.swift
@@ -3,8 +3,10 @@ import Foundation
 
 final class MockPluginVersionChecker: PluginVersionCheckerProtocol {
     var result: Result<PluginVersionResult, Error> = .success(.compatible)
+    var onCheckCompatibility: (() -> Void)?
 
     func checkCompatibility() async throws -> PluginVersionResult {
-        try result.get()
+        onCheckCompatibility?()
+        return try result.get()
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -833,6 +833,144 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertFalse(storedSiteIDs.contains("\(siteID)"), "Site ID should be unmarked after 404 error")
     }
 
+    func test_registerDeviceToken_when_plugin_version_is_incompatible_then_unmarks_site_and_skips_registration() async {
+        // Given
+        let siteID: Int64 = 99
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(siteID)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        // Set up mock plugin version checker to return incompatible version
+        let mockChecker = MockPluginVersionChecker()
+        mockChecker.result = .success(.incompatible(currentVersion: "10.5.0", requiredVersion: "10.8.0"))
+        let mockCheckerFactory = MockPluginVersionCheckerFactory(checker: mockChecker)
+
+        manager = makeManager(featureFlagService: featureFlagService, pluginVersionCheckerFactory: mockCheckerFactory)
+
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        // No registration action should be dispatched since version check fails
+        var registrationAttempted = false
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case .registerDeviceForSelfDrivenPushNotifications = action {
+                registrationAttempted = true
+            }
+        }
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            return XCTFail("Invalid sample token")
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+
+        // Wait a bit for async operations to complete
+        try? await Task.sleep(nanoseconds: 500_000_000)
+
+        // Then
+        XCTAssertFalse(registrationAttempted, "Registration should not be attempted when plugin version is incompatible")
+        let storedSiteIDs = defaults.string(
+            forKey: PushNotificationSharedConstants.UserDefaultsKeys.siteIDsRegisteredForWooPushNotifications
+        ) ?? ""
+        XCTAssertFalse(storedSiteIDs.contains("\(siteID)"), "Site ID should be unmarked when plugin version is incompatible")
+    }
+
+    func test_registerDeviceToken_when_plugin_version_is_compatible_then_proceeds_with_registration() async {
+        // Given
+        let siteID: Int64 = 99
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(siteID)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        // Set up mock plugin version checker to return compatible version
+        let mockChecker = MockPluginVersionChecker()
+        mockChecker.result = .success(.compatible)
+        let mockCheckerFactory = MockPluginVersionCheckerFactory(checker: mockChecker)
+
+        manager = makeManager(featureFlagService: featureFlagService, pluginVersionCheckerFactory: mockCheckerFactory)
+
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        let registrationExpectation = expectation(description: "Registration attempted")
+        registrationExpectation.assertForOverFulfill = false
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion) = action {
+                onCompletion(.success(42))
+                registrationExpectation.fulfill()
+            }
+        }
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            return XCTFail("Invalid sample token")
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [registrationExpectation], timeout: 1.0)
+
+        // Then
+        let storedSiteIDs = defaults.string(
+            forKey: PushNotificationSharedConstants.UserDefaultsKeys.siteIDsRegisteredForWooPushNotifications
+        ) ?? ""
+        XCTAssertTrue(storedSiteIDs.contains("\(siteID)"), "Site ID should be marked as registered when plugin version is compatible")
+    }
+
+    func test_registerDeviceToken_when_plugin_version_check_fails_then_proceeds_with_registration() async {
+        // Given
+        let siteID: Int64 = 99
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(siteID)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        // Set up mock plugin version checker to throw an error
+        let mockChecker = MockPluginVersionChecker()
+        mockChecker.result = .failure(NSError(domain: "test", code: -1))
+        let mockCheckerFactory = MockPluginVersionCheckerFactory(checker: mockChecker)
+
+        manager = makeManager(featureFlagService: featureFlagService, pluginVersionCheckerFactory: mockCheckerFactory)
+
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        // Registration should still proceed even when version check fails
+        let registrationExpectation = expectation(description: "Registration attempted")
+        registrationExpectation.assertForOverFulfill = false
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion) = action {
+                onCompletion(.success(42))
+                registrationExpectation.fulfill()
+            }
+        }
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            return XCTFail("Invalid sample token")
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [registrationExpectation], timeout: 1.0)
+
+        // Then - registration should have proceeded despite version check failure
+        let storedSiteIDs = defaults.string(
+            forKey: PushNotificationSharedConstants.UserDefaultsKeys.siteIDsRegisteredForWooPushNotifications
+        ) ?? ""
+        XCTAssertTrue(storedSiteIDs.contains("\(siteID)"), "Site ID should be registered even when version check fails")
+    }
+
     func test_registerDeviceToken_when_token_changes_then_clears_registered_sites_before_reregistration() async {
         // Given — site is registered with an old token
         let siteID: Int64 = 99
@@ -1229,7 +1367,8 @@ final class PushNotificationsManagerTests: XCTestCase {
 //
 private extension PushNotificationsManagerTests {
     func makeManager(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-                     storageManager: MockStorageManager? = nil) -> PushNotificationsManager {
+                     storageManager: MockStorageManager? = nil,
+                     pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol? = nil) -> PushNotificationsManager {
         // Capture strong local references so the @autoclosure closures in
         // PushNotificationsConfiguration don't go through the test's IUO
         // properties, which may be nilled in tearDown while async Tasks are still in flight.
@@ -1246,7 +1385,8 @@ private extension PushNotificationsManagerTests {
         return PushNotificationsManager(configuration: configuration,
                                         backgroundSynchronizerFactory: backgroundSynchronizerFactory,
                                         storageManager: storageManager ?? self.storageManager,
-                                        featureFlagService: featureFlagService)
+                                        featureFlagService: featureFlagService,
+                                        pluginVersionCheckerFactory: pluginVersionCheckerFactory ?? MockPluginVersionCheckerFactory())
     }
 
 
@@ -1369,5 +1509,17 @@ private class MockPushNotificationBackgroundSynchronizerFactory: PushNotificatio
     var synchronizer = MockPushNotificationBackgroundSynchronizer()
     func make(userInfo: [AnyHashable: Any], stores: StoresManager) -> any PushNotificationBackgroundSynchronizerProtocol {
         return synchronizer
+    }
+}
+
+private class MockPluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol {
+    let checker: MockPluginVersionChecker
+
+    init(checker: MockPluginVersionChecker = MockPluginVersionChecker()) {
+        self.checker = checker
+    }
+
+    func makeChecker(siteID: Int64, pluginPath: String, minimumVersion: String) -> PluginVersionCheckerProtocol {
+        return checker
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -850,6 +850,11 @@ final class PushNotificationsManagerTests: XCTestCase {
         mockChecker.result = .success(.incompatible(currentVersion: "10.5.0", requiredVersion: "10.8.0"))
         let mockCheckerFactory = MockPluginVersionCheckerFactory(checker: mockChecker)
 
+        let versionCheckExpectation = expectation(description: "Version check completed")
+        mockChecker.onCheckCompatibility = {
+            versionCheckExpectation.fulfill()
+        }
+
         manager = makeManager(featureFlagService: featureFlagService, pluginVersionCheckerFactory: mockCheckerFactory)
 
         await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
@@ -868,9 +873,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         // When
         manager.registerDeviceToken(with: tokenAsData)
-
-        // Wait a bit for async operations to complete
-        try? await Task.sleep(nanoseconds: 500_000_000)
+        await fulfillment(of: [versionCheckExpectation], timeout: 1.0)
 
         // Then
         XCTAssertFalse(registrationAttempted, "Registration should not be attempted when plugin version is incompatible")


### PR DESCRIPTION
## Description
Addresses WOOMOB-2677.

When a user downgrades the WooCommerce plugin to a version between 10.6.0 (when the PN registration endpoint was added) and 10.8.0 (the minimum version for full push notification support), registration succeeds but notifications don't actually work. The current 404-based check doesn't catch this scenario.

This PR adds a plugin version check before attempting push notification registration:
- Check the site's WooCommerce plugin version against `WooPluginRequirements.minimumVersion` (10.8.0)
- If incompatible, unmark the site from registered sites and skip registration
- This causes the dashboard card to appear, prompting the user to update the plugin
- If the version check fails (network error, etc.), proceed with registration and let the server validate

## Test Steps
1. Install WooCommerce plugin version below 10.8.0 on a test site
2. Log in to the app with that site
3. Verify push notification registration is skipped
4. Verify the dashboard shows the push notification setup card

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.