### PR TITLE
CI: standardize Danger step label to :danger:

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,7 +74,7 @@ steps:
   #################
   - group: Linters
     steps:
-      - label: ":radioactive_sign: Danger - PR Check"
+      - label: ":danger: Danger - PR Check"
         command: danger
         key: danger
         if: build.pull_request.id != null


### PR DESCRIPTION
Normalizes the Buildkite Danger step icon to `:danger:`, replacing the `:radioactive_sign:` variant previously used in this repo. The label now matches what `WordPress-iOS` and `WordPress-Android` already use, so the Danger step looks the same across the a8c mobile portfolio.

This is a Buildkite icon / label normalization only — no behavior change. The step still runs `danger`, same key, same retry policy.

Part of the Orchard `danger-label` campaign, which walks a8c mobile repos one at a time to converge on a single icon.

---

Generated with the help of Claude Code, https://claude.com/claude-code

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>