### PR TITLE
Enable SwiftLint rule: shorthand_optional_binding

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -56,6 +56,9 @@ only_rules:
 
   - overridden_super_call
 
+  # Prefer the shorthand `if let foo` form over `if let foo = foo`.
+  - shorthand_optional_binding
+
   # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - toggle_bool
 

--- a/Modules/Sources/Hardware/CardReader/Email.swift
+++ b/Modules/Sources/Hardware/CardReader/Email.swift
@@ -24,7 +24,7 @@ public struct Email<Value: StringProtocol> {
         }
     }
     private func validate(email: Value?) -> Bool {
-        guard let email = email else { return false }
+        guard let email else { return false }
         // https://emailregex.com
         let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
         let emailPred = NSPredicate(format: "SELF MATCHES %@", emailRegEx)

--- a/Modules/Sources/Hardware/CardReader/PaymentIntent.swift
+++ b/Modules/Sources/Hardware/CardReader/PaymentIntent.swift
@@ -121,7 +121,7 @@ public extension PaymentIntent {
         metadata[PaymentIntent.MetadataKeys.customerName] = customerName
         metadata[PaymentIntent.MetadataKeys.customerEmail] = customerEmail
         metadata[PaymentIntent.MetadataKeys.siteURL] = siteURL
-        if let orderID = orderID {
+        if let orderID {
             metadata[PaymentIntent.MetadataKeys.orderID] = String(orderID)
         }
         metadata[PaymentIntent.MetadataKeys.orderKey] = orderKey

--- a/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
+++ b/Modules/Sources/Hardware/CardReader/StatementDescriptor.swift
@@ -19,7 +19,7 @@ public struct StatementDescriptor {
 
     public var wrappedValue: String? {
         get {
-            guard let value = value else {
+            guard let value else {
                 return nil
             }
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/Cancelable+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/Cancelable+Stripe.swift
@@ -10,7 +10,7 @@ final class StripeCancelable: FallibleCancelable {
 
     func cancel(completion: @escaping (Result<Void, Error>) -> Void) {
         cancelable.cancel { error in
-            if let error = error {
+            if let error {
                 completion(.failure(error))
             } else {
                 completion(.success(()))

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -46,7 +46,7 @@ private extension Hardware.PaymentIntentParameters {
             builder.setStatementDescriptor(descriptor)
         }
 
-        if let applicationFee = applicationFee {
+        if let applicationFee {
             /// Stripe requires that "The amount must be provided as a boxed UInt in the currency's smallest unit."
             /// Smallest-unit and UInt conversion is done in the same way as for the total amount, but that does not need to be boxed.
             let applicationFeeForStripe = NSNumber(value: prepareAmountForStripe(applicationFee))
@@ -65,7 +65,7 @@ private extension Hardware.PaymentIntentParameters {
     /// Updates the existing PaymentIntentParameters metadata with our CardReader metadata, if any.
     ///
     func prepareMetadataForStripe(with meta: CardReaderMetadata? = nil) -> [String: String]? {
-        guard let meta = meta else {
+        guard let meta else {
             return metadata
         }
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
@@ -5,7 +5,7 @@ extension PaymentMethod {
     /// Failable initializer.
     /// Maps a SCPPaymentMethodDetails to PaymentMethod
     init?(method: StripeTerminal.PaymentMethodDetails?) {
-        guard let method = method else {
+        guard let method else {
             return nil
         }
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/ShouldRetryStripeRefundAfterFailureDeterminer.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/ShouldRetryStripeRefundAfterFailureDeterminer.swift
@@ -11,7 +11,7 @@ struct ShouldRetryStripeRefundAfterFailureDeterminer {
     /// - Returns: `true` if they can retry, `false` otherwise
     ///
     public func shouldRetryRefund(after stripeFailureReason: String?) -> Bool {
-        guard let stripeFailureReason = stripeFailureReason else {
+        guard let stripeFailureReason else {
             return false
         }
         switch DeclineReason(with: stripeFailureReason) {

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -218,7 +218,7 @@ extension StripeCardReaderService: CardReaderService {
              * discovering mode before attempting a cancellation
              *
              */
-            guard let self = self,
+            guard let self,
                   let discoveryCancellable = self.discoveryCancellable,
                   self.discoveryStatusSubject.value == .discovering else {
                 return promise(.success(()))
@@ -241,7 +241,7 @@ extension StripeCardReaderService: CardReaderService {
                 // Horrible, terrible workaround.
                 // And yet, it is the classic "dispatch to the next run cycle".
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [discoveryLock] in
-                    guard let error = error else {
+                    guard let error else {
                         self?.switchStatusToIdle()
                         discoveryLock.unlock()
                         return promise(.success(()))
@@ -281,7 +281,7 @@ extension StripeCardReaderService: CardReaderService {
             /// (for example, starting a `tapToPay` connection after a BlueTooth reader has been disconnected)
             Terminal.shared.disconnectReader { error in
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                    if let error = error {
+                    if let error {
                         let underlyingError = Self.logAndDecodeError(error)
                         promise(.failure(CardReaderServiceError.disconnection(underlyingError: underlyingError)))
                     }
@@ -297,7 +297,7 @@ extension StripeCardReaderService: CardReaderService {
 
     public func waitForInsertedCardToBeRemoved() -> Future<Void, Never> {
         return Future() { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -362,7 +362,7 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error> {
-        guard let activePaymentIntent = activePaymentIntent else {
+        guard let activePaymentIntent else {
             return Fail(error: CardReaderServiceError.retryNotPossibleNoActivePayment)
                 .eraseToAnyPublisher()
         }
@@ -420,7 +420,7 @@ extension StripeCardReaderService: CardReaderService {
 
     public func cancelPaymentIntent() -> Future<Void, Error> {
         return Future() { [weak self] promise in
-            guard let self = self,
+            guard let self,
                   let activePaymentIntent = self.activePaymentIntent else {
                 promise(.failure(CardReaderServiceError.paymentCancellation(underlyingError: .noActivePaymentIntent)))
                 return
@@ -430,7 +430,7 @@ extension StripeCardReaderService: CardReaderService {
 
             let cancelPaymentIntent = { [weak self] in
                 Terminal.shared.cancelPaymentIntent(activePaymentIntent) { (intent, error) in
-                    if let error = error {
+                    if let error {
                         let underlyingError = Self.logAndDecodeError(error)
                         promise(.failure(CardReaderServiceError.paymentCancellation(underlyingError: underlyingError)))
                     }
@@ -488,7 +488,7 @@ extension StripeCardReaderService: CardReaderService {
 
     private func getBluetoothConfiguration(_ reader: StripeTerminal.Reader) -> Future<BluetoothConnectionConfiguration, Error> {
         return Future() { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 promise(.failure(CardReaderServiceError.connection()))
                 return
             }
@@ -518,7 +518,7 @@ extension StripeCardReaderService: CardReaderService {
     private func getTapToPayConfiguration(_ reader: StripeTerminal.Reader,
                                              options: CardReaderConnectionOptions?) -> Future<TapToPayConnectionConfiguration, Error> {
         return Future() { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 promise(.failure(CardReaderServiceError.connection()))
                 return
             }
@@ -554,20 +554,20 @@ extension StripeCardReaderService: CardReaderService {
         let batteryLevel = reader.batteryLevel?.doubleValue
 
         return Future { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 promise(.failure(CardReaderServiceError.connection()))
                 return
             }
 
             Terminal.shared.connectReader(reader, connectionConfig: configuration) { [weak self] (reader, error) in
-                guard let self = self else {
+                guard let self else {
                     promise(.failure(CardReaderServiceError.connection()))
                     return
                 }
                 // Clear cached readers, as per Stripe's documentation.
                 self.discoveredStripeReadersCache.clear()
 
-                if let error = error {
+                if let error {
                     let underlyingError = Self.logAndDecodeError(error)
                     // Starting with StripeTerminal 2.0, required software updates happen transparently on connection
                     // Any error related to that will be reported here, but we don't want to treat it as a connection error
@@ -579,7 +579,7 @@ extension StripeCardReaderService: CardReaderService {
                     promise(.failure(serviceError))
                 }
 
-                if let reader = reader {
+                if let reader {
                     guard !self.connectionAttemptInvalidated else {
                         _ = self.disconnect()
                         promise(.failure(CardReaderServiceError.connection(underlyingError: .connectionAttemptInvalidated)))
@@ -595,20 +595,20 @@ extension StripeCardReaderService: CardReaderService {
 
     public func connect(_ reader: StripeTerminal.Reader, configuration: TapToPayConnectionConfiguration) -> Future <CardReader, Error> {
         return Future { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 promise(.failure(CardReaderServiceError.connection()))
                 return
             }
 
             Terminal.shared.connectReader(reader, connectionConfig: configuration) { [weak self] (reader, error) in
-                guard let self = self else {
+                guard let self else {
                     promise(.failure(CardReaderServiceError.connection()))
                     return
                 }
                 // Clear cached readers, as per Stripe's documentation.
                 self.discoveredStripeReadersCache.clear()
 
-                if let error = error {
+                if let error {
                     let underlyingError = Self.logAndDecodeError(error)
                     // Starting with StripeTerminal 2.0, required software updates happen transparently on connection
                     // Any error related to that will be reported here, but we don't want to treat it as a connection error
@@ -620,7 +620,7 @@ extension StripeCardReaderService: CardReaderService {
                     promise(.failure(serviceError))
                 }
 
-                if let reader = reader {
+                if let reader {
                     guard !self.connectionAttemptInvalidated else {
                         _ = self.disconnect()
                         promise(.failure(CardReaderServiceError.connection(underlyingError: .connectionAttemptInvalidated)))
@@ -661,7 +661,7 @@ extension StripeCardReaderService: CardReaderService {
                     DDLogInfo("💳 Reconnection cancellation: reconnection already completed")
                     self?.reconnectionStateSubject.send(.idle)
                     promise(.success(()))
-                } else if let error = error {
+                } else if let error {
                     self?.connectedReadersSubject.send([])
                     self?.reconnectionStateSubject.send(.idle)
                     let underlyingError = Self.logAndDecodeError(error)
@@ -711,14 +711,14 @@ private extension StripeCardReaderService {
             }
 
             Terminal.shared.createPaymentIntent(parameters) { (intent, error) in
-                if let error = error {
+                if let error {
                     let underlyingError = Self.logAndDecodeError(error)
                     promise(.failure(CardReaderServiceError.intentCreation(underlyingError: underlyingError)))
                 }
 
                 self?.activePaymentIntent = intent
 
-                if let intent = intent {
+                if let intent {
                     promise(.success(intent))
                 }
             }
@@ -731,7 +731,7 @@ private extension StripeCardReaderService {
             /// Because we are chaining promises, we need to retain a reference
             /// to this cancellable if we want to cancel
             self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent) { (intent, error) in
-                if let error = error {
+                if let error {
                     var underlyingError = Self.logAndDecodeError(error)
                     /// the completion block for collectPaymentMethod will be called
                     /// with error Canceled when collectPaymentMethod is canceled
@@ -752,7 +752,7 @@ private extension StripeCardReaderService {
                     promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: underlyingError)))
                 }
 
-                if let intent = intent {
+                if let intent {
                     self?.paymentCancellable = nil
                     self?.sendReaderEvent(.cardDetailsCollected)
                     promise(.success(intent))
@@ -780,8 +780,8 @@ private extension StripeCardReaderService {
     func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {
         return Future() { [weak self] promise in
             Terminal.shared.confirmPaymentIntent(intent) { (intent, error) in
-                guard let self = self else { return }
-                if let error = error {
+                guard let self else { return }
+                if let error {
                     let underlyingError = Self.logAndDecodeError(error)
 
                     guard let paymentIntent = error.paymentIntent else {
@@ -802,7 +802,7 @@ private extension StripeCardReaderService {
                     }
                 }
 
-                if let intent = intent {
+                if let intent {
                     self.activePaymentIntent = nil
                     return promise(.success(intent))
                 }
@@ -861,7 +861,7 @@ extension StripeCardReaderService {
                 } else {
                     // Process refund
                     Terminal.shared.confirmRefund { [weak self] processedRefund, processError in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         self.refundCancellable = nil
                         if let error = processError {
                             promise(.failure(CardReaderServiceError.refundPayment(
@@ -921,7 +921,7 @@ extension StripeCardReaderService {
             }
 
             refundCancellable.cancel({ error in
-                if let error = error {
+                if let error {
                     let underlyingError = Self.logAndDecodeError(error)
                     promise(.failure(CardReaderServiceError.refundCancellation(underlyingError: underlyingError)))
                 }
@@ -965,7 +965,7 @@ extension StripeCardReaderService: MobileReaderDelegate {
     public func reader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
         // Note that this function is called with an error when updates are cancelled, so this is enough to ensure we re-enable sleep.
         UIApplication.shared.isIdleTimerDisabled = false
-        if let error = error {
+        if let error {
             let underlyingError = Self.logAndDecodeError(error)
             softwareUpdateSubject.send(.failed(
                 error: CardReaderServiceError.softwareUpdate(underlyingError: underlyingError,
@@ -1098,7 +1098,7 @@ extension StripeCardReaderService: TapToPayReaderDelegate {
 
     public func tapToPayReader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
         UIApplication.shared.isIdleTimerDisabled = false
-        if let error = error {
+        if let error {
             let underlyingError = Self.logAndDecodeError(error)
             softwareUpdateSubject.send(.failed(
                 error: CardReaderServiceError.softwareUpdate(underlyingError: underlyingError,
@@ -1141,7 +1141,7 @@ private extension StripeCardReaderService {
     }
 
     func resetDiscoveredReadersSubject(error: Error? = nil) {
-        if let error = error {
+        if let error {
             let underlyingError = Self.logAndDecodeError(error)
             discoveredReadersSubject.send(completion:
                     .failure(CardReaderServiceError.discovery(underlyingError: underlyingError))

--- a/Modules/Sources/Networking/Model/PaymentGateway.swift
+++ b/Modules/Sources/Networking/Model/PaymentGateway.swift
@@ -122,7 +122,7 @@ extension PaymentGateway: Codable {
         try container.encode(enabled, forKey: .enabled)
         try container.encode(features, forKey: .features)
 
-        guard let instructions = instructions else {
+        guard let instructions else {
             return
         }
         let settings = [Setting.Keys.instructions: instructions]

--- a/Modules/Sources/Networking/Model/Product/Product.swift
+++ b/Modules/Sources/Networking/Model/Product/Product.swift
@@ -186,7 +186,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
     private var hasIntegerStockQuantity: Bool {
-        guard let stockQuantity = stockQuantity else {
+        guard let stockQuantity else {
             return true
         }
 

--- a/Modules/Sources/Networking/Model/Product/ProductVariation.swift
+++ b/Modules/Sources/Networking/Model/Product/ProductVariation.swift
@@ -81,7 +81,7 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
     private var hasIntegerStockQuantity: Bool {
-        guard let stockQuantity = stockQuantity else {
+        guard let stockQuantity else {
             return true
         }
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/WooShippingSelectedRate.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/CarriersAndRates/WooShippingSelectedRate.swift
@@ -38,9 +38,9 @@ public struct WooShippingSelectedRate: Equatable, GeneratedFakeable {
 
 public extension WooShippingSelectedRate {
     var purchaseRate: ShippingLabelCarrierRate {
-        if let signatureRate = signatureRate {
+        if let signatureRate {
             return signatureRate
-        } else if let adultSignatureRate = adultSignatureRate {
+        } else if let adultSignatureRate {
             return adultSignatureRate
         }
         return rate

--- a/Modules/Sources/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/ShippingLabelAddressValidationResponse.swift
@@ -10,10 +10,10 @@ internal struct ShippingLabelAddressValidationResponse: Equatable {
     let result: Result<ShippingLabelAddressValidationSuccess, ShippingLabelAddressValidationError>
 
     init(address: ShippingLabelAddress?, errors: ShippingLabelAddressValidationError?, isTrivialNormalization: Bool?) {
-        if let errors = errors {
+        if let errors {
             result = .failure(errors)
-        } else if let address = address,
-                  let isTrivialNormalization = isTrivialNormalization {
+        } else if let address,
+                  let isTrivialNormalization {
             result = .success(.init(address: address, isTrivialNormalization: isTrivialNormalization))
         } else {
             // This case should never happen, but that's not guaranteed.

--- a/Modules/Sources/Networking/Remote/BookingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/BookingsRemote.swift
@@ -179,7 +179,7 @@ public final class BookingsRemote: Remote, BookingsRemoteProtocol {
             }
         }
 
-        if let searchQuery = searchQuery, !searchQuery.isEmpty {
+        if let searchQuery, !searchQuery.isEmpty {
             parameters[ParameterKey.search] = searchQuery
         }
 

--- a/Modules/Sources/Networking/Remote/CouponsRemote.swift
+++ b/Modules/Sources/Networking/Remote/CouponsRemote.swift
@@ -214,7 +214,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                              completion: @escaping (Result<Coupon, Error>) -> Void) {
         do {
             let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-            if let siteTimezone = siteTimezone {
+            if let siteTimezone {
                 dateFormatter.timeZone = siteTimezone
             }
 
@@ -250,7 +250,7 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
                              completion: @escaping (Result<Coupon, Error>) -> Void) {
         do {
             let dateFormatter = DateFormatter.Defaults.dateTimeFormatter
-            if let siteTimezone = siteTimezone {
+            if let siteTimezone {
                 dateFormatter.timeZone = siteTimezone
             }
 

--- a/Modules/Sources/Networking/Remote/GenerativeContentRemote.swift
+++ b/Modules/Sources/Networking/Remote/GenerativeContentRemote.swift
@@ -228,7 +228,7 @@ private extension GenerativeContentRemote {
 
         // Name will be added only if `productName` is available.
         // TODO: this code related to `productName` can be removed after releasing the new product creation with AI flow. Github issue: 13108
-        if let productName = productName, !productName.isEmpty {
+        if let productName, !productName.isEmpty {
             inputComponents.insert("name: ```\(productName)```", at: 1)
         }
 

--- a/Modules/Sources/Networking/Remote/InboxNotesRemote.swift
+++ b/Modules/Sources/Networking/Remote/InboxNotesRemote.swift
@@ -63,11 +63,11 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
             ParameterKey.fields: ParameterValue.noteFields
         ] as [String: Any]
 
-        if let type = type {
+        if let type {
             let stringOfTypes = type.map { $0.rawValue }
             parameters[ParameterKey.type] = stringOfTypes.joined(separator: ",")
         }
-        if let status = status {
+        if let status {
             let stringOfStatuses = status.map { $0.rawValue }
             parameters[ParameterKey.status] = stringOfStatuses.joined(separator: ",")
         }
@@ -137,11 +137,11 @@ public final class InboxNotesRemote: Remote, InboxNotesRemoteProtocol {
             ParameterKey.fields: ParameterValue.noteFields
         ] as [String: Any]
 
-        if let type = type {
+        if let type {
             let stringOfTypes = type.map { $0.rawValue }
             parameters[ParameterKey.type] = stringOfTypes.joined(separator: ",")
         }
-        if let status = status {
+        if let status {
             let stringOfStatuses = status.map { $0.rawValue }
             parameters[ParameterKey.status] = stringOfStatuses.joined(separator: ",")
         }

--- a/Modules/Sources/Networking/Remote/JustInTimeMessagesRemote.swift
+++ b/Modules/Sources/Networking/Remote/JustInTimeMessagesRemote.swift
@@ -46,7 +46,7 @@ public final class JustInTimeMessagesRemote: Remote, JustInTimeMessagesRemotePro
     private func getParameters(messagePath: JustInTimeMessagesRemote.MessagePath,
                                     query: [String: String?]?) -> [String: String] {
         var parameters = [ParameterKey.messagePath: messagePath.requestValue]
-        if let query = query,
+        if let query,
            let queryString = justInTimeMessageQuery(from: query) {
             parameters[ParameterKey.query] = queryString
         }

--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -130,7 +130,7 @@ public class POSCatalogSyncRemote: Remote, POSCatalogSyncRemoteProtocol {
             ParameterKey.posProductsOnly: String(posProductsOnly)
         ]
 
-        if let includeStatus = includeStatus {
+        if let includeStatus {
             parameters[ParameterKey.includeStatus] = includeStatus
         }
 

--- a/Modules/Sources/Networking/Remote/ProductAttributeTermRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductAttributeTermRemote.swift
@@ -33,10 +33,10 @@ public final class ProductAttributeTermRemote: Remote {
         let mapper = ProductAttributeTermListMapper(siteID: siteID)
 
         enqueue(request, mapper: mapper) { terms, error in
-            if let error = error {
+            if let error {
                 return completion(.failure(error))
             }
-            if let terms = terms {
+            if let terms {
                 return completion(.success(terms))
             }
         }

--- a/Modules/Sources/Networking/Remote/ProductCategoriesRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductCategoriesRemote.swift
@@ -98,7 +98,7 @@ public final class ProductCategoriesRemote: Remote, ProductCategoriesRemoteProto
             ParameterKey.name: name
         ]
 
-        if let parentID = parentID {
+        if let parentID {
             parameters[ParameterKey.parent] = String(parentID)
         }
 

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -811,7 +811,7 @@ private extension ProductsRemote {
     /// Returns the category Id in string format, or empty string if the product category is nil
     ///
     func filterProductCategoryParemeterValue(from productCategory: ProductCategory?) -> String {
-        guard let productCategory = productCategory else {
+        guard let productCategory else {
             return ""
         }
 

--- a/Modules/Sources/Networking/Remote/RefundsRemote.swift
+++ b/Modules/Sources/Networking/Remote/RefundsRemote.swift
@@ -150,7 +150,7 @@ extension RefundsRemote: POSRefundsRemoteProtocol {
     public func loadRefunds(for siteID: Int64, by orderID: Int64, with refundIDs: [Int64]) async throws -> [Refund] {
         return try await withCheckedThrowingContinuation { continuation in
             loadRefunds(for: siteID, by: orderID, with: refundIDs) { refunds, error in
-                if let error = error {
+                if let error {
                     continuation.resume(throwing: error)
                 } else {
                     continuation.resume(returning: refunds ?? [])
@@ -163,9 +163,9 @@ extension RefundsRemote: POSRefundsRemoteProtocol {
     public func createRefund(for siteID: Int64, by orderID: Int64, refund: Refund) async throws -> Refund {
         return try await withCheckedThrowingContinuation { continuation in
             createRefund(for: siteID, by: orderID, refund: refund) { createdRefund, error in
-                if let error = error {
+                if let error {
                     continuation.resume(throwing: error)
-                } else if let createdRefund = createdRefund {
+                } else if let createdRefund {
                     continuation.resume(returning: createdRefund)
                 } else {
                     continuation.resume(throwing: RefundsRemoteError.unexpectedNilRefund)

--- a/Modules/Sources/Networking/Remote/ShippingLabelRemote.swift
+++ b/Modules/Sources/Networking/Remote/ShippingLabelRemote.swift
@@ -165,10 +165,10 @@ public final class ShippingLabelRemote: Remote, ShippingLabelRemoteProtocol {
             var customPackageList: [[String: Any]] = []
             var predefinedOptionDictionary: [String: [String]] = [:]
 
-            if let customPackage = customPackage {
+            if let customPackage {
                 let customPackageDictionary = try customPackage.toDictionary()
                 customPackageList = [customPackageDictionary]
-            } else if let predefinedOption = predefinedOption {
+            } else if let predefinedOption {
                 let packageIDs = predefinedOption.predefinedPackages.map({ $0.id })
                 predefinedOptionDictionary = [predefinedOption.providerID: packageIDs]
             } else {

--- a/Modules/Sources/Networking/Tools/String+MinMaxQuantities.swift
+++ b/Modules/Sources/Networking/Tools/String+MinMaxQuantities.swift
@@ -5,7 +5,7 @@ import Foundation
 ///
 extension Optional where Wrapped == String {
     var refinedMinMaxQuantityEmptyValue: String? {
-        guard let self = self else {
+        guard let self else {
             return nil
         }
 

--- a/Modules/Sources/NetworkingCore/Model/NoteRange.swift
+++ b/Modules/Sources/NetworkingCore/Model/NoteRange.swift
@@ -103,7 +103,7 @@ private extension NoteRange {
     /// Parses the NoteRange.Type field into a Swift Native enum. Returns .unknown on failure.
     ///
     static func kind(forType type: String?, siteID: Int64?, url: URL?) -> Kind {
-        if let type = type, let kind = Kind(rawValue: type) {
+        if let type, let kind = Kind(rawValue: type) {
             return kind
         }
 

--- a/Modules/Sources/NetworkingCore/Model/OrderItem.swift
+++ b/Modules/Sources/NetworkingCore/Model/OrderItem.swift
@@ -192,7 +192,7 @@ public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeab
             try container.encode(total, forKey: .total)
         }
 
-        if let image = image {
+        if let image {
             try container.encode(image, forKey: .image)
         }
 

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -43,7 +43,7 @@ public final class WordPressOrgNetwork: Network {
     public func responseData(for request: URLRequestConvertible) async throws -> Data? {
         let request = requestConverter.convert(request)
         return try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.alamofireSession.request(request)
                 .validate()
@@ -139,7 +139,7 @@ public final class WordPressOrgNetwork: Network {
     public func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Swift.Result<Data, Error>, Never> {
         let request = requestConverter.convert(request)
         return Future() { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.alamofireSession.request(request).validate().responseData { response in
                 do {
                     try self.validateResponse(response.data)

--- a/Modules/Sources/NetworkingCore/Remote/NotificationsRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/NotificationsRemote.swift
@@ -124,7 +124,7 @@ private extension NotificationsRemote {
     ///
     func requestForNotifications(fields: Fields? = nil, noteIDs: [Int64]? = nil, pageSize: Int?) -> DotcomRequest {
         var parameters = [ParameterKeys.locale: Locale.current.description]
-        if let fields = fields {
+        if let fields {
             parameters[ParameterKeys.fields] = fields.rawValue
         }
 
@@ -133,7 +133,7 @@ private extension NotificationsRemote {
             parameters[ParameterKeys.identifiers] = identifiersAsStrings.joined(separator: ",")
         }
 
-        if let pageSize = pageSize {
+        if let pageSize {
             parameters[ParameterKeys.number] = String(pageSize)
         }
 

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -57,10 +57,10 @@ public class OrdersRemote: Remote, OrdersRemoteProtocol {
                 ParameterKeys.fields: ParameterValues.fieldValues,
             ]
 
-            if let after = after {
+            if let after {
                 parameters[ParameterKeys.after] = utcDateFormatter.string(from: after)
             }
-            if let before = before {
+            if let before {
                 parameters[ParameterKeys.before] = utcDateFormatter.string(from: before)
             }
             if let modifiedAfter {

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -87,11 +87,11 @@ open class Remote: NSObject {
     ///
     public func enqueue<M: Mapper>(_ request: Request, mapper: M, completion: @escaping (M.Output?, Error?) -> Void) {
         network.responseData(for: request) { [weak self] (data, networkError) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
-            guard let data = data else {
+            guard let data else {
                 let error: Error? = networkError.map { self.mapNetworkError(error: $0, for: request) }
                 completion(nil, error)
                 return
@@ -124,7 +124,7 @@ open class Remote: NSObject {
     public func enqueue<M: Mapper>(_ request: Request, mapper: M,
                             completion: @escaping (Result<M.Output, Error>) -> Void) {
         network.responseData(for: request) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -203,11 +203,11 @@ open class Remote: NSObject {
                                                    completion: @escaping (Result<M.Output, Error>) -> Void) {
         network.uploadMultipartFormData(multipartFormData: multipartFormData,
                                         to: request) { [weak self] (data, networkError) in
-                                            guard let self = self else {
+                                            guard let self else {
                                                 return
                                             }
 
-                                            guard let data = data else {
+                                            guard let data else {
                                                 completion(.failure(networkError ?? NetworkError.notFound()))
                                                 return
                                             }

--- a/Modules/Sources/NetworkingCore/Remote/SiteStatsRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/SiteStatsRemote.swift
@@ -21,7 +21,7 @@ public class SiteStatsRemote: Remote {
                                      completion: @escaping (Result<SiteVisitStats, Error>) -> Void) {
         let path = "\(Path.sites)/\(siteID)/\(Path.siteVisitStats)/"
         let dateFormatter = DateFormatter.Stats.statsDayFormatter
-        if let siteTimezone = siteTimezone {
+        if let siteTimezone {
             dateFormatter.timeZone = siteTimezone
         }
         let parameters = [ParameterKeys.unit: unit.rawValue,
@@ -52,7 +52,7 @@ public class SiteStatsRemote: Remote {
                                      completion: @escaping (Result<SiteSummaryStats, Error>) -> Void) {
         let path = "\(Path.sites)/\(siteID)/\(Path.siteSummaryStats)/"
         let dateFormatter = DateFormatter.Stats.statsDayFormatter
-        if let siteTimezone = siteTimezone {
+        if let siteTimezone {
             dateFormatter.timeZone = siteTimezone
         }
         let parameters = [ParameterKeys.period: period.rawValue,

--- a/Modules/Sources/NetworkingCore/Requests/JetpackRequest.swift
+++ b/Modules/Sources/NetworkingCore/Requests/JetpackRequest.swift
@@ -143,15 +143,15 @@ private extension JetpackRequest {
             "path": jetpackPath + "&_method=" + method.rawValue.lowercased()
         ]
 
-        if let locale = locale {
+        if let locale {
             output["locale"] = locale
         }
 
-        if let jetpackQueryParams = jetpackQueryParams {
+        if let jetpackQueryParams {
             output["query"] = jetpackQueryParams
         }
 
-        if let jetpackBodyParams = jetpackBodyParams {
+        if let jetpackBodyParams {
             output["body"] = jetpackBodyParams
         }
 

--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSale.swift
@@ -199,7 +199,7 @@ extension WooAnalyticsEvent {
                 Key.itemType: itemType.rawValue
             ]
 
-            if let productType = productType {
+            if let productType {
                 properties[Key.productType] = productType.rawValue
             }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -274,7 +274,7 @@ private extension PointOfSaleObservableItemsController {
         }
 
         // Error state for data source observation
-        if let error = error, items.isEmpty {
+        if let error, items.isEmpty {
             return .error(errorType(error))
         }
 

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -120,7 +120,7 @@ protocol PointOfSaleOrderControllerProtocol {
 
     @MainActor
     func collectCashPayment(changeDueAmount: String?) async throws {
-        guard let order = order else {
+        guard let order else {
             throw PointOfSaleOrderControllerError.noOrder
         }
 

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlow.swift
@@ -78,7 +78,7 @@ class PointOfSaleBarcodeScannerSetupFlow {
     // MARK: - Private Methods
 
     private func transition(to transitionType: PointOfSaleBarcodeScannerTransitionType, fallback: (() -> Void)? = nil) {
-        guard let currentStep = currentStep,
+        guard let currentStep,
               let targetStep = currentStep.transitions[transitionType] else {
             fallback?()
             return

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManager.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/PointOfSaleBarcodeScannerSetupFlowManager.swift
@@ -86,7 +86,7 @@ class PointOfSaleBarcodeScannerSetupFlowManager {
     }
 
     private func removeKeyboardObserver() {
-        if let keyboardObserver = keyboardObserver {
+        if let keyboardObserver {
             NotificationCenter.default.removeObserver(keyboardObserver)
             self.keyboardObserver = nil
         }

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanning/BarcodeScannerContainer.swift
@@ -166,7 +166,7 @@ final class GameControllerBarcodeScannerHostingController: UIHostingController<E
     /// as this could cause unexpected behavior.
     override func pressesEnded(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
         // Forward UIPress events to UIKit observer if active
-        if let uiKitObserver = uiKitObserver {
+        if let uiKitObserver {
             uiKitObserver.processUIPress(presses)
         } else {
             super.pressesEnded(presses, with: event)
@@ -185,7 +185,7 @@ final class GameControllerBarcodeScannerHostingController: UIHostingController<E
     /// It makes sense to clear the buffer when this happens.
     /// We call super in case other presses are handled elsewhere in the responder chain.
     override func pressesCancelled(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
-        if let uiKitObserver = uiKitObserver {
+        if let uiKitObserver {
             uiKitObserver.barcodeParser?.cancel()
         }
         super.pressesCancelled(presses, with: event)

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanning/GameControllerBarcodeObserver.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanning/GameControllerBarcodeObserver.swift
@@ -112,7 +112,7 @@ final class GameControllerBarcodeObserver {
         )
 
         keyboard.keyboardInput?.keyChangedHandler = { [weak self] _, _, keyCode, pressed in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if keyCode == .leftShift || keyCode == .rightShift {
                 self.isShiftPressed = pressed

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
@@ -11,7 +11,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel: 
         self.cancelButtonViewModel = .init(title: Localization.cancel, actionHandler: cancelUpdateAction)
         self.retrySearchButtonViewModel = .init(title: Localization.retry, actionHandler: retrySearchAction)
         self.batteryLevelInfo = {
-            if let batteryLevel = batteryLevel {
+            if let batteryLevel {
                 return String(format: Localization.message, 100 * batteryLevel)
             } else {
                 return Localization.messageNoBatteryLevel

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -458,7 +458,7 @@ private struct PurchasableItemsCartSection: View {
                 .accessibilityFocused($accessibilityFocusedItem, equals: cartItem.id)
             }
             .onChange(of: posModel.cart.accessibilityFocusedItemID) { _, itemID in
-                 if let itemID = itemID {
+                 if let itemID {
                      Task { @MainActor in
                          accessibilityFocusedItem = itemID
                      }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -610,7 +610,7 @@ private enum Localization {
         )
         var label = String(format: baseFormat, date, status)
 
-        if let email = email, email.isNotEmpty {
+        if let email, email.isNotEmpty {
             let emailFormat = NSLocalizedString(
                 "pos.orderDetailsView.headerBottomContent.accessibilityLabel.email",
                 value: "Customer email: %1$@",
@@ -624,7 +624,7 @@ private enum Localization {
 
     static func productRowAccessibilityLabel(name: String, attributes: String?, quantity: String, unitPrice: String, total: String) -> String {
         var label = name
-        if let attributes = attributes {
+        if let attributes {
             label += ", \(attributes)"
         }
         let format = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -432,7 +432,7 @@ extension POSOrderListView {
             )
             var label = String(format: baseFormat, orderNumber, total, date, status)
 
-            if let email = email, email.isNotEmpty {
+            if let email, email.isNotEmpty {
                 let emailFormat = NSLocalizedString(
                     "pos.orderListView.orderRow.accessibilityLabel.email",
                     value: "Email: %1$@",

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -99,7 +99,7 @@ struct PointOfSaleCollectCashView: View {
                                     .foregroundColor(.posOnSurfaceVariantLowest)
                             }
 
-                            if let errorMessage = errorMessage {
+                            if let errorMessage {
                                 Text(errorMessage)
                                     .font(.posBodySmallRegular())
                                     .foregroundColor(.posError)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -85,7 +85,7 @@ public struct PointOfSaleEntryPointView: View {
 
         // Use observable controller with GRDB if local catalog is eligible,
         // otherwise fall back to standard controller.
-        if isLocalCatalogEligible, let grdbManager = grdbManager, let catalogSyncCoordinator {
+        if isLocalCatalogEligible, let grdbManager, let catalogSyncCoordinator {
             self.itemsController = PointOfSaleObservableItemsController(
                 siteID: siteID,
                 grdbManager: grdbManager,

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -84,7 +84,7 @@ struct POSModalViewModifier<Item: Identifiable & Equatable, ModalContent: View>:
     func body(content: Content) -> some View {
         content
             .onChange(of: item) { _, newItem in
-                if let newItem = newItem {
+                if let newItem {
                     // Don't show a modal if a full screen overlay is presented on top
                     guard !coverManager.isPresented else { return }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -43,7 +43,7 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
 
                 NavigationStack(path: $detailNavigationPath) {
                     VStack {
-                        if let selection = selection {
+                        if let selection {
                             detail(selection, $detailNavigationPath)
                                 .frame(maxWidth: .infinity)
                                 .transition(.opacity)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSTotalsSectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSTotalsSectionView.swift
@@ -270,7 +270,7 @@ private enum Localization {
         )
         var label = String(format: baseFormat, index, amount)
 
-        if let reason = reason, !reason.isEmpty {
+        if let reason, !reason.isEmpty {
             let reasonFormat = NSLocalizedString(
                 "pos.totalsSectionView.refund.accessibilityLabel.reason",
                 value: "Reason: %1$@",

--- a/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
@@ -66,7 +66,7 @@ enum POSFontStyle {
     private func scaledValue(_ value: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> CGFloat {
         let metrics = UIFontMetrics.default
         let scaledValue = metrics.scaledValue(for: value)
-        guard let maximumContentSizeCategory = maximumContentSizeCategory else {
+        guard let maximumContentSizeCategory else {
             return scaledValue
         }
 

--- a/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
+++ b/Modules/Sources/Storage/Tools/StorageType+Extensions.swift
@@ -460,7 +460,7 @@ public extension StorageType {
     /// Retrieves a stored TaxClass for the provided tax slug.
     ///
     func loadTaxClass(slug: String?) -> TaxClass? {
-        guard let slug = slug else {
+        guard let slug else {
             return nil
         }
 

--- a/Modules/Sources/TestKit/Assertions.swift
+++ b/Modules/Sources/TestKit/Assertions.swift
@@ -36,7 +36,7 @@ public func assertThat(_ subject: String, contains value: String, file: StaticSt
 /// If `subject`'s type is just a subclass of `expectedType`, then this will fail.
 ///
 public func assertThat<T>(_ subject: Any?, isAnInstanceOf expectedType: T.Type, file: StaticString = #file, line: UInt = #line) {
-    guard let subject = subject else {
+    guard let subject else {
         XCTFail("Expected nil to be an instance of \(expectedType)",
                 file: file,
                 line: line)

--- a/Modules/Sources/WooFoundation/Colors/UIColor+ColorStudio.swift
+++ b/Modules/Sources/WooFoundation/Colors/UIColor+ColorStudio.swift
@@ -52,7 +52,7 @@ public extension UIColor {
 
 public extension UIColor {
     func color(for trait: UITraitCollection?) -> UIColor {
-        if let trait = trait {
+        if let trait {
             return resolvedColor(with: trait)
         }
         return self

--- a/Modules/Sources/WooFoundation/Extensions/Publishers+KeyboardFrame.swift
+++ b/Modules/Sources/WooFoundation/Extensions/Publishers+KeyboardFrame.swift
@@ -27,7 +27,7 @@ public extension Publishers {
 
 private extension Notification {
     var keyboardFrame: CGRect {
-        guard let userInfo = userInfo,
+        guard let userInfo,
               let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
             return .zero
         }

--- a/Modules/Sources/WooFoundation/UI Components/SafariSheet.swift
+++ b/Modules/Sources/WooFoundation/UI Components/SafariSheet.swift
@@ -25,7 +25,7 @@ extension View {
     ///
     @ViewBuilder
     public func safariSheet(isPresented: Binding<Bool>, url: URL?, onDismiss: (() -> Void)? = nil) -> some View {
-        if let url = url {
+        if let url {
             sheet(isPresented: isPresented, onDismiss: onDismiss) {
                 SafariSheetView(url: url)
                     .ignoresSafeArea()

--- a/Modules/Sources/WooFoundation/Utilities/Connectivity/DefaultConnectivityObserver.swift
+++ b/Modules/Sources/WooFoundation/Utilities/Connectivity/DefaultConnectivityObserver.swift
@@ -22,7 +22,7 @@ public final class DefaultConnectivityObserver: ConnectivityObserver {
         self.networkMonitor = networkMonitor
         startObserving()
         networkMonitor.networkUpdateHandler = { [weak self] path in
-            guard let self = self else { return }
+            guard let self else { return }
             DispatchQueue.main.async {
                 self.currentStatus = self.connectivityStatus(from: path)
             }

--- a/Modules/Sources/WooFoundation/Utilities/UTMParameters.swift
+++ b/Modules/Sources/WooFoundation/Utilities/UTMParameters.swift
@@ -31,7 +31,7 @@ public extension UTMParametersProviding {
             return nil
         }
 
-        if let limitToHosts = limitToHosts {
+        if let limitToHosts {
             return urlAddingUTMParamsForAllowedHosts(limitToHosts, urlComponents: components)
         } else {
             return urlAddingUTMParams(urlComponents: components)

--- a/Modules/Sources/WooFoundation/Utilities/WooCommerceComUTMProvider.swift
+++ b/Modules/Sources/WooFoundation/Utilities/WooCommerceComUTMProvider.swift
@@ -10,7 +10,7 @@ public struct WooCommerceComUTMProvider: UTMParametersProviding {
                 content: String?,
                 siteID: Int64?) {
         let siteIDString: String?
-        if let siteID = siteID {
+        if let siteID {
             siteIDString = String(siteID)
         } else {
             siteIDString = nil

--- a/Modules/Sources/WordPressShared/Utility/Debouncer.swift
+++ b/Modules/Sources/WordPressShared/Utility/Debouncer.swift
@@ -18,7 +18,7 @@ public final class Debouncer {
     }
 
     deinit {
-        if let timer = timer, timer.fireDate >= Date() {
+        if let timer, timer.fireDate >= Date() {
             timer.invalidate()
             callback?()
         }

--- a/Modules/Sources/WordPressShared/Utility/NSDate+Helpers.swift
+++ b/Modules/Sources/WordPressShared/Utility/NSDate+Helpers.swift
@@ -127,7 +127,7 @@ extension Date {
 
         let absoluteFormatter = DateFormatters.mediumDate
 
-        if let timeZone = timeZone {
+        if let timeZone {
             absoluteFormatter.timeZone = timeZone
         }
 
@@ -145,7 +145,7 @@ extension Date {
     /// - Parameter timeZone: An optional time zone used to adjust the date formatters.
     public func mediumStringWithTime(timeZone: TimeZone? = nil) -> String {
         let formatter = DateFormatters.mediumDateTime
-        if let timeZone = timeZone {
+        if let timeZone {
             formatter.timeZone = timeZone
         }
         return formatter.string(from: self)

--- a/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/BottomSheetViewController.swift
@@ -80,7 +80,7 @@ public class BottomSheetViewController: UIViewController {
             } else {
                 modalPresentationStyle = .popover
 
-                if let sourceBarButtonItem = sourceBarButtonItem {
+                if let sourceBarButtonItem {
                     popoverPresentationController?.barButtonItem = sourceBarButtonItem
                 } else {
                     popoverPresentationController?.permittedArrowDirections = arrowDirections
@@ -145,7 +145,7 @@ public class BottomSheetViewController: UIViewController {
             gripButton.heightAnchor.constraint(equalToConstant: Constants.gripHeight)
         ])
 
-        guard let childViewController = childViewController else {
+        guard let childViewController else {
             return
         }
 
@@ -293,7 +293,7 @@ extension BottomSheetViewController: DrawerPresentable {
     }
 
     public func handleDismiss() {
-        if let childViewController = childViewController {
+        if let childViewController {
             childViewController.handleDismiss()
         }
     }

--- a/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
+++ b/Modules/Sources/WordPressUI/BottomSheet/DrawerPresentationController.swift
@@ -550,8 +550,8 @@ extension DrawerPresentationController: UIGestureRecognizerDelegate {
 
         /// Shouldn't happen; should always have container & presented view when tapped
         guard
-            let containerView = containerView,
-            let presentedView = presentedView,
+            let containerView,
+            let presentedView,
             currentPosition != .hidden
         else {
             return false

--- a/Modules/Sources/WordPressUI/Extensions/UIImage+Assets.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImage+Assets.swift
@@ -65,7 +65,7 @@ extension UIImage {
 
             cgContext.restoreGState()
 
-            if let border = border {
+            if let border {
                 border.setStroke()
                 path.stroke()
             }

--- a/Modules/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -76,7 +76,7 @@ extension UIImageView {
     ///   This method uses deprecated types. Please check the deprecation warning in `GravatarRatings`. Also check out the UIImageView extension from the Gravatar iOS SDK as an alternative to download images. See: https://github.com/Automattic/Gravatar-SDK-iOS.
     @available(*, deprecated, message: "Usage of the deprecated type: Gravatar.")
     public func downloadGravatar(_ gravatar: Gravatar?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> Void)? = nil) {
-        guard let gravatar = gravatar else {
+        guard let gravatar else {
             self.image = placeholder
             return
         }
@@ -113,7 +113,7 @@ extension UIImageView {
     ///   - email: associated email of the new gravatar
     @objc public func updateGravatar(image: UIImage, email: String?) {
         self.image = image
-        guard let email = email else {
+        guard let email else {
             return
         }
         NotificationCenter.default.post(name: .GravatarImageUpdateNotification, object: self, userInfo: [Defaults.emailKey: email, Defaults.imageKey: image])

--- a/Modules/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -40,10 +40,10 @@ public extension UIImageView {
     @objc func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
         // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
         // If the actual URL was nil, at least we set the Placeholder Image. Capicci?
-        guard let url = url else {
+        guard let url else {
             cancelImageDownload()
 
-            if let placeholderImage = placeholderImage {
+            if let placeholderImage {
                 self.image = placeholderImage
             }
 
@@ -71,7 +71,7 @@ public extension UIImageView {
         }
 
         guard let url = request.url else {
-            if let placeholderImage = placeholderImage {
+            if let placeholderImage {
                 image = placeholderImage
             }
 
@@ -86,12 +86,12 @@ public extension UIImageView {
 
         // Using the placeholder only makes sense if we know we're going to download an image
         // that's not immediately available to us.
-        if let placeholderImage = placeholderImage {
+        if let placeholderImage {
             self.image = placeholderImage
         }
 
         let task = URLSession.shared.dataTask(with: request, completionHandler: { [weak self] data, response, error in
-            guard let data = data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+            guard let data, let image = UIImage(data: data, scale: UIScreen.main.scale) else {
                 DispatchQueue.main.async {
                     failure?(error)
                     self?.downloadTask = nil

--- a/Modules/Sources/WordPressUI/Extensions/UITableViewController+Helpers.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UITableViewController+Helpers.swift
@@ -22,7 +22,7 @@ extension UITableViewController {
                     self.tableView.deselectRow(at: indexPath, animated: true)
                 }
                 let completionBlock: (UIViewControllerTransitionCoordinatorContext?) -> Void = { [unowned self] context in
-                    if let context = context,
+                    if let context,
                         context.isCancelled {
                         self.tableView.selectRow(at: indexPath, animated: true, scrollPosition: .none)
                     }

--- a/Modules/Sources/WordPressUI/FancyAlert/FancyAlertPresentationController.swift
+++ b/Modules/Sources/WordPressUI/FancyAlert/FancyAlertPresentationController.swift
@@ -16,7 +16,7 @@ open class FancyAlertPresentationController: UIPresentationController, UIViewCon
     }(UIView())
 
     override open func presentationTransitionWillBegin() {
-        guard let containerView = containerView else { return }
+        guard let containerView else { return }
 
         containerView.addSubview(dimmingView)
         containerView.pinSubviewToAllEdges(dimmingView)

--- a/Modules/Sources/WordPressUI/FancyAlert/FancyAlertViewController.swift
+++ b/Modules/Sources/WordPressUI/FancyAlert/FancyAlertViewController.swift
@@ -246,7 +246,7 @@ open class FancyAlertViewController: UIViewController {
 
     private func updateViewConfiguration() {
         guard isViewLoaded else { return }
-        guard let configuration = configuration else { return }
+        guard let configuration else { return }
 
         buttonHandlers.removeAll()
 
@@ -349,7 +349,7 @@ open class FancyAlertViewController: UIViewController {
     }
 
     private func update(_ button: UIButton, with buttonConfig: Config.ButtonConfig?) {
-        guard let buttonConfig = buttonConfig else {
+        guard let buttonConfig else {
             button.isHiddenInStackView = true
             return
         }
@@ -361,7 +361,7 @@ open class FancyAlertViewController: UIViewController {
     }
 
     private func updateBottomSwitch(with config: Config.SwitchConfig?) {
-        guard let config = config else {
+        guard let config else {
             alertView.bottomSwitchStackView.isHiddenInStackView = true
             return
         }

--- a/Modules/Sources/WordPressUI/FancyAlert/FancyButton.swift
+++ b/Modules/Sources/WordPressUI/FancyAlert/FancyButton.swift
@@ -128,7 +128,7 @@ open class FancyButton: UIButton {
     // wrap appropriately including insets above and below.
     //
     open override var intrinsicContentSize: CGSize {
-        guard let titleLabel = titleLabel else {
+        guard let titleLabel else {
             return super.intrinsicContentSize
         }
 

--- a/Modules/Sources/WordPressUI/FlingableView/FlingableViewHandler.swift
+++ b/Modules/Sources/WordPressUI/FlingableView/FlingableViewHandler.swift
@@ -139,7 +139,7 @@ open class FlingableViewHandler: NSObject {
         // Check for the view leaving the screen
         pushBehavior.action = { [weak self] in
             guard let strongSelf = self,
-                  let referenceView = referenceView else { return }
+                  let referenceView else { return }
 
             if !view.frame.intersects(referenceView.bounds) {
                 strongSelf.animator.removeAllBehaviors()

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
@@ -36,7 +36,7 @@ struct MockCardPresentPaymentActionHandler: MockActionHandler {
         let accounts = objectGraph.paymentGatewayAccounts(for: siteID)
 
         save(mocks: accounts, as: StoragePaymentGatewayAccount.self) { error in
-            if let error = error {
+            if let error {
                 onCompletion(.failure(error))
             } else {
                 onCompletion(.success(()))

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockProductReviewAction.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockProductReviewAction.swift
@@ -25,7 +25,7 @@ struct MockProductReviewActionHandler: MockActionHandler {
         storage.deleteAllObjects(ofType: StorageProductReview.self)
 
         save(mocks: reviews, as: StorageProductReview.self) { error in
-            if let error = error {
+            if let error {
                 onCompletion(.failure(error))
             } else {
                 onCompletion(.success(reviews))

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSystemStatusActionHandler.swift
@@ -28,7 +28,7 @@ struct MockSystemStatusActionHandler: MockActionHandler {
         let systemPlugins = objectGraph.systemPlugins(for: siteID)
 
         save(mocks: systemPlugins, as: StorageSystemPlugin.self) { error in
-            if let error = error {
+            if let error {
                 onCompletion(.failure(error))
             } else {
                 onCompletion(.success([]))

--- a/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
+++ b/Modules/Sources/Yosemite/Model/Orders/StoredOrderSettings.swift
@@ -30,10 +30,10 @@ public struct StoredOrderSettings: Codable, Equatable {
 
         public func numberOfActiveFilters() -> Int {
             var total = 0
-            if let orderStatusesFilter = orderStatusesFilter, !orderStatusesFilter.isEmpty {
+            if let orderStatusesFilter, !orderStatusesFilter.isEmpty {
                 total += 1
             }
-            if let dateRangeFilter = dateRangeFilter, dateRangeFilter.filter != .any {
+            if let dateRangeFilter, dateRangeFilter.filter != .any {
                 total += 1
             }
             if productFilter != nil {
@@ -42,7 +42,7 @@ public struct StoredOrderSettings: Codable, Equatable {
             if customerFilter != nil {
                 total += 1
             }
-            if let salesChannelFilter = salesChannelFilter, salesChannelFilter != .any {
+            if let salesChannelFilter, salesChannelFilter != .any {
                 total += 1
             }
 

--- a/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -134,7 +134,7 @@ extension Storage.Order: ReadOnlyConvertible {
     // MARK: - Private Helpers
 
     private func createReadOnlyBillingAddress() -> Yosemite.Address? {
-        guard let billingCountry = billingCountry else {
+        guard let billingCountry else {
             return nil
         }
 
@@ -152,7 +152,7 @@ extension Storage.Order: ReadOnlyConvertible {
     }
 
     private func createReadOnlyShippingAddress() -> Yosemite.Address? {
-        guard let shippingCountry = shippingCountry else {
+        guard let shippingCountry else {
             return nil
         }
 

--- a/Modules/Sources/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -115,7 +115,7 @@ extension Storage.Product: ReadOnlyConvertible {
         let productCustomFields = customFields?.map { $0.toReadOnly() } ?? [Yosemite.MetaData]()
 
         var quantity: Decimal?
-        if let stockQuantity = stockQuantity {
+        if let stockQuantity {
             quantity = Decimal(string: stockQuantity)
         }
         var productBundleStockStatus: ProductStockStatus?
@@ -209,7 +209,7 @@ extension Storage.Product: ReadOnlyConvertible {
     // MARK: - Private Helpers
 
     private func createReadOnlyDimensions() -> Yosemite.ProductDimensions {
-        guard let dimensions = dimensions else {
+        guard let dimensions else {
             return ProductDimensions(length: "", width: "", height: "")
         }
 
@@ -217,7 +217,7 @@ extension Storage.Product: ReadOnlyConvertible {
     }
 
     private func convertIDArray(_ array: [Int64]? ) -> [Int64] {
-        guard let array = array else {
+        guard let array else {
             return [Int64]()
         }
 

--- a/Modules/Sources/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/ProductVariation+ReadOnlyConvertible.swift
@@ -126,7 +126,7 @@ extension Storage.ProductVariation: ReadOnlyConvertible {
 //
 private extension Storage.ProductVariation {
     func createReadOnlyDimensions() -> Yosemite.ProductDimensions {
-        guard let dimensions = dimensions else {
+        guard let dimensions else {
             return ProductDimensions(length: "", width: "", height: "")
         }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/POSCoupon.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/POSCoupon.swift
@@ -14,7 +14,7 @@ public struct POSCoupon: Equatable, Hashable {
     }
 
     public var isExpired: Bool {
-        guard let dateExpires = dateExpires else {
+        guard let dateExpires else {
             return false
         }
         return dateExpires <= Date()

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemFetchStrategyFactory.swift
@@ -54,7 +54,7 @@ public final class PointOfSaleItemFetchStrategyFactory: PointOfSaleItemFetchStra
                                analytics: POSItemFetchAnalyticsTracking) -> PointOfSalePurchasableItemFetchStrategy {
         // Use local search if local catalog is enabled and dependencies are available
         // The strategy will use FTS when enabled, or fall back to LIKE-based queries
-        if isLocalCatalogEnabled, let grdbManager = grdbManager, let itemMapper = itemMapper {
+        if isLocalCatalogEnabled, let grdbManager, let itemMapper {
             return PointOfSaleLocalSearchPurchasableItemFetchStrategy(siteID: siteID,
                                                                       searchTerm: searchTerm,
                                                                       grdbManager: grdbManager,

--- a/Modules/Sources/Yosemite/Stores/AccountStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AccountStore.swift
@@ -111,7 +111,7 @@ private extension AccountStore {
             onCompletion(.success(site))
         } else {
             synchronizeSites(selectedSiteID: siteID) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 guard let site = self.storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly() else {
                     return onCompletion(.failure(SynchronizeSiteError.unknownSite))
                 }
@@ -147,7 +147,7 @@ private extension AccountStore {
                 case .success(let sites):
                     return sites.publisher.flatMap { [weak self] site -> AnyPublisher<Site, Never> in
                         let sitePublisher = Just<Site>(site).eraseToAnyPublisher()
-                        guard let self = self else {
+                        guard let self else {
                             return sitePublisher
                         }
 

--- a/Modules/Sources/Yosemite/Stores/AnnouncementsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AnnouncementsStore.swift
@@ -81,7 +81,7 @@ private extension AnnouncementsStore {
                                  locale: Locale.current.identifier) { [weak self] result in
             switch result {
             case .success(let announcements):
-                guard let self = self, let announcement = announcements.first else {
+                guard let self, let announcement = announcements.first else {
                     return onCompletion(.failure(AnnouncementsError.announcementNotFound))
                 }
                 do {
@@ -140,7 +140,7 @@ private extension AnnouncementsStore {
                                  locale: Locale.current.identifier) { [weak self] result in
             switch result {
             case .success(let announcements):
-                guard let self = self, let announcement = announcements.first else {
+                guard let self, let announcement = announcements.first else {
                     return onCompletion(.failure(AnnouncementsError.announcementNotFound))
                 }
                 do {

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -29,7 +29,7 @@ public final class CardPresentPaymentStore: Store {
 
     /// Which backend is the store using? Default to WCPay until told otherwise
     private var usingBackend: CardPresentPaymentsPlugin {
-        guard let paymentGatewayAccount = paymentGatewayAccount else {
+        guard let paymentGatewayAccount else {
             return .wcPay
         }
 
@@ -520,7 +520,7 @@ private extension CardPresentPaymentStore {
 
         /// Fetch the WCPay account
         remote.loadAccount(for: siteID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -540,7 +540,7 @@ private extension CardPresentPaymentStore {
 
     func loadStripeAccount(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         stripeRemote.loadAccount(for: siteID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Sources/Yosemite/Stores/DataStore.swift
+++ b/Modules/Sources/Yosemite/Stores/DataStore.swift
@@ -44,7 +44,7 @@ private extension DataStore {
     func synchronizeCountries(siteID: Int64,
                               completion: @escaping (Result<[Country], Error>) -> Void) {
         remote.loadCountries(siteID: siteID) { [weak self] (result) in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let countries):

--- a/Modules/Sources/Yosemite/Stores/Helpers/CouponStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/CouponStoreMethods.swift
@@ -127,7 +127,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
     ///
     func deleteCoupon(siteID: Int64, couponID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         remote.deleteCoupon(for: siteID, couponID: couponID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
@@ -157,7 +157,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
                       siteTimezone: TimeZone? = nil,
                       onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
         remote.updateCoupon(coupon, siteTimezone: siteTimezone) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
@@ -180,7 +180,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
                       siteTimezone: TimeZone? = nil,
                       onCompletion: @escaping (Result<Coupon, Error>) -> Void) {
         remote.createCoupon(coupon, siteTimezone: siteTimezone) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
@@ -285,7 +285,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
                         onCompletion: @escaping (_ result: Result<Coupon, Error>) -> Void) {
         remote.retrieveCoupon(for: siteID,
                               couponID: couponID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
@@ -306,7 +306,7 @@ internal class CouponStoreMethods: CouponStoreMethodsProtocol {
                      couponIDs: [Int64],
                      onCompletion: @escaping (_ result: Result<[Coupon], Error>) -> Void) {
         remote.loadCoupons(for: siteID, by: couponIDs) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -36,7 +36,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         siteSettingsRemote.loadGeneralSettings(for: siteID) { [weak self] (settings, error) in
-            guard let settings = settings else {
+            guard let settings else {
                 onCompletion(error)
                 return
             }
@@ -51,7 +51,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
         siteSettingsRemote.loadProductSettings(for: siteID) { [weak self] (settings, error) in
-            guard let settings = settings else {
+            guard let settings else {
                 onCompletion(error)
                 return
             }
@@ -80,7 +80,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func retrieveCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         siteSettingsRemote.loadSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let setting):
                 self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
@@ -97,7 +97,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func enableCouponSetting(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         siteSettingsRemote.updateSetting(for: siteID, settingGroup: .general, settingID: SettingKeys.coupons, value: SettingValue.yes) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let setting):
                 self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
@@ -113,7 +113,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func retrieveAnalyticsSetting(siteID: Int64, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         siteSettingsRemote.loadSetting(for: siteID, settingGroup: .advanced, settingID: SettingKeys.analytics) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let setting):
                 self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
@@ -133,7 +133,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
                                             settingGroup: .advanced,
                                             settingID: SettingKeys.analytics,
                                             value: SettingValue.yes) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let setting):
                 self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {
@@ -149,7 +149,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     ///
     func retrieveTaxBasedOnSetting(siteID: Int64, onCompletion: @escaping (Result<TaxBasedOnSetting, Error>) -> Void) {
         siteSettingsRemote.loadSetting(for: siteID, settingGroup: .custom("tax"), settingID: SettingKeys.taxBasedOn) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let setting):
                 self.upsertSingleStoredSettingInBackground(siteID: siteID, readOnlySiteSetting: setting) {

--- a/Modules/Sources/Yosemite/Stores/InboxNotesStore.swift
+++ b/Modules/Sources/Yosemite/Stores/InboxNotesStore.swift
@@ -67,7 +67,7 @@ private extension InboxNotesStore {
                            status: [InboxNotesRemote.Status]? = nil,
                            completion: @escaping (Result<[InboxNote], Error>) -> ()) {
         remote.loadAllInboxNotes(for: siteID, pageNumber: pageNumber, pageSize: pageSize, orderBy: orderBy, type: type, status: status) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 completion(.failure(error))
@@ -162,7 +162,7 @@ private extension InboxNotesStore {
                                             shouldDeleteExistingNotes: Bool,
                                             onCompletion: @escaping () -> Void) {
         storageManager.performAndSave({ [weak self] storage in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if shouldDeleteExistingNotes {
                 self.deleteStoredInboxNotes(siteID: siteID, in: storage)

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -149,7 +149,7 @@ private extension NotificationStore {
     ///
     func synchronizeNotifications(onCompletion: @escaping (Error?) -> Void) {
         remote.loadHashes(pageSize: Constants.maximumPageSize) { [weak self] (hashes, error) in
-            guard let hashes = hashes else {
+            guard let hashes else {
                 onCompletion(error)
                 return
             }
@@ -162,7 +162,7 @@ private extension NotificationStore {
                 }
 
                 self?.remote.loadNotes(noteIDs: outdatedIDs, pageSize: Constants.maximumPageSize) { result in
-                    guard let self = self else {
+                    guard let self else {
                         return
                     }
                     switch result {
@@ -187,7 +187,7 @@ private extension NotificationStore {
     ///
     func synchronizeNotification(with noteID: Int64, onCompletion: @escaping (Note?, Error?) -> Void) {
         remote.loadNotes(noteIDs: [noteID]) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             switch result {

--- a/Modules/Sources/Yosemite/Stores/Order/ProductInputTransformer.swift
+++ b/Modules/Sources/Yosemite/Stores/Order/ProductInputTransformer.swift
@@ -99,7 +99,7 @@ public struct ProductInputTransformer {
             return nil
         }()
 
-        guard let product = product else {
+        guard let product else {
             DDLogError("⛔️ Product with ID: \(item.productID) not found.")
             return nil
         }

--- a/Modules/Sources/Yosemite/Stores/OrderNoteStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderNoteStore.swift
@@ -44,7 +44,7 @@ private extension OrderNoteStore {
     ///
     func retrieveOrderNotes(siteID: Int64, orderID: Int64, onCompletion: @escaping ([OrderNote]?, Error?) -> Void) {
         remote.loadOrderNotes(for: siteID, orderID: orderID) { [weak self] (orderNotes, error) in
-            guard let orderNotes = orderNotes else {
+            guard let orderNotes else {
                 onCompletion(nil, error)
                 return
             }

--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -280,7 +280,7 @@ private extension OrderStore {
     ///
     private func loadOrderFromRemote(siteID: Int64, orderID: Int64, onCompletion: @escaping (Order?, Error?) -> Void) {
         remote.loadOrder(for: siteID, orderID: orderID) { [weak self] (order, error) in
-            guard let order = order else {
+            guard let order else {
                 if case NetworkError.notFound? = error {
                     self?.deleteStoredOrder(siteID: siteID, orderID: orderID) {
                         onCompletion(nil, error)

--- a/Modules/Sources/Yosemite/Stores/PaymentGatewayStore.swift
+++ b/Modules/Sources/Yosemite/Stores/PaymentGatewayStore.swift
@@ -41,7 +41,7 @@ private extension PaymentGatewayStore {
     /// Loads and stores all payment gateways for the provided `siteID`
     func synchronizePaymentGateways(siteID: Int64, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         remote.loadAllPaymentGateways(siteID: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let paymentGateways):
@@ -64,7 +64,7 @@ private extension PaymentGatewayStore {
                       siteTimezone: TimeZone? = nil,
                       onCompletion: @escaping (Result<PaymentGateway, Error>) -> Void) {
         remote.updatePaymentGateway(paymentGateway) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/Modules/Sources/Yosemite/Stores/ProductAttributeTermStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductAttributeTermStore.swift
@@ -28,7 +28,7 @@ public final class ProductAttributeTermStore: Store {
         case let .synchronizeProductAttributeTerms(siteID, attributeID, onCompletion):
             synchronizeAllProductAttributeTerms(siteID: siteID, attributeID: attributeID, fromPageNumber: Store.Default.firstPageNumber) { error in
                 let result: Result<Void, ProductAttributeTermActionError> = {
-                    if let error = error {
+                    if let error {
                         return .failure(error)
                     }
                     return .success(())
@@ -108,7 +108,7 @@ private extension ProductAttributeTermStore {
                                     name: String,
                                     onCompletion: @escaping (Result<ProductAttributeTerm, Error>) -> Void) {
         remote.createProductAttributeTerm(for: siteID, attributeID: attributeID, name: name) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case let .success(term):
                 self.upsertStoredProductAttributeTermsInBackground([term], siteID: siteID, attributeID: attributeID) {

--- a/Modules/Sources/Yosemite/Stores/ProductCategoryStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductCategoryStore.swift
@@ -60,12 +60,12 @@ private extension ProductCategoryStore {
     func synchronizeAllProductCategories(siteID: Int64, fromPageNumber: Int, onCompletion: @escaping (ProductCategoryActionError?) -> Void) {
         // Start fetching the provided initial page
         synchronizeProductCategories(siteID: siteID, pageNumber: fromPageNumber, pageSize: Constants.defaultMaxPageSize) { [weak self] categories, error in
-            guard let self = self  else {
+            guard let self  else {
                 return
             }
 
             // If there is an error, end the recursion and call `onCompletion` with an `error`
-            if let error = error {
+            if let error {
                 let synchronizationError = ProductCategoryActionError.categoriesSynchronization(pageNumber: fromPageNumber, rawError: error)
                 onCompletion(synchronizationError)
                 return
@@ -78,7 +78,7 @@ private extension ProductCategoryStore {
             }
 
             // If categories is empty, end the recursion and call `onCompletion`
-            if let categories = categories, categories.isEmpty {
+            if let categories, categories.isEmpty {
                 onCompletion(nil)
                 return
             }
@@ -92,7 +92,7 @@ private extension ProductCategoryStore {
     ///
     func synchronizeProductCategories(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping ([ProductCategory]?, Error?) -> Void) {
         remote.loadAllProductCategories(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (productCategories, error) in
-            guard let productCategories = productCategories else {
+            guard let productCategories else {
                 onCompletion(nil, error)
                 return
             }

--- a/Modules/Sources/Yosemite/Stores/ProductReviewStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductReviewStore.swift
@@ -99,7 +99,7 @@ private extension ProductReviewStore {
     ///
     func retrieveProductReview(siteID: Int64, reviewID: Int64, onCompletion: @escaping (Networking.ProductReview?, Error?) -> Void) {
         remote.loadProductReview(for: siteID, reviewID: reviewID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Sources/Yosemite/Stores/ProductShippingClassStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductShippingClassStore.swift
@@ -48,7 +48,7 @@ private extension ProductShippingClassStore {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let models):
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -67,7 +67,7 @@ private extension ProductShippingClassStore {
     ///
     func retrieveProductShippingClass(siteID: Int64, remoteID: Int64, onCompletion: @escaping (ProductShippingClass?, Error?) -> Void) {
         remote.loadOne(for: siteID, remoteID: remoteID) { [weak self] (model, error) in
-            guard let model = model else {
+            guard let model else {
                 onCompletion(nil, error)
                 return
             }

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -384,7 +384,7 @@ private extension ProductStore {
     ///
     func retrieveProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Product, Error>) -> Void) {
         remote.loadProduct(for: siteID, productID: productID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -544,7 +544,7 @@ private extension ProductStore {
     /// Validates the Product SKU against other Products in storage.
     ///
     func validateProductSKU(_ sku: String?, siteID: Int64, onCompletion: @escaping (Bool) -> Void) {
-        guard let sku = sku, sku.isEmpty == false else {
+        guard let sku, sku.isEmpty == false else {
             // It is valid to not have a sku.
             onCompletion(true)
             return

--- a/Modules/Sources/Yosemite/Stores/ProductTagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductTagStore.swift
@@ -47,7 +47,7 @@ private extension ProductTagStore {
 
         // Start fetching the provided initial page
         synchronizeProductTags(siteID: siteID, pageNumber: fromPageNumber, pageSize: Constants.defaultMaxPageSize) { [weak self] (result) in
-            guard let self = self  else {
+            guard let self  else {
                 return
             }
 

--- a/Modules/Sources/Yosemite/Stores/ProductVariationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductVariationStore.swift
@@ -105,7 +105,7 @@ private extension ProductVariationStore {
                                         context: nil,
                                         pageNumber: pageNumber,
                                         pageSize: pageSize) { [weak self] (productVariations, error) in
-            guard let productVariations = productVariations else {
+            guard let productVariations else {
                 onCompletion(.failure(error ?? ProductVariationLoadError.unexpected))
                 return
             }
@@ -128,7 +128,7 @@ private extension ProductVariationStore {
     func retrieveProductVariation(siteID: Int64, productID: Int64, variationID: Int64,
                                   onCompletion: @escaping (Result<ProductVariation, Error>) -> Void) {
         remote.loadProductVariation(for: siteID, productID: productID, variationID: variationID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             switch result {
@@ -154,7 +154,7 @@ private extension ProductVariationStore {
                                  newVariation: CreateProductVariation,
                                  onCompletion: @escaping (Result<ProductVariation, Error>) -> Void) {
         remote.createProductVariation(for: siteID, productID: productID, newVariation: newVariation) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             switch result {
@@ -187,7 +187,7 @@ private extension ProductVariationStore {
         remote.createProductVariations(siteID: siteID,
                                        productID: productID,
                                        productVariations: productVariations) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let productVariations):
                 self.productVariationStorageManager.upsertStoredProductVariationsInBackground(readOnlyProductVariations: productVariations,
@@ -210,7 +210,7 @@ private extension ProductVariationStore {
     ///
     func updateProductVariation(productVariation: ProductVariation, onCompletion: @escaping (Result<ProductVariation, ProductUpdateError>) -> Void) {
         remote.updateProductVariation(productVariation: productVariation) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             switch result {
@@ -241,7 +241,7 @@ private extension ProductVariationStore {
                                            productID: productID,
                                            variationID: variationID,
                                            image: image) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             switch result {
@@ -271,7 +271,7 @@ private extension ProductVariationStore {
         remote.updateProductVariations(siteID: siteID,
                                        productID: productID,
                                        productVariations: productVariations) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))
@@ -308,7 +308,7 @@ private extension ProductVariationStore {
             remote.loadProductVariation(for: order.siteID,
                                         productID: orderItem.productID,
                                         variationID: orderItem.variationID) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .failure(let error):
                     results.append(.failure(error))
@@ -339,7 +339,7 @@ private extension ProductVariationStore {
         remote.deleteProductVariation(siteID: productVariation.siteID,
                                       productID: productVariation.productID,
                                       variationID: productVariation.productVariationID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let productVariation):
                 self.productVariationStorageManager.deleteStoredProductVariation(siteID: productVariation.siteID,

--- a/Modules/Sources/Yosemite/Stores/RefundStore.swift
+++ b/Modules/Sources/Yosemite/Stores/RefundStore.swift
@@ -51,7 +51,7 @@ private extension RefundStore {
     ///
     func createRefund(siteID: Int64, orderID: Int64, refund: Refund, onCompletion: @escaping (Refund?, Error?) -> Void) {
         remote.createRefund(for: siteID, by: orderID, refund: refund) { [weak self] (refund, error) in
-            guard let refund = refund else {
+            guard let refund else {
                 onCompletion(nil, error)
                 return
             }
@@ -66,7 +66,7 @@ private extension RefundStore {
     ///
     func retrieveRefund(siteID: Int64, orderID: Int64, refundID: Int64, onCompletion: @escaping (Networking.Refund?, Error?) -> Void) {
         remote.loadRefund(siteID: siteID, orderID: orderID, refundID: refundID) { [weak self] (refund, error) in
-            guard let refund = refund else {
+            guard let refund else {
                 if case NetworkError.notFound? = error {
                     self?.deleteStoredRefund(siteID: siteID, orderID: orderID, refundID: refundID) {
                         onCompletion(nil, error)
@@ -138,7 +138,7 @@ private extension RefundStore {
     ///
     func synchronizeRefunds(siteID: Int64, orderID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
         remote.loadAllRefunds(for: siteID, by: orderID) { [weak self] (refunds, error) in
-            guard let refunds = refunds else {
+            guard let refunds else {
                 onCompletion(error)
                 return
             }

--- a/Modules/Sources/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ShippingLabelStore.swift
@@ -89,7 +89,7 @@ public final class ShippingLabelStore: Store {
 private extension ShippingLabelStore {
     func synchronizeShippingLabels(siteID: Int64, orderID: Int64, completion: @escaping (Result<[ShippingLabel], Error>) -> Void) {
         remote.loadShippingLabels(siteID: siteID, orderID: orderID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .failure(let error):
@@ -117,7 +117,7 @@ private extension ShippingLabelStore {
         remote.refundShippingLabel(siteID: shippingLabel.siteID,
                                    orderID: shippingLabel.orderID,
                                    shippingLabelID: shippingLabel.shippingLabelID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .failure(let error):
@@ -202,7 +202,7 @@ private extension ShippingLabelStore {
     func synchronizeShippingLabelAccountSettings(siteID: Int64,
                                                  completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
         remote.loadShippingLabelAccountSettings(siteID: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .failure(let error):
@@ -219,7 +219,7 @@ private extension ShippingLabelStore {
                                             settings: ShippingLabelAccountSettings,
                                             completion: @escaping (Result<Bool, Error>) -> Void) {
         remote.updateShippingLabelAccountSettings(siteID: siteID, settings: settings) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let success):
@@ -260,7 +260,7 @@ private extension ShippingLabelStore {
 
                 // Wait to give the backend time to process the purchase
                 DispatchQueue.main.asyncAfter(deadline: .now() + backendProcessingDelay) { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     // Poll the status of the label purchases from the response above
                     self.pollLabelStatus(withDelayInSeconds: pollingDelay,
@@ -291,7 +291,7 @@ private extension ShippingLabelStore {
         }
 
         storageManager.performAndSave ({ [weak self] storage in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let order = storage.loadOrder(siteID: siteID, orderID: orderID) else {
                 return
             }
@@ -306,7 +306,7 @@ private extension ShippingLabelStore {
                                                refund: ShippingLabelRefund,
                                                onCompletion: @escaping () -> Void) {
         storageManager.performAndSave ({ [weak self] storage in
-            guard let self = self else { return }
+            guard let self else { return }
             // If a shipping label does not exist in storage, skip upserting the refund in storage.
             guard let shippingLabel = storage.loadShippingLabel(siteID: shippingLabel.siteID,
                                                                 orderID: shippingLabel.orderID,
@@ -352,7 +352,7 @@ private extension ShippingLabelStore {
     }
 
     func update(shippingLabel storageShippingLabel: StorageShippingLabel, withRefund refund: ShippingLabelRefund?, using storage: StorageType) {
-        if let refund = refund {
+        if let refund {
             let storageRefund = storageShippingLabel.refund ?? storage.insertNewObject(ofType: Storage.ShippingLabelRefund.self)
             storageRefund.update(with: refund)
             storageShippingLabel.refund = storageRefund

--- a/Modules/Sources/Yosemite/Stores/SitePluginStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SitePluginStore.swift
@@ -57,7 +57,7 @@ public final class SitePluginStore: Store {
 private extension SitePluginStore {
     func synchronizeSitePlugins(siteID: Int64, completionHandler: @escaping (Result<Void, Error>) -> Void) {
         remote.loadPlugins(for: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let plugins):
                 self.upsertSitePluginsInBackground(siteID: siteID, readonlyPlugins: plugins, completionHandler: completionHandler)
@@ -69,7 +69,7 @@ private extension SitePluginStore {
 
     func installSitePlugin(siteID: Int64, slug: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         remote.installPlugin(for: siteID, slug: slug) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let plugin):
                 self.upsertSitePluginsInBackground(siteID: siteID, readonlyPlugins: [plugin], completionHandler: onCompletion)
@@ -81,7 +81,7 @@ private extension SitePluginStore {
 
     func activateSitePlugin(siteID: Int64, pluginName: String, onCompletion: @escaping (Result<Void, Error>) -> Void) {
         remote.activatePlugin(for: siteID, pluginName: pluginName) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let plugin):
                 guard plugin.status == .active else {
@@ -97,7 +97,7 @@ private extension SitePluginStore {
 
     func getPluginDetails(siteID: Int64, pluginName: String, onCompletion: @escaping (Result<SitePlugin, Error>) -> Void) {
         remote.getPluginDetails(for: siteID, pluginName: pluginName) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let plugin):
                 self.upsertSitePluginsInBackground(siteID: siteID, readonlyPlugins: [plugin]) { result in

--- a/Modules/Sources/Yosemite/Stores/TaxStore.swift
+++ b/Modules/Sources/Yosemite/Stores/TaxStore.swift
@@ -58,7 +58,7 @@ private extension TaxStore {
     ///
     func retrieveTaxClasses(siteID: Int64, onCompletion: @escaping ([TaxClass]?, Error?) -> Void) {
         remote.loadAllTaxClasses(for: siteID) { [weak self] (taxClasses, error) in
-            guard let taxClasses = taxClasses else {
+            guard let taxClasses else {
                 onCompletion(nil, error)
                 return
             }
@@ -85,7 +85,7 @@ private extension TaxStore {
         }
         else {
             remote.loadAllTaxClasses(for: taxClassRequestable.siteID) { [weak self] (taxClasses, error) in
-                guard let taxClasses = taxClasses else {
+                guard let taxClasses else {
                     onCompletion(nil, error)
                     return
                 }
@@ -171,7 +171,7 @@ private extension TaxStore {
                                           shouldDeleteExistingTaxRates: Bool,
                                           onCompletion: @escaping () -> Void) {
         storageManager.performAndSave({ [weak self] storage in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if shouldDeleteExistingTaxRates {
                 storage.deleteTaxRates(siteID: siteID)

--- a/Modules/Sources/Yosemite/Stores/TelemetryStore.swift
+++ b/Modules/Sources/Yosemite/Stores/TelemetryStore.swift
@@ -45,7 +45,7 @@ private extension TelemetryStore {
                        telemetryLastReportedTime: Date?,
                        installationDate: Date?,
                        onCompletion: @escaping (Result<Void, Error>) -> Void) {
-        if let telemetryLastReportedTime = telemetryLastReportedTime,
+        if let telemetryLastReportedTime,
            Date().timeIntervalSince(telemetryLastReportedTime) < minimalIntervalBetweenReports {
             // send telemetry for same store only after timeout
             onCompletion(.failure(TelemetryError.requestThrottled))

--- a/Modules/Sources/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Modules/Sources/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -168,7 +168,7 @@ private extension MediaAssetExporter {
     }
 
     func preferredExportTypeFor(uti: String?) -> String? {
-        guard let uti = uti else {
+        guard let uti else {
             return nil
         }
 

--- a/Modules/Sources/Yosemite/Tools/Media/MediaFileManager.swift
+++ b/Modules/Sources/Yosemite/Tools/Media/MediaFileManager.swift
@@ -58,7 +58,7 @@ final class MediaFileManager {
     func createLocalMediaURL(filename: String, fileExtension: String?) throws -> URL {
         let baseURL = try createDirectoryURL()
         let url: URL
-        if let fileExtension = fileExtension {
+        if let fileExtension {
             let basename = (filename as NSString).deletingPathExtension.lowercased()
             url = baseURL.appendingPathComponent(basename, isDirectory: false)
                 .appendingPathExtension(fileExtension)

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -184,7 +184,7 @@ private extension POSOrderService {
 
     /// Extracts variation_id from error data dictionary
     func extractVariationID(from data: [String: AnyDecodable]?) -> Int64? {
-        guard let data = data,
+        guard let data,
               let variationIDValue = data["variation_id"]?.value else {
             return nil
         }
@@ -215,7 +215,7 @@ private extension POSOrderService {
         let productName: String
         let parentProductID: Int64
 
-        if let cartItem = cartItem,
+        if let cartItem,
            let variation = cartItem.item as? POSVariation {
             // Found the variation in the cart - use its parent product name and variation name
             productName = "\(variation.parentProductName) - \(variation.name)"

--- a/Modules/Sources/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
+++ b/Modules/Sources/Yosemite/Tools/ProductVariations/VariationAttributeViewModel.swift
@@ -14,7 +14,7 @@ public struct VariationAttributeViewModel: Equatable {
     /// Returns the attribute value, e.g. "100g", or "Any \(name)" if the attribute value is nil or empty
     ///
     public var nameOrValue: String {
-        guard let value = value, !value.isEmpty else {
+        guard let value, !value.isEmpty else {
             return anyAttributeDescription
         }
         return value

--- a/Modules/Sources/YosemiteTestHelpers/MockStorageManager+Sample.swift
+++ b/Modules/Sources/YosemiteTestHelpers/MockStorageManager+Sample.swift
@@ -68,7 +68,7 @@ public extension MockStorageManager {
         let newProductVariation = viewStorage.insertNewObject(ofType: StorageProductVariation.self)
         newProductVariation.update(with: readOnlyProductVariation)
 
-        if let readOnlyProduct = readOnlyProduct {
+        if let readOnlyProduct {
             let newProduct = viewStorage.insertNewObject(ofType: StorageProduct.self)
             newProduct.update(with: readOnlyProduct)
             newProductVariation.product = newProduct

--- a/Modules/Sources/YosemiteTestHelpers/MockStorageManager.swift
+++ b/Modules/Sources/YosemiteTestHelpers/MockStorageManager.swift
@@ -74,7 +74,7 @@ open class MockStorageManager: StorageManagerType {
             }
 
             storeCoordinator.addPersistentStore(with: storeDescriptor) { (_, error) in
-                guard let error = error else {
+                guard let error else {
                     onCompletion?()
                     return
                 }

--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -222,7 +222,7 @@ final class OrdersRemoteTests: XCTestCase {
         // When
         let order: Order = waitFor { promise in
             remote.loadOrder(for: self.sampleSiteID, orderID: self.sampleOrderID) { order, error in
-                if let order = order {
+                if let order {
                     promise(order)
                 }
             }

--- a/Modules/Tests/NetworkingTests/Remote/ProductCategoriesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductCategoriesRemoteTests.swift
@@ -36,7 +36,7 @@ final class ProductCategoriesRemoteTests: XCTestCase {
 
         // When
         let result: (categories: [ProductCategory]?, error: Error?) = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -59,7 +59,7 @@ final class ProductCategoriesRemoteTests: XCTestCase {
 
         // When
         let result: (categories: [ProductCategory]?, error: Error?) = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -106,7 +106,7 @@ final class ProductCategoriesRemoteTests: XCTestCase {
 
         // When
         let result: Result<ProductCategory, Error>? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -168,7 +168,7 @@ final class ProductCategoriesRemoteTests: XCTestCase {
 
         // When
         let result: Result<ProductCategory, Error>? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -190,7 +190,7 @@ final class ProductCategoriesRemoteTests: XCTestCase {
 
         // When
         let result: Result<ProductCategory, Error>? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Tests/NetworkingTests/Remote/TaxRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/TaxRemoteTests.swift
@@ -31,7 +31,7 @@ final class TaxRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
 
         remote.loadAllTaxClasses(for: sampleSiteID) { [weak self] (taxClasses, error) in
-            guard let self = self else {
+            guard let self else {
                 expectation.fulfill()
                 return
             }

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockNotificationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockNotificationsRemote.swift
@@ -26,12 +26,12 @@ final class MockNotificationsRemote {
 extension MockNotificationsRemote: NotificationsRemoteProtocol {
 
     func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void) {
-        guard let noteIDs = noteIDs else {
+        guard let noteIDs else {
             return XCTFail("Expected noteIDs to not be nil.")
         }
 
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductReviewsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductReviewsRemote.swift
@@ -33,7 +33,7 @@ extension MockProductReviewsRemote: ProductReviewsRemoteProtocol {
                            reviewID: Int64,
                            completion: @escaping (Result<ProductReview, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductVariationsRemote.swift
@@ -117,7 +117,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
 
     func loadProductVariation(for siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -137,7 +137,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
                                  newVariation: CreateProductVariation,
                                  completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -161,7 +161,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
 
     func updateProductVariation(productVariation: ProductVariation, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -182,7 +182,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
                                      image: ProductImage,
                                      completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -202,7 +202,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
                                  productVariations: [ProductVariation],
                                  completion: @escaping (Result<[ProductVariation], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID,
                                 productID: productID,
@@ -217,7 +217,7 @@ extension MockProductVariationsRemote: ProductVariationsRemoteProtocol {
 
     func deleteProductVariation(siteID: Int64, productID: Int64, variationID: Int64, completion: @escaping (Result<ProductVariation, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -188,7 +188,7 @@ final class MockProductsRemote {
 extension MockProductsRemote: ProductsRemoteProtocol {
     func addProduct(product: Product, completion: @escaping (Result<Product, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -202,7 +202,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
 
     func deleteProduct(for siteID: Int64, productID: Int64, completion: @escaping (Result<Product, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -218,7 +218,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
                      productID: Int64,
                      completion: @escaping (Result<Product, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -352,7 +352,7 @@ extension MockProductsRemote: ProductsRemoteProtocol {
 
     func updateProductImages(siteID: Int64, productID: Int64, images: [ProductImage], completion: @escaping (Result<Product, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID, productIDs: [productID])
             if let result = self.updateProductImagesResultsBySiteID[key] {

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockShippingLabelRemote.swift
@@ -203,7 +203,7 @@ final class MockShippingLabelRemote {
 extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
     func loadShippingLabels(siteID: Int64, orderID: Int64, completion: @escaping (Result<OrderShippingLabelListResponse, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = LoadAllResultKey(siteID: siteID, orderID: orderID)
             if let result = self.loadAllResults[key] {
@@ -219,7 +219,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                             paperSize: ShippingLabelPaperSize,
                             completion: @escaping (Result<ShippingLabelPrintData, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = PrintResultKey(siteID: siteID, shippingLabelIDs: shippingLabelIDs, paperSize: paperSize.rawValue)
             if let result = self.printResults[key] {
@@ -232,7 +232,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
     func refundShippingLabel(siteID: Int64, orderID: Int64, shippingLabelID: Int64, completion: @escaping (Result<ShippingLabelRefund, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = RefundResultKey(siteID: siteID, orderID: orderID, shippingLabelID: shippingLabelID)
             if let result = self.refundResults[key] {
@@ -246,7 +246,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
     func addressValidation(siteID: Int64, address: ShippingLabelAddressVerification,
                            completion: @escaping (Result<ShippingLabelAddressValidationSuccess, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = AddressValidationResultKey(siteID: siteID)
             if let result = self.addressValidationResults[key] {
@@ -259,7 +259,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
     func packagesDetails(siteID: Int64, completion: @escaping (Result<ShippingLabelPackagesResponse, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = PackagesDetailsResultKey(siteID: siteID)
             if let result = self.packagesDetailsResults[key] {
@@ -275,7 +275,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                        predefinedOption: ShippingLabelPredefinedOption?,
                        completion: @escaping (Result<Bool, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = CreatePackageResultKey(siteID: siteID)
             if let result = self.createPackageResults[key] {
@@ -293,7 +293,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                               packages: [ShippingLabelPackageSelected],
                               completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let key = LoadCarriersAndRatesKey(siteID: siteID)
 
             if let result = self.loadCarriersAndRatesResults[key] {
@@ -306,7 +306,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
 
     func loadShippingLabelAccountSettings(siteID: Int64, completion: @escaping (Result<ShippingLabelAccountSettings, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = LoadAccountSettingsResultKey(siteID: siteID)
             if let result = self.loadAccountSettings[key] {
@@ -321,7 +321,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                                             settings: ShippingLabelAccountSettings,
                                             completion: @escaping (Result<Bool, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = UpdateAccountSettingsResultKey(siteID: siteID)
             if let result = self.updateAccountSettings[key] {
@@ -336,7 +336,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                                   orderID: Int64,
                                   completion: @escaping (Result<ShippingLabelCreationEligibilityResponse, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = CreationEligibilityResultKey(siteID: siteID,
                                                    orderID: orderID)
@@ -356,7 +356,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                                emailCustomerReceipt: Bool,
                                completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = PurchaseShippingLabelResultKey(siteID: siteID)
             if let result = self.purchaseShippingLabelResults[key] {
@@ -373,7 +373,7 @@ extension MockShippingLabelRemote: ShippingLabelRemoteProtocol {
                           labelIDs: [Int64],
                           completion: @escaping (Result<[ShippingLabelStatusPollingResponse], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = CheckLabelStatusResultKey(siteID: siteID)
             if let result = self.checkLabelStatusResults[key] {

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockWooShippingRemote.swift
@@ -233,7 +233,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                                   orderID: Int64,
                                   completion: @escaping (Result<Networking.ShippingLabelCreationEligibilityResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.checkEligibilityResults[key] {
@@ -249,7 +249,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                        predefinedOption: Networking.WooShippingPredefinedSavedOption?,
                        completion: @escaping (Result<Networking.WooShippingCreatePackageResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.createPackageResults[key] {
@@ -265,7 +265,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                        packageType: WooShippingPackageType,
                        completion: @escaping (Result<Networking.WooShippingCreatePackageResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.deletePackageResults[key] {
@@ -283,7 +283,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                         packages: [ShippingLabelPackageSelected],
                         completion: @escaping (Result<[ShippingLabelCarriersAndRates], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadLabelRatesResults[key] {
@@ -297,7 +297,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
     func loadPackages(siteID: Int64,
                       completion: @escaping (Result<Networking.WooShippingPackagesResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadPackagesResults[key] {
@@ -311,7 +311,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
     func loadAccountSettings(siteID: Int64,
                              completion: @escaping (Result<WooShippingAccountSettings, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadAccountSettingsResults[key] {
@@ -345,7 +345,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                                markOrderComplete: Bool?,
                                completion: @escaping (Result<[ShippingLabelPurchase], Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.purchaseShippingLabelResults[key] {
@@ -362,7 +362,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                           labelID: Int64,
                           completion: @escaping (Result<ShippingLabelStatusPollingResponse, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.checkLabelStatus[key] {
@@ -379,7 +379,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                     paperSize: Networking.ShippingLabelPaperSize,
                     completion: @escaping (Result<Networking.ShippingLabelPrintData, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.printLabel[key] {
@@ -393,7 +393,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
     func loadOriginAddresses(siteID: Int64,
                              completion: @escaping (Result<[Networking.WooShippingOriginAddress], any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadOriginAddresses[key] {
@@ -408,7 +408,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                            address: WooShippingAddress,
                            completion: @escaping (Result<WooShippingAddressValidationSuccess, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.addressValidation[key] {
@@ -424,7 +424,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                              isVerified: Bool,
                              completion: @escaping (Result<WooShippingOriginAddressUpdate, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.updateOriginAddress[key] {
@@ -439,7 +439,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                                   orderID: Int64,
                                   completion: @escaping (Result<WooShippingVerifyDestinationAddressSuccess, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.verifyDestinationAddress[key] {
@@ -456,7 +456,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                                   isVerified: Bool,
                                   completion: @escaping (Result<WooShippingDestinationAddressUpdate, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.updateDestinationAddress[key] {
@@ -471,7 +471,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                     orderID: Int64,
                     completion: @escaping (Result<WooShippingConfig, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.loadConfig[key] {
@@ -487,7 +487,7 @@ extension MockWooShippingRemote: WooShippingRemoteProtocol {
                         shipmentToUpdate: WooShippingUpdateShipment,
                         completion: @escaping (Result<WooShippingShipments, any Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let key = ResultKey(siteID: siteID)
             if let result = self.updateShipment[key] {

--- a/Modules/Tests/YosemiteTests/Stores/InboxNotesStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/InboxNotesStoreTests.swift
@@ -68,7 +68,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `loadAllInboxNotes` action
         let result: Result<[Networking.InboxNote], Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -93,7 +93,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `loadAllInboxNotes` action
         let result: Result<[Networking.InboxNote], Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -122,7 +122,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `loadAllInboxNotes` action
         let result: Result<[Networking.InboxNote], Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -143,7 +143,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `loadAllInboxNotes` action
         let result: Result<[Networking.InboxNote], Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -166,7 +166,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissInboxNote` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -191,7 +191,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissInboxNote` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -214,7 +214,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissInboxNote` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -236,7 +236,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissInboxNote` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -258,7 +258,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissAllInboxNotes` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -284,7 +284,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissAllInboxNotes` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -306,7 +306,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissAllInboxNotes` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -327,7 +327,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `dismissAllInboxNotes` action
         let result: Result<Void, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -353,7 +353,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `markInboxNoteAsActioned` action
         let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -381,7 +381,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `markInboxNoteAsActioned` action
         let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -404,7 +404,7 @@ final class InboxNotesStoreTests: XCTestCase {
 
         // When dispatching a `markInboxNoteAsActioned` action
         let result: Result<Networking.InboxNote, Error> = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Tests/YosemiteTests/Stores/MediaStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/MediaStoreTests.swift
@@ -736,7 +736,7 @@ private extension MediaStoreTests {
 
         let uploadableMedia = createSampleUploadableMedia(targetURL: targetURL)
         let mediaExportService = MockMediaExportService(uploadableMedia: uploadableMedia)
-        if let remote = remote {
+        if let remote {
             return MediaStore(mediaExportService: mediaExportService,
                               dispatcher: dispatcher,
                               storageManager: storageManager,

--- a/Modules/Tests/YosemiteTests/Stores/OrderNoteStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderNoteStoreTests.swift
@@ -64,7 +64,7 @@ class OrderNoteStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/notes/", filename: "order-notes")
         let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { (orderNotes, error) in
             XCTAssertNil(error)
-            guard let orderNotes = orderNotes else {
+            guard let orderNotes else {
                 XCTFail()
                 return
             }

--- a/Modules/Tests/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -73,7 +73,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeProductCategories` action
         let errorResponse: ProductCategoryActionError? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -98,7 +98,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeProductCategories` action
         let errorResponse: ProductCategoryActionError? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -123,7 +123,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeProductCategories` action
         let errorResponse: ProductCategoryActionError? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -151,7 +151,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeProductCategories` action
         let errorResponse: ProductCategoryActionError? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -183,7 +183,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeProductCategories` action
         let errorResponse: ProductCategoryActionError? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -204,7 +204,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeProductCategories` action
         let errorResponse: ProductCategoryActionError? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -296,7 +296,7 @@ final class ProductCategoryStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/categories", filename: "categories-empty")
 
         let _: Bool = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -315,7 +315,7 @@ final class ProductCategoryStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/categories/\(categoryID)", filename: "category")
 
         let addedCategory: Storage.ProductCategory? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -334,7 +334,7 @@ final class ProductCategoryStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "products/categories/\(categoryID)", filename: "category")
 
         let result: Result<Networking.ProductCategory, Error>? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -353,7 +353,7 @@ final class ProductCategoryStoreTests: XCTestCase {
         network.simulateError(requestUrlSuffix: "products/categories/\(categoryID)", error: DotcomError.resourceDoesNotExist())
 
         let retrievedError: Error? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/Modules/Tests/YosemiteTests/Stores/ProductStore+FilterProductsTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStore+FilterProductsTests.swift
@@ -55,7 +55,7 @@ final class ProductStore_FilterProductsTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let _: Bool = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 XCTFail()
                 return
             }
@@ -84,7 +84,7 @@ final class ProductStore_FilterProductsTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let _: Bool = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 XCTFail()
                 return
             }
@@ -113,7 +113,7 @@ final class ProductStore_FilterProductsTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let _: Bool = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 XCTFail()
                 return
             }
@@ -142,7 +142,7 @@ final class ProductStore_FilterProductsTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let _: Bool = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 XCTFail()
                 return
             }
@@ -173,7 +173,7 @@ final class ProductStore_FilterProductsTests: XCTestCase {
         let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         let _: Bool = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 XCTFail()
                 return
             }
@@ -326,7 +326,7 @@ private extension ProductStore_FilterProductsTests {
         }
 
         let stockStatusParameter = "stock_status"
-        if let stockStatusValue = stockStatusValue {
+        if let stockStatusValue {
             let expectedParam = "\(stockStatusParameter)=\(stockStatusValue)"
             XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {
@@ -334,7 +334,7 @@ private extension ProductStore_FilterProductsTests {
         }
 
         let productStatusParameter = "status"
-        if let productStatusValue = productStatusValue {
+        if let productStatusValue {
             let expectedParam = "\(productStatusParameter)=\(productStatusValue)"
             XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {
@@ -342,7 +342,7 @@ private extension ProductStore_FilterProductsTests {
         }
 
         let productTypeParameter = "type"
-        if let productTypeValue = productTypeValue {
+        if let productTypeValue {
             let expectedParam = "\(productTypeParameter)=\(productTypeValue)"
             XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {
@@ -350,7 +350,7 @@ private extension ProductStore_FilterProductsTests {
         }
 
         let productCategoryParameter = "category"
-        if let productCategoryValue = productCategoryValue {
+        if let productCategoryValue {
             let expectedParam = "\(productCategoryParameter)=\(productCategoryValue)"
             XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
         } else {

--- a/Modules/Tests/YosemiteTests/Stores/ProductStore+ProductsSortOrderTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStore+ProductsSortOrderTests.swift
@@ -56,7 +56,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productType: nil,
                                                        productCategory: nil,
                                                        sortOrder: .nameAscending) { [weak self] error in
-                                                        guard let self = self else {
+                                                        guard let self else {
                                                             XCTFail()
                                                             return
                                                         }
@@ -81,7 +81,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productType: nil,
                                                        productCategory: nil,
                                                        sortOrder: .nameDescending) { [weak self] error in
-                                                        guard let self = self else {
+                                                        guard let self else {
                                                             XCTFail()
                                                             return
                                                         }
@@ -106,7 +106,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productType: nil,
                                                        productCategory: nil,
                                                        sortOrder: .dateAscending) { [weak self] error in
-                                                        guard let self = self else {
+                                                        guard let self else {
                                                             XCTFail()
                                                             return
                                                         }
@@ -131,7 +131,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productType: nil,
                                                        productCategory: nil,
                                                        sortOrder: .dateDescending) { [weak self] error in
-                                                        guard let self = self else {
+                                                        guard let self else {
                                                             XCTFail()
                                                             return
                                                         }

--- a/Modules/Tests/YosemiteTests/Stores/TaxStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/TaxStoreTests.swift
@@ -199,7 +199,7 @@ final class TaxStoreTests: XCTestCase {
 
         // When
         let result: Result<[Yosemite.TaxRate], Error> = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let action = TaxAction.retrieveTaxRates(siteID: self.sampleSiteID, pageNumber: 1, pageSize: 25) { result in
                 promise(result)
@@ -218,7 +218,7 @@ final class TaxStoreTests: XCTestCase {
 
         // When
         let result: Result<Yosemite.TaxRate, Error> = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let action = TaxAction.retrieveTaxRate(siteID: self.sampleSiteID, taxRateID: taxRateID) { result in
                 promise(result)

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -229,7 +229,7 @@ private extension Analytics {
         let properties: [AnyHashable: Any]?
         let errorProperties = errorProperties(from: error)
 
-        if let passedProperties = passedProperties {
+        if let passedProperties {
             properties = passedProperties.merging(errorProperties ?? [:], uniquingKeysWith: { current, _ in
                 current
             })
@@ -240,7 +240,7 @@ private extension Analytics {
     }
 
     func errorProperties(from error: Error?) -> [AnyHashable: Any]? {
-        guard let error = error else {
+        guard let error else {
             return nil
         }
 
@@ -300,7 +300,7 @@ private extension WooAnalytics {
 
     @objc func trackApplicationOpened() {
         WidgetCenter.shared.getCurrentConfigurations { [weak self] configurationResult in
-            guard let self = self else { return }
+            guard let self else { return }
             self.track(.applicationOpened, withProperties: self.applicationOpenedProperties(configurationResult))
         }
         applicationOpenedTime = Date()
@@ -312,7 +312,7 @@ private extension WooAnalytics {
     }
 
     func applicationClosedProperties() -> [String: Any]? {
-        guard let applicationOpenedTime = applicationOpenedTime else {
+        guard let applicationOpenedTime else {
             return nil
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
@@ -37,11 +37,11 @@ extension WooAnalyticsEvent {
                 Keys.isLowPowerMode: isLowPowerMode
             ]
 
-            if let backgroundTimeGranted = backgroundTimeGranted {
+            if let backgroundTimeGranted {
                 properties[Keys.backgroundTimeGranted] = Int64(backgroundTimeGranted)
             }
 
-            if let timeSinceLastRun = timeSinceLastRun {
+            if let timeSinceLastRun {
                 properties[Keys.timeSinceLastRun] = Int64(timeSinceLastRun)
             }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -1382,7 +1382,7 @@ extension WooAnalyticsEvent {
                                                                        Keys.paymentMethod: method.rawValue,
                                                                        Keys.orderID: orderID]
 
-            if let cardReaderType = cardReaderType {
+            if let cardReaderType {
                 properties[Keys.cardReaderType] = cardReaderType.rawValue
             }
 
@@ -1421,7 +1421,7 @@ extension WooAnalyticsEvent {
                 Keys.currency: currency
             ]
 
-            if let cardReaderType = cardReaderType {
+            if let cardReaderType {
                 properties[Keys.cardReaderType] = cardReaderType.rawValue
             }
 
@@ -1630,7 +1630,7 @@ extension WooAnalyticsEvent {
                 Keys.connectionType: connectionType
             ]
 
-            if let batteryLevel = batteryLevel {
+            if let batteryLevel {
                 properties[Keys.batteryLevel] = String(format: "%.2f", batteryLevel)
             }
 
@@ -3115,7 +3115,7 @@ extension WooAnalyticsEvent {
         static func productSearchViaSKUSuccess(from source: String, stockManaged: Bool? = nil) -> WooAnalyticsEvent {
             var properties = [Keys.source: source]
 
-            if let stockManaged = stockManaged {
+            if let stockManaged {
                 properties["stock_managed"] = "\(stockManaged)"
             }
             return WooAnalyticsEvent(statName: .orderProductSearchViaSKUSuccess, properties: properties)
@@ -3124,7 +3124,7 @@ extension WooAnalyticsEvent {
         static func productSearchViaGlobalUniqueIDSuccess(from source: String, stockManaged: Bool? = nil) -> WooAnalyticsEvent {
             var properties = [Keys.source: source]
 
-            if let stockManaged = stockManaged {
+            if let stockManaged {
                 properties["stock_managed"] = "\(stockManaged)"
             }
             return WooAnalyticsEvent(statName: .orderProductSearchViaGlobalUniqueIdentifierSuccess, properties: properties)
@@ -3137,7 +3137,7 @@ extension WooAnalyticsEvent {
             var properties = [Keys.source: source,
                               Keys.reason: reason]
 
-            if let symbology = symbology {
+            if let symbology {
                 properties[Keys.barcodeFormat] = symbology.rawValue
             }
 

--- a/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
+++ b/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
@@ -83,7 +83,7 @@ private extension AppleIDCredentialChecker {
             default:
                 // An error exists only for the notFound state.
                 // notFound is a valid state when logging in with an Apple account for the first time.
-                if let error = error {
+                if let error {
                     DDLogDebug("checkAppleIDCredentialState: Apple ID state not found: \(error.localizedDescription)")
                 }
                 break
@@ -95,7 +95,7 @@ private extension AppleIDCredentialChecker {
 private extension AppleIDCredentialChecker {
     func startObservingAppleIDCredentialRevoked() {
         authenticator.startObservingAppleIDCredentialRevoked { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             // The user could have SIWA'ed earlier then changed to authenticate with another method, and thus the app still receives notifications on

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -94,7 +94,7 @@ class AuthenticationManager: Authentication {
     func authenticationUI() -> UIViewController {
         let loginViewController: UIViewController = {
             let loginUI = WordPressAuthenticator.loginUI(onLoginButtonTapped: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 // Resets Apple ID at the beginning of the authentication.
                 self.appleUserID = nil
 
@@ -330,7 +330,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                                          isJetpackActive: siteInfo?.isJetpackActive ?? false,
                                                          isJetpackConnected: siteInfo?.isJetpackConnected ?? false))
 
-        guard let site = siteInfo, let navigationController = navigationController else {
+        guard let site = siteInfo, let navigationController else {
             navigationController?.show(noWPUI, sender: nil)
             return
         }
@@ -562,7 +562,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         // If Apple ID is previously set, saves it to Keychain now that authentication is complete.
-        if let appleUserID = appleUserID {
+        if let appleUserID {
             keychain.wooAppleID = appleUserID
         }
         appleUserID = nil
@@ -661,7 +661,7 @@ private extension AuthenticationManager {
         let viewModel = JetpackErrorViewModel(siteURL: siteURL,
                                               siteCredentials: credentials.wporg,
                                               onJetpackSetupCompletion: { [weak self] authorizedEmailAddress in
-            guard let self = self else { return }
+            guard let self else { return }
             // Resets the referenced site since the setup completed now.
             self.currentSelfHostedSite = nil
             guard credentials.wpcom != nil else {
@@ -692,7 +692,7 @@ private extension AuthenticationManager {
                                                         config: config,
                                                         switchStoreUseCase: switchStoreUseCase)
         storePickerCoordinator?.onDismiss = onDismiss
-        if let siteID = siteID {
+        if let siteID {
             storePickerCoordinator?.didSelectStore(with: siteID, onCompletion: onDismiss)
         } else {
             storePickerCoordinator?.start()
@@ -736,7 +736,7 @@ private extension AuthenticationManager {
             site: site,
             showsConnectedStores: matcher.hasConnectedStores,
             onSetupCompletion: { [weak self] siteID in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.startStorePicker(with: siteID, in: navigationController, onDismiss: onStorePickerDismiss)
         })
         let noWooUI = ULErrorViewController(viewModel: viewModel)

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -113,7 +113,7 @@ private extension StorePickerCoordinator {
     /// After successfully switching, the store picker screen should be dismissed.
     func switchStore(with storeID: Int64, onCompletion: @escaping SelectStoreClosure) {
         switchStoreUseCase.switchStore(with: storeID) { [weak self] siteChanged in
-            guard let self = self else { return }
+            guard let self else { return }
             if self.selectedConfiguration == .login {
                 MainTabBarController.switchToMyStoreTab(animated: true)
             }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -152,7 +152,7 @@ final class StorePickerViewController: UIViewController {
 
     private lazy var closeAccountCoordinator: CloseAccountCoordinator =
     CloseAccountCoordinator(sourceViewController: self) { [weak self] in
-        guard let self = self else { throw CloseAccountError.presenterDeallocated }
+        guard let self else { throw CloseAccountError.presenterDeallocated }
         return try await self.closeAccount()
     } onRemoveSuccess: { [weak self] in
         self?.restartAuthentication()
@@ -295,7 +295,7 @@ private extension StorePickerViewController {
 
     func observeStateChange() {
         viewModel.$state.sink { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.preselectStoreIfPossible()
             self.reloadInterface()
             self.updateFooterViewIfNeeded()
@@ -784,7 +784,7 @@ extension StorePickerViewController: UITableViewDelegate {
 private extension StorePickerViewController {
     func closeAccount() async throws {
         try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self = self else { return }
+            guard let self else { return }
             let action = AccountAction.closeAccount { result in
                 continuation.resume(with: result)
             }
@@ -804,7 +804,7 @@ private extension StorePickerViewController {
             site: site,
             showsConnectedStores: false, // avoid looping from store picker > no woo > store picker
             onSetupCompletion: { [weak self] siteID in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.navigationController?.popViewController(animated: true)
                 self.viewModel.refreshSites(currentlySelectedSiteID: siteID)
                 self.delegate?.didSelectStore(with: siteID) { [weak self] in
@@ -817,14 +817,14 @@ private extension StorePickerViewController {
     }
 
     func checkRoleEligibility(for site: Site) {
-        guard let delegate = delegate else {
+        guard let delegate else {
             return
         }
 
         updateActionButtonAndTableState(animating: true, enabled: false)
 
         viewModel.checkEligibility(for: site.siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.updateActionButtonAndTableState(animating: false, enabled: true)
 

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -33,7 +33,7 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
     @MainActor
     func switchStore(with storeID: Int64) async -> Bool {
         await withCheckedContinuation { [weak self] continuation in
-            guard let self = self else { return }
+            guard let self else { return }
             self.switchStore(with: storeID) { siteChanged in
                 continuation.resume(returning: siteChanged)
             }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
@@ -88,7 +88,7 @@ private extension LoginJetpackSetupCoordinator {
 
         // Tries re-syncing to get an updated store list
         stores.synchronizeEntities { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let matcher = ULAccountMatcher()
             matcher.refreshStoredSites()
             guard let matchedSite = matcher.matchedSite(originalURL: self.siteURL) else {
@@ -142,7 +142,7 @@ private extension LoginJetpackSetupCoordinator {
             site: site,
             showsConnectedStores: false, // avoid looping from store picker > no woo > store picker
             onSetupCompletion: { [weak self] siteID in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.navigationController.popViewController(animated: true)
                 self.storePickerCoordinator?.didSelectStore(with: siteID, onCompletion: {})
         })

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackErrorViewModel.swift
@@ -62,7 +62,7 @@ struct JetpackErrorViewModel: ULErrorViewModel {
     }
 
     private func showJetpackSetupScreen(in viewController: UIViewController?) {
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
 
@@ -96,7 +96,7 @@ struct JetpackErrorViewModel: ULErrorViewModel {
     }
 
     func didTapRightBarButtonItem(in viewController: UIViewController?) {
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         authentication.presentSupport(from: viewController, screen: .jetpackRequired, siteURL: URL(string: siteURL))

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupRequiredViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/JetpackSetupRequiredViewModel.swift
@@ -123,7 +123,7 @@ final class JetpackSetupRequiredViewModel: ULErrorViewModel {
     }
 
     func didTapRightBarButtonItem(in viewController: UIViewController?) {
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         authentication.presentSupport(from: viewController, screen: .jetpackRequired, siteURL: URL(string: siteURL))

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NoWooErrorViewModel.swift
@@ -68,11 +68,11 @@ final class NoWooErrorViewModel: ULErrorViewModel {
     // MARK: - Actions
     func didTapPrimaryButton(in viewController: UIViewController?) {
         analytics.track(.loginWooCommerceSetupButtonTapped)
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         let viewModel = WooSetupWebViewModel(siteURL: site.url, onCompletion: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             viewController.navigationController?.popViewController(animated: true)
             self.showInProgressView(in: viewController)
             self.handleSetupCompletion(in: viewController)
@@ -99,7 +99,7 @@ final class NoWooErrorViewModel: ULErrorViewModel {
     }
 
     func didTapRightBarButtonItem(in viewController: UIViewController?) {
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         authentication.presentSupport(from: viewController, screen: .noWooError, siteURL: URL(string: site.url))
@@ -114,7 +114,7 @@ final class NoWooErrorViewModel: ULErrorViewModel {
 private extension NoWooErrorViewModel {
     func handleSetupCompletion(in viewController: UIViewController, retryCount: Int = 0) {
         let action = AccountAction.synchronizeSites(selectedSiteID: site.siteID) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let matcher = ULAccountMatcher()
             matcher.refreshStoredSites()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/NotWPAccountViewModel.swift
@@ -70,7 +70,7 @@ final class NotWPAccountViewModel: ULErrorViewModel {
 private extension NotWPAccountViewModel {
     func whatIsWPComButtonTapped() {
         analytics.track(.whatIsWPComOnInvalidEmailScreenTapped)
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         WebviewHelper.launch(WooConstants.URLs.whatIsWPCom.asURL(), with: viewController)

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/RoleErrorViewModel.swift
@@ -60,7 +60,7 @@ final class RoleErrorViewModel {
     func didTapPrimaryButton() {
         output?.updatePrimaryButtonState(loading: true)
         roleEligibilityUseCase.checkEligibility(for: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.output?.updatePrimaryButtonState(loading: false)
 
             switch result {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -198,7 +198,7 @@ private extension ULErrorViewController {
         // We need to wait until view did appear to make sure the indicator stays at the correct position
         primaryButtonSubscription = viewModel.isPrimaryButtonLoading.combineLatest(viewDidAppearSubject.prefix(1))
             .sink { [weak self] (isLoading, _) in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.primaryButton.isEnabled = !isLoading
                 if isLoading {
                     self.primaryButton.showActivityIndicator()

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -128,7 +128,7 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         analytics.track(.loginJetpackConnectButtonTapped)
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
 
@@ -161,7 +161,7 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
     }
 
     func didTapRightBarButtonItem(in viewController: UIViewController?) {
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         authentication.presentSupport(from: viewController, screen: .wrongAccountError, siteURL: URL(string: siteURL))
@@ -216,7 +216,7 @@ private extension WrongAccountErrorViewModel {
     func fetchSiteInfo() {
         primaryButtonLoading = true
         authenticatorType.fetchSiteInfo(for: siteURL) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.primaryButtonLoading = false
 
             switch result {

--- a/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoggedOutAppSettingsProtocol.swift
@@ -33,7 +33,7 @@ extension LoggedOutAppSettings: LoggedOutAppSettingsProtocol {
     }
 
     func setErrorLoginSiteAddress(_ address: String?) {
-        if let address = address {
+        if let address {
             userDefaults.set(address, forKey: .errorLoginSiteAddress)
         } else {
             userDefaults.removeObject(forKey: .errorLoginSiteAddress)

--- a/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
+++ b/WooCommerce/Classes/Authentication/Prologue/LoginOnboardingViewController.swift
@@ -124,7 +124,7 @@ private extension LoginOnboardingViewController {
         button.applyPrimaryButtonStyle()
         button.setTitle(Localization.continueButtonTitle, for: .normal)
         button.on(.touchUpInside) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
 
             guard self.pageViewController.goToNextPageIfPossible() else {
                 return self.onDismiss(.next)

--- a/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
+++ b/WooCommerce/Classes/Authentication/RoleEligibilityUseCase.swift
@@ -56,7 +56,7 @@ extension RoleEligibilityUseCase: RoleEligibilityUseCaseProtocol {
         }
 
         let action = UserAction.retrieveUser(siteID: storeID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let user):
                 let roles = user.roles.compactMap { User.Role(rawValue: $0) }

--- a/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
+++ b/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
@@ -168,7 +168,7 @@ class WebKitViewController: UIViewController {
     }
 
     @objc func loadWebViewRequest() {
-        guard let url = url else {
+        guard let url else {
             return
         }
 
@@ -285,9 +285,9 @@ class WebKitViewController: UIViewController {
     /// - Parameter width: The width value to set the webView to
     /// - Parameter viewWidth: The view width the webView must fit within, used to manage view transitions, e.g. orientation change
     func setWidth(_ width: CGFloat?, viewWidth: CGFloat? = nil) {
-        if let width = width {
+        if let width {
             let horizontalViewBound: CGFloat
-            if let viewWidth = viewWidth {
+            if let viewWidth {
                 horizontalViewBound = viewWidth
             } else if let superViewWidth = view.superview?.frame.width {
                 horizontalViewBound = superViewWidth
@@ -357,7 +357,7 @@ class WebKitViewController: UIViewController {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let object = object as? WKWebView,
             object == webView,
-            let keyPath = keyPath else {
+            let keyPath else {
                 return
         }
 

--- a/WooCommerce/Classes/Authentication/WebAuth/WebProgressView.swift
+++ b/WooCommerce/Classes/Authentication/WebAuth/WebProgressView.swift
@@ -40,7 +40,7 @@ class WebProgressView: UIProgressView {
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let webView = object as? WKWebView,
-            let keyPath = keyPath else {
+            let keyPath else {
                 return
         }
 

--- a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
+++ b/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
@@ -149,7 +149,7 @@ private extension BlazeCampaignCreationCoordinator {
     /// For native Blaze campaign creation, determine destination based existence of productID, or if not then
     /// based on number of eligible products.
     func determineDestination() -> CreateCampaignDestination {
-        if let productID = productID {
+        if let productID {
             return .campaignForm(productID: productID)
         } else {
             let fetchedObjects = productResultsController.fetchedObjects

--- a/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
+++ b/WooCommerce/Classes/Bookings/BookingList/BookingListContainerViewModel.swift
@@ -250,7 +250,7 @@ private extension BookingListContainerViewModel {
             dateRange: filters.dateRange
         )
         let action = AppSettingsAction.upsertBookingFilters(siteID: siteID, filters: persistedFilters) { error in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error saving booking filters: \(error)")
             }
         }

--- a/WooCommerce/Classes/Extensions/Optional+String.swift
+++ b/WooCommerce/Classes/Extensions/Optional+String.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Optional where Wrapped == String {
     var isNilOrEmpty: Bool {
-        guard let self = self else {
+        guard let self else {
             return true
         }
         return self.isEmpty

--- a/WooCommerce/Classes/Extensions/UIViewController+AppReview.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+AppReview.swift
@@ -31,7 +31,7 @@ private extension UIViewController {
             return window.windowScene
         }
 
-        if let parent = parent {
+        if let parent {
             return parent.currentScene
         }
 

--- a/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIViewController+Helpers.swift
@@ -24,7 +24,7 @@ extension UIViewController {
         /// We can't make self the default value for the `target` parameter without a warning being added.
         /// The compiler-recommended fix for the warning causes a crash when the button is tapped.
         let targetOrSelf = target ?? self
-        if let title = title {
+        if let title {
             navigationItem.leftBarButtonItem = UIBarButtonItem(title: title, style: .plain, target: targetOrSelf, action: action)
         }
         else {

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -81,7 +81,7 @@ private extension DefaultGoogleAdsEligibilityChecker {
     }
 
     func checkIfGoogleAdsIsSupported(plugin: SystemPlugin?) -> Bool {
-        guard let plugin = plugin, plugin.active else {
+        guard let plugin, plugin.active else {
             return false
         }
         return VersionHelpers.isVersionSupported(version: plugin.version,

--- a/WooCommerce/Classes/JustInTimeMessages/JustInTimeMessagesProvider.swift
+++ b/WooCommerce/Classes/JustInTimeMessages/JustInTimeMessagesProvider.swift
@@ -31,7 +31,7 @@ final class JustInTimeMessagesProvider {
                 siteID: siteID,
                 screen: source,
                 hook: .adminNotices) { [weak self] result in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     switch result {
                     case let .success(messages):
                         guard let message = messages.first else {

--- a/WooCommerce/Classes/Model/Address+Shared.swift
+++ b/WooCommerce/Classes/Model/Address+Shared.swift
@@ -61,7 +61,7 @@ private extension Address {
     /// Per US Post Office standardized rules for address lines. Ref. https://pe.usps.com/text/pub28/28c2_001.htm
     ///
     var combinedAddress: String {
-        guard let address2 = address2, address2.isEmpty == false else {
+        guard let address2, address2.isEmpty == false else {
             return address1
         }
 

--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -14,7 +14,7 @@ extension Address {
         if fullName.isEmpty == false {
             output.append(fullName)
         }
-        if let company = company, company.isEmpty == false {
+        if let company, company.isEmpty == false {
             output.append(company)
         }
 
@@ -27,7 +27,7 @@ extension Address {
     var fullNameWithCompanyAndAddress: String {
         var output: [String] = [fullNameWithCompany]
 
-        if let formattedPostalAddress = formattedPostalAddress, formattedPostalAddress.isEmpty == false {
+        if let formattedPostalAddress, formattedPostalAddress.isEmpty == false {
             output.append(formattedPostalAddress)
         }
 

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
@@ -11,7 +11,7 @@ extension MarkOrderAsReadUseCase {
     static func markOrderNoteAsReadIfNeeded(stores: StoresManager, noteID: Int64, orderID: Int) async -> Result<Note, Error> {
         let syncronizedNoteResult: Result<Note, Error> = await withCheckedContinuation { continuation in
             let action = NotificationAction.synchronizeNotification(noteID: noteID) { syncronizedNote, error in
-                guard let syncronizedNote = syncronizedNote else {
+                guard let syncronizedNote else {
                     continuation.resume(returning: .failure(MarkOrderAsReadUseCase.Error.unavailableNote))
                     return
                 }

--- a/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
@@ -13,7 +13,7 @@ extension ShippingLabelAddress {
     var fullNameWithCompanyAndAddress: String {
         var output: [String] = [fullNameWithCompany]
 
-        if let formattedPostalAddress = formattedPostalAddress, formattedPostalAddress.isNotEmpty {
+        if let formattedPostalAddress, formattedPostalAddress.isNotEmpty {
             output.append(formattedPostalAddress)
         }
 

--- a/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelPackageItem.swift
@@ -61,12 +61,12 @@ extension ShippingLabelPackageItem {
         let product = products.first { $0.productID == orderItem.productID }
         let productVariation = productVariations.first { $0.productVariationID == orderItem.variationID }
 
-        if isVariation, let productVariation = productVariation, !productVariation.virtual {
+        if isVariation, let productVariation, !productVariation.virtual {
             self.productOrVariationID = productVariation.productVariationID
             self.weight = Double(productVariation.weight ?? "0") ?? 0
             self.dimensions = productVariation.dimensions
             self.imageURL = productVariation.imageURL
-        } else if let product = product, !product.virtual {
+        } else if let product, !product.virtual {
             self.productOrVariationID = product.productID
             self.weight = Double(product.weight ?? "0") ?? 0
             self.dimensions = product.dimensions

--- a/WooCommerce/Classes/Model/ShippingLabelSelectedRate.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelSelectedRate.swift
@@ -19,27 +19,27 @@ struct ShippingLabelSelectedRate: GeneratedCopiable {
 
 extension ShippingLabelSelectedRate {
     var retailRate: Double {
-        if let signatureRate = signatureRate {
+        if let signatureRate {
             return signatureRate.retailRate
-        } else if let adultSignatureRate = adultSignatureRate {
+        } else if let adultSignatureRate {
             return adultSignatureRate.retailRate
         }
         return rate.retailRate
     }
 
     var discount: Double {
-        if let signatureRate = signatureRate {
+        if let signatureRate {
             return signatureRate.rate - signatureRate.retailRate
-        } else if let adultSignatureRate = adultSignatureRate {
+        } else if let adultSignatureRate {
             return adultSignatureRate.rate - adultSignatureRate.retailRate
         }
         return rate.rate - rate.retailRate
     }
 
     var totalRate: Double {
-        if let signatureRate = signatureRate {
+        if let signatureRate {
             return signatureRate.rate
-        } else if let adultSignatureRate = adultSignatureRate {
+        } else if let adultSignatureRate {
             return adultSignatureRate.rate
         }
         return rate.rate

--- a/WooCommerce/Classes/Model/StorageNote+Woo.swift
+++ b/WooCommerce/Classes/Model/StorageNote+Woo.swift
@@ -21,7 +21,7 @@ extension StorageNote {
     /// Returns the Timestamp as a Date instance. If parsing fails, this method returns now()
     ///
     private var timestampAsDate: Date {
-        guard let timestamp = timestamp, let parsed = DateFormatter.Defaults.iso8601.date(from: timestamp) else {
+        guard let timestamp, let parsed = DateFormatter.Defaults.iso8601.date(from: timestamp) else {
             return Date()
         }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -300,7 +300,7 @@ extension PushNotificationsManager {
         if stores.isAuthenticatedWithoutWPCom == false {
             group.enter()
             unregisterDotcomDeviceIfPossible() { error in
-                if let error = error {
+                if let error {
                     DDLogError("⛔️ Unable to unregister from WordPress.com Push Notifications: \(error)")
                 } else {
                     DDLogInfo("📱 Successfully unregistered from WordPress.com Push Notifications!")
@@ -319,7 +319,7 @@ extension PushNotificationsManager {
     /// Resets the Badge Count.
     ///
     func resetBadgeCount(type: Note.Kind) {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
         let action = NotificationCountAction.reset(siteID: siteID, type: type) { [weak self] in
@@ -330,7 +330,7 @@ extension PushNotificationsManager {
 
     func resetBadgeCountForAllStores(onCompletion: @escaping () -> Void) {
         let action = NotificationCountAction.resetForAllSites() { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.configuration.application.applicationIconBadgeNumber = AppIconBadgeNumber.clearsBadgeAndPotentiallyAllPushNotifications
             self.removeAllNotifications()
             onCompletion()
@@ -339,7 +339,7 @@ extension PushNotificationsManager {
     }
 
     func reloadBadgeCount() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
         loadNotificationCountAndUpdateApplicationBadgeNumber(siteID: siteID, type: nil, postNotifications: true)
@@ -495,7 +495,7 @@ extension PushNotificationsManager {
                                           subtitle: foregroundNotification.subtitle,
                                           message: foregroundNotification.message,
                                           actionTitle: Localization.viewInAppNotification) { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.presentDetails(for: foregroundNotification)
                     self.foregroundNotificationsToViewSubject.send(foregroundNotification)
                     self.analytics.track(.viewInAppPushNotificationPressed,
@@ -649,7 +649,7 @@ private extension PushNotificationsManager {
     }
 
     func postBadgeReloadNotifications(type: Note.Kind?) {
-        guard let type = type else {
+        guard let type else {
             postBadgeReloadNotification(type: .comment)
             postBadgeReloadNotification(type: .storeOrder)
             return
@@ -703,7 +703,7 @@ private extension PushNotificationsManager {
 
         if let typeString = userInfo.string(forKey: APNSKey.type),
            let type = Note.Kind(rawValue: typeString),
-           let siteID = siteID,
+           let siteID,
            let notificationSiteID = userInfo[APNSKey.siteID] as? Int64 {
             // Badge: Update
             incrementNotificationCount(siteID: notificationSiteID, type: type, incrementCount: 1) { [weak self] in
@@ -924,7 +924,7 @@ private extension PushNotificationsManager {
             appVersion: Bundle.main.version,
             availableAsRESTRequest: isTargetSiteSelected
         ) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let tokenID):

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -149,7 +149,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     private func setupUniversalLinkRouter() {
-        guard let tabBarController = tabBarController else { return }
+        guard let tabBarController else { return }
         universalLinkRouter = UniversalLinkRouter.defaultUniversalLinkRouter(tabBarController: tabBarController)
     }
 

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -295,7 +295,7 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         }
 
         imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: handler) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             onProductSave(result)
             if case let .failure(error) = result {
                 self.errorsSubject.send(.init(siteID: key.siteID,
@@ -367,7 +367,7 @@ private extension ProductImageUploader {
 
     func observeStatusUpdates(key: Key, actionHandler: ProductImageActionHandler) {
         let observationToken = actionHandler.addUpdateObserver(self) { [weak self] productImageStatuses in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if featureFlagService.isFeatureFlagEnabled(.backgroundProductImageUpload) {
                 // Update the states in userDefaultsStatuses

--- a/WooCommerce/Classes/Spotlight/SearchableActivityConvertable.swift
+++ b/WooCommerce/Classes/Spotlight/SearchableActivityConvertable.swift
@@ -38,7 +38,7 @@ extension SearchableActivityConvertible where Self: UIViewController {
             activity.keywords = keywords
         }
 
-        if let activityDescription = activityDescription {
+        if let activityDescription {
             let contentAttributeSet = CSSearchableItemAttributeSet(contentType: UTType.text)
             contentAttributeSet.contentDescription = activityDescription
             activity.contentAttributeSet = contentAttributeSet

--- a/WooCommerce/Classes/Spotlight/SpotlightManager.swift
+++ b/WooCommerce/Classes/Spotlight/SpotlightManager.swift
@@ -25,7 +25,7 @@ struct SpotlightManager {
     }
 
     private static func trackActivityBeingOpenedIfNecessary(with type: WooActivityType?) {
-        guard let type = type else {
+        guard let type else {
             return
         }
 

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -115,7 +115,7 @@ private extension WooNavigationControllerDelegate {
     func observeConnectivity() {
         connectivityObserver.statusPublisher
             .sink { [weak self] status in
-                guard let self = self, let currentController = self.currentController else { return }
+                guard let self, let currentController = self.currentController else { return }
                 self.configureOfflineBanner(for: currentController, status: status)
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/Tools/AsyncDictionary.swift
+++ b/WooCommerce/Classes/Tools/AsyncDictionary.swift
@@ -28,7 +28,7 @@ final class AsyncDictionary<Key, Value> where Key: Hashable {
         DispatchQueue.global().async {
             let value = operation()
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else {
+                guard let self else {
                     onCompletion(nil)
                     return
                 }

--- a/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
@@ -91,7 +91,7 @@ struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
     }
 
     private func getSystemPlugin(from configuration: CardPresentPaymentsPlugin) -> Yosemite.SystemPlugin? {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return nil
         }
         return storageManager.viewStorage

--- a/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
@@ -99,14 +99,14 @@ final class PaginationTracker {
 private extension PaginationTracker {
     /// Syncs a given page number.
     func sync(pageNumber: Int, reason: String? = nil, onCompletion: (() -> Void)? = nil) {
-        guard let delegate = delegate else {
+        guard let delegate else {
             fatalError()
         }
 
         markAsBeingSynced(pageNumber: pageNumber)
 
         delegate.sync(pageNumber: pageNumber, pageSize: pageSize, reason: reason) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/ScrollWatcher.swift
@@ -26,7 +26,7 @@ final class ScrollWatcher {
 
     func startObservingScrollPosition(tableView: UITableView) {
         offsetObservation = tableView.observe(\UITableView.contentOffset, options: .new) { [weak self] tableView, change in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             guard let newContentOffsetY = change.newValue?.y else {

--- a/WooCommerce/Classes/Tools/MapsHelper.swift
+++ b/WooCommerce/Classes/Tools/MapsHelper.swift
@@ -5,7 +5,7 @@ final class MapsHelper {
     /// The method accept a string of the address info you already have, and open Apple Maps on that address if found.
     ///
     static func openAppleMaps(address: String?, completion: @escaping (Result<Void, MapsHelperError>) -> Void) {
-        guard let address = address else {
+        guard let address else {
             completion(.failure(.locationNotFound))
             return
         }

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -109,7 +109,7 @@ private extension DefaultNoticePresenter {
 
         var onScreenBottomOffsetAdjustedForKeyboard: CGFloat = 0
         keyboardFrameObserver = KeyboardFrameObserver { [weak self] keyboardFrame in
-            guard let self = self else { return }
+            guard let self else { return }
 
             onScreenBottomOffsetAdjustedForKeyboard = -keyboardFrame.height
 
@@ -141,7 +141,7 @@ private extension DefaultNoticePresenter {
         ])
 
         let offScreenState = { [weak noticeView, weak self] in
-            guard let noticeView = noticeView, let self = self else {
+            guard let noticeView, let self else {
                 return
             }
             noticeView.alpha = UIKitConstants.alphaZero
@@ -158,7 +158,7 @@ private extension DefaultNoticePresenter {
         }
 
         let hiddenState = { [weak noticeView] in
-            guard let noticeView = noticeView else {
+            guard let noticeView else {
                 return
             }
             noticeView.alpha = UIKitConstants.alphaZero
@@ -206,7 +206,7 @@ private extension DefaultNoticePresenter {
     }
 
     func makeBottomConstraintForNoticeContainer(_ container: UIView) -> NSLayoutConstraint {
-        guard let presentingViewController = presentingViewController else {
+        guard let presentingViewController else {
             fatalError("NoticePresenter requires a presentingViewController!")
         }
 

--- a/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticePresenter.swift
@@ -75,7 +75,7 @@ private extension PermanentNoticePresenter {
     }
 
     func animateDismiss() {
-        guard let hostingController = hostingController else {
+        guard let hostingController else {
             return
         }
 

--- a/WooCommerce/Classes/Tools/PhoneHelper.swift
+++ b/WooCommerce/Classes/Tools/PhoneHelper.swift
@@ -5,7 +5,7 @@ final class PhoneHelper {
     /// Call a specific phone number, and return success or failure
     ///
     static func callPhoneNumber(phone: String?) -> Bool {
-        guard let phone = phone, let url = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(url) else {
+        guard let phone, let url = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(url) else {
             return false
         }
 
@@ -14,7 +14,7 @@ final class PhoneHelper {
     }
 
     static func canCallPhoneNumber(phone: String?) -> Bool {
-        guard let phone = phone, let url = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(url) else {
+        guard let phone, let url = URL(string: "tel://\(phone)"), UIApplication.shared.canOpenURL(url) else {
             return false
         }
 

--- a/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
+++ b/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
@@ -92,11 +92,11 @@ private extension ResultsController {
 
             switch fixedType {
             case .delete:
-                if let indexPath = indexPath {
+                if let indexPath {
                     tableView.deleteRows(at: [indexPath], with: animations.delete)
                 }
             case .insert:
-                if let newIndexPath = newIndexPath {
+                if let newIndexPath {
                     tableView.insertRows(at: [newIndexPath], with: animations.insert)
                 }
             case .move:
@@ -104,11 +104,11 @@ private extension ResultsController {
                     tableView.deleteRows(at: [oldIndexPath], with: animations.move)
                 }
 
-                if let newIndexPath = newIndexPath {
+                if let newIndexPath {
                     tableView.insertRows(at: [newIndexPath], with: animations.move)
                 }
             case .update:
-                if let indexPath = indexPath {
+                if let indexPath {
                     tableView.reloadRows(at: [indexPath], with: animations.update)
                 }
             @unknown default:

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -70,7 +70,7 @@ extension SelectedSiteSettings {
     ///
     private func configureResultsController() {
         resultsController.onDidChangeObject = { [weak self] (object, indexPath, type, newIndexPath) in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.currencySettings.updateCurrencyOptions(with: object)
             self.siteSettings = self.resultsController.fetchedObjects
             guard let siteID = stores.sessionManager.defaultStoreID else {

--- a/WooCommerce/Classes/Tools/SharingHelper.swift
+++ b/WooCommerce/Classes/Tools/SharingHelper.swift
@@ -104,11 +104,11 @@ private extension SharingHelper {
         }
 
         var items: [Any] = []
-        if let title = title {
+        if let title {
             items.append(title)
         }
 
-        if let url = url {
+        if let url {
             items.append(url)
         }
 

--- a/WooCommerce/Classes/Tools/ShippingValueLocalizer/DefaultShippingValueLocalizer.swift
+++ b/WooCommerce/Classes/Tools/ShippingValueLocalizer/DefaultShippingValueLocalizer.swift
@@ -29,7 +29,7 @@ struct DefaultShippingValueLocalizer: ShippingValueLocalizer {
     /// Because, API does not support having thousand separators in shipping values like weight and package dimensions.
     ///
     func localized(shippingValue: String?) -> String? {
-        guard let shippingValue = shippingValue else {
+        guard let shippingValue else {
             return nil
         }
         return localizedString(using: shippingValue, from: apiLocale, to: deviceLocale)
@@ -42,7 +42,7 @@ struct DefaultShippingValueLocalizer: ShippingValueLocalizer {
     /// Because, API does not support having thousand separators in shipping values like weight and package dimensions.
     ///
     func unLocalized(shippingValue: String?) -> String? {
-        guard let shippingValue = shippingValue else {
+        guard let shippingValue else {
             return nil
         }
         return localizedString(using: shippingValue, from: deviceLocale, to: apiLocale)

--- a/WooCommerce/Classes/Tools/SyncCoordinator.swift
+++ b/WooCommerce/Classes/Tools/SyncCoordinator.swift
@@ -132,7 +132,7 @@ private extension SyncingCoordinator {
     /// Synchronizes a given Page Number
     ///
     func synchronize(pageNumber: Int, reason: String? = nil, onCompletion: (() -> Void)? = nil) {
-        guard let delegate = delegate else {
+        guard let delegate else {
             fatalError()
         }
 

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/IntegerInputFormatter.swift
@@ -25,7 +25,7 @@ struct IntegerInputFormatter: UnitInputFormatter {
     }
 
     func format(input text: String?) -> String {
-        guard let text = text, text.isEmpty == false else {
+        guard let text, text.isEmpty == false else {
             return defaultValue
         }
 

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -43,7 +43,7 @@ struct PriceInputFormatter: UnitInputFormatter {
     }
 
     func format(input text: String?) -> String {
-        guard let text = text, text.isEmpty == false else {
+        guard let text, text.isEmpty == false else {
             return ""
         }
 

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/ShippingInputFormatter.swift
@@ -17,7 +17,7 @@ struct ShippingInputFormatter: UnitInputFormatter {
     }
 
     func format(input text: String?) -> String {
-        guard let text = text, text.isEmpty == false else {
+        guard let text, text.isEmpty == false else {
             return ""
         }
 

--- a/WooCommerce/Classes/Tools/WeightFormatter.swift
+++ b/WooCommerce/Classes/Tools/WeightFormatter.swift
@@ -15,7 +15,7 @@ final class WeightFormatter {
         self.weightUnit = weightUnit
         formatter = MeasurementFormatter()
         formatter.unitOptions = .providedUnit
-        if let locale = locale {
+        if let locale {
             formatter.locale = locale
         }
     }
@@ -70,7 +70,7 @@ private extension WeightFormatter {
     }
 
     func coalesceWeight(_ weight: String?) -> String {
-        guard let weight = weight, weight.isNotEmpty else {
+        guard let weight, weight.isNotEmpty else {
             return "0"
         }
         return weight

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -377,7 +377,7 @@ private extension ZendeskManager {
 
     func createZendeskIdentity(completion: @escaping (Bool) -> Void) {
 
-        guard let userEmail = userEmail else {
+        guard let userEmail else {
             DDLogInfo("No user email to create Zendesk identity with.")
             let identity = Identity.createAnonymous()
             Zendesk.instance?.setIdentity(identity)
@@ -486,7 +486,7 @@ private extension ZendeskManager {
         // Name Text Field
         if withName {
             alertController.addTextField { [weak self] textField in
-                guard let self = self else { return }
+                guard let self else { return }
                 textField.clearButtonMode = .always
                 textField.placeholder = LocalizedText.namePlaceholder
                 textField.text = self.userName

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -56,7 +56,7 @@ struct UniversalLinkRouter {
     ///
     static func defaultRoutes(navigator: DeepLinkNavigator?) -> [Route] {
         let routes: [Route] = [OrderDetailsRoute(), MyStoreRoute()]
-        guard let navigator = navigator else {
+        guard let navigator else {
             DDLogWarn("⛔️ Unable to create tab bar dependent Universal Link routes, some links will not be handled")
             return routes
         }

--- a/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
+++ b/WooCommerce/Classes/View Modifiers/View+NoticesModifier.swift
@@ -56,7 +56,7 @@ struct NoticeModifier: ViewModifier {
     /// Builds a notice view at the bottom of the screen.
     ///
     @ViewBuilder private func buildNoticeStack() -> some View {
-        if let notice = notice {
+        if let notice {
             // Geometry reader to provide the correct view width.
             GeometryReader { geometry in
                 // VStack with spacer to push content to the bottom
@@ -163,7 +163,7 @@ struct NoticeModifier: ViewModifier {
     /// Sends haptic feedback if required.
     ///
     private func provideHapticFeedbackIfNecessary(_ feedbackType: UINotificationFeedbackGenerator.FeedbackType?) {
-        if let feedbackType = feedbackType {
+        if let feedbackType {
             feedbackGenerator.notificationOccurred(feedbackType)
         }
     }
@@ -200,7 +200,7 @@ extension UIHostingController {
             parent?.isBeingDismissed ?? false   // when it's parent is being dismissed as modal (EG: inside a navigation controller)
         }()
 
-        if let notice = notice, isBeingRemoved {
+        if let notice, isBeingRemoved {
             noticePresenter.enqueue(notice: notice)
         }
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -31,7 +31,7 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     let bottomSubtitle: String? = nil
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
         return topTitle + bottomTitle

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorEmailSent.swift
@@ -30,7 +30,7 @@ final class CardPresentModalErrorEmailSent: CardPresentPaymentsModalViewModel {
     let bottomAttributedSubtitle: NSAttributedString?
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
         return topTitle + bottomTitle

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalErrorWithoutEmail.swift
@@ -28,7 +28,7 @@ final class CardPresentModalErrorWithoutEmail: CardPresentPaymentsModalViewModel
     let bottomSubtitle: String? = nil
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
         return topTitle + bottomTitle

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -34,7 +34,7 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     let bottomSubtitle: String? = nil
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorEmailSent.swift
@@ -34,7 +34,7 @@ final class CardPresentModalNonRetryableErrorEmailSent: CardPresentPaymentsModal
 
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
@@ -30,7 +30,7 @@ final class CardPresentModalNonRetryableErrorWithoutEmail: CardPresentPaymentsMo
     let bottomSubtitle: String? = nil
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningForReader.swift
@@ -26,7 +26,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
     var bottomSubtitle: String?
 
     var accessibilityLabel: String? {
-        guard let bottomTitle = bottomTitle else {
+        guard let bottomTitle else {
             return topTitle
         }
         return topTitle + bottomTitle
@@ -44,7 +44,7 @@ final class CardPresentModalScanningForReader: CardPresentPaymentsModalViewModel
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
         ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         WebviewHelper.launch(Constants.learnMoreURL.asURL(), with: viewController)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapToPayReaderCheckingDeviceSupport.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapToPayReaderCheckingDeviceSupport.swift
@@ -43,7 +43,7 @@ final class CardPresentModalTapToPayReaderCheckingDeviceSupport: CardPresentPaym
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {
         ServiceLocator.analytics.track(.cardPresentOnboardingLearnMoreTapped)
-        guard let viewController = viewController else {
+        guard let viewController else {
             return
         }
         WebviewHelper.launch(Constants.learnMoreURL.asURL(), with: viewController)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateFailedLowBattery.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateFailedLowBattery.swift
@@ -30,7 +30,7 @@ final class CardPresentModalUpdateFailedLowBattery: CardPresentPaymentsModalView
     init(batteryLevel: Double?, retrySearch: @escaping () -> Void, close: @escaping () -> Void) {
         self.retrySearch = retrySearch
         self.close = close
-        if let batteryLevel = batteryLevel {
+        if let batteryLevel {
             bottomTitle = String(format: Localization.message, 100 * batteryLevel)
         } else {
             bottomTitle = Localization.messageNoBatteryLevel

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -50,7 +50,7 @@ final class CardPresentRefundOrchestrator {
                 break
             }
         }, onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.allowPassPresentation()
             onProcessingMessage()
             onCompletion(result)
@@ -105,7 +105,7 @@ private extension CardPresentRefundOrchestrator {
             return
         }
 
-        guard let walletSuppressionRequestToken = walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
+        guard let walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
             return
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -250,7 +250,7 @@ private extension PaymentCaptureOrchestrator {
             return
         }
 
-        guard let walletSuppressionRequestToken = walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
+        guard let walletSuppressionRequestToken, walletSuppressionRequestToken != 0 else {
             return
         }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -39,7 +39,7 @@ struct PaymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {
             return nil
         }
 
-        guard let wcPay = wcPay,
+        guard let wcPay,
               paymentPluginsStatus == .onlyWCPayIsInstalledAndActive else {
             return order.billingAddress?.email
         }

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModel.swift
@@ -98,7 +98,7 @@ class FeatureAnnouncementCardViewModel: AnnouncementCardViewModelProtocol {
 
     private func updateShouldBeVisible() {
         let action = AppSettingsAction.getFeatureAnnouncementVisibility(campaign: config.campaign) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let visible):
                 self.shouldBeVisible = visible

--- a/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Feature Announcement Cards/JustInTimeMessageViewModel.swift
@@ -91,7 +91,7 @@ final class JustInTimeMessageViewModel {
     // MARK: - Actions
     func ctaTapped() {
         trackCtaTapped()
-        guard let url = url else {
+        guard let url else {
             return
         }
 

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -148,7 +148,7 @@ private extension MainTabViewModel {
     ///
     func processBadgeCount(_ ordersStatus: OrderStatus?) {
         // Exit early if there is not data, or the count is zero
-        guard let ordersStatus = ordersStatus,
+        guard let ordersStatus,
               ordersStatus.slug == OrderStatusEnum.processing.rawValue,
               ordersStatus.total > 0 else {
             onOrdersBadgeReload?(nil)

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -151,14 +151,14 @@ final class AddTrackingViewModel: ManualTrackingViewModel {
 //
 extension AddTrackingViewModel {
     func saveSelectedShipmentProvider() {
-        guard let shipmentProvider = shipmentProvider else {
+        guard let shipmentProvider else {
             return
         }
 
         let siteID = order.siteID
 
         let action = AppSettingsAction.addTrackingProvider(siteID: siteID, providerName: shipmentProvider.name) { error in
-            guard let error = error else {
+            guard let error else {
                 return
             }
 
@@ -172,7 +172,7 @@ extension AddTrackingViewModel {
         let siteID = order.siteID
 
         let action = AppSettingsAction.loadTrackingProvider(siteID: siteID) { [weak self] (provider, providerGroup, error) in
-            guard let error = error else {
+            guard let error else {
                 self?.shipmentProvider = provider
                 self?.shipmentProviderGroupName = providerGroup?.name
                 return
@@ -238,8 +238,8 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
     }
 
     var canCommit: Bool {
-        guard let providerName = providerName,
-                let trackingNumber = trackingNumber else {
+        guard let providerName,
+                let trackingNumber else {
             return false
         }
         return providerName.isNotEmpty && trackingNumber.isNotEmpty
@@ -265,14 +265,14 @@ final class AddCustomTrackingViewModel: ManualTrackingViewModel {
 
 extension AddCustomTrackingViewModel {
     func saveSelectedShipmentProvider() {
-        guard let providerName = providerName else {
+        guard let providerName else {
             return
         }
 
         let siteID = order.siteID
 
         let action = AppSettingsAction.addCustomTrackingProvider(siteID: siteID, providerName: providerName, providerURL: trackingLink) { error in
-            guard let error = error else {
+            guard let error else {
                 return
             }
 
@@ -286,7 +286,7 @@ extension AddCustomTrackingViewModel {
         let siteID = order.siteID
 
         let action = AppSettingsAction.loadCustomTrackingProvider(siteID: siteID) { [weak self] (provider, error) in
-            guard let error = error else {
+            guard let error else {
                 self?.providerName = provider?.name
                 self?.trackingLink = provider?.url
                 return

--- a/WooCommerce/Classes/ViewModels/Order Details/CardPresentPaymentsReadinessUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/CardPresentPaymentsReadinessUseCase.swift
@@ -39,7 +39,7 @@ final class CardPresentPaymentsReadinessUseCase {
     ///
     func checkCardPaymentReadiness() {
         let readerConnected = CardPresentPaymentAction.publishCardReaderConnections { [weak self] connectPublisher in
-            guard let self = self else { return }
+            guard let self else { return }
             let readerConnectedReadiness = connectPublisher
                 .map { readers -> CardPaymentReadiness in
                     if readers.isNotEmpty {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -777,7 +777,7 @@ private extension OrderDetailsDataSource {
                        title: Titles.reprintShippingLabel,
                        topSpacing: 0,
                        bottomSpacing: 8) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let shippingLabel = self.shippingLabel(at: indexPath) else {
                 return
             }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -179,7 +179,7 @@ final class OrderDetailsResultsControllers {
         // so we need to recreate it whenever receiving an updated order.
         self.productVariationResultsController = getProductVariationResultsController()
         self.productResultsController = createProductResultsController()
-        if let onReload = onReload {
+        if let onReload {
             configureProductVariationResultsController(onReload: onReload)
             configureProductResultsController(onReload: onReload)
         }
@@ -203,7 +203,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         shipmentResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.refetchAllResultsControllers()
@@ -231,7 +231,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         trackingResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.refetchAllResultsControllers()
@@ -253,7 +253,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         productResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.refetchAllResultsControllers()
@@ -274,7 +274,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         productVariationResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.refetchAllResultsControllers()
@@ -294,7 +294,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         refundResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.refetchAllResultsControllers()
@@ -314,7 +314,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         addOnGroupResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }
@@ -332,7 +332,7 @@ private extension OrderDetailsResultsControllers {
         }
 
         sitePluginsResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -255,7 +255,7 @@ extension OrderDetailsViewModel {
             }
 
             // Products require order.items data, so sync them only after the order is loaded
-            guard let self = self else { return }
+            guard let self else { return }
 
             group.enter()
             self.syncProducts { [weak self] _ in
@@ -386,7 +386,7 @@ extension OrderDetailsViewModel {
 
     func syncOrder(onCompletion: ((Error?) -> ())? = nil) {
         syncOrder { [weak self] (order, error) in
-            guard let self = self, let order = order else {
+            guard let self, let order else {
                 onCompletion?(error)
                 return
             }
@@ -619,7 +619,7 @@ extension OrderDetailsViewModel {
         case .seeLegacyReceipt:
             let countryCode = configurationLoader.configuration.countryCode
             ServiceLocator.analytics.track(event: .InPersonPayments.receiptViewTapped(countryCode: countryCode, source: .local))
-            guard let receipt = receipt else {
+            guard let receipt else {
                 return
             }
             let viewModel = LegacyReceiptViewModel(order: order, receipt: receipt, countryCode: countryCode)
@@ -675,7 +675,7 @@ extension OrderDetailsViewModel {
 
     func syncNotes(onCompletion: ((Error?) -> ())? = nil) {
         let action = OrderNoteAction.retrieveOrderNotes(siteID: order.siteID, orderID: order.orderID) { [weak self] (orderNotes, error) in
-            guard let orderNotes = orderNotes else {
+            guard let orderNotes else {
                 DDLogError("⛔️ Error synchronizing Order Notes: \(error.debugDescription)")
                 self?.orderNotes = []
                 onCompletion?(error)
@@ -693,7 +693,7 @@ extension OrderDetailsViewModel {
 
     func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
         let action = ProductAction.requestMissingProducts(for: order) { (error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing Products: \(error)")
                 onCompletion?(error)
 
@@ -708,7 +708,7 @@ extension OrderDetailsViewModel {
 
     func syncProductVariations(onCompletion: ((Error?) -> ())? = nil) {
         let action = ProductVariationAction.requestMissingVariations(for: order) { error in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing missing variations in an Order: \(error)")
                 onCompletion?(error)
                 return
@@ -728,7 +728,7 @@ extension OrderDetailsViewModel {
         }
 
         let action = RefundAction.retrieveRefunds(siteID: order.siteID, orderID: order.orderID, refundIDs: refundIDs, deleteStaleRefunds: true) { (error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing detailed Refunds: \(error)")
                 onCompletion?(error)
 
@@ -897,7 +897,7 @@ extension OrderDetailsViewModel {
         let deleteTrackingAction = ShipmentAction.deleteTracking(siteID: siteID,
                                                                  orderID: orderID,
                                                                  trackingID: trackingID) { error in
-                                                                    if let error = error {
+                                                                    if let error {
                                                                         DDLogError("⛔️ Order Details - Delete Tracking: orderID \(orderID). Error: \(error)")
 
                                                                         ServiceLocator.analytics.track(.orderTrackingDeleteFailed,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -130,7 +130,7 @@ final class OrderPaymentDetailsViewModel {
     /// Example: Oct 28, 2019 via Credit Card (Stripe)
     ///
     var refundSummary: String? {
-        guard let refund = refund else {
+        guard let refund else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderStatusListViewModel.swift
@@ -108,7 +108,7 @@ final class OrderStatusListViewModel {
     }
 
     func confirmSelectedStatus() {
-        guard let indexOfSelectedStatus = indexOfSelectedStatus else {
+        guard let indexOfSelectedStatus else {
             didCancelSelection?()
             return
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptViewModel.swift
@@ -25,7 +25,7 @@ final class ReceiptViewModel {
     }
 
     func formattedReceiptJobName(_ jobName: String) -> String {
-        if let siteName = siteName, !siteName.isEmpty {
+        if let siteName, !siteName.isEmpty {
             return String.localizedStringWithFormat(Localization.receiptJobNameWithStoreName,
                                                     jobName,
                                                     String(orderID),

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -70,14 +70,14 @@ struct ProductDetailsCellViewModel {
         }()
 
         self.total = {
-            guard let total = total else {
+            guard let total else {
                 return String()
             }
             return currencyFormatter.formatAmount(total, with: currency) ?? String()
         }()
 
         self.subtitle = {
-            guard let price = price else {
+            guard let price else {
                 return String()
             }
             let itemPrice = currencyFormatter.formatAmount(price, with: currency) ?? String()

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -258,8 +258,8 @@ extension ShippingProvidersViewModel {
 
     /// Indicates if the item at `indexPath` is the same as the currently selected provider.
     func isSelected(_ indexPath: IndexPath) -> Bool {
-        guard let selectedProvider = selectedProvider,
-            let selectedProviderGroupName = selectedProviderGroupName,
+        guard let selectedProvider,
+            let selectedProviderGroupName,
             let provider = provider(at: indexPath),
             let groupName = groupName(at: indexPath) else {
             return false

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -75,7 +75,7 @@ final class AppCoordinator {
     func start() {
         authStatesSubscription = Publishers.CombineLatest(stores.isLoggedInPublisher, stores.needsDefaultStorePublisher)
             .sink {  [weak self] isLoggedIn, needsDefaultStore in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 // More details about the UI states: https://github.com/woocommerce/woocommerce-ios/pull/3498
                 switch (isLoggedIn, needsDefaultStore) {
@@ -121,7 +121,7 @@ private extension AppCoordinator {
     func updateSitePropertiesIfNeeded() {
         if let siteID = stores.sessionManager.defaultSite?.siteID {
             let action = SiteAction.syncSite(siteID: siteID, completion: { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let site):
                     self.stores.updateDefaultStore(site)
@@ -192,7 +192,7 @@ private extension AppCoordinator {
     ///
     func synchronizeAndShowWhatsNew() {
         stores.dispatch(AnnouncementsAction.synchronizeAnnouncements(onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let announcement):
                 DDLogInfo("📣 Announcements Synced! AppVersion: \(announcement.appVersionName) | AnnouncementVersion: \(announcement.announcementVersion)")
@@ -211,7 +211,7 @@ private extension AppCoordinator {
     ///
     func showWhatsNewIfNeeded() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let (announcement, displayed) = try? result.get(), !displayed else {
                 return DDLogInfo("📣 There are no announcements to show!")
             }
@@ -231,7 +231,7 @@ private extension AppCoordinator {
             // at the end of app launch.
             setWindowRootViewControllerAndAnimateIfNeeded(.init())
             presentLoginOnboarding { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 // Only displays the authenticator when dismissing onboarding to allow time for A/B test setup.
                 self.displayAuthenticator()
             }
@@ -262,7 +262,7 @@ private extension AppCoordinator {
     func displayAuthenticator() -> UIViewController {
         let authenticationUI = authenticationManager.authenticationUI()
         setWindowRootViewControllerAndAnimateIfNeeded(authenticationUI) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.tabBarController.removeViewControllers()
         }
         ServiceLocator.analytics.track(.openedLogin)
@@ -287,7 +287,7 @@ private extension AppCoordinator {
     /// - Parameter onDismiss: invoked when the onboarding is dismissed.
     func presentLoginOnboarding(onDismiss: @escaping () -> Void) {
         let onboardingViewController = LoginOnboardingViewController { [weak self] action in
-            guard let self = self else { return }
+            guard let self else { return }
             onDismiss()
             self.loggedOutAppSettings.setHasFinishedOnboarding(true)
             self.window.rootViewController?.dismiss(animated: true)
@@ -354,7 +354,7 @@ private extension AppCoordinator {
         storePickerCoordinator = StorePickerCoordinator(navigationController, config: .standard)
         storePickerCoordinator?.start()
         storePickerCoordinator?.onDismiss = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if self.isLoggedIn == false {
                 self.displayAuthenticatorWithOnboardingIfNeeded()
             }
@@ -394,7 +394,7 @@ private extension AppCoordinator {
         }
 
         let action = AppSettingsAction.loadEligibilityErrorInfo { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             // if the previous role check indicates that the user is ineligible, let's show the error message.
             if let errorInfo = try? result.get() {

--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
@@ -56,11 +56,11 @@ final class BlazeAdDestinationSettingViewModel: ObservableObject {
             remainingCharacters: adjustedRemainingCharacters,
             parameter: selectedParameter,
             onCancel: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.clearSelectedParameter()
             },
             onCompletion: { [weak self] key, value in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if selectedParameter != nil {
                     updateSelectedParameter(newKey: key, newValue: value)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -622,7 +622,7 @@ private extension BlazeCampaignCreationFormViewModel {
 
     func initializeAdTargetUrl() {
         // Default to promoting Product URL at the beginning.
-        if let productURL = productURL {
+        if let productURL {
             targetUrl = productURL
         }
     }

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -17,7 +17,7 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
 
     /// Used for calculating the full content height in `DrawerPresentable` implementation.
     var contentSize: CGSize {
-        guard let tableView = tableView else {
+        guard let tableView else {
             return .zero
         }
         return tableView.contentSize

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -129,7 +129,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
 
     @MainActor
     private func checkForConnectedReader(connectionAttemptID: Int) async {
-        if let connectedReader = connectedReader,
+        if let connectedReader,
            let paymentGatewayAccount = await selectedPaymentGateway() {
             // The reader was already connected when the analyticsTracker was created,
             //`so we need to pass it along for properties to be correct
@@ -167,7 +167,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
     private func checkOnboarding(connectionAttemptID: Int) {
         // Can't currently make this async without leaking the continuation.
         onboardingPresenter.showOnboardingIfRequired(from: rootViewController) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             Task { @MainActor in
                 guard self.isCurrentConnectionAttempt(connectionAttemptID) else { return }
                 await self.continuePreflight(connectionAttemptID: connectionAttemptID)
@@ -229,7 +229,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
 
     private func adoptReconnection(using paymentGatewayAccount: PaymentGatewayAccount, connectionAttemptID: Int) {
         tapToPayReconnectionController.showAlertsForReconnection(from: alertsPresenter) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard self.isCurrentConnectionAttempt(connectionAttemptID) else { return }
             switch self.discoveryMethod {
             case .bluetoothScan:
@@ -248,7 +248,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
         analytics.track(event: .InPersonPayments.cardReaderSelectTypeShown(forGatewayID: paymentGatewayAccount.gatewayID,
                                                                            countryCode: configuration.countryCode))
         alertsPresenter.present(viewModel: tapToPayAlertProvider.selectSearchType(tapToPay: {[weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.analytics.track(event: .InPersonPayments.cardReaderSelectTypeTapToPayTapped(
                 forGatewayID: paymentGatewayAccount.gatewayID,
                 countryCode: self.configuration.countryCode))
@@ -256,7 +256,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                 self?.handleConnectionResult(result, paymentGatewayAccount: paymentGatewayAccount)
             })
         }, bluetooth: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.analytics.track(event: .InPersonPayments.cardReaderSelectTypeBluetoothTapped(
                 forGatewayID: paymentGatewayAccount.gatewayID,
                 countryCode: self.configuration.countryCode))
@@ -264,7 +264,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                 self?.handleConnectionResult(result, paymentGatewayAccount: paymentGatewayAccount)
             })
         }, cancel: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.alertsPresenter.dismiss()
             self.handleConnectionResult(.success(.canceled(.selectReaderType)),
                                         paymentGatewayAccount: paymentGatewayAccount)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionAnalyticsTracker.swift
@@ -184,10 +184,10 @@ private extension CardReaderConnectionAnalyticsTracker {
 
     func observeSoftwareUpdateState() {
         let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { [weak self] softwareUpdateEvents in
-            guard let self = self else { return }
+            guard let self else { return }
             self.softwareUpdateCancelable = softwareUpdateEvents
                 .sink { [weak self] state in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     switch state {
                     case .started:
                         self.analytics.track(

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -171,7 +171,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
 
     func searchAndConnect(onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void) {
         Task { @MainActor [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             await self.cancelReconnection()
             self.onCompletion = onCompletion
             self.state = .initializing
@@ -197,7 +197,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
 private extension CardReaderConnectionController {
     func configureResultsControllers() {
         dataSource.configureResultsControllers(onReload: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.gatewayID = self.dataSource.cardPresentPaymentGatewayID()
         })
         // Sets gateway ID from initial fetch.
@@ -316,7 +316,7 @@ private extension CardReaderConnectionController {
         knownCardReaderProvider.knownReader
             .subscribe(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] readerID in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -345,7 +345,7 @@ private extension CardReaderConnectionController {
             siteID: siteID,
             discoveryMethod: .bluetoothScan,
             onReaderDiscovered: { [weak self] cardReaders in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -403,7 +403,7 @@ private extension CardReaderConnectionController {
                 }
             },
             onError: { [weak self] error in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.analyticsTracker.discoveryFailed(error: error)
                 self.state = .discoveryFailed(error)
@@ -455,7 +455,7 @@ private extension CardReaderConnectionController {
     /// Opens a confirmation modal for the user to accept the candidate reader (or keep searching)
     ///
     func onFoundReader() {
-        guard let candidateReader = candidateReader else {
+        guard let candidateReader else {
             return
         }
 
@@ -483,7 +483,7 @@ private extension CardReaderConnectionController {
         alertsPresenter.foundSeveralReaders(
             readerIDs: getFoundReaderIDs(),
             connect: { [weak self] readerID in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 self.candidateReader = self.getFoundReaderByID(readerID: readerID)
@@ -500,7 +500,7 @@ private extension CardReaderConnectionController {
     func onUpdateProgress(progress: Float) {
         let cancel = softwareUpdateCancelable.map { cancelable in
             return { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.state = .cancel(.readerSoftwareUpdate)
                 self.analyticsTracker.cardReaderSoftwareUpdateCancelTapped()
                 cancelable.cancel { [weak self] result in
@@ -576,19 +576,19 @@ private extension CardReaderConnectionController {
     /// Connect to the candidate card reader
     ///
     func onConnectToReader() {
-        guard let candidateReader = candidateReader else {
+        guard let candidateReader else {
             return
         }
 
         analyticsTracker.setCandidateReader(candidateReader)
 
         let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { [weak self] softwareUpdateEvents in
-            guard let self = self else { return }
+            guard let self else { return }
 
             softwareUpdateEvents
                 .subscribe(on: DispatchQueue.main)
                 .sink { [weak self] event in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 switch event {
                 case .started(cancelable: let cancelable):
@@ -611,7 +611,7 @@ private extension CardReaderConnectionController {
         stores.dispatch(softwareUpdateAction)
 
         let action = CardPresentPaymentAction.connect(reader: candidateReader) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.analyticsTracker.setCandidateReader(nil)
 
@@ -736,7 +736,7 @@ private extension CardReaderConnectionController {
 
     private func openWCSettingsAction(adminUrl: URL?,
                                       retrySearch: @escaping () -> Void) -> (() -> Void)? {
-        if let adminUrl = adminUrl {
+        if let adminUrl {
             if isWPCOMStore() {
                 return { [weak self] in
                     self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/LegacyReceiptViewController.swift
@@ -74,7 +74,7 @@ private extension LegacyReceiptViewController {
 
     @objc func emailReceipt() {
         emailDataSubscription = viewModel.emailReceiptTapped().sink { [weak self] data, countryCode in
-            guard let self = self else { return }
+            guard let self else { return }
             let emailCoordinator = CardPresentPaymentReceiptEmailCoordinator(countryCode: countryCode, cardReaderModel: nil)
             self.emailCoordinator = emailCoordinator
             emailCoordinator.presentEmailForm(data: data,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
@@ -180,7 +180,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
 private extension TapToPayCardReaderConnectionController {
     func configureResultsControllers() {
         dataSource.configureResultsControllers(onReload: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.gatewayID = self.dataSource.cardPresentPaymentGatewayID()
         })
         // Sets gateway ID from initial fetch.
@@ -265,7 +265,7 @@ private extension TapToPayCardReaderConnectionController {
             siteID: siteID,
             discoveryMethod: .tapToPay,
             onReaderDiscovered: { [weak self] cardReaders in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -289,7 +289,7 @@ private extension TapToPayCardReaderConnectionController {
                 }
             },
             onError: { [weak self] error in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.analyticsTracker.discoveryFailed(error: error)
                 self.state = .discoveryFailed(error)
@@ -323,7 +323,7 @@ private extension TapToPayCardReaderConnectionController {
     func onUpdateProgress(progress: Float) {
         let cancel = softwareUpdateCancelable.map { cancelable in
             return { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.state = .cancel(.searchingForReader)
                 self.analyticsTracker.cardReaderSoftwareUpdateCancelTapped()
                 cancelable.cancel { [weak self] result in
@@ -400,19 +400,19 @@ private extension TapToPayCardReaderConnectionController {
     /// Connect to the candidate card reader
     ///
     func onConnectToReader() {
-        guard let candidateReader = candidateReader else {
+        guard let candidateReader else {
             return
         }
 
         analyticsTracker.setCandidateReader(candidateReader)
 
         let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { [weak self] softwareUpdateEvents in
-            guard let self = self else { return }
+            guard let self else { return }
 
             softwareUpdateEvents
                 .subscribe(on: DispatchQueue.main)
                 .sink { [weak self] event in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 switch event {
                 case .started(cancelable: let cancelable):
@@ -465,7 +465,7 @@ private extension TapToPayCardReaderConnectionController {
             tapToPayOptions: TapToPayCardReaderConnectionOptions(termsOfServiceAcceptancePermitted: allowTermsOfServiceAcceptance))
 
         let action = CardPresentPaymentAction.connect(reader: candidateReader, options: options) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.analyticsTracker.setCandidateReader(nil)
 
@@ -608,7 +608,7 @@ private extension TapToPayCardReaderConnectionController {
 
     private func openWCSettingsAction(adminUrl: URL?,
                                       retrySearch: @escaping () -> Void) -> (() -> Void)? {
-        if let adminUrl = adminUrl {
+        if let adminUrl {
             if isWPCOMStore() {
                 return { [weak self] in
                     self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -16,9 +16,9 @@ final class AddEditCouponHostingController: UIHostingController<AddEditCoupon> {
         }
 
         rootView.discountTypeHandler = { [weak self] viewProperties in
-            guard let self = self else { return }
+            guard let self else { return }
             let command = DiscountTypeBottomSheetListSelectorCommand(selected: self.viewModel.discountType) { [weak self] selectedType in
-                guard let self = self else { return }
+                guard let self else { return }
                 viewModel.discountType = selectedType
                 self.presentedViewController?.dismiss(animated: true, completion: nil)
             }

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCouponViewModel.swift
@@ -383,7 +383,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
         isLoading = true
         let action = CouponAction.createCoupon(coupon, siteTimezone: timezone) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.isLoading = false
             switch result {
             case .success(let coupon):
@@ -412,7 +412,7 @@ final class AddEditCouponViewModel: ObservableObject {
 
         isLoading = true
         let action = CouponAction.updateCoupon(coupon, siteTimezone: timezone) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.isLoading = false
             switch result {
             case .success(let updatedCoupon):

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetails.swift
@@ -18,7 +18,7 @@ final class CouponDetailsHostingController: UIHostingController<CouponDetails> {
         // Set manually the edit coupon button click event to present
         // the AddEditCoupon view on top of the Coupon details
         rootView.onEditCoupon = { [weak self] addEditCouponViewModel in
-            guard let self = self else { return }
+            guard let self else { return }
             let addEditHostingController = AddEditCouponHostingController(
                 viewModel: addEditCouponViewModel,
                 onDisappear: {

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponDetails/CouponDetailsViewModel.swift
@@ -155,7 +155,7 @@ final class CouponDetailsViewModel: ObservableObject {
 
     func syncCoupon() {
         let action = CouponAction.retrieveCoupon(siteID: coupon.siteID, couponID: coupon.couponID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let coupon):
                 self.coupon = coupon
@@ -177,7 +177,7 @@ final class CouponDetailsViewModel: ObservableObject {
         // Get "ancient" date to fetch all possible reports
         let startDate = Date(timeIntervalSince1970: 1)
         let action = CouponAction.loadCouponReport(siteID: siteID, couponID: coupon.couponID, startDate: startDate) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let report):
                 self.discountedOrdersCount = "\(report.ordersCount)"
@@ -187,7 +187,7 @@ final class CouponDetailsViewModel: ObservableObject {
                 DDLogError("⛔️ Error loading coupon report: \(error)")
 
                 self.retrieveAnalyticsSetting { [weak self] result in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     switch result {
                     case .success(let isEnabled):
                         if isEnabled {
@@ -280,7 +280,7 @@ private extension CouponDetailsViewModel {
 
     func createAddEditCouponViewModel(with coupon: Coupon) -> AddEditCouponViewModel {
         .init(existingCoupon: coupon, onSuccess: { [weak self] updatedCoupon in
-            guard let self = self else { return }
+            guard let self else { return }
             self.updateCoupon(updatedCoupon)
             self.onUpdate()
         })

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -76,7 +76,7 @@ final class CouponListViewController: UIViewController, GhostableViewController 
         viewModel.$state
             .removeDuplicates()
             .sink { [weak self] state in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.resetViews()
                 switch state {
                 case .empty:
@@ -111,7 +111,7 @@ final class CouponListViewController: UIViewController, GhostableViewController 
 
         viewModel.$couponViewModels
             .sink { [weak self] viewModels in
-                guard let self = self else { return }
+                guard let self else { return }
                 var snapshot = NSDiffableDataSourceSnapshot<Section, CouponListViewModel.CellViewModel>()
                 snapshot.appendSections([.main])
                 snapshot.appendItems(viewModels, toSection: Section.main)
@@ -162,7 +162,7 @@ private extension CouponListViewController {
             self?.refreshCouponList()
         })
         let addEditHostingController = AddEditCouponHostingController(viewModel: viewModel, onDisappear: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.dismiss(animated: true)
         })
         present(addEditHostingController, animated: true)
@@ -288,7 +288,7 @@ private extension CouponListViewController {
     /// Removes EmptyStateViewController child view controller if applicable.
     ///
     func removeNoResultsOverlay() {
-        guard let emptyStateViewController = emptyStateViewController,
+        guard let emptyStateViewController,
               emptyStateViewController.parent == self
         else { return }
 

--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewModel.swift
@@ -124,7 +124,7 @@ final class CouponListViewModel {
 
         state = .loading
         let action = SettingAction.enableCouponSetting(siteID: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 self.syncingCoordinator.synchronizeFirstPage(reason: nil, onCompletion: nil)
@@ -202,7 +202,7 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
             .synchronizeCoupons(siteID: siteID,
                                 pageNumber: pageNumber,
                                 pageSize: pageSize) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.handleCouponSyncResult(result: result, pageNumber: pageNumber)
                 onCompletion?(result.isSuccess)
         }
@@ -221,7 +221,7 @@ extension CouponListViewModel: SyncingCoordinatorDelegate {
             DDLogError("⛔️ Error synchronizing coupons: \(error)")
             ServiceLocator.analytics.track(.couponsLoadedFailed, withError: error)
             loadCouponSetting { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let isEnabled):
                     if isEnabled {

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnableAnalytics/EnableAnalyticsViewModel.swift
@@ -26,7 +26,7 @@ final class EnableAnalyticsViewModel: ObservableObject {
                          onFailure: @escaping () -> Void) {
         enablingAnalyticsInProgress = true
         let action = SettingAction.enableAnalyticsSetting(siteID: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.enablingAnalyticsInProgress = false
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/EnhancedCouponListViewController.swift
@@ -115,7 +115,7 @@ private extension EnhancedCouponListViewController {
             self?.couponListViewController?.refreshCouponList()
         })
         let addEditHostingController = AddEditCouponHostingController(viewModel: viewModel, onDisappear: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.dismiss(animated: true)
         })
         present(addEditHostingController, animated: true)
@@ -125,7 +125,7 @@ private extension EnhancedCouponListViewController {
         ServiceLocator.analytics.track(.couponsListCreateTapped)
         let viewProperties = BottomSheetListSelectorViewProperties(subtitle: Localization.createCouponAction)
         let command = DiscountTypeBottomSheetListSelectorCommand(selected: nil) { [weak self] selectedType in
-            guard let self = self else { return }
+            guard let self else { return }
             self.presentedViewController?.dismiss(animated: true, completion: nil)
             self.startCouponCreation(discountType: selectedType)
         }
@@ -137,10 +137,10 @@ private extension EnhancedCouponListViewController {
 
     func showDetails(from coupon: Coupon) {
         let detailsViewModel = CouponDetailsViewModel(coupon: coupon, onUpdate: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.couponListViewController?.refreshCouponList()
         }, onDeletion: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.navigationController?.popViewController(animated: true)
             let notice = Notice(title: Localization.couponDeleted, feedbackType: .success)
             self.noticePresenter.enqueue(notice: notice)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldViewModel.swift
@@ -50,7 +50,7 @@ struct CustomFieldViewModel: Identifiable, Equatable {
 
     func asDictionary() -> [String: Any] {
         var json: [String: Any] = [:]
-            if let fieldID = fieldID {
+            if let fieldID {
                 json["id"] = fieldID
             }
             json["key"] = key

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -79,7 +79,7 @@ final class CustomFieldsListViewModel: ObservableObject {
 extension CustomFieldsListViewModel {
     func saveField(key: String, value: String, fieldID: Int64?) {
         let newField = CustomFieldViewModel(fieldID: fieldID, key: key, value: value)
-        if let fieldID = fieldID {
+        if let fieldID {
             if let index = combinedList.firstIndex(where: { $0.fieldID == fieldID }) {
                 editField(at: index, newField: newField)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeData.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeData.swift
@@ -20,8 +20,8 @@ extension AnalyticsHubTimeRangeData {
     }
 
     private func generateTimeRangeFrom(startDate: Date?, endDate: Date?) -> AnalyticsHubTimeRange? {
-        if let startDate = startDate,
-           let endDate = endDate {
+        if let startDate,
+           let endDate {
             return AnalyticsHubTimeRange(start: startDate, end: endDate)
         } else {
             return nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -55,7 +55,7 @@ public class AnalyticsHubTimeRangeSelection {
     /// provided during initialization.
     /// - throws an `.selectedRangeGenerationFailed` error if the unwrap fails.
     func unwrapCurrentTimeRange() throws -> AnalyticsHubTimeRange {
-        guard let currentTimeRange = currentTimeRange else {
+        guard let currentTimeRange else {
             throw TimeRangeGeneratorError.selectedRangeGenerationFailed
         }
         return currentTimeRange
@@ -64,7 +64,7 @@ public class AnalyticsHubTimeRangeSelection {
     /// based on the `selectedTimeRange` provided during initialization.
     /// - throws a `.previousRangeGenerationFailed` error if the unwrap fails.
     func unwrapPreviousTimeRange() throws -> AnalyticsHubTimeRange {
-        guard let previousTimeRange = previousTimeRange else {
+        guard let previousTimeRange else {
             throw TimeRangeGeneratorError.previousRangeGenerationFailed
         }
         return previousTimeRange

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -275,13 +275,13 @@ private extension DashboardViewHostingController {
             guard let self else { return }
             let detailsViewModel = CouponDetailsViewModel(coupon: coupon,
                                                           onUpdate: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 Task { @MainActor in
                     await self.viewModel.mostActiveCouponsViewModel.reloadData()
                 }
             },
                                                           onDeletion: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 Task { @MainActor in
                     await self.viewModel.mostActiveCouponsViewModel.reloadData()
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -998,7 +998,7 @@ private extension DashboardViewModel {
     ///
     func onInAppFeedbackCardAction() {
         let action = AppSettingsAction.updateFeedbackStatus(type: .general, status: .given(Date())) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -1014,7 +1014,7 @@ private extension DashboardViewModel {
     /// Calculates and updates the value of `isInAppFeedbackCardVisible`.
     func refreshIsInAppFeedbackCardVisibleValue() {
         let action = AppSettingsAction.loadFeedbackVisibility(type: .general) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderSettingsConnectedViewModel.swift
@@ -76,7 +76,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
 
     private func configureResultsControllers() {
         dataSource.configureResultsControllers(onReload: { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.connectedGatewayID = self.dataSource.cardPresentPaymentGatewayID()
@@ -102,7 +102,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
     private func beginObservation() {
         // This completion should be called repeatedly as the list of connected readers changes
         let action = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -118,7 +118,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
         let softwareUpdateAction = CardPresentPaymentAction.observeCardReaderUpdateState { softwareUpdateEvents in
             softwareUpdateEvents
                 .sink { [weak self] state in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     switch state {
                     case .started(cancelable: let cancelable):
@@ -157,7 +157,7 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
         let reconnectionAction = CardPresentPaymentAction.observeCardReaderReconnectionState { reconnectionEvents in
             reconnectionEvents
                 .sink { [weak self] state in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     switch state {
                     case .reconnecting(let reader):
@@ -236,10 +236,10 @@ final class BluetoothCardReaderSettingsConnectedViewModel: PaymentSettingsFlowPr
             return nil
         }
         return { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.analyticsTracker.cardReaderSoftwareUpdateCancelTapped()
             self.softwareUpdateCancelable?.cancel(completion: { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if case .failure(let error) = result {
                     DDLogError("💳 Error: canceling software update \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -50,7 +50,7 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
 
     func updatingFailed(tryAgain: (() -> Void)?,
                         close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        if let tryAgain = tryAgain {
+        if let tryAgain {
             return CardPresentModalUpdateFailed(tryAgain: tryAgain, close: close)
         } else {
             return CardPresentModalUpdateFailedNonRetryable(close: close)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -83,7 +83,7 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
                              cancelSearch: @escaping () -> Void) {
         severalFoundController = SeveralReadersFoundViewController()
 
-        if let severalFoundController = severalFoundController {
+        if let severalFoundController {
             severalFoundController.configureController(
                 readerIDs: readerIDs,
                 connect: connect,
@@ -131,7 +131,7 @@ private extension CardReaderSettingsAlerts {
             let shouldAnimateDismissal = animated && present == nil
             modalController?.dismiss(animated: shouldAnimateDismissal, completion: { [weak self] in
                 self?.modalController = nil
-                guard let from = from, let present = present else {
+                guard let from, let present else {
                     return
                 }
                 from.present(present, animated: false)
@@ -141,7 +141,7 @@ private extension CardReaderSettingsAlerts {
 
         /// Or, if there was no common modal to dismiss, present straight-away
         ///
-        guard let from = from, let present = present else {
+        guard let from, let present else {
             return
         }
         from.present(present, animated: animated)
@@ -155,7 +155,7 @@ private extension CardReaderSettingsAlerts {
             let shouldAnimateDismissal = animated && present == nil
             severalFoundController?.dismiss(animated: shouldAnimateDismissal, completion: { [weak self] in
                 self?.severalFoundController = nil
-                guard let from = from, let present = present else {
+                guard let from, let present else {
                     return
                 }
                 from.present(present, animated: false)
@@ -164,7 +164,7 @@ private extension CardReaderSettingsAlerts {
         }
         /// Or, if there was no several-found modal to dismiss, present straight-away
         ///
-        guard let from = from, let present = present else {
+        guard let from, let present else {
             return
         }
         from.present(present, animated: animated)
@@ -220,7 +220,7 @@ private extension CardReaderSettingsAlerts {
     }
 
     func updatingFailed(from: UIViewController, tryAgain: (() -> Void)?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        if let tryAgain = tryAgain {
+        if let tryAgain {
             return CardPresentModalUpdateFailed(tryAgain: tryAgain, close: close)
         } else {
             return CardPresentModalUpdateFailedNonRetryable(close: close)
@@ -244,7 +244,7 @@ private extension CardReaderSettingsAlerts {
         }
 
         modalController = CardPresentPaymentsModalViewController(viewModel: viewModel)
-        guard let modalController = modalController else {
+        guard let modalController else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsResultsControllers.swift
@@ -40,7 +40,7 @@ final class CardReaderSettingsResultsControllers {
         }
 
         paymentGatewayAccountResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -47,7 +47,7 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
             self?.searchAndConnect()
         }
         rootView.showURL = { [weak self] url in
-            guard let self = self else { return }
+            guard let self else { return }
             WebviewHelper.launch(url, with: self)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewModel.swift
@@ -92,7 +92,7 @@ final class CardReaderSettingsSearchingViewModel: PaymentSettingsFlowPresentedVi
     private func beginConnectedReaderObservation() {
         // This completion should be called repeatedly as the list of connected readers changes
         let connectedAction = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.noConnectedReader = readers.isEmpty ? .isTrue : .isFalse
@@ -107,7 +107,7 @@ final class CardReaderSettingsSearchingViewModel: PaymentSettingsFlowPresentedVi
         let reconnectionAction = CardPresentPaymentAction.observeCardReaderReconnectionState { reconnectionEvents in
             reconnectionEvents
                 .sink { [weak self] state in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     switch state {
                     case .reconnecting:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/PaymentSettingsFlowPresentingViewController.swift
@@ -42,7 +42,7 @@ final class PaymentSettingsFlowPresentingViewController: UIViewController {
         childViewController?.removeFromParent()
         childViewController?.view.removeFromSuperview()
 
-        guard let viewModelAndView = viewModelAndView else {
+        guard let viewModelAndView else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -50,7 +50,7 @@ final class SetUpTapToPayInformationViewController: UIHostingController<SetUpTap
 
     private func configureView() {
         rootView.showURL = { [weak self] url in
-            guard let self = self else { return }
+            guard let self else { return }
             WebviewHelper.launch(url, with: self)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -79,7 +79,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     private func beginConnectedReaderObservation() {
         // This completion should be called repeatedly as the list of connected readers changes
         let connectedAction = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.disconnectFromBluetoothReader(in: readers)
@@ -106,7 +106,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
 
     private func beginConnectivityObservation() {
         connectivityObserver.statusPublisher.sink { [weak self] status in
-            guard let self = self else { return }
+            guard let self else { return }
             switch (status, self.enableSetup) {
             case (.notReachable, true),
                 (.reachable, false):

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayOnboardingViewController.swift
@@ -16,13 +16,13 @@ final class SetUpTapToPayOnboardingViewController: UIHostingController<SetUpTapT
         }
 
         viewModel.showSupport = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let supportForm = SupportFormHostingController(viewModel: .init())
             supportForm.show(from: self)
         }
 
         viewModel.showURL = { [weak self] url in
-            guard let self = self else { return }
+            guard let self else { return }
             WebviewHelper.launch(url, with: self)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -78,7 +78,7 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
     private func beginConnectedReaderObservation() {
         // This completion should be called repeatedly as the list of connected readers changes
         let connectedAction = CardPresentPaymentAction.observeConnectedReaders() { [weak self] readers in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.connectedReader = readers.isNotEmpty ? .isTrue : .isFalse
@@ -102,7 +102,7 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
                                                            status: .pending,
                                                            amount: trialPaymentAmount,
                                                            taxable: false) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.loading = false
 
             switch result {
@@ -151,7 +151,7 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
                 let refundAction = RefundAction.createRefund(siteID: siteID,
                                                              orderID: summaryViewModel.orderID,
                                                              refund: refund) { [weak self] refund, error in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     defer {
                         self.refundInProgress = false
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPayReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/TapToPayReaderConnectionAlertsProvider.swift
@@ -50,7 +50,7 @@ struct TapToPayReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidi
 
     func updatingFailed(tryAgain: (() -> Void)?,
                         close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        if let tryAgain = tryAgain {
+        if let tryAgain {
             return CardPresentModalUpdateFailed(image: .tapToPayReaderError, tryAgain: tryAgain, close: close)
         } else {
             return CardPresentModalUpdateFailedNonRetryable(image: .tapToPayReaderError, close: close)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CloseAccountCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CloseAccountCoordinator.swift
@@ -43,14 +43,14 @@ private extension CloseAccountCoordinator {
         alertController.addActionWithTitle(Localization.ConfirmationAlert.cancelButtonTitle, style: .cancel) { _ in }
         let closeAccountAction = alertController.addActionWithTitle(Localization.ConfirmationAlert.removeButtonTitle,
                                                                     style: .destructive) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
 
             // TODO: 7068 - analytics
 
             self.presentInProgressUI()
 
             Task { @MainActor [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 var dismissInProgressUICompletion: () -> Void
 
@@ -102,7 +102,7 @@ private extension CloseAccountCoordinator {
                                                 message: generateLocalizedMessage(error: error),
                                                 preferredStyle: .alert)
         alertController.addActionWithTitle(Localization.ErrorAlert.contactSupportButtonTitle, style: .default) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             let supportForm = SupportFormHostingController(viewModel: .init())
             supportForm.show(from: self.sourceViewController)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -350,7 +350,7 @@ private extension HelpAndSupportViewController {
     /// Help Center action
     ///
     func helpCenterWasPressed() {
-        if let customHelpCenterContent = customHelpCenterContent {
+        if let customHelpCenterContent {
             launchCustomHelpCenterWebPage(customHelpCenterContent)
         } else {
             ZendeskProvider.shared.showHelpCenter(from: self)
@@ -376,7 +376,7 @@ private extension HelpAndSupportViewController {
                 return
             }
 
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
@@ -28,7 +28,7 @@ final class SystemStatusReportViewModel: ObservableObject {
     func fetchReport() {
         errorFetchingReport = false
         let action = SystemStatusAction.fetchSystemStatusReport(siteID: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let status):
                 self.statusReport = self.formatReport(with: status)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -119,14 +119,14 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func installCardPresentPlugin() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
         // Only WCPay is currently supported, so we don't expose a different plugin option
         let pluginSlug = CardPresentPaymentsPlugin.wcPay.gatewayID
 
         let installPluginAction = SitePluginAction.installSitePlugin(siteID: siteID, slug: pluginSlug, onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.state = .loading
             switch result {
             case .success:
@@ -141,14 +141,14 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func activateCardPresentPlugin() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
         // Only WCPay is currently supported, so we don't expose a different plugin option
         let pluginName = CardPresentPaymentsPlugin.wcPay.fileNameWithPathExtension
 
         let activatePluginAction = SitePluginAction.activateSitePlugin(siteID: siteID, pluginName: pluginName, onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.state = .loading
             switch result {
             case .success:
@@ -172,12 +172,12 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     /// But first we also need to prompt the CardPresentPaymentStore to use the right backend based on the active plugin.
     ///
     func updateAccounts() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
 
         let paymentGatewayAccountsAction = CardPresentPaymentAction.loadAccounts(siteID: siteID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -221,7 +221,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     }
 
     func clearPluginSelection() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
         preferredPluginLocal = nil
@@ -241,7 +241,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
 //
 private extension CardPresentPaymentsOnboardingUseCase {
     func synchronizeStoreCountryAndPlugins(completion: () -> Void) {
-        guard let siteID = siteID else {
+        guard let siteID else {
             completion()
             return
         }
@@ -251,7 +251,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
         // We need to sync settings to check the store's country
         let settingsAction = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { error in
-            if let error = error {
+            if let error {
                 DDLogError("[CardPresentPaymentsOnboarding] Error syncing site settings: \(error)")
                 errors.append(error)
             }
@@ -272,7 +272,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         stores.dispatch(systemPluginsAction)
 
         group.notify(queue: .main, execute: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if errors.isNotEmpty,
                errors.contains(where: self.isNetworkError(_:)) {
                 self.state = .noConnectionError
@@ -451,7 +451,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     var storedPreferredPlugin: CardPresentPaymentsPlugin? {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return nil
         }
 
@@ -464,7 +464,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func savePreferredPlugin(_ plugin: CardPresentPaymentsPlugin) {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
         let action = AppSettingsAction.setPreferredInPersonPaymentGateway(siteID: siteID, gateway: plugin.gatewayID)
@@ -478,7 +478,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     // Note: This counts on synchronizeStoreCountryAndPlugins having been called to get
     // the appropriate account for the site, be that Stripe or WCPay
     func getPaymentGatewayAccount(plugin: CardPresentPaymentsPlugin) -> PaymentGatewayAccount? {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return nil
         }
         return storageManager.viewStorage
@@ -527,7 +527,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func checkIfCashOnDeliveryStepSkipped() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
 
@@ -540,7 +540,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
     func isCashOnDeliverySetUp() -> Bool {
         let gatewayID = PaymentGateway.Constants.cashOnDeliveryGatewayID
-        guard let siteID = siteID,
+        guard let siteID,
               let codGateway = storageManager.viewStorage.loadPaymentGateway(siteID: siteID,
                                                                              gatewayID: gatewayID)?.toReadOnly()
         else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
@@ -10,12 +10,12 @@ final class CardPresentPaymentsOnboardingViewController: UIHostingController<Car
         self.onWillDisappear = onWillDisappear
         super.init(rootView: CardPresentPaymentsOnboardingView(viewModel: viewModel))
         viewModel.showSupport = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let supportForm = SupportFormHostingController(viewModel: .init())
             supportForm.show(from: self)
         }
         viewModel.showURL = { [weak self] url in
-            guard let self = self else { return }
+            guard let self else { return }
             WebviewHelper.launch(url, with: self)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewViewModel.swift
@@ -70,7 +70,7 @@ final class WooPaymentsPayoutsCurrencyOverviewViewModel: ObservableObject {
     }
 
     private func formatDate(_ date: Date?) -> String? {
-        guard let date = date else {
+        guard let date else {
             return nil
         }
         let dateFormatter = DateFormatter()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift
@@ -85,7 +85,7 @@ final class InPersonPaymentsCashOnDeliveryToggleRowViewModel: ObservableObject, 
 
     private static func createPaymentGatewaysResultsController(siteID: Int64?,
                                                                storageManager: StorageManagerType) -> ResultsController<StoragePaymentGateway>? {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return nil
         }
 
@@ -97,7 +97,7 @@ final class InPersonPaymentsCashOnDeliveryToggleRowViewModel: ObservableObject, 
     }
 
     func refreshState() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
 
@@ -128,12 +128,12 @@ final class InPersonPaymentsCashOnDeliveryToggleRowViewModel: ObservableObject, 
     }
 
     private func enableCashOnDeliveryGateway() {
-        guard let siteID = siteID else {
+        guard let siteID else {
             return
         }
 
         let action = PaymentGatewayAction.updatePaymentGateway(PaymentGateway.defaultPayInPersonGateway(siteID: siteID)) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard result.isSuccess else {
                 DDLogError("💰 Could not update Payment Gateway: \(String(describing: result.failure))")
                 // Resetting the toggle to the most recent stored value, or false because we failed to make it true.
@@ -159,13 +159,13 @@ final class InPersonPaymentsCashOnDeliveryToggleRowViewModel: ObservableObject, 
     }
 
     private func disableCashOnDeliveryGateway() {
-        guard let cashOnDeliveryGateway = cashOnDeliveryGateway else {
+        guard let cashOnDeliveryGateway else {
             return
         }
 
         let disabledPaymentGateway = cashOnDeliveryGateway.copy(enabled: false)
         let action = PaymentGatewayAction.updatePaymentGateway(disabledPaymentGateway) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard result.isSuccess else {
                 DDLogError("💰 Could not update Payment Gateway: \(String(describing: result.failure))")
                 // Resetting the toggle to the most recent stored value, or true because we failed to make it false.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -87,7 +87,7 @@ struct InPersonPaymentsSelectPluginView: View {
     }
 
     private func confirmPluginSelection() {
-        guard let selectedPlugin = selectedPlugin else {
+        guard let selectedPlugin else {
             // This should not be possible
             assertionFailure()
             return DDLogError("Attempt to confirm a payment gateway selection with no gateway selected")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/LearnMoreViewModel.swift
@@ -48,7 +48,7 @@ class LearnMoreViewModel: ObservableObject {
     }
 
     func learnMoreTapped() {
-        guard let tappedAnalyticEvent = tappedAnalyticEvent else {
+        guard let tappedAnalyticEvent else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -67,7 +67,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
     func skipTapped() {
         trackSkipTapped()
 
-        guard let siteID = siteID else {
+        guard let siteID else {
             return completion()
         }
 
@@ -79,14 +79,14 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
     func enableTapped() {
         trackEnableTapped()
 
-        guard let siteID = siteID else {
+        guard let siteID else {
             return completion()
         }
 
         awaitingResponse = true
 
         let action = PaymentGatewayAction.updatePaymentGateway(PaymentGateway.defaultPayInPersonGateway(siteID: siteID)) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard result.isSuccess else {
                 DDLogError("💰 Could not update Payment Gateway: \(String(describing: result.failure))")
                 self.awaitingResponse = false

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -28,12 +28,12 @@ struct InPersonPaymentsOnboardingError: View {
 
                 Spacer()
 
-                if let buttonViewModel = buttonViewModel {
+                if let buttonViewModel {
                     Button(buttonViewModel.text, action: buttonViewModel.action)
                         .buttonStyle(PrimaryButtonStyle())
                         .padding(.bottom, secondaryButtonViewModel == nil ? 24.0 : 0)
                 }
-                if let secondaryButtonViewModel = secondaryButtonViewModel {
+                if let secondaryButtonViewModel {
                     Button(secondaryButtonViewModel.text, action: secondaryButtonViewModel.action)
                         .buttonStyle(SecondaryButtonStyle())
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -29,7 +29,7 @@ struct InPersonPaymentsStripeAccountPending: View {
     }
 
     private var message: String {
-        guard let deadline = deadline else {
+        guard let deadline else {
             DDLogError("In-Person Payments not available. Stripe has pending requirements without known deadline")
             return Localization.messageUnknownDeadline
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
@@ -32,7 +32,7 @@ final class SilenceablePassthroughCardPresentPaymentAlertsPresenter<AlertPresent
         self.alertsPresenter = alertsPresenter
         alertSubscription = alertSubject.share().sink { viewModel in
             DispatchQueue.main.async {
-                guard let viewModel = viewModel else {
+                guard let viewModel else {
                     alertsPresenter.dismiss()
                     return
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
@@ -125,7 +125,7 @@ private extension TapToPayReconnectionController {
         let connectionController = tapToPayConnectionControllerForReconnection()
 
         connectionController.searchAndConnect(onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.adoptedConnectionCompletionHandler?(result)
             self.reset()
         })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
@@ -102,7 +102,7 @@ struct PluginDetailsRowUpdateAvailable: View {
             Image(systemName: Constants.softwareUpdateSymbolName)
             Text(Localization.updateAvailableTitle)
             Spacer()
-            if let versionLatest = versionLatest {
+            if let versionLatest {
                 Text(versionLatest)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginDetailsViewModel.swift
@@ -46,7 +46,7 @@ final class PluginDetailsViewModel: ObservableObject {
     let updatePluginTitle: String
 
     var updateAvailable: Bool {
-        guard let plugin = plugin else {
+        guard let plugin else {
             return false
         }
         return !VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: plugin.versionLatest)
@@ -118,7 +118,7 @@ private extension PluginDetailsViewModel {
     }
 
     private func updateAvailable(for plugin: SystemPlugin?) -> Bool {
-        guard let plugin = plugin else {
+        guard let plugin else {
             return false
         }
         return !VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: plugin.versionLatest)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -32,7 +32,7 @@ final class SettingsViewController: UIViewController {
 
     private lazy var closeAccountCoordinator: CloseAccountCoordinator =
     CloseAccountCoordinator(sourceViewController: self) { [weak self] in
-        guard let self = self else { throw CloseAccountError.presenterDeallocated }
+        guard let self else { throw CloseAccountError.presenterDeallocated }
         try await self.closeAccount()
     } onRemoveSuccess: { [weak self] in
         self?.logOutUser()
@@ -333,7 +333,7 @@ private extension SettingsViewController {
 
     func closeAccount() async throws {
         try await withCheckedThrowingContinuation { [weak self] continuation in
-            guard let self = self else { return }
+            guard let self else { return }
             let action = AccountAction.closeAccount { result in
                 continuation.resume(with: result)
             }
@@ -365,11 +365,11 @@ private extension SettingsViewController {
 
     func switchStoreWasPressed() {
         ServiceLocator.analytics.track(.settingsSelectedStoreTapped)
-        if let navigationController = navigationController {
+        if let navigationController {
             storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
             storePickerCoordinator?.start()
             storePickerCoordinator?.onDismiss = { [weak self] in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 self.viewModel.onStorePickerDismiss()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -187,7 +187,7 @@ private extension SettingsViewModel {
 
     func loadWhatsNewOnWooCommerce() {
         stores.dispatch(AnnouncementsAction.loadSavedAnnouncement(onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let (announcement, _) = try? result.get(),
                     announcement.shownInThisAppVersion else {
                 return DDLogInfo("📣 There are no announcements to show!")
@@ -410,14 +410,14 @@ private extension SettingsViewModel {
 
         func configureResultsController<T>(_ resultsController: ResultsController<T>?,
                           onReload: @escaping () -> Void) where T: ResultsControllerMutableType {
-            guard let resultsController = resultsController else { return }
+            guard let resultsController else { return }
 
             resultsController.onDidChangeContent = {
                 onReload()
             }
 
             resultsController.onDidResetContent = { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 /// Refetching all the results controllers is necessary after a storage reset in `onDidResetContent` callback and before reloading UI that
                 /// involves more than one results controller.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -40,11 +40,11 @@ struct StoreStatsChart: View {
                                              endPoint: .bottom))
 
             // Vertical line for a selected point
-            if let selectedDate = selectedDate, viewModel.hasRevenue {
+            if let selectedDate, viewModel.hasRevenue {
                 RuleMark(x: .value(Localization.xSelectedValue, selectedDate))
                     .foregroundStyle(Constants.chartHighlightLineColor)
 
-                if let selectedRevenue = selectedRevenue {
+                if let selectedRevenue {
                     PointMark(x: .value(Localization.xSelectedValue, selectedDate),
                               y: .value(Localization.ySelectedValue, selectedRevenue))
                     .foregroundStyle(Constants.chartHighlightLineColor)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStatsUsageTracksEventEmitter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStatsUsageTracksEventEmitter.swift
@@ -60,12 +60,12 @@ final class StoreStatsUsageTracksEventEmitter {
 
     func interacted(at interactionTime: Date = Date()) {
         // Check if they were idle for some time.
-        if let lastInteractionTime = lastInteractionTime,
+        if let lastInteractionTime,
            interactionTime.timeIntervalSince(lastInteractionTime) >= idleTimeThreshold {
             reset()
         }
 
-        guard let firstInteractionTime = firstInteractionTime else {
+        guard let firstInteractionTime else {
             interactions = 1
             self.firstInteractionTime = interactionTime
             self.lastInteractionTime = interactionTime

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -62,7 +62,7 @@ final class AztecEditorViewController: UIViewController, Editor {
     ///
     private lazy var formatBar: Aztec.FormatBar = {
         let toolbar = formatBarFactory.formatBar() { [weak self] (formatBarItem, formatBar) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.formatBarCommandCoordinator.handleAction(formatBarItem: formatBarItem,

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecTextViewAttachmentHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecTextViewAttachmentHandler.swift
@@ -20,19 +20,19 @@ final class AztecTextViewAttachmentHandler: TextViewAttachmentDelegate {
             let imageService = ServiceLocator.imageService
 
             imageService.retrieveImageFromCache(with: url) { image in
-                if let image = image {
+                if let image {
                     success(image)
                 }
             }
 
             let task = imageService.downloadImage(with: url, shouldCacheImage: true) { image, error in
-                guard let image = image else {
+                guard let image else {
                     failure()
                     return
                 }
                 success(image)
             }
-            if let task = task {
+            if let task {
                 activeImageTasks.append(task)
             }
         default:

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+UnifiedLogin.swift
@@ -175,7 +175,7 @@ private extension FancyAlertViewController {
             let identifier = HelpAndSupportViewController.classNameWithoutNamespaces
             let supportViewController = UIStoryboard.settings.instantiateViewController(identifier: identifier,
                                                                                          creator: { coder -> HelpAndSupportViewController? in
-                guard let customHelpCenterContent = customHelpCenterContent else {
+                guard let customHelpCenterContent else {
                     /// Returning nil as we don't need to customise the HelpAndSupportViewController
                     /// In this case `instantiateViewController` method will use the default `HelpAndSupportViewController` created from storyboard.
                     ///

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -35,7 +35,7 @@ final class Tooltip: UIView {
     /// Determines whether a leading icon for the title, should be placed or not.
     var shouldPrefixLeadingIcon: Bool = true {
         didSet {
-            guard let title = title else { return }
+            guard let title else { return }
 
             Self.updateTitleLabel(
                 titleLabel,
@@ -49,7 +49,7 @@ final class Tooltip: UIView {
     /// If `shouldPrefixLeadingIcon` is `true`, a leading icon will be prefixed.
     var title: String? {
         didSet {
-            guard let title = title else {
+            guard let title else {
                 titleLabel.text = nil
                 return
             }
@@ -227,7 +227,7 @@ final class Tooltip: UIView {
         arrowPath.close()
 
         arrowShapeLayer = CAShapeLayer()
-        guard let arrowShapeLayer = arrowShapeLayer else {
+        guard let arrowShapeLayer else {
             return
         }
 
@@ -347,13 +347,13 @@ final class Tooltip: UIView {
 
         totalHeight += Constants.Spacing.contentStackViewTop
 
-        if let title = title {
+        if let title {
             totalHeight += title.height(withMaxWidth: maxContentWidth(), font: UIFont.body)
         }
 
         totalHeight += Constants.Spacing.contentStackViewInterItemSpacing * 2
 
-        if let message = message {
+        if let message {
             totalHeight += message.height(withMaxWidth: maxContentWidth(), font: UIFont.body)
         }
 
@@ -373,11 +373,11 @@ final class Tooltip: UIView {
         let messageWidth = message?.width(withMaxWidth: maxContentWidth(), font: UIFont.body) ?? 0
 
         var buttonsWidth: CGFloat = 0
-        if let primaryButtonTitle = primaryButtonTitle {
+        if let primaryButtonTitle {
             buttonsWidth += primaryButtonTitle.width(withMaxWidth: maxContentWidth(), font: UIFont.subheadline)
         }
 
-        if let secondaryButtonTitle = secondaryButtonTitle {
+        if let secondaryButtonTitle {
             buttonsWidth += secondaryButtonTitle.width(
                 withMaxWidth: maxContentWidth(),
                 font: UIFont.subheadline

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -190,7 +190,7 @@ final class TooltipPresenter {
     ///  states too. The sizing won't be affected in these cases so no need to reset the tooltip. Here we filter out changes
     ///  to and from `faceUp` & `faceDown`.
     @objc private func didDeviceOrientationChange() {
-        guard let previousDeviceOrientation = previousDeviceOrientation else {
+        guard let previousDeviceOrientation else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/FilterTabBar.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/FilterTabBar.swift
@@ -69,7 +69,7 @@ final class FilterTabBar: UIControl {
 
     private var tabBarHeightConstraint: NSLayoutConstraint! {
         didSet {
-            if let oldValue = oldValue {
+            if let oldValue {
                 NSLayoutConstraint.deactivate([oldValue])
                 tabBarHeightConstraint.isActive = true
             }
@@ -152,11 +152,11 @@ final class FilterTabBar: UIControl {
     ///
     var accessoryView: UIView? = nil {
         didSet {
-            if let oldValue = oldValue {
+            if let oldValue {
                 oldValue.removeFromSuperview()
             }
 
-            if let accessoryView = accessoryView {
+            if let accessoryView {
                 accessoryView.setContentCompressionResistancePriority(.required, for: .horizontal)
                 stackView.insertArrangedSubview(accessoryView, at: 0)
             }
@@ -166,7 +166,7 @@ final class FilterTabBar: UIControl {
     // MARK: - Tab Sizing
     private var stackViewEdgeConstraints: [NSLayoutConstraint]! {
         didSet {
-            if let oldValue = oldValue {
+            if let oldValue {
                 NSLayoutConstraint.deactivate(oldValue)
             }
         }
@@ -174,7 +174,7 @@ final class FilterTabBar: UIControl {
 
     private var stackViewWidthConstraint: NSLayoutConstraint! {
         didSet {
-            if let oldValue = oldValue {
+            if let oldValue {
                 NSLayoutConstraint.deactivate([oldValue])
             }
         }
@@ -328,7 +328,7 @@ final class FilterTabBar: UIControl {
     }
 
     private func addColor(_ color: UIColor, toAttributedString attributedString: NSAttributedString?) -> NSAttributedString? {
-        guard let attributedString = attributedString else {
+        guard let attributedString else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -196,7 +196,7 @@ final class FilterListViewController<ViewModel: FilterListViewModel>: UIViewCont
     //
     @objc private func filterActionButtonTapped() {
         dismiss(animated: true) { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             let criteria = self.viewModel.criteria
@@ -270,7 +270,7 @@ private extension FilterListViewController {
 
     func observeListSelectorCommandItemSelection() {
         selectedFilterTypeSubscription = listSelectorCommand.onItemSelected.sink { [weak self] selected in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -62,7 +62,7 @@ final class HubMenuCoordinator {
         hubMenuController = HubMenuViewController(siteID: siteID,
                                                   stores: storesManager,
                                                   tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker)
-        if let hubMenuController = hubMenuController {
+        if let hubMenuController {
             let navigationController = UINavigationController(rootViewController: hubMenuController)
             tabContainerController.wrappedController = navigationController
         }
@@ -139,7 +139,7 @@ final class HubMenuCoordinator {
 // MARK: - Deeplinks
 extension HubMenuCoordinator: DeepLinkNavigator {
     func navigate(to destination: any DeepLinkDestinationProtocol) {
-        guard let hubMenuController = hubMenuController else {
+        guard let hubMenuController else {
             return
         }
         hubMenuController.navigate(to: destination)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -100,7 +100,7 @@ private extension HubMenuViewController {
     /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.
     ///
     func presentSwitchStore() {
-        if let navigationController = navigationController {
+        if let navigationController {
             storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
             storePickerCoordinator?.start()
         }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -115,7 +115,7 @@ extension InboxViewModel: PaginationTrackerDelegate {
                                                         pageSize: pageSize,
                                                         type: Self.noteTypes,
                                                         status: Self.noteStatuses) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let notes):
                 ServiceLocator.analytics.track(.inboxNotesLoaded,
@@ -171,7 +171,7 @@ private extension InboxViewModel {
     func configureFirstPageLoad() {
         onLoadTrigger
             .sink { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.syncFirstPage()
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
+++ b/WooCommerce/Classes/ViewRelated/Keyboard/KeyboardFrameObserver.swift
@@ -18,7 +18,7 @@ final class KeyboardFrameObserver {
 
     private var keyboardFrame: CGRect? {
         didSet {
-            if let keyboardFrame = keyboardFrame, oldValue != keyboardFrame {
+            if let keyboardFrame, oldValue != keyboardFrame {
                 onKeyboardFrameUpdate(keyboardFrame)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -234,7 +234,7 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: SyncCompletion?) {
         transitionToSyncingState(pageNumber: pageNumber)
         dataSource.sync(pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -832,7 +832,7 @@ private extension MainTabBarController {
 
     func observeSiteIDForViewControllers() {
         cancellableSiteID = stores.siteID.sink { [weak self] siteID in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.updateViewControllers(siteID: siteID)
@@ -996,7 +996,7 @@ private extension MainTabBarController {
 private extension MainTabBarController {
     func startListeningToOrdersBadge() {
         viewModel.onOrdersBadgeReload = { [weak self] countReadableString in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -1019,7 +1019,7 @@ private extension MainTabBarController {
 private extension MainTabBarController {
     func observeProductImageUploadStatusUpdates() {
         productImageUploadErrorsSubscription = productImageUploader.errors.sink { [weak self] error in
-            guard let self = self else { return }
+            guard let self else { return }
             switch error.error {
             case .failedSavingProductAfterImageUpload:
                 self.handleErrorSavingProductAfterImageUpload(error)
@@ -1045,9 +1045,9 @@ private extension MainTabBarController {
                             notificationInfo: nil,
                             actionTitle: Localization.imageUploadFailureNoticeActionTitle,
                             actionHandler: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             Task { @MainActor [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 await self.showProductDetails(for: error)
                 self.analytics.track(event: .ImageUpload
                     .failureSavingProductAfterImageUploadNoticeTapped(productOrVariation: error.productOrVariationEventProperty))
@@ -1068,9 +1068,9 @@ private extension MainTabBarController {
                             notificationInfo: nil,
                             actionTitle: Localization.imageUploadFailureNoticeActionTitle,
                             actionHandler: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             Task { @MainActor [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 await self.showProductDetails(for: error)
                 self.analytics.track(event: .ImageUpload
                     .failureUploadingImageNoticeTapped(productOrVariation: error.productOrVariationEventProperty))

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -49,7 +49,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
     /// If the `viewModel` is not given, then the UI will be set to empty.
     ///
     func configureCell(viewModel: OrderListCellViewModel?) {
-        guard let viewModel = viewModel else {
+        guard let viewModel else {
             resetLabels()
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
@@ -38,7 +38,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
         }
 
         modalController = CardPresentPaymentsModalViewController(viewModel: viewModel)
-        guard let modalController = modalController else {
+        guard let modalController else {
             return
         }
 
@@ -57,7 +57,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
             let shouldAnimateDismissal = animated && present == nil
             modalController?.dismiss(animated: shouldAnimateDismissal, completion: { [weak self] in
                 self?.modalController = nil
-                guard let from = from, let present = present else {
+                guard let from, let present else {
                     return
                 }
                 from.present(present, animated: false)
@@ -67,7 +67,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
 
         /// Or, if there was no common modal to dismiss, present straight-away
         ///
-        guard let from = from, let present = present else {
+        guard let from, let present else {
             return
         }
         from.present(present, animated: animated)
@@ -94,7 +94,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
             let shouldAnimateDismissal = animated && present == nil
             severalFoundController?.dismiss(animated: shouldAnimateDismissal, completion: { [weak self] in
                 self?.severalFoundController = nil
-                guard let from = from, let present = present else {
+                guard let from, let present else {
                     return
                 }
                 from.present(present, animated: false)
@@ -103,7 +103,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
         }
         /// Or, if there was no several-found modal to dismiss, present straight-away
         ///
-        guard let from = from, let present = present else {
+        guard let from, let present else {
             return
         }
         from.present(present, animated: animated)
@@ -121,7 +121,7 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
                              cancelSearch: @escaping () -> Void) {
         severalFoundController = SeveralReadersFoundViewController()
 
-        if let severalFoundController = severalFoundController {
+        if let severalFoundController {
             severalFoundController.configureController(
                 readerIDs: readerIDs,
                 connect: connect,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentReceiptEmailCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentReceiptEmailCoordinator.swift
@@ -151,7 +151,7 @@ private extension CardPresentPaymentReceiptEmailCoordinator {
         private static let emailSubjectWithoutStoreName = NSLocalizedString("Your receipt",
                                                                             comment: "Subject of email sent with a card present payment receipt")
         static func emailSubject(storeName: String?) -> String {
-            guard let storeName = storeName, storeName.isNotEmpty else {
+            guard let storeName, storeName.isNotEmpty else {
                 return emailSubjectWithoutStoreName
             }
             return .localizedStringWithFormat(emailSubjectWithStoreName, storeName)
@@ -162,7 +162,7 @@ private extension CardPresentPaymentReceiptEmailCoordinator {
         private static let collectPaymentWithName = NSLocalizedString("Collect payment from %1$@",
                                                                       comment: "Alert title when starting the collect payment flow with a user name.")
         static func collectPaymentTitle(username: String?) -> String {
-            guard let username = username, username.isNotEmpty else {
+            guard let username, username.isNotEmpty else {
                 return collectPaymentWithoutName
             }
             return .localizedStringWithFormat(collectPaymentWithName, username)

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -147,7 +147,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                         onPaymentCompletion: @escaping () -> Void,
                         onCompleted: @escaping () -> Void) {
         preflightController.readerConnection.sink { [weak self] connectionResult in
-            guard let self = self else { return }
+            guard let self else { return }
             self.analyticsTracker.preflightResultReceived(connectionResult)
             switch connectionResult {
             case .completed(let reader, let paymentGatewayAccount):
@@ -156,7 +156,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                                     paymentGatewayAccount: paymentGatewayAccount,
                                     channel: channel,
                                     onCompletion: { [weak self] result in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     // Inform about the collect payment state
                     switch result {
                     case .failure(CollectOrderPaymentUseCaseError.flowCanceledByUser):
@@ -170,7 +170,7 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                         self.storeInPersonPaymentsTransactionDateIfFirst(using: reader.readerType)
 
                         self.receiptEligibilityUseCase.isEligibleForBackendReceipts { [weak self] isEligible in
-                            guard let self = self else { return }
+                            guard let self else { return }
                             switch isEligible {
                             case true:
                                 self.presentBackendReceiptAlert(alertProvider: paymentAlertProvider, onCompleted: onCompleted)
@@ -228,7 +228,7 @@ private extension CollectOrderPaymentUseCase {
     /// Checks whether the amount to be collected is valid: (not nil, convertible to decimal, higher than minimum amount ...)
     ///
     func isTotalAmountValid() -> Bool {
-        guard let orderTotal = orderTotal else {
+        guard let orderTotal else {
             return false
         }
 
@@ -274,7 +274,7 @@ private extension CollectOrderPaymentUseCase {
         }))
 
         let action = OrderAction.retrieveOrderRemotely(siteID: order.siteID, orderID: order.orderID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let order):
@@ -311,7 +311,7 @@ private extension CollectOrderPaymentUseCase {
                         channel: PaymentChannel,
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         checkOrderIsStillEligibleForPayment(alertProvider: paymentAlerts, onPaymentCompletion: onCompletion) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 return self.checkThenHandlePaymentFailureAndRetryPayment(error,
@@ -341,7 +341,7 @@ private extension CollectOrderPaymentUseCase {
                         }))
                     },
                     onWaitingForInput: { [weak self] inputMethods in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         self.alertsPresenter.present(
                             viewModel: paymentAlerts.tapOrInsertCard(
                                 title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
@@ -355,7 +355,7 @@ private extension CollectOrderPaymentUseCase {
                                 })
                         )
                     }, onCardInserted: { [weak self] in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
                             title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
                                 username: self.order.billingAddress?.firstName),
@@ -367,14 +367,14 @@ private extension CollectOrderPaymentUseCase {
                             })
                         )
                     }, onProcessingMessage: { [weak self] in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         // Waiting message
                         self.alertsPresenter.present(
                             viewModel: paymentAlerts.processingTransaction(
                                 title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
                                     username: self.order.billingAddress?.firstName)))
                     }, onDisplayMessage: { [weak self] message in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         // Reader messages. EG: Remove Card
                         self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
                     }, onProcessingCompletion: { [weak self] intent in
@@ -520,7 +520,7 @@ private extension CollectOrderPaymentUseCase {
                                            tryAgain: { [weak self] in
                                                // Cancel current payment
                                                self?.paymentOrchestrator.cancelPayment() { [weak self] result in
-                                                   guard let self = self else { return }
+                                                   guard let self else { return }
 
                                                    switch result {
                                                    case .success, .failure(CardReaderServiceError.paymentCancellation(.noActivePaymentIntent)):
@@ -555,7 +555,7 @@ private extension CollectOrderPaymentUseCase {
                 error: error,
                 receiptState: receiptState,
                 tryAgain: { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.checkOrderIsStillEligibleForPayment(alertProvider: paymentAlerts, onPaymentCompletion: onCompletion) { result in
                         switch result {
                         case .failure(let error):
@@ -566,7 +566,7 @@ private extension CollectOrderPaymentUseCase {
                                                                                      onCompletion: onCompletion)
                         case .success:
                             self.paymentOrchestrator.retryPayment(for: self.order) { [weak self] result in
-                                guard let self = self else { return }
+                                guard let self else { return }
                                 switch result {
                                 case .success(let capturedPaymentData):
                                     self.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
@@ -653,7 +653,7 @@ private extension CollectOrderPaymentUseCase {
                              onCompleted: @escaping () -> ()) {
         // Present receipt alert
         alertsPresenter.present(viewModel: paymentAlerts.success(receiptState: .init(printReceipt: { [order, configuration, weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             guard let receiptParameters else {
                 return self.presentReceiptFailedNotice(
@@ -673,7 +673,7 @@ private extension CollectOrderPaymentUseCase {
                 onCompleted()
             }
         }, emailReceipt: { [order, analyticsTracker, paymentOrchestrator, weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             alertsPresenter.dismiss()
 
@@ -777,7 +777,7 @@ private extension CollectOrderPaymentUseCase {
                                                          emailReceiptAction: { [weak self] in
                     guard let self else { return }
                     self.presentSendReceiptAfterPayment { order in
-                        if let order  = order, let email = order.billingAddress?.email, email.isNotEmpty {
+                        if let order, let email = order.billingAddress?.email, email.isNotEmpty {
                             self.order = order
                             completion(.paymentSuccessEmailSent(email: email,
                                                                 printReceiptAction: presentBackendReceiptAction,
@@ -877,7 +877,7 @@ private enum CollectOrderPaymentUseCaseDefinitions {
         private static let emailSubjectWithoutStoreName = NSLocalizedString("Your receipt",
                                                                     comment: "Subject of email sent with a card present payment receipt")
         static func emailSubject(storeName: String?) -> String {
-            guard let storeName = storeName, storeName.isNotEmpty else {
+            guard let storeName, storeName.isNotEmpty else {
                 return emailSubjectWithoutStoreName
             }
             return .localizedStringWithFormat(emailSubjectWithStoreName, storeName)
@@ -888,7 +888,7 @@ private enum CollectOrderPaymentUseCaseDefinitions {
         private static let collectPaymentWithName = NSLocalizedString("Collect payment from %1$@",
                                                                  comment: "Alert title when starting the collect payment flow with a user name.")
         static func collectPaymentTitle(username: String?) -> String {
-            guard let username = username, username.isNotEmpty else {
+            guard let username, username.isNotEmpty else {
                 return collectPaymentWithoutName
             }
             return .localizedStringWithFormat(collectPaymentWithName, username)
@@ -901,7 +901,7 @@ private enum CollectOrderPaymentUseCaseDefinitions {
             "Processing payment from %1$@",
             comment: "Alert title when processing a payment with a user name.")
         static func processingPaymentTitle(username: String?) -> String {
-            guard let username = username, username.isNotEmpty else {
+            guard let username, username.isNotEmpty else {
                 return processingPaymentWithoutName
             }
             return .localizedStringWithFormat(processingPaymentWithName, username)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModel.swift
@@ -131,7 +131,7 @@ final class AddCustomAmountViewModel: ObservableObject {
     }
 
     func deleteButtonPressed() {
-        guard let feeID = feeID else {
+        guard let feeID else {
             DDLogError("Failed attempt to delete feeID \(String(describing: feeID))")
             return
         }
@@ -157,7 +157,7 @@ private extension AddCustomAmountViewModel {
 
     func listenToAmountChanges() {
         inputTypeViewModelAdapter.amountPublisher?.map { [weak self] value in
-            guard let self = self else { return false }
+            guard let self else { return false }
 
             return self.amountIsValid(amount: value)
         }.assign(to: &$shouldEnableDoneButton)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewController.swift
@@ -103,7 +103,7 @@ private extension CustomerSelectorViewController {
     func loadCustomersContent() {
         if viewModel.isEligibleForAdvancedSearch() {
             viewModel.loadCustomersListData(onCompletion: { [weak self] result in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/Legacy/LegacyOrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/Legacy/LegacyOrderCustomerSection.swift
@@ -120,7 +120,7 @@ private struct OrderCustomerSectionContent: View {
         VStack(alignment: .leading, spacing: Layout.verticalAddressSpacing) {
             Text(title)
                 .headlineStyle()
-            if let formattedAddress = formattedAddress, formattedAddress.isNotEmpty {
+            if let formattedAddress, formattedAddress.isNotEmpty {
                 Text(formattedAddress)
                     .bodyStyle()
             } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -205,7 +205,7 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     var storedTaxRateViewModel: TaxRateViewModel? {
-        guard let storedTaxRate = storedTaxRate else { return nil }
+        guard let storedTaxRate else { return nil }
 
         return TaxRateViewModel(taxRate: storedTaxRate, showChevron: false)
     }
@@ -861,7 +861,7 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func addTaxRateAddressToOrder(taxRate: TaxRate) {
-        guard let taxBasedOnSetting = taxBasedOnSetting else {
+        guard let taxBasedOnSetting else {
             return
         }
 
@@ -920,7 +920,7 @@ final class EditableOrderViewModel: ObservableObject {
         performingNetworkRequest = true
 
         orderSynchronizer.commitAllChanges { [weak self] result, usesGiftCard in
-            guard let self = self else { return }
+            guard let self else { return }
             self.performingNetworkRequest = false
 
             switch result {
@@ -1081,7 +1081,7 @@ final class EditableOrderViewModel: ObservableObject {
         },
                                                  onCustomAmountEntered: { [weak self] amount, name, feeID, isTaxable in
             let taxStatus: OrderFeeTaxStatus = isTaxable ? .taxable : .none
-            if let feeID = feeID {
+            if let feeID {
                 self?.updateFee(with: feeID, total: amount, name: name, taxStatus: taxStatus)
             } else {
                 self?.addFee(with: amount, name: name, taxStatus: taxStatus)
@@ -1425,7 +1425,7 @@ private extension EditableOrderViewModel {
     func configureSyncErrors() {
         orderSynchronizer.statePublisher
             .map { [weak self] state in
-                guard let self = self else { return nil }
+                guard let self else { return nil }
                 switch state {
                 case let .error(error, usesGiftCard):
                     DDLogError("⛔️ Error syncing order remotely: \(error)")
@@ -1604,7 +1604,7 @@ private extension EditableOrderViewModel {
             .map { $0.items }
             .removeDuplicates()
             .map { [weak self] items -> [CollapsibleProductCardViewModel] in
-                guard let self = self else { return [] }
+                guard let self else { return [] }
                 return self.createProductRows(items: items)
             }
             .assign(to: &$productRows)
@@ -1616,7 +1616,7 @@ private extension EditableOrderViewModel {
             .map { $0.fees }
             .removeDuplicates()
             .map { [weak self] fees -> [CustomAmountRowViewModel] in
-                guard let self = self else { return [] }
+                guard let self else { return [] }
                 return fees.compactMap { fee in
                     guard !fee.isDeleted else { return nil }
 
@@ -1776,7 +1776,7 @@ private extension EditableOrderViewModel {
                 let taxBasedOnSetting = combinedPublisher.3
                 let giftCardToApply = giftCardPublisher.0
                 let isGiftCardEnabled = giftCardPublisher.1
-                guard let self = self else {
+                guard let self else {
                     return PaymentDataViewModel()
                 }
 
@@ -1900,7 +1900,7 @@ private extension EditableOrderViewModel {
 
         stores.dispatch(SettingAction.retrieveTaxBasedOnSetting(siteID: siteID,
                                                                 onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
                 case .success(let setting):
@@ -2140,8 +2140,8 @@ private extension EditableOrderViewModel {
     /// Creates an `OrderSyncAddressesInput` type if the given data exists, otherwise returns nil
     ///
     static func createAddressesInputIfPossible(billingAddress: Address?, shippingAddress: Address?)  -> OrderSyncAddressesInput? {
-        guard let billingAddress = billingAddress,
-                let shippingAddress = shippingAddress else {
+        guard let billingAddress,
+                let shippingAddress else {
             return nil
         }
 
@@ -2179,7 +2179,7 @@ private extension EditableOrderViewModel {
             addedDiscount: currentDiscount(on: orderItem),
             baseAmountForDiscountPercentage: subTotalDecimal as Decimal,
             onSave: { [weak self] discount in
-                guard let discount = discount else {
+                guard let discount else {
                     self?.addDiscountToOrderItem(item: orderItem, discount: 0)
                     return
                 }
@@ -2414,7 +2414,7 @@ extension EditableOrderViewModel {
     func addScannedProductToOrder(barcode: ScannedBarcode, onCompletion: @escaping (Result<Void, Error>) -> Void, onRetryRequested: @escaping () -> Void) {
         analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningSuccess(from: .orderCreation))
         mapScannedBarcodetoBaseItem(barcode: barcode) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case let .success(result):
                 Task { @MainActor in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -42,7 +42,7 @@ final class OrderFormHostingController: UIHostingController<OrderFormPresentatio
         super.viewDidLoad()
 
         // Set presentation delegate to track the user dismiss flow event
-        if let navigationController = navigationController {
+        if let navigationController {
             navigationController.presentationController?.delegate = self
         } else {
             presentationController?.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
@@ -51,7 +51,7 @@ final class CouponLineDetailsViewModel: Identifiable, ObservableObject {
     }
 
     func removeCoupon() {
-        guard let initialCode = initialCode else {
+        guard let initialCode else {
             return
         }
 
@@ -81,7 +81,7 @@ final class CouponLineDetailsViewModel: Identifiable, ObservableObject {
 
 private extension CouponLineDetailsViewModel {
     func saveData() {
-        guard let initialCode = initialCode,
+        guard let initialCode,
              initialCode.isNotEmpty else {
             return didSelectSave(.added(newCode: code))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -188,7 +188,7 @@ private extension RemoteOrderSynchronizer {
 
         setProduct.withLatestFrom(orderPublisher)
             .map { [weak self] productInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let localInput = self.replaceInputWithLocalIDIfNeeded(productInput)
                 let updatedOrder = ProductInputTransformer.update(input: localInput, on: order, shouldUpdateOrDeleteZeroQuantities: .update)
                 // Calculate order total locally while order is being synced
@@ -202,7 +202,7 @@ private extension RemoteOrderSynchronizer {
 
         setProducts.withLatestFrom(orderPublisher)
             .map { [weak self] productsInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
 
                 let localInputs = productsInput.map {
                     self.replaceInputWithLocalIDIfNeeded($0)
@@ -233,7 +233,7 @@ private extension RemoteOrderSynchronizer {
 
         setShipping.withLatestFrom(orderPublisher)
             .map { [weak self] shippingLineInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let updatedOrder = ShippingInputTransformer.update(input: shippingLineInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
@@ -259,7 +259,7 @@ private extension RemoteOrderSynchronizer {
 
         addFee.withLatestFrom(orderPublisher)
             .map { [weak self] feeLineInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let updatedOrder = FeesInputTransformer.append(input: feeLineInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
@@ -272,7 +272,7 @@ private extension RemoteOrderSynchronizer {
 
         updateFee.withLatestFrom(orderPublisher)
             .map { [weak self] feeLineInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let updatedOrder = FeesInputTransformer.update(input: feeLineInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
@@ -285,7 +285,7 @@ private extension RemoteOrderSynchronizer {
 
         removeFee.withLatestFrom(orderPublisher)
             .map { [weak self] feeLineInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let updatedOrder = FeesInputTransformer.remove(input: feeLineInput, from: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
@@ -298,7 +298,7 @@ private extension RemoteOrderSynchronizer {
 
         addCoupon.withLatestFrom(orderPublisher)
             .map { [weak self] couponLineInput, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let updatedOrder = CouponInputTransformer.append(input: couponLineInput, on: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
@@ -310,7 +310,7 @@ private extension RemoteOrderSynchronizer {
             .store(in: &subscriptions)
         removeCoupon.withLatestFrom(orderPublisher)
             .map { [weak self] couponCode, order -> Order in
-                guard let self = self else { return order }
+                guard let self else { return order }
                 let updatedOrder = CouponInputTransformer.remove(code: couponCode, from: order)
                 // Calculate order total locally while order is being synced
                 return OrderTotalsCalculator(for: updatedOrder, using: self.currencyFormatter).updateOrderTotal()
@@ -374,7 +374,7 @@ private extension RemoteOrderSynchronizer {
     func bindOrderSync(flow: EditableOrderViewModel.Flow) {
         let syncTrigger: AnyPublisher<Order, Never> = orderSyncTrigger
             .compactMap { [weak self] order in
-                guard let self = self else { return nil }
+                guard let self else { return nil }
                 switch self.state {
                 case .syncing(blocking: true):
                     return nil // Don't continue if the current state is `blocking`.
@@ -400,7 +400,7 @@ private extension RemoteOrderSynchronizer {
                 $0.orderID == .zero
             }
             .flatMap(maxPublishers: .max(1)) { [weak self] order -> AnyPublisher<Order, Never> in // Only allow one request at a time.
-                guard let self = self else { return Empty().eraseToAnyPublisher() }
+                guard let self else { return Empty().eraseToAnyPublisher() }
                 self.state = .syncing(blocking: true) // Creating an order is always a blocking operation
 
                 return self.createOrderRemotely(order, type: .sync, includesGiftCard: false)
@@ -439,7 +439,7 @@ private extension RemoteOrderSynchronizer {
             })
             .debounce(for: .seconds(debounceDuration), scheduler: DispatchQueue.main) // Group & wait for 1.0 since the last signal was emitted.
             .map { [weak self] order -> AnyPublisher<Order, Never> in // Allow multiple requests, once per update request.
-                guard let self = self else { return Empty().eraseToAnyPublisher() }
+                guard let self else { return Empty().eraseToAnyPublisher() }
 
                 let syncType: OperationType = flow == .creation ? .sync : .commit
                 let includesGiftCard = flow != .creation
@@ -464,14 +464,14 @@ private extension RemoteOrderSynchronizer {
     ///
     func createOrderRemotely(_ order: Order, type: OperationType, includesGiftCard: Bool) -> AnyPublisher<Order, Error> {
         Future<Order, Error> { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let giftCard = includesGiftCard ? self.giftCardToApply: nil
 
             let apiOrderStatus = self.orderStatus(for: type)
             let draftOrder = order.copy(status: apiOrderStatus).sanitizingLocalItems()
             let action = OrderAction.createOrder(siteID: self.siteID, order: draftOrder, giftCard: giftCard) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 switch result {
                 case .success(let remoteOrder):
@@ -495,7 +495,7 @@ private extension RemoteOrderSynchronizer {
     ///
     func updateOrderRemotely(_ order: Order, type: OperationType, includesGiftCard: Bool) -> AnyPublisher<Order, Error> {
         Future<Order, Error> { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let operationUpdateFields = self.orderUpdateFields(for: type)
             let orderToSubmit = order.sanitizingLocalItems()
@@ -504,7 +504,7 @@ private extension RemoteOrderSynchronizer {
                                                  order: orderToSubmit,
                                                  giftCard: giftCard,
                                                  fields: operationUpdateFields) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 switch result {
                 case .success(let remoteOrder):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorViewModel.swift
@@ -111,7 +111,7 @@ extension NewTaxRateSelectorViewModel: PaginationTrackerDelegate {
         transitionToSyncingState()
 
         let action = TaxAction.retrieveTaxRates(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let results):
                 let hasNextPage = results.count == pageSize
@@ -141,7 +141,7 @@ private extension NewTaxRateSelectorViewModel {
         // Listens only to the first emitted event.
         onLoadTriggerOnce.first()
             .sink { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.syncFirstPage()
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
@@ -6,7 +6,7 @@ struct TaxRateRow: View {
 
     var body: some View {
         HStack {
-            if let onSelect = onSelect {
+            if let onSelect {
                 Button(action: onSelect) {
                     content
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
@@ -79,7 +79,7 @@ open class AddressFormViewModel: ObservableObject {
 
         // Listen only to the first emitted event.
         onLoadTrigger.first().sink { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.bindSyncTrigger()
             self.bindNavigationTrailingItemPublisher()
             self.bindHasPendingChangesPublisher()
@@ -366,7 +366,7 @@ private extension AddressFormViewModel {
 
         // Updates the initial fields when/if the data store changes(after sync).
         countriesResultsController.onDidChangeContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.refreshCountryAndStateObjects()
         }
@@ -408,7 +408,7 @@ private extension AddressFormViewModel {
     ///
     func makeSyncCountriesFuture() -> AnyPublisher<Void, EditAddressError> {
         Future<Void, EditAddressError> { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let action = DataAction.synchronizeCountries(siteID: self.siteID) { result in
                 let newResult = result

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -197,7 +197,7 @@ struct AddressFormFields {
     ///
     var selectedState: Yosemite.StateOfACountry? {
         didSet {
-            if let selectedState = selectedState {
+            if let selectedState {
                 self.state = selectedState.name
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -38,7 +38,7 @@ final class EditOrderAddressHostingController: UIHostingController<EditOrderAddr
         super.viewDidLoad()
 
         // Set presentation delegate to track the user dismiss flow event
-        if let navigationController = navigationController {
+        if let navigationController {
             navigationController.presentationController?.delegate = self
         } else {
             presentationController?.delegate = self
@@ -239,7 +239,7 @@ struct SingleAddressForm: View {
     var body: some View {
         content
             .onPreferenceChange(MaxWidthPreferenceKey.self) { value in
-                if let value = value {
+                if let value {
                     titleWidth = value
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -137,7 +137,7 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         }
 
         let action = OrderAction.updateOrder(siteID: order.siteID, order: modifiedOrder, giftCard: nil, fields: orderFields) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.performingNetworkRequest.send(false)
             switch result {
@@ -224,7 +224,7 @@ private extension Address {
     /// Needed because core has a validation where a billing address can only be a valid email or `nil`(instead of empty).
     ///
     func removingEmptyEmail() -> Yosemite.Address {
-        guard let email = email, email.isEmpty else {
+        guard let email, email.isEmpty else {
             return self
         }
         return copy(email: .some(nil))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -577,7 +577,7 @@ private extension BillingInformationViewController {
     ///   - includeTrailingNewline: It true, insert a trailing newline; defaults to true
     ///
     func sendToPasteboard(_ text: String?, includeTrailingNewline: Bool = true) {
-        guard var text = text, text.isEmpty == false else {
+        guard var text, text.isEmpty == false else {
             return
         }
         if includeTrailingNewline {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundCoordinatingController.swift
@@ -67,7 +67,7 @@ private extension IssueRefundCoordinatingController {
     ///
     func navigateToItemQuantitySelection(using command: RefundItemQuantityListSelectorCommand, onCompletion: @escaping (Int) -> Void) {
         let selectorViewController = ListSelectorViewController(command: command, tableViewStyle: .plain) { selectedQuantity in
-            guard let selectedQuantity = selectedQuantity else {
+            guard let selectedQuantity else {
                 return
             }
             onCompletion(selectedQuantity)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewController.swift
@@ -84,7 +84,7 @@ private extension IssueRefundViewController {
         }
 
         viewModel.showFetchChargeErrorNotice = { [weak self] retryAction in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let notice = Notice(title: Localization.retryFetchChargeNoticeTitle,
                                 feedbackType: .error,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/IssueRefundViewModel.swift
@@ -167,7 +167,7 @@ final class IssueRefundViewModel {
     /// confirm and submit the refund.
     func createRefundConfirmationViewModel(onCompletion: @escaping ((RefundConfirmationViewModel) -> Void)) {
         let action = CardPresentPaymentAction.selectedPaymentGatewayAccount { [weak self] paymentGatewayAccount in
-            guard let self = self else { return }
+            guard let self else { return }
             let details = RefundConfirmationViewModel.Details(order: self.state.order,
                                                               charge: self.state.charge,
                                                               amount: "\(self.calculateRefundTotal())",
@@ -301,7 +301,7 @@ private extension IssueRefundViewModel {
 
     func observeCharge() {
         chargeResultsController?.onDidChangeContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.state.charge = self.charge
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewController.swift
@@ -119,7 +119,7 @@ private extension RefundConfirmationViewController {
 
     func configureButtonTableFooterView() {
         tableView.tableFooterView = ButtonTableFooterView(frame: .zero, title: Localization.refund) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.onRefundButtonAction?()
             self.viewModel.trackSummaryButtonTapped()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -111,7 +111,7 @@ final class RefundConfirmationViewModel {
         submissionUseCase.submitRefund(refund,
                                        showInProgressUI: showInProgressUI,
                                        onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:
@@ -130,7 +130,7 @@ final class RefundConfirmationViewModel {
     ///
     func updateOrder(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let action = OrderAction.retrieveOrder(siteID: details.order.siteID, orderID: details.order.orderID) { _, error  in
-            if let error = error {
+            if let error {
                 return onCompletion(.failure(error))
             }
             onCompletion(.success(()))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/UseCases/RefundCreationUseCase.swift
@@ -60,7 +60,7 @@ struct RefundCreationUseCase {
                             total: calculateTotal(of: refundable))
         }
 
-        if let shippingLine = shippingLine {
+        if let shippingLine {
             refundItems.append(createShippingItem(from: shippingLine))
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -67,7 +67,7 @@ class NewNoteViewController: UIViewController {
                                                   orderID: viewModel.orderID,
                                                   isCustomerNote: isCustomerNote,
                                                   note: noteText) { [weak self] (orderNote, error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
                 self?.viewModel.track(.orderNoteAddFailed, withError: error)
 
@@ -76,7 +76,7 @@ class NewNoteViewController: UIViewController {
                 return
             }
 
-            if let orderNote = orderNote {
+            if let orderNote {
                 self?.viewModel.onDidFinishEditing?(orderNote)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Customer Note/EditCustomerNoteViewModel.swift
@@ -126,7 +126,7 @@ private extension EditCustomerNoteViewModel {
         let modifiedOrder = order.copy(customerNote: customerNote)
 
         let updateAction = makeUpdateAction(order: modifiedOrder) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -214,7 +214,7 @@ private extension OrderDetailsViewController {
     ///
     func configureEntityListener() {
         entityListener.onUpsert = { [weak self] order in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             let previousStatus = self.viewModel.order.status
@@ -399,7 +399,7 @@ private extension OrderDetailsViewController {
         case .summary:
             displayOrderStatusList()
         case .tracking:
-            guard let indexPath = indexPath else {
+            guard let indexPath else {
                 break
             }
             trackingWasPressed(at: indexPath)
@@ -453,7 +453,7 @@ private extension OrderDetailsViewController {
                 }
             }
             shippingLabelFormVC.onLabelSave = { [weak self] in
-                guard let self = self, let navigationController = self.navigationController, navigationController.viewControllers.contains(self) else {
+                guard let self, let navigationController = self.navigationController, navigationController.viewControllers.contains(self) else {
                     // Navigate back to order details when presented from push notification
                     if let orderLoaderVC = self?.parent as? OrderLoaderViewController {
                         self?.navigationController?.popToViewController(orderLoaderVC, animated: true)
@@ -488,7 +488,7 @@ private extension OrderDetailsViewController {
         ServiceLocator.analytics.track(.orderFulfillmentCompleteButtonTapped)
         let reviewOrderViewModel = ReviewOrderViewModel(order: viewModel.order, products: viewModel.products, showAddOns: viewModel.dataSource.showAddOns)
         let controller = ReviewOrderViewController(viewModel: reviewOrderViewModel) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let fulfillmentProcess = self.viewModel.markCompleted(flow: .editing)
             let presenter = OrderFulfillmentNoticePresenter()
             presenter.present(process: fulfillmentProcess)
@@ -647,7 +647,7 @@ private extension OrderDetailsViewController {
         // Only shows the tracking action when there is a tracking URL.
         if let url = ShippingLabelTrackingURLGenerator.url(for: shippingLabel) {
             actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelTrackingMoreMenu.trackShipmentAction) { [weak self] _ in
-                guard let self = self else { return }
+                guard let self else { return }
                 ServiceLocator.analytics.track(event: .shipmentTrackingMenu(action: .track))
                 WebviewHelper.launch(url, with: self)
             }
@@ -924,7 +924,7 @@ private extension OrderDetailsViewController {
     ///
     private static func updateOrderStatusAction(viewModel: OrderDetailsViewModel, siteID: Int64, orderID: Int64, status: OrderStatusEnum) -> Action {
         return OrderAction.updateOrderStatus(siteID: siteID, orderID: orderID, status: status, onCompletion: { error in
-            guard let error = error else {
+            guard let error else {
                 let updatedOrder = viewModel.order.copy(status: status)
                 viewModel.update(order: updatedOrder)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderFulfillmentUseCase.swift
@@ -69,7 +69,7 @@ final class OrderFulfillmentUseCase {
 
         let result: Future<Void, FulfillmentError> = Future { promise in
             let action = OrderAction.updateOrderStatus(siteID: order.siteID, orderID: order.orderID, status: targetStatus) { error in
-                guard let error = error else {
+                guard let error else {
                     NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
                     self.analytics.track(.orderStatusChangeSuccess)
                     promise(.success(()))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -101,11 +101,11 @@ private extension OrderLoaderViewController {
         }
 
         let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { [weak self] (order, error) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
-            guard let order = order else {
+            guard let order else {
                 DDLogError("## Error loading Order \(self.siteID).\(self.orderID): \(error.debugDescription)")
                 self.state = .failure
                 return
@@ -288,7 +288,7 @@ private extension OrderLoaderViewController {
             startSpinner()
         case .success(let order):
             presentOrderDetails(for: order)
-            if let note = note {
+            if let note {
                 markNotificationAsReadIfNeeded(note: note)
             }
         case .failure:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundedProductsViewController.swift
@@ -111,7 +111,7 @@ private extension RefundedProductsViewController {
     ///
     func configureEntityListener() {
         entityListener.onUpsert = { [weak self] order in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.viewModel.updateOrderStatus(order: order)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
@@ -92,7 +92,7 @@ final class ReceiptViewController: UIViewController, WKNavigationDelegate, UIPri
         configurePrintController(with: printInfo)
 
         printController.present(animated: true, completionHandler: { [weak self] _, isCompleted, error in
-            if let error = error {
+            if let error {
                 ServiceLocator.analytics.track(event: .InPersonPayments.receiptPrintFailed(error: error, source: .backend))
                 DDLogError("Failed to print receipt for orderID \(String(describing: self?.viewModel.orderID)). Error: \(error)")
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -280,7 +280,7 @@ private extension ReviewOrderViewController {
 
         let addOns = viewModel.addOns(for: item)
         cell.onViewAddOnsTouchUp = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.itemAddOnsButtonTapped(addOns: addOns)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -150,7 +150,7 @@ final class ReviewOrderViewModel {
         let deleteTrackingAction = ShipmentAction.deleteTracking(siteID: siteID,
                                                                  orderID: orderID,
                                                                  trackingID: trackingID) { error in
-                                                                    if let error = error {
+                                                                    if let error {
                                                                         DDLogError("⛔️ Order Details - Delete Tracking: orderID \(orderID). Error: \(error)")
 
                                                                         ServiceLocator.analytics.track(.orderTrackingDeleteFailed,
@@ -236,7 +236,7 @@ private extension ReviewOrderViewModel {
         let action = ShipmentAction.synchronizeShipmentTrackingData(
             siteID: siteID,
             orderID: orderID) { error in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing tracking: \(error.localizedDescription)")
                 onCompletion?(error)
                 return
@@ -281,7 +281,7 @@ private extension ReviewOrderViewModel {
                     order.items.first(where: { $0.productID == product.productID}) != nil
                 }
                 .allSatisfy { $0.virtual == true }
-            guard let shippingAddress = shippingAddress, !orderContainsOnlyVirtualProducts else {
+            guard let shippingAddress, !orderContainsOnlyVirtualProducts else {
                 return nil
             }
             return Row.shippingAddress(address: shippingAddress)
@@ -406,7 +406,7 @@ private extension ReviewOrderViewModel {
         }
 
         trackingResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }
@@ -422,7 +422,7 @@ private extension ReviewOrderViewModel {
         }
 
         shippingLabelResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }
@@ -438,7 +438,7 @@ private extension ReviewOrderViewModel {
         }
 
         addOnGroupResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }
@@ -454,7 +454,7 @@ private extension ReviewOrderViewModel {
         }
 
         refundResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.refetchAllResultsControllers()
             onReload()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -515,7 +515,7 @@ private extension ManualTrackingViewController {
                                                            dateShipped: dateShipped,
                                                            trackingNumber: trackingNumber) { [weak self] error in
 
-                                                            if let error = error {
+                                                            if let error {
                                                                 DDLogError("⛔️ Add Tracking Failure: orderID \(orderID). Error: \(error)")
 
                                                                 ServiceLocator.analytics.track(.orderTrackingAddFailed,
@@ -562,7 +562,7 @@ private extension ManualTrackingViewController {
                                                       trackingNumber: trackingNumber,
                                                       trackingURL: trackingLink,
                                                       dateShipped: dateShipped) { [weak self] error in
-                                                        if let error = error {
+                                                        if let error {
                                                             DDLogError("⛔️ Add Tracking Failure: orderID \(orderID). Error: \(error)")
 
                                                             ServiceLocator.analytics.track(.orderTrackingAddFailed,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ShipmentProvidersViewController.swift
@@ -86,7 +86,7 @@ private extension ShipmentProvidersViewController {
 
         let loadGroupsAction = ShipmentAction.synchronizeShipmentTrackingProviders(siteID: siteID,
                                                                                    orderID: orderID) { [weak self] error in
-                                                                                    if let error = error {
+                                                                                    if let error {
                                                                                         self?.presentNotice(error)
                                                                                     }
                                                                                     ServiceLocator.analytics.track(.orderTrackingProvidersLoaded)
@@ -266,7 +266,7 @@ private extension ShipmentProvidersViewController {
 //
 private extension ShipmentProvidersViewController {
     func resetUIState(searchTerm: String?) {
-        guard let searchTerm = searchTerm,
+        guard let searchTerm,
             searchTerm.isEmpty == false else {
                 viewModel.clearFilters()
                 table.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarrierRowViewModel.swift
@@ -58,10 +58,10 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
 
         price = {
-            if signatureSelected, let signatureRate = signatureRate {
+            if signatureSelected, let signatureRate {
                     return currencyFormatter.formatAmount(Decimal(signatureRate.rate)) ?? ""
                 }
-                if adultSignatureSelected, let adultSignatureRate = adultSignatureRate {
+                if adultSignatureSelected, let adultSignatureRate {
                     return currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate)) ?? ""
                 }
             return currencyFormatter.formatAmount(Decimal(rate.rate)) ?? ""
@@ -92,14 +92,14 @@ struct ShippingLabelCarrierRowViewModel: Identifiable {
         displaySignatureRequired = signatureRate != nil
         displayAdultSignatureRequired = adultSignatureRate != nil
 
-        if displaySignatureRequired, let signatureRate = signatureRate {
+        if displaySignatureRequired, let signatureRate {
             let amount = currencyFormatter.formatAmount(Decimal(signatureRate.rate - rate.rate)) ?? ""
               signatureRequiredText = String(format: Localization.signatureRequired, amount)
         } else {
             signatureRequiredText = ""
         }
 
-        if displayAdultSignatureRequired, let adultSignatureRate = adultSignatureRate {
+        if displayAdultSignatureRequired, let adultSignatureRate {
             let amount = currencyFormatter.formatAmount(Decimal(adultSignatureRate.rate - rate.rate)) ?? ""
             adultSignatureRequiredText = String(format: Localization.adultSignatureRequired, amount)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
@@ -94,7 +94,7 @@ final class ShippingLabelCarriersViewModel: ObservableObject {
                                                         signatureRate: signature,
                                                         adultSignatureRate: adultSignature,
                                                         currencySettings: currencySettings) { [weak self] (rate, signature, adultSignature) in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     // update the existing selected rate for the package
                     if let index = self.selectedRates.firstIndex(where: { $0.packageID == resp.packageID }) {
@@ -150,7 +150,7 @@ private extension ShippingLabelCarriersViewModel {
                                                               originAddress: originAddress,
                                                               destinationAddress: destinationAddress,
                                                               packages: packages) { [weak self] (result) in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let response):
                 self.generateSections(response: response)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -110,7 +110,7 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
     }
 
     func setDiscount(_ discount: String?) {
-        guard let discount = discount else {
+        guard let discount else {
             discountView.isHidden = true
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetailsViewModel.swift
@@ -196,7 +196,7 @@ private extension ShippingLabelCustomsFormItemDetailsViewModel {
         let groupTwo = $hsTariffNumber.combineLatest($originCountry)
         groupOne.combineLatest(groupTwo)
             .map { [weak self] groupOne, groupTwo -> Bool in
-                guard let self = self else {
+                guard let self else {
                     return false
                 }
                 let (description, value, weight) = groupOne
@@ -216,7 +216,7 @@ private extension ShippingLabelCustomsFormItemDetailsViewModel {
     func configureValidatedTotalValue() {
         $value
             .map { [weak self] value -> Decimal? in
-                guard let self = self,
+                guard let self,
                       let validatedValue = self.getValidatedValue(from: value) else {
                     return nil
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInputViewModel.swift
@@ -223,7 +223,7 @@ private extension ShippingLabelCustomsFormInputViewModel {
         let groupTwo = $itn.combineLatest($restrictionType, $restrictionComments, $itemsValidation)
         groupOne.combineLatest(groupTwo)
             .map { [weak self] groupOne, groupTwo -> Bool in
-                guard let self = self else {
+                guard let self else {
                     return false
                 }
                 let (classesAbove2500usd, contentsType, contentExplanation) = groupOne
@@ -250,8 +250,8 @@ private extension ShippingLabelCustomsFormInputViewModel {
         itemViewModels.forEach { viewModel in
             viewModel.$validatedHSTariffNumber.combineLatest(viewModel.$validatedTotalValue)
                 .sink { [weak self] number, totalValue in
-                    if let number = number, number.isNotEmpty,
-                       let totalValue = totalValue {
+                    if let number, number.isNotEmpty,
+                       let totalValue {
                         self?.itemTariffNumbersAndValues[viewModel.productID] = (hsTariffNumber: number, totalValue: totalValue)
                     } else {
                         self?.itemTariffNumbersAndValues.removeValue(forKey: viewModel.productID)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -216,7 +216,7 @@ private extension ShippingLabelPackagesFormViewModel {
             if index == packageIndex {
                 let (matchingItem, updatedItems) = package.partitionItems(using: productOrVariationID)
 
-                guard let matchingItem = matchingItem else {
+                guard let matchingItem else {
                     assertionFailure("⛔️ Cannot find item with product or variationID \(productOrVariationID) in current package!")
                     return
                 }
@@ -259,7 +259,7 @@ private extension ShippingLabelPackagesFormViewModel {
         if !currentPackage.isOriginalPackaging {
             let (matchingItem, updatedItems) = currentPackage.partitionItems(using: productOrVariationID)
 
-            guard let matchingItem = matchingItem else {
+            guard let matchingItem else {
                 assertionFailure("⛔️ Cannot find item with product or variationID \(productOrVariationID) in current package!")
                 return
             }
@@ -322,7 +322,7 @@ private extension ShippingLabelPackagesFormViewModel {
             }
         }
 
-        guard let itemToMove = itemToMove else {
+        guard let itemToMove else {
             assertionFailure("⛔️ Cannot find item with product or variationID \(productOrVariationID) in current package!")
             return
         }
@@ -344,7 +344,7 @@ private extension ShippingLabelPackagesFormViewModel {
                                                                selectedHazmatCategory: newPackage.selectedHazmatCategory)
         temporaryPackages[newPackageIndex] = updatedNewPackage
 
-        if let updatedCurrentPackage = updatedCurrentPackage {
+        if let updatedCurrentPackage {
             temporaryPackages[currentPackageIndex] = updatedCurrentPackage
         } else {
             // Remove current package from list
@@ -391,10 +391,10 @@ private extension ShippingLabelPackagesFormViewModel {
                                                                            orderItems: order.items,
                                                                            storageManager: storageManager,
            onProductReload: { [weak self] (products) in
-            guard let self = self else { return }
+            guard let self else { return }
             self.products = products
         }, onProductVariationsReload: { [weak self] (productVariations) in
-            guard let self = self else { return }
+            guard let self else { return }
             self.productVariations = productVariations
         })
 
@@ -408,7 +408,7 @@ private extension ShippingLabelPackagesFormViewModel {
 private extension ShippingLabelPackagesFormViewModel {
     func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
         let action = ProductAction.requestMissingProducts(for: order) { (error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing Products: \(error)")
                 onCompletion?(error)
                 return
@@ -422,7 +422,7 @@ private extension ShippingLabelPackagesFormViewModel {
 
     func syncProductVariations(onCompletion: ((Error?) -> ())? = nil) {
         let action = ProductVariationAction.requestMissingVariations(for: order) { error in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing missing variations in an Order: \(error)")
                 onCompletion?(error)
                 return

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelAddNewPackageViewModel.swift
@@ -83,7 +83,7 @@ extension ShippingLabelAddNewPackageViewModel {
             onCompletion(success)
 
             // On success, reset tab state and save new package details
-            guard let self = self, success else { return }
+            guard let self, success else { return }
             self.customPackageVM = ShippingLabelCustomPackageFormViewModel()
             self.onCompletion(newCustomPackage, nil, self.packagesResponse)
         }
@@ -92,7 +92,7 @@ extension ShippingLabelAddNewPackageViewModel {
     /// Activates the selected service package remotely and updates the package details to select the new package
     ///
     func activateServicePackage(onCompletion: @escaping (Bool) -> Void) {
-        guard let selectedServicePackage = selectedServicePackage,
+        guard let selectedServicePackage,
               let shippingProvider = servicePackageVM.predefinedOptions.first(where: { $0.predefinedPackages.contains(selectedServicePackage) } ) else {
             onCompletion(false)
             return
@@ -106,7 +106,7 @@ extension ShippingLabelAddNewPackageViewModel {
             onCompletion(success)
 
             // On success, reset tab state and save new package details
-            guard let self = self, success else { return }
+            guard let self, success else { return }
             self.customPackageVM = ShippingLabelCustomPackageFormViewModel()
             self.servicePackageVM = ShippingLabelServicePackageListViewModel(packagesResponse: self.packagesResponse)
             self.onCompletion(nil, selectedServicePackage, self.packagesResponse)
@@ -131,7 +131,7 @@ private extension ShippingLabelAddNewPackageViewModel {
         let action = ShippingLabelAction.createPackage(siteID: siteID,
                                                        customPackage: customPackage,
                                                        predefinedOption: predefinedOption) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:
@@ -165,7 +165,7 @@ private extension ShippingLabelAddNewPackageViewModel {
     ///
     func syncPackageDetails(onCompletion: ((Bool) -> Void)? = nil) {
         let action = ShippingLabelAction.packagesDetails(siteID: siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let value):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
@@ -37,7 +37,7 @@ final class ShippingLabelPackageListViewModel: ObservableObject {
     lazy var addNewPackageViewModel = ShippingLabelAddNewPackageViewModel(siteID: siteID,
                                                                           packagesResponse: packagesResponse,
                                                                           onCompletion: { [weak self] (customPackage, predefinedOption, packagesResponse) in
-                                                                            guard let self = self else { return }
+                                                                            guard let self else { return }
                                                                             self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                                                           })
 
@@ -64,21 +64,21 @@ extension ShippingLabelPackageListViewModel {
 
     func confirmPackageSelection() {
         let newPackageID: String? = {
-            if let selectedCustomPackage = selectedCustomPackage {
+            if let selectedCustomPackage {
                 return selectedCustomPackage.title
-            } else if let selectedPredefinedPackage = selectedPredefinedPackage {
+            } else if let selectedPredefinedPackage {
                 return selectedPredefinedPackage.id
             }
             return nil
         }()
-        guard let newPackageID = newPackageID else {
+        guard let newPackageID else {
             return
         }
         delegate?.didSelectPackage(id: newPackageID)
     }
 
     private func selectCustomPackage(_ id: String) {
-        guard let packagesResponse = packagesResponse else {
+        guard let packagesResponse else {
             return
         }
 
@@ -92,7 +92,7 @@ extension ShippingLabelPackageListViewModel {
     }
 
     private func selectPredefinedPackage(_ id: String) {
-        guard let packagesResponse = packagesResponse else {
+        guard let packagesResponse else {
             return
         }
 
@@ -112,7 +112,7 @@ extension ShippingLabelPackageListViewModel {
     private func handleNewPackage(_ customPackage: ShippingLabelCustomPackage?,
                           _ servicePackage: ShippingLabelPredefinedPackage?,
                           _ packagesResponse: ShippingLabelPackagesResponse?) {
-        guard let packagesResponse = packagesResponse else {
+        guard let packagesResponse else {
             return
         }
         let shouldNotifyDelegate = !hasCustomOrPredefinedPackages
@@ -122,16 +122,16 @@ extension ShippingLabelPackageListViewModel {
         addNewPackageViewModel = .init(siteID: siteID,
                                        packagesResponse: packagesResponse,
                                        onCompletion: { [weak self] (customPackage, predefinedOption, packagesResponse) in
-                                         guard let self = self else { return }
+                                         guard let self else { return }
                                          self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                        })
 
-        if let customPackage = customPackage {
+        if let customPackage {
             selectCustomPackage(customPackage.title)
             if shouldNotifyDelegate {
                 delegate?.didSelectPackage(id: customPackage.title)
             }
-        } else if let servicePackage = servicePackage {
+        } else if let servicePackage {
             selectPredefinedPackage(servicePackage.id)
             if shouldNotifyDelegate {
                 delegate?.didSelectPackage(id: servicePackage.id)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelPackageDetailsResultsControllers.swift
@@ -75,12 +75,12 @@ final class ShippingLabelPackageDetailsResultsControllers {
 
     private func configureProductResultsController(onReload: @escaping ([ShippingLabelProduct]) -> ()) {
         productResultsController.onDidChangeContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             onReload(self.productResultsController.fetchedObjects)
         }
 
         productResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             try? self.productResultsController.performFetch()
             onReload(self.productResultsController.fetchedObjects)
         }
@@ -94,12 +94,12 @@ final class ShippingLabelPackageDetailsResultsControllers {
 
     private func configureProductVariationResultsController(onReload: @escaping ([ProductVariation]) -> Void) {
         productVariationResultsController.onDidChangeContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             onReload(self.productVariationResultsController.fetchedObjects)
         }
 
         productVariationResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             try? self.productVariationResultsController.performFetch()
             onReload(self.productVariationResultsController.fetchedObjects)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
@@ -115,7 +115,7 @@ extension ShippingLabelPaymentMethodsViewModel {
     func syncShippingLabelAccountSettings() {
         isUpdating = true
         let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: accountSettings.siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.isUpdating = false
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -179,7 +179,7 @@ private extension ShippingLabelSuggestedAddressViewController {
             validationError: nil,
             countries: countries,
             completion: { [weak self] (newShippingLabelAddress) in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.onCompletion(newShippingLabelAddress)
                 self.navigationController?.popViewController(animated: true)
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -35,7 +35,7 @@ final class ShippingLabelAddressFormViewController: UIViewController {
                 }
             }
         } contactCustomerPressed: { [weak self] sourceView in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.analytics.track(.shippingLabelEditAddressContactCustomerButtonTapped)
 
             guard PhoneHelper.canCallPhoneNumber(phone: phone)
@@ -49,7 +49,7 @@ final class ShippingLabelAddressFormViewController: UIViewController {
             actionSheet.view.tintColor = .text
 
             actionSheet.addCancelActionWithTitle(Localization.contactActionCancel)
-            if let email = email, email.isNotEmpty && MFMailComposeViewController.canSendMail() {
+            if let email, email.isNotEmpty && MFMailComposeViewController.canSendMail() {
                 actionSheet.addDefaultActionWithTitle(Localization.contactActionEmail) { _ in
                     self.sendEmail(to: email)
                 }
@@ -189,7 +189,7 @@ private extension ShippingLabelAddressFormViewController {
 
     func observeViewModel() {
         viewModel.onChange = { [weak self] focusedIndex in
-            guard let self = self else { return }
+            guard let self else { return }
             self.configureNavigationBar()
             self.updateTopBannerView()
             self.tableView.reloadData()
@@ -245,7 +245,7 @@ private extension ShippingLabelAddressFormViewController {
     @objc func doneButtonTapped() {
         ServiceLocator.analytics.track(.shippingLabelEditAddressDoneButtonTapped)
         viewModel.validateAddress(onlyLocally: false) { [weak self] (result) in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 self.onCompletion(self.viewModel.address)
@@ -261,7 +261,7 @@ private extension ShippingLabelAddressFormViewController {
     @objc func confirmButtonTapped() {
         ServiceLocator.analytics.track(.shippingLabelEditAddressUseAddressAsIsButtonTapped)
         viewModel.validateAddress(onlyLocally: true) { [weak self] (result) in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 self.onCompletion(self.viewModel.address)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -100,7 +100,7 @@ final class ShippingLabelAddressFormViewModel {
         self.phoneNumberRequired = phoneNumberRequired
         self.needsPhoneNumberValidation = needsPhoneNumberValidation
         self.stores = stores
-        if let validationError = validationError {
+        if let validationError {
             addressValidationError = validationError
             addressValidated = .remote
         }
@@ -213,7 +213,7 @@ extension ShippingLabelAddressFormViewModel {
             .removeDuplicates()
             .withLatestFrom(currentRow)
             .sink { [weak self] _, row in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.updateSections()
                 let index: Int? = self.sections.first?.rows.firstIndex(where: { $0 == row })
                 self.onChange?(index)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -141,7 +141,7 @@ private extension ShippingLabelFormViewController {
 
     func observeViewModel() {
         viewModel.onChange = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.tableView.reloadData()
         }
     }
@@ -257,7 +257,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.shipFromCellTitle,
                        body: viewModel.originAddress?.fullNameWithCompanyAndAddress,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "origin_address_started"])
 
             // Skip remote validation and navigate to edit address
@@ -267,7 +267,7 @@ private extension ShippingLabelFormViewController {
                 return self.displayEditAddressFormVC(address: originAddress, email: nil, validationError: nil, type: .origin)
             }
             self.viewModel.validateAddress(type: .origin) { [weak self] (validationState, response) in
-                guard let self = self else { return }
+                guard let self else { return }
                 let shippingLabelAddress = self.viewModel.originAddress
                 switch validationState {
                 case .validated:
@@ -291,7 +291,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.shipToCellTitle,
                        body: viewModel.destinationAddress?.fullNameWithCompanyAndAddress,
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "destination_address_started"])
 
             // Skip remote validation and navigate to edit address
@@ -306,7 +306,7 @@ private extension ShippingLabelFormViewController {
             }
 
             self.viewModel.validateAddress(type: .destination) { [weak self] (validationState, response) in
-                guard let self = self else { return }
+                guard let self else { return }
                 let shippingLabelAddress = self.viewModel.destinationAddress
                 switch validationState {
                 case .validated:
@@ -341,7 +341,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.packageDetailsCellTitle,
                        body: viewModel.getPackageDetailsBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.displayPackageDetailsVC(inputPackages: self.viewModel.selectedPackagesDetails)
         }
     }
@@ -352,7 +352,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.customsCellTitle,
                        body: viewModel.getCustomsFormBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.displayCustomsFormListVC(customsForms: self.viewModel.customsForms)
         }
     }
@@ -363,7 +363,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.shippingCarrierAndRatesCellTitle,
                        body: viewModel.getCarrierAndRatesBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.displayCarriersAndRatesVC(selectedRates: self.viewModel.selectedRates)
         }
     }
@@ -374,7 +374,7 @@ private extension ShippingLabelFormViewController {
                        title: Localization.paymentMethodCellTitle,
                        body: viewModel.getPaymentMethodBody(),
                        buttonTitle: Localization.continueButtonInCells) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.displayPaymentMethodVC()
         }
     }
@@ -388,13 +388,13 @@ private extension ShippingLabelFormViewController {
         } onSwitchChange: { [weak self] (switchIsOn) in
             self?.shouldMarkOrderComplete = switchIsOn
         } onButtonTouchUp: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "purchase_initiated",
                  "amount": self.viewModel.totalAmount,
                 "fulfill_order": self.shouldMarkOrderComplete])
             self.displayPurchaseProgressView()
             self.viewModel.purchaseLabel { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let totalDuration):
                     ServiceLocator.analytics.track(.shippingLabelPurchaseFlow, withProperties: ["state": "purchase_succeeded",
@@ -444,7 +444,7 @@ private extension ShippingLabelFormViewController {
             validationError: validationError,
             countries: viewModel.filteredCountries(for: type),
             completion: { [weak self] (newShippingLabelAddress) in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch type {
                 case .origin:
                     self.viewModel.handleOriginAddressValueChanges(address: newShippingLabelAddress,
@@ -543,7 +543,7 @@ private extension ShippingLabelFormViewController {
 
         let vm = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettings)
         let paymentMethod = ShippingLabelPaymentMethods(viewModel: vm) { [weak self] newSettings in
-            guard let self = self else { return }
+            guard let self else { return }
             self.viewModel.handlePaymentMethodValueChanges(settings: newSettings, editable: true)
         }
 
@@ -563,7 +563,7 @@ private extension ShippingLabelFormViewController {
     /// This prevents navigating back to the purchase form after successfully purchasing the label.
     ///
     func displayPrintShippingLabelVC() {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -56,7 +56,7 @@ final class ShippingLabelFormViewModel {
     }
 
     var selectedPackages: [ShippingLabelPackageSelected] {
-        guard let packagesResponse = packagesResponse else {
+        guard let packagesResponse else {
             return []
         }
 
@@ -138,8 +138,8 @@ final class ShippingLabelFormViewModel {
     /// Check for the need of customs form
     ///
     var customsFormRequired: Bool {
-        guard let originAddress = originAddress,
-              let destinationAddress = destinationAddress else {
+        guard let originAddress,
+              let destinationAddress else {
             return false
         }
         // Special case: Any shipment from/to military addresses must have Customs
@@ -613,7 +613,7 @@ private extension ShippingLabelFormViewModel {
     }
 
     static func fromAddressToShippingLabelAddress(address: Address?) -> ShippingLabelAddress? {
-        guard let address = address else { return nil }
+        guard let address else { return nil }
 
         // In this way we support localized name correctly,
         // because the order is often reversed in a few Asian languages.
@@ -653,7 +653,7 @@ private extension ShippingLabelFormViewModel {
     // Search the custom package based on the id
     //
     private func searchCustomPackage(id: String) -> ShippingLabelCustomPackage? {
-        guard let packagesResponse = packagesResponse else {
+        guard let packagesResponse else {
             return nil
         }
 
@@ -669,7 +669,7 @@ private extension ShippingLabelFormViewModel {
     // Search the predefined package based on the id
     //
     private func searchPredefinedPackage(id: String) -> ShippingLabelPredefinedPackage? {
-        guard let packagesResponse = packagesResponse else {
+        guard let packagesResponse else {
             return nil
         }
 
@@ -724,13 +724,13 @@ private extension ShippingLabelFormViewModel {
     ///
     private func monitorAccountSettingsResultsController() {
         accountSettingsResultsController.onDidChangeContent = { [weak self] in
-            guard let self = self, let fetchedAccountSettings = self.accountSettingsResultsController.fetchedObjects.first else { return }
+            guard let self, let fetchedAccountSettings = self.accountSettingsResultsController.fetchedObjects.first else { return }
 
             self.handlePaymentMethodValueChanges(settings: fetchedAccountSettings, editable: true)
         }
 
         accountSettingsResultsController.onDidResetContent = { [weak self] in
-            guard let self = self, let fetchedAccountSettings = self.accountSettingsResultsController.fetchedObjects.first else { return }
+            guard let self, let fetchedAccountSettings = self.accountSettingsResultsController.fetchedObjects.first else { return }
 
             self.handlePaymentMethodValueChanges(settings: fetchedAccountSettings, editable: true)
         }
@@ -744,7 +744,7 @@ extension ShippingLabelFormViewModel {
     func fetchCountries() {
         try? resultsController.performFetch()
         let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] (result) in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 try? self.resultsController.performFetch()
@@ -775,7 +775,7 @@ extension ShippingLabelFormViewModel {
 
         let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] (result) in
 
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let response):
                 self.updateValidatingAddressState(false, type: type)
@@ -801,7 +801,7 @@ extension ShippingLabelFormViewModel {
     ///
     func syncShippingLabelAccountSettings() {
         let action = ShippingLabelAction.synchronizeShippingLabelAccountSettings(siteID: order.siteID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success(let value):
@@ -837,8 +837,8 @@ extension ShippingLabelFormViewModel {
     /// - Parameter onCompletion: Closure to be executed on completion with the success/failure result of the purchase.
     ///
     func purchaseLabel(onCompletion: @escaping ((Result<TimeInterval, Error>) -> Void)) {
-        guard let originAddress = originAddress,
-              let destinationAddress = destinationAddress,
+        guard let originAddress,
+              let destinationAddress,
               selectedPackages.isNotEmpty,
               selectedRates.isNotEmpty,
               let accountSettings = shippingLabelAccountSettings else {
@@ -878,7 +878,7 @@ extension ShippingLabelFormViewModel {
                                                                destinationAddress: destinationAddress,
                                                                packages: packages,
                                                                emailCustomerReceipt: accountSettings.isEmailReceiptsEnabled) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let labels):
                 self.purchasedShippingLabels = labels.filter { $0.orderID == self.order.orderID && $0.status == .purchased }
@@ -916,7 +916,7 @@ extension ShippingLabelFormViewModel {
 
     private func updateEUShippingNoticeVisibility() {
         verifyEUShippingNoticeDismissState { [weak self] dismissed in
-            guard let self = self, dismissed else {
+            guard let self, dismissed else {
                 self?.shouldPresentEUShippingNotice = false
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -76,7 +76,7 @@ extension PrintShippingLabelViewController {
 // MARK: Action Handling
 private extension PrintShippingLabelViewController {
     func printShippingLabel() {
-        guard let selectedPaperSize = selectedPaperSize else {
+        guard let selectedPaperSize else {
             return
         }
         onAction?(.print(paperSize: selectedPaperSize))
@@ -149,7 +149,7 @@ private extension PrintShippingLabelViewController {
     func observeSelectedPaperSize() {
         viewModel.loadShippingLabelSettingsForDefaultPaperSize()
         viewModel.$selectedPaperSize.removeDuplicates().sink { [weak self] paperSize in
-            guard let self = self else { return }
+            guard let self else { return }
             self.selectedPaperSize = paperSize
             self.tableView.reloadData()
             self.reprintButton.isEnabled = paperSize != nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewModel.swift
@@ -29,8 +29,8 @@ extension PrintShippingLabelViewModel {
             return
         }
         let action = ShippingLabelAction.loadShippingLabelSettings(shippingLabel: firstLabel) { [weak self] settings in
-            guard let self = self else { return }
-            guard let settings = settings, self.selectedPaperSize == nil else {
+            guard let self else { return }
+            guard let settings, self.selectedPaperSize == nil else {
                 return
             }
             // It is possible for the paper size setting (e.g. A4) to be unavailable in the paper sizes we support now (label, legal, and letter).

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -224,7 +224,7 @@ final class WooShippingShipmentDetailsViewModel: ObservableObject {
     func purchaseLabel(markOrderComplete: Bool? = nil) async throws {
         guard let originAddress, let destinationAddress,
               let package = currentPackage,
-              let selectedRate = selectedRate else {
+              let selectedRate else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/Custom Range Filter/DateRangeFilterViewController.swift
@@ -130,7 +130,7 @@ extension DateRangeFilterViewController: UITableViewDelegate {
         guard startDateExpanded, startDate == nil else { return }
 
         let today = Date()
-        if let endDate = endDate {
+        if let endDate {
             startDate = today <= endDate ? today : endDate
         } else {
             startDate = today
@@ -145,7 +145,7 @@ extension DateRangeFilterViewController: UITableViewDelegate {
         guard endDateExpanded, endDate == nil else { return }
 
         let today = Date()
-        if let startDate = startDate {
+        if let startDate {
             endDate = today >= startDate ? today : startDate
         } else {
             endDate = today
@@ -188,13 +188,13 @@ private extension DateRangeFilterViewController {
     }
 
     func configureStartDatePicker(cell: DatePickerTableViewCell) {
-        if let startDate = startDate {
+        if let startDate {
             cell.getPicker().setDate(startDate, animated: false)
         }
         cell.getPicker().maximumDate = endDate
         cell.getPicker().preferredDatePickerStyle = .inline
         cell.onDateSelected = { [weak self] date in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.startDate = date
@@ -210,13 +210,13 @@ private extension DateRangeFilterViewController {
     }
 
     func configureEndDatePicker(cell: DatePickerTableViewCell) {
-        if let endDate = endDate {
+        if let endDate {
             cell.getPicker().setDate(endDate, animated: false)
         }
         cell.getPicker().minimumDate = startDate
         cell.getPicker().preferredDatePickerStyle = .inline
         cell.onDateSelected = { [weak self] date in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.endDate = date

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/OrderDatesFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/OrderDatesFilterViewController.swift
@@ -103,7 +103,7 @@ extension OrderDatesFilterViewController: UITableViewDelegate {
             //
             let dateRangeFilterVC = DateRangeFilterViewController(startDate: selected?.startDate,
                                                                   endDate: selected?.endDate) { [weak self] (startDate, endDate) in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.selected = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
                 self.configureRows()
                 self.onCompletion(self.selected)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -42,20 +42,20 @@ final class FilterOrderListViewModel: FilterListViewModel {
 
         var readableString: String {
             var readable: [String] = []
-            if let orderStatus = orderStatus, !orderStatus.isEmpty {
+            if let orderStatus, !orderStatus.isEmpty {
                 readable = orderStatus.map { $0.rawValue.capitalized }
             }
-            if let dateRange = dateRange {
+            if let dateRange {
                 readable.append(dateRange.description)
             }
-            if let product = product {
+            if let product {
                 readable.append(product.name)
             }
-            if let customer = customer {
+            if let customer {
                 readable.append(customer.description)
             }
 
-            if let salesChannel = salesChannel {
+            if let salesChannel {
                 readable.append(salesChannel.description)
             }
 
@@ -364,10 +364,10 @@ extension CustomerFilter: FilterType {
 
         if fullName.isNotEmpty {
             return fullName
-        } else if let email = email,
+        } else if let email,
                   email.isNotEmpty {
             return email
-        } else if let username = username,
+        } else if let username,
                   username.isNotEmpty {
             return username
         } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -42,7 +42,7 @@ final class FilteredOrdersHeaderBar: UIView {
             contentSizeTraitRegistration = registerForTraitChanges([
                 UITraitPreferredContentSizeCategory.self
             ]) { [weak self] (_: FilteredOrdersHeaderBar, _: UITraitCollection) in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.updateStackViewAxis(for: self.traitCollection)
             }
         } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -260,7 +260,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
         return { [weak self] tableView, indexPath, objectID in
             let cell = tableView.dequeueReusableCell(OrderTableViewCell.self, for: indexPath)
-            guard let self = self else {
+            guard let self else {
                 return cell
             }
 
@@ -301,7 +301,7 @@ private extension OrderListViewController {
 
         /// Update the `dataSource` whenever there is a new snapshot.
         viewModel.snapshot.sink { [weak self] snapshot in
-            guard let self = self else { return }
+            guard let self else { return }
 
             dataSource?.apply(snapshot)
 
@@ -317,7 +317,7 @@ private extension OrderListViewController {
         /// Update the top banner when needed
         viewModel.$topBanner
             .sink { [weak self] topBannerType in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch topBannerType {
                 case .none:
                     self.hideTopBannerView()
@@ -437,7 +437,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
             pageSize: pageSize,
             reason: SyncReason(rawValue: reason ?? ""),
             lastFullSyncTimestamp: lastFullSyncTimestamp) { [weak self] totalDuration, error in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -478,7 +478,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
     /// Sets the current top banner in the table view header
     ///
     private func showTopBannerView() {
-        guard let topBannerView = topBannerView else { return }
+        guard let topBannerView else { return }
 
         // Configure header container view
         let headerContainer = UIView(frame: CGRect(x: 0, y: 0, width: Int(tableView.frame.width), height: 0))
@@ -829,7 +829,7 @@ extension OrderListViewController: UITableViewDelegate {
         let allViewModels = allViewModels()
         let currentIndex = allViewModels.firstIndex(where: { $0.order.orderID == order.orderID })
 
-        guard let currentIndex = currentIndex else { return }
+        guard let currentIndex else { return }
 
         let allowOrderNavigation = splitViewController?.isCollapsed ?? true
         // There is no point of having order navigation in the order details view when we have a split screen,
@@ -951,14 +951,14 @@ private extension OrderListViewController {
             self?.tableView.updateHeaderHeight()
         },
         onTroubleshootButtonPressed: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             ServiceLocator.analytics.track(event: .ConnectivityTool.topBannerTroubleshootTapped())
             let connectivityToolViewController = ConnectivityToolViewController()
             self.show(connectivityToolViewController, sender: self)
         },
         onContactSupportButtonPressed: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let supportForm = SupportFormHostingController(viewModel: .init())
             supportForm.show(from: self)
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -110,7 +110,7 @@ final class OrdersRootViewController: UIViewController {
         /// If there are some info stored when this screen is loaded, the data will be updated using the stored filters.
         ///
         syncLocalOrdersSettings { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.configureStatusResultsController()
         }
     }
@@ -205,14 +205,14 @@ final class OrdersRootViewController: UIViewController {
     /// Coordinates the navigation between the different views involved in Order Creation, Editing, and Details
     ///
     private func setupNavigation(viewModel: EditableOrderViewModel) {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
 
         let viewController = OrderFormHostingController(viewModel: viewModel)
 
         viewModel.onFinished = { [weak self] order in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.dismiss(animated: true) {
                 self.navigateToOrderDetail(order)
@@ -245,7 +245,7 @@ final class OrdersRootViewController: UIViewController {
     @objc func presentOrderCreationFlowByProductScanning() {
         analytics.track(event: .Orders.orderAddNewFromBarcodeScanningTapped())
 
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
 
@@ -255,7 +255,7 @@ final class OrdersRootViewController: UIViewController {
 
             self?.navigationItem.configureLeftBarButtonItemAsLoader()
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case let .success(product):
                     self.analytics.track(event: .Orders.orderProductAdd(flow: .creation,
@@ -389,7 +389,7 @@ private extension OrdersRootViewController {
     ///
     func configureStatusResultsController() {
         statusResultsController.onDidChangeObject = { [weak self] (updatedOrdersStatus, _, _, _) in
-            guard let self = self else { return }
+            guard let self else { return }
             self.resetFiltersIfAnyStatusFilterIsNoMoreExisting(orderStatuses: self.statusResultsController.fetchedObjects)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
@@ -23,7 +23,7 @@ final class PaymentMethodsHostingController: UIHostingController<HostedPaymentMe
         rootView.rootViewController = self
 
         // Set presentation delegate to track the user dismiss flow event
-        if let navigationController = navigationController {
+        if let navigationController {
             navigationController.presentationController?.delegate = self
         } else {
             presentationController?.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -217,7 +217,7 @@ final class PaymentMethodsViewModel: ObservableObject {
         trackCollectIntention(method: .card, cardReaderType: discoveryMethod.analyticsCardReaderType)
         orderDurationRecorder.recordCardPaymentStarted()
 
-        guard let rootViewController = rootViewController else {
+        guard let rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
             return presentNoticeSubject.send(.error(Localization.genericCollectError))
         }
@@ -432,7 +432,7 @@ private extension PaymentMethodsViewModel {
                 orderID: orderID,
                 isCustomerNote: false,
                 note: Localization.scanToPayNoteText) { [weak self] orderNote, _ in
-                    if let orderNote = orderNote {
+                    if let orderNote {
                         self?.onNoteAdded?(orderNote)
                     }
                     continuation.resume(returning: ())

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -165,7 +165,7 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
         if let charge = details.charge, shouldRefundWithCardReader(details: details) {
             cardPresentPaymentsOnboardingPresenter.showOnboardingIfRequired(
                 from: rootViewController) { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 guard let refundAmount = self.currencyFormatter.convertToDecimal(self.details.amount) else {
                     DDLogError("Error: attempted to refund an order without a valid amount.")
                     return onCompletion(.failure(RefundSubmissionUseCaseSubmissionError.invalidRefundAmount))
@@ -177,13 +177,13 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
 
                 self.observeConnectedReadersForAnalytics()
                 self.connectReader(charge: charge, paymentGatewayAccount: paymentGatewayAccount) { [weak self] result in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     switch result {
                     case .success:
                         self.attemptCardPresentRefund(refundAmount: refundAmount as Decimal,
                                                       charge: charge,
                                                       paymentGatewayAccount: paymentGatewayAccount) { [weak self] result in
-                            guard let self = self else { return }
+                            guard let self else { return }
                             switch result {
                             case .success:
                                 self.submitRefundToSite(refund: refund) { result in
@@ -248,10 +248,10 @@ private extension RefundSubmissionUseCase {
         // - Sends one value if there is no reader connected.
         // - Completes when a reader is connected.
         let readerConnected = CardPresentPaymentAction.publishCardReaderConnections { [weak self] connectPublisher in
-            guard let self = self else { return }
+            guard let self else { return }
             self.readerSubscription = connectPublisher
                 .sink() { [weak self] readers in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     if readers.isNotEmpty {
                         // Dismisses the current connection alert before notifying the completion.
@@ -269,7 +269,7 @@ private extension RefundSubmissionUseCase {
                     } else {
                         // Attempts reader connection
                         self.cardReaderConnectionController.searchAndConnect() { [weak self] result in
-                            guard let self = self else { return }
+                            guard let self else { return }
                             switch result {
                             case let .success(connectionResult):
                                 switch connectionResult {
@@ -314,7 +314,7 @@ private extension RefundSubmissionUseCase {
                                              paymentGatewayAccount: paymentGatewayAccount,
                                              onWaitingForInput: { [weak self] inputMethods in
             // Requests card input.
-            guard let self = self else { return }
+            guard let self else { return }
             self.alerts.tapOrInsertCard(title: RefundSubmissionUseCaseDefinitions.Localization.refundPaymentTitle(username: self.order.billingAddress?.firstName),
                                         amount: self.formattedAmount,
                                         inputMethods: inputMethods,
@@ -330,7 +330,7 @@ private extension RefundSubmissionUseCase {
             // Shows reader messages (e.g. Remove Card).
             self?.alerts.displayReaderMessage(message: message)
         }, onCompletion: { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 self.trackClientSideRefundRequestSuccess(charge: charge, paymentGatewayAccount: paymentGatewayAccount)
@@ -394,13 +394,13 @@ private extension RefundSubmissionUseCase {
         let action = RefundAction.createRefund(siteID: details.order.siteID, orderID: details.order.orderID, refund: refund) { [weak self]
             refundData, error  in
 
-            guard let self = self else { return }
+            guard let self else { return }
 
-            if let refundData = refundData {
+            if let refundData {
                 // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
                 self.retrieveUpdatedRefundData(refund: refundData)
             }
-            if let error = error {
+            if let error {
                 DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")
                 self.trackCreateRefundRequestFailed(error: error)
                 return onCompletion(.failure(error))
@@ -417,7 +417,7 @@ private extension RefundSubmissionUseCase {
     ///   - refund: the refund to retrieve details from.
     private func retrieveUpdatedRefundData(refund: Refund) {
         let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) { (_, error) in
-                if let error = error {
+                if let error {
                     DDLogError("Error retrieving refund: \(String(describing: refund))\nWith Error: \(error)")
                 }
             }
@@ -519,7 +519,7 @@ private enum RefundSubmissionUseCaseDefinitions {
         private static let refundPaymentWithName = NSLocalizedString("Refund payment from %1$@",
                                                                      comment: "Alert title when starting the in-person refund flow with a user name.")
         static func refundPaymentTitle(username: String?) -> String {
-            guard let username = username, username.isNotEmpty else {
+            guard let username, username.isNotEmpty else {
                 return refundPaymentWithoutName
             }
             return .localizedStringWithFormat(refundPaymentWithName, username)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -199,7 +199,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         }
 
         // Used mostly in previews
-        if let noteContent = noteContent {
+        if let noteContent {
             noteViewModel = SimplePaymentsNoteViewModel(originalNote: noteContent)
         }
 
@@ -264,7 +264,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                                                            taxable: enableTaxes,
                                                            orderNote: noteContent,
                                                            email: email.isEmpty ? nil : email) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.showLoadingIndicator = false
 
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -399,7 +399,7 @@ private extension ProductDetailPreviewViewModel {
         var shippingDetails = [String]()
 
         // Weight[unit]
-        if let weight = product.weight, let weightUnit = weightUnit, !weight.isEmpty {
+        if let weight = product.weight, let weightUnit, !weight.isEmpty {
             let localizedWeight = shippingValueLocalizer.localized(shippingValue: weight) ?? weight
             shippingDetails.append(String.localizedStringWithFormat(Localization.weightFormat,
                                                                     localizedWeight, weightUnit))
@@ -413,7 +413,7 @@ private extension ProductDetailPreviewViewModel {
             .map({ shippingValueLocalizer.localized(shippingValue: $0) ?? $0 })
             .filter({ !$0.isEmpty })
 
-        if let dimensionUnit = dimensionUnit,
+        if let dimensionUnit,
            !dimensions.isEmpty {
             switch dimensions.count {
             case 1:

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -111,7 +111,7 @@ private extension ProductCategoryListViewController {
 
         viewModel.$selectedCategories.combineLatest(viewModel.$categoryViewModels)
             .map { [weak self] selectedItems, models -> Bool in
-                guard let self = self, self.configuration.clearSelectionEnabled else {
+                guard let self, self.configuration.clearSelectionEnabled else {
                     return true
                 }
                 return selectedItems.isEmpty || models.isEmpty
@@ -143,7 +143,7 @@ private extension ProductCategoryListViewController {
 
         viewModel.$syncCategoriesState.combineLatest(viewModel.$categoryViewModels)
             .sink { [weak self] syncState, models in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.emptyStateViewController.view.isHidden = true
                 self.tableView.isHidden = false
                 switch syncState {

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -196,7 +196,7 @@ final class ProductCategoryListViewModel {
         } else {
             let selectedCategory = resultController.fetchedObjects.first(where: { $0.categoryID == categoryViewModel.categoryID })
 
-            if let selectedCategory = selectedCategory {
+            if let selectedCategory {
                 selectedCategories.append(selectedCategory)
             }
 
@@ -268,7 +268,7 @@ final class ProductCategoryListViewModel {
             .removeDuplicates()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] newQuery in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if newQuery.isNotEmpty {
                     let searchPredicate = NSPredicate(format: "siteID = %lld AND ((name CONTAINS[cd] %@) OR (slug CONTAINS[cd] %@))",
@@ -298,7 +298,7 @@ private extension ProductCategoryListViewModel {
             // Make sure we always have view models to display
             self?.updateViewModelsArray()
 
-            if let error = error {
+            if let error {
                 ServiceLocator.analytics.track(.productCategoryListLoadFailed, withError: error)
                 self?.handleSychronizeAllCategoriesError(error)
             } else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -262,7 +262,7 @@ private extension ImageAndTitleAndTextTableViewCell {
         cancellable = NotificationCenter.default
                 .publisher(for: UIContentSizeCategory.didChangeNotification)
                 .sink { [weak self] notification in
-                    guard let self = self,
+                    guard let self,
                           let contentSizeCategory = notification.userInfo?[UIContentSizeCategory.newValueUserInfoKey] as? UIContentSizeCategory else {
                         return
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ProductReviewsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ProductReviewsTableViewCell.swift
@@ -9,7 +9,7 @@ final class ProductReviewsTableViewCell: UITableViewCell {
 
     private var starRating: Double? {
         didSet {
-            guard let starRating = starRating else {
+            guard let starRating else {
                 ratingView.isHidden = true
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -348,7 +348,7 @@ private extension DefaultProductFormTableViewModel {
         var shippingDetails = [String]()
 
         // Weight[unit]
-        if let weight = product.weight, let weightUnit = weightUnit, !weight.isEmpty {
+        if let weight = product.weight, let weightUnit, !weight.isEmpty {
             let localizedWeight = shippingValueLocalizer.localized(shippingValue: weight) ?? weight
             shippingDetails.append(String.localizedStringWithFormat(Localization.weightFormat,
                                                                     localizedWeight, weightUnit))
@@ -362,7 +362,7 @@ private extension DefaultProductFormTableViewModel {
             .map({ shippingValueLocalizer.localized(shippingValue: $0) ?? $0 })
             .filter({ !$0.isEmpty })
 
-        if let dimensionUnit = dimensionUnit,
+        if let dimensionUnit,
             !dimensions.isEmpty {
             switch dimensions.count {
             case 1:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewModel.swift
@@ -89,7 +89,7 @@ extension ProductDownloadFileViewModel: ProductDownloadFileActionHandler {
     // MARK: - Navigation actions
 
     func completeUpdating(onCompletion: ProductDownloadFileViewController.Completion) {
-        if let fileURL = fileURL, isChangesValid() {
+        if let fileURL, isChangesValid() {
             onCompletion(fileName, fileURL, fileID, hasUnsavedChanges())
         }
         return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -189,7 +189,7 @@ extension ProductDownloadListViewController {
         let actions = viewModel.bottomSheetActions
         let dataSource = DownloadableFileBottomSheetListSelectorCommand(actions: actions) { [weak self] action in
             self?.dismiss(animated: true) { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch action {
                 case .deviceMedia:
                     self.showDeviceMediaLibraryPicker(origin: self)
@@ -260,7 +260,7 @@ private extension ProductDownloadListViewController {
                                                                                           name: fileName ?? "",
                                                                                           fileURL: fileURL)))
         case .edit:
-            if let indexPath = indexPath {
+            if let indexPath {
                 viewModel.update(at: indexPath.row,
                                  element: (ProductDownloadDragAndDrop(downloadableFile: ProductDownload(downloadID: fileID ?? "",
                                                                                                         name: fileName ?? "",
@@ -272,7 +272,7 @@ private extension ProductDownloadListViewController {
     }
 
     func onDownloadableFileDeletion(indexPath: IndexPath?) {
-        guard let indexPath = indexPath else {
+        guard let indexPath else {
             return
         }
         viewModel.remove(at: indexPath.row)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewModel.swift
@@ -67,7 +67,7 @@ extension ProductDownloadSettingsViewModel: ProductDownloadSettingsActionHandler
             return
         }
 
-        guard let downloadLimit = downloadLimit, let downloadLimitUnwrapped = Int64(downloadLimit), downloadLimitUnwrapped >= 0 else {
+        guard let downloadLimit, let downloadLimitUnwrapped = Int64(downloadLimit), downloadLimitUnwrapped >= 0 else {
             self.downloadLimit = Constants.invalidValue
             onValidation(areChangesValid())
             return
@@ -83,7 +83,7 @@ extension ProductDownloadSettingsViewModel: ProductDownloadSettingsActionHandler
             return
         }
 
-        guard let downloadExpiry = downloadExpiry, let downloadExpiryUnwrapped = Int64(downloadExpiry), downloadExpiryUnwrapped >= 0 else {
+        guard let downloadExpiry, let downloadExpiryUnwrapped = Int64(downloadExpiry), downloadExpiryUnwrapped >= 0 else {
             self.downloadExpiry = Constants.invalidValue
             onValidation(areChangesValid())
             return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceSettingsViewModel.swift
@@ -97,7 +97,7 @@ final class BulkUpdatePriceSettingsViewModel {
         let action = ProductVariationAction.updateProductVariations(siteID: siteID,
                                                                     productID: productID,
                                                                     productVariations: variationsWithUpdatedPrice()) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/BulkUpdatePriceViewController.swift
@@ -31,7 +31,7 @@ final class BulkUpdatePriceViewController: UIViewController {
     init(viewModel: BulkUpdatePriceSettingsViewModel, noticePresenter: NoticePresenter? = nil) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        if let noticePresenter = noticePresenter {
+        if let noticePresenter {
             self.noticePresenter = noticePresenter
         }
     }
@@ -81,7 +81,7 @@ final class BulkUpdatePriceViewController: UIViewController {
         }.store(in: &subscriptions)
 
         viewModel.$bulkUpdatePriceError.sink { [weak self] error in
-            guard let error = error else {
+            guard let error else {
                 return
             }
             self?.displayNoticeForError(error)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsValidator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsValidator.swift
@@ -22,7 +22,7 @@ final class ProductPriceSettingsValidator {
     /// Returns the decimal value from a price string.
     ///
     func getDecimalPrice(_ price: String?) -> NSDecimalNumber? {
-        guard let price = price else {
+        guard let price else {
             return nil
         }
         return currencyFormatter.convertToDecimal(price)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -269,7 +269,7 @@ extension ProductPriceSettingsViewController: UITableViewDelegate {
         case .taxStatus:
             let command = ProductTaxStatusListSelectorCommand(selected: viewModel.taxStatus)
             let listSelectorViewController = ListSelectorViewController(command: command) { [weak self] selected in
-                                                                            if let selected = selected {
+                                                                            if let selected {
                                                                                 self?.viewModel.handleTaxStatusChange(selected)
                                                                             }
                                                                             self?.refreshViewContent()
@@ -289,7 +289,7 @@ extension ProductPriceSettingsViewController: UITableViewDelegate {
             let selectorViewController =
                 PaginatedListSelectorViewController(viewProperties: viewProperties,
                                                     dataSource: dataSource) { [weak self] selected in
-                                                        guard let self = self else {
+                                                        guard let self else {
                                                             return
                                                         }
                                                         self.viewModel.handleTaxClassChange(selected)
@@ -428,7 +428,7 @@ private extension ProductPriceSettingsViewController {
         cell.subtitle = NSLocalizedString("Automatically start and end a sale", comment: "Subtitle of the cell in Product Price Settings > Schedule sale")
         cell.isOn = (viewModel.dateOnSaleStart != nil || viewModel.dateOnSaleEnd != nil) ? true : false
         cell.onChange = { [weak self] isOn in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -451,7 +451,7 @@ private extension ProductPriceSettingsViewController {
         }
         cell.getPicker().timeZone = timezoneForScheduleSaleDates
         cell.onDateSelected = { [weak self] date in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.viewModel.handleSaleStartDateChange(date)
@@ -474,7 +474,7 @@ private extension ProductPriceSettingsViewController {
         }
         cell.getPicker().timeZone = timezoneForScheduleSaleDates
         cell.onDateSelected = { [weak self] date in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.viewModel.handleSaleEndDateChange(date)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -235,7 +235,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     func handleSaleStartDateChange(_ date: Date) {
         dateOnSaleStart = date.startOfDay(timezone: timezoneForScheduleSaleDates)
 
-        if let dateOnSaleEnd = dateOnSaleEnd, dateOnSaleEnd < date {
+        if let dateOnSaleEnd, dateOnSaleEnd < date {
             self.dateOnSaleEnd = date.endOfDay(timezone: timezoneForScheduleSaleDates)
         }
     }
@@ -244,7 +244,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
         if date == nil {
             datePickerSaleToVisible = false
         }
-        if let date = date, let dateOnSaleStart = dateOnSaleStart, date < dateOnSaleStart {
+        if let date, let dateOnSaleStart, date < dateOnSaleStart {
             return
         }
         else {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -217,7 +217,7 @@ private extension ProductTagsViewController {
         }
 
         let action = ProductTagAction.synchronizeAllProductTags(siteID: product.siteID) { [weak self] error in
-            if let error = error {
+            if let error {
                 ServiceLocator.analytics.track(.productTagListLoadFailed, withError: error)
                 self?.tagsFailedLoading()
                 return
@@ -257,7 +257,7 @@ private extension ProductTagsViewController {
         configureRightBarButtonItemAsSpinner()
 
         let action = ProductTagAction.addProductTags(siteID: product.siteID, tags: allTags) { [weak self] (result) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.configureRightBarButtonItemAsSave()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -398,7 +398,7 @@ private extension ProductInventorySettingsViewController {
     }
 
     func startBarcodeScanning(onCompletion: @escaping (_ barcode: String) -> Void) {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewModel.swift
@@ -151,7 +151,7 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
         throttler.throttle {
             DispatchQueue.main.async { [weak self] in
                 let action = ProductAction.validateProductSKU(sku, siteID: siteID) { [weak self] isValid in
-                    guard let self = self else {
+                    guard let self else {
                         return
                     }
                     self.skuIsValid = isValid
@@ -220,7 +220,7 @@ extension ProductInventorySettingsViewModel: ProductInventorySettingsActionHandl
     }
 
     func handleStockQuantityChange(_ stockQuantity: String?) {
-        guard let stockQuantity = stockQuantity else {
+        guard let stockQuantity else {
             return
         }
         self.stockQuantity = Decimal(string: stockQuantity)
@@ -307,7 +307,7 @@ private extension ProductInventorySettingsViewModel {
     func createSKUSection() -> Section {
         let skuError = errors.first { $0 == .invalidSKU || $0 == .duplicatedSKU }
 
-        if let skuError = skuError {
+        if let skuError {
             return Section(errorTitle: skuError.errorDescription, rows: [.sku])
         } else {
             return Section(rows: [.sku])

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSource.swift
@@ -8,7 +8,7 @@ final class LinkedProductListSelectorDataSource: PaginatedListSelectorDataSource
     typealias StorageModel = StorageProduct
 
     lazy var customResultsSortOrder: ((Product, Product) -> Bool)? = { [weak self] (lhs, rhs) in
-        guard let self = self else {
+        guard let self else {
             return true
         }
         let lhsProductID = lhs.productID
@@ -78,7 +78,7 @@ final class LinkedProductListSelectorDataSource: PaginatedListSelectorDataSource
         cell.update(viewModel: viewModel, imageService: imageService)
 
         cell.configureAccessoryDeleteButton { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.analytics.track(.connectedProductsList, withProperties: ["action": "delete_tapped", "context": self.trackingContext])
             self.deleteProduct(model)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductTaxClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductTaxClassListSelectorDataSource.swift
@@ -44,7 +44,7 @@ struct ProductTaxClassListSelectorDataSource: PaginatedListSelectorDataSource {
 
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Result<Bool, Error>) -> Void)?) {
         let action = TaxAction.retrieveTaxClasses(siteID: siteID) { (taxClasses, error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing tax classes: \(error)")
                 onCompletion?(.failure(error))
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -56,10 +56,10 @@ final class ProductSettingsViewModel {
             /// and user is authenticated with WP.com, enter here, otherwise we skip this.
             else if (product.password == nil || product.password?.isEmpty == true) && ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
                 retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
-                    guard let self = self else {
+                    guard let self else {
                         return
                     }
-                    guard error == nil, let password = password else {
+                    guard error == nil, let password else {
                         return
                     }
                     self.onPasswordRetrieved?(password)
@@ -77,7 +77,7 @@ final class ProductSettingsViewModel {
         let section = sections[indexPath.section]
         let row = section.rows[indexPath.row]
         row.handleTap(sourceViewController: sourceViewController) { [weak self] (settings) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.productSettings = settings

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Slug/ProductSlugViewController.swift
@@ -141,7 +141,7 @@ private extension ProductSlugViewController {
         let placeholder = NSLocalizedString("Slug", comment: "Placeholder in the Product Slug row on Edit Product Slug screen.")
 
         let viewModel = TextFieldTableViewCell.ViewModel(text: productSettings.slug, placeholder: placeholder, onTextChange: { [weak self] newName in
-            if let newName = newName {
+            if let newName {
                 self?.productSettings.slug = newName
             }
             }, onTextDidBeginEditing: {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -96,7 +96,7 @@ protocol ProductFormDataModel {
 extension ProductFormDataModel {
     /// Returns the full description without the HTML tags and leading/trailing white spaces and new lines.
     var trimmedFullDescription: String? {
-        guard let description = description else {
+        guard let description else {
             return nil
         }
         return description.removedHTMLTags.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -150,7 +150,7 @@ final class ProductFormRemoteActionUseCase {
         }
 
         group.notify(queue: .main) {
-            guard let productResult = productResult, let passwordResult = passwordResult else {
+            guard let productResult, let passwordResult else {
                 assertionFailure("Unexpected nil result after updating product and password remotely")
                 onCompletion(.failure(.unexpected))
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -232,7 +232,7 @@ private extension ProductFormTableViewDataSource {
     }
 
     func configureDescription(cell: UITableViewCell, description: String?, isEditable: Bool, isAIEnabled: Bool) {
-        if let description = description, description.isEmpty == false {
+        if let description, description.isEmpty == false {
             guard let cell = cell as? ImageAndTitleAndTextTableViewCell else {
                 fatalError()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -164,7 +164,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         observeTraitChanges()
 
         productImageStatusesSubscription = productImageActionHandler.addUpdateObserver(self) { [weak self] productImageStatuses in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -811,7 +811,7 @@ private extension ProductFormViewController {
     ///
     func observeProductName() {
         productNameSubscription = viewModel.productName?.sink { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.updateBackButtonTitle()
             if self.view.window == nil { // If window is nil, this screen isn't the active screen.
                 self.onProductUpdated(product: self.product)
@@ -920,7 +920,7 @@ private extension ProductFormViewController {
         updateDataSourceActions()
         tableView.dataSource = tableViewDataSource
 
-        if let reloadClosure = reloadClosure {
+        if let reloadClosure {
             reloadClosure()
         } else {
             tableView.reloadData()
@@ -934,7 +934,7 @@ private extension ProductFormViewController {
             self?.editLinkedProducts()
         }
         tableViewDataSource.reloadLinkedPromoAction = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.reloadLinkedPromoCell()
         }
         tableViewDataSource.descriptionAIAction = { [weak self] in
@@ -1207,7 +1207,7 @@ private extension ProductFormViewController {
 
     func deleteProduct() {
         self.viewModel.deleteProductRemotely { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 ServiceLocator.analytics.track(.productDetailProductDeleted)
@@ -1237,7 +1237,7 @@ private extension ProductFormViewController {
                                                            password: password,
                                                            formType: viewModel.formType,
                                                            completion: { [weak self] (productSettings) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.viewModel.updateProductSettings(productSettings)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -252,7 +252,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.favoriteProductsUseCase = favoriteProductsUseCase ?? DefaultFavoriteProductsUseCase(siteID: product.siteID)
 
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
-            guard let self = self else { return }
+            guard let self else { return }
             self.isUpdateEnabledSubject.send(self.hasUnsavedChanges())
         }
 
@@ -569,7 +569,7 @@ extension ProductFormViewModel {
 extension ProductFormViewModel {
     func saveProductRemotely(status: ProductStatus?, onCompletion: @escaping (Result<EditableProductModel, ProductUpdateError>) -> Void) {
         let productModelToSave: EditableProductModel = {
-            guard let status = status, status != product.status else {
+            guard let status, status != product.status else {
                 return product
             }
             let productWithStatusUpdated = product.product.copy(statusKey: status.rawValue)
@@ -584,7 +584,7 @@ extension ProductFormViewModel {
                 case .failure(let error):
                     onCompletion(.failure(error))
                 case .success(let data):
-                    guard let self = self else {
+                    guard let self else {
                         return
                     }
                     self.resetProduct(data.product)
@@ -606,7 +606,7 @@ extension ProductFormViewModel {
                                               originalProduct: originalProduct,
                                               password: password,
                                               originalPassword: originalPassword) { [weak self] result in
-                                                guard let self = self else {
+                                                guard let self else {
                                                     return
                                                 }
                                                 switch result {
@@ -628,7 +628,7 @@ extension ProductFormViewModel {
 
         remoteActionUseCase.duplicateProduct(originalProduct: product,
                                              password: password) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .failure(let error):
                 onCompletion(.failure(error))
@@ -675,7 +675,7 @@ private extension ProductFormViewModel {
             .saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: product.siteID,
                                                                         productOrVariationID: .product(id: product.productID),
                                                                         isLocalID: !product.existsRemotely)) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
             switch result {
             case .success(let images):
                 let currentProduct = self.product
@@ -799,7 +799,7 @@ private extension ProductFormViewModel {
     ///
     func queryAddOnsFeatureState() {
         let action = AppSettingsAction.loadOrderAddOnsSwitchState { [weak self] result in
-            guard let self = self, case .success(let addOnsEnabled) = result else {
+            guard let self, case .success(let addOnsEnabled) = result else {
                 return
             }
             self.isAddOnsFeatureEnabled = addOnsEnabled

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -132,7 +132,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
         self.productImagesUploader = productImagesUploader
         self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
-            guard let self = self else { return }
+            guard let self else { return }
             self.isUpdateEnabledSubject.send(self.hasUnsavedChanges())
         }
     }
@@ -404,7 +404,7 @@ extension ProductVariationFormViewModel {
 extension ProductVariationFormViewModel {
     func saveProductRemotely(status: ProductStatus?, onCompletion: @escaping (Result<EditableProductVariationModel, ProductUpdateError>) -> Void) {
         let updateAction = ProductVariationAction.updateProductVariation(productVariation: productVariation.productVariation) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             switch result {
@@ -434,7 +434,7 @@ extension ProductVariationFormViewModel {
         let deleteAction = ProductVariationAction.deleteProductVariation(productVariation: productVariation.productVariation) { [weak self] result in
             switch result {
             case .success:
-                if let self = self {
+                if let self {
                     self.onVariationDeletion?(self.productVariation.productVariation)
                 }
                 onCompletion(.success(()))
@@ -457,7 +457,7 @@ extension ProductVariationFormViewModel {
                     .variation(productID: productVariation.productVariation.productID,
                                variationID: productVariation.productVariation.productVariationID),
                                                                         isLocalID: !productVariation.existsRemotely)) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let images):
                     let currentProduct = self.productVariation

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -88,7 +88,7 @@ private extension ProductShippingSettingsViewController {
         let action = ProductShippingClassAction
             .retrieveProductShippingClass(siteID: viewModel.product.siteID,
                                           remoteID: viewModel.product.shippingClassID) { [weak self] (shippingClass, error) in
-                                            guard let shippingClass = shippingClass, error == nil else {
+                                            guard let shippingClass, error == nil else {
                                                 return
                                             }
                                             self?.viewModel.onShippingClassRetrieved(shippingClass: shippingClass)
@@ -172,7 +172,7 @@ extension ProductShippingSettingsViewController: UITableViewDelegate {
             let selectorViewController =
                 PaginatedListSelectorViewController(viewProperties: viewProperties,
                                                     dataSource: dataSource) { [weak self] selected in
-                                                        guard let self = self else {
+                                                        guard let self else {
                                                             return
                                                         }
                                                         self.viewModel.handleShippingClassChange(selected)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewModel.swift
@@ -168,7 +168,7 @@ private extension ProductShippingSettingsViewModel {
 
 extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler {
     func handleWeightChange(_ weight: String?) {
-        guard let weight = weight else {
+        guard let weight else {
             self.weight = nil
             return
         }
@@ -177,7 +177,7 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
     }
 
     func handleLengthChange(_ length: String?) {
-        guard let length = length else {
+        guard let length else {
             self.length = nil
             return
         }
@@ -185,7 +185,7 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
     }
 
     func handleWidthChange(_ width: String?) {
-        guard let width = width else {
+        guard let width else {
             self.width = nil
             return
         }
@@ -194,7 +194,7 @@ extension ProductShippingSettingsViewModel: ProductShippingSettingsActionHandler
     }
 
     func handleHeightChange(_ height: String?) {
-        guard let height = height else {
+        guard let height else {
             self.height = nil
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductCategoryListViewController.swift
@@ -18,7 +18,7 @@ final class FilterProductCategoryListViewController: UIViewController {
         self.viewModel = FilterProductCategoryListViewModel(anyCategoryIsSelected: selectedCategory == nil)
 
         var selectedCategories: [ProductCategory] = []
-        if let selectedCategory = selectedCategory {
+        if let selectedCategory {
             selectedCategories.append(selectedCategory)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -23,7 +23,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
     private let phAssetImageLoaderProvider: (() -> PHAssetImageLoader)?
     /// `PHAssetImageLoader` is lazy loaded to avoid triggering permission alert by initializing `PHImageManager` before it is used.
     private lazy var phAssetImageLoader: PHAssetImageLoader = {
-        guard let phAssetImageLoaderProvider = phAssetImageLoaderProvider else {
+        guard let phAssetImageLoaderProvider else {
             assertionFailure("Trying to call `PHAssetImageLoader` without setting a provider during initialization")
             return PHImageManager.default()
         }
@@ -48,7 +48,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
         self.imageStorage = ImageStorage()
 
         assetUploadSubscription = productImageActionHandler?.addAssetUploadObserver(self) { [weak self] asset, result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard case let .success(productImage) = result else {
                 return
             }
@@ -89,7 +89,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
 
         if let imageFromCache = await withCheckedContinuation({ continuation in
             imageService.retrieveImageFromCache(with: url) { image in
-                if let image = image {
+                if let image {
                     continuation.resume(returning: image)
                 } else {
                     continuation.resume(returning: nil)
@@ -101,7 +101,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
 
         if let downloadedImage = await withCheckedContinuation({ continuation in
             _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, error) in
-                if let image = image {
+                if let image {
                     continuation.resume(returning: image)
                 } else {
                     continuation.resume(returning: nil)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/Media+WPMediaAsset.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/Media+WPMediaAsset.swift
@@ -14,7 +14,7 @@ extension CancellableMedia: WPMediaAsset {
         // extension.
         let imageService = ServiceLocator.imageService
         imageService.retrieveImageFromCache(with: url) { [weak self] (image) in
-            if let image = image {
+            if let image {
                 completionHandler(image, nil)
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -48,7 +48,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     private(set) var productImageStatuses: [ProductImageStatus] {
         didSet {
             queue.async { [weak self] in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 self.observations.allStatusesUpdated.values.forEach { closure in
@@ -93,12 +93,12 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
         let id = UUID()
 
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
             self.observations.allStatusesUpdated[id] = { [weak self, weak observer] allStatuses in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -133,7 +133,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
         let id = UUID()
 
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -158,7 +158,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
 
     func addSiteMediaLibraryImagesToProduct(mediaItems: [Media]) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -172,7 +172,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
 
     func uploadMediaAssetToSiteMediaLibrary(asset: ProductImageAssetType) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             let uploadingStatus = ProductImageStatus.uploading(asset: asset, siteID: self.siteID, productID: self.productOrVariationID)
@@ -187,7 +187,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
 
             self.uploadMediaAssetToSiteMediaLibrary(asset: asset) { [weak self] result in
                                                 self?.queue.async { [weak self] in
-                                                    guard let self = self else {
+                                                    guard let self else {
                                                         return
                                                     }
 
@@ -215,7 +215,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
 
     private func uploadMediaAssetToSiteMediaLibrary(asset: ProductImageAssetType, onCompletion: @escaping (Result<Media, Error>) -> Void) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let action: MediaAction
             switch asset {
                 case .phAsset(let asset):
@@ -256,7 +256,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     ///
     func updateProductID(_ remoteProductID: ProductOrVariationID) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.productOrVariationID = remoteProductID
@@ -275,7 +275,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
 
     func deleteProductImage(_ productImage: ProductImage) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -294,7 +294,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     ///
     func resetProductImages(to product: ProductFormDataModel) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -306,7 +306,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
     ///
     func updateProductImageStatusesAfterReordering(_ productImageStatuses: [ProductImageStatus]) {
         queue.async { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagePicker/ProductImagePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagePicker/ProductImagePickerView.swift
@@ -21,7 +21,7 @@ final class ProductImagePickerViewController: UIHostingController<ProductImagePi
         super.viewDidLoad()
 
         // Set presentation delegate to track the user dismiss flow event
-        if let navigationController = navigationController {
+        if let navigationController {
             navigationController.presentationController?.delegate = self
         } else {
             presentationController?.delegate = self

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesGalleryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesGalleryViewController.swift
@@ -132,7 +132,7 @@ private extension ProductImagesGalleryViewController {
             "Remove",
             comment: "Confirm button on the alert when the user taps to delete a Product image"
         ), style: .destructive) { [weak self] _ in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             if let index = self.currentImageIndex {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -75,7 +75,7 @@ private extension ProductImagesSaver {
             let action = ProductAction.updateProductImages(siteID: siteID,
                                                            productID: productID,
                                                            images: images) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let product):
                     savedProduct = product
@@ -100,7 +100,7 @@ private extension ProductImagesSaver {
                                                                             productID: productID,
                                                                             variationID: variationID,
                                                                             image: image) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
                 switch result {
                 case .success(let productVariation):
                     onProductSave(.success(productVariation.image.map { [$0] } ?? []))
@@ -126,7 +126,7 @@ private extension ProductImagesSaver {
 
     func observeAssetUploadsToUpdateImageStatuses(imageActionHandler: ProductImageActionHandlerProtocol) {
         assetUploadSubscription = imageActionHandler.addAssetUploadObserver(self) { [weak self] asset, result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let index = self.imageStatusesToSave.firstIndex(where: { status -> Bool in
                 switch status {
                 case .uploading(let uploadingAsset, _, _):

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesViewController.swift
@@ -192,7 +192,7 @@ private extension ProductImagesViewController {
 
     func configureProductImagesObservation() {
         productImageStatusesObservationToken = productImageActionHandler.addUpdateObserver(self) { [weak self] productImageStatuses in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -329,7 +329,7 @@ private extension ProductImagesViewController {
 //
 private extension ProductImagesViewController {
     func onCameraCaptureCompletion(asset: PHAsset?, error: Error?) {
-        guard let asset = asset else {
+        guard let asset else {
             displayErrorAlert(error: error)
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
@@ -128,7 +128,7 @@ extension WordPressMediaLibraryPickerDataSource: WPMediaCollectionDataSource {
     func loadData(with options: WPMediaLoadOptions, success successBlock: WPMediaSuccessBlock?, failure failureBlock: WPMediaFailureBlock? = nil) {
         syncingCoordinator.resetInternalState()
         retrieveMedia(pageNumber: syncingCoordinator.pageFirstIndex, pageSize: Constants.numberOfItemsPerPage) { [weak self] (mediaItems, error) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -163,7 +163,7 @@ extension WordPressMediaLibraryPickerDataSource: WPMediaCollectionDataSource {
 extension WordPressMediaLibraryPickerDataSource: SyncingCoordinatorDelegate {
     func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: ((Bool) -> Void)?) {
         retrieveMedia(pageNumber: pageNumber, pageSize: pageSize) { [weak self] (mediaItems, error) in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             guard error == nil else {

--- a/WooCommerce/Classes/ViewRelated/Products/PriceInputViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/PriceInputViewController.swift
@@ -57,7 +57,7 @@ private extension PriceInputViewController {
             }.store(in: &subscriptions)
 
         viewModel.$inputValidationError.sink { [weak self] error in
-            guard let error = error else {
+            guard let error else {
                 return
             }
             self?.displayNoticeForError(error)

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductLoaderViewController.swift
@@ -113,7 +113,7 @@ private extension ProductLoaderViewController {
     ///
     func loadProduct(productID: Int64) {
         let action = ProductAction.retrieveProduct(siteID: siteID, productID: productID) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -214,7 +214,7 @@ private extension ProductLoaderViewController {
     /// Removes EmptyStateViewController child view controller if applicable.
     ///
     func removeAllOverlays() {
-        guard let emptyStateViewController = emptyStateViewController, emptyStateViewController.parent == self else {
+        guard let emptyStateViewController, emptyStateViewController.parent == self else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductVariationLoadUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Product Loader/ProductVariationLoadUseCase.swift
@@ -47,7 +47,7 @@ final class ProductVariationLoadUseCase {
         stores.dispatch(productAction)
 
         group.notify(queue: .main) {
-            guard let parentProductResult = parentProductResult, let productVariationResult = productVariationResult else {
+            guard let parentProductResult, let productVariationResult else {
                 assertionFailure("Unexpected nil result after updating product and password remotely")
                 onCompletion(.failure(.init(ProductVariationLoadError.unexpected)))
                 return

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -141,7 +141,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         let formattedTrialDetails = {
             // If trial period is missing, we can skip formatting the rest
-            guard let trialPeriod = trialPeriod else { return "" }
+            guard let trialPeriod else { return "" }
             switch trialLength {
             case "", "0":
                 // The API allows empty and 0 as values for trial length, with a non-nil trial period.
@@ -192,7 +192,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Formatted price label for an individual product
     ///
     var priceLabel: String? {
-        guard let price = price else {
+        guard let price else {
             return nil
         }
         return currencyFormatter.formatAmount(price)
@@ -202,14 +202,14 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// e.g: If price is $5 and discount is $1, outputs "$5.00 - $1.00"
     ///
     var priceAndDiscountsLabel: String? {
-        guard let price = price else {
+        guard let price else {
             return nil
         }
         let productSubtotal = quantity * (currencyFormatter.convertToDecimal(price)?.decimalValue ?? Decimal.zero)
         let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal)
 
         guard let priceLabelComponent = currencyFormatter.formatAmount(productSubtotal),
-              let discount = discount,
+              let discount,
               let discountLabelComponent = currencyFormatter.formatAmount(discount) else {
             return priceLabelComponent
         }
@@ -276,7 +276,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Label showing product SKU
     ///
     private(set) lazy var skuLabel: String = {
-        guard let sku = sku, sku.isNotEmpty else {
+        guard let sku, sku.isNotEmpty else {
             return ""
         }
         return String.localizedStringWithFormat(Localization.skuFormat, sku)
@@ -508,7 +508,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     private func createStockText() -> String {
         switch stockStatus {
         case .inStock:
-            if let stockQuantity = stockQuantity, manageStock {
+            if let stockQuantity, manageStock {
                 let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
                 return String.localizedStringWithFormat(Localization.stockFormat, localizedStockQuantity)
             } else {
@@ -524,7 +524,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     private func createStockQuantityText() -> String {
         switch stockStatus {
         case .inStock:
-            if let stockQuantity = stockQuantity, manageStock {
+            if let stockQuantity, manageStock {
                 let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
                 return String.localizedStringWithFormat(Localization.stockFormat, localizedStockQuantity)
             } else {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -536,7 +536,7 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
                                                        sortOrder: .nameAscending,
                                                        productIDs: (filtersSubject.value.favoriteProduct != nil) ? favoriteProductIDs : [],
                                                        shouldDeleteStoredProductsOnFirstPage: shouldDeleteStoredProductsOnFirstPage) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:
@@ -569,7 +569,7 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
                                                   productType: filtersSubject.value.promotableProductType?.productType,
                                                   productCategory: filtersSubject.value.productCategory) { [weak self] result in
             // Don't continue if this isn't the latest search.
-            guard let self = self, keyword == self.searchTerm else {
+            guard let self, keyword == self.searchTerm else {
                 return
             }
 
@@ -602,7 +602,7 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
         }
 
         let action = ProductAction.searchProductsInCache(siteID: siteID, keyword: keyword, pageSize: pageSize) { [weak self ] thereAreCachedResults in
-            guard let self = self,
+            guard let self,
                   keyword == self.searchTerm else {
                 return
             }
@@ -784,7 +784,7 @@ private extension ProductSelectorViewModel {
         // Listen only to the first emitted event.
         onLoadTrigger.first()
             .sink { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.syncFirstPage()
             }
             .store(in: &subscriptions)
@@ -804,7 +804,7 @@ private extension ProductSelectorViewModel {
 
         Publishers.CombineLatest3(searchTermPublisher, filtersPublisher, searchFilterPublisher)
             .sink { [weak self] searchTerm, filtersSubject, productSearchFilter in
-                guard let self = self else { return }
+                guard let self else { return }
                 Task { @MainActor in
                     self.updateFilterButtonTitle(with: filtersSubject)
                     await self.updatePredicate(searchTerm: searchTerm, filters: filtersSubject, productSearchFilter: productSearchFilter)
@@ -831,7 +831,7 @@ private extension ProductSelectorViewModel {
     func observeSelections() {
         $sections.combineLatest($selectedItemsIDs) {
             [weak self] sections, selectedItemsIDs -> [ProductsSectionViewModel] in
-            guard let self = self else {
+            guard let self else {
                 return []
             }
             return self.generateProductsSectionViewModels(sections: sections,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModelTracker.swift
@@ -80,7 +80,7 @@ final class ProductSelectorViewModelTracker {
 private extension ProductSelectorViewModelTracker {
     func retrieveTrackingSource(for productID: Int64) -> ProductTrackingSource? {
         guard trackProductsSource,
-              let viewModel = viewModel else {
+              let viewModel else {
             return nil
         }
 
@@ -100,7 +100,7 @@ private extension ProductSelectorViewModelTracker {
     }
 
     func sectionContainsProductID(sectionType: ProductSelectorSectionType, productID: Int64) -> Bool {
-        guard let viewModel = viewModel else {
+        guard let viewModel else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -228,7 +228,7 @@ extension ProductVariationSelectorViewModel: SyncingCoordinatorDelegate {
                                                                                variationIDs: allowedProductVariationIDs,
                                                                                pageNumber: pageNumber,
                                                                                pageSize: pageSize) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:
@@ -312,7 +312,7 @@ private extension ProductVariationSelectorViewModel {
         // Listen only to the first emitted event.
         onLoadTrigger.first()
             .sink { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.syncFirstPage()
             }
             .store(in: &subscriptions)
@@ -329,7 +329,7 @@ private extension ProductVariationSelectorViewModel {
     ///
     func observeSelections() {
         $productVariations.combineLatest($selectedProductVariationIDs) { [weak self] variations, selectedIDs -> [ProductRowViewModel] in
-            guard let self = self else { return [] }
+            guard let self else { return [] }
             return variations.map { variation in
                 let selectedState: ProductRow.SelectedState = selectedIDs.contains(variation.productVariationID) ? .selected : .notSelected
                 return ProductRowViewModel(productVariation: variation,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -321,7 +321,7 @@ private extension ProductsViewController {
     @objc func scanProducts() {
         ServiceLocator.analytics.track(.productListProductBarcodeScanningTapped)
 
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
 
@@ -329,7 +329,7 @@ private extension ProductsViewController {
 
         let productSKUBarcodeScannerCoordinator = ProducBarcodeScannerCoordinator(sourceNavigationController: navigationController,
                                                                                   onBarcodeScanned: { [weak self] scannedBarcode in
-            guard let self = self else { return }
+            guard let self else { return }
             ServiceLocator.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningSuccess(from: .productList))
 
             Task {
@@ -372,9 +372,9 @@ private extension ProductsViewController {
                     sourceView: UIView? = nil,
                     isFirstProduct: Bool) {
         let sourceView: AddProductCoordinator.SourceView? = {
-            if let sourceBarButtonItem = sourceBarButtonItem {
+            if let sourceBarButtonItem {
                 return .barButtonItem(sourceBarButtonItem)
-            } else if let sourceView = sourceView {
+            } else if let sourceView {
                 return .view(sourceView)
             } else {
                 assertionFailure("No source view for adding a product")
@@ -860,7 +860,7 @@ private extension ProductsViewController {
                 WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
             },
             onContactSupportButtonPressed: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 let supportForm = SupportFormHostingController(viewModel: .init())
                 supportForm.show(from: self)
             })
@@ -1383,7 +1383,7 @@ private extension ProductsViewController {
     /// Removes EmptyStateViewController child view controller if applicable.
     ///
     func removeAllOverlays() {
-        guard let emptyStateViewController = emptyStateViewController, emptyStateViewController.parent == self else {
+        guard let emptyStateViewController, emptyStateViewController.parent == self else {
             return
         }
 
@@ -1441,7 +1441,7 @@ extension ProductsViewController: PaginationTrackerDelegate {
                                  productCategory: filters.productCategory,
                                  sortOrder: sortOrder,
                                  productIDs: (filters.favoriteProduct != nil) ? viewModel.favoriteProductIDs : []) { [weak self] result in
-                                    guard let self = self else {
+                                    guard let self else {
                                         return
                                     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
@@ -104,7 +104,7 @@ extension CodeScannerViewController: AVCaptureVideoDataOutputSampleBufferDelegat
         throttler.throttle { [weak self] in
             // Access of view frame is required on the main thread.
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 let orientation = self.imageOrientationFromDeviceOrientation()
                 guard let ciImage = self.imageForBarcodeDetection(from: sampleBuffer, orientation: orientation) else {
@@ -112,7 +112,7 @@ extension CodeScannerViewController: AVCaptureVideoDataOutputSampleBufferDelegat
                 }
 
                 DispatchQueue.global().async { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     // Configures options for `VNImageRequestHandler`.
                     var requestOptions: [VNImageOption: Any] = [:]
@@ -192,7 +192,7 @@ private extension CodeScannerViewController {
 
         rotationCoordinator?.publisher(for: \.videoRotationAngleForHorizonLevelPreview)
             .sink { [weak self] angle in
-                guard let self = self,
+                guard let self,
                       let connection = self.previewLayer?.connection else { return }
                 connection.videoRotationAngle = angle
             }
@@ -241,7 +241,7 @@ private extension CodeScannerViewController {
         }.uniqued()
 
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             guard self.session.isRunning, barcodes.isNotEmpty else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/GiftCardCodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/GiftCardCodeScannerViewController.swift
@@ -5,7 +5,7 @@ final class GiftCardCodeScannerViewController: UIViewController {
     private lazy var codeScannerChildViewController: CodeScannerViewController = {
         return CodeScannerViewController(instructionText: Localization.instructionText,
                                          format: .text(recognitionLevel: .accurate) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard self.hasDetectedCode == false else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/ScannerContainerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/ScannerContainerViewController.swift
@@ -5,7 +5,7 @@ final class ScannerContainerViewController: UIViewController {
     private lazy var barcodeScannerChildViewController: CodeScannerViewController = {
         return CodeScannerViewController(instructionText: instructionText,
                                             format: .barcode { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             guard self.hasDetectedBarcode == false else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -21,7 +21,7 @@ struct UpdateProductInventoryView: View {
     }
 
     private func displayErrorNotice(_ productName: String, _ error: Error? = nil) {
-        if let error = error {
+        if let error {
             DDLogError("Update inventory error: \(error)")
         }
         viewModel.displayErrorNotice(productName)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -129,7 +129,7 @@ private extension AddAttributeOptionsViewController {
 
     func observeViewModel() {
         viewModel.onChange = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.renderViewModel()
         }
     }
@@ -291,7 +291,7 @@ private extension AddAttributeOptionsViewController {
                                                          onTextChange: nil,
                                                          onTextDidBeginEditing: nil,
                                                          onTextDidReturn: { [weak self] text in
-                                                            if let text = text {
+                                                            if let text {
                                                                 self?.viewModel.addNewOption(name: text)
                                                             }
 
@@ -345,7 +345,7 @@ extension AddAttributeOptionsViewController {
 
     @objc private func nextButtonPressed() {
         viewModel.updateProductAttributes { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case let .success(product):
                 self.onCompletion(product)
@@ -410,7 +410,7 @@ extension AddAttributeOptionsViewController {
 
         alertController.addCancelActionWithTitle(Localization.cancelAction)
         alertController.addDestructiveActionWithTitle(Localization.removeAction) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             self.analytics.track(event: WooAnalyticsEvent.Variations.removeAttributeButtonTapped(productID: self.viewModel.product.productID))
             self.removeCurrentAttribute()
         }
@@ -422,7 +422,7 @@ extension AddAttributeOptionsViewController {
     ///
     func removeCurrentAttribute() {
         viewModel.removeCurrentAttribute { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case let .success(product):
                 self.onCompletion(product)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewModel.swift
@@ -279,7 +279,7 @@ extension AddAttributeOptionsViewModel {
 
         state.isUpdating = true
         let action = ProductAction.updateProduct(product: newProduct) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             self.handleProductUpdate(requestStartDate: startDate, result: result, onCompletion: onCompletion)
         }
         stores.dispatch(action)
@@ -296,7 +296,7 @@ extension AddAttributeOptionsViewModel {
 
         state.isUpdating = true
         remoteActionUseCase.addProduct(product: productViewModel, password: nil) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             let productResult = result.map { $0.product.product }
             self.handleProductUpdate(requestStartDate: startDate, result: productResult, onCompletion: onCompletion)
         }
@@ -428,7 +428,7 @@ private extension AddAttributeOptionsViewModel {
     func synchronizeGlobalOptions(of attribute: ProductAttribute) {
         let fetchOptions = ProductAttributeTermAction.synchronizeProductAttributeTerms(siteID: attribute.siteID,
                                                                                        attributeID: attribute.attributeID) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success:
                 self.state.existingOptions = self.existingOptionsResultsController.fetchedObjects.map { .global(option: $0) }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewController.swift
@@ -31,7 +31,7 @@ final class BulkUpdateViewController: UIViewController, GhostableViewController 
     init(viewModel: BulkUpdateViewModel, noticePresenter: NoticePresenter? = nil) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        if let noticePresenter = noticePresenter {
+        if let noticePresenter {
             self.noticePresenter = noticePresenter
         }
     }
@@ -63,7 +63,7 @@ final class BulkUpdateViewController: UIViewController, GhostableViewController 
     ///
     private func configureViewModel() {
         viewModel.$syncState.sink { [weak self] state in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch state {
             // `.notStarted` is the initial state of the VM
@@ -141,7 +141,7 @@ final class BulkUpdateViewController: UIViewController, GhostableViewController 
     ///
     private func navigateToEditPriceSettings() {
         let bulkUpdatePriceSettingsViewModel = viewModel.viewModelForBulkUpdatePriceOfType(.regular, priceUpdateDidFinish: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.navigationController?.popToViewController(self, animated: true)
             self.displayPriceUpdatedNotice()
         })

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModel.swift
@@ -86,12 +86,12 @@ final class BulkUpdateViewModel {
         let pageNumber = Constants.pageNumber
         let action = ProductVariationAction
             .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: numberOfObjects) { [weak self] result in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 switch result {
                 case .success:
                     self.configureResultsControllerAndFetchData { [weak self] error in
-                        guard let self = self else { return }
+                        guard let self else { return }
                         if error != nil {
                             self.syncState = .error
                         } else {
@@ -151,7 +151,7 @@ final class BulkUpdateViewModel {
     ///
     private func configureResultsControllerAndFetchData(onCompletion: @escaping (Error?) -> Void) {
         resultsController.onDidChangeContent = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.updateDataModel()
             onCompletion(nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributeOptionListSelectorCommand.swift
@@ -23,7 +23,7 @@ final class AttributeOptionListSelectorCommand: ListSelectorCommand {
         self.navigationBarTitle = attribute.name
         self.data = [Row.anyOption(attribute.name)] + attribute.options.map { Row.option($0) }
 
-        if let selectedOption = selectedOption {
+        if let selectedOption {
             self.selected = .option(selectedOption.option)
         } else {
             self.selected = .anyOption(attribute.name)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/AttributePickerViewController.swift
@@ -125,7 +125,7 @@ extension AttributePickerViewController: UITableViewDelegate {
 //
 private extension AttributePickerViewController {
     func configureAttribute(cell: TitleAndValueTableViewCell, attribute: ProductAttribute?) {
-        guard let attribute = attribute else {
+        guard let attribute else {
             return
         }
 
@@ -164,7 +164,7 @@ private extension AttributePickerViewController {
     }
 
     func presentAttributeOptions(for existingAttribute: ProductAttribute?) {
-        guard let existingAttribute = existingAttribute else {
+        guard let existingAttribute else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/EditAttributesViewController.swift
@@ -155,7 +155,7 @@ extension EditAttributesViewController {
     private func navigateToAddAttributeViewController() {
         let addAttributeVM = AddAttributeViewModel(product: viewModel.product)
         let addAttributeViewController = AddAttributeViewController(viewModel: addAttributeVM) { [weak self] updatedProduct in
-            guard let self = self else { return }
+            guard let self else { return }
             self.viewModel.updateProduct(updatedProduct)
             self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()
@@ -169,7 +169,7 @@ extension EditAttributesViewController {
     private func navigateToEditAttribute(_ attribute: ProductAttribute) {
         let editViewModel = AddAttributeOptionsViewModel(product: viewModel.product, attribute: .existing(attribute: attribute), allowsEditing: true)
         let editViewController = AddAttributeOptionsViewController(viewModel: editViewModel) { [weak self] updatedProduct in
-            guard let self = self else { return }
+            guard let self else { return }
             self.viewModel.updateProduct(updatedProduct)
             self.onAttributesUpdate?(updatedProduct)
             self.tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Edit Attributes/RenameAttributesViewController.swift
@@ -167,7 +167,7 @@ private extension RenameAttributesViewController {
         let cellViewModel = TextFieldTableViewCell.ViewModel(text: viewModel.attributeName,
                                                          placeholder: placeholder,
                                                          onTextChange: { [weak self] newAttributeName in
-                                                            guard let self = self else {return}
+                                                            guard let self else {return}
                                                             self.viewModel.handleAttributeNameChange(newAttributeName)
                                                             self.enableDoneButton(self.viewModel.shouldEnableDoneButton)
                                                          },

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -466,7 +466,7 @@ private extension ProductVariationsViewController {
     func navigateToAddAttributeViewController() {
         let viewModel = AddAttributeViewModel(product: product)
         let addAttributeViewController = AddAttributeViewController(viewModel: viewModel) { [weak self] updatedProduct in
-            guard let self = self else { return }
+            guard let self else { return }
             self.product = updatedProduct
             self.navigateToEditAttributeViewController(allowVariationCreation: true)
 
@@ -481,7 +481,7 @@ private extension ProductVariationsViewController {
     /// Cleans the navigation stack until `self` and navigates to `EditAttributesViewController`
     ///
     func navigateToEditAttributeViewController(allowVariationCreation: Bool) {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
 
@@ -492,7 +492,7 @@ private extension ProductVariationsViewController {
             self?.onFirstVariationCreated()
         }
         editAttributeViewController.onAttributesUpdate = { [weak self] updatedProduct in
-            guard let self = self else { return }
+            guard let self else { return }
             self.product = updatedProduct
             self.onAttributesUpdate(editAttributesViewController: editAttributeViewController)
         }
@@ -526,7 +526,7 @@ private extension ProductVariationsViewController {
             noticePresenter.enqueue(notice: .init(title: Localization.variationCreated, feedbackType: .success))
         }
 
-        guard let initialViewController = initialViewController else {
+        guard let initialViewController else {
             navigationController?.popViewController(animated: true)
             return
         }
@@ -555,7 +555,7 @@ private extension ProductVariationsViewController {
                                                       formType: self.viewModel.formType,
                                                       productImageActionHandler: productImageActionHandler)
         viewModel.onVariationDeletion = { [weak self] variation in
-            guard let self = self else { return }
+            guard let self else { return }
 
             // Remove deleted variation from variations array
             let variationsUpdated = self.product.variations.filter { $0 != variation.productVariationID }
@@ -594,7 +594,7 @@ private extension ProductVariationsViewController {
         actionSheet.view.tintColor = .text
 
         actionSheet.addDefaultActionWithTitle(ActionSheetStrings.bulkUpdate) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let viewModel = BulkUpdateViewModel(siteID: self.siteID,
                                                 productID: self.productID,
@@ -659,7 +659,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
 
         let action = ProductVariationAction
             .synchronizeProductVariations(siteID: siteID, productID: productID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -689,7 +689,7 @@ extension ProductVariationsViewController: SyncingCoordinatorDelegate {
         viewModel.generateVariation(for: product) { [weak self] result in
             progressViewController.dismiss(animated: true)
 
-            guard let self = self else { return }
+            guard let self else { return }
             switch result {
             case .success(let (updatedProduct, newVariation)):
                 self.noticePresenter.enqueue(notice: .init(title: Localization.variationCreated, feedbackType: .success))

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -86,7 +86,7 @@ private extension ProductListItem {
                                                             .foregroundColor: UIColor.textSubtle,
                                                             .font: StyleManager.footerLabelFont
             ])
-        if let statusText = statusText {
+        if let statusText {
             attributedString.addAttributes([.foregroundColor: productStatus.descriptionColor],
                                            range: NSRange(location: 0, length: statusText.count))
         }

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/String+ProductStock.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/String+ProductStock.swift
@@ -20,7 +20,7 @@ extension String {
 
         switch stockStatus {
         case .inStock:
-            if let stockQuantity = stockQuantity, manageStock {
+            if let stockQuantity, manageStock {
                 let localizedStockQuantity = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
                 return String.localizedStringWithFormat(Localization.stockQuantity, localizedStockQuantity)
             } else {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ColumnFlowLayout.swift
@@ -23,7 +23,7 @@ final class ColumnFlowLayout: UICollectionViewFlowLayout {
     }
 
     override func prepare() {
-        guard let collectionView = collectionView else { return }
+        guard let collectionView else { return }
         let marginsAndInsets = sectionInset.left + sectionInset.right
             + collectionView.safeAreaInsets.left + collectionView.safeAreaInsets.right
             + minimumInteritemSpacing * CGFloat(cellsPerRow - 1)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -121,7 +121,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     private var topBannerView: TopBannerView?
 
     convenience init(style: Style = .basic, configuration: Config? = nil, zendeskManager: ZendeskManagerProtocol? = nil) {
-        if let zendeskManager = zendeskManager {
+        if let zendeskManager {
             self.init(style: style, configuration: configuration, zendesk: zendeskManager)
         } else {
             #if !targetEnvironment(macCatalyst)
@@ -158,7 +158,7 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
 
         keyboardFrameObserver.startObservingKeyboardFrame(sendInitialEvent: true)
 
-        if let configuration = configuration {
+        if let configuration {
             configure(configuration)
         }
     }
@@ -188,19 +188,19 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
             switch config {
             case .withLink(_, _, _, _, let linkURL, _):
                 return { [weak self] in
-                    if let self = self {
+                    if let self {
                         WebviewHelper.launch(linkURL, with: self)
                     }
                 }
             case .withButton(_, _, _, _, let tapClosure, _):
                 return { [weak self] in
-                    if let self = self {
+                    if let self {
                         tapClosure(self.actionButton)
                     }
                 }
             case .withSupportRequest:
                 return { [weak self] in
-                    if let self = self {
+                    if let self {
                         let supportForm = SupportFormHostingController(viewModel: .init())
                         supportForm.show(from: self)
                     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EnhancedTextView.swift
@@ -34,7 +34,7 @@ final class EnhancedTextView: UITextView {
 
     private func animatePlaceholder() {
         UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.placeholderLabel?.alpha = self.text.isEmpty && !self.isFirstResponder ? 1 : 0
@@ -43,7 +43,7 @@ final class EnhancedTextView: UITextView {
 
     private func hidePlaceholder() {
         UIView.animate(withDuration: Constants.animationDuration) { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.placeholderLabel?.alpha = 0

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/HostingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/HostingTableViewCell.swift
@@ -7,7 +7,7 @@ class HostingTableViewCell<Content: View>: UITableViewCell {
     private weak var controller: UIHostingController<Content>?
 
     func host(_ view: Content, parent: UIViewController) {
-        if let controller = controller {
+        if let controller {
             controller.rootView = view
             controller.view.layoutIfNeeded()
         } else {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ModalHostingPresentationController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ModalHostingPresentationController.swift
@@ -10,7 +10,7 @@ final class ModalHostingPresentationController: FancyAlertPresentationController
     ///
     override func containerViewWillLayoutSubviews() {
         super.containerViewWillLayoutSubviews()
-        guard let presentedView = presentedView, let containerView = containerView else {
+        guard let presentedView, let containerView else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/Section Headers/PrimarySectionHeaderView.swift
@@ -40,7 +40,7 @@ final class PrimarySectionHeaderView: UITableViewHeaderFooterView {
         titleLabel.text = title
         actionButton.isHidden = action == nil
 
-        if let action = action {
+        if let action {
             actionButton.applyIconButtonStyle(icon: action.image)
             actionHandler = action.actionHandler
             actionButton.addTarget(self, action: #selector(onAction(_:)), for: .touchUpInside)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveAsyncImage.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveAsyncImage.swift
@@ -23,7 +23,7 @@ struct AdaptiveAsyncImage<Content>: View where Content: View {
 
     @ViewBuilder var body: some View {
         if colorScheme == .dark,
-           let darkUrl = darkUrl {
+           let darkUrl {
             AsyncImage(url: darkUrl, scale: scale, content: content)
         } else {
             AsyncImage(url: anyAppearanceUrl, scale: scale, content: content)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveImage.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveImage.swift
@@ -7,7 +7,7 @@ struct AdaptiveImage: View {
 
     @ViewBuilder var body: some View {
         if colorScheme == .dark,
-           let dark = dark {
+           let dark {
             Image(uiImage: dark)
                 .resizable()
         } else {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BottomButtonView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BottomButtonView.swift
@@ -11,7 +11,7 @@ struct BottomButtonView<Style>: View where Style: ButtonStyle {
             Divider()
             Button(action: { onButtonTapped() }) {
                 HStack {
-                    if let image = image {
+                    if let image {
                         Image(uiImage: image)
                     }
                     Text(title)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmptyState.swift
@@ -10,7 +10,7 @@ struct EmptyState: View {
 
     var body: some View {
         VStack {
-            if let image = image {
+            if let image {
                 Image(uiImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -23,7 +23,7 @@ struct EmptyState: View {
             Text(title)
                 .multilineTextAlignment(.center)
                 .headlineStyle()
-            if let description = description {
+            if let description {
                 Text(description)
                     .multilineTextAlignment(.center)
                     .bodyStyle()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeatureAnnouncementCardView.swift
@@ -59,7 +59,7 @@ struct FeatureAnnouncementCardView: View {
             }
         }
         .overlay(alignment: .topTrailing) {
-            if let dismiss = dismiss {
+            if let dismiss {
                 Menu {
                     Button(Localization.hideContent) {
                         viewModel.dontShowAgainTapped()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyNavigationLink.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/LazyNavigationLink.swift
@@ -28,7 +28,7 @@ struct LazyNavigationLink<Destination: View, Label: View>: View {
     }
 
     var body: some View {
-        if let isActive = isActive {
+        if let isActive {
             NavigationLink(destination: LazyView(destination), isActive: isActive, label: label)
         } else {
             NavigationLink(destination: LazyView(destination), label: label)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/OptionalBinding.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/OptionalBinding.swift
@@ -88,7 +88,7 @@ struct OptionalBinding<Value>: DynamicProperty {
     }
 
     init(_ binding: Binding<Value>?, default defaultValue: Value) {
-        if let binding = binding {
+        if let binding {
             self.external = binding
             self._internalValue = State(initialValue: binding.wrappedValue)
         } else {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndTextFieldRow.swift
@@ -86,7 +86,7 @@ struct TitleAndTextFieldRow: View {
                     .keyboardType(keyboardType)
                     .disabled(!editable)
                     .textInputAutocapitalization(autocapitalization)
-                if let symbol = symbol {
+                if let symbol {
                     Text(symbol)
                         .bodyStyle()
                         .font(valueFont)
@@ -99,7 +99,7 @@ struct TitleAndTextFieldRow: View {
     }
 
     private func formatText(_ newValue: String) -> String {
-        guard let inputFormatter = inputFormatter else {
+        guard let inputFormatter else {
             return newValue
         }
         return inputFormatter.format(input: newValue)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndValueRow.swift
@@ -126,7 +126,7 @@ extension TitleAndValueRow {
         /// Returns `.content` if content is provided. Returns `.placeholder` otherwise.
         ///
         init (placeHolder: String, content: String?) {
-            if let content = content, content.isNotEmpty {
+            if let content, content.isNotEmpty {
                 self = .content(content)
             } else {
                 self = .placeholder(placeHolder)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/VerticalButton.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/VerticalButton.swift
@@ -16,7 +16,7 @@ class VerticalButton: UIButton {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        guard let imageView = imageView, let image = imageView.image, let titleLabel = titleLabel else {
+        guard let imageView, let image = imageView.image, let titleLabel else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -57,7 +57,7 @@ class WooBasicTableViewCell: UITableViewCell {
     /// Add the accessoryView image, if any
     ///
     func configureAccessoryView() {
-        guard let accessoryImage = accessoryImage else {
+        guard let accessoryImage else {
             accessoryView = nil
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/Cells/NoteDetailsCommentTableViewCell.swift
@@ -179,7 +179,7 @@ final class NoteDetailsCommentTableViewCell: UITableViewCell {
     ///
     var starRating: Int? {
         didSet {
-            guard let starRating = starRating else {
+            guard let starRating else {
                 starRatingView.isHidden = true
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Reviews/Cells/ProductReviewTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/Cells/ProductReviewTableViewCell.swift
@@ -39,7 +39,7 @@ final class ProductReviewTableViewCell: UITableViewCell {
     ///
     private var starRating: Int? {
         didSet {
-            guard let starRating = starRating else {
+            guard let starRating else {
                 starRatingView.isHidden = true
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -153,7 +153,7 @@ private extension ReviewDetailsViewController {
     ///
     func synchronizeReview(reviewID: Int64, onCompletion: @escaping () -> Void) {
         let action = ProductReviewAction.retrieveProductReview(siteID: siteID, reviewID: reviewID) { (productReview, error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing product review [\(reviewID)]: \(error)")
                 ServiceLocator.analytics.track(.reviewLoadFailed,
                                                withError: error)
@@ -338,7 +338,7 @@ private extension ReviewDetailsViewController {
         let reviewSiteID = productReview.siteID
 
         commentCell.onApprove = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -349,7 +349,7 @@ private extension ReviewDetailsViewController {
         }
 
         commentCell.onUnapprove = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             ServiceLocator.analytics.track(.notificationReviewApprovedTapped)
@@ -359,7 +359,7 @@ private extension ReviewDetailsViewController {
         }
 
         commentCell.onTrash = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -370,7 +370,7 @@ private extension ReviewDetailsViewController {
         }
 
         commentCell.onSpam = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -409,7 +409,7 @@ private extension ReviewDetailsViewController {
 private extension ReviewDetailsViewController {
     func moderateReview(siteID: Int64, reviewID: Int64, doneStatus: ProductReviewStatus, undoStatus: ProductReviewStatus) {
         guard let undo = moderateReviewAction(siteID: siteID, reviewID: reviewID, status: undoStatus, onCompletion: { error in
-            guard let error = error else {
+            guard let error else {
                 ServiceLocator.analytics.track(.notificationReviewActionSuccess)
                 return
             }
@@ -422,7 +422,7 @@ private extension ReviewDetailsViewController {
         }
 
         guard let done = moderateReviewAction(siteID: siteID, reviewID: reviewID, status: doneStatus, onCompletion: { error in
-            guard let error = error else {
+            guard let error else {
                 ServiceLocator.analytics.track(.notificationReviewActionSuccess)
                 ReviewDetailsViewController.displayModerationCompleteNotice(newStatus: doneStatus, onUndoAction: {
                     ServiceLocator.analytics.track(.notificationReviewActionUndo)
@@ -483,7 +483,7 @@ private extension ReviewDetailsViewController {
     /// Marks a specific Notification as read.
     ///
     func markAsReadIfNeeded(_ note: Note?) {
-        guard let note = note, note.read == false else {
+        guard let note, note.read == false else {
             return
         }
 
@@ -492,7 +492,7 @@ private extension ReviewDetailsViewController {
                                                         "remote_note_id": note.noteID])
 
         let action = NotificationAction.updateReadStatus(noteID: note.noteID, read: true) { (error) in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error marking single notification as read: \(error)")
                 ServiceLocator.analytics.track(.reviewMarkReadFailed,
                                                withError: error)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewReplyViewModel.swift
@@ -64,7 +64,7 @@ final class ReviewReplyViewModel: ObservableObject {
         }
 
         let action = CommentAction.replyToComment(siteID: siteID, commentID: reviewID, productID: productID, content: newReply) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.performingNetworkRequest.send(false)
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -274,11 +274,11 @@ private extension ReviewsViewController {
             let tracks = ServiceLocator.analytics
             tracks.track(.reviewsMarkAllRead)
 
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error marking multiple notifications as read: \(error)")
                 self.hapticGenerator.notificationOccurred(.error)
 
@@ -528,7 +528,7 @@ extension ReviewsViewController: SyncingCoordinatorDelegate {
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, onCompletion: ((Bool) -> Void)? = nil) {
         transitionToSyncingState(pageNumber: pageNumber)
         viewModel.synchronizeReviews(pageNumber: pageNumber, pageSize: pageSize) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.transitionToResultsUpdatedState()
             if let error = self.viewModel.dataLoadingError {
                 self.showTopBannerView(for: error)

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewModel.swift
@@ -207,7 +207,7 @@ extension ReviewsViewModel {
     ///
     private func synchronizeNotifications(onCompletion: (() -> Void)? = nil) {
         let action = NotificationAction.synchronizeNotifications { [weak self] error in
-            if let error = error {
+            if let error {
                 DDLogError("⛔️ Error synchronizing notifications: \(error)")
                 ServiceLocator.analytics.track(.notificationsLoadFailed,
                                                withError: error)

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -78,7 +78,7 @@ final class OrderSearchUICommand: SearchUICommand {
     ///
     func synchronizeModels(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) {
         let action = OrderAction.searchOrders(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize) { error in
-            if let error = error {
+            if let error {
                 DDLogError("☠️ Order Search Failure! \(error)")
             }
 

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -439,7 +439,7 @@ private extension SearchViewController {
 
     func configureSearchResync() {
         searchUICommand.resynchronizeModels = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.synchronizeSearchResults(with: self.searchQuery)
         }
     }
@@ -498,7 +498,7 @@ extension SearchViewController: SyncingCoordinatorDelegate {
                                           pageNumber: pageNumber,
                                           pageSize: pageSize,
                                           onCompletion: { [weak self] isCompleted in
-            guard let self = self else { return }
+            guard let self else { return }
             // Disregard OPs that don't really match the latest keyword
             if keyword == self.searchUICommand.sanitizeKeyword(self.searchQuery) {
                 self.transitionToResultsUpdatedState()
@@ -701,7 +701,7 @@ private extension SearchViewController {
         searchUICommand.didSelectSearchResult(model: object, from: self, reloadData: { [weak self] in
             self?.tableView.reloadData()
         }, updateActionButton: { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.searchUICommand.configureActionButton(self.cancelButton, onDismiss: { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -59,7 +59,7 @@ private extension SurveyCoordinatingController {
         analytics.track(event: .surveyScreen(context: survey.feedbackContextForEvents, action: .opened))
 
         let surveyViewController = viewControllersFactory.makeSurveyViewController(survey: survey) { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -76,7 +76,7 @@ private extension SurveyCoordinatingController {
     ///
     func navigateToSurveySubmitted() {
         let completionViewController = viewControllersFactory.makeSurveySubmittedViewController(onContactUsAction: { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             let supportForm = SupportFormHostingController(viewModel: .init())

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -172,13 +172,13 @@ extension URL {
                      storeUUID: String?,
                      storeURL: String?) -> URL {
         var url = self
-        if let siteID = siteID {
+        if let siteID {
             url = url.appendingQueryItem(URLQueryItem(name: Tags.surveyRequestSiteIdTag, value: "\(siteID)"))
         }
-        if let storeUUID = storeUUID {
+        if let storeUUID {
             url = url.appendingQueryItem(URLQueryItem(name: Tags.surveyRequestStoreUUIDTag, value: storeUUID))
         }
-        if let storeURL = storeURL {
+        if let storeURL {
             url = url.appendingQueryItem(URLQueryItem(name: Tags.surveyRequestStoreURLTag, value: storeURL))
         }
         return url

--- a/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerWrapperView.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/TopBannerWrapperView.swift
@@ -62,7 +62,7 @@ final class TopBannerWrapperView: UIView {
     /// Returns the preferred size of the view using on a fixed width.
     ///
     override var intrinsicContentSize: CGSize {
-        guard let bannerView = bannerView else {
+        guard let bannerView else {
             return .zero
         }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -411,7 +411,7 @@ private extension DefaultStoresManager {
     ///
     func restoreSessionAccount(with accountID: Int64) {
         let action = AccountAction.loadAccount(userID: accountID) { [weak self] account in
-            guard let `self` = self, let account = account else {
+            guard let `self` = self, let account else {
                 return
             }
             self.replaceTempCredentialsIfNecessary(account: account)
@@ -427,7 +427,7 @@ private extension DefaultStoresManager {
         let action = AccountAction.synchronizeAccount { [weak self] result in
             switch result {
             case .success(let account):
-                if let self = self, self.isAuthenticated {
+                if let self, self.isAuthenticated {
                     self.sessionManager.defaultAccount = account
                     ServiceLocator.analytics.refreshUserData()
                 }
@@ -451,7 +451,7 @@ private extension DefaultStoresManager {
         let action = AccountAction.synchronizeAccountSettings(userID: userID) { [weak self] result in
             switch result {
             case .success(let accountSettings):
-                if let self = self, self.isAuthenticated {
+                if let self, self.isAuthenticated {
                     // Save the user's preference
                     ServiceLocator.analytics.setUserHasOptedOut(accountSettings.tracksOptOut)
                 }
@@ -509,7 +509,7 @@ private extension DefaultStoresManager {
         group.enter()
         let generalSettingsAction = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { error in
             ServiceLocator.selectedSiteSettings.refresh()
-            if let error = error {
+            if let error {
                 errors.append(error)
             }
             group.leave()
@@ -518,7 +518,7 @@ private extension DefaultStoresManager {
 
         group.enter()
         let productSettingsAction = SettingAction.synchronizeProductSiteSettings(siteID: siteID) { error in
-            if let error = error {
+            if let error {
                 errors.append(error)
             }
             group.leave()
@@ -701,7 +701,7 @@ private extension DefaultStoresManager {
     ///
     func sendTelemetryIfNeeded(siteID: Int64) {
         let checkAvailabilityAction = AppSettingsAction.getTelemetryInfo(siteID: siteID) { [weak self] isAvailable, telemetryLastReportedTime in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if isAvailable {
                 self.sendTelemetry(siteID: siteID,
@@ -719,7 +719,7 @@ private extension DefaultStoresManager {
                                                    versionString: UserAgent.bundleShortVersion,
                                                    telemetryLastReportedTime: telemetryLastReportedTime,
                                                    installationDate: installationDate) { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             switch result {
             case .success:

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -99,7 +99,7 @@ public class CrashLogging {
         }
 
         /// If we shouldn't send the event we have nothing else to do here
-        guard let event = event, shouldSendEvent else {
+        guard let event, shouldSendEvent else {
             return nil
         }
 

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -56,7 +56,7 @@ struct WatchCrashLoggingStack: CrashLoggingStack {
     }
 
     static func tracksUserFrom(_ account: Account?) -> TracksUser? {
-        guard let account = account else {
+        guard let account else {
             return nil
         }
         return TracksUser(userID: "\(account.userID)", email: account.email, username: account.username)

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -285,7 +285,7 @@ private final class MockAuthenticator: Authenticator {
 
     static func showSiteCredentialLogin(from presenter: UIViewController, siteURL: String, onCompletion: @escaping (WordPressOrgCredentials) -> Void) {
         siteCredentialLoginTriggered = true
-        guard let credentials = credentials else {
+        guard let credentials else {
             return
         }
         onCompletion(credentials)
@@ -293,7 +293,7 @@ private final class MockAuthenticator: Authenticator {
 
     static func fetchSiteInfo(for siteURL: String, onCompletion: @escaping (Result<WordPressComSiteInfo, Error>) -> Void) {
         fetchSiteInfoTriggered = true
-        guard let siteInfo = siteInfo else {
+        guard let siteInfo else {
             return onCompletion(.failure(AuthenticatorError.serviceError))
         }
         onCompletion(.success(siteInfo))

--- a/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAnalyticsProvider.swift
@@ -41,7 +41,7 @@ public extension MockAnalyticsProvider {
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         lock.lock()
         _receivedEvents.append(eventName)
-        if let properties = properties {
+        if let properties {
             _receivedProperties.append(properties)
         }
         lock.unlock()

--- a/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCaptureDevicePermissionChecker.swift
@@ -26,7 +26,7 @@ extension MockCaptureDevicePermissionChecker: CaptureDevicePermissionChecker {
     }
 
     func requestAccess(for mediaType: AVMediaType, completionHandler handler: @escaping (_ isGranted: Bool) -> Void) {
-        if let updatedAuthorizationStatus = updatedAuthorizationStatus {
+        if let updatedAuthorizationStatus {
             authorizationStatus = updatedAuthorizationStatus
         }
         handler(isAccessGranted)

--- a/WooCommerce/WooCommerceTests/Mocks/MockKingfisherImageDownloader.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockKingfisherImageDownloader.swift
@@ -16,7 +16,7 @@ final class MockKingfisherImageDownloader: Kingfisher.ImageDownloader {
                                 options: KingfisherOptionsInfo? = nil,
                                 progressBlock: DownloadProgressBlock?,
                                 completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
-        if let options = options {
+        if let options {
             for option in options {
                 if case .processor(let processor) = option {
                     capturedProcessor = processor

--- a/WooCommerce/WooCommerceTests/Mocks/MockMediaStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockMediaStoresManager.swift
@@ -27,25 +27,25 @@ final class MockMediaStoresManager: DefaultStoresManager {
     private func onMediaAction(action: MediaAction) {
         switch action {
         case .retrieveMedia(_, _, let onCompletion):
-            guard let media = media else {
+            guard let media else {
                 onCompletion(.failure(MediaActionError.unknown))
                 return
             }
             onCompletion(.success(media))
         case .uploadMedia(_, _, _, _, _, let onCompletion):
-            guard let media = media else {
+            guard let media else {
                 onCompletion(.failure(MediaActionError.unknown))
                 return
             }
             onCompletion(.success(media))
         case .retrieveMediaLibrary(_, _, _, _, _, let onCompletion):
-            guard let media = media else {
+            guard let media else {
                 onCompletion(.failure(MediaActionError.unknown))
                 return
             }
             onCompletion(.success([media]))
         case .updateProductID(_, _, _, let onCompletion):
-            guard let media = media else {
+            guard let media else {
                 onCompletion(.failure(MediaActionError.unknown))
                 return
             }

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductSKUValidationStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductSKUValidationStoresManager.swift
@@ -20,7 +20,7 @@ final class MockProductSKUValidationStoresManager: DefaultStoresManager {
     private func handleProductVariationAction(_ action: ProductAction) {
         switch action {
         case let .validateProductSKU(sku, _, onCompletion):
-            guard let sku = sku else {
+            guard let sku else {
                 onCompletion(true)
                 return
             }

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -162,7 +162,7 @@ class WooAnalyticsTests: XCTestCase {
 
     func test_events_when_logged_in_include_site_properties() {
         // Given
-        guard let testingProvider = testingProvider else {
+        guard let testingProvider else {
             return XCTFail("Testing provider not available")
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
@@ -204,7 +204,7 @@ class WooAnalyticsTests: XCTestCase {
 
     func test_events_when_logged_out_do_not_include_site_properties() {
         // Given
-        guard let testingProvider = testingProvider else {
+        guard let testingProvider else {
             return XCTFail("Testing provider not available")
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false,
@@ -242,7 +242,7 @@ class WooAnalyticsTests: XCTestCase {
 
     func test_track_Trackable_when_authenticated_then_includes_site_properties() {
         // Given
-        guard let testingProvider = testingProvider else {
+        guard let testingProvider else {
             return XCTFail("Testing provider not available")
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
@@ -267,7 +267,7 @@ class WooAnalyticsTests: XCTestCase {
 
     func test_track_Trackable_when_not_authenticated_then_skips_site_properties() {
         // Given
-        guard let testingProvider = testingProvider else {
+        guard let testingProvider else {
             return XCTFail("Testing provider not available")
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -225,7 +225,7 @@ final class DefaultImageServiceTests: XCTestCase {
             XCTAssertNil(error)
 
             // Verify image size
-            if let image = image {
+            if let image {
                 XCTAssertLessThanOrEqual(image.size.width, targetSize.width)
                 XCTAssertLessThanOrEqual(image.size.height, targetSize.height)
                 // Check aspect ratio is maintained (with some floating point tolerance)

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -212,7 +212,7 @@ private extension UniversalLinkRouterTests {
         } else {
             components.path = subPath
         }
-        if let queryItem = queryItem {
+        if let queryItem {
             components.queryItems = [
                 queryItem
             ]

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -154,7 +154,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // When
         let errorAlert: CardPresentModalNonRetryableErrorWithoutEmail = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.alertsPresenter.onPresentCalled = { viewModel in
                 guard let viewModel = viewModel as? CardPresentModalNonRetryableErrorWithoutEmail else {
                     return

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageViewModelTests.swift
@@ -33,7 +33,7 @@ final class JustInTimeMessageViewModelTests: XCTestCase {
 
         sut.$showWebViewSheet
             .sink { [weak self] webViewSheetViewModel in
-                if let webViewSheetViewModel = webViewSheetViewModel {
+                if let webViewSheetViewModel {
                     self?.webviewPublishes.append(webViewSheetViewModel)
                 }
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -339,7 +339,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
         var expectedProductID: Int64?
         stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
+            guard let self else { return }
             switch action {
             case let .fetchAISuggestions(_, productID, completion):
                 expectedProductID = productID
@@ -1087,7 +1087,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         let textContent = String(attributedText.characters)
         if let range = textContent.range(of: "I can cancel anytime") {
             let attributedRange = Range(range, in: attributedText)
-            if let attributedRange = attributedRange {
+            if let attributedRange {
                 let linkAttributes = attributedText[attributedRange]
                 XCTAssertNotNil(linkAttributes.link, "I can cancel anytime text should have a link attribute")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -157,7 +157,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return false
         }
 
-        guard let headerSection = headerSection,
+        guard let headerSection,
               case let .header(headerContent) = headerSection.content else {
             XCTFail("Header section not found")
             return
@@ -202,7 +202,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return false
         }
 
-        guard let customerSection = customerSection,
+        guard let customerSection,
               case let .customer(customerContent) = customerSection.content else {
             XCTFail("Customer section not found")
             return
@@ -249,7 +249,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return false
         }
 
-        guard let customerSection = customerSection,
+        guard let customerSection,
               case let .customer(customerContent) = customerSection.content else {
             XCTFail("Customer section not found")
             return
@@ -352,7 +352,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return false
         }
 
-        guard let headerSection = headerSection,
+        guard let headerSection,
               case let .header(headerContent) = headerSection.content else {
             XCTFail("Header section not found")
             return
@@ -423,7 +423,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return false
         }
 
-        guard let paymentSection = paymentSection,
+        guard let paymentSection,
               case let .payment(paymentContent) = paymentSection.content else {
             XCTFail("Payment section not found")
             return
@@ -465,7 +465,7 @@ final class BookingDetailsViewModelTests: XCTestCase {
             return false
         }
 
-        guard let appointmentSection = appointmentSection,
+        guard let appointmentSection,
               case let .appointmentDetails(content) = appointmentSection.content else {
             XCTFail("Appointment details section not found")
             return

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
@@ -55,7 +55,7 @@ final class MockCardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboard
 
         /// Assign the publisher if provided
         ///
-        if let publisher = publisher {
+        if let publisher {
             publisher.assign(to: &$state)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStorageTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/CardReaderSettingsKnownReadersStorageTests.swift
@@ -43,7 +43,7 @@ final class CardReaderSettingsKnownReadersStorageTests: XCTestCase {
         var recordedObservations: [String] = []
 
         cancellable = readerList.knownReader.sink(receiveValue: { readerID in
-            guard let readerID = readerID else {
+            guard let readerID else {
                 return
             }
             recordedObservations.append(readerID)
@@ -69,7 +69,7 @@ final class CardReaderSettingsKnownReadersStorageTests: XCTestCase {
         var recordedObservations: [String] = []
 
         cancellable = readerList.knownReader.sink(receiveValue: { readerID in
-            guard let readerID = readerID else {
+            guard let readerID else {
                 return
             }
             recordedObservations.append(readerID)
@@ -97,7 +97,7 @@ final class CardReaderSettingsKnownReadersStorageTests: XCTestCase {
         var recordedObservations: [String] = []
 
         cancellable = readerList.knownReader.sink(receiveValue: { readerID in
-            guard let readerID = readerID else {
+            guard let readerID else {
                 recordedObservations.append("NIL")
                 expectation.fulfill()
                 return

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentOnboardingViewModelTests.swift
@@ -34,7 +34,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
     func test_when_onboarding_state_changes_to_loading_shouldShow_isTrue() {
         // Given
         waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             /// When the View Model receives an _onboarding_ state, it debounces, so goes async.
             /// Waiting for the View Model's state to change at the end of this means we're done with
             /// the shouldShow changes too. We ignore the first state, as it comes from `sut.init`
@@ -53,7 +53,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
     func test_when_onboarding_state_changes_to_loading_didChangeShouldShow_is_called_with_newShouldShow_isTrue() {
         // Given
         let receivedShouldShow = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.sut.didChangeShouldShow = { newShouldShow in
                 promise(newShouldShow)
             }
@@ -69,7 +69,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
     func test_when_onboarding_state_changes_to_completed_shouldShow_isFalse() {
         // Given
         waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             /// When the View Model receives an _onboarding_ state, it debounces, so goes async.
             /// Waiting for the View Model's state to change at the end of this means we're done with
             /// the shouldShow changes too. We ignore the first state, as it comes from `sut.init`
@@ -88,7 +88,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
     func test_when_onboarding_state_changes_to_completed_didChangeShouldShow_is_called_with_newShouldShow_isFalse() {
         // Given
         let receivedShouldShow = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.sut.didChangeShouldShow = { newShouldShow in
                 promise(newShouldShow)
             }
@@ -104,7 +104,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
     func test_when_onboarding_state_changes_to_error_shouldShow_isTrue() {
         // Given
         waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.sut.$state.dropFirst(1).sink { _ in
                 promise(())
             }.store(in: &self.cancellables)
@@ -120,7 +120,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
     func test_when_onboarding_state_changes_to_error_didChangeShouldShow_is_called_with_newShouldShow_isTrue() {
         // Given
         let receivedShouldShow = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.sut.didChangeShouldShow = { newShouldShow in
                 promise(newShouldShow)
             }
@@ -138,7 +138,7 @@ final class CardPresentPaymentOnboardingViewModelTests: XCTestCase {
         stateSubject.send(.noConnectionError)
 
         let receivedShouldShow = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.sut.didChangeShouldShow = { newShouldShow in
                 promise(newShouldShow)
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardStateProviderTests.swift
@@ -76,7 +76,7 @@ final class KeyboardStateProviderTests: XCTestCase {
 private extension NotificationCenter {
     func postKeyboardWillShowNotification(frameEnd: CGRect? = nil) {
         let userInfo: [AnyHashable: Any]? = {
-            if let frameEnd = frameEnd {
+            if let frameEnd {
                 return [UIResponder.keyboardFrameEndUserInfoKey: frameEnd]
             } else {
                 return nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1406,9 +1406,9 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let displayingPopularIds = viewModel.productsSectionViewModels.first?.productRows.map { $0.productOrVariationID }
         let displayingLastSoldIds = viewModel.productsSectionViewModels[safe: 1]?.productRows.map { $0.productOrVariationID }
 
-        guard let displayingPopularIds = displayingPopularIds,
+        guard let displayingPopularIds,
               displayingPopularIds.isNotEmpty,
-              let displayingLastSoldIds = displayingLastSoldIds,
+              let displayingLastSoldIds,
               displayingLastSoldIds.isNotEmpty else {
             XCTFail()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Categories/ProductCategoryListViewModelTests.swift
@@ -61,7 +61,7 @@ final class ProductCategoryListViewModelTests: XCTestCase {
         let productCategory = ProductCategory(categoryID: 443, siteID: 123, parentID: 0, name: name, slug: "")
 
         let passedCategory: Yosemite.ProductCategory? = waitFor { [weak self] promise in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -124,7 +124,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
             }
         }
 
-        if let isVariation = isVariation {
+        if let isVariation {
             XCTAssertTrue(isVariation)
         } else {
             XCTFail("Cell not found")
@@ -159,7 +159,7 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
             }
         }
 
-        if let isVariation = isVariation {
+        if let isVariation {
             XCTAssertFalse(isVariation)
         } else {
             XCTFail("Cell not found")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductCategoryListViewModelTests.swift
@@ -80,9 +80,9 @@ final class FilterProductCategoryListViewModelTests: XCTestCase {
         productCategoryListViewModel.performFetch()
 
         let categoryViewModels: [ProductCategoryCellViewModel] = waitFor { [weak self] promise in
-            guard let self = self else { return }
+            guard let self else { return }
             self.subscription = self.productCategoryListViewModel.$syncCategoriesState.sink { [weak self] state in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/UpdateInventory/UpdateProductInventoryViewModelTests.swift
@@ -120,7 +120,7 @@ final class UpdateProductInventoryViewModelTests: XCTestCase {
         let parentProduct = Product.fake().copy(siteID: siteID, productID: parentProductID, name: name)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: ProductAction.self) { [weak self ]action in
-            guard let self = self else { return }
+            guard let self else { return }
             switch action {
             case let .retrieveProduct(passingSiteID, productID, onCompletion):
                 if passingSiteID == self.siteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Survey/SurveyViewControllerTests.swift
@@ -206,7 +206,7 @@ private extension SurveyViewControllerTests {
 
         override var request: URLRequest {
             var urlComponents = URLComponents(url: WooConstants.URLs.inAppFeedback.asURL(), resolvingAgainstBaseURL: false) ?? URLComponents()
-            if let messageParameterValue = messageParameterValue {
+            if let messageParameterValue {
                 let item = URLQueryItem(name: "msg", value: messageParameterValue)
                 urlComponents.queryItems = [item]
             }

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Events.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Events.swift
@@ -26,7 +26,7 @@ extension WordPressAuthenticator {
     ///
     @objc
     public static func track(_ event: WPAnalyticsStat, error: Error?) {
-        guard let error = error else {
+        guard let error else {
             track(event)
             return
         }

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -22,7 +22,7 @@ import WordPressUI
     /// Shared Instance.
     ///
     @objc public static var shared: WordPressAuthenticator {
-        guard let privateInstance = privateInstance else {
+        guard let privateInstance else {
             fatalError("WordPressAuthenticator wasn't initialized")
         }
 
@@ -186,7 +186,7 @@ import WordPressUI
         let controller = SiteCredentialsViewController.instantiate(from: .siteAddress) { coder in
             SiteCredentialsViewController(coder: coder, isDismissible: true, onCompletion: onCompletion)
         }
-        guard let controller = controller else {
+        guard let controller else {
             WPAuthenticatorLogError("Failed to navigate from GetStartedViewController to SiteCredentialsViewController")
             return
         }
@@ -228,7 +228,7 @@ import WordPressUI
         controller.loginFields.restrictToWPCom = true
         controller.loginFields.username = connectedEmail ?? String()
         controller.loginFields.meta.jetpackLogin = jetpackLogin
-        if let siteURL = siteURL {
+        if let siteURL {
             controller.loginFields.siteAddress = siteURL
         }
 
@@ -246,7 +246,7 @@ import WordPressUI
 
         controller.loginFields.restrictToWPCom = true
         controller.loginFields.meta.jetpackLogin = jetpackLogin
-        if let siteURL = siteURL {
+        if let siteURL {
             controller.loginFields.siteAddress = siteURL
         }
 

--- a/WooCommerce/WordPressAuthenticator/GoogleSignIn/OAuthTokenResponseBody.swift
+++ b/WooCommerce/WordPressAuthenticator/GoogleSignIn/OAuthTokenResponseBody.swift
@@ -13,7 +13,7 @@ struct OAuthTokenResponseBody: Codable, Equatable {
     let tokenType: String
 
     var idToken: IDToken? {
-        guard let rawIDToken = rawIDToken else {
+        guard let rawIDToken else {
             return nil
         }
 

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
@@ -171,7 +171,7 @@ public struct NUXButtonStyle {
     /// Setup: BackgroundImage
     ///
     private func configureBackgrounds() {
-        guard let buttonStyle = buttonStyle else {
+        guard let buttonStyle else {
             legacyConfigureBackgrounds()
             return
         }
@@ -220,7 +220,7 @@ public struct NUXButtonStyle {
     /// Setup: TitleColor
     ///
     private func configureTitleColors() {
-        guard let buttonStyle = buttonStyle else {
+        guard let buttonStyle else {
             legacyConfigureTitleColors()
             return
         }

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButtonViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButtonViewController.swift
@@ -84,7 +84,7 @@ open class NUXButtonViewController: UIViewController {
     }
 
     private func configure(button: NUXButton?, withConfig buttonConfig: NUXButtonConfig?, and style: NUXButtonStyle?) {
-        if let buttonConfig = buttonConfig, let button = button {
+        if let buttonConfig, let button {
 
             if let attributedTitle = buttonConfig.attributedTitle {
                 button.setAttributedTitle(attributedTitle, for: .normal)
@@ -110,7 +110,7 @@ open class NUXButtonViewController: UIViewController {
 
     private func updateShadowViewEdgeConstraints() {
         guard let layoutGuide = shadowLayoutGuide,
-              let shadowView = shadowView else {
+              let shadowView else {
             return
         }
 

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
@@ -184,7 +184,7 @@ private extension NUXStackedButtonsViewController {
 
     func updateShadowViewEdgeConstraints() {
         guard let layoutGuide = shadowLayoutGuide,
-              let shadowView = shadowView else {
+              let shadowView else {
             return
         }
 
@@ -239,7 +239,7 @@ extension NUXStackedButtonsViewController {
 
 private extension NUXButton {
     func configure(withConfig buttonConfig: NUXButtonConfig?, and style: NUXButtonStyle?) {
-        guard let buttonConfig = buttonConfig else {
+        guard let buttonConfig else {
             isHidden = true
             return
         }

--- a/WooCommerce/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/NUXLinkMailViewController.swift
@@ -12,7 +12,7 @@ class NUXLinkMailViewController: LoginViewController {
     var emailMagicLinkSource: EmailMagicLinkSource?
     override var sourceTag: WordPressSupportSourceTag {
         get {
-            if let emailMagicLinkSource = emailMagicLinkSource,
+            if let emailMagicLinkSource,
                 emailMagicLinkSource == .signup {
                 return .wpComSignupMagicLink
             }
@@ -46,7 +46,7 @@ class NUXLinkMailViewController: LoginViewController {
     // MARK: - Configuration
 
     private func styleUsePasswordButton() {
-        guard let usePasswordButton = usePasswordButton else {
+        guard let usePasswordButton else {
             return
         }
         WPStyleGuide.configureTextButton(usePasswordButton)
@@ -67,7 +67,7 @@ class NUXLinkMailViewController: LoginViewController {
         usePasswordButton?.titleLabel?.numberOfLines = 0
         usePasswordButton?.accessibilityIdentifier = "Use Password"
 
-        guard let emailMagicLinkSource = emailMagicLinkSource else {
+        guard let emailMagicLinkSource else {
             return
         }
 
@@ -87,7 +87,7 @@ class NUXLinkMailViewController: LoginViewController {
 
     @IBAction func handleOpenMailTapped(_ sender: UIButton) {
         defer {
-            if let emailMagicLinkSource = emailMagicLinkSource {
+            if let emailMagicLinkSource {
                 switch emailMagicLinkSource {
                 case .login:
                     WordPressAuthenticator.track(.loginMagicLinkOpenEmailClientViewed)

--- a/WooCommerce/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -323,7 +323,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     /// Displays the support vc.
     ///
     func displaySupportViewController(from source: WordPressSupportSourceTag) {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             fatalError()
         }
 

--- a/WooCommerce/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/LoginFacade.swift
@@ -12,7 +12,7 @@ public extension LoginFacade {
             username: loginFields.username,
             password: loginFields.password,
             success: { [weak self] in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -33,7 +33,7 @@ public extension LoginFacade {
             userID: loginFields.nonceUserID,
             nonce: nonce,
             success: { [weak self] newNonce in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -43,7 +43,7 @@ public extension LoginFacade {
                     WordPressAuthenticator.track(.twoFactorSentSMS)
                 }
         }) { (_, newNonce) in
-            if let newNonce = newNonce {
+            if let newNonce {
                 loginFields.nonceInfo?.nonceSMS = newNonce
             }
             WPAuthenticatorLogError("Failed to request one time code")

--- a/WooCommerce/WordPressAuthenticator/Services/SafariCredentialsService.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/SafariCredentialsService.swift
@@ -63,7 +63,7 @@ class SafariCredentialsService {
                 return
             }
 
-            guard let credentials = credentials, CFArrayGetCount(credentials) > 0 else {
+            guard let credentials, CFArrayGetCount(credentials) > 0 else {
                 // Saved credentials exist but were not selected.
                 DispatchQueue.main.async(execute: {
                     completion(true, nil, nil)

--- a/WooCommerce/WordPressAuthenticator/Services/WordPressComBlogService.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/WordPressComBlogService.swift
@@ -16,7 +16,7 @@ class WordPressComBlogService {
      func fetchUnauthenticatedSiteInfoForAddress(for address: String, success: @escaping (WordPressComSiteInfo) -> Void, failure: @escaping (Error) -> Void) {
         let remote = BlogServiceRemoteREST(wordPressComRestApi: anonymousAPI, siteID: 0)
         remote.fetchUnauthenticatedSiteInfo(forAddress: address, success: { response in
-            guard let response = response else {
+            guard let response else {
                 failure(WordPressComBlogServiceError.unknown)
                 return
             }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -134,7 +134,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Add the log in with Google button to the view
     ///
     func addGoogleButton() {
-        guard let instructionLabel = instructionLabel,
+        guard let instructionLabel,
             let stackView = inputStack else {
             return
         }
@@ -154,7 +154,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Add the log in with site address button to the view
     ///
     func addSelfHostedLogInButton() {
-        guard let instructionLabel = instructionLabel,
+        guard let instructionLabel,
             let stackView = inputStack else {
                 return
         }
@@ -176,7 +176,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Note: This is only used during Jetpack setup, not the normal flows
     ///
     func addSignupButton() {
-        guard let instructionLabel = instructionLabel,
+        guard let instructionLabel,
             let stackView = inputStack else {
                 return
         }
@@ -192,7 +192,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
                 return
             }
 
-            guard let self = self else { return }
+            guard let self else { return }
 
             vc.loginFields = self.loginFields
             vc.dismissBlock = self.dismissBlock
@@ -210,7 +210,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             }
 
             vc.googleTapped = { [weak self] in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -304,7 +304,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     func handleFetchedWebCredentials(_ found: Bool, username: String?, password: String?) {
         didFindSafariSharedCredentials = found
 
-        guard let username = username, let password = password else {
+        guard let username, let password else {
             return
         }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -77,7 +77,7 @@ class LoginLinkRequestViewController: LoginViewController {
     }
 
     private func configureUsePasswordButton() {
-        guard let usePasswordButton = usePasswordButton else {
+        guard let usePasswordButton else {
             return
         }
         WPStyleGuide.configureTextButton(usePasswordButton)

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueLoginMethodViewController.swift
@@ -44,14 +44,14 @@ class LoginPrologueLoginMethodViewController: NUXViewController {
     }
 
     private func configureButtonVC() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 
         let wordpressTitle = NSLocalizedString("Log in or sign up with WordPress.com", comment: "Button title. Tapping begins our normal log in process.")
         buttonViewController.setupTopButton(title: wordpressTitle, isPrimary: false, accessibilityIdentifier: "Log in with Email Button") { [weak self] in
 
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueSignupMethodViewController.swift
@@ -40,7 +40,7 @@ class LoginPrologueSignupMethodViewController: NUXViewController {
     }
 
     private func configureButtonVC() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -140,7 +140,7 @@ class LoginPrologueViewController: LoginViewController {
     ///
     private func showiCloudKeychainLoginFlow() {
         guard WordPressAuthenticator.shared.configuration.enableUnifiedAuth,
-              let navigationController = navigationController else {
+              let navigationController else {
                   return
         }
 
@@ -159,12 +159,12 @@ class LoginPrologueViewController: LoginViewController {
             buildUnifiedPrologueButtons()
         }
 
-        if let buttonViewController = buttonViewController {
+        if let buttonViewController {
             buttonViewController.shadowLayoutGuide = view.safeAreaLayoutGuide
             buttonViewController.topButtonStyle = WordPressAuthenticator.shared.style.prologuePrimaryButtonStyle
             buttonViewController.bottomButtonStyle = WordPressAuthenticator.shared.style.prologueSecondaryButtonStyle
             buttonViewController.tertiaryButtonStyle = WordPressAuthenticator.shared.style.prologueSecondaryButtonStyle
-        } else if let stackedButtonsViewController = stackedButtonsViewController {
+        } else if let stackedButtonsViewController {
             stackedButtonsViewController.shadowLayoutGuide = view.safeAreaLayoutGuide
         }
     }
@@ -172,7 +172,7 @@ class LoginPrologueViewController: LoginViewController {
     /// Displays the old UI prologue buttons.
     ///
     private func buildPrologueButtons() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 
@@ -204,7 +204,7 @@ class LoginPrologueViewController: LoginViewController {
     /// Displays the Unified prologue buttons.
     ///
     private func buildUnifiedPrologueButtons() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 
@@ -252,7 +252,7 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     private func buildPrologueButtonsUsingStackedButtonsViewController() {
-        guard let stackedButtonsViewController = stackedButtonsViewController else {
+        guard let stackedButtonsViewController else {
             return
         }
 
@@ -345,7 +345,7 @@ class LoginPrologueViewController: LoginViewController {
 
     private func loginTapCallback() -> NUXButtonViewController.CallBackType {
         return { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -356,7 +356,7 @@ class LoginPrologueViewController: LoginViewController {
 
     private func simplifiedLoginSiteCreationCallback() -> NUXButtonViewController.CallBackType {
         { [weak self] in
-            guard let self = self, let navigationController = self.navigationController else { return }
+            guard let self, let navigationController = self.navigationController else { return }
             // triggers the delegate to ask the host app to handle site creation
             WordPressAuthenticator.shared.delegate?.showSiteCreation(in: navigationController)
         }
@@ -424,7 +424,7 @@ class LoginPrologueViewController: LoginViewController {
 
         // Continue with WordPress.com button action
         vc.emailTapped = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -470,7 +470,7 @@ class LoginPrologueViewController: LoginViewController {
         vc.modalPresentationStyle = .custom
 
         vc.emailTapped = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -483,7 +483,7 @@ class LoginPrologueViewController: LoginViewController {
         }
 
         vc.googleTapped = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -155,14 +155,14 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         facade.guessXMLRPCURL(forSite: loginFields.siteAddress, success: { [weak self] (url) in
             // Success! We now know that we have a valid XML-RPC endpoint.
             // At this point, we do NOT know if this is a WP.com site or a self-hosted site.
-            if let url = url {
+            if let url {
                 self?.loginFields.meta.xmlrpcURL = url as NSURL
             }
             // Let's try to grab site info in preparation for the next screen.
             self?.fetchSiteInfo()
 
         }, failure: { [weak self] (error) in
-            guard let error = error, let self = self else {
+            guard let error, let self else {
                 return
             }
             WPAuthenticatorLogError(error.localizedDescription)
@@ -193,7 +193,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         let baseSiteUrl = WordPressAuthenticator.baseSiteURL(string: loginFields.siteAddress)
         let service = WordPressComBlogService()
         let successBlock: (WordPressComSiteInfo) -> Void = { [weak self] siteInfo in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.configureViewLoading(false)
@@ -206,7 +206,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         }
         service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] _ in
             self?.configureViewLoading(false)
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.presentNextControllerIfPossible(siteInfo: nil)

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginSocialErrorViewController.swift
@@ -88,7 +88,7 @@ class LoginSocialErrorViewController: NUXTableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard indexPath.section == Sections.buttons.rawValue,
-            let delegate = delegate else {
+            let delegate else {
             return
         }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -112,7 +112,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
         errorLabel?.text = message
         errorToPresent = nil
 
-        if moveVoiceOverFocus, let errorLabel = errorLabel {
+        if moveVoiceOverFocus, let errorLabel {
             UIAccessibility.post(notification: .layoutChanged, argument: errorLabel)
         }
     }
@@ -128,7 +128,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     // MARK: - Epilogue
 
     func showSignupEpilogue(for credentials: AuthenticatorCredentials) {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             fatalError()
         }
 
@@ -140,7 +140,7 @@ open class LoginViewController: NUXViewController, LoginFacadeDelegate {
     }
 
     func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             fatalError("No navigation controller found to show login epilogue")
         }
 
@@ -258,7 +258,7 @@ extension LoginViewController {
         configureStatusLabel(LocalizedText.gettingAccountInfo)
 
         syncWPCom(credentials: credentials) { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -371,8 +371,8 @@ extension LoginViewController {
     /// Used only in unified views.
     ///
     func setTableViewMargins(forWidth viewWidth: CGFloat) {
-        guard let tableViewLeadingConstraint = tableViewLeadingConstraint,
-            let tableViewTrailingConstraint = tableViewTrailingConstraint else {
+        guard let tableViewLeadingConstraint,
+            let tableViewTrailingConstraint else {
                 return
         }
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -124,7 +124,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
     }
 
     private func configureForgotPasswordButton() {
-        guard let forgotPasswordButton = forgotPasswordButton else {
+        guard let forgotPasswordButton else {
             return
         }
         WPStyleGuide.configureTextButton(forgotPasswordButton)

--- a/WooCommerce/WordPressAuthenticator/Signup/SignupEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signup/SignupEmailViewController.swift
@@ -151,7 +151,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
                     return
                 }
 
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -162,7 +162,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
             }
             completion(available)
         }, failure: { error in
-            guard let error = error else {
+            guard let error else {
                 self.displayError(message: ErrorMessage.availabilityCheckFail.description())
                 completion(false)
                 return

--- a/WooCommerce/WordPressAuthenticator/UI/LoginTextField.swift
+++ b/WooCommerce/WordPressAuthenticator/UI/LoginTextField.swift
@@ -33,8 +33,8 @@ open class LoginTextField: WPWalkthroughTextField {
 
     override open var placeholder: String? {
         didSet {
-            guard let placeholder = placeholder,
-                let font = font else {
+            guard let placeholder,
+                let font else {
                 return
             }
 

--- a/WooCommerce/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -124,7 +124,7 @@ extension SearchTableViewCell: UITextFieldDelegate {
     /// - Precondition: make sure you check if `liveSearch` is enabled before calling this method.
     ///
     private func startLiveSearch() {
-        guard let delegate = delegate,
+        guard let delegate,
               let text = textField.text else {
             return
         }

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -72,7 +72,7 @@ class StoredCredentialsAuthenticator: NSObject {
         }
 
         picker.show(in: window) { [weak self] result in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -202,7 +202,7 @@ extension StoredCredentialsAuthenticator {
             return
         }
 
-        if let loginFields = loginFields {
+        if let loginFields {
             toVC.loginFields = loginFields
         }
         toVC.errorToPresent = error
@@ -220,7 +220,7 @@ extension StoredCredentialsAuthenticator {
             return
         }
 
-        if let loginFields = loginFields {
+        if let loginFields {
             toVC.loginFields = loginFields
         }
 
@@ -229,7 +229,7 @@ extension StoredCredentialsAuthenticator {
     }
 
     private func presentTwoFactorAuthenticationView() {
-        guard let loginFields = loginFields else {
+        guard let loginFields else {
             return
         }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -416,7 +416,7 @@ private extension TwoFAViewController {
     }
 
     @objc func applicationBecameActive() {
-        guard let codeField = codeField else {
+        guard let codeField else {
             return
         }
 
@@ -556,7 +556,7 @@ private extension TwoFAViewController {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.textCodeButtonTitle, icon: .authenticatorPhoneIcon)
 
         cell.actionHandler = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.tracker.track(click: .sendCodeWithText)
             self.requestCode()
@@ -571,7 +571,7 @@ private extension TwoFAViewController {
                              accessibilityIdentifier: TextLinkButtonTableViewCell.Constants.passkeysID)
 
         cell.actionHandler = { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.tracker.track(click: .enterSecurityKey)
             if #available(iOS 16, *) {

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -29,7 +29,7 @@ public enum SignInError: Error {
         }
 
         if let restApiError, restApiError.code == .unknown {
-            if let source = source, restApiError.apiErrorCode == "unknown_user" {
+            if let source, restApiError.apiErrorCode == "unknown_user" {
                 self = .invalidWPComEmail(source: source)
             } else {
                 return nil
@@ -541,7 +541,7 @@ private extension GetStartedViewController {
             failure: { [weak self] error in
                 WordPressAuthenticator.track(.loginFailed, error: error)
                 WPAuthenticatorLogError(error.localizedDescription)
-                guard let self = self else {
+                guard let self else {
                     return
                 }
                 self.configureViewLoading(false)
@@ -568,7 +568,7 @@ private extension GetStartedViewController {
     /// Show the password or magic link view based on the configuration.
     ///
     func showPasswordOrMagicLinkView() {
-        guard let navigationController = navigationController else {
+        guard let navigationController else {
             return
         }
         configureViewLoading(true)
@@ -579,7 +579,7 @@ private extension GetStartedViewController {
                                               configuration: configuration)
         passwordCoordinator = coordinator
         Task { @MainActor [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             await coordinator.start()
             self.configureViewLoading(false)
         }
@@ -643,7 +643,7 @@ private extension GetStartedViewController {
             }, failure: { [weak self] (error: Error) in
                 WPAuthenticatorLogError("Request for signup link email failed.")
 
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -685,7 +685,7 @@ private extension GetStartedViewController {
                                             self?.configureViewLoading(false)
 
             }, failure: { [weak self] (error: Error) in
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 
@@ -795,7 +795,7 @@ private extension GetStartedViewController {
 private extension GetStartedViewController {
 
     func configureSocialButtons() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 
@@ -817,7 +817,7 @@ private extension GetStartedViewController {
     }
 
     func configureButtonViewControllerForSiteAddressMode(isWPComSite: Bool) {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 
@@ -857,7 +857,7 @@ private extension GetStartedViewController {
     }
 
     func configureButtonViewControllerWithoutSocialLogin() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequestedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequestedViewController.swift
@@ -87,7 +87,7 @@ private extension MagicLinkRequestedViewController {
     /// Configures the primary button using the shared NUXButton style without a Storyboard.
     func setupContinueMailButton() {
         buttonViewController.setupTopButton(title: WordPressAuthenticator.shared.displayStrings.openMailButtonTitle, isPrimary: true, onTap: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             guard let topButton = self.buttonViewController.topButton else {
                 return
             }

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -130,7 +130,7 @@ class PasswordViewController: LoginViewController {
             return
         }
 
-        if let source = source, loginFields.meta.userIsDotCom {
+        if let source, loginFields.meta.userIsDotCom {
             let passwordError = SignInError.invalidWPComPassword(source: source)
             if authenticationDelegate.shouldHandleError(passwordError) {
                 authenticationDelegate.handleError(passwordError) { _ in
@@ -278,7 +278,7 @@ private extension PasswordViewController {
             secondaryButton.accessibilityIdentifier = AccessibilityIdentifier.loginWithMagicLink
             secondaryButton.on(.touchUpInside) { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     self.secondaryButton.isEnabled = false
                     await self.loginWithMagicLink()
                     self.secondaryButton.isEnabled = true
@@ -427,7 +427,7 @@ private extension PasswordViewController {
             return configuration.wpcomPasswordInstructions
         }()
 
-        guard let instructions = instructions else {
+        guard let instructions else {
             return
         }
 
@@ -464,7 +464,7 @@ private extension PasswordViewController {
                              accessibilityTrait: .link,
                              showBorder: true)
         cell.actionHandler = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -491,7 +491,7 @@ private extension PasswordViewController {
         loginLinkCell = cell
 
         cell.actionHandler = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Reusable Views/GravatarEmailTableViewCell.swift
@@ -31,7 +31,7 @@ class GravatarEmailTableViewCell: UITableViewCell {
 
         let gridicon: UIImage = .gridicon(.userCircle, size: hasBorders ? girdiconSmallSize : gridiconSize)
 
-        guard let email = email,
+        guard let email,
             email.isValidEmail() else {
                 gravatarImageView?.image = gridicon
                 return

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Sign up/UnifiedSignupViewController.swift
@@ -227,7 +227,7 @@ extension UnifiedSignupViewController {
             }, failure: { [weak self] (error: Error) in
                 WPAuthenticatorLogError("Request for signup link email failed.")
 
-                guard let self = self else {
+                guard let self else {
                     return
                 }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -349,7 +349,7 @@ private extension SiteAddressViewController {
     func configureTextLinkButton(_ cell: TextLinkButtonTableViewCell) {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.findSiteButtonTitle)
         cell.actionHandler = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -450,7 +450,7 @@ private extension SiteAddressViewController {
 
         // Checks that the site exists
         checkSiteExistence(url: url) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             // skips XMLRPC check for site discovery or site address login if needed
             if (self.isSiteDiscovery && self.configuration.skipXMLRPCCheckForSiteDiscovery) ||
                 self.configuration.skipXMLRPCCheckForSiteAddressLogin {
@@ -468,9 +468,9 @@ private extension SiteAddressViewController {
         request.timeoutInterval = 10.0 // waits for 10 seconds
         let task = URLSession.shared.dataTask(with: request) { [weak self] _, _, error in
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
-                if let error = error, (error as NSError).code != NSURLErrorAppTransportSecurityRequiresSecureConnection {
+                if let error, (error as NSError).code != NSURLErrorAppTransportSecurityRequiresSecureConnection {
                     self.configureViewLoading(false)
 
                     if self.authenticationDelegate.shouldHandleError(error) {
@@ -528,7 +528,7 @@ private extension SiteAddressViewController {
         let service = WordPressComBlogService()
 
         let successBlock: (WordPressComSiteInfo) -> Void = { [weak self] siteInfo in
-            guard let self = self else {
+            guard let self else {
                 return
             }
             self.configureViewLoading(false)
@@ -541,7 +541,7 @@ private extension SiteAddressViewController {
         }
 
         service.fetchUnauthenticatedSiteInfoForAddress(for: baseSiteUrl, success: successBlock, failure: { [weak self] error in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -696,7 +696,7 @@ private extension SiteAddressViewController {
     ///
     func attemptAPIDiscoveryFallback(for siteURL: String, siteInfoError: Error) {
         authenticationDelegate.handleSiteInfoFailure(siteURL: siteURL, error: siteInfoError) { [weak self] hasRESTAPI in
-            guard let self = self else { return }
+            guard let self else { return }
             self.configureViewLoading(false)
 
             if hasRESTAPI {

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewModel.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewModel.swift
@@ -37,14 +37,14 @@ struct SiteAddressViewModel {
         xmlrpcFacade.guessXMLRPCURL(forSite: siteAddress, success: { url in
             // Success! We now know that we have a valid XML-RPC endpoint.
             // At this point, we do NOT know if this is a WP.com site or a self-hosted site.
-            if let url = url {
+            if let url {
                 self.loginFields.meta.xmlrpcURL = url as NSURL
             }
 
             completion(.success)
 
         }, failure: { error in
-            guard let error = error else {
+            guard let error else {
                 return
             }
             // Intentionally log the attempted address on failures.

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteCredentialsViewController.swift
@@ -358,7 +358,7 @@ private extension SiteCredentialsViewController {
     func configureForgotPassword(_ cell: TextLinkButtonTableViewCell) {
         cell.configureButton(text: WordPressAuthenticator.shared.displayStrings.resetPasswordButtonTitle, accessibilityTrait: .link)
         cell.actionHandler = { [weak self] in
-            guard let self = self else {
+            guard let self else {
                 return
             }
 
@@ -582,7 +582,7 @@ extension SiteCredentialsViewController {
     func finishedLogin(withUsername username: String, password: String, xmlrpc: String, options: [AnyHashable: Any]) {
         let wporg = WordPressOrgCredentials(username: username, password: password, xmlrpc: xmlrpc, options: options)
         /// If `completionHandler` is available, return early with the credentials.
-        if let completionHandler = completionHandler {
+        if let completionHandler {
             completionHandler(wporg)
         } else {
             syncDataOrPresentWPComLogin(with: wporg)

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -98,7 +98,7 @@ private extension VerifyEmailViewController {
     /// Configure bottom buttons.
     ///
     func configureButtonViewController() {
-        guard let buttonViewController = buttonViewController else {
+        guard let buttonViewController else {
             return
         }
 
@@ -192,7 +192,7 @@ private extension VerifyEmailViewController {
                                             self?.configureViewLoading(false)
 
             }, failure: { [weak self] (error: Error) in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.tracker.track(failure: error.localizedDescription)
 

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/AppTransportSecuritySettings.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/AppTransportSecuritySettings.swift
@@ -49,7 +49,7 @@ struct AppTransportSecuritySettings {
             return !allowsInsecureHTTPLoads
         }
 
-        guard let settings = settings else {
+        guard let settings else {
             return true
         }
 

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCApi.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCApi.swift
@@ -202,14 +202,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     fileprivate static func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
         let responseCode = statusCode == 403 ? 403 : error.code
-        if let data = data {
+        if let data {
             var userInfo: [String: Any] = error.userInfo
             userInfo[Self.WordPressOrgXMLRPCApiErrorKeyData as String] = data
             userInfo[Self.WordPressOrgXMLRPCApiErrorKeyDataString as String] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             userInfo[Self.WordPressOrgXMLRPCApiErrorKeyStatusCode as String] = statusCode
             userInfo[NSLocalizedFailureErrorKey] = error.localizedDescription
 
-            if let statusCode = statusCode, (400..<600).contains(statusCode) {
+            if let statusCode, (400..<600).contains(statusCode) {
                 let formatString = NSLocalizedString("An HTTP error code %i was returned.", comment: "A failure reason for when an error HTTP status code was returned from the site, with the specific error code.")
                 userInfo[NSLocalizedFailureReasonErrorKey] = String(format: formatString, statusCode)
             } else {

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
@@ -268,11 +268,11 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         var isWpSite = false
         let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
         let dataTask = session.dataTask(with: htmlURL, completionHandler: { (data, _, error) in
-            if let error = error {
+            if let error {
                 failure(error as NSError)
                 return
             }
-            guard let data = data,
+            guard let data,
                   let responseString = String(data: data, encoding: String.Encoding.utf8),
                   let rsdURL = self.extractRSDURLFromHTML(responseString)
             else {
@@ -345,11 +345,11 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         }
         let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
         let dataTask = session.dataTask(with: rsdURL, completionHandler: { (data, _, error) in
-            if let error = error {
+            if let error {
                 failure(error as NSError)
                 return
             }
-            guard let data = data,
+            guard let data,
                 let responseString = String(data: data, encoding: String.Encoding.utf8),
                 let parser = WordPressRSDParser(xmlString: responseString),
                 let xmlrpc = try? parser.parsedEndpoint(),

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
@@ -33,7 +33,7 @@ extension AccountServiceRemoteREST {
             "id_token": token
         ] as [String: AnyObject]
 
-        if let connectParameters = connectParameters {
+        if let connectParameters {
             params.merge(connectParameters, uniquingKeysWith: { (current, _) in current })
         }
 

--- a/WooCommerce/WordPressAuthenticatorTests/Email Client Picker/AppSelectorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Email Client Picker/AppSelectorTests.swift
@@ -37,7 +37,7 @@ class AppSelectorTests: XCTestCase {
         XCTAssertNotNil(appSelector?.alertController)
         XCTAssertEqual(appSelector!.alertController.actions.count, 3)
         waitForExpectations(timeout: 4) { error in
-            if let error = error {
+            if let error {
                 XCTFail("waitForExpectationsWithTimeout errored: \(error)")
             }
         }
@@ -62,7 +62,7 @@ class AppSelectorTests: XCTestCase {
         // Then
         XCTAssertNil(appSelector)
         waitForExpectations(timeout: 4) { error in
-            if let error = error {
+            if let error {
                 XCTFail("waitForExpectationsWithTimeout errored: \(error)")
             }
         }

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/DynamicMockProvider.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/DynamicMockProvider.swift
@@ -27,13 +27,13 @@ internal extension DynamicMockProvider {
     static func randomURLAsString(withLength length: Int, subDirectories: [String]?, file: String?) -> String {
         var urlString = randomURLAsString(length: length)
 
-        if let subDirectories = subDirectories {
+        if let subDirectories {
             for directory in subDirectories {
                 urlString += "/\(directory)"
             }
         }
 
-        if let file = file {
+        if let file {
             urlString += "/\(file)"
         }
 


### PR DESCRIPTION

## Rule

[`shorthand_optional_binding`](https://realm.github.io/SwiftLint/shorthand_optional_binding.html) — Prefer `if let foo` over `if let foo = foo` (Swift 5.7+).

## Changes

- 497 source files auto-fixed (~1294 changes), all from `swiftlint --fix`.
- 0 manual fixes.
- 0 violations left for human review.

## Verification

- Lint clean locally.
- Local build was attempted but failed in the `Woo Watch App` target (`AppIcon` thinning error for `iPhone18,3` simulator) — pre-existing, unrelated to this change. Trusting CI to verify the WooCommerce app build.