### PR TITLE
Force Jetpack tunnel for cross-site push token registration

### DIFF
--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -69,13 +69,19 @@ public class DevicesRemote: Remote {
     ///     - applicationID: App ID.
     ///     - deviceLocale: Device locale in `xx_XX` format (e.g. `en_US`).
     ///     - appVersion: App version string (e.g. `1.0.0`).
+    ///     - availableAsRESTRequest: Whether the request can be sent as a direct REST call when an
+    ///       application password is available. Only safe when the target `siteID` is the currently
+    ///       selected site, because the REST fallback routes to the current site's URL. For cross-site
+    ///       calls (e.g. registering a non-selected site) pass `false` to force the Jetpack tunnel,
+    ///       which carries the `siteID` in the URL path and always reaches the correct site.
     /// - Returns: The unique ID of the push token record
     ///
     public func registerForSelfDrivenPushNotifications(siteID: Int64,
                                                        device: APNSDevice,
                                                        applicationID: String,
                                                        deviceLocale: String,
-                                                       appVersion: String) async throws -> Int64 {
+                                                       appVersion: String,
+                                                       availableAsRESTRequest: Bool = false) async throws -> Int64 {
         var parameters: [String: Any] = [
             ParameterKeys.origin: applicationID,
             ParameterKeys.token: device.token,
@@ -97,7 +103,7 @@ public class DevicesRemote: Remote {
                                      siteID: siteID,
                                      path: Paths.selfDrivenPN,
                                      parameters: parameters,
-                                     availableAsRESTRequest: true)
+                                     availableAsRESTRequest: availableAsRESTRequest)
         let mapper = TokenIDMapper()
         return try await enqueue(request, mapper: mapper)
     }

--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -121,7 +121,7 @@ public class DevicesRemote: Remote {
     ///
     public func unregisterFromSelfDrivenPushNotifications(siteID: Int64,
                                                           tokenID: Int64,
-                                                          availableAsRESTRequest: Bool = true) async throws {
+                                                          availableAsRESTRequest: Bool = false) async throws {
         let path = Paths.selfDrivenPN + "/\(tokenID)"
         let request = JetpackRequest(wooApiVersion: .none,
                                      method: .delete,

--- a/Modules/Sources/Yosemite/Actions/NotificationAction.swift
+++ b/Modules/Sources/Yosemite/Actions/NotificationAction.swift
@@ -41,11 +41,22 @@ public enum NotificationAction: Action {
 
     /// Registers a device for Push Notifications Delivery with the self-driven push notification system.
     ///
+    /// - Parameters:
+    ///     - siteID: ID of the site
+    ///     - device: APNS Device to be registered
+    ///     - applicationID: App ID
+    ///     - deviceLocale: Device locale in `xx_XX` format (e.g. `en_US`)
+    ///     - appVersion: App version string
+    ///     - availableAsRESTRequest: Whether the underlying request can be sent as a direct REST
+    ///       call when an application password is available. Safe only when `siteID` is the currently
+    ///       selected site. For cross-site registration pass `false` to force the Jetpack tunnel.
+    ///
     case registerDeviceForSelfDrivenPushNotifications(siteID: Int64,
                                                       device: APNSDevice,
                                                       applicationID: String,
                                                       deviceLocale: String,
                                                       appVersion: String,
+                                                      availableAsRESTRequest: Bool,
                                                       onCompletion: (Result<Int64, Error>) -> Void)
 
     /// Removes a given tokenID from the the self-driven push notification system.

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -56,13 +56,14 @@ public class NotificationStore: Store {
             updateReadStatus(for: noteIDs, read: read, onCompletion: onCompletion)
         case .updateLocalDeletedStatus(let noteID, let deleteInProgress, let onCompletion):
             updateDeletedStatus(noteID: noteID, deleteInProgress: deleteInProgress, onCompletion: onCompletion)
-        case let .registerDeviceForSelfDrivenPushNotifications(siteID, device, applicationID, deviceLocale, appVersion, onCompletion):
+        case let .registerDeviceForSelfDrivenPushNotifications(siteID, device, applicationID, deviceLocale, appVersion, availableAsRESTRequest, onCompletion):
             registerDeviceForSelfDrivenPushNotifications(
                 siteID: siteID,
                 device: device,
                 applicationID: applicationID,
                 deviceLocale: deviceLocale,
                 appVersion: appVersion,
+                availableAsRESTRequest: availableAsRESTRequest,
                 onCompletion: onCompletion
             )
         case let .unregisterFromSelfDrivenPushNotifications(siteID, tokenID, availableAsRESTRequest, onCompletion):
@@ -104,6 +105,7 @@ private extension NotificationStore {
                                                       applicationID: String,
                                                       deviceLocale: String,
                                                       appVersion: String,
+                                                      availableAsRESTRequest: Bool,
                                                       onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         Task { @MainActor in
             do {
@@ -112,7 +114,8 @@ private extension NotificationStore {
                     device: device,
                     applicationID: applicationID,
                     deviceLocale: deviceLocale,
-                    appVersion: appVersion
+                    appVersion: appVersion,
+                    availableAsRESTRequest: availableAsRESTRequest
                 )
                 onCompletion(.success(tokenID))
             } catch {

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -457,7 +457,8 @@ final class NotificationStoreTests: XCTestCase {
                 device: self.sampleAPNSDevice(),
                 applicationID: self.sampleApplicationID,
                 deviceLocale: "en_US",
-                appVersion: "1.0.0"
+                appVersion: "1.0.0",
+                availableAsRESTRequest: false
             ) { result in
                 promise(result)
             }
@@ -488,7 +489,8 @@ final class NotificationStoreTests: XCTestCase {
                 device: self.sampleAPNSDevice(),
                 applicationID: self.sampleApplicationID,
                 deviceLocale: "en_US",
-                appVersion: "1.0.0"
+                appVersion: "1.0.0",
+                availableAsRESTRequest: false
             ) { result in
                 promise(result)
             }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
 - [Internal] Attribute per-site push token registration analytics to the target site instead of the selected site
+- [Internal] Route per-site push token registration to the target site's endpoint to prevent REST fallback mis-routing for multi-store users
 
 
 24.6

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -872,12 +872,18 @@ private extension PushNotificationsManager {
 
     private func performDeviceRegistration(siteID: Int64, deviceToken: String, onCompletion: @escaping (Result<Int64, Error>) -> Void) {
         let device = APNSDevice(deviceToken: deviceToken)
+        // REST fallback via `RequestConverter` routes to the currently selected site's URL, dropping
+        // the target `siteID` from the original `JetpackRequest`. It's only safe when the target is
+        // the selected site (e.g. site-credentials users with no Jetpack tunnel). For any cross-site
+        // registration (multi-store fan-out, re-enabling a hidden site) force the Jetpack tunnel.
+        let isTargetSiteSelected = siteID == self.siteID
         let action = NotificationAction.registerDeviceForSelfDrivenPushNotifications(
             siteID: siteID,
             device: device,
             applicationID: WooConstants.pushApplicationID,
             deviceLocale: Locale.current.languageRegionIdentifier ?? Locale.current.identifier,
-            appVersion: Bundle.main.version
+            appVersion: Bundle.main.version,
+            availableAsRESTRequest: isTargetSiteSelected
         ) { [weak self] result in
             guard let self = self else { return }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -772,7 +772,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         fallbackExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion):
+            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NSError(domain: "Failure", code: 404)))
             case .registerDevice:
                 fallbackExpectation.fulfill()
@@ -813,7 +813,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let registrationExpectation = expectation(description: "Registration attempted")
         registrationExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion) = action {
                 onCompletion(.failure(NetworkError.notFound()))
                 registrationExpectation.fulfill()
             }
@@ -908,7 +908,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let registrationExpectation = expectation(description: "Registration attempted")
         registrationExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion) = action {
                 onCompletion(.success(42))
                 registrationExpectation.fulfill()
             }
@@ -954,7 +954,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let registrationExpectation = expectation(description: "Registration attempted")
         registrationExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion) = action {
                 onCompletion(.success(42))
                 registrationExpectation.fulfill()
             }
@@ -999,7 +999,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         fallbackExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion):
+            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(NetworkError.unacceptableStatusCode(statusCode: 500)))
             case .registerDevice:
                 fallbackExpectation.fulfill()
@@ -1046,7 +1046,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let allRegisteredExpectation = expectation(description: "All sites registered")
         allRegisteredExpectation.expectedFulfillmentCount = 3
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion) = action {
                 registeredSiteIDs.insert(siteID)
                 onCompletion(.success(Int64(siteID + 1000)))
                 allRegisteredExpectation.fulfill()
@@ -1091,7 +1091,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let allAttemptedExpectation = expectation(description: "All sites attempted")
         allAttemptedExpectation.expectedFulfillmentCount = 3
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion) = action {
                 if siteID == 200 {
                     onCompletion(.failure(NSError(domain: "test", code: 500)))
                 } else {
@@ -1137,7 +1137,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         var registeredSiteIDs = Set<Int64>()
         let registrationExpectation = expectation(description: "Only unregistered site attempted")
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion) = action {
                 registeredSiteIDs.insert(siteID)
                 onCompletion(.success(Int64(siteID + 1000)))
                 registrationExpectation.fulfill()
@@ -1176,7 +1176,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         fallbackExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion):
+            case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion):
                 if siteID == 200 {
                     onCompletion(.failure(NSError(domain: "test", code: 500)))
                 } else {
@@ -1231,7 +1231,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         fallbackExpectation.assertForOverFulfill = false
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion):
+            case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion):
                 if siteID == 200 {
                     onCompletion(.failure(NSError(domain: "test", code: 500)))
                 } else {
@@ -1270,6 +1270,45 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertEqual(errorProperties["is_jetpack_connected"] as? Bool, false)
     }
 
+    func test_registerDeviceToken_when_target_site_is_not_the_selected_site_then_forces_jetpack_tunnel() async throws {
+        // Given — selected site is 100, storage has two WC-active sites.
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        let featureFlagService = MockFeatureFlagService(selfDrivenPushToken: true)
+
+        let eligibilityCheckExpectation = expectation(description: "Eligibility check completed")
+        mockRemoteFeatureFlagAction(isEnabled: true, onCompletion: {
+            eligibilityCheckExpectation.fulfill()
+        })
+
+        await insertSitesIntoStorage(siteIDs: [100, 200])
+
+        manager = makeManager(featureFlagService: featureFlagService)
+        await fulfillment(of: [eligibilityCheckExpectation], timeout: 1.0)
+
+        // Capture the REST-fallback flag per target site.
+        var restFallbackBySite: [Int64: Bool] = [:]
+        let bothAttempted = expectation(description: "Both sites attempted")
+        bothAttempted.expectedFulfillmentCount = 2
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, availableAsRESTRequest, onCompletion) = action {
+                restFallbackBySite[siteID] = availableAsRESTRequest
+                onCompletion(.success(Int64(siteID + 1000)))
+                bothAttempted.fulfill()
+            }
+        }
+
+        let tokenAsData = try XCTUnwrap(Sample.deviceToken.data(using: .utf8))
+
+        // When
+        manager.registerDeviceToken(with: tokenAsData)
+        await fulfillment(of: [bothAttempted], timeout: 2.0)
+
+        // Then — selected site may use REST fastpath; non-selected site must force the Jetpack tunnel.
+        XCTAssertEqual(restFallbackBySite[100], true, "Selected site should allow REST fallback")
+        XCTAssertEqual(restFallbackBySite[200], false, "Non-selected site must force Jetpack tunnel to avoid mis-routing")
+    }
+
     func test_registerDeviceToken_when_site_returns_notFound_then_unmarks_that_site() async {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
@@ -1289,7 +1328,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let allAttemptedExpectation = expectation(description: "All sites attempted")
         allAttemptedExpectation.expectedFulfillmentCount = 2
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion) = action {
                 if siteID == 200 {
                     onCompletion(.failure(NetworkError.notFound()))
                 } else {
@@ -1333,7 +1372,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         var registeredSiteIDs = Set<Int64>()
         let registrationExpectation = expectation(description: "Registration attempted")
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion) = action {
                 registeredSiteIDs.insert(siteID)
                 onCompletion(.success(Int64(siteID + 1000)))
                 registrationExpectation.fulfill()
@@ -1413,7 +1452,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         registrationExpectation.assertForOverFulfill = false
         mockRemoteFeatureFlagAction(isEnabled: true)
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion) = action {
+            if case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion) = action {
                 onCompletion(.success(42))
                 registrationExpectation.fulfill()
             }
@@ -1453,7 +1492,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         let dotcomExpectation = expectation(description: "Dotcom registerDevice dispatched")
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, onCompletion):
+            case let .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, onCompletion):
                 onCompletion(.success(123))
             case let .registerDevice(_, _, _, onCompletion):
                 dotcomExpectation.fulfill()
@@ -1620,7 +1659,7 @@ private extension PushNotificationsManagerTests {
     func mockSelfDrivenRegistrationActions(token: Int64 = 42, error: Error? = nil) {
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
             switch action {
-            case .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, let completion):
+            case .registerDeviceForSelfDrivenPushNotifications(_, _, _, _, _, _, let completion):
                 if let error {
                     completion(.failure(error))
                 } else {


### PR DESCRIPTION
## Description

Fixes: WOOMOB-2758

`DevicesRemote.registerForSelfDrivenPushNotifications(...)` hard-coded `availableAsRESTRequest: true`. When the currently selected site has an active application password, `RequestConverter` rewrites the Jetpack tunnel call into a direct REST call using the **selected site's** URL, silently dropping the target `siteID`. For multi-store users this mis-routes the POST (launch fan-out, or re-enabling a hidden site) — at best a `rest_no_route` 404, at worst the token gets registered against the wrong site with no error signal.

This mirrors the fix already in place on the sibling `unregisterFromSelfDrivenPushNotifications` path:

- Expose `availableAsRESTRequest` on `DevicesRemote.registerForSelfDrivenPushNotifications` with a safe default of `false`, and carry the same routing warning in the docstring.
- Thread the flag through `NotificationAction.registerDeviceForSelfDrivenPushNotifications` and `NotificationStore`.
- At the call site in `PushNotificationsManager.performDeviceRegistration`, pass `true` only when the target `siteID` matches the currently selected site (preserving the REST fastpath for site-credentials users). Any cross-site registration forces the Jetpack tunnel, which carries `siteID` in the URL path.

### Why default to `false`

The ticket proposed two options (expose with default `false`, or drop the REST fastpath entirely). Exposing the flag keeps the fastpath available for the selected-site case (site-credentials users with no Jetpack tunnel) while making the safer default the one callers get when they forget — the opposite of the pitfall we just fell into.

### Base branch

Targets `WOOMOB-2757-fix-push-token-register-events-site-attribution` (the sibling analytics mis-attribution fix) since both surfaced during the same investigation and touch adjacent code; will be rebased onto `trunk` after that PR merges.

## Requests Before Fix

<img width="1029" height="241" alt="Screenshot 2026-04-21 at 16 19 03" src="https://github.com/user-attachments/assets/29296dd9-272c-4353-91e8-9f8c3ad92c9e" />

## Requests After Fix

<img width="799" height="43" alt="Screenshot 2026-04-22 at 00 11 14" src="https://github.com/user-attachments/assets/4a9c8093-ff9d-4ea5-9b9c-9e64751b7420" />
<img width="786" height="288" alt="Screenshot 2026-04-22 at 00 11 03" src="https://github.com/user-attachments/assets/419ebc61-0d0d-4ff7-bb35-9c27b1036fc3" />


## Test Steps

Automated:
- `WooCommerceTests/PushNotificationsManagerTests` — new `test_registerDeviceToken_when_target_site_is_not_the_selected_site_then_forces_jetpack_tunnel` asserts that with two WC-active sites in storage and site 100 selected, the dispatched register action carries `availableAsRESTRequest: true` for site 100 and `false` for site 200.
- `YosemiteTests/NotificationStoreTests` + `NetworkingTests/DevicesRemoteTests` — existing register/unregister coverage still passes against the new API surface.

Manual network capture (Proxyman / Charles):
1. Log in with a WPCom account that has multiple WC-active sites; make sure the app-password flow is live for the selected site.
2. Launch the app and observe the per-site registration fan-out in `registerSelfDrivenPushNotificationsForAllSites`.
3. For every target `siteID` other than the selected one, verify the POST goes through the WPCom Jetpack tunnel (`public-api.wordpress.com/.../jetpack-blogs/<siteID>/rest-api/?path=%2Fwc-push-notifications%2Fpush-tokens`), **not** the selected site's host.
4. For the selected site, the POST may still use the REST fastpath (`<selectedSite>/wp-json/wc-push-notifications/push-tokens`) — that's intentional and unchanged.

## Screenshots

N/A — networking-only change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.