### PR TITLE
Add localized strings to watch app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] POS: update prices on checkout if they've changed since last catalog sync [https://github.com/woocommerce/woocommerce-ios/pull/16921]
 - [*] Update Tap to Pay requirement to iOS 18.0.1 [https://github.com/woocommerce/woocommerce-ios/pull/16914]
 - [*] Add clear button to search fields [https://github.com/woocommerce/woocommerce-ios/pull/16913]
+- [*] Fix localization issue in watch app [https://github.com/woocommerce/woocommerce-ios/pull/16968]
 - [Internal] Tag CIAB support tickets with commerce_in_a_box for proper routing [https://github.com/woocommerce/woocommerce-ios/pull/16910]
 - [Internal] Fix analytics crash caused by concurrent access to TracksService [https://github.com/woocommerce/woocommerce-ios/pull/16944]
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		3FA6FD9E2F2C941600F48C4E /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				/Localized/Localizable.strings,
 				Sounds/o.caf,
 			);
 			target = 26F81B142BE433A2009EC58E /* Woo Watch App */;


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

Closes WOOMOB-2785

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the localization issue on the watch app by updating the reference of the localized strings to be included in the bundle of the watch app.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

- If your phone is in English, switch to a non-English to test localization.
- Reinstall the Woo app on your watch.
- Open the app again and confirm that the app is localized.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="324" height="394" alt="incoming-8FAC7E74-6184-4EDB-8631-EE4F081BEA19" src="https://github.com/user-attachments/assets/e9dc005f-03db-48f4-b03b-0f14ea84469c" /><img width="324" height="394" alt="incoming-DDAC3947-A4A4-436C-AEAD-8A1F548DD74B" src="https://github.com/user-attachments/assets/aaceb761-e152-45a6-b781-24ffc3f0304a" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
