### PR TITLE
Unify self-driven push notification feature flags

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -99,9 +99,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .pointOfSaleBookings:
             return true
-        case .selfDrivenPushTokenWPCom:
-            return false
-        case .selfDrivenPushTokenAppPasswords:
+        case .selfDrivenPushToken:
             return false
         case .clientSideDashboardBanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -209,13 +209,9 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case pointOfSaleBookings
 
-    /// Enables self driven push token registration for users authenticated with WPCom
+    /// Enables self driven push token registration
     ///
-    case selfDrivenPushTokenWPCom
-
-    /// Enables self driven push token registration for users authenticated with app passwords
-    ///
-    case selfDrivenPushTokenAppPasswords
+    case selfDrivenPushToken
 
     /// Enables client-side promotional banners for non-Jetpack stores on the dashboard
     ///

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -737,7 +737,7 @@ private extension PushNotificationsManager {
 
     func checkSelfDrivenPushNotificationsEligibility() {
         Task { @MainActor in
-            let isEnabled = await selfDriventPNEligiblityChecker.checkM1Eligibility()
+            let isEnabled = await selfDriventPNEligiblityChecker.checkEligibility()
             if selfDrivenPushNotificationEnabled != isEnabled {
                 selfDrivenPushNotificationEnabled = isEnabled
                 if let pendingTokenData {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
@@ -14,7 +14,7 @@ final class WooPushNotificationEligibilityCheck {
     }
 
     @MainActor
-    func checkM1Eligibility() async -> Bool {
+    func checkEligibility() async -> Bool {
         let defaultM1Value = featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)
 
         return await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
@@ -15,7 +15,7 @@ final class WooPushNotificationEligibilityCheck {
 
     @MainActor
     func checkM1Eligibility() async -> Bool {
-        let defaultM1Value = featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenWPCom)
+        let defaultM1Value = featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)
 
         return await withCheckedContinuation { continuation in
             stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -986,7 +986,7 @@ private extension DashboardViewModel {
             registeredSiteIDs.contains(siteID) == false &&
             (stores.isAuthenticatedWithoutWPCom || stores.sessionManager.defaultSite?.isJetpackCPConnected == true) &&
             !dismissedWPComConnectionSuggestion &&
-            featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords)
+            featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -307,7 +307,7 @@ private extension SettingsViewModel {
                 guard let siteID = stores.sessionManager.defaultSite?.siteID else {
                     return false
                 }
-                return featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenWPCom) &&
+                return featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken) &&
                 pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID)
             }()
             if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {
@@ -381,7 +381,7 @@ private extension SettingsViewModel {
             return false
         }
 
-        guard featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords) else {
+        guard featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken) else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -68,7 +68,7 @@ final class JetpackSetupCoordinator {
     /// Skips the benefits modal when the self-driven push notifications feature flag is enabled.
     ///
     func startSetup() {
-        if featureFlagService.isFeatureFlagEnabled(.selfDrivenPushTokenAppPasswords) {
+        if featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken) {
             Task { @MainActor in
                 await startSetupDirectly()
             }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,8 +24,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
     var isFeatureFlagEnabledReturnValue: [FeatureFlag: Bool] = [:]
     var isCIABBookingsEnabled: Bool
     var isCIABBookingRescheduleEnabled: Bool
-    var selfDrivenPushTokenWPCom: Bool
-    var selfDrivenPushTokenAppPasswords: Bool
+    var selfDrivenPushToken: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -47,8 +46,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
          isProductImageOptimizedHandlingEnabled: Bool = false,
          isCIABBookingsEnabled: Bool = false,
          isCIABBookingRescheduleEnabled: Bool = false,
-         selfDrivenPushTokenWPCom: Bool = false,
-         selfDrivenPushTokenAppPasswords: Bool = false) {
+         selfDrivenPushToken: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -69,8 +67,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
         self.isProductImageOptimizedHandlingEnabled = isProductImageOptimizedHandlingEnabled
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
         self.isCIABBookingRescheduleEnabled = isCIABBookingRescheduleEnabled
-        self.selfDrivenPushTokenWPCom = selfDrivenPushTokenWPCom
-        self.selfDrivenPushTokenAppPasswords = selfDrivenPushTokenAppPasswords
+        self.selfDrivenPushToken = selfDrivenPushToken
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -121,10 +118,8 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
             return isCIABBookingsEnabled
         case .ciabBookingReschedule:
             return isCIABBookingRescheduleEnabled
-        case .selfDrivenPushTokenWPCom:
-            return selfDrivenPushTokenWPCom
-        case .selfDrivenPushTokenAppPasswords:
-            return selfDrivenPushTokenAppPasswords
+        case .selfDrivenPushToken:
+            return selfDrivenPushToken
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -690,7 +690,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         mockSelfDrivenRegistrationActions(token: 123)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -750,7 +750,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -798,7 +798,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let siteID: Int64 = 99
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(siteID)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -838,7 +838,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let siteID: Int64 = 99
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(siteID)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -888,7 +888,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let siteID: Int64 = 99
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(siteID)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -933,7 +933,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let siteID: Int64 = 99
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(siteID)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -981,7 +981,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         defaults.set("old-token", forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(siteID)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1029,7 +1029,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1075,7 +1075,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1121,7 +1121,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
         defaults.set("100,200", forKey: PushNotificationSharedConstants.UserDefaultsKeys.siteIDsRegisteredForWooPushNotifications)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1159,7 +1159,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1208,7 +1208,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1253,7 +1253,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given — no sites in storage, but defaultStoreID is set
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1294,7 +1294,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Set the same device token so token-change logic doesn't clear sites
         defaults.set(Sample.deviceToken.data(using: .utf8)!.hexString,
                      forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1368,7 +1368,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
@@ -1438,7 +1438,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         mockSelfDrivenRegistrationActions(token: 123)
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(100)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
 
         let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
         mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {

--- a/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
@@ -19,9 +19,9 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - checkM1Eligibility
+    // MARK: - checkEligibility
 
-    func test_checkM1Eligibility_returns_true_when_remote_flag_is_enabled() async {
+    func test_checkEligibility_returns_true_when_remote_flag_is_enabled() async {
         // Given
         let checker = WooPushNotificationEligibilityCheck(
             featureFlagService: featureFlagService,
@@ -30,13 +30,13 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
         mockRemoteFeatureFlagAction(isEnabled: true)
 
         // When
-        let result = await checker.checkM1Eligibility()
+        let result = await checker.checkEligibility()
 
         // Then
         XCTAssertTrue(result)
     }
 
-    func test_checkM1Eligibility_returns_false_when_remote_flag_is_disabled() async {
+    func test_checkEligibility_returns_false_when_remote_flag_is_disabled() async {
         // Given
         let checker = WooPushNotificationEligibilityCheck(
             featureFlagService: featureFlagService,
@@ -45,13 +45,13 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
         mockRemoteFeatureFlagAction(isEnabled: false)
 
         // When
-        let result = await checker.checkM1Eligibility()
+        let result = await checker.checkEligibility()
 
         // Then
         XCTAssertFalse(result)
     }
 
-    func test_checkM1Eligibility_passes_local_feature_flag_as_default_value() async {
+    func test_checkEligibility_passes_local_feature_flag_as_default_value() async {
         // Given
         featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let checker = WooPushNotificationEligibilityCheck(
@@ -69,13 +69,13 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
         }
 
         // When
-        _ = await checker.checkM1Eligibility()
+        _ = await checker.checkEligibility()
 
         // Then
         XCTAssertEqual(capturedDefaultValue, true)
     }
 
-    func test_checkM1Eligibility_passes_correct_remote_feature_flag_key() async {
+    func test_checkEligibility_passes_correct_remote_feature_flag_key() async {
         // Given
         let checker = WooPushNotificationEligibilityCheck(
             featureFlagService: featureFlagService,
@@ -92,13 +92,13 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
         }
 
         // When
-        _ = await checker.checkM1Eligibility()
+        _ = await checker.checkEligibility()
 
         // Then
         XCTAssertEqual(capturedFeatureFlag, .selfDrivenPushNotificationsM1)
     }
 
-    func test_checkM1Eligibility_uses_cache() async {
+    func test_checkEligibility_uses_cache() async {
         // Given
         let checker = WooPushNotificationEligibilityCheck(
             featureFlagService: featureFlagService,
@@ -115,7 +115,7 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
         }
 
         // When
-        _ = await checker.checkM1Eligibility()
+        _ = await checker.checkEligibility()
 
         // Then
         XCTAssertEqual(capturedUseCache, true)

--- a/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
@@ -53,7 +53,7 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
 
     func test_checkM1Eligibility_passes_local_feature_flag_as_default_value() async {
         // Given
-        featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let checker = WooPushNotificationEligibilityCheck(
             featureFlagService: featureFlagService,
             stores: storesManager

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1035,7 +1035,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: false)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: false)
         let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
                                                             hasStoredSiteIDsRegisteredForWooPNs: true)
 
@@ -1060,7 +1060,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
                                                             hasStoredSiteIDsRegisteredForWooPNs: true)
 
@@ -1133,7 +1133,7 @@ final class DashboardViewModelTests: XCTestCase {
         stores.updateDefaultStore(jcpSite)
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
                                                             hasStoredSiteIDsRegisteredForWooPNs: true)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -29,7 +29,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_startSetup_when_feature_flag_disabled_then_presents_benefit_modal() {
         // Given
         let testSite = Site.fake()
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: false)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: false)
         let coordinator = JetpackSetupCoordinator(site: testSite,
                                                   rootViewController: navigationController,
                                                   featureFlagService: featureFlagService)
@@ -191,7 +191,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_startSetup_when_feature_flag_enabled_then_presents_email_login_directly() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite,
                                                   rootViewController: navigationController,
@@ -221,7 +221,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_startSetup_when_feature_flag_enabled_then_does_not_present_benefit_modal() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: WooConstants.placeholderStoreID)
         let coordinator = JetpackSetupCoordinator(site: testSite,
                                                   rootViewController: navigationController,
@@ -250,7 +250,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_startSetup_when_feature_flag_enabled_and_wpcom_credentials_then_presents_setup_steps_directly() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true))
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let coordinator = JetpackSetupCoordinator(site: testSite,
                                                   rootViewController: navigationController,
@@ -270,7 +270,7 @@ final class JetpackSetupCoordinatorTests: XCTestCase {
     func test_startSetup_when_feature_flag_enabled_and_no_wpcom_credentials_then_proceeds_with_connection_check() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let coordinator = JetpackSetupCoordinator(site: testSite,
                                                   rootViewController: navigationController,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -275,7 +275,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_contains_does_not_contain_notifications_row_for_selfregisteredtoken() {
         // Given
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenWPCom: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
         let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123], hasStoredSiteIDsRegisteredForWooPNs: true)
@@ -293,7 +293,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_contains_enable_push_notifications_row_for_app_password_users_when_feature_flag_on() {
         // Given
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores,
@@ -309,7 +309,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_does_not_contain_enable_push_notifications_row_when_feature_flag_off() {
         // Given
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: false)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: false)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false, defaultSite: testSite))
         let viewModel = SettingsViewModel(stores: stores,
@@ -325,7 +325,7 @@ final class SettingsViewModelTests: XCTestCase {
 
     func test_sections_contains_enablePushNotifications_row_when_site_is_JCP_and_feature_flag_enabled_and_not_registered() {
         // Given
-        let featureFlagService = MockFeatureFlagService(selfDrivenPushTokenAppPasswords: true)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: false, isJetpackConnected: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
         let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])


### PR DESCRIPTION
Closes WOOMOB-2733

## Description
Consolidates the two separate feature flags `selfDrivenPushTokenWPCom` and `selfDrivenPushTokenAppPasswords` into a single unified flag `selfDrivenPushToken`.

Also renames `checkM1Eligibility()` to `checkEligibility()` in `WooPushNotificationEligibilityCheck` for clarity.

## Test Steps
1. Build the app and verify it compiles successfully
2. Run the unit tests for the affected classes
3. Smoke test push notifications (Woo + WPCom) to confirm that everything still works correctly

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.