### PR TITLE
Fix disabling WPCom push notifications when all sites registered with Woo PN

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -371,7 +371,8 @@ extension PushNotificationsManager {
             return
         }
 
-        func registerForWPComPushNotifications() {
+        func registerForWPComPushNotificationsIfPossible() {
+            guard !stores.isAuthenticatedWithoutWPCom else { return }
             // Register in the Dotcom's Infrastructure
             registerDotcomDevice(with: newToken) { (device, error) in
                 guard let deviceID = device?.deviceID else {
@@ -391,14 +392,22 @@ extension PushNotificationsManager {
                 guard let self else { return }
                 do {
                     try await registerSelfDrivenPushNotificationsForAllSites(with: newToken)
-                } catch {
-                    if !stores.isAuthenticatedWithoutWPCom {
-                        registerForWPComPushNotifications()
+                    // Disable WPCom PNs for successfully registered sites
+                    if let deviceID = registrationState.deviceID {
+                        disableWPComPushNotificationsIfNeeded(
+                            siteIDs: registrationState.siteIDsRegisteredForWooPNs,
+                            deviceID: deviceID
+                        )
+                    } else {
+                        // Register with WPCom to get deviceID for disabling
+                        registerForWPComPushNotificationsIfPossible()
                     }
+                } catch {
+                    registerForWPComPushNotificationsIfPossible()
                 }
             }
-        } else if !stores.isAuthenticatedWithoutWPCom {
-            registerForWPComPushNotifications()
+        } else {
+            registerForWPComPushNotificationsIfPossible()
         }
     }
 
@@ -782,8 +791,6 @@ private extension PushNotificationsManager {
                 failedSiteIDs.append(siteID)
             }
         }
-
-        disableWPComPushNotificationsIfNeeded(siteIDs: registrationState.siteIDsRegisteredForWooPNs, deviceID: registrationState.deviceID)
 
         if failedSiteIDs.isNotEmpty {
             throw PushNotificationError.siteRegistrationFailed(siteIDs: failedSiteIDs)

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -372,7 +372,7 @@ extension PushNotificationsManager {
         }
 
         func registerForWPComPushNotificationsIfPossible() {
-            guard !stores.isAuthenticatedWithoutWPCom else { return }
+            if stores.isAuthenticatedWithoutWPCom { return }
             // Register in the Dotcom's Infrastructure
             registerDotcomDevice(with: newToken) { (device, error) in
                 guard let deviceID = device?.deviceID else {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -67,7 +67,7 @@ final class WooPushNotificationSetupCoordinator {
 
 enum WooPluginRequirements {
     static let pluginPath = "woocommerce/woocommerce.php"
-    static let minimumVersion = "10.8.0" // This is for testing
+    static let minimumVersion = "10.8.0-dev" // This is for testing
 }
 
 private extension WooPushNotificationSetupCoordinator {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1363,6 +1363,127 @@ final class PushNotificationsManagerTests: XCTestCase {
             return false
         }))
     }
+
+    func test_registerDeviceToken_when_self_driven_succeeds_and_deviceID_is_nil_then_registers_dotcom_and_disables_WPCom() async throws {
+        // Given
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        await insertSitesIntoStorage(siteIDs: [100])
+
+        manager = makeManager(featureFlagService: featureFlagService)
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        // Decode a DotcomDevice with a fresh deviceID to return from the fallback Dotcom registration
+        let dotcomDeviceJSON = #"{"ID": "789"}"#.data(using: .utf8)!
+        let freshDotcomDevice = try JSONDecoder().decode(DotcomDevice.self, from: dotcomDeviceJSON)
+
+        let dotcomExpectation = expectation(description: "Dotcom registerDevice dispatched")
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion):
+                onCompletion(.success(123))
+            case let .registerDevice(_, _, _, onCompletion):
+                dotcomExpectation.fulfill()
+                onCompletion(freshDotcomDevice, nil)
+            default:
+                break
+            }
+        }
+
+        let disableExpectation = expectation(description: "WPCom disable dispatched")
+        storesManager.whenReceivingAction(ofType: AccountAction.self) { _ in
+            disableExpectation.fulfill()
+        }
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            return XCTFail("Invalid sample token")
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [dotcomExpectation, disableExpectation], timeout: 2.0)
+
+        // Then
+        // It falls back to Dotcom registration to obtain a deviceID
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssertTrue(notificationActions.contains(where: {
+            if case .registerDevice = $0 { return true }
+            return false
+        }))
+
+        // It disables WPCom PNs for the Woo-registered site using the fresh deviceID (789)
+        let accountActions = storesManager.receivedActions.compactMap { $0 as? AccountAction }
+        XCTAssertTrue(accountActions.contains(where: {
+            if case let .updateNotificationSettings(settings, _) = $0,
+               let blog = settings.blogs.first(where: { $0.blogID == 100 }),
+               let device = blog.devices.first(where: { $0.deviceID == 789 }),
+               device.newComment == false,
+               device.storeOrder == false {
+                return true
+            }
+            return false
+        }))
+    }
+
+    func test_registerDeviceToken_when_self_driven_succeeds_and_deviceID_is_set_then_disables_WPCom_without_dotcom_registration() async {
+        // Given
+        defaults.set("456", forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceID)
+        mockSelfDrivenRegistrationActions(token: 123)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        await insertSitesIntoStorage(siteIDs: [100])
+
+        manager = makeManager(featureFlagService: featureFlagService)
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        let disableExpectation = expectation(description: "WPCom disable dispatched")
+        storesManager.whenReceivingAction(ofType: AccountAction.self) { _ in
+            disableExpectation.fulfill()
+        }
+
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            return XCTFail("Invalid sample token")
+        }
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [disableExpectation], timeout: 2.0)
+
+        // Then
+        // It disables WPCom PNs using the existing deviceID (456)
+        let accountActions = storesManager.receivedActions.compactMap { $0 as? AccountAction }
+        XCTAssertTrue(accountActions.contains(where: {
+            if case let .updateNotificationSettings(settings, _) = $0,
+               let blog = settings.blogs.first(where: { $0.blogID == 100 }),
+               let device = blog.devices.first(where: { $0.deviceID == 456 }),
+               device.newComment == false,
+               device.storeOrder == false {
+                return true
+            }
+            return false
+        }))
+
+        // It does NOT re-register with Dotcom since deviceID was already present
+        let notificationActions = storesManager.receivedActions.compactMap { $0 as? NotificationAction }
+        XCTAssertFalse(notificationActions.contains(where: {
+            if case .registerDevice = $0 { return true }
+            return false
+        }))
+    }
 }
 
 


### PR DESCRIPTION
## Description

Fixes an issue where WPCom push notifications were not being disabled for sites that successfully registered for self-driven (Woo) push notifications, causing duplicate notifications.

**Root cause**: When self-driven PN registration succeeded for all sites, `disableWPComPushNotificationsIfNeeded` was called inside `registerSelfDrivenPushNotificationsForAllSites` but the `deviceID` was often `nil` (since WPCom registration was skipped), causing the function to silently return without disabling anything.

**Changes**:
- Move `disableWPComPushNotificationsIfNeeded` out of `registerSelfDrivenPushNotificationsForAllSites` and into the success path of the caller
- In the success case, check if `deviceID` exists:
  - If yes, disable WPCom PNs directly
  - If no, register with WPCom to obtain the `deviceID`, then disable
- Move the `isAuthenticatedWithoutWPCom` guard inside `registerForWPComPushNotificationsIfPossible` to reduce duplication
- Update minimum plugin version to `10.8.0-dev` for testing

Relates to WOOMOB-2729

## Test Steps

1. Log in with a WPCom account that has multiple stores
2. Ensure at least one store has WooCommerce plugin version 10.8.0-dev or higher
3. Enable push notifications
4. Trigger an order on the eligible store
5. Verify only one notification is received (not duplicates)

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.