### PR TITLE
Enable SwiftLint rule: prefer_zero_over_explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -63,6 +63,9 @@ only_rules:
   # Prefer the shorthand `if let foo` form over `if let foo = foo`.
   - shorthand_optional_binding
 
+  # Prefer `0` over explicit type initializers like `CGFloat(0)`.
+  - prefer_zero_over_explicit_init
+
   # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - toggle_bool
 

--- a/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
+++ b/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
@@ -117,7 +117,7 @@ extension XCUIElement {
 
     public func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
 
-        let startCoordinate = self.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        let startCoordinate = self.coordinate(withNormalizedOffset: CGVector.zero)
         let destination = startCoordinate.withOffset(CGVector(dx: deltaX, dy: deltaY * -1))
 
         startCoordinate.press(forDuration: 0.01, thenDragTo: destination)

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -213,7 +213,7 @@ final class Tooltip: UIView {
         }
 
         let arrowPath = UIBezierPath()
-        arrowPath.move(to: CGPoint(x: 0, y: 0))
+        arrowPath.move(to: CGPoint.zero)
         let arrowOriginX = (Self.arrowWidth/2 - 1)
         // In order to have a full width of `arrowWidth`, first draw the left side of the triangle until arrowOriginX.
         arrowPath.addLine(to: CGPoint(x: arrowOriginX, y: arrowTipY))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -302,7 +302,7 @@ private extension ShippingLabelSuggestedAddressViewController {
     }
 
     enum Constants {
-        static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        static let headerContainerInsets = UIEdgeInsets.zero
     }
 
     enum SelectedAddress {

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesFlowLayout.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesFlowLayout.swift
@@ -29,7 +29,7 @@ final class ProductImagesFlowLayout: UICollectionViewFlowLayout {
         case .extendedAddImages:
             minimumInteritemSpacing = 0.0
             minimumLineSpacing = 0.00
-            sectionInset = UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0)
+            sectionInset = UIEdgeInsets.zero
         default:
             minimumInteritemSpacing = defaultInset
             minimumLineSpacing = defaultInset

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1648,7 +1648,7 @@ private extension ProductsViewController {
         static let estimatedRowHeight = CGFloat(86)
         static let placeholderRowsPerSection = [3]
         static let headerDefaultHeight = CGFloat(130)
-        static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        static let headerContainerInsets = UIEdgeInsets.zero
         static let toolbarButtonInsets = NSDirectionalEdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TooltipView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TooltipView.swift
@@ -115,7 +115,7 @@ private struct TooltipOverlay: View {
             .padding()
         }
         .shadow(color: Color.secondary, radius: Layout.toolTipShadowCornerRadius)
-        .offset(offset ?? CGSize(width: 0, height: 0))
+        .offset(offset ?? CGSize.zero)
         .padding(insets: safeAreaInsets)
     }
 


### PR DESCRIPTION
## Summary

Enables the `prefer_zero_over_explicit_init` SwiftLint rule, which prefers the `.zero` literal over explicit zero-initializers such as `CGFloat(0)`, `UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)`, and `CGSize(width: 0, height: 0)`.

- Auto-fixed violations: 6 (across 6 files)
- Manual fixes: 0
- Violations left for human review: none

Part of the Orchard SwiftLint rollout campaign.

@woocommerce/ios-developers I admit this is a bit pedantic and I don't know if there is a runtime benefit (unlike say using `isEmpty` vs `count > 0`). [The docs](https://realm.github.io/SwiftLint/prefer_zero_over_explicit_init.html) don't have any extra information.

If it was up to me, I'd enable it, but I'll leave it up to you to decide.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*