### PR TITLE
Add 2.7% percentage and split Canada/Interac flat application fees

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -317,7 +317,9 @@ private extension PaymentCaptureOrchestrator {
             return nil
         }
 
-        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee).adding(Constants.canadaFlatFee)
+        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee)
+            .adding(Constants.canadaFlatFee)
+            .adding(Constants.interacFlatFee)
 
         let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
                                                    scale: 2,
@@ -354,8 +356,12 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Constants {
-        static let canadaFlatFee = NSDecimalNumber(string: "0.15")
-        static let canadaPercentageFee = NSDecimalNumber(0)
+        // The base Canada fee and percentage are overwritten by Transact Server at the
+        // capture step for non-Interac payments. Interac payments have no capture step,
+        // so the full combined fee (base + Interac + percentage) is what Stripe charges.
+        static let canadaFlatFee = NSDecimalNumber(string: "0.05")
+        static let interacFlatFee = NSDecimalNumber(string: "0.15")
+        static let canadaPercentageFee = NSDecimalNumber(string: "0.027")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -188,7 +188,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertNil(parameters.applicationFee)
     }
 
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_15cents_applicationFee_in_the_payment_intent() throws {
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_canada_applicationFee_in_the_payment_intent() throws {
         // Given
         let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
                                                         defaultCurrency: "CAD",
@@ -223,7 +223,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         }
 
         // Then
-        let expectedFee = NSDecimalNumber(string: "0.15").decimalValue
+        // 150 * 0.027 + 0.05 (Canada base) + 0.15 (Interac) = 4.25
+        let expectedFee = NSDecimalNumber(string: "4.25").decimalValue
         assertEqual(expectedFee, parameters.applicationFee)
     }
 }


### PR DESCRIPTION
## Description
TRAPLAT-3863

Updates the hardcoded Canadian card-present application fee. Previously the app applied a flat $0.15 on every CA card-present payment. This PR splits that into three components and adds a 2.7% element:

- `canadaFlatFee` — $0.05 (was $0.15)
- `interacFlatFee` — $0.15 (new)
- `canadaPercentageFee` — 2.7% (was 0%)

The full combined fee (base + Interac + percentage) is what Stripe charges for Interac payments, since Interac has no capture step. For non-Interac card-present payments, Transact Server overwrites these values at the capture step, so the code here is effectively an Interac pricing change.

## Test Steps
On a CA-configured test store, connect a WisePad3 and take a payment
- [ ] Using an Interac card, confirm the `application_fee_amount` on the Stripe PaymentIntent equals `orderTotal × 0.027 + 0.20` (rounded to 2dp).
- [ ] Using a normal card, confirm the `application_fee_amount` on the Stripe PaymentIntent equals `orderTotal × 0.027 + 0.05` (rounded to 2dp).
- [ ] Check the order notes match the fee in WCPay  (n.b. known issue with this for Interac fees https://linear.app/a8c/issue/TRAPLAT-3863/interac-transactions-not-charging-the-full-fee#comment-6f8fa098)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.