### PR TITLE
Add POS custom amounts homescreen entry point

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 import WooFoundation
 
 struct CartView: View {
@@ -24,6 +25,7 @@ struct CartView: View {
 
     @State private var headerSize: CGSize = .zero
     @State private var showBarcodeScanningModal: Bool = false
+    @State private var showAddCustomAmountSheet: Bool = false
 
     var body: some View {
         ZStack {
@@ -32,7 +34,8 @@ struct CartView: View {
                     shouldApplyHeaderBottomShadow: shouldApplyHeaderBottomShadow,
                     shouldShowClearCartButton: shouldShowClearCartButton,
                     itemCount: posModel.cart.purchasableItems.count,
-                    backgroundColor: backgroundColor
+                    backgroundColor: backgroundColor,
+                    onAddCustomAmountTapped: { showAddCustomAmountSheet = true }
                 )
                 .zIndex(1)
                 .trackSize(size: $headerSize)
@@ -60,6 +63,9 @@ struct CartView: View {
             .posModal(isPresented: $showBarcodeScanningModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
             }
+            .posModal(isPresented: $showAddCustomAmountSheet) {
+                AddCustomAmountView(isPresented: $showAddCustomAmountSheet)
+            }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)
             .background(content: {
@@ -77,12 +83,19 @@ struct CartView: View {
 private struct CartHeaderView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posFeatureFlags) private var featureFlags
     private let viewHelper = CartViewHelper()
 
     let shouldApplyHeaderBottomShadow: Bool
     let shouldShowClearCartButton: Bool
     let itemCount: Int
     let backgroundColor: Color
+    let onAddCustomAmountTapped: () -> Void
+
+    private var shouldShowAddCustomAmountButton: Bool {
+        featureFlags.isFeatureFlagEnabled(.pointOfSaleCustomAmounts)
+            && posModel.orderStage == .building
+    }
 
     private var shouldPreventCartEditing: Bool {
         viewHelper.shouldPreventCartEditing(
@@ -115,6 +128,10 @@ private struct CartHeaderView: View {
                         .minimumScaleFactor(0.5)
                         .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                         .foregroundColor(Color.posOnSurfaceVariantLowest)
+                }
+
+                if shouldShowAddCustomAmountButton {
+                    CartAddCustomAmountButton(onTap: onAddCustomAmountTapped)
                 }
 
                 CartClearMenuButton(removeAllItemsFromCart: {
@@ -260,7 +277,34 @@ private extension CartView {
         }
         .background(backgroundColor.ignoresSafeArea(.all))
     }
+}
 
+private struct CartAddCustomAmountButton: View {
+    let onTap: () -> Void
+
+    @State private var tip = AddCustomAmountTip()
+
+    var body: some View {
+        Button(action: {
+            tip.invalidate(reason: .actionPerformed)
+            onTap()
+        }) {
+            Image(systemName: "plus")
+                .font(.posButtonSymbolMedium)
+                .foregroundStyle(Color.posOnSurface)
+                .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                .accessibilityLabel(Localization.addCustomAmountAccessibilityLabel)
+        }
+        .popoverTip(tip, arrowEdge: .top)
+        .accessibilityIdentifier("pos-add-custom-amount-header-button")
+    }
+
+    enum Localization {
+        static let addCustomAmountAccessibilityLabel = NSLocalizedString(
+            "pos.cartView.addCustomAmount.header.accessibilityLabel",
+            value: "Add custom amount",
+            comment: "Accessibility label for the Point of Sale cart header button that opens the add custom amount form.")
+    }
 }
 
 private struct CartClearMenuButton: View {

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -93,8 +93,9 @@ private struct CartHeaderView: View {
     let onAddCustomAmountTapped: () -> Void
 
     private var shouldShowAddCustomAmountButton: Bool {
-        featureFlags.isFeatureFlagEnabled(.pointOfSaleCustomAmounts)
-            && posModel.orderStage == .building
+        viewHelper.shouldShowAddCustomAmountButton(
+            featureFlags: featureFlags,
+            orderStage: posModel.orderStage)
     }
 
     private var shouldPreventCartEditing: Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountTip.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountTip.swift
@@ -1,11 +1,5 @@
 import TipKit
 
-/// TipKit tip that points to the POS cart header button for adding a custom
-/// amount. Invalidated permanently when the user taps the button (via
-/// `.actionPerformed`) or the popover's close button (via TipKit's built-in
-/// `.tipClosed`). If the user dismisses the popover by tapping outside, the
-/// tip remains eligible and can reappear at most once per day because
-/// `Tips.configure` uses the default `.daily` display frequency.
 struct AddCustomAmountTip: Tip {
     var title: Text {
         Text(Localization.title)

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountTip.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountTip.swift
@@ -1,7 +1,11 @@
 import TipKit
 
 /// TipKit tip that points to the POS cart header button for adding a custom
-/// amount. Shown once, invalidated after the user taps the button.
+/// amount. Invalidated permanently when the user taps the button (via
+/// `.actionPerformed`) or the popover's close button (via TipKit's built-in
+/// `.tipClosed`). If the user dismisses the popover by tapping outside, the
+/// tip remains eligible and can reappear at most once per day because
+/// `Tips.configure` uses the default `.daily` display frequency.
 struct AddCustomAmountTip: Tip {
     var title: Text {
         Text(Localization.title)

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountTip.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountTip.swift
@@ -1,0 +1,30 @@
+import TipKit
+
+/// TipKit tip that points to the POS cart header button for adding a custom
+/// amount. Shown once, invalidated after the user taps the button.
+struct AddCustomAmountTip: Tip {
+    var title: Text {
+        Text(Localization.title)
+    }
+
+    var message: Text? {
+        Text(Localization.message)
+    }
+
+    var image: Image? {
+        Image(systemName: "plus.circle")
+    }
+}
+
+private extension AddCustomAmountTip {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.addCustomAmountTip.title",
+            value: "Add a custom amount",
+            comment: "Title for the TipKit popover pointing to the add-custom-amount button in the Point of Sale cart header.")
+        static let message = NSLocalizedString(
+            "pos.addCustomAmountTip.message",
+            value: "Tap here to add a service fee, tip, or any custom line to the order.",
+            comment: "Body text for the TipKit popover pointing to the add-custom-amount button in the Point of Sale cart header.")
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
@@ -1,9 +1,5 @@
 import SwiftUI
 
-/// Placeholder sheet for adding a custom amount to the POS cart.
-/// The form UI and model wiring land on follow-up branches; this view only
-/// exists so the homescreen entry points resolve to a visible modal while the
-/// `.pointOfSaleCustomAmounts` feature flag is being rolled out.
 struct AddCustomAmountView: View {
     @Binding var isPresented: Bool
     @Environment(\.posModalParentSize) private var parentSize

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Placeholder sheet for adding a custom amount to the POS cart.
+/// The form UI and model wiring land on follow-up branches; this view only
+/// exists so the homescreen entry points resolve to a visible modal while the
+/// `.pointOfSaleCustomAmounts` feature flag is being rolled out.
+struct AddCustomAmountView: View {
+    @Binding var isPresented: Bool
+    @Environment(\.posModalParentSize) private var parentSize
+
+    var body: some View {
+        VStack(spacing: POSSpacing.large) {
+            Text(Localization.title)
+                .font(.posHeadingBold)
+                .foregroundColor(.posOnSurface)
+
+            Text(Localization.comingSoon)
+                .font(.posBodyMediumRegular())
+                .foregroundColor(.posOnSurfaceVariantLowest)
+                .multilineTextAlignment(.center)
+        }
+        .frame(
+            maxWidth: parentSize.width * Constants.parentWidthRatio,
+            maxHeight: parentSize.height * Constants.parentHeightRatio
+        )
+        .padding(POSPadding.xLarge)
+        .background(Color.posSurfaceBright)
+        .posModalCloseButton(action: {
+            isPresented = false
+        })
+    }
+}
+
+private extension AddCustomAmountView {
+    enum Constants {
+        static let parentWidthRatio: CGFloat = 0.5
+        static let parentHeightRatio: CGFloat = 0.5
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.addCustomAmount.title",
+            value: "Add custom amount",
+            comment: "Title of the sheet for adding a custom amount to the Point of Sale cart.")
+        static let comingSoon = NSLocalizedString(
+            "pos.addCustomAmount.comingSoon",
+            value: "The custom amount form is coming soon.",
+            comment: "Placeholder text shown on the Point of Sale add custom amount sheet while the form is under development.")
+    }
+}
+
+#if DEBUG
+#Preview {
+    AddCustomAmountView(isPresented: .constant(true))
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
@@ -15,15 +15,15 @@ struct AddCustomAmountView: View {
                 .foregroundColor(.posOnSurfaceVariantLowest)
                 .multilineTextAlignment(.center)
         }
+        .posModalCloseButton(action: {
+            isPresented = false
+        })
+        .padding(POSPadding.xLarge)
+        .background(Color.posSurfaceBright)
         .frame(
             maxWidth: parentSize.width * Constants.parentWidthRatio,
             maxHeight: parentSize.height * Constants.parentHeightRatio
         )
-        .padding(POSPadding.xLarge)
-        .background(Color.posSurfaceBright)
-        .posModalCloseButton(action: {
-            isPresented = false
-        })
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -176,10 +176,6 @@ public struct PointOfSaleEntryPointView: View {
             }
         }
         .task {
-            // `Tips.configure` throws if called twice in the same process, so swallow
-            // the error rather than gate on a flag. We rely on TipKit's default
-            // `.daily` display frequency so a tip dismissed by tapping outside the
-            // popover can only reappear once per day instead of on every view appearance.
             try? Tips.configure()
 
             // We create the posModel in a task, not init, to avoid creating multiple copies during the view's lifecycle.

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -176,9 +176,11 @@ public struct PointOfSaleEntryPointView: View {
             }
         }
         .task {
-            // `Tips.configure` is idempotent but throws if called twice in the same process,
-            // so swallow the error rather than gate on a flag.
-            try? Tips.configure([.displayFrequency(.immediate), .datastoreLocation(.applicationDefault)])
+            // `Tips.configure` throws if called twice in the same process, so swallow
+            // the error rather than gate on a flag. We rely on TipKit's default
+            // `.daily` display frequency so a tip dismissed by tapping outside the
+            // popover can only reappear once per day instead of on every view appearance.
+            try? Tips.configure()
 
             // We create the posModel in a task, not init, to avoid creating multiple copies during the view's lifecycle.
             // Confusingly, init can be called more than once, but `task` matches the lifecycle.

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 import class WooFoundation.CurrencyFormatter
 import protocol Storage.GRDBManagerProtocol
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
@@ -175,6 +176,10 @@ public struct PointOfSaleEntryPointView: View {
             }
         }
         .task {
+            // `Tips.configure` is idempotent but throws if called twice in the same process,
+            // so swallow the error rather than gate on a flag.
+            try? Tips.configure([.displayFrequency(.immediate), .datastoreLocation(.applicationDefault)])
+
             // We create the posModel in a task, not init, to avoid creating multiple copies during the view's lifecycle.
             // Confusingly, init can be called more than once, but `task` matches the lifecycle.
             // See https://developer.apple.com/documentation/swiftui/state#Store-observable-objects for details.

--- a/Modules/Sources/PointOfSale/ViewHelpers/CartViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/CartViewHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Experiments
 import WooFoundation
 
 struct CartViewHelper {
@@ -21,6 +22,11 @@ struct CartViewHelper {
 
     func shouldShowClearCartButton(cart: Cart, orderStage: PointOfSaleOrderStage) -> Bool {
         cart.isNotEmpty && orderStage == .building
+    }
+
+    func shouldShowAddCustomAmountButton(featureFlags: POSFeatureFlagProviding,
+                                         orderStage: PointOfSaleOrderStage) -> Bool {
+        featureFlags.isFeatureFlagEnabled(.pointOfSaleCustomAmounts) && orderStage == .building
     }
 
     func shouldShowCheckout(orderStage: PointOfSaleOrderStage, cart: Cart) -> Bool {

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/CartViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/CartViewHelperTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import PointOfSale
+import Experiments
 import struct Yosemite.POSItemIdentifier
 
 struct CartViewHelperTests {
@@ -111,6 +112,34 @@ struct CartViewHelperTests {
 
     @Test func shouldShowClearCartButton_items_in_cart_and_finalizing_false() async throws {
         #expect(sut.shouldShowClearCartButton(cart: .init(purchasableItems: [makeItem()]), orderStage: .finalizing) == false)
+    }
+
+    @Test func shouldShowAddCustomAmountButton_when_feature_flag_disabled_then_false() async throws {
+        // Given
+        let featureFlags = MockFeatureFlagService()
+        featureFlags.isFeatureFlagEnabledReturnValue[.pointOfSaleCustomAmounts] = false
+
+        // When, Then
+        #expect(sut.shouldShowAddCustomAmountButton(featureFlags: featureFlags, orderStage: .building) == false)
+        #expect(sut.shouldShowAddCustomAmountButton(featureFlags: featureFlags, orderStage: .finalizing) == false)
+    }
+
+    @Test func shouldShowAddCustomAmountButton_when_feature_flag_enabled_and_building_then_true() async throws {
+        // Given
+        let featureFlags = MockFeatureFlagService()
+        featureFlags.isFeatureFlagEnabledReturnValue[.pointOfSaleCustomAmounts] = true
+
+        // When, Then
+        #expect(sut.shouldShowAddCustomAmountButton(featureFlags: featureFlags, orderStage: .building) == true)
+    }
+
+    @Test func shouldShowAddCustomAmountButton_when_feature_flag_enabled_and_finalizing_then_false() async throws {
+        // Given
+        let featureFlags = MockFeatureFlagService()
+        featureFlags.isFeatureFlagEnabledReturnValue[.pointOfSaleCustomAmounts] = true
+
+        // When, Then
+        #expect(sut.shouldShowAddCustomAmountButton(featureFlags: featureFlags, orderStage: .finalizing) == false)
     }
 
     @Test func couponRowState_building_stage_returns_idle() async throws {


### PR DESCRIPTION
## Description
Introduces the homescreen entry point for the upcoming Point of Sale custom amounts feature:

- **Cart header button**: a compact `+` icon rendered in the POS cart header trailing area, between the item count and the existing clear-cart menu. Shown whenever the `pointOfSaleCustomAmounts` feature flag is on and the order stage is `.building` — so it's reachable in both empty and populated carts.
- **TipKit discoverability hint**: a popover (`AddCustomAmountTip`) points to the button to teach the affordance. It's invalidated permanently when the user taps the button (`.actionPerformed`) or taps the popover's close button (TipKit's built-in `.tipClosed`). If the user dismisses the popover by tapping outside, the tip can reappear at most once per day because `Tips.configure` uses TipKit's default `.daily` display frequency. `Tips.configure` is set up in `PointOfSaleEntryPointView.task`.
- **Placeholder sheet**: tapping the button presents `AddCustomAmountView`, which is intentionally a placeholder ("Add custom amount" title + "Coming soon" body + close button). The real form UI, `Cart` model extension, and `POSOrderService` fee-line mapping will land on follow-up PRs.

All UI is gated behind `pointOfSaleCustomAmounts`, so production builds are unchanged until the flag flips.

The gating logic is extracted into `CartViewHelper.shouldShowAddCustomAmountButton(featureFlags:orderStage:)` so it can be unit tested in isolation.

This PR targets the [feature flag PR](https://github.com/woocommerce/woocommerce-ios/pull/16969) branch so its diff is scoped to the UI changes. Once that PR merges, this one auto-rebases onto `trunk`.

## Test Steps
On a `localDeveloper` or `alpha` build (flag defaults to on):
- [ ] Open the Point of Sale tab. With an **empty cart**, verify the `+` icon appears in the cart header trailing area (to the left of the trash/clear menu should it appear). A TipKit popover labeled "Add a custom amount" should appear, pointing at the button.
- [ ] Tap the `+` button: the placeholder sheet appears with title "Add custom amount" and the "Coming soon" body. Dismiss via the close button.
- [ ] Re-open the POS tab and verify the TipKit popover does not show again (tip invalidated by `.actionPerformed`).
- [ ] Separately, trigger the tip again (e.g. by clearing app data or a fresh install), but this time dismiss it via the popover's `×` close button. Re-open POS — the tip should not show again (invalidated by `.tipClosed`).
- [ ] Separately again, trigger the tip and dismiss it by tapping outside the popover (no `×`, no button tap). Re-open POS immediately — the tip should **not** show again the same day (default `.daily` frequency), but can reappear on a subsequent day.
- [ ] Add a product to the cart. Verify the `+` icon is still visible in the header, alongside the item count and trash menu. Tap it — sheet still appears.
- [ ] Start checkout (tap **Check out**). Verify the `+` icon is hidden during the `.finalizing` stage.
- [ ] Run the POS unit tests: `CartViewHelperTests` should pass with the three new `shouldShowAddCustomAmountButton_*` cases.

On an App Store build (flag off):
- [ ] Verify no `+` icon in the cart header and no TipKit popover — the cart is identical to trunk.

## Screenshots

https://github.com/user-attachments/assets/3bf389a5-e520-426d-8d49-ef0a8bb2bd6a

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.