### PR TITLE
POS: Update empty orders state copy

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListEmptyViewModel.swift
@@ -29,15 +29,15 @@ private enum Localization {
     )
 
     static let emptyOrdersSubtitle = NSLocalizedString(
-        "pos.orderListView.emptyOrdersSubtitle2",
-        value: "Explore how you can increase your store sales.",
+        "pos.orderListView.emptyOrdersSubtitle.3",
+        value: "Orders will appear here once you start processing sales on the POS.",
         comment: "Subtitle appearing when there are no orders to display."
     )
 
     static let emptyOrdersButtonTitle = NSLocalizedString(
-        "pos.orderListView.emptyOrdersButtonTitle2",
-        value: "Learn more",
-        comment: "Button text for opening an information view when orders when list is empty."
+        "pos.orderListView.emptyOrdersButtonTitle.3",
+        value: "Refresh",
+        comment: "Button text for reloading the orders list when it's empty."
     )
 
     static let emptyOrdersSearchTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -112,7 +112,7 @@ struct POSOrdersView: View {
                     viewModel: POSOrderListEmptyViewModel(isSearching: false)
                 ) {
                     Task { @MainActor in
-                        await orderListModel.ordersController.refreshOrders()
+                        await orderListModel.ordersController.loadOrders()
                     }
                 }
                 Spacer()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import UIKit
 import struct WooFoundation.WooAnalyticsEvent
-import struct WooFoundation.SafariView
 
 struct POSOrdersView: View {
     @Binding var isPresented: Bool
@@ -10,7 +9,6 @@ struct POSOrdersView: View {
     @Environment(\.posAnalytics) private var analytics
     @State private var isSearching: Bool = false
     @State private var searchTerm: String = ""
-    @State private var showBlog = false
 
     var body: some View {
         contentView
@@ -113,7 +111,9 @@ struct POSOrdersView: View {
                 POSListEmptyView(
                     viewModel: POSOrderListEmptyViewModel(isSearching: false)
                 ) {
-                    showBlog = true
+                    Task { @MainActor in
+                        await orderListModel.ordersController.refreshOrders()
+                    }
                 }
                 Spacer()
             }
@@ -127,9 +127,6 @@ struct POSOrdersView: View {
                 .posHeaderBackButtonIcon(systemName: "xmark")
                 Spacer()
             }
-        }
-        .posFullScreenCover(isPresented: $showBlog) {
-            SafariView(url: POSConstants.URLs.wooCommerceBlog.asURL())
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Utils/POSConstants.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSConstants.swift
@@ -20,10 +20,6 @@ enum POSConstants {
         ///
         case inPersonPaymentsLearnMoreWCPay =
                 "https://woocommerce.com/document/getting-started-with-in-person-payments-woopayments/"
-
-        /// URL for WooCommerce blog
-        ///
-        case wooCommerceBlog = "https://woocommerce.com/blog/"
     }
 }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 24.7
 -----
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
-- [*] POS: Update empty orders state copy and replace "Learn more" with "Refresh"
+- [*] POS: Update empty orders state copy and replace "Learn more" with "Refresh" [https://github.com/woocommerce/woocommerce-ios/pull/16961]
 
 
 24.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 24.7
 -----
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
+- [*] POS: Update empty orders state copy and replace "Learn more" with "Refresh"
 
 
 24.6


### PR DESCRIPTION
Fixes #WOOMOB-2731

## Description
Updates the iOS POS Orders empty state to match the final decision captured for Android in WOOMOB-2724:

- Replaces the subtitle *"Explore how you can increase your store sales."* with *"Orders will appear here once you start processing sales on the POS."*
- Replaces the **Learn more** button (which opened the WooCommerce blog) with a **Refresh** button that reloads the orders list.

## Test Steps
1. Sign in to a store that has no POS orders (or temporarily filter/mock to reach the empty state).
2. Open the Point of Sale tab on an iPad.
3. Tap **Orders**.
4. Verify the empty state shows:
   - Title: **No orders yet**
   - Subtitle: **Orders will appear here once you start processing sales on the POS.**
   - Button: **Refresh**
5. Tap **Refresh** — the orders list should reload (a loading indicator briefly appears and orders are re-fetched).
6. Verify the old *Learn more* button no longer opens the WooCommerce blog.

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - 2026-04-21 at 09 23 05" src="https://github.com/user-attachments/assets/b3381aab-bd57-4ff3-a2a2-373b56a6b4e1" /> | <img width="2420" height="1668" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - 2026-04-21 at 09 19 01" src="https://github.com/user-attachments/assets/6ad2d6f8-08ac-4e1c-8b22-cd4f7f68bc4a" /> |


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.