### PR TITLE
Attribute per-site push token register events to the target site [WOOMOB-2757]

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1435,6 +1435,11 @@ extension WooAnalyticsStat {
              .loginWhatIsJetpackHelpScreenViewed, .loginWhatIsJetpackHelpScreenOkButtonTapped,
              .loginWhatIsJetpackHelpScreenLearnMoreButtonTapped, .watchConnectingOpened, .watchStoreDataSynced:
             return false
+        // Per-site push token registration events attribute properties to the target site via a factory,
+        // so opt out of the default-site enrichment that would otherwise overwrite `blog_id` / `site_url`
+        // with the currently selected site.
+        case .wooPushTokenRegisterSuccess, .wooPushTokenRegisterError:
+            return false
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 24.7
 -----
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
+- [Internal] Attribute per-site push token registration analytics to the target site instead of the selected site
 
 
 24.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 24.7
 -----
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
-- [Internal] Attribute per-site push token registration analytics to the target site instead of the selected site
 
 
 24.6

--- a/WooCommerce/Classes/Analytics/Site+AnalyticsProperties.swift
+++ b/WooCommerce/Classes/Analytics/Site+AnalyticsProperties.swift
@@ -22,7 +22,7 @@ extension Site {
         return properties
     }
 
-    enum PropertyKeys {
+    private enum PropertyKeys {
         static let blogID = "blog_id"
         static let siteURL = "site_url"
         static let isWPComStore = "is_wpcom_store"

--- a/WooCommerce/Classes/Analytics/Site+AnalyticsProperties.swift
+++ b/WooCommerce/Classes/Analytics/Site+AnalyticsProperties.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Yosemite
+import protocol WooFoundation.WooAnalyticsEventPropertyType
+
+extension Site {
+    /// Analytics properties describing this site. Used by both the default-site enrichment in
+    /// `WooAnalytics` (for events about the currently selected site) and by per-target-site event
+    /// factories that need to attribute an event to a site other than the selected one.
+    var analyticsProperties: [String: WooAnalyticsEventPropertyType] {
+        var properties: [String: WooAnalyticsEventPropertyType] = [
+            PropertyKeys.blogID: siteID,
+            PropertyKeys.siteURL: url,
+            PropertyKeys.isWPComStore: isWordPressComStore,
+            PropertyKeys.isJetpackInstalled: isJetpackThePluginInstalled,
+            PropertyKeys.isJetpackConnected: isJetpackConnected,
+            PropertyKeys.isJetpackCPConnected: isJetpackCPConnected,
+            PropertyKeys.isCIAB: isCIAB
+        ]
+        if let gardenPartner {
+            properties[PropertyKeys.gardenPartner] = gardenPartner
+        }
+        return properties
+    }
+
+    enum PropertyKeys {
+        static let blogID = "blog_id"
+        static let siteURL = "site_url"
+        static let isWPComStore = "is_wpcom_store"
+        static let isJetpackInstalled = "is_jetpack_installed"
+        static let isJetpackConnected = "is_jetpack_connected"
+        static let isJetpackCPConnected = "is_jetpack_cp_connected"
+        static let isCIAB = "is_ciab"
+        static let gardenPartner = "garden_partner"
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -199,8 +199,7 @@ extension Analytics {
 fileprivate extension Analytics {
     /// Appends site properties (blog_id, is_wpcom_store, etc.) to the given properties dictionary,
     /// using the currently selected site from the session. Delegates the per-site property mapping
-    /// to `Site.analyticsProperties(ciabEligibilityChecker:)` so per-target-site event factories can
-    /// share the same logic.
+    /// to `Site.analyticsProperties` so per-target-site event factories can share the same logic.
     func appendSiteProperties(to properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
         guard ServiceLocator.stores.isAuthenticated else {
             return properties

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -197,28 +197,23 @@ extension Analytics {
 // MARK: - Site Property Enrichment
 
 fileprivate extension Analytics {
-    /// Appends site properties (blog_id, is_wpcom_store, etc.) to the given properties dictionary.
+    /// Appends site properties (blog_id, is_wpcom_store, etc.) to the given properties dictionary,
+    /// using the currently selected site from the session. Delegates the per-site property mapping
+    /// to `Site.analyticsProperties(ciabEligibilityChecker:)` so per-target-site event factories can
+    /// share the same logic.
     func appendSiteProperties(to properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
         guard ServiceLocator.stores.isAuthenticated else {
             return properties
         }
 
         var updatedProperties = properties ?? [:]
-        let site = ServiceLocator.stores.sessionManager.defaultSite
-        updatedProperties[PropertyKeys.blogIDKey] = site?.siteID
-        updatedProperties[PropertyKeys.wpcomStoreKey] = site?.isWordPressComStore
-        updatedProperties[PropertyKeys.siteURL] = site?.url
-        updatedProperties[PropertyKeys.isJetpackInstalled] = site?.isJetpackThePluginInstalled
-        updatedProperties[PropertyKeys.isJetpackConnected] = site?.isJetpackConnected
-        updatedProperties[PropertyKeys.isJetpackCPConnected] = site?.isJetpackCPConnected
-        updatedProperties[PropertyKeys.storeID] = ServiceLocator.stores.sessionManager.defaultStoreUUID
-        updatedProperties[PropertyKeys.cachedWooCommerceVersionKey] = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion
-        if let site {
-            updatedProperties[PropertyKeys.isCIAB] = ServiceLocator.ciabEligibilityChecker.isSiteCIAB(site)
-            if let gardenPartner = site.gardenPartner {
-                updatedProperties[PropertyKeys.gardenPartner] = gardenPartner
+        if let site = ServiceLocator.stores.sessionManager.defaultSite {
+            for (key, value) in site.analyticsProperties {
+                updatedProperties[key] = value
             }
         }
+        updatedProperties[PropertyKeys.storeID] = ServiceLocator.stores.sessionManager.defaultStoreUUID
+        updatedProperties[PropertyKeys.cachedWooCommerceVersionKey] = ServiceLocator.stores.sessionManager.cachedWooCommerceVersion
         return updatedProperties
     }
 }
@@ -361,14 +356,6 @@ private enum Constants {
 
 private enum PropertyKeys {
     static let propertyKeyTimeInApp = "time_in_app"
-    static let blogIDKey            = "blog_id"
-    static let wpcomStoreKey        = "is_wpcom_store"
-    static let siteURL              = "site_url"
     static let storeID              = "store_id"
     static let cachedWooCommerceVersionKey = "cached_woo_core_version"
-    static let isCIAB               = "is_ciab"
-    static let gardenPartner        = "garden_partner"
-    static let isJetpackInstalled   = "is_jetpack_installed"
-    static let isJetpackConnected   = "is_jetpack_connected"
-    static let isJetpackCPConnected = "is_jetpack_cp_connected"
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import protocol WooFoundation.WooAnalyticsEventPropertyType
 
 extension WooAnalyticsEvent {
     enum PushNotifications {
@@ -8,7 +9,7 @@ extension WooAnalyticsEvent {
         /// correct site instead of the currently selected one.
         static func wooPushTokenRegisterSuccess(targetSite: Site?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .wooPushTokenRegisterSuccess,
-                              properties: targetSite?.analyticsProperties ?? [:])
+                              properties: properties(for: targetSite))
         }
 
         /// Tracked when the self-driven push token registration fails for a specific target site.
@@ -16,8 +17,29 @@ extension WooAnalyticsEvent {
         /// correct site instead of the currently selected one.
         static func wooPushTokenRegisterError(targetSite: Site?, error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .wooPushTokenRegisterError,
-                              properties: targetSite?.analyticsProperties ?? [:],
+                              properties: properties(for: targetSite),
                               error: error)
+        }
+
+        /// Combines the target site's analytics properties with session-level fields (`store_id`,
+        /// `cached_woo_core_version`) that the default-site enrichment would normally attach.
+        /// These events opt out of that enrichment to protect the target-site attribution, so the
+        /// session fields are re-added here to preserve the pre-existing payload shape.
+        private static func properties(for targetSite: Site?) -> [String: WooAnalyticsEventPropertyType] {
+            var properties: [String: WooAnalyticsEventPropertyType] = targetSite?.analyticsProperties ?? [:]
+            let sessionManager = ServiceLocator.stores.sessionManager
+            if let storeID = sessionManager.defaultStoreUUID {
+                properties[SessionPropertyKeys.storeID] = storeID
+            }
+            if let cachedWooCoreVersion = sessionManager.cachedWooCommerceVersion {
+                properties[SessionPropertyKeys.cachedWooCoreVersion] = cachedWooCoreVersion
+            }
+            return properties
+        }
+
+        private enum SessionPropertyKeys {
+            static let storeID = "store_id"
+            static let cachedWooCoreVersion = "cached_woo_core_version"
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Yosemite
+
+extension WooAnalyticsEvent {
+    enum PushNotifications {
+        /// Tracked when the self-driven push token is successfully registered for a specific target site.
+        /// Emits the target site's analytics properties so per-site dashboards attribute the event to the
+        /// correct site instead of the currently selected one.
+        static func wooPushTokenRegisterSuccess(targetSite: Site?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .wooPushTokenRegisterSuccess,
+                              properties: targetSite?.analyticsProperties ?? [:])
+        }
+
+        /// Tracked when the self-driven push token registration fails for a specific target site.
+        /// Emits the target site's analytics properties so per-site dashboards attribute the event to the
+        /// correct site instead of the currently selected one.
+        static func wooPushTokenRegisterError(targetSite: Site?, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .wooPushTokenRegisterError,
+                              properties: targetSite?.analyticsProperties ?? [:],
+                              error: error)
+        }
+    }
+}

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -805,6 +805,12 @@ private extension PushNotificationsManager {
         }
     }
 
+    /// Looks up the target `Yosemite.Site` for analytics attribution. The lookup is best-effort —
+    /// a missing local record simply results in an event without per-site properties.
+    private func loadTargetSite(siteID: Int64) -> Yosemite.Site? {
+        storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly()
+    }
+
     /// Registers the push notification token for a single site and handles the result.
     /// - Returns: `true` on success, `false` on failure.
     @MainActor
@@ -817,11 +823,11 @@ private extension PushNotificationsManager {
                 }
             }
             DDLogDebug("📱 Push token registration succeeded for site \(siteID): tokenID \(tokenID)")
-            analytics.track(.wooPushTokenRegisterSuccess)
+            analytics.track(event: .PushNotifications.wooPushTokenRegisterSuccess(targetSite: loadTargetSite(siteID: siteID)))
             return true
         } catch {
             DDLogDebug("📱 Push token registration failed for site \(siteID): \(error)")
-            analytics.track(.wooPushTokenRegisterError, withError: error)
+            analytics.track(event: .PushNotifications.wooPushTokenRegisterError(targetSite: loadTargetSite(siteID: siteID), error: error))
             if case .notFound = error as? NetworkError {
                 registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -805,10 +805,20 @@ private extension PushNotificationsManager {
         }
     }
 
-    /// Looks up the target `Yosemite.Site` for analytics attribution. The lookup is best-effort —
-    /// a missing local record simply results in an event without per-site properties.
+    /// Looks up the target `Yosemite.Site` for analytics attribution.
+    ///
+    /// For WPCom users, sites are persisted in storage, so the primary path is a direct lookup.
+    /// For site-credentials users, the synced site is assigned to `sessionManager.defaultSite`
+    /// but not written to storage, so we fall back to the session's default site when — and only
+    /// when — its `siteID` matches the requested one. The match guard prevents a storage miss on a
+    /// non-default site (unlikely, but possible in the WPCom multi-site case) from silently
+    /// attributing the event to the selected site, which is the very bug this fix addresses.
     private func loadTargetSite(siteID: Int64) -> Yosemite.Site? {
-        storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly()
+        if let site = storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly() {
+            return site
+        }
+        let defaultSite = stores.sessionManager.defaultSite
+        return defaultSite?.siteID == siteID ? defaultSite : nil
     }
 
     /// Registers the push notification token for a single site and handles the result.

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1270,6 +1270,57 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertEqual(errorProperties["is_jetpack_connected"] as? Bool, false)
     }
 
+    func test_registerDeviceToken_when_site_credentials_login_then_token_register_event_uses_session_default_site() async throws {
+        // Given — site-credentials style login: the session holds the site, but storage doesn't.
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        storesManager.authenticate(credentials: SessionSettings.wporgCredentials)
+        storesManager.sessionManager.setStoreId(500)
+        storesManager.updateDefaultStore(Yosemite.Site.fake().copy(
+            siteID: 500,
+            url: "https://gamma.example",
+            isJetpackThePluginInstalled: true,
+            isJetpackConnected: false,
+            isWordPressComStore: false
+        ))
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        // Deliberately do NOT insert any sites into storage — this mirrors the site-creds path
+        // where `restoreWordPressSite` writes only to `sessionManager.defaultSite`.
+
+        manager = makeManager(featureFlagService: featureFlagService, analytics: analytics)
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        let registrationExpectation = expectation(description: "Site registered")
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion) = action {
+                onCompletion(.success(Int64(siteID + 1000)))
+                registrationExpectation.fulfill()
+            }
+        }
+
+        let tokenAsData = try XCTUnwrap(Sample.deviceToken.data(using: .utf8))
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [registrationExpectation], timeout: 2.0)
+
+        // Then — the event picks up the session's default site even though storage is empty.
+        let successIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_register_success"),
+                                         "Expected a woo_push_token_register_success event")
+        let successProperties = analyticsProvider.receivedProperties[successIndex]
+        XCTAssertEqual(successProperties["blog_id"] as? Int64, 500)
+        XCTAssertEqual(successProperties["site_url"] as? String, "https://gamma.example")
+        XCTAssertEqual(successProperties["is_wpcom_store"] as? Bool, false)
+        XCTAssertEqual(successProperties["is_jetpack_installed"] as? Bool, true)
+        XCTAssertEqual(successProperties["is_jetpack_connected"] as? Bool, false)
+    }
+
     func test_registerDeviceToken_when_site_returns_notFound_then_unmarks_that_site() async {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Yosemite
 import YosemiteTestHelpers
 import enum NetworkingCore.NetworkError
+import protocol WooFoundation.Analytics
 @testable import WooCommerce
 import class Storage.Site
 
@@ -1204,6 +1205,71 @@ final class PushNotificationsManagerTests: XCTestCase {
         }))
     }
 
+    func test_registerDeviceToken_when_multiple_sites_then_token_register_events_carry_target_site_properties() async throws {
+        // Given — two stored sites with distinct URLs and capability flags; selected site is site 100.
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: 100, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true),
+            (siteID: 200, url: "https://beta.example", isWPCom: false, isJetpackInstalled: false, isJetpackConnected: false)
+        ])
+
+        manager = makeManager(featureFlagService: featureFlagService, analytics: analytics)
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        // Site 100 succeeds; site 200 fails, which triggers the WPCom fallback we use to sync on flow completion.
+        let fallbackExpectation = expectation(description: "WPCom fallback triggered")
+        fallbackExpectation.assertForOverFulfill = false
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion):
+                if siteID == 200 {
+                    onCompletion(.failure(NSError(domain: "test", code: 500)))
+                } else {
+                    onCompletion(.success(Int64(siteID + 1000)))
+                }
+            case .registerDevice:
+                fallbackExpectation.fulfill()
+            default:
+                break
+            }
+        }
+
+        let tokenAsData = try XCTUnwrap(Sample.deviceToken.data(using: .utf8))
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [fallbackExpectation], timeout: 2.0)
+
+        // Then — each event carries the target site's identifiers and capability flags, not the selected site's.
+        let successIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_register_success"),
+                                         "Expected a woo_push_token_register_success event for the site that succeeded")
+        let successProperties = analyticsProvider.receivedProperties[successIndex]
+        XCTAssertEqual(successProperties["blog_id"] as? Int64, 100)
+        XCTAssertEqual(successProperties["site_url"] as? String, "https://alpha.example")
+        XCTAssertEqual(successProperties["is_wpcom_store"] as? Bool, true)
+        XCTAssertEqual(successProperties["is_jetpack_installed"] as? Bool, true)
+        XCTAssertEqual(successProperties["is_jetpack_connected"] as? Bool, true)
+
+        let errorIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_register_error"),
+                                       "Expected a woo_push_token_register_error event for the site that failed")
+        let errorProperties = analyticsProvider.receivedProperties[errorIndex]
+        XCTAssertEqual(errorProperties["blog_id"] as? Int64, 200)
+        XCTAssertEqual(errorProperties["site_url"] as? String, "https://beta.example")
+        XCTAssertEqual(errorProperties["is_wpcom_store"] as? Bool, false)
+        XCTAssertEqual(errorProperties["is_jetpack_installed"] as? Bool, false)
+        XCTAssertEqual(errorProperties["is_jetpack_connected"] as? Bool, false)
+    }
+
     func test_registerDeviceToken_when_site_returns_notFound_then_unmarks_that_site() async {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
@@ -1492,7 +1558,8 @@ final class PushNotificationsManagerTests: XCTestCase {
 private extension PushNotificationsManagerTests {
     func makeManager(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      storageManager: MockStorageManager? = nil,
-                     pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol? = nil) -> PushNotificationsManager {
+                     pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol? = nil,
+                     analytics: Analytics = ServiceLocator.analytics) -> PushNotificationsManager {
         // Capture strong local references so the @autoclosure closures in
         // PushNotificationsConfiguration don't go through the test's IUO
         // properties, which may be nilled in tearDown while async Tasks are still in flight.
@@ -1508,6 +1575,7 @@ private extension PushNotificationsManagerTests {
 
         return PushNotificationsManager(configuration: configuration,
                                         backgroundSynchronizerFactory: backgroundSynchronizerFactory,
+                                        analytics: analytics,
                                         storageManager: storageManager ?? self.storageManager,
                                         featureFlagService: featureFlagService,
                                         pluginVersionCheckerFactory: pluginVersionCheckerFactory ?? MockPluginVersionCheckerFactory())
@@ -1585,6 +1653,22 @@ private extension PushNotificationsManagerTests {
                 let site = storage.insertNewObject(ofType: Site.self)
                 site.siteID = siteID
                 site.isWooCommerceActive = NSNumber(value: true)
+            }
+        })
+    }
+
+    func insertSitesIntoStorageWithCapabilities(
+        _ sites: [(siteID: Int64, url: String, isWPCom: Bool, isJetpackInstalled: Bool, isJetpackConnected: Bool)]
+    ) async {
+        await storageManager.performAndSaveAsync({ storage in
+            for descriptor in sites {
+                let site = storage.insertNewObject(ofType: Site.self)
+                site.siteID = descriptor.siteID
+                site.url = descriptor.url
+                site.isWooCommerceActive = NSNumber(value: true)
+                site.isWordPressStore = NSNumber(value: descriptor.isWPCom)
+                site.isJetpackThePluginInstalled = descriptor.isJetpackInstalled
+                site.isJetpackConnected = descriptor.isJetpackConnected
             }
         })
     }


### PR DESCRIPTION
## Description

Fixes: WOOMOB-2757

`woo_push_token_register_success` and `woo_push_token_register_error` fan out one event per target site during self-driven push registration, but the tracking calls at `PushNotificationsManager.swift:820/824` passed only the event name — so the generic default-site enrichment in `WooAnalytics.appendSiteProperties` tagged every per-site outcome with `sessionManager.defaultSite`. For multi-store users, all N per-site events end up with the same `blog_id` / `site_url`, making per-site failure dashboards and plugin-version debugging effectively blind.

Changes:
- Extract `Site.analyticsProperties` (using `Site.isCIAB` directly) as the shared mapping for `blog_id`, `site_url`, `is_wpcom_store`, jetpack flags, `is_ciab`, `garden_partner`. Both the default-site enrichment and the new per-target-site factory call it — no duplication.
- Opt `wooPushTokenRegisterSuccess` / `wooPushTokenRegisterError` out of the default-site enrichment in `WooAnalyticsStat.shouldSendSiteProperties` so factory-provided target-site values aren't overwritten.
- Add `WooAnalyticsEvent.PushNotifications` factory emitting target-site properties. The factory also re-attaches the session-level fields `store_id` and `cached_woo_core_version` that the default-site enrichment used to set — opting out of that enrichment would otherwise silently drop them, so these are preserved to keep the pre-existing payload shape.
- `PushNotificationsManager` now routes both success and failure tracking through the factory. The target site is resolved via `storageManager.viewStorage.loadSite(siteID:)?.toReadOnly()`, with a fallback to `sessionManager.defaultSite` **only when its `siteID` matches the requested one**. The fallback covers the site-credentials path where `restoreWordPressSite` assigns the site to `sessionManager.defaultSite` without persisting it to Core Data; the match guard keeps the multi-site misattribution fix intact so a storage miss on a non-default siteID never silently attributes to the selected site. Same flow is shared by the bulk registration path and the single-site path introduced in #16955.

## Test Steps

- Unit tests:
  - `PushNotificationsManagerTests.test_registerDeviceToken_when_multiple_sites_then_token_register_events_carry_target_site_properties` — multi-WPCom-site case: selected site = 100, sites 100 and 200 stored; site 100 succeeds, site 200 fails; asserts each tracked event carries its target site's `blog_id` / `site_url` / capability flags.
  - `PushNotificationsManagerTests.test_registerDeviceToken_when_site_credentials_login_then_token_register_event_uses_session_default_site` — site-credentials case: storage is empty, only `sessionManager.defaultSite` holds the site; asserts the tracked event still carries the correct per-site properties via the fallback.
- Full `PushNotificationsManagerTests` and `WooAnalyticsTests` suites pass.
- Manual: log in with an account that has multiple WooCommerce-active sites, intercept the self-driven push token POST and force a 404 for one site (or observe real failures when some sites don't meet the plugin version minimum), then filter Xcode console / Tracks for `woo_push_token_register_error` and confirm each event carries the correct per-site `blog_id` / `site_url`.

## Screenshots

N/A — analytics attribution change, no UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.