### PR TITLE
Enable SwiftLint rule: joined_default_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -45,6 +45,10 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `string` to `""`.
   - empty_string
 
+  # When calling the `joined` method on an array of strings, omit an
+  # explicit empty-string separator since that is the default.
+  - joined_default_parameter
+
   - line_length
 
   # MARK comment should be in valid format.


### PR DESCRIPTION
## What

Enables the SwiftLint [`joined_default_parameter`](https://realm.github.io/SwiftLint/joined_default_parameter.html) rule, which flags calls to `joined(separator:)` that pass the default empty-string separator and should just use `joined()`.

## Details

- Auto-fixed violations: 0
- Manual (agentic) fixes: 0
- Violations left for human review: 0

The codebase was already clean for this rule — no call sites use the default empty-string separator. The only change is adding `joined_default_parameter` to `only_rules` in `.swiftlint.yml` (alphabetically placed).

@woocommerce/ios-developers given this rule does not change the codebase, this is more of an FYI/RFC PR. If you don't like this rule, or any of the rules in that will be proposed in the future, feel free to close the PR unmerged.

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint), progressively enabling SwiftLint rules across Automattic's iOS repositories one rule at a time.