### PR TITLE
Enable SwiftLint rule: toggle_bool

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -56,6 +56,9 @@ only_rules:
 
   - overridden_super_call
 
+  # Prefer `someBool.toggle()` over `someBool = !someBool`.
+  - toggle_bool
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/SelectableShipmentItemRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/SelectableShipmentItemRowViewModel.swift
@@ -29,7 +29,7 @@ final class SelectableShipmentItemRowViewModel: ObservableObject, Identifiable {
     }
 
     func handleTap() {
-        selected = !selected
+        selected.toggle()
         if let onSelectedChange {
             onSelectedChange(self)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -196,11 +196,11 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     // MARK: - Tap actions
 
     func didTapScheduleSaleFromRow() {
-        datePickerSaleFromVisible = !datePickerSaleFromVisible
+        datePickerSaleFromVisible.toggle()
     }
 
     func didTapScheduleSaleToRow() {
-        datePickerSaleToVisible = !datePickerSaleToVisible
+        datePickerSaleToVisible.toggle()
     }
 
     // MARK: - UI changes

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/TextFieldTableViewCell.swift
@@ -169,7 +169,7 @@ private extension TextFieldTableViewCell {
     }
 
     @objc func secureTextEntryToggleAction(_ sender: Any) {
-        textField.isSecureTextEntry = !textField.isSecureTextEntry
+        textField.isSecureTextEntry.toggle()
 
         // Save and re-apply the current selection range to save the cursor position
         let currentTextRange = textField.selectedTextRange


### PR DESCRIPTION
## Summary

Enables the `toggle_bool` SwiftLint rule, which prefers `someBool.toggle()` over `someBool = !someBool`.

- Auto-fixed violations: 4 (across 3 files)
- Manual fixes: 0
- Violations left for human review: none

Part of the Orchard SwiftLint rollout campaign.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*