### PR TITLE
Skip notification sync and unread indicators for Woo-driven PN sites

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -474,9 +474,14 @@ extension PushNotificationsManager {
                 }
 
             foregroundNotificationsSubject.send(foregroundNotification)
+
+            // Only sync WPCom notifications if this is a WPCom notification (has noteID).
+            // Woo-driven notifications don't have noteID and don't need WPCom notification sync.
+            if foregroundNotification.noteID != nil {
+                _ = await synchronizeNotifications()
+            }
         }
 
-        _ = await synchronizeNotifications()
         return UNNotificationPresentationOptions(rawValue: 0)
     }
 

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -138,3 +138,14 @@ protocol PushNotesManager {
     /// This is the app's default state
     func enableInAppNotifications()
 }
+
+extension PushNotesManager {
+    /// Whether WPCom notifications-based features should be available for a site.
+    /// Returns false for non-WPCom authenticated sites or sites using Woo-driven push notifications.
+    func supportsWPComNotifications(for siteID: Int64, stores: StoresManager) -> Bool {
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        return !siteIDsRegisteredForWooPNs.contains(siteID)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -178,7 +178,7 @@ private extension ReviewsDashboardCard {
 
     func unreadIndicatorColor(for reviewViewModel: ReviewViewModel) -> Color {
         // Don't show unread indicator for Woo-driven sites (notifications not available)
-        guard viewModel.supportsNotificationBasedFeatures else {
+        guard viewModel.supportsWPComNotifications else {
             return Color.secondary
         }
         // Show purple for unread, secondary for read or no notification

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -134,7 +134,7 @@ private extension ReviewsDashboardCard {
             HStack(alignment: .firstTextBaseline, spacing: Layout.padding) {
                 Image(systemName: "bubble.fill")
                     .foregroundStyle(
-                        unreadIndicatorColor(for: viewModel)
+                        self.viewModel.shouldHighlightAsUnread(viewModel) ? Color(.wooCommercePurple(.shade60)) : .secondary
                     )
 
                 VStack(alignment: .leading, spacing: Layout.padding) {
@@ -174,16 +174,6 @@ private extension ReviewsDashboardCard {
             }
             .padding(.leading, Layout.padding)
         }
-    }
-
-    func unreadIndicatorColor(for reviewViewModel: ReviewViewModel) -> Color {
-        // Don't show unread indicator for Woo-driven sites (notifications not available)
-        guard viewModel.supportsWPComNotifications else {
-            return Color.secondary
-        }
-        // Show purple for unread, secondary for read or no notification
-        let isRead = reviewViewModel.notification == nil || reviewViewModel.notification?.read == true
-        return isRead ? Color.secondary : Color(.wooCommercePurple(.shade60))
     }
 
     func reviewText(text: String,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -134,9 +134,7 @@ private extension ReviewsDashboardCard {
             HStack(alignment: .firstTextBaseline, spacing: Layout.padding) {
                 Image(systemName: "bubble.fill")
                     .foregroundStyle(
-                        viewModel.notification == nil || viewModel.notification?.read == true
-                        ? Color.secondary
-                        : Color(.wooCommercePurple(.shade60))
+                        unreadIndicatorColor(for: viewModel)
                     )
 
                 VStack(alignment: .leading, spacing: Layout.padding) {
@@ -176,6 +174,16 @@ private extension ReviewsDashboardCard {
             }
             .padding(.leading, Layout.padding)
         }
+    }
+
+    func unreadIndicatorColor(for reviewViewModel: ReviewViewModel) -> Color {
+        // Don't show unread indicator for Woo-driven sites (notifications not available)
+        guard viewModel.supportsNotificationBasedFeatures else {
+            return Color.secondary
+        }
+        // Show purple for unread, secondary for read or no notification
+        let isRead = reviewViewModel.notification == nil || reviewViewModel.notification?.read == true
+        return isRead ? Color.secondary : Color(.wooCommercePurple(.shade60))
     }
 
     func reviewText(text: String,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -56,8 +56,23 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let analytics: Analytics
+    private let pushNotesManager: PushNotesManager
 
     public let siteID: Int64
+
+    /// Whether notifications-based features (unread indicators) should be available.
+    /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
+    var supportsNotificationBasedFeatures: Bool {
+        // Skip if authenticated without WPCom (no notifications available)
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        // Skip if site is registered for Woo-driven push notifications (WPCom notifications not used)
+        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
+            return false
+        }
+        return true
+    }
     public let filters: [ReviewsFilter] = [.all, .hold, .approved]
     @Published private(set) var currentFilter: ReviewsFilter = .all
 
@@ -67,11 +82,13 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.siteID = siteID
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
+        self.pushNotesManager = pushNotesManager
 
         self.productsResultsController = ResultsController<StorageProduct>(storageManager: storageManager,
                                                                            matching: nil,
@@ -249,11 +266,13 @@ private extension ReviewsDashboardCardViewModel {
             updateProductsResultsController(for: productIDs)
 
             // Get product names and, optionally, read status from notifications.
+            // Skip syncing notifications if WPCom notifications are not available
+            // (authenticated without WPCom or site uses Woo-driven push notifications).
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask { [weak self] in
                     try await self?.retrieveProducts(for: productIDs)
                 }
-                if stores.isAuthenticatedWithoutWPCom == false {
+                if supportsNotificationBasedFeatures {
                     group.addTask { [weak self] in
                         try await self?.synchronizeNotifications()
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -250,7 +250,7 @@ private extension ReviewsDashboardCardViewModel {
                 showProductTitle: product != nil,
                 review: review,
                 product: product,
-                notification: notification
+                notification: supportsNotificationBasedFeatures ? notification : nil
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -62,7 +62,7 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
 
     /// Whether notifications-based features (unread indicators) should be available.
     /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    var supportsNotificationBasedFeatures: Bool {
+    var supportsWPComNotifications: Bool {
         // Skip if authenticated without WPCom (no notifications available)
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
@@ -250,7 +250,7 @@ private extension ReviewsDashboardCardViewModel {
                 showProductTitle: product != nil,
                 review: review,
                 product: product,
-                notification: supportsNotificationBasedFeatures ? notification : nil
+                notification: supportsWPComNotifications ? notification : nil
             )
         }
     }
@@ -272,7 +272,7 @@ private extension ReviewsDashboardCardViewModel {
                 group.addTask { [weak self] in
                     try await self?.retrieveProducts(for: productIDs)
                 }
-                if supportsNotificationBasedFeatures {
+                if supportsWPComNotifications {
                     group.addTask { [weak self] in
                         try await self?.synchronizeNotifications()
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -63,15 +63,7 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
     /// Whether notifications-based features (unread indicators) should be available.
     /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
     var supportsWPComNotifications: Bool {
-        // Skip if authenticated without WPCom (no notifications available)
-        guard stores.isAuthenticatedWithoutWPCom == false else {
-            return false
-        }
-        // Skip if site is registered for Woo-driven push notifications (WPCom notifications not used)
-        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
-            return false
-        }
-        return true
+        pushNotesManager.supportsWPComNotifications(for: siteID, stores: stores)
     }
     public let filters: [ReviewsFilter] = [.all, .hold, .approved]
     @Published private(set) var currentFilter: ReviewsFilter = .all

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -62,9 +62,18 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
 
     /// Whether notifications-based features (unread indicators) should be available.
     /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    var supportsWPComNotifications: Bool {
+    private var supportsWPComNotifications: Bool {
         pushNotesManager.supportsWPComNotifications(for: siteID, stores: stores)
     }
+
+    func shouldHighlightAsUnread(_ reviewViewModel: ReviewViewModel) -> Bool {
+        guard supportsWPComNotifications else {
+            return false
+        }
+        let isRead = reviewViewModel.notification == nil || reviewViewModel.notification?.read == true
+        return !isRead
+    }
+
     public let filters: [ReviewsFilter] = [.all, .hold, .approved]
     @Published private(set) var currentFilter: ReviewsFilter = .all
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -70,15 +70,13 @@ final class ProductReviewsViewController: UIViewController, GhostableViewControl
         viewModel = ProductReviewsViewModel(siteID: product.siteID,
                                             data: ReviewsDataSource(siteID: product.siteID,
                                                                     customizer: ProductReviewsDataSourceCustomizer(product: product),
-                                                                    supportsWPComNotifications: supportsWPComNotifications),
-                                            stores: stores,
-                                            pushNotesManager: pushNotesManager)
+                                                                    supportsWPComNotifications: supportsWPComNotifications))
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
     private static func supportsWPComNotifications(siteID: Int64,
-                                                          stores: StoresManager,
-                                                          pushNotesManager: PushNotesManager) -> Bool {
+                                                   stores: StoresManager,
+                                                   pushNotesManager: PushNotesManager) -> Bool {
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -58,12 +58,34 @@ final class ProductReviewsViewController: UIViewController, GhostableViewControl
     @IBOutlet private weak var tableView: UITableView!
 
     // MARK: - View Lifecycle
-    init(product: Product) {
+    init(product: Product,
+         stores: StoresManager = ServiceLocator.stores,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.product = product
+        let supportsNotificationBasedFeatures = Self.supportsNotificationBasedFeatures(
+            siteID: product.siteID,
+            stores: stores,
+            pushNotesManager: pushNotesManager
+        )
         viewModel = ProductReviewsViewModel(siteID: product.siteID,
                                             data: ReviewsDataSource(siteID: product.siteID,
-                                                                           customizer: ProductReviewsDataSourceCustomizer(product: product)))
+                                                                    customizer: ProductReviewsDataSourceCustomizer(product: product),
+                                                                    supportsNotificationBasedFeatures: supportsNotificationBasedFeatures),
+                                            stores: stores,
+                                            pushNotesManager: pushNotesManager)
         super.init(nibName: type(of: self).nibName, bundle: nil)
+    }
+
+    private static func supportsNotificationBasedFeatures(siteID: Int64,
+                                                          stores: StoresManager,
+                                                          pushNotesManager: PushNotesManager) -> Bool {
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
+            return false
+        }
+        return true
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -62,7 +62,7 @@ final class ProductReviewsViewController: UIViewController, GhostableViewControl
          stores: StoresManager = ServiceLocator.stores,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.product = product
-        let supportsNotificationBasedFeatures = Self.supportsNotificationBasedFeatures(
+        let supportsWPComNotifications = Self.supportsWPComNotifications(
             siteID: product.siteID,
             stores: stores,
             pushNotesManager: pushNotesManager
@@ -70,13 +70,13 @@ final class ProductReviewsViewController: UIViewController, GhostableViewControl
         viewModel = ProductReviewsViewModel(siteID: product.siteID,
                                             data: ReviewsDataSource(siteID: product.siteID,
                                                                     customizer: ProductReviewsDataSourceCustomizer(product: product),
-                                                                    supportsNotificationBasedFeatures: supportsNotificationBasedFeatures),
+                                                                    supportsWPComNotifications: supportsWPComNotifications),
                                             stores: stores,
                                             pushNotesManager: pushNotesManager)
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
-    private static func supportsNotificationBasedFeatures(siteID: Int64,
+    private static func supportsWPComNotifications(siteID: Int64,
                                                           stores: StoresManager,
                                                           pushNotesManager: PushNotesManager) -> Bool {
         guard stores.isAuthenticatedWithoutWPCom == false else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -62,28 +62,12 @@ final class ProductReviewsViewController: UIViewController, GhostableViewControl
          stores: StoresManager = ServiceLocator.stores,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.product = product
-        let supportsWPComNotifications = Self.supportsWPComNotifications(
-            siteID: product.siteID,
-            stores: stores,
-            pushNotesManager: pushNotesManager
-        )
+        let supportsWPComNotifications = pushNotesManager.supportsWPComNotifications(for: product.siteID, stores: stores)
         viewModel = ProductReviewsViewModel(siteID: product.siteID,
                                             data: ReviewsDataSource(siteID: product.siteID,
                                                                     customizer: ProductReviewsDataSourceCustomizer(product: product),
                                                                     supportsWPComNotifications: supportsWPComNotifications))
         super.init(nibName: type(of: self).nibName, bundle: nil)
-    }
-
-    private static func supportsWPComNotifications(siteID: Int64,
-                                                   stores: StoresManager,
-                                                   pushNotesManager: PushNotesManager) -> Bool {
-        guard stores.isAuthenticatedWithoutWPCom == false else {
-            return false
-        }
-        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
-            return false
-        }
-        return true
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -7,8 +7,6 @@ import class AutomatticTracks.CrashLogging
 /// The Product Reviews view model used in ProductReviewsViewController
 final class ProductReviewsViewModel {
     private let data: ReviewsDataSourceProtocol
-    private let stores: StoresManager
-    private let pushNotesManager: PushNotesManager
 
     var isEmpty: Bool {
         return data.isEmpty
@@ -24,26 +22,10 @@ final class ProductReviewsViewModel {
 
     private let siteID: Int64
 
-    /// Whether notifications-based features (unread indicators) should be available.
-    /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    private var supportsWPComNotifications: Bool {
-        guard stores.isAuthenticatedWithoutWPCom == false else {
-            return false
-        }
-        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
-            return false
-        }
-        return true
-    }
-
     init(siteID: Int64,
-         data: ReviewsDataSourceProtocol,
-         stores: StoresManager = ServiceLocator.stores,
-         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+         data: ReviewsDataSourceProtocol) {
         self.siteID = siteID
         self.data = data
-        self.stores = stores
-        self.pushNotesManager = pushNotesManager
     }
 
     func configureResultsController(tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -7,6 +7,8 @@ import class AutomatticTracks.CrashLogging
 /// The Product Reviews view model used in ProductReviewsViewController
 final class ProductReviewsViewModel {
     private let data: ReviewsDataSourceProtocol
+    private let stores: StoresManager
+    private let pushNotesManager: PushNotesManager
 
     var isEmpty: Bool {
         return data.isEmpty
@@ -22,9 +24,29 @@ final class ProductReviewsViewModel {
 
     private let siteID: Int64
 
-    init(siteID: Int64, data: ReviewsDataSourceProtocol) {
+    /// Whether notifications-based features (unread indicators) should be available.
+    /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
+    private var supportsNotificationBasedFeatures: Bool {
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
+            return false
+        }
+        return true
+    }
+
+    init(siteID: Int64,
+         data: ReviewsDataSourceProtocol,
+         stores: StoresManager = ServiceLocator.stores,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.siteID = siteID
         self.data = data
+        self.stores = stores
+        self.pushNotesManager = pushNotesManager
+
+        // Propagate notification support status to the data source
+        self.data.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
     }
 
     func configureResultsController(tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -44,9 +44,6 @@ final class ProductReviewsViewModel {
         self.data = data
         self.stores = stores
         self.pushNotesManager = pushNotesManager
-
-        // Propagate notification support status to the data source
-        self.data.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
     }
 
     func configureResultsController(tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewModel.swift
@@ -26,7 +26,7 @@ final class ProductReviewsViewModel {
 
     /// Whether notifications-based features (unread indicators) should be available.
     /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    private var supportsNotificationBasedFeatures: Bool {
+    private var supportsWPComNotifications: Bool {
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
@@ -81,6 +81,10 @@ final class ReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
         return reviewsResultsController.numberOfObjects
     }
 
+    /// Whether notifications-based features (unread indicators) should be available.
+    /// Set to false for sites using Woo-driven push notifications.
+    var supportsNotificationBasedFeatures: Bool = true
+
     init(siteID: Int64, customizer: ReviewsDataSourceCustomizing) {
         self.siteID = siteID
         self.customizer = customizer
@@ -177,7 +181,7 @@ private extension ReviewsDataSource {
     private func reviewViewModel(at indexPath: IndexPath) -> ReviewViewModel {
         let review = reviewsResultsController.object(at: indexPath)
         let reviewProduct = product(id: review.productID)
-        let note = notification(id: review.reviewID)
+        let note = supportsNotificationBasedFeatures ? notification(id: review.reviewID) : nil
 
         return ReviewViewModel(showProductTitle: customizer.shouldShowProductTitleOnCells, review: review, product: reviewProduct, notification: note)
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
@@ -82,12 +82,13 @@ final class ReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
     }
 
     /// Whether notifications-based features (unread indicators) should be available.
-    /// Set to false for sites using Woo-driven push notifications.
-    var supportsNotificationBasedFeatures: Bool = true
+    /// Returns false for sites using Woo-driven push notifications.
+    let supportsNotificationBasedFeatures: Bool
 
-    init(siteID: Int64, customizer: ReviewsDataSourceCustomizing) {
+    init(siteID: Int64, customizer: ReviewsDataSourceCustomizing, supportsNotificationBasedFeatures: Bool = true) {
         self.siteID = siteID
         self.customizer = customizer
+        self.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
         super.init()
         observeResults()
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSource.swift
@@ -83,12 +83,12 @@ final class ReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
 
     /// Whether notifications-based features (unread indicators) should be available.
     /// Returns false for sites using Woo-driven push notifications.
-    let supportsNotificationBasedFeatures: Bool
+    let supportsWPComNotifications: Bool
 
-    init(siteID: Int64, customizer: ReviewsDataSourceCustomizing, supportsNotificationBasedFeatures: Bool = true) {
+    init(siteID: Int64, customizer: ReviewsDataSourceCustomizing, supportsWPComNotifications: Bool = true) {
         self.siteID = siteID
         self.customizer = customizer
-        self.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
+        self.supportsWPComNotifications = supportsWPComNotifications
         super.init()
         observeResults()
     }
@@ -182,7 +182,7 @@ private extension ReviewsDataSource {
     private func reviewViewModel(at indexPath: IndexPath) -> ReviewViewModel {
         let review = reviewsResultsController.object(at: indexPath)
         let reviewProduct = product(id: review.productID)
-        let note = supportsNotificationBasedFeatures ? notification(id: review.reviewID) : nil
+        let note = supportsWPComNotifications ? notification(id: review.reviewID) : nil
 
         return ReviewViewModel(showProductTitle: customizer.shouldShowProductTitleOnCells, review: review, product: reviewProduct, notification: note)
     }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSourceProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSourceProtocol.swift
@@ -47,7 +47,7 @@ protocol ReviewsDataSourceProtocol: UITableViewDataSource, ReviewsInteractionDel
     /// Whether notifications-based features (unread indicators) should be available.
     /// Returns false for sites using Woo-driven push notifications.
     ///
-    var supportsNotificationBasedFeatures: Bool { get }
+    var supportsWPComNotifications: Bool { get }
 
     /// Initializes observers for incoming reviews
     ///

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSourceProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSourceProtocol.swift
@@ -45,9 +45,9 @@ protocol ReviewsDataSourceProtocol: UITableViewDataSource, ReviewsInteractionDel
     var notifications: [Note] { get }
 
     /// Whether notifications-based features (unread indicators) should be available.
-    /// Set to false for sites using Woo-driven push notifications.
+    /// Returns false for sites using Woo-driven push notifications.
     ///
-    var supportsNotificationBasedFeatures: Bool { get set }
+    var supportsNotificationBasedFeatures: Bool { get }
 
     /// Initializes observers for incoming reviews
     ///

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSourceProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsDataSourceProtocol.swift
@@ -44,6 +44,11 @@ protocol ReviewsDataSourceProtocol: UITableViewDataSource, ReviewsInteractionDel
     ///
     var notifications: [Note] { get }
 
+    /// Whether notifications-based features (unread indicators) should be available.
+    /// Set to false for sites using Woo-driven push notifications.
+    ///
+    var supportsNotificationBasedFeatures: Bool { get set }
+
     /// Initializes observers for incoming reviews
     ///
     func observeReviews() throws

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -104,10 +104,32 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
 
     // MARK: - Initializers
     //
-    convenience init(siteID: Int64) {
+    convenience init(siteID: Int64,
+                     stores: StoresManager = ServiceLocator.stores,
+                     pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+        let supportsNotificationBasedFeatures = Self.supportsNotificationBasedFeatures(
+            siteID: siteID,
+            stores: stores,
+            pushNotesManager: pushNotesManager
+        )
         self.init(viewModel: ReviewsViewModel(siteID: siteID,
                                               data: ReviewsDataSource(siteID: siteID,
-                                                                             customizer: GlobalReviewsDataSourceCustomizer())))
+                                                                      customizer: GlobalReviewsDataSourceCustomizer(),
+                                                                      supportsNotificationBasedFeatures: supportsNotificationBasedFeatures),
+                                              stores: stores,
+                                              pushNotesManager: pushNotesManager))
+    }
+
+    private static func supportsNotificationBasedFeatures(siteID: Int64,
+                                                          stores: StoresManager,
+                                                          pushNotesManager: PushNotesManager) -> Bool {
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
+            return false
+        }
+        return true
     }
 
     init(viewModel: ViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -108,29 +108,13 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
     convenience init(siteID: Int64,
                      stores: StoresManager = ServiceLocator.stores,
                      pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
-        let supportsWPComNotifications = Self.supportsWPComNotifications(
-            siteID: siteID,
-            stores: stores,
-            pushNotesManager: pushNotesManager
-        )
+        let supportsWPComNotifications = pushNotesManager.supportsWPComNotifications(for: siteID, stores: stores)
         self.init(viewModel: ReviewsViewModel(siteID: siteID,
                                               data: ReviewsDataSource(siteID: siteID,
                                                                       customizer: GlobalReviewsDataSourceCustomizer(),
                                                                       supportsWPComNotifications: supportsWPComNotifications),
                                               stores: stores,
                                               supportsWPComNotifications: supportsWPComNotifications))
-    }
-
-    private static func supportsWPComNotifications(siteID: Int64,
-                                                   stores: StoresManager,
-                                                   pushNotesManager: PushNotesManager) -> Bool {
-        guard stores.isAuthenticatedWithoutWPCom == false else {
-            return false
-        }
-        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
-            return false
-        }
-        return true
     }
 
     init(viewModel: ViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 // MARK: - ReviewsViewController
 //
@@ -117,12 +118,12 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
                                                                       customizer: GlobalReviewsDataSourceCustomizer(),
                                                                       supportsWPComNotifications: supportsWPComNotifications),
                                               stores: stores,
-                                              pushNotesManager: pushNotesManager))
+                                              supportsWPComNotifications: supportsWPComNotifications))
     }
 
     private static func supportsWPComNotifications(siteID: Int64,
-                                                          stores: StoresManager,
-                                                          pushNotesManager: PushNotesManager) -> Bool {
+                                                   stores: StoresManager,
+                                                   pushNotesManager: PushNotesManager) -> Bool {
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -107,7 +107,7 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
     convenience init(siteID: Int64,
                      stores: StoresManager = ServiceLocator.stores,
                      pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
-        let supportsNotificationBasedFeatures = Self.supportsNotificationBasedFeatures(
+        let supportsWPComNotifications = Self.supportsWPComNotifications(
             siteID: siteID,
             stores: stores,
             pushNotesManager: pushNotesManager
@@ -115,12 +115,12 @@ final class ReviewsViewController: UIViewController, GhostableViewController {
         self.init(viewModel: ReviewsViewModel(siteID: siteID,
                                               data: ReviewsDataSource(siteID: siteID,
                                                                       customizer: GlobalReviewsDataSourceCustomizer(),
-                                                                      supportsNotificationBasedFeatures: supportsNotificationBasedFeatures),
+                                                                      supportsWPComNotifications: supportsWPComNotifications),
                                               stores: stores,
                                               pushNotesManager: pushNotesManager))
     }
 
-    private static func supportsNotificationBasedFeatures(siteID: Int64,
+    private static func supportsWPComNotifications(siteID: Int64,
                                                           stores: StoresManager,
                                                           pushNotesManager: PushNotesManager) -> Bool {
         guard stores.isAuthenticatedWithoutWPCom == false else {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -47,6 +47,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     private let data: ReviewsDataSourceProtocol
     private let stores: StoresManager
+    private let pushNotesManager: PushNotesManager
 
     var isEmpty: Bool {
         return data.isEmpty
@@ -60,7 +61,24 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
         return data
     }
 
+    /// Whether notifications-based features (unread indicators, mark as read) should be available.
+    /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
+    private var supportsNotificationBasedFeatures: Bool {
+        // Skip if authenticated without WPCom (no notifications available)
+        guard stores.isAuthenticatedWithoutWPCom == false else {
+            return false
+        }
+        // Skip if site is registered for Woo-driven push notifications (WPCom notifications not used)
+        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
+            return false
+        }
+        return true
+    }
+
     var hasUnreadNotifications: Bool {
+        guard supportsNotificationBasedFeatures else {
+            return false
+        }
         return !unreadNotifications.isEmpty
     }
 
@@ -78,10 +96,14 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
     ///
     var dataLoadingError: Error?
 
-    init(siteID: Int64, data: ReviewsDataSourceProtocol, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64,
+         data: ReviewsDataSourceProtocol,
+         stores: StoresManager = ServiceLocator.stores,
+         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
         self.siteID = siteID
         self.data = data
         self.stores = stores
+        self.pushNotesManager = pushNotesManager
     }
 
     func configureResultsController(tableView: UITableView) {
@@ -136,8 +158,9 @@ extension ReviewsViewModel {
             }
         }
 
-        // skips checking notifications if authenticated without WPCom.
-        if stores.isAuthenticatedWithoutWPCom == false {
+        // Skip syncing notifications if WPCom notifications are not available
+        // (authenticated without WPCom or site uses Woo-driven push notifications).
+        if supportsNotificationBasedFeatures {
             group.enter()
             synchronizeNotifications {
                 group.leave()

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -63,7 +63,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     /// Whether notifications-based features (unread indicators, mark as read) should be available.
     /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    var supportsNotificationBasedFeatures: Bool {
+    var supportsWPComNotifications: Bool {
         // Skip if authenticated without WPCom (no notifications available)
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
@@ -76,7 +76,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
     }
 
     var hasUnreadNotifications: Bool {
-        guard supportsNotificationBasedFeatures else {
+        guard supportsWPComNotifications else {
             return false
         }
         return !unreadNotifications.isEmpty
@@ -160,7 +160,7 @@ extension ReviewsViewModel {
 
         // Skip syncing notifications if WPCom notifications are not available
         // (authenticated without WPCom or site uses Woo-driven push notifications).
-        if supportsNotificationBasedFeatures {
+        if supportsWPComNotifications {
             group.enter()
             synchronizeNotifications {
                 group.leave()

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -47,7 +47,10 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     private let data: ReviewsDataSourceProtocol
     private let stores: StoresManager
-    private let pushNotesManager: PushNotesManager
+
+    /// Whether notifications-based features (unread indicators, mark as read) should be available.
+    /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
+    let supportsWPComNotifications: Bool
 
     var isEmpty: Bool {
         return data.isEmpty
@@ -59,20 +62,6 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     var delegate: ReviewsInteractionDelegate {
         return data
-    }
-
-    /// Whether notifications-based features (unread indicators, mark as read) should be available.
-    /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    var supportsWPComNotifications: Bool {
-        // Skip if authenticated without WPCom (no notifications available)
-        guard stores.isAuthenticatedWithoutWPCom == false else {
-            return false
-        }
-        // Skip if site is registered for Woo-driven push notifications (WPCom notifications not used)
-        guard pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) == false else {
-            return false
-        }
-        return true
     }
 
     var hasUnreadNotifications: Bool {
@@ -99,11 +88,11 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
     init(siteID: Int64,
          data: ReviewsDataSourceProtocol,
          stores: StoresManager = ServiceLocator.stores,
-         pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager) {
+         supportsWPComNotifications: Bool) {
         self.siteID = siteID
         self.data = data
         self.stores = stores
-        self.pushNotesManager = pushNotesManager
+        self.supportsWPComNotifications = supportsWPComNotifications
     }
 
     func configureResultsController(tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -104,6 +104,9 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
         self.data = data
         self.stores = stores
         self.pushNotesManager = pushNotesManager
+
+        // Propagate notification support status to the data source
+        self.data.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
     }
 
     func configureResultsController(tableView: UITableView) {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -63,7 +63,7 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
 
     /// Whether notifications-based features (unread indicators, mark as read) should be available.
     /// Returns false for sites using Woo-driven push notifications since they don't have WPCom notifications.
-    private var supportsNotificationBasedFeatures: Bool {
+    var supportsNotificationBasedFeatures: Bool {
         // Skip if authenticated without WPCom (no notifications available)
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -104,9 +104,6 @@ final class ReviewsViewModel: ReviewsViewModelOutput, ReviewsViewModelActionsHan
         self.data = data
         self.stores = stores
         self.pushNotesManager = pushNotesManager
-
-        // Propagate notification support status to the data source
-        self.data.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
     }
 
     func configureResultsController(tableView: UITableView) {

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -205,7 +205,7 @@ final class ReviewsViewModelTests: XCTestCase {
     func test_supportsNotificationBasedFeatures_returns_false_when_authenticated_without_wpcom() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isAuthenticatedWithoutWPCom: true))
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
 
         // When

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -170,32 +170,6 @@ final class ReviewsViewModelTests: XCTestCase {
 
     // MARK: - Woo-driven Push Notifications Tests
 
-    func test_supportsWPComNotifications_returns_true_when_passed_true() {
-        // Given
-        let mockDataSource = MockReviewsDataSource()
-
-        // When
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
-                                         data: mockDataSource,
-                                         supportsWPComNotifications: true)
-
-        // Then
-        XCTAssertTrue(viewModel.supportsWPComNotifications)
-    }
-
-    func test_supportsWPComNotifications_returns_false_when_passed_false() {
-        // Given
-        let mockDataSource = MockReviewsDataSource()
-
-        // When
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
-                                         data: mockDataSource,
-                                         supportsWPComNotifications: false)
-
-        // Then
-        XCTAssertFalse(viewModel.supportsWPComNotifications)
-    }
-
     func test_hasUnreadNotifications_returns_false_when_supportsWPComNotifications_is_false() {
         // Given
         let mockDataSource = MockReviewsDataSource()
@@ -255,7 +229,7 @@ final class ReviewsViewModelTests: XCTestCase {
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
 
         // Then
         XCTAssertFalse(notificationSyncCalled)
@@ -306,7 +280,7 @@ final class ReviewsViewModelTests: XCTestCase {
         viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
             expectation.fulfill()
         }
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
 
         // Then
         XCTAssertTrue(notificationSyncCalled)

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -167,6 +167,177 @@ final class ReviewsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(retrievedProductIDs, [55, 668, 789])
     }
+
+    // MARK: - Woo-driven Push Notifications Tests
+
+    func test_supportsNotificationBasedFeatures_returns_true_when_site_not_registered_for_woo_pns() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+
+        // When
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
+                                         data: mockDataSource,
+                                         stores: mockStores,
+                                         pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertTrue(viewModel.supportsNotificationBasedFeatures)
+    }
+
+    func test_supportsNotificationBasedFeatures_returns_false_when_site_registered_for_woo_pns() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
+
+        // When
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
+                                         data: mockDataSource,
+                                         stores: mockStores,
+                                         pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+    }
+
+    func test_supportsNotificationBasedFeatures_returns_false_when_authenticated_without_wpcom() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isAuthenticatedWithoutWPCom: true))
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+
+        // When
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
+                                         data: mockDataSource,
+                                         stores: mockStores,
+                                         pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+    }
+
+    func test_hasUnreadNotifications_returns_false_when_site_registered_for_woo_pns() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        mockDataSource.mockNotifications = [Note.fake().copy(read: false)]
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
+
+        // When
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
+                                         data: mockDataSource,
+                                         stores: mockStores,
+                                         pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertFalse(viewModel.hasUnreadNotifications)
+    }
+
+    func test_synchronizeReviews_skips_notification_sync_when_site_registered_for_woo_pns() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let sampleReviews: [ProductReview] = [.fake().copy(productID: 55)]
+
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        mockStores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
+                onCompletion(.success(sampleReviews))
+            default:
+                break
+            }
+        }
+
+        mockStores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProducts(_, _, _, _, onCompletion):
+                onCompletion(.success((products: [], hasNextPage: false)))
+            default:
+                break
+            }
+        }
+
+        var notificationSyncCalled = false
+        mockStores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .synchronizeNotifications(let onCompletion):
+                notificationSyncCalled = true
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
+                                         data: mockDataSource,
+                                         stores: mockStores,
+                                         pushNotesManager: mockPushNotesManager)
+
+        // When
+        let expectation = expectation(description: "Wait for synchronizeReviews to complete")
+        viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+
+        // Then
+        XCTAssertFalse(notificationSyncCalled)
+    }
+
+    func test_synchronizeReviews_syncs_notifications_when_site_not_registered_for_woo_pns() {
+        // Given
+        let mockDataSource = MockReviewsDataSource()
+        let sampleReviews: [ProductReview] = [.fake().copy(productID: 55)]
+
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        mockStores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
+                onCompletion(.success(sampleReviews))
+            default:
+                break
+            }
+        }
+
+        mockStores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProducts(_, _, _, _, onCompletion):
+                onCompletion(.success((products: [], hasNextPage: false)))
+            default:
+                break
+            }
+        }
+
+        var notificationSyncCalled = false
+        mockStores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .synchronizeNotifications(let onCompletion):
+                notificationSyncCalled = true
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
+                                         data: mockDataSource,
+                                         stores: mockStores,
+                                         pushNotesManager: mockPushNotesManager)
+
+        // When
+        let expectation = expectation(description: "Wait for synchronizeReviews to complete")
+        viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+
+        // Then
+        XCTAssertTrue(notificationSyncCalled)
+    }
 }
 
 
@@ -179,6 +350,7 @@ private extension ReviewsViewModelTests {
 final class MockReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
 
     var reviews: [ProductReview] = []
+    var mockNotifications: [Note] = []
 
     var isEmpty: Bool {
         return reviews.isEmpty
@@ -195,7 +367,7 @@ final class MockReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
     }
 
     var notifications: [Note] {
-        return []
+        return mockNotifications
     }
 
     var startForwardingEventsWasHit = false

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -351,6 +351,7 @@ final class MockReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
 
     var reviews: [ProductReview] = []
     var mockNotifications: [Note] = []
+    var supportsNotificationBasedFeatures: Bool = true
 
     var isEmpty: Bool {
         return reviews.isEmpty

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -351,7 +351,11 @@ final class MockReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
 
     var reviews: [ProductReview] = []
     var mockNotifications: [Note] = []
-    var supportsNotificationBasedFeatures: Bool = true
+    let supportsNotificationBasedFeatures: Bool
+
+    init(supportsNotificationBasedFeatures: Bool = true) {
+        self.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
+    }
 
     var isEmpty: Bool {
         return reviews.isEmpty

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -10,7 +10,7 @@ final class ReviewsViewModelTests: XCTestCase {
     func testDataSourceReturnsInjectedReviewsDataSource() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, supportsWPComNotifications: true)
 
         // When
         let dataSource = viewModel.dataSource
@@ -22,7 +22,7 @@ final class ReviewsViewModelTests: XCTestCase {
     func testDelegateReturnsInjectedReviewsDelegate() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, supportsWPComNotifications: true)
 
         // When
         let delegate = viewModel.delegate
@@ -34,7 +34,7 @@ final class ReviewsViewModelTests: XCTestCase {
     func testIsEmptyReturnsTheSameAsTheDataSource() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, supportsWPComNotifications: true)
 
         // Then
         XCTAssertEqual(viewModel.isEmpty, mockDataSource.isEmpty)
@@ -44,7 +44,7 @@ final class ReviewsViewModelTests: XCTestCase {
         // Given
         let table = UITableView()
         let mockDataSource = MockReviewsDataSource()
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, supportsWPComNotifications: true)
 
         // When
         viewModel.configureResultsController(tableView: table)
@@ -57,7 +57,7 @@ final class ReviewsViewModelTests: XCTestCase {
         // Given
         let storesManager = MockReviewsStoresManager()
         let mockDataSource = MockReviewsDataSource()
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager, supportsWPComNotifications: true)
 
         // Then
         let expectation = expectation(description: "Wait for synchronizeReviews to complete")
@@ -85,7 +85,7 @@ final class ReviewsViewModelTests: XCTestCase {
                 return
             }
         }
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager, supportsWPComNotifications: true)
         viewModel.dataLoadingError = MockError()
 
         // When
@@ -107,7 +107,7 @@ final class ReviewsViewModelTests: XCTestCase {
                 return
             }
         }
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: storesManager, supportsWPComNotifications: true)
         viewModel.dataLoadingError = nil
 
         // When
@@ -155,7 +155,7 @@ final class ReviewsViewModelTests: XCTestCase {
                 break
             }
         }
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: mockStores)
+        let viewModel = ReviewsViewModel(siteID: sampleSiteID, data: mockDataSource, stores: mockStores, supportsWPComNotifications: true)
 
         // When
         let expectation = expectation(description: "Wait for synchronizeReviews to complete")
@@ -170,72 +170,47 @@ final class ReviewsViewModelTests: XCTestCase {
 
     // MARK: - Woo-driven Push Notifications Tests
 
-    func test_supportsWPComNotifications_returns_true_when_site_not_registered_for_woo_pns() {
+    func test_supportsWPComNotifications_returns_true_when_passed_true() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
 
         // When
         let viewModel = ReviewsViewModel(siteID: sampleSiteID,
                                          data: mockDataSource,
-                                         stores: mockStores,
-                                         pushNotesManager: mockPushNotesManager)
+                                         supportsWPComNotifications: true)
 
         // Then
         XCTAssertTrue(viewModel.supportsWPComNotifications)
     }
 
-    func test_supportsWPComNotifications_returns_false_when_site_registered_for_woo_pns() {
+    func test_supportsWPComNotifications_returns_false_when_passed_false() {
         // Given
         let mockDataSource = MockReviewsDataSource()
-        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
 
         // When
         let viewModel = ReviewsViewModel(siteID: sampleSiteID,
                                          data: mockDataSource,
-                                         stores: mockStores,
-                                         pushNotesManager: mockPushNotesManager)
+                                         supportsWPComNotifications: false)
 
         // Then
         XCTAssertFalse(viewModel.supportsWPComNotifications)
     }
 
-    func test_supportsWPComNotifications_returns_false_when_authenticated_without_wpcom() {
-        // Given
-        let mockDataSource = MockReviewsDataSource()
-        let mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
-
-        // When
-        let viewModel = ReviewsViewModel(siteID: sampleSiteID,
-                                         data: mockDataSource,
-                                         stores: mockStores,
-                                         pushNotesManager: mockPushNotesManager)
-
-        // Then
-        XCTAssertFalse(viewModel.supportsWPComNotifications)
-    }
-
-    func test_hasUnreadNotifications_returns_false_when_site_registered_for_woo_pns() {
+    func test_hasUnreadNotifications_returns_false_when_supportsWPComNotifications_is_false() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         mockDataSource.mockNotifications = [Note.fake().copy(read: false)]
-        let mockStores = MockStoresManager(sessionManager: .makeForTesting())
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
 
         // When
         let viewModel = ReviewsViewModel(siteID: sampleSiteID,
                                          data: mockDataSource,
-                                         stores: mockStores,
-                                         pushNotesManager: mockPushNotesManager)
+                                         supportsWPComNotifications: false)
 
         // Then
         XCTAssertFalse(viewModel.hasUnreadNotifications)
     }
 
-    func test_synchronizeReviews_skips_notification_sync_when_site_registered_for_woo_pns() {
+    func test_synchronizeReviews_skips_notification_sync_when_supportsWPComNotifications_is_false() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let sampleReviews: [ProductReview] = [.fake().copy(productID: 55)]
@@ -270,11 +245,10 @@ final class ReviewsViewModelTests: XCTestCase {
             }
         }
 
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
         let viewModel = ReviewsViewModel(siteID: sampleSiteID,
                                          data: mockDataSource,
                                          stores: mockStores,
-                                         pushNotesManager: mockPushNotesManager)
+                                         supportsWPComNotifications: false)
 
         // When
         let expectation = expectation(description: "Wait for synchronizeReviews to complete")
@@ -287,7 +261,7 @@ final class ReviewsViewModelTests: XCTestCase {
         XCTAssertFalse(notificationSyncCalled)
     }
 
-    func test_synchronizeReviews_syncs_notifications_when_site_not_registered_for_woo_pns() {
+    func test_synchronizeReviews_syncs_notifications_when_supportsWPComNotifications_is_true() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let sampleReviews: [ProductReview] = [.fake().copy(productID: 55)]
@@ -322,11 +296,10 @@ final class ReviewsViewModelTests: XCTestCase {
             }
         }
 
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
         let viewModel = ReviewsViewModel(siteID: sampleSiteID,
                                          data: mockDataSource,
                                          stores: mockStores,
-                                         pushNotesManager: mockPushNotesManager)
+                                         supportsWPComNotifications: true)
 
         // When
         let expectation = expectation(description: "Wait for synchronizeReviews to complete")

--- a/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Reviews/ReviewsViewModelTests.swift
@@ -170,7 +170,7 @@ final class ReviewsViewModelTests: XCTestCase {
 
     // MARK: - Woo-driven Push Notifications Tests
 
-    func test_supportsNotificationBasedFeatures_returns_true_when_site_not_registered_for_woo_pns() {
+    func test_supportsWPComNotifications_returns_true_when_site_not_registered_for_woo_pns() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let mockStores = MockStoresManager(sessionManager: .makeForTesting())
@@ -183,10 +183,10 @@ final class ReviewsViewModelTests: XCTestCase {
                                          pushNotesManager: mockPushNotesManager)
 
         // Then
-        XCTAssertTrue(viewModel.supportsNotificationBasedFeatures)
+        XCTAssertTrue(viewModel.supportsWPComNotifications)
     }
 
-    func test_supportsNotificationBasedFeatures_returns_false_when_site_registered_for_woo_pns() {
+    func test_supportsWPComNotifications_returns_false_when_site_registered_for_woo_pns() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let mockStores = MockStoresManager(sessionManager: .makeForTesting())
@@ -199,10 +199,10 @@ final class ReviewsViewModelTests: XCTestCase {
                                          pushNotesManager: mockPushNotesManager)
 
         // Then
-        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+        XCTAssertFalse(viewModel.supportsWPComNotifications)
     }
 
-    func test_supportsNotificationBasedFeatures_returns_false_when_authenticated_without_wpcom() {
+    func test_supportsWPComNotifications_returns_false_when_authenticated_without_wpcom() {
         // Given
         let mockDataSource = MockReviewsDataSource()
         let mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
@@ -215,7 +215,7 @@ final class ReviewsViewModelTests: XCTestCase {
                                          pushNotesManager: mockPushNotesManager)
 
         // Then
-        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+        XCTAssertFalse(viewModel.supportsWPComNotifications)
     }
 
     func test_hasUnreadNotifications_returns_false_when_site_registered_for_woo_pns() {
@@ -351,10 +351,10 @@ final class MockReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
 
     var reviews: [ProductReview] = []
     var mockNotifications: [Note] = []
-    let supportsNotificationBasedFeatures: Bool
+    let supportsWPComNotifications: Bool
 
-    init(supportsNotificationBasedFeatures: Bool = true) {
-        self.supportsNotificationBasedFeatures = supportsNotificationBasedFeatures
+    init(supportsWPComNotifications: Bool = true) {
+        self.supportsWPComNotifications = supportsWPComNotifications
     }
 
     var isEmpty: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -256,7 +256,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
     // MARK: - Woo-driven Push Notifications Tests
 
     @MainActor
-    func test_supportsNotificationBasedFeatures_returns_true_when_site_not_registered_for_woo_pns() async {
+    func test_supportsWPComNotifications_returns_true_when_site_not_registered_for_woo_pns() async {
         // Given
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
 
@@ -267,11 +267,11 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       pushNotesManager: mockPushNotesManager)
 
         // Then
-        XCTAssertTrue(viewModel.supportsNotificationBasedFeatures)
+        XCTAssertTrue(viewModel.supportsWPComNotifications)
     }
 
     @MainActor
-    func test_supportsNotificationBasedFeatures_returns_false_when_site_registered_for_woo_pns() async {
+    func test_supportsWPComNotifications_returns_false_when_site_registered_for_woo_pns() async {
         // Given
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
 
@@ -282,11 +282,11 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       pushNotesManager: mockPushNotesManager)
 
         // Then
-        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+        XCTAssertFalse(viewModel.supportsWPComNotifications)
     }
 
     @MainActor
-    func test_supportsNotificationBasedFeatures_returns_false_when_authenticated_without_wpcom() async {
+    func test_supportsWPComNotifications_returns_false_when_authenticated_without_wpcom() async {
         // Given
         let storesWithoutWPCom = MockStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true, isWPCom: false))
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
@@ -298,7 +298,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       pushNotesManager: mockPushNotesManager)
 
         // Then
-        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+        XCTAssertFalse(viewModel.supportsWPComNotifications)
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -252,6 +252,146 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.syncingError as? NSError, error)
     }
+
+    // MARK: - Woo-driven Push Notifications Tests
+
+    @MainActor
+    func test_supportsNotificationBasedFeatures_returns_true_when_site_not_registered_for_woo_pns() async {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+
+        // When
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertTrue(viewModel.supportsNotificationBasedFeatures)
+    }
+
+    @MainActor
+    func test_supportsNotificationBasedFeatures_returns_false_when_site_registered_for_woo_pns() async {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
+
+        // When
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+    }
+
+    @MainActor
+    func test_supportsNotificationBasedFeatures_returns_false_when_authenticated_without_wpcom() async {
+        // Given
+        let storesWithoutWPCom = MockStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true,
+                                                                                                  isAuthenticatedWithoutWPCom: true))
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+
+        // When
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: storesWithoutWPCom,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+
+        // Then
+        XCTAssertFalse(viewModel.supportsNotificationBasedFeatures)
+    }
+
+    @MainActor
+    func test_reloadData_skips_notification_sync_when_site_registered_for_woo_pns() async {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+        insertReviews(sampleReviews)
+
+        stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
+                onCompletion(.success(self.sampleReviews))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProducts(_, _, _, _, onCompletion):
+                onCompletion(.success(([], true)))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        var notificationSyncCalled = false
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case .synchronizeNotifications:
+                notificationSyncCalled = true
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        await viewModel.reloadData()
+
+        // Then
+        XCTAssertFalse(notificationSyncCalled)
+    }
+
+    @MainActor
+    func test_reloadData_syncs_notifications_when_site_not_registered_for_woo_pns() async {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+        insertReviews(sampleReviews)
+
+        stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
+                onCompletion(.success(self.sampleReviews))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .retrieveProducts(_, _, _, _, onCompletion):
+                onCompletion(.success(([], true)))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        var notificationSyncCalled = false
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .synchronizeNotifications(onCompletion):
+                notificationSyncCalled = true
+                onCompletion(nil)
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+
+        // When
+        await viewModel.reloadData()
+
+        // Then
+        XCTAssertTrue(notificationSyncCalled)
+    }
 }
 
 extension ReviewsDashboardCardViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -39,7 +39,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
         let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
                                                       stores: stores,
                                                       storageManager: storageManager)
-        insertReviews(sampleReviews)
+        await insertReviews(sampleReviews)
 
         // When
         stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
@@ -173,7 +173,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       storageManager: storageManager)
         XCTAssertNil(viewModel.syncingError)
         let error = NSError(domain: "test", code: 500)
-        insertReviews(sampleReviews)
+        await insertReviews(sampleReviews)
 
         // When
         stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
@@ -217,7 +217,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       storageManager: storageManager)
         XCTAssertNil(viewModel.syncingError)
         let error = NSError(domain: "test", code: 500)
-        insertReviews(sampleReviews)
+        await insertReviews(sampleReviews)
 
         // When
         stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
@@ -309,7 +309,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       storageManager: storageManager,
                                                       pushNotesManager: mockPushNotesManager)
-        insertReviews(sampleReviews)
+        await insertReviews(sampleReviews)
 
         stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
@@ -354,7 +354,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       storageManager: storageManager,
                                                       pushNotesManager: mockPushNotesManager)
-        insertReviews(sampleReviews)
+        await insertReviews(sampleReviews)
 
         stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
             switch action {
@@ -394,16 +394,17 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
 }
 
 extension ReviewsDashboardCardViewModelTests {
-    func insertReviews(_ readOnlyReviews: [ProductReview]) {
-        let expectation = expectation(description: "Insert reviews")
-        storageManager.performAndSave({ storage in
-            readOnlyReviews.forEach { review in
-                let newReview = storage.insertNewObject(ofType: StorageProductReview.self)
-                newReview.update(with: review)
-            }
-        }, completion: {
-            expectation.fulfill()
-        }, on: .main)
-        wait(for: [expectation], timeout: 1.0)
+    @MainActor
+    func insertReviews(_ readOnlyReviews: [ProductReview]) async {
+        await withCheckedContinuation { continuation in
+            storageManager.performAndSave({ storage in
+                readOnlyReviews.forEach { review in
+                    let newReview = storage.insertNewObject(ofType: StorageProductReview.self)
+                    newReview.update(with: review)
+                }
+            }, completion: {
+                continuation.resume()
+            }, on: .main)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -395,10 +395,15 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
 
 extension ReviewsDashboardCardViewModelTests {
     func insertReviews(_ readOnlyReviews: [ProductReview]) {
-        readOnlyReviews.forEach { review in
-            let newReview = storage.insertNewObject(ofType: StorageProductReview.self)
-            newReview.update(with: review)
-        }
-        storage.saveIfNeeded()
+        let expectation = expectation(description: "Insert reviews")
+        storageManager.performAndSave({ storage in
+            readOnlyReviews.forEach { review in
+                let newReview = storage.insertNewObject(ofType: StorageProductReview.self)
+                newReview.update(with: review)
+            }
+        }, completion: {
+            expectation.fulfill()
+        }, on: .main)
+        wait(for: [expectation], timeout: 1.0)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -253,52 +253,102 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.syncingError as? NSError, error)
     }
 
-    // MARK: - Woo-driven Push Notifications Tests
+    // MARK: - shouldHighlightAsUnread Tests
 
     @MainActor
-    func test_supportsWPComNotifications_returns_true_when_site_not_registered_for_woo_pns() async {
-        // Given
-        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
-
-        // When
-        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
-                                                      stores: stores,
-                                                      storageManager: storageManager,
-                                                      pushNotesManager: mockPushNotesManager)
-
-        // Then
-        XCTAssertTrue(viewModel.supportsWPComNotifications)
-    }
-
-    @MainActor
-    func test_supportsWPComNotifications_returns_false_when_site_registered_for_woo_pns() async {
+    func test_shouldHighlightAsUnread_returns_false_when_site_registered_for_woo_pns() {
         // Given
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [sampleSiteID])
-
-        // When
         let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
                                                       stores: stores,
                                                       storageManager: storageManager,
                                                       pushNotesManager: mockPushNotesManager)
+        let reviewViewModel = ReviewViewModel(review: ProductReview.fake(),
+                                              product: nil,
+                                              notification: Note.fake().copy(read: false))
+
+        // When
+        let result = viewModel.shouldHighlightAsUnread(reviewViewModel)
 
         // Then
-        XCTAssertFalse(viewModel.supportsWPComNotifications)
+        XCTAssertFalse(result)
     }
 
     @MainActor
-    func test_supportsWPComNotifications_returns_false_when_authenticated_without_wpcom() async {
+    func test_shouldHighlightAsUnread_returns_false_when_authenticated_without_wpcom() {
         // Given
         let storesWithoutWPCom = MockStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true, isWPCom: false))
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
-
-        // When
         let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
                                                       stores: storesWithoutWPCom,
                                                       storageManager: storageManager,
                                                       pushNotesManager: mockPushNotesManager)
+        let reviewViewModel = ReviewViewModel(review: ProductReview.fake(),
+                                              product: nil,
+                                              notification: Note.fake().copy(read: false))
+
+        // When
+        let result = viewModel.shouldHighlightAsUnread(reviewViewModel)
 
         // Then
-        XCTAssertFalse(viewModel.supportsWPComNotifications)
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_shouldHighlightAsUnread_returns_false_when_notification_is_nil() {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+        let reviewViewModel = ReviewViewModel(review: ProductReview.fake(),
+                                              product: nil,
+                                              notification: nil)
+
+        // When
+        let result = viewModel.shouldHighlightAsUnread(reviewViewModel)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_shouldHighlightAsUnread_returns_false_when_notification_is_read() {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+        let reviewViewModel = ReviewViewModel(review: ProductReview.fake(),
+                                              product: nil,
+                                              notification: Note.fake().copy(read: true))
+
+        // When
+        let result = viewModel.shouldHighlightAsUnread(reviewViewModel)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_shouldHighlightAsUnread_returns_true_when_notification_is_unread_and_supports_wpcom() {
+        // Given
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager,
+                                                      pushNotesManager: mockPushNotesManager)
+        let reviewViewModel = ReviewViewModel(review: ProductReview.fake(),
+                                              product: nil,
+                                              notification: Note.fake().copy(read: false))
+
+        // When
+        let result = viewModel.shouldHighlightAsUnread(reviewViewModel)
+
+        // Then
+        XCTAssertTrue(result)
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -288,8 +288,7 @@ final class ReviewsDashboardCardViewModelTests: XCTestCase {
     @MainActor
     func test_supportsNotificationBasedFeatures_returns_false_when_authenticated_without_wpcom() async {
         // Given
-        let storesWithoutWPCom = MockStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true,
-                                                                                                  isAuthenticatedWithoutWPCom: true))
+        let storesWithoutWPCom = MockStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true, isWPCom: false))
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
@@ -69,6 +69,8 @@ final class MockProductReviewsDataSource: NSObject, ReviewsDataSourceProtocol {
         return [.fake()]
     }()
 
+    let supportsWPComNotifications: Bool = true
+
     var isEmpty: Bool {
         return reviews.isEmpty
     }


### PR DESCRIPTION
Closes: WOOMOB-2730

## Description

Sites using Woo-driven push notifications don't have WPCom notifications, so notification-based features (unread indicators, notification sync) should be skipped for these sites. This PR:

1. **Skips WPCom notification sync** for sites registered with Woo-driven push notifications:
   - `ReviewsViewModel` and `ReviewsDashboardCardViewModel` skip `synchronizeNotifications()` when `supportsWPComNotifications` is false
   - `PushNotificationsManager` only syncs notifications for WPCom notifications (identified by having a `noteID`)

2. **Hides unread indicators** for Woo-driven sites:
   - `ReviewsDataSource` passes `nil` for the notification when creating `ReviewViewModel` if WPCom notifications aren't supported
   - `ReviewsDashboardCard` shows secondary color for the bubble indicator instead of purple for Woo-driven sites

## Test Steps

1. Log in with a WPCom account that has a site registered for Woo-driven push notifications.
2. Submit a review for a product on the test site.
3. On the app, navigate to Reviews tab or Reviews dashboard card.
4. Verify no purple unread indicators are shown for the new review.
5. Verify notification sync is not triggered (check logs or network)
6. Switch to a site NOT registered for Woo PNs and verify unread indicators still work.

## Screenshots

/ | WPCom notifications | Woo Notifications
--- | --- | ---
Dashboard card | <img width="320" alt="IMG_0913" src="https://github.com/user-attachments/assets/274ad08e-1183-47eb-8c37-1072ba496c88" /> | <img width="320" alt="IMG_0916" src="https://github.com/user-attachments/assets/139e5530-66cd-460b-8069-05d8f96fe0a5" />
Review list | <img width="320" alt="IMG_0914" src="https://github.com/user-attachments/assets/b9f9a7e7-a8ee-4cdc-b71c-bdac415799cd" /> | <img width="320" alt="IMG_0915" src="https://github.com/user-attachments/assets/c100830b-7d7c-4ac5-bf51-d6b4cf1f3101" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.