### PR TITLE
[AI Suport Chat] Networking layer

### DIFF
--- a/Modules/Sources/Networking/Mapper/SupportChatResponseMapper.swift
+++ b/Modules/Sources/Networking/Mapper/SupportChatResponseMapper.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Mapper: `SupportChatResponse` returned by the `/wpcom/v2/odie/chat/{bot_slug}` endpoint.
+///
+struct SupportChatResponseMapper: Mapper {
+    func map(response: Data) throws -> SupportChatResponse {
+        try JSONDecoder().decode(SupportChatResponse.self, from: response)
+    }
+}

--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// A conversation with a support chat assistant.
+///
+/// Response shape returned by `POST /wpcom/v2/odie/chat/{bot_slug}` and its follow-up
+/// endpoint `/wpcom/v2/odie/chat/{bot_slug}/{chat_id}`. Each POST returns the thread
+/// with any new bot messages appended to `messages`.
+///
+public struct SupportChatResponse: Decodable, Equatable {
+    public let chatID: Int64
+    public let sessionID: String
+    public let botSlug: String
+    public let botVersion: String
+    public let messages: [SupportChatMessage]
+
+    public init(chatID: Int64,
+                sessionID: String,
+                botSlug: String,
+                botVersion: String,
+                messages: [SupportChatMessage]) {
+        self.chatID = chatID
+        self.sessionID = sessionID
+        self.botSlug = botSlug
+        self.botVersion = botVersion
+        self.messages = messages
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case chatID = "chat_id"
+        case sessionID = "session_id"
+        case botSlug = "bot_slug"
+        case botVersion = "bot_version"
+        case messages
+    }
+}
+
+/// A single message in a chat thread.
+///
+public struct SupportChatMessage: Decodable, Equatable {
+    public let messageID: Int64
+    public let role: String
+    public let content: String
+    public let context: SupportChatMessageContext?
+
+    public init(messageID: Int64,
+                role: String,
+                content: String,
+                context: SupportChatMessageContext?) {
+        self.messageID = messageID
+        self.role = role
+        self.content = content
+        self.context = context
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case messageID = "message_id"
+        case role
+        case content
+        case context
+    }
+}
+
+/// Per-message metadata attached by the bot: RAG sources + routing/branch flags.
+///
+public struct SupportChatMessageContext: Decodable, Equatable {
+    public let sources: [SupportChatSource]
+    public let flags: SupportChatFlags?
+
+    public init(sources: [SupportChatSource], flags: SupportChatFlags?) {
+        self.sources = sources
+        self.flags = flags
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sources = (try? container.decode([SupportChatSource].self, forKey: .sources)) ?? []
+        self.flags = try? container.decode(SupportChatFlags.self, forKey: .flags)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case sources
+        case flags
+    }
+}
+
+/// A source document cited by the bot (RAG grounding).
+///
+public struct SupportChatSource: Decodable, Equatable {
+    public let title: String
+    public let url: String
+    public let heading: String?
+    public let content: String?
+
+    public init(title: String, url: String, heading: String?, content: String?) {
+        self.title = title
+        self.url = url
+        self.heading = heading
+        self.content = content
+    }
+}
+
+/// Routing / state flags returned alongside a bot message.
+///
+public struct SupportChatFlags: Decodable, Equatable {
+    public let forwardToHumanSupport: Bool
+    public let cannedResponse: Bool
+    public let loggedIn: Bool
+    public let branch: String?
+
+    public init(forwardToHumanSupport: Bool,
+                cannedResponse: Bool,
+                loggedIn: Bool,
+                branch: String?) {
+        self.forwardToHumanSupport = forwardToHumanSupport
+        self.cannedResponse = cannedResponse
+        self.loggedIn = loggedIn
+        self.branch = branch
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.forwardToHumanSupport = (try? container.decode(Bool.self, forKey: .forwardToHumanSupport)) ?? false
+        self.cannedResponse = (try? container.decode(Bool.self, forKey: .cannedResponse)) ?? false
+        self.loggedIn = (try? container.decode(Bool.self, forKey: .loggedIn)) ?? false
+        self.branch = try? container.decode(String.self, forKey: .branch)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case forwardToHumanSupport = "forward_to_human_support"
+        case cannedResponse = "canned_response"
+        case loggedIn = "logged_in"
+        case branch
+    }
+}

--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -34,16 +34,29 @@ public struct SupportChatResponse: Decodable, Equatable {
     }
 }
 
+/// Role of a message sender in a support chat thread.
+///
+public enum SupportChatRole: String, Decodable, Equatable {
+    case bot
+    case unknown
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = SupportChatRole(rawValue: rawValue) ?? .unknown
+    }
+}
+
 /// A single message in a chat thread.
 ///
 public struct SupportChatMessage: Decodable, Equatable {
     public let messageID: Int64
-    public let role: String
+    public let role: SupportChatRole
     public let content: String
     public let context: SupportChatMessageContext?
 
     public init(messageID: Int64,
-                role: String,
+                role: SupportChatRole,
                 content: String,
                 context: SupportChatMessageContext?) {
         self.messageID = messageID

--- a/Modules/Sources/Networking/Remote/SupportChatRemote.swift
+++ b/Modules/Sources/Networking/Remote/SupportChatRemote.swift
@@ -1,0 +1,62 @@
+import Alamofire
+import Foundation
+
+/// Protocol for `SupportChatRemote` — mockable for tests.
+///
+public protocol SupportChatRemoteProtocol {
+    /// Sends a message to the support chat assistant.
+    ///
+    /// - Parameters:
+    ///   - botSlug: Assistant slug (e.g. `woo-chat-allusers`).
+    ///   - message: The user's message text.
+    ///   - chatID: If provided, continues an existing chat; otherwise starts a new one.
+    ///   - context: Optional context object forwarded to the assistant (e.g. selected site, current screen).
+    /// - Returns: The full chat thread with the assistant's reply appended.
+    func sendMessage(botSlug: String,
+                     message: String,
+                     chatID: Int64?,
+                     context: [String: Any]?) async throws -> SupportChatResponse
+}
+
+/// Remote for the support chat endpoint (`/wpcom/v2/odie/chat/{bot_slug}`).
+///
+public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
+
+    public func sendMessage(botSlug: String,
+                            message: String,
+                            chatID: Int64?,
+                            context: [String: Any]?) async throws -> SupportChatResponse {
+        let path: String = {
+            if let chatID {
+                return "\(Path.chat)/\(botSlug)/\(chatID)"
+            }
+            return "\(Path.chat)/\(botSlug)"
+        }()
+
+        var parameters: [String: Any] = [ParameterKey.message: message]
+        if let context {
+            parameters[ParameterKey.context] = context
+        }
+
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
+                                    method: .post,
+                                    path: path,
+                                    parameters: parameters,
+                                    encoding: JSONEncoding.default)
+        let mapper = SupportChatResponseMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+// MARK: - Constants
+//
+private extension SupportChatRemote {
+    enum Path {
+        static let chat = "odie/chat"
+    }
+
+    enum ParameterKey {
+        static let message = "message"
+        static let context = "context"
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+import Testing
+@testable import Networking
+@testable import NetworkingCore
+
+struct SupportChatRemoteTests {
+    private let network = MockNetwork()
+    private let botSlug = "woo-chat-allusers"
+
+    // MARK: - Request shape
+
+    @Test func sendMessage_when_no_chatID_then_posts_to_new_chat_path() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+
+        // When
+        _ = try? await remote.sendMessage(botSlug: botSlug,
+                                          message: "hi",
+                                          chatID: nil,
+                                          context: nil)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? DotcomRequest)
+        #expect(request.path == "odie/chat/\(botSlug)")
+    }
+
+    @Test func sendMessage_when_chatID_provided_then_posts_to_follow_up_path() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4242
+
+        // When
+        _ = try? await remote.sendMessage(botSlug: botSlug,
+                                          message: "hi",
+                                          chatID: chatID,
+                                          context: nil)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? DotcomRequest)
+        #expect(request.path == "odie/chat/\(botSlug)/\(chatID)")
+    }
+
+    @Test func sendMessage_sends_message_in_request_parameters() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let message = "How do I set up shipping zones?"
+
+        // When
+        _ = try? await remote.sendMessage(botSlug: botSlug,
+                                          message: message,
+                                          chatID: nil,
+                                          context: nil)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters["message"] as? String == message)
+    }
+
+    @Test func sendMessage_when_context_provided_then_context_is_in_request_parameters() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let context: [String: Any] = [
+            "selectedSiteId": 220224716,
+            "pathname": "/home/example.com"
+        ]
+
+        // When
+        _ = try? await remote.sendMessage(botSlug: botSlug,
+                                          message: "hi",
+                                          chatID: nil,
+                                          context: context)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        let sentContext = try #require(parameters["context"] as? [String: Any])
+        #expect(sentContext["selectedSiteId"] as? Int == 220224716)
+        #expect(sentContext["pathname"] as? String == "/home/example.com")
+    }
+
+    @Test func sendMessage_when_context_nil_then_context_is_absent_from_parameters() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+
+        // When
+        _ = try? await remote.sendMessage(botSlug: botSlug,
+                                          message: "hi",
+                                          chatID: nil,
+                                          context: nil)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters["context"] == nil)
+    }
+
+    // MARK: - Response decoding
+
+    @Test func sendMessage_when_response_is_valid_then_returns_parsed_chat() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)",
+                                 filename: "support-chat-send-message")
+
+        // When
+        let response = try await remote.sendMessage(botSlug: botSlug,
+                                                    message: "hi",
+                                                    chatID: nil,
+                                                    context: nil)
+
+        // Then
+        #expect(response.chatID == 1001)
+        #expect(response.sessionID == "8c1e24b8-7d67-4f1f-92b2-f45d53136fd4")
+        #expect(response.botSlug == botSlug)
+        #expect(response.botVersion == "1.4.3")
+        #expect(response.messages.count == 1)
+
+        let firstMessage = try #require(response.messages.first)
+        #expect(firstMessage.messageID == 3003)
+        #expect(firstMessage.role == .bot)
+        #expect(firstMessage.content.contains("Placeholder Markdown answer"))
+    }
+
+    @Test func sendMessage_when_response_has_sources_then_sources_are_decoded() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)",
+                                 filename: "support-chat-send-message")
+
+        // When
+        let response = try await remote.sendMessage(botSlug: botSlug,
+                                                    message: "hi",
+                                                    chatID: nil,
+                                                    context: nil)
+
+        // Then
+        let context = try #require(response.messages.first?.context)
+        #expect(context.sources.count == 2)
+
+        let firstSource = try #require(context.sources.first)
+        #expect(firstSource.title == "Placeholder Source Title")
+        #expect(firstSource.url == "https://example.com/docs/source-a")
+        #expect(firstSource.heading == "Excerpted heading")
+    }
+
+    @Test func sendMessage_when_response_has_flags_then_flags_are_decoded() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)",
+                                 filename: "support-chat-send-message")
+
+        // When
+        let response = try await remote.sendMessage(botSlug: botSlug,
+                                                    message: "hi",
+                                                    chatID: nil,
+                                                    context: nil)
+
+        // Then
+        let flags = try #require(response.messages.first?.context?.flags)
+        #expect(flags.forwardToHumanSupport == false)
+        #expect(flags.cannedResponse == false)
+        #expect(flags.loggedIn == false)
+        #expect(flags.branch == "default")
+    }
+
+    @Test func sendMessage_when_response_role_is_unknown_then_decodes_as_unknown_case() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)",
+                                 filename: "support-chat-unknown-role")
+
+        // When
+        let response = try await remote.sendMessage(botSlug: botSlug,
+                                                    message: "hi",
+                                                    chatID: nil,
+                                                    context: nil)
+
+        // Then — unrecognized roles must not crash decoding; they fall back to .unknown.
+        let firstMessage = try #require(response.messages.first)
+        #expect(firstMessage.role == .unknown)
+    }
+
+    @Test func sendMessage_when_response_signals_forward_to_human_then_flag_is_true() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)",
+                                 filename: "support-chat-forward-to-human")
+
+        // When
+        let response = try await remote.sendMessage(botSlug: botSlug,
+                                                    message: "I need a human",
+                                                    chatID: nil,
+                                                    context: nil)
+
+        // Then
+        let flags = try #require(response.messages.first?.context?.flags)
+        #expect(flags.forwardToHumanSupport == true)
+        #expect(flags.branch == "escalation")
+    }
+
+    // MARK: - Error paths
+
+    @Test func sendMessage_when_no_response_stubbed_then_throws_notFound() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+
+        // When / Then
+        await #expect(throws: NetworkError.notFound()) {
+            try await remote.sendMessage(botSlug: botSlug,
+                                         message: "hi",
+                                         chatID: nil,
+                                         context: nil)
+        }
+    }
+
+    @Test func sendMessage_when_network_errors_then_propagates_error() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateError(requestUrlSuffix: "odie/chat/\(botSlug)",
+                              error: NetworkError.timeout())
+
+        // When / Then
+        await #expect(throws: NetworkError.timeout()) {
+            try await remote.sendMessage(botSlug: botSlug,
+                                         message: "hi",
+                                         chatID: nil,
+                                         context: nil)
+        }
+    }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-forward-to-human.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-forward-to-human.json
@@ -1,0 +1,22 @@
+{
+    "chat_id": 1001,
+    "session_id": "8c1e24b8-7d67-4f1f-92b2-f45d53136fd4",
+    "bot_slug": "woo-chat-allusers",
+    "bot_version": "1.4.3",
+    "messages": [
+        {
+            "message_id": 3004,
+            "content": "Let me connect you with a human.",
+            "role": "bot",
+            "context": {
+                "sources": [],
+                "flags": {
+                    "forward_to_human_support": true,
+                    "canned_response": true,
+                    "logged_in": true,
+                    "branch": "escalation"
+                }
+            }
+        }
+    ]
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-send-message.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-send-message.json
@@ -1,0 +1,50 @@
+{
+    "chat_id": 1001,
+    "wpcom_user_id": 2002,
+    "external_id": null,
+    "external_id_provider": null,
+    "session_id": "8c1e24b8-7d67-4f1f-92b2-f45d53136fd4",
+    "bot_slug": "woo-chat-allusers",
+    "bot_version": "1.4.3",
+    "created_at": "2026-04-23 02:59:45",
+    "zendesk_ticket_id": null,
+    "messages": [
+        {
+            "message_id": 3003,
+            "content": "Placeholder Markdown answer with a [link](https://example.com/docs).",
+            "role": "bot",
+            "created_at": "2026-04-23 02:59:55",
+            "context": {
+                "sources": [
+                    {
+                        "title": "Placeholder Source Title",
+                        "url": "https://example.com/docs/source-a",
+                        "heading": "Excerpted heading",
+                        "content": "Excerpted source chunk used as RAG grounding.",
+                        "blog_id": 113771570,
+                        "post_id": 8734757,
+                        "score": 0.91,
+                        "last_indexed_at": "2025-03-30T13:55:22.390370"
+                    },
+                    {
+                        "title": "Second Source",
+                        "url": "https://example.com/docs/source-b",
+                        "heading": "Another excerpt",
+                        "content": "Another chunk.",
+                        "blog_id": 113771570,
+                        "post_id": 8734758,
+                        "score": 0.82,
+                        "last_indexed_at": "2025-04-01T10:00:00.000000"
+                    }
+                ],
+                "flags": {
+                    "forward_to_human_support": false,
+                    "canned_response": false,
+                    "logged_in": false,
+                    "branch": "default"
+                }
+            },
+            "ts": 1776913195
+        }
+    ]
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-unknown-role.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-unknown-role.json
@@ -1,0 +1,13 @@
+{
+    "chat_id": 1001,
+    "session_id": "8c1e24b8-7d67-4f1f-92b2-f45d53136fd4",
+    "bot_slug": "woo-chat-allusers",
+    "bot_version": "1.4.3",
+    "messages": [
+        {
+            "message_id": 3005,
+            "content": "Message from a role we don't recognize.",
+            "role": "some_future_role"
+        }
+    ]
+}


### PR DESCRIPTION
## Description

Adds the Networking layer for the AI support chat. Adds `SupportChatRemote`, response models, mapper, and unit tests. No app-facing impact yet.

## Test Steps
Tests and CI should pass.

## Screenshots
N/A
