### PR TITLE
Unregister hidden sites from self-driven push notifications

### DIFF
--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -107,15 +107,21 @@ public class DevicesRemote: Remote {
     /// - Parameters:
     ///     - siteID: ID of the site
     ///     - tokenID: The push token ID to delete
+    ///     - availableAsRESTRequest: Whether the request can be sent as a direct REST call when an
+    ///       application password is available. Only safe when the target `siteID` is the currently
+    ///       selected site, because the REST fallback routes to the current site's URL. For cross-site
+    ///       calls (e.g. unregistering a non-selected site) pass `false` to force the Jetpack tunnel,
+    ///       which carries the `siteID` in the URL path and always reaches the correct site.
     ///
     public func unregisterFromSelfDrivenPushNotifications(siteID: Int64,
-                                                          tokenID: Int64) async throws {
+                                                          tokenID: Int64,
+                                                          availableAsRESTRequest: Bool = true) async throws {
         let path = Paths.selfDrivenPN + "/\(tokenID)"
         let request = JetpackRequest(wooApiVersion: .none,
                                      method: .delete,
                                      siteID: siteID,
                                      path: path,
-                                     availableAsRESTRequest: true)
+                                     availableAsRESTRequest: availableAsRESTRequest)
         try await enqueue(request)
     }
 }

--- a/Modules/Sources/Yosemite/Actions/NotificationAction.swift
+++ b/Modules/Sources/Yosemite/Actions/NotificationAction.swift
@@ -50,5 +50,15 @@ public enum NotificationAction: Action {
 
     /// Removes a given tokenID from the the self-driven push notification system.
     ///
-    case unregisterFromSelfDrivenPushNotifications(siteID: Int64, tokenID: Int64, onCompletion: (Result<Void, Error>) -> Void)
+    /// - Parameters:
+    ///     - siteID: ID of the site
+    ///     - tokenID: The push token ID to delete
+    ///     - availableAsRESTRequest: Whether the underlying request can be sent as a direct REST
+    ///       call when an application password is available. Safe only when `siteID` is the currently
+    ///       selected site. For cross-site unregistration pass `false` to force the Jetpack tunnel.
+    ///
+    case unregisterFromSelfDrivenPushNotifications(siteID: Int64,
+                                                   tokenID: Int64,
+                                                   availableAsRESTRequest: Bool,
+                                                   onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -65,8 +65,11 @@ public class NotificationStore: Store {
                 appVersion: appVersion,
                 onCompletion: onCompletion
             )
-        case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, onCompletion):
-            unregisterFromSelfDrivenPushNotifications(siteID: siteID, tokenID: tokenID, onCompletion: onCompletion)
+        case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, availableAsRESTRequest, onCompletion):
+            unregisterFromSelfDrivenPushNotifications(siteID: siteID,
+                                                      tokenID: tokenID,
+                                                      availableAsRESTRequest: availableAsRESTRequest,
+                                                      onCompletion: onCompletion)
         }
     }
 }
@@ -122,10 +125,15 @@ private extension NotificationStore {
     ///
     func unregisterFromSelfDrivenPushNotifications(siteID: Int64,
                                                    tokenID: Int64,
+                                                   availableAsRESTRequest: Bool,
                                                    onCompletion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
             do {
-                try await devicesRemote.unregisterFromSelfDrivenPushNotifications(siteID: siteID, tokenID: tokenID)
+                try await devicesRemote.unregisterFromSelfDrivenPushNotifications(
+                    siteID: siteID,
+                    tokenID: tokenID,
+                    availableAsRESTRequest: availableAsRESTRequest
+                )
                 onCompletion(.success(()))
             } catch {
                 onCompletion(.failure(error))

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -519,7 +519,8 @@ final class NotificationStoreTests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = NotificationAction.unregisterFromSelfDrivenPushNotifications(
                 siteID: self.sampleSiteID,
-                tokenID: self.sampleTokenID
+                tokenID: self.sampleTokenID,
+                availableAsRESTRequest: true
             ) { result in
                 promise(result)
             }
@@ -548,7 +549,8 @@ final class NotificationStoreTests: XCTestCase {
         let result: Result<Void, Error> = waitFor { promise in
             let action = NotificationAction.unregisterFromSelfDrivenPushNotifications(
                 siteID: self.sampleSiteID,
-                tokenID: self.sampleTokenID
+                tokenID: self.sampleTokenID,
+                availableAsRESTRequest: true
             ) { result in
                 promise(result)
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -132,6 +132,11 @@ private extension EditStoreListViewModel {
                     stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
                         siteID: siteID,
                         tokenID: tokenID,
+                        // Force Jetpack tunnel: the hidden site is never the currently selected site,
+                        // so the REST fallback in `RequestConverter` would route to the wrong host.
+                        // The Jetpack tunnel carries `siteID` in the URL path and always reaches the
+                        // correct site.
+                        availableAsRESTRequest: false,
                         onCompletion: { result in
                             continuation.resume(with: result)
                         }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -58,6 +58,7 @@ final class EditStoreListViewModel: ObservableObject {
         isUpdatingNotificationSettings = true
         do {
             try await updateNotificationSettings(displayedSiteIDs: displayedSiteIDs, hiddenSiteIDs: hiddenSiteIDs)
+            await unregisterHiddenSitesFromSelfDrivenPushNotifications(hiddenSiteIDs: hiddenSiteIDs)
             userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
             analytics.track(event: .SitePicker.listEditSavingSuccess())
             onCompletion()
@@ -110,6 +111,36 @@ private extension EditStoreListViewModel {
             stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: settings, onCompletion: { result in
                 continuation.resume(with: result)
             }))
+        }
+    }
+
+    /// Unregisters hidden sites from the self-driven push notification system.
+    /// This is best-effort — failures are logged but do not block the save operation.
+    @MainActor
+    func unregisterHiddenSitesFromSelfDrivenPushNotifications(hiddenSiteIDs: [Int64]) async {
+        guard let tokenString = pushNotificationManager.wooPushNotificationToken,
+              let tokenID = Int64(tokenString) else {
+            return
+        }
+
+        let registeredSiteIDs = pushNotificationManager.siteIDsRegisteredForWooPNs
+        let siteIDsToUnregister = hiddenSiteIDs.filter { registeredSiteIDs.contains($0) }
+
+        for siteID in siteIDsToUnregister {
+            do {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
+                        siteID: siteID,
+                        tokenID: tokenID,
+                        onCompletion: { result in
+                            continuation.resume(with: result)
+                        }
+                    ))
+                }
+                pushNotificationManager.unmarkSiteAsRegisteredForWooPNs(siteID)
+            } catch {
+                DDLogError("⛔️ Failed to unregister site \(siteID) from self-driven push notifications: \(error)")
+            }
         }
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -941,6 +941,10 @@ private extension PushNotificationsManager {
         stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
             siteID: siteID,
             tokenID: tokenIDInt,
+            // The target siteID is the currently selected site, so REST fallback via
+            // `RequestConverter` is safe and preserved for site-credentials users who have no
+            // Jetpack tunnel available.
+            availableAsRESTRequest: true,
             onCompletion: completion
         ))
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -90,6 +90,14 @@ final class PushNotificationsManager: PushNotesManager {
         registrationState.deviceID
     }
 
+    var wooPushNotificationToken: String? {
+        registrationState.wooPushNotificationToken
+    }
+
+    func unmarkSiteAsRegisteredForWooPNs(_ siteID: Int64) {
+        registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
+    }
+
     /// Site IDs registered to Woo PN system.
     ///
     var siteIDsRegisteredForWooPNs: [Int64] {

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -33,6 +33,10 @@ protocol PushNotesManager {
     ///
     var deviceID: String? { get }
 
+    /// Self-driven push notification token ID
+    ///
+    var wooPushNotificationToken: String? { get }
+
     /// Site IDs registered for Woo Push Notifications.
     ///
     var siteIDsRegisteredForWooPNs: [Int64] { get }
@@ -44,6 +48,10 @@ protocol PushNotesManager {
     /// Indicates whether the registered site IDs value exists in storage.
     ///
     var hasStoredSiteIDsRegisteredForWooPNs: Bool { get }
+
+    /// Unmarks a site as registered for Woo Push Notifications.
+    ///
+    func unmarkSiteAsRegisteredForWooPNs(_ siteID: Int64)
 
     /// Resets the Badge Count.
     ///

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -220,8 +220,11 @@ struct EditStoreListViewModelTests {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, onCompletion):
+            case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, availableAsRESTRequest, onCompletion):
                 #expect(tokenID == 99)
+                // EditStoreListViewModel always unregisters non-current sites, so REST fallback
+                // must be disabled to force the Jetpack tunnel to the correct site.
+                #expect(availableAsRESTRequest == false)
                 unregisteredSiteIDs.append(siteID)
                 onCompletion(.success(()))
             default:
@@ -331,7 +334,7 @@ struct EditStoreListViewModelTests {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .unregisterFromSelfDrivenPushNotifications(_, _, onCompletion):
+            case let .unregisterFromSelfDrivenPushNotifications(_, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "test", code: 500)))
             default:
                 break
@@ -370,7 +373,7 @@ struct EditStoreListViewModelTests {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .unregisterFromSelfDrivenPushNotifications(siteID, _, onCompletion):
+            case let .unregisterFromSelfDrivenPushNotifications(siteID, _, _, onCompletion):
                 unregisteredSiteIDs.append(siteID)
                 onCompletion(.success(()))
             default:

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -204,4 +204,194 @@ struct EditStoreListViewModelTests {
         #expect(completionTriggered == false)
         #expect(viewModel.shouldShowErrorAlert == true)
     }
+
+    // MARK: - Self-driven push notification unregistration
+
+    @MainActor
+    @Test func saveChanges_unregisters_hidden_sites_from_self_driven_push_notifications() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager(
+            wooPushNotificationToken: "99",
+            siteIDsRegisteredForWooPNs: [site1.siteID]
+        )
+
+        var unregisteredSiteIDs: [Int64] = []
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, onCompletion):
+                #expect(tokenID == 99)
+                unregisteredSiteIDs.append(siteID)
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then
+        #expect(unregisteredSiteIDs == [site1.siteID])
+        #expect(notificationManager.unmarkedSiteIDs == [site1.siteID])
+    }
+
+    @MainActor
+    @Test func saveChanges_skips_self_driven_unregistration_when_site_is_not_registered() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager(
+            wooPushNotificationToken: "99",
+            siteIDsRegisteredForWooPNs: [] // site1 is NOT registered
+        )
+
+        var unregisterActionDispatched = false
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .unregisterFromSelfDrivenPushNotifications:
+                unregisterActionDispatched = true
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then
+        #expect(unregisterActionDispatched == false)
+    }
+
+    @MainActor
+    @Test func saveChanges_skips_self_driven_unregistration_when_no_token() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager(
+            wooPushNotificationToken: nil,
+            siteIDsRegisteredForWooPNs: [site1.siteID]
+        )
+
+        var unregisterActionDispatched = false
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .unregisterFromSelfDrivenPushNotifications:
+                unregisterActionDispatched = true
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then
+        #expect(unregisterActionDispatched == false)
+    }
+
+    @MainActor
+    @Test func saveChanges_succeeds_even_when_self_driven_unregistration_fails() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        var completionTriggered = false
+        let notificationManager = MockPushNotificationsManager(
+            wooPushNotificationToken: "99",
+            siteIDsRegisteredForWooPNs: [site1.siteID]
+        )
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .unregisterFromSelfDrivenPushNotifications(_, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "test", code: 500)))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: { completionTriggered = true })
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then — save should still succeed despite self-driven PN unregistration failure
+        #expect(userDefaults.hiddenStoreIDs == [site1.siteID])
+        #expect(completionTriggered == true)
+        #expect(notificationManager.unmarkedSiteIDs.isEmpty) // not unmarked because API failed
+    }
+
+    @MainActor
+    @Test func saveChanges_unregisters_self_driven_PNs_even_without_WPCom_deviceID() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager(
+            mockedDeviceID: nil, // no WPCom device ID
+            wooPushNotificationToken: "99",
+            siteIDsRegisteredForWooPNs: [site1.siteID]
+        )
+
+        var unregisteredSiteIDs: [Int64] = []
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .unregisterFromSelfDrivenPushNotifications(siteID, _, onCompletion):
+                unregisteredSiteIDs.append(siteID)
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then — self-driven PN unregistration should still happen
+        #expect(unregisteredSiteIDs == [site1.siteID])
+        #expect(notificationManager.unmarkedSiteIDs == [site1.siteID])
+    }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -43,8 +43,10 @@ final class MockPushNotificationsManager: PushNotesManager {
     }
 
     private let mockedDeviceID: String?
-    let siteIDsRegisteredForWooPNs: [Int64]
+    let wooPushNotificationToken: String?
+    private(set) var siteIDsRegisteredForWooPNs: [Int64]
     let hasStoredSiteIDsRegisteredForWooPNs: Bool
+    private(set) var unmarkedSiteIDs: [Int64] = []
     var siteIDsRegisteredForWooPNsPublisher: AnyPublisher<[Int64], Never> {
         siteIDsRegisteredForWooPNsSubject.eraseToAnyPublisher()
     }
@@ -70,12 +72,19 @@ final class MockPushNotificationsManager: PushNotesManager {
     var registerDeviceAndWaitForTokenAcceptanceResult: Result<Int64, Error> = .success(1)
 
     init(mockedDeviceID: String? = nil,
+         wooPushNotificationToken: String? = nil,
          siteIDsRegisteredForWooPNs: [Int64] = [],
          hasStoredSiteIDsRegisteredForWooPNs: Bool? = nil) {
         self.mockedDeviceID = mockedDeviceID
+        self.wooPushNotificationToken = wooPushNotificationToken
         self.siteIDsRegisteredForWooPNs = siteIDsRegisteredForWooPNs
         self.hasStoredSiteIDsRegisteredForWooPNs = hasStoredSiteIDsRegisteredForWooPNs ?? !siteIDsRegisteredForWooPNs.isEmpty
         self.siteIDsRegisteredForWooPNsSubject = CurrentValueSubject(siteIDsRegisteredForWooPNs)
+    }
+
+    func unmarkSiteAsRegisteredForWooPNs(_ siteID: Int64) {
+        unmarkedSiteIDs.append(siteID)
+        siteIDsRegisteredForWooPNs.removeAll { $0 == siteID }
     }
 
     func resetBadgeCount(type: Note.Kind) {


### PR DESCRIPTION
Closes WOOMOB-2713

## Description

When a merchant hides a store via `EditStoreListView`, the app previously disabled WPCom push notifications for that site but never told the self-driven WooCommerce push-notification system to stop. Sites registered via the new system (tracked in `PushNotificationRegistrationState.siteIDsRegisteredForWooPNs`) kept receiving notifications for a store the user had chosen to hide.

This PR adds cross-site unregistration at the point of hide:

- **Protocol surface**: `PushNotesManager` gains `wooPushNotificationToken` and `unmarkSiteAsRegisteredForWooPNs(_:)` so the Auth layer can read the token and update local state. `MockPushNotificationsManager` is updated accordingly.
- **EditStoreListViewModel.saveChanges()**: after the existing WPCom notification-settings update, the view model now filters the hidden site IDs against `siteIDsRegisteredForWooPNs` and dispatches `NotificationAction.unregisterFromSelfDrivenPushNotifications` for each match. On success, it calls `unmarkSiteAsRegisteredForWooPNs` so local state stays in sync. Failures are logged and swallowed (best-effort — we do not want a flaky unregister to block the hide).
- **No-WPCom-deviceID edge case**: the existing `updateNotificationSettings` early-returns when there is no WPCom device ID. The new self-driven unregister runs independently so it still executes in that case (covered by a dedicated test).

### Cross-site routing fix

During manual testing the `DELETE` was landing on the currently-selected site's host and returning `404`. Root cause:

- `DevicesRemote.unregisterFromSelfDrivenPushNotifications` built a `JetpackRequest` with `availableAsRESTRequest: true`.
- The networking layer's `RequestConverter` rewrites any such request into a direct REST call using the **currently-selected** site's URL, silently dropping the `siteID` carried in the `JetpackRequest`. That assumption holds for every existing caller (they all target the current site) but breaks for this new cross-site case.
- Proxy traces showed a REST `DELETE` to the current site returning `404`, followed by an internal retry that eventually sent a JP-tunneled `DELETE` to the correct site. A side effect of that retry was flagging the current site as "application-password-unsupported" for the session.

Fix: thread an `availableAsRESTRequest: Bool` flag through `DevicesRemote` → `NotificationAction` → `NotificationStore` so each call site declares intent.

- `EditStoreListViewModel` passes `false`: the hidden site is never the currently-selected site, so force the Jetpack tunnel. The `siteID` is encoded in the WPCom tunnel URL path and always routes correctly. This is always safe here because `EditStoreListView` is only reachable when logged in with WordPress.com, and every site in the selector is Jetpack-connected.
- `PushNotificationsManager` (logout path) keeps `true`: the target is the currently-selected site, so the REST fallback is correct and must be preserved for site-credentials-authenticated users who have no Jetpack tunnel.

### Out of scope / follow-up

Re-registration when a previously-hidden site is un-hidden is **not** implemented here — the ticket explicitly flags it as an open question. Recommend filing a follow-up ticket to decide the re-registration policy (when to trigger, plugin-compatibility handling, token reuse vs. fresh registration).

## Test Steps

**Prerequisites**
- WordPress.com account with at least two Jetpack-connected WooCommerce sites.
- `selfDrivenPushNotificationEnabled` feature flag enabled.
- At least one site running a Woo plugin version that exposes `/wc-push-notifications/push-tokens` (use the debug "Minimum Woo version" override in `DebugPanelView` if needed on `-dev` builds). Or follow setup steps from testing guide: paaHJt-9VE-p2.

**Happy path — hide a registered site**
1. Switch to a different site first (the currently-selected site cannot be hidden).
2. Menu → Switch store → Edit → deselect the registered site → Save.
3. In a proxy (Proxyman/Charles), verify **exactly one** request:
   ```
   GET https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/<HIDDEN_SITE_ID>/rest-api/?...&_method=delete
   ```
   returns `200`.
4. In `UserDefaults`, `siteIDsRegisteredForWooPushNotifications` should no longer contain the hidden site's ID.
5. Create a test order on the hidden site from the web → device should not receive a push.

**Failure handling (best-effort)**
1. Use Proxyman's Map Local to force the `DELETE` to fail (e.g., `500`).
2. Hide the site. Save should still succeed.
3. Xcode console should show `⛔️ Failed to unregister site <id> from self-driven push notifications: ...`.

**Hide a non-registered site**
1. Hide a site whose ID is not in `siteIDsRegisteredForWooPushNotifications`.
2. Verify no `DELETE` is sent and the existing WPCom notification-settings update still happens.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.