### PR TITLE
Register sites with Woo PN when re-enabled in store list

### DIFF
--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -129,11 +129,16 @@ private extension EditStoreListViewModel {
     /// Sites that fail to register will fall back to WPCom push notifications via `updateNotificationSettings`.
     @MainActor
     func registerNewlyEnabledSitesForSelfDrivenPushNotifications(newlyEnabledSiteIDs: [Int64]) async {
-        for siteID in newlyEnabledSiteIDs {
-            do {
-                try await pushNotificationManager.registerSiteForSelfDrivenPushNotifications(siteID)
-            } catch {
-                DDLogError("⛔️ Failed to register site \(siteID) for self-driven push notifications: \(error)")
+        await withTaskGroup(of: Void.self) { group in
+            for siteID in newlyEnabledSiteIDs {
+                group.addTask { [weak self] in
+                    guard let self else { return }
+                    do {
+                        try await pushNotificationManager.registerSiteForSelfDrivenPushNotifications(siteID)
+                    } catch {
+                        DDLogError("⛔️ Failed to register site \(siteID) for self-driven push notifications: \(error)")
+                    }
+                }
             }
         }
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -53,11 +53,21 @@ final class EditStoreListViewModel: ObservableObject {
         let hiddenSiteIDs = Array(hiddenSites).map { $0.siteID }
         let displayedSiteIDs = Array(selectedSites).map { $0.siteID }
 
+        let originalHiddenSiteIDs = Set(availableSites.map(\.siteID)).subtracting(originalSelectedSites.map(\.siteID))
+        let newlyEnabledSiteIDs = displayedSiteIDs.filter { originalHiddenSiteIDs.contains($0) }
+
         analytics.track(event: .SitePicker.listSaveButtonTapped(hiddenSiteCount: hiddenSiteIDs.count))
         shouldShowErrorAlert = false
         isUpdatingNotificationSettings = true
         do {
-            try await updateNotificationSettings(displayedSiteIDs: displayedSiteIDs, hiddenSiteIDs: hiddenSiteIDs)
+            await registerNewlyEnabledSitesForSelfDrivenPushNotifications(newlyEnabledSiteIDs: newlyEnabledSiteIDs)
+
+            // Sites registered with Woo should be disabled in WPCom to avoid duplicate notifications
+            let siteIDsRegisteredForWooPNs = Set(pushNotificationManager.siteIDsRegisteredForWooPNs)
+            let wpcomEnabledSiteIDs = displayedSiteIDs.filter { !siteIDsRegisteredForWooPNs.contains($0) }
+            let wpcomDisabledSiteIDs = hiddenSiteIDs + displayedSiteIDs.filter { siteIDsRegisteredForWooPNs.contains($0) }
+
+            try await updateNotificationSettings(displayedSiteIDs: wpcomEnabledSiteIDs, hiddenSiteIDs: wpcomDisabledSiteIDs)
             await unregisterHiddenSitesFromSelfDrivenPushNotifications(hiddenSiteIDs: hiddenSiteIDs)
             userDefaults.saveHiddenStoreIDs(hiddenSiteIDs)
             analytics.track(event: .SitePicker.listEditSavingSuccess())
@@ -111,6 +121,20 @@ private extension EditStoreListViewModel {
             stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: settings, onCompletion: { result in
                 continuation.resume(with: result)
             }))
+        }
+    }
+
+    /// Registers newly enabled sites for the self-driven push notification system.
+    /// This is best-effort — failures are logged but do not block the save operation.
+    /// Sites that fail to register will fall back to WPCom push notifications via `updateNotificationSettings`.
+    @MainActor
+    func registerNewlyEnabledSitesForSelfDrivenPushNotifications(newlyEnabledSiteIDs: [Int64]) async {
+        for siteID in newlyEnabledSiteIDs {
+            do {
+                try await pushNotificationManager.registerSiteForSelfDrivenPushNotifications(siteID)
+            } catch {
+                DDLogError("⛔️ Failed to register site \(siteID) for self-driven push notifications: \(error)")
+            }
         }
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -359,11 +359,7 @@ extension PushNotificationsManager {
             DDLogDebug("📱 Site \(siteID) is already registered for self-driven push notifications")
             return
         }
-        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int64, Error>) in
-            registerSelfDrivenPushNotificationFlow(with: deviceToken, siteID: siteID) { result in
-                continuation.resume(with: result)
-            }
-        }
+        try await registerSelfDrivenPushNotification(with: deviceToken, siteID: siteID)
     }
 
     /// Registers the Device Token agains WordPress.com backend, if there's a default account.
@@ -814,8 +810,12 @@ private extension PushNotificationsManager {
         await withTaskGroup(of: (Int64, Bool).self) { group in
             for siteID in siteIDsToRegister {
                 group.addTask { [weak self] in
-                    let succeeded = await self?.registerSelfDrivenPushNotification(with: deviceToken, siteID: siteID) ?? false
-                    return (siteID, succeeded)
+                    do {
+                        try await self?.registerSelfDrivenPushNotification(with: deviceToken, siteID: siteID)
+                        return (siteID, true)
+                    } catch {
+                        return (siteID, false)
+                    }
                 }
             }
             for await (siteID, succeeded) in group where !succeeded {
@@ -828,10 +828,10 @@ private extension PushNotificationsManager {
         }
     }
 
-    /// Registers the push notification token for a single site and handles the result.
-    /// - Returns: `true` on success, `false` on failure.
+    /// Registers the push notification token for a single site with analytics tracking.
+    /// - Throws: Error if registration fails.
     @MainActor
-    private func registerSelfDrivenPushNotification(with deviceToken: String, siteID: Int64) async -> Bool {
+    private func registerSelfDrivenPushNotification(with deviceToken: String, siteID: Int64) async throws {
         DDLogDebug("📱 Requesting push token registration for site \(siteID)")
         do {
             let tokenID = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int64, Error>) in
@@ -841,14 +841,13 @@ private extension PushNotificationsManager {
             }
             DDLogDebug("📱 Push token registration succeeded for site \(siteID): tokenID \(tokenID)")
             analytics.track(.wooPushTokenRegisterSuccess)
-            return true
         } catch {
             DDLogDebug("📱 Push token registration failed for site \(siteID): \(error)")
             analytics.track(.wooPushTokenRegisterError, withError: error)
             if case .notFound = error as? NetworkError {
                 registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
             }
-            return false
+            throw error
         }
     }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -348,6 +348,10 @@ extension PushNotificationsManager {
     /// - Throws: If registration fails or device token is not available.
     @MainActor
     func registerSiteForSelfDrivenPushNotifications(_ siteID: Int64) async throws {
+        guard selfDrivenPushNotificationEnabled == true else {
+            DDLogDebug("📱 Self-driven push notifications not enabled — skipping registration for site \(siteID)")
+            return
+        }
         guard let deviceToken = registrationState.deviceToken else {
             throw PushNotificationError.missingDeviceToken
         }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -343,6 +343,25 @@ extension PushNotificationsManager {
         loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: nil, postNotifications: true)
     }
 
+    /// Registers a specific site for self-driven push notifications.
+    /// - Parameter siteID: The site ID to register.
+    /// - Throws: If registration fails or device token is not available.
+    @MainActor
+    func registerSiteForSelfDrivenPushNotifications(_ siteID: Int64) async throws {
+        guard let deviceToken = registrationState.deviceToken else {
+            throw PushNotificationError.missingDeviceToken
+        }
+        guard !registrationState.isSiteRegisteredForWooPNs(siteID) else {
+            DDLogDebug("📱 Site \(siteID) is already registered for self-driven push notifications")
+            return
+        }
+        _ = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Int64, Error>) in
+            registerSelfDrivenPushNotificationFlow(with: deviceToken, siteID: siteID) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
     /// Registers the Device Token agains WordPress.com backend, if there's a default account.
     ///
     /// - Parameters:
@@ -1043,6 +1062,7 @@ private enum AnalyticKey {
 private enum PushNotificationError: Error {
     case deviceTokenTimeout
     case missingSiteID
+    case missingDeviceToken
     case siteRegistrationFailed(siteIDs: [Int64])
     case pluginVersionIncompatible(currentVersion: String, requiredVersion: String)
 }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -73,6 +73,11 @@ protocol PushNotesManager {
     /// - Throws: If any step in the registration pipeline fails.
     @MainActor func registerDeviceAndWaitForTokenAcceptance() async throws -> Int64
 
+    /// Registers a specific site for self-driven push notifications.
+    /// - Parameter siteID: The site ID to register.
+    /// - Throws: If registration fails or device token is not available.
+    @MainActor func registerSiteForSelfDrivenPushNotifications(_ siteID: Int64) async throws
+
     /// Registers the Application for Remote Notifications.
     ///
     func registerForRemoteNotifications()

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -397,4 +397,112 @@ struct EditStoreListViewModelTests {
         #expect(unregisteredSiteIDs == [site1.siteID])
         #expect(notificationManager.unmarkedSiteIDs == [site1.siteID])
     }
+
+    // MARK: - Self-driven push notification registration for newly enabled sites
+
+    @MainActor
+    @Test func saveChanges_registers_newly_enabled_sites_for_self_driven_push_notifications() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager()
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site2], // site1 was hidden
+                                               currentlySelectedSite: nil,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When — re-enable site1
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then — site1 should be registered for self-driven push notifications
+        #expect(notificationManager.registeredSiteIDsForSelfDrivenPushNotifications == [site1.siteID])
+    }
+
+    @MainActor
+    @Test func saveChanges_does_not_register_sites_that_were_already_enabled() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager()
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2], // both were already enabled
+                                               currentlySelectedSite: nil,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When — no changes, just save
+        await viewModel.saveChanges()
+
+        // Then — no registration attempts for already enabled sites
+        #expect(notificationManager.registeredSiteIDsForSelfDrivenPushNotifications.isEmpty)
+    }
+
+    @MainActor
+    @Test func saveChanges_succeeds_even_when_self_driven_registration_fails() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        var completionTriggered = false
+        let notificationManager = MockPushNotificationsManager()
+        notificationManager.registerSiteForSelfDrivenPushNotificationsResult = .failure(NSError(domain: "test", code: 500))
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site2], // site1 was hidden
+                                               currentlySelectedSite: nil,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: { completionTriggered = true })
+
+        // When — re-enable site1
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then — save should still succeed despite self-driven PN registration failure
+        #expect(completionTriggered == true)
+        // Registration was attempted even though it failed
+        #expect(notificationManager.registeredSiteIDsForSelfDrivenPushNotifications == [site1.siteID])
+    }
+
+    @MainActor
+    @Test func saveChanges_disables_woo_registered_sites_in_wpcom_to_avoid_duplicates() async {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let deviceID = "13435352"
+        let notificationManager = MockPushNotificationsManager(
+            mockedDeviceID: deviceID,
+            siteIDsRegisteredForWooPNs: [site1.siteID] // site1 is registered with Woo
+        )
+
+        var capturedEnabledSites: [Int64]?
+        var capturedDisabledSites: [Int64]?
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            switch action {
+            case .updateNotificationSettings(let settings, let onCompletion):
+                capturedEnabledSites = settings.blogs?.filter { $0.devices?.first?.newComment == true }.map { $0.blogID }
+                capturedDisabledSites = settings.blogs?.filter { $0.devices?.first?.newComment == false }.map { $0.blogID }
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2], // both displayed
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               onCompletion: {})
+
+        // When
+        await viewModel.saveChanges()
+
+        // Then — site1 (Woo-registered) should be disabled in WPCom, site2 should be enabled
+        #expect(capturedEnabledSites == [site2.siteID])
+        #expect(capturedDisabledSites == [site1.siteID])
+    }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -472,8 +472,7 @@ struct EditStoreListViewModelTests {
         let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
         let deviceID = "13435352"
         let notificationManager = MockPushNotificationsManager(
-            mockedDeviceID: deviceID,
-            siteIDsRegisteredForWooPNs: [site1.siteID] // site1 is registered with Woo
+            mockedDeviceID: deviceID
         )
 
         var capturedEnabledSites: [Int64]?
@@ -491,18 +490,19 @@ struct EditStoreListViewModelTests {
         }
 
         let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
-                                               displayedSites: [site1, site2], // both displayed
+                                               displayedSites: [site2], // site1 starts hidden
                                                currentlySelectedSite: nil,
                                                stores: stores,
                                                pushNotificationManager: notificationManager,
                                                userDefaults: userDefaults,
                                                onCompletion: {})
 
-        // When
+        // When — re-enable site1 and save
+        viewModel.toggleSelection(site1)
         await viewModel.saveChanges()
 
-        // Then — site1 (Woo-registered) should be disabled in WPCom, site2 should be enabled
-        #expect(capturedEnabledSites == [site2.siteID])
-        #expect(capturedDisabledSites == [site1.siteID])
+        // Then — site1 (now Woo-registered after save) should be disabled in WPCom, site2 should be enabled
+        #expect(Set(capturedEnabledSites ?? []) == Set([site2.siteID]))
+        #expect(Set(capturedDisabledSites ?? []) == Set([site1.siteID]))
     }
 }

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -482,8 +482,8 @@ struct EditStoreListViewModelTests {
         stores.whenReceivingAction(ofType: AccountAction.self) { action in
             switch action {
             case .updateNotificationSettings(let settings, let onCompletion):
-                capturedEnabledSites = settings.blogs?.filter { $0.devices?.first?.newComment == true }.map { $0.blogID }
-                capturedDisabledSites = settings.blogs?.filter { $0.devices?.first?.newComment == false }.map { $0.blogID }
+                capturedEnabledSites = settings.blogs.filter { $0.devices.first?.newComment == true }.map { $0.blogID }
+                capturedDisabledSites = settings.blogs.filter { $0.devices.first?.newComment == false }.map { $0.blogID }
                 onCompletion(.success(()))
             default:
                 break

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -112,6 +112,9 @@ final class MockPushNotificationsManager: PushNotesManager {
     func registerSiteForSelfDrivenPushNotifications(_ siteID: Int64) async throws {
         registeredSiteIDsForSelfDrivenPushNotifications.append(siteID)
         try registerSiteForSelfDrivenPushNotificationsResult.get()
+        if !siteIDsRegisteredForWooPNs.contains(siteID) {
+            siteIDsRegisteredForWooPNs.append(siteID)
+        }
     }
 
     func registerForRemoteNotifications() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -70,6 +70,8 @@ final class MockPushNotificationsManager: PushNotesManager {
     private var authorizationCompletion: ((Bool) -> Void)?
     var onRequestLocalNotificationCalled: (() -> Void)?
     var registerDeviceAndWaitForTokenAcceptanceResult: Result<Int64, Error> = .success(1)
+    var registerSiteForSelfDrivenPushNotificationsResult: Result<Void, Error> = .success(())
+    private(set) var registeredSiteIDsForSelfDrivenPushNotifications: [Int64] = []
 
     init(mockedDeviceID: String? = nil,
          wooPushNotificationToken: String? = nil,
@@ -104,6 +106,12 @@ final class MockPushNotificationsManager: PushNotesManager {
         // Yield to allow MainActor scheduling to settle
         await Task.yield()
         return try registerDeviceAndWaitForTokenAcceptanceResult.get()
+    }
+
+    @MainActor
+    func registerSiteForSelfDrivenPushNotifications(_ siteID: Int64) async throws {
+        registeredSiteIDsForSelfDrivenPushNotifications.append(siteID)
+        try registerSiteForSelfDrivenPushNotificationsResult.get()
     }
 
     func registerForRemoteNotifications() {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1484,6 +1484,40 @@ final class PushNotificationsManagerTests: XCTestCase {
             return false
         }))
     }
+
+    func test_registerSiteForSelfDrivenPushNotifications_when_feature_disabled_then_skips_registration() async {
+        // Given
+        let siteID: Int64 = 99
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(siteID)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: false, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        manager = makeManager()
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        // Provide a device token so the manager has one
+        guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
+            return XCTFail("Invalid sample token")
+        }
+        manager.registerDeviceToken(with: tokenAsData)
+
+        var registrationAttempted = false
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case .registerDeviceForSelfDrivenPushNotifications = action {
+                registrationAttempted = true
+            }
+        }
+
+        // When
+        try? await manager.registerSiteForSelfDrivenPushNotifications(siteID)
+
+        // Then
+        XCTAssertFalse(registrationAttempted, "Should not attempt registration when feature is disabled")
+    }
 }
 
 


### PR DESCRIPTION
Related to WOOMOB-2713
Follows up with #16953 

## Description
When a site is re-enabled in the store list (Edit Store List), this PR attempts to register it with the self-driven (Woo) push notification system first, then falls back to WPCom if registration fails.

Additionally, sites that are successfully registered with Woo are sent as disabled to WPCom to avoid duplicate notifications.

**Changes:**
- Added `registerSiteForSelfDrivenPushNotifications` method to `PushNotesManager` protocol
- Implemented the method in `PushNotificationsManager` reusing `registerSelfDrivenPushNotificationFlow`
- Updated `EditStoreListViewModel.saveChanges()` to:
  - Register newly enabled sites with Woo PN first
  - Send Woo-registered sites as disabled to WPCom to avoid duplicates

## Test Steps
1. Have multiple sites, with at least one hidden in the store list
2. Go to Edit Store List and re-enable a hidden site
3. Verify the site attempts to register with Woo PN (check logs for "📱 Registering self-driven push notification token for site")
4. Verify Woo-registered sites are sent as disabled to WPCom notification settings

## Screenshots
N/A - No UI changes

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
