### PR TITLE
Enable SwiftLint rule: unused_import

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,6 +65,8 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  - unused_import
+
   - vertical_whitespace
 
   - weak_delegate


### PR DESCRIPTION
## What

Enables the SwiftLint `unused_import` opt-in rule in `.swiftlint.yml`. The rule flags module imports that are never referenced by the file's code.

## Results

- **Auto-fixed violations**: 0
- **Agentic (manual) fixes**: 0
- **Violations left for human review**: 0

Running the repo-pinned SwiftLint (0.63.2) over `trunk` reports no violations, so no source changes are needed. The rule starts clean and guards against future unused imports.

## Campaign

Part of the Orchard SwiftLint rollout campaign: progressively enabling more SwiftLint rules across repos, one rule and one PR at a time.