### PR TITLE
Add feature flag for POS custom amounts

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleRefundsi1:
             return true
+        case .pointOfSaleCustomAmounts:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .selfDrivenPushToken:
             return false
         case .clientSideDashboardBanner:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -199,6 +199,10 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case pointOfSaleRefundsi1
 
+    /// Enables adding custom amounts to the cart in Point of Sale
+    ///
+    case pointOfSaleCustomAmounts
+
     /// Enables self driven push token registration
     ///
     case selfDrivenPushToken


### PR DESCRIPTION
## Description
Introduces a new `pointOfSaleCustomAmounts` feature flag to gate the upcoming Point of Sale custom amounts UI. The flag is enabled by default on `localDeveloper` and `alpha` builds and disabled in App Store builds — matching the rollout pattern used by other new POS features (`pointOfSale`, `pointOfSaleCatalogAPI`).

No user-visible changes: this PR only adds the scaffolding so follow-up PRs can land the UI, cart model, and order sync behind the flag without disturbing production.

## Test Steps
- [ ] Build the project on a `localDeveloper` configuration and confirm it compiles.
- [ ] In a debug build, verify `DefaultFeatureFlagService().isFeatureFlagEnabled(.pointOfSaleCustomAmounts)` returns `true` on dev/alpha builds and `false` on App Store builds.
- [ ] Confirm no existing Point of Sale behavior changes — the flag is not yet consumed anywhere.

## Screenshots
N/A — no UI changes.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.