### PR TITLE
Add AI support chat interface to Connectivity Tool

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -20,8 +20,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     init() {
         viewModel = ConnectivityToolViewModel()
-        var view = ConnectivityTool(cards: viewModel.cards)
-        view.showChatButton = viewModel.showChatButton
+        let view = ConnectivityTool(cards: viewModel.cards)
         super.init(rootView: view)
         self.hidesBottomBarWhenPushed = true
         self.title = NSLocalizedString("Troubleshoot Connection", comment: "Screen title for the connectivity tool")
@@ -29,9 +28,16 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         // Bind cards to view
         viewModel.$cards.sink { [weak self] cards in
             self?.rootView.cards = cards
+        }
+        .store(in: &subscriptions)
+
+        // Bind chat button visibility
+        viewModel.$showChatButton.sink { [weak self] show in
+            self?.rootView.showChatButton = show
         }
         .store(in: &subscriptions)
 
@@ -151,7 +157,7 @@ struct ConnectivityTool: View {
     ///
     var onChatWithSupportTapped: (() -> ())?
 
-    /// Whether the chat button should be shown (controlled by feature flag).
+    /// Whether the chat button should be shown.
     ///
     var showChatButton: Bool = false
 
@@ -403,3 +409,4 @@ struct ConnectivityToolCard: View {
             .navigationBarTitleDisplayMode(.inline)
     }
 }
+

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -20,7 +20,8 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     init() {
         viewModel = ConnectivityToolViewModel()
-        let view = ConnectivityTool(cards: viewModel.cards)
+        var view = ConnectivityTool(cards: viewModel.cards)
+        view.showChatButton = viewModel.showChatButton
         super.init(rootView: view)
         self.hidesBottomBarWhenPushed = true
         self.title = NSLocalizedString("Troubleshoot Connection", comment: "Screen title for the connectivity tool")
@@ -65,6 +66,11 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         rootView.onContactSupportTapped = { [weak self] in
             self?.showContactSupportForm()
         }
+
+        // Listen to the chat with support button
+        rootView.onChatWithSupportTapped = { [weak self] in
+            self?.showSupportChat()
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -97,6 +103,16 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         supportController.show(from: self)
 
         ServiceLocator.analytics.track(event: .ConnectivityTool.contactSupportTapped())
+    }
+
+    private func showSupportChat() {
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+            self?.showContactSupportForm()
+        }
+
+        let chatController = SupportChatHostingController(viewModel: chatViewModel)
+        chatController.show(from: self)
     }
 }
 
@@ -131,6 +147,14 @@ struct ConnectivityTool: View {
     ///
     var onContactSupportTapped: (() -> ())?
 
+    /// Closure to be invoked when the "Chat with Support" button is tapped.
+    ///
+    var onChatWithSupportTapped: (() -> ())?
+
+    /// Whether the chat button should be shown (controlled by feature flag).
+    ///
+    var showChatButton: Bool = false
+
     /// Internal layout values
     ///
     private static let dividerVerticalSpacing = 8.0
@@ -159,11 +183,19 @@ struct ConnectivityTool: View {
 
             Divider().ignoresSafeArea()
 
-            Button(Localization.contactSupport) {
-                onContactSupportTapped?()
+            if showChatButton {
+                Button(Localization.chatWithSupport) {
+                    onChatWithSupportTapped?()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding()
+            } else {
+                Button(Localization.contactSupport) {
+                    onContactSupportTapped?()
+                }
+                .buttonStyle(SecondaryButtonStyle())
+                .padding()
             }
-            .buttonStyle(SecondaryButtonStyle())
-            .padding()
         }
         .background(Color(uiColor: .listBackground))
         .navigationTitle(Localization.title)
@@ -177,6 +209,11 @@ private extension ConnectivityTool {
                                                 comment: "Subtitle on the connectivity tool screen")
         static let contactSupport = NSLocalizedString("Contact Support",
                                                       comment: "Contact support button in the connectivity tool screen")
+        static let chatWithSupport = NSLocalizedString(
+            "connectivityTool.chatWithSupport",
+            value: "Chat with Support",
+            comment: "Button to open AI chat support in the connectivity tool screen"
+        )
         static let title = NSLocalizedString(
             "connectivityTool.title",
             value: "Troubleshoot Connection",

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -419,4 +419,3 @@ struct ConnectivityToolCard: View {
             .navigationBarTitleDisplayMode(.inline)
     }
 }
-

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -41,6 +41,12 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         }
         .store(in: &subscriptions)
 
+        // Bind contact support button visibility
+        viewModel.$showContactSupportButton.sink { [weak self] show in
+            self?.rootView.showContactSupportButton = show
+        }
+        .store(in: &subscriptions)
+
         // Open selected URL — system URLs (e.g. notification settings) via UIApplication,
         // web URLs in-app using Safari.
         viewModel.$selectedURL
@@ -161,6 +167,10 @@ struct ConnectivityTool: View {
     ///
     var showChatButton: Bool = false
 
+    /// Whether the contact support button should be shown.
+    ///
+    var showContactSupportButton: Bool = false
+
     /// Internal layout values
     ///
     private static let dividerVerticalSpacing = 8.0
@@ -195,7 +205,7 @@ struct ConnectivityTool: View {
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .padding()
-            } else {
+            } else if showContactSupportButton {
                 Button(Localization.contactSupport) {
                     onContactSupportTapped?()
                 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -28,11 +28,24 @@ final class ConnectivityToolViewModel {
     ///
     @Published var shouldStartJetpackSetup = false
 
+    /// Whether all connectivity tests have completed (with success or failure).
+    ///
+    private(set) var allTestsCompleted = false {
+        didSet {
+            updateShowChatButton()
+        }
+    }
+
     /// Whether the AI support chat button should be shown.
+    /// True when bot chat is supported and all tests have completed.
+    ///
+    @Published private(set) var showChatButton = false
+
+    /// Whether the AI support chat is supported.
     /// Only available when the feature flag is enabled and user is authenticated with WPCom
     /// (not application password), since the chatbot requires WPCom authentication.
     ///
-    var showChatButton: Bool {
+    var isBotChatSupported: Bool {
         featureFlagService.isFeatureFlagEnabled(.aiSupportChat) && stores.isAuthenticatedWithoutWPCom == false
     }
 
@@ -123,6 +136,10 @@ final class ConnectivityToolViewModel {
         }
     }
 
+    private func updateShowChatButton() {
+        showChatButton = allTestsCompleted && isBotChatSupported
+    }
+
     /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.
     /// Provide a `sinceTest` parameter to omit test cases before it..
     ///
@@ -163,12 +180,14 @@ final class ConnectivityToolViewModel {
 
             // Only continue with another test if the current test was successful.
             if !testResult.isSuccess {
+                allTestsCompleted = true
                 return // Exit connectivity test.
             }
         }
 
         // Add no connections issues card if all tests are successful.
         cards.append(noConnectionsIssueState())
+        allTestsCompleted = true
     }
 
     /// This is not a user facing text but will be part of the Zendesk submission for troubleshooting.
@@ -237,6 +256,8 @@ final class ConnectivityToolViewModel {
         if !cards.isEmpty {
             cards.removeLast()
         }
+
+        allTestsCompleted = false
 
         // Run tests again from the failed one.
         Task {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -41,6 +41,11 @@ final class ConnectivityToolViewModel {
     ///
     @Published private(set) var showChatButton = false
 
+    /// Whether the contact support button should be shown.
+    /// True when bot chat is NOT supported and all tests have completed.
+    ///
+    @Published private(set) var showContactSupportButton = false
+
     /// Whether the AI support chat is supported.
     /// Only available when the feature flag is enabled and user is authenticated with WPCom
     /// (not application password), since the chatbot requires WPCom authentication.
@@ -138,6 +143,7 @@ final class ConnectivityToolViewModel {
 
     private func updateShowChatButton() {
         showChatButton = allTestsCompleted && isBotChatSupported
+        showContactSupportButton = allTestsCompleted && !isBotChatSupported
     }
 
     /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -12,6 +12,7 @@ import class Networking.ProductsRemote
 import class Networking.UserAgent
 import struct Networking.SystemPlugin
 import protocol WooFoundation.Analytics
+import protocol Experiments.FeatureFlagService
 
 final class ConnectivityToolViewModel {
 
@@ -26,6 +27,12 @@ final class ConnectivityToolViewModel {
     /// Set to `true` when the user taps "Setup Jetpack" to signal the view layer to start the Jetpack setup flow.
     ///
     @Published var shouldStartJetpackSetup = false
+
+    /// Whether the AI support chat button should be shown.
+    ///
+    var showChatButton: Bool {
+        featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
+    }
 
     /// Remote used to check the connection to WPCom servers.
     ///
@@ -50,6 +57,10 @@ final class ConnectivityToolViewModel {
     /// Analytics tracker.
     ///
     private let analytics: Analytics
+
+    /// Feature flag service for checking AI support chat availability.
+    ///
+    private let featureFlagService: FeatureFlagService
 
     /// Adapter for checking notification authorization status.
     ///
@@ -86,6 +97,7 @@ final class ConnectivityToolViewModel {
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          userNotificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          network: Network? = nil) {
@@ -98,6 +110,7 @@ final class ConnectivityToolViewModel {
         self.productsRemote = ProductsRemote(network: network)
         self.stores = stores
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
         self.userNotificationCenter = userNotificationCenter
         self.pushNotesManager = pushNotesManager
         self.siteURL = session.defaultSite?.url
@@ -165,6 +178,30 @@ final class ConnectivityToolViewModel {
         return latestTestResult.enumerated().map { index, result in
             "## \(index + 1). " + result.description()
         }.joined()
+    }
+
+    /// Creates a SupportChatViewModel with the current troubleshooting context.
+    ///
+    @MainActor
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping () -> Void) -> SupportChatViewModel {
+        var context: [String: Any] = [:]
+
+        if let troubleshootingDescription = troubleshootingDescription() {
+            context["troubleshooting_results"] = troubleshootingDescription
+        }
+
+        if let site = stores.sessionManager.defaultSite {
+            context["site_id"] = site.siteID
+            context["site_url"] = site.url
+        }
+
+        context["app_version"] = Bundle.main.marketingVersion
+        context["ios_version"] = UIDevice.current.systemVersion
+
+        return SupportChatViewModel(
+            initialContext: context,
+            onContactHumanSupport: onContactHumanSupport
+        )
     }
 
     /// Perform the test for a provided test case.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -29,9 +29,11 @@ final class ConnectivityToolViewModel {
     @Published var shouldStartJetpackSetup = false
 
     /// Whether the AI support chat button should be shown.
+    /// Only available when the feature flag is enabled and user is authenticated with WPCom
+    /// (not application password), since the chatbot requires WPCom authentication.
     ///
     var showChatButton: Bool {
-        featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
+        featureFlagService.isFeatureFlagEnabled(.aiSupportChat) && stores.isAuthenticatedWithoutWPCom == false
     }
 
     /// Remote used to check the connection to WPCom servers.

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import UIKit
+
+/// Hosting controller for the AI support chat view.
+///
+final class SupportChatHostingController: UIHostingController<SupportChatView> {
+
+    private let viewModel: SupportChatViewModel
+
+    init(viewModel: SupportChatViewModel) {
+        self.viewModel = viewModel
+        let view = SupportChatView(viewModel: viewModel)
+        super.init(rootView: view)
+
+        self.hidesBottomBarWhenPushed = true
+        self.title = Localization.title
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.largeTitleDisplayMode = .never
+    }
+}
+
+// MARK: - Presentation
+//
+extension SupportChatHostingController {
+
+    /// Shows the support chat from the given view controller.
+    ///
+    /// - Parameter presenter: The view controller to present from.
+    func show(from presenter: UIViewController) {
+        if let navigationController = presenter.navigationController {
+            navigationController.pushViewController(self, animated: true)
+        } else {
+            let navigationController = UINavigationController(rootViewController: self)
+            navigationController.modalPresentationStyle = .formSheet
+            presenter.present(navigationController, animated: true)
+        }
+    }
+}
+
+// MARK: - Localization
+//
+private extension SupportChatHostingController {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "supportChatHostingController.title",
+            value: "Chat with Support",
+            comment: "Navigation title for the AI support chat screen"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// Shared layout constants for the support chat UI.
+///
+enum SupportChatLayout {
+    static let bubbleCornerRadius: CGFloat = 16
+    static let bubblePadding: CGFloat = 12
+    static let maxBubbleWidthRatio: CGFloat = 0.75
+    static let messageSpacing: CGFloat = 12
+    static let inputSpacing: CGFloat = 12
+    static let bannerSpacing: CGFloat = 8
+    static let sendButtonSize: CGFloat = 20
+    static let disabledOpacity: CGFloat = 0.5
+
+    enum TypingIndicator {
+        static let dotSize: CGFloat = 8
+        static let dotSpacing: CGFloat = 4
+        static let dotCount: Int = 3
+        static let animationDuration: CGFloat = 0.5
+        static let animationOffset: CGFloat = -4
+        static let delayMultiplier: Double = 0.15
+    }
+}
+
+/// A chat bubble component that displays a single message.
+///
+struct SupportChatMessageRow: View {
+    let message: SupportChatViewModel.ChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user {
+                Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
+            }
+
+            Text(message.content)
+                .padding(SupportChatLayout.bubblePadding)
+                .background(bubbleBackground)
+                .foregroundColor(bubbleForeground)
+                .cornerRadius(SupportChatLayout.bubbleCornerRadius)
+
+            if message.role == .assistant {
+                Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
+            }
+        }
+    }
+
+    private var bubbleBackground: Color {
+        switch message.role {
+        case .user:
+            return Color(.accent)
+        case .assistant:
+            return Color(.systemGray5)
+        }
+    }
+
+    private var bubbleForeground: Color {
+        switch message.role {
+        case .user:
+            return .white
+        case .assistant:
+            return Color(.label)
+        }
+    }
+}
+
+/// A typing indicator shown while the bot is generating a response.
+///
+struct TypingIndicatorRow: View {
+    @State private var animationOffset: CGFloat = 0
+
+    private typealias Layout = SupportChatLayout.TypingIndicator
+
+    var body: some View {
+        HStack {
+            HStack(spacing: Layout.dotSpacing) {
+                ForEach(0..<Layout.dotCount, id: \.self) { index in
+                    Circle()
+                        .frame(width: Layout.dotSize, height: Layout.dotSize)
+                        .foregroundColor(Color(.systemGray3))
+                        .offset(y: animationOffset(for: index))
+                }
+            }
+            .padding(SupportChatLayout.bubblePadding)
+            .background(Color(.systemGray5))
+            .cornerRadius(SupportChatLayout.bubbleCornerRadius)
+
+            Spacer()
+        }
+        .onAppear {
+            withAnimation(Animation.easeInOut(duration: Layout.animationDuration).repeatForever(autoreverses: true)) {
+                animationOffset = Layout.animationOffset
+            }
+        }
+    }
+
+    private func animationOffset(for index: Int) -> CGFloat {
+        let delay = Double(index) * Layout.delayMultiplier
+        return animationOffset * cos(delay * .pi)
+    }
+}
+
+#Preview("User Message") {
+    SupportChatMessageRow(
+        message: .init(role: .user, content: "How do I fix my connection issue?")
+    )
+    .padding()
+}
+
+#Preview("Assistant Message") {
+    SupportChatMessageRow(
+        message: .init(role: .assistant, content: "I can help you troubleshoot your connection. Let's start by checking a few things.")
+    )
+    .padding()
+}
+
+#Preview("Typing Indicator") {
+    TypingIndicatorRow()
+        .padding()
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
@@ -33,7 +33,7 @@ struct SupportChatMessageRow: View {
                 Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
             }
 
-            Text(message.content)
+            messageText
                 .padding(SupportChatLayout.bubblePadding)
                 .background(bubbleBackground)
                 .foregroundColor(bubbleForeground)
@@ -42,6 +42,16 @@ struct SupportChatMessageRow: View {
             if message.role == .assistant {
                 Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
             }
+        }
+    }
+
+    @ViewBuilder
+    private var messageText: some View {
+        switch message.role {
+        case .user:
+            Text(message.content)
+        case .assistant:
+            Text(.init(message.content))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -61,6 +61,7 @@ struct SupportChatView: View {
                 }
                 .padding()
             }
+            .scrollDismissesKeyboard(.immediately)
             .onChange(of: viewModel.messages.count) { _, _ in
                 scrollToBottom(proxy: proxy)
             }
@@ -133,6 +134,7 @@ struct SupportChatView: View {
 
     private func sendMessageIfPossible() {
         guard canSendMessage else { return }
+        isInputFocused = false
         viewModel.sendMessage()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// The main chat interface view for AI support.
+///
+struct SupportChatView: View {
+    @Bindable var viewModel: SupportChatViewModel
+    @FocusState private var isInputFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            messageList
+
+            if viewModel.shouldPromptHumanSupport {
+                humanSupportBanner
+            }
+
+            Divider()
+
+            inputArea
+        }
+        .background(Color(.listBackground))
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(
+            Localization.errorTitle,
+            isPresented: .init(
+                get: { viewModel.state != .idle && viewModel.state != .sending },
+                set: { if !$0 { viewModel.dismissError() } }
+            ),
+            actions: {
+                Button(Localization.ok) {
+                    viewModel.dismissError()
+                }
+            },
+            message: {
+                if case .error(let message) = viewModel.state {
+                    Text(message)
+                }
+            }
+        )
+        .onAppear {
+            viewModel.showGreeting()
+        }
+    }
+
+    // MARK: - Message List
+
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: SupportChatLayout.messageSpacing) {
+                    ForEach(viewModel.messages) { message in
+                        SupportChatMessageRow(message: message)
+                            .id(message.id)
+                    }
+
+                    if viewModel.state == .sending {
+                        TypingIndicatorRow()
+                            .id("typing")
+                    }
+                }
+                .padding()
+            }
+            .onChange(of: viewModel.messages.count) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: viewModel.state) { _, newState in
+                if newState == .sending {
+                    scrollToBottom(proxy: proxy)
+                }
+            }
+        }
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy) {
+        withAnimation {
+            if viewModel.state == .sending {
+                proxy.scrollTo("typing", anchor: .bottom)
+            } else if let lastMessage = viewModel.messages.last {
+                proxy.scrollTo(lastMessage.id, anchor: .bottom)
+            }
+        }
+    }
+
+    // MARK: - Human Support Banner
+
+    private var humanSupportBanner: some View {
+        VStack(spacing: SupportChatLayout.bannerSpacing) {
+            Text(Localization.humanSupportMessage)
+                .font(.subheadline)
+                .foregroundColor(Color(.secondaryLabel))
+                .multilineTextAlignment(.center)
+
+            Button(Localization.contactSupport) {
+                viewModel.contactHumanSupport()
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+    }
+
+    // MARK: - Input Area
+
+    private var inputArea: some View {
+        HStack(spacing: SupportChatLayout.inputSpacing) {
+            TextField(Localization.placeholder, text: $viewModel.inputText, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(1...5)
+                .focused($isInputFocused)
+                .submitLabel(.send)
+                .onSubmit {
+                    sendMessageIfPossible()
+                }
+
+            Button {
+                sendMessageIfPossible()
+            } label: {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: SupportChatLayout.sendButtonSize))
+            }
+            .disabled(!canSendMessage)
+            .opacity(canSendMessage ? 1.0 : SupportChatLayout.disabledOpacity)
+        }
+        .padding()
+        .background(Color(.systemBackground))
+    }
+
+    private var canSendMessage: Bool {
+        !viewModel.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        viewModel.state != .sending
+    }
+
+    private func sendMessageIfPossible() {
+        guard canSendMessage else { return }
+        viewModel.sendMessage()
+    }
+}
+
+// MARK: - Localization
+//
+private extension SupportChatView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "supportChatView.title",
+            value: "Chat with Support",
+            comment: "Navigation title for the AI support chat screen"
+        )
+        static let placeholder = NSLocalizedString(
+            "supportChatView.placeholder",
+            value: "Type a message...",
+            comment: "Placeholder text for the chat input field"
+        )
+        static let errorTitle = NSLocalizedString(
+            "supportChatView.errorTitle",
+            value: "Error",
+            comment: "Title for the error alert in support chat"
+        )
+        static let ok = NSLocalizedString(
+            "supportChatView.ok",
+            value: "OK",
+            comment: "OK button in support chat error alert"
+        )
+        static let humanSupportMessage = NSLocalizedString(
+            "supportChatView.humanSupportMessage",
+            value: "It looks like you might need additional help. Would you like to contact our support team?",
+            comment: "Message shown when the bot suggests contacting human support"
+        )
+        static let contactSupport = NSLocalizedString(
+            "supportChatView.contactSupport",
+            value: "Contact Support",
+            comment: "Button to contact human support from the chat"
+        )
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SupportChatView(
+            viewModel: SupportChatViewModel(
+                onContactHumanSupport: {}
+            )
+        )
+        .navigationTitle("Chat with Support")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -12,11 +12,11 @@ struct SupportChatView: View {
 
             if viewModel.shouldPromptHumanSupport {
                 humanSupportBanner
+            } else {
+                Divider()
+
+                inputArea
             }
-
-            Divider()
-
-            inputArea
         }
         .background(Color(.listBackground))
         .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -67,7 +67,7 @@ final class SupportChatViewModel {
 
     // MARK: - Initialization
 
-    init(botSlug: String = "woo-chat-allusers",
+    init(botSlug: String = "woo-workflow-support_woomobile",
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,
          onContactHumanSupport: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -130,7 +130,7 @@ final class SupportChatViewModel {
         case .success(let response):
             chatID = response.chatID
 
-            if let lastBotMessage = response.messages.last(where: { $0.role == "assistant" }) {
+            if let lastBotMessage = response.messages.last(where: { $0.role == .bot }) {
                 let assistantMessage = ChatMessage(
                     role: .assistant,
                     content: lastBotMessage.content

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -67,7 +67,7 @@ final class SupportChatViewModel {
 
     // MARK: - Initialization
 
-    init(botSlug: String = "woo-workflow-support_woomobile",
+    init(botSlug: String = "woo-workflow-support_mobile_inapp",
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,
          onContactHumanSupport: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Observation
+import Yosemite
+import protocol WooFoundation.Analytics
+
+/// View model for the AI support chat interface.
+///
+@MainActor
+@Observable
+final class SupportChatViewModel {
+
+    /// Represents the current state of the chat.
+    ///
+    enum State: Equatable {
+        case idle
+        case sending
+        case error(String)
+
+        static func == (lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.idle, .idle), (.sending, .sending):
+                return true
+            case let (.error(lhsMessage), .error(rhsMessage)):
+                return lhsMessage == rhsMessage
+            default:
+                return false
+            }
+        }
+    }
+
+    /// A message in the chat thread (local UI model).
+    ///
+    struct ChatMessage: Identifiable, Equatable {
+        let id: UUID
+        let role: Role
+        let content: String
+        let timestamp: Date
+
+        enum Role {
+            case user
+            case assistant
+        }
+
+        init(id: UUID = UUID(), role: Role, content: String, timestamp: Date = Date()) {
+            self.id = id
+            self.role = role
+            self.content = content
+            self.timestamp = timestamp
+        }
+    }
+
+    // MARK: - Published State
+
+    private(set) var messages: [ChatMessage] = []
+    private(set) var state: State = .idle
+    private(set) var shouldPromptHumanSupport: Bool = false
+
+    var inputText: String = ""
+
+    // MARK: - Private Properties
+
+    private var chatID: Int64?
+    private let botSlug: String
+    private let stores: StoresManager
+    private let initialContext: [String: Any]?
+    private let onContactHumanSupport: () -> Void
+
+    // MARK: - Initialization
+
+    init(botSlug: String = "woo-chat-allusers",
+         stores: StoresManager = ServiceLocator.stores,
+         initialContext: [String: Any]? = nil,
+         onContactHumanSupport: @escaping () -> Void) {
+        self.botSlug = botSlug
+        self.stores = stores
+        self.initialContext = initialContext
+        self.onContactHumanSupport = onContactHumanSupport
+    }
+
+    // MARK: - Actions
+
+    func showGreeting() {
+        guard messages.isEmpty else { return }
+        state = .sending
+
+        Task {
+            try? await Task.sleep(for: .seconds(1))
+            let greetingMessage = ChatMessage(role: .assistant, content: Localization.greetingMessage)
+            messages.append(greetingMessage)
+            state = .idle
+        }
+    }
+
+    func sendMessage() {
+        let trimmedText = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else { return }
+        guard state != .sending else { return }
+
+        let userMessage = ChatMessage(role: .user, content: trimmedText)
+        messages.append(userMessage)
+        inputText = ""
+        state = .sending
+
+        let context = chatID == nil ? initialContext : nil
+
+        let action = SupportChatAction.sendMessage(
+            botSlug: botSlug,
+            message: trimmedText,
+            chatID: chatID,
+            context: context
+        ) { [weak self] result in
+            self?.handleSendMessageResult(result)
+        }
+
+        stores.dispatch(action)
+    }
+
+    func contactHumanSupport() {
+        onContactHumanSupport()
+    }
+
+    func dismissError() {
+        state = .idle
+    }
+
+    // MARK: - Private Methods
+
+    private func handleSendMessageResult(_ result: Result<SupportChatResponse, Error>) {
+        switch result {
+        case .success(let response):
+            chatID = response.chatID
+
+            if let lastBotMessage = response.messages.last(where: { $0.role == "assistant" }) {
+                let assistantMessage = ChatMessage(
+                    role: .assistant,
+                    content: lastBotMessage.content
+                )
+                messages.append(assistantMessage)
+
+                if let flags = lastBotMessage.context?.flags, flags.forwardToHumanSupport {
+                    shouldPromptHumanSupport = true
+                }
+            }
+
+            state = .idle
+
+        case .failure(let error):
+            DDLogError("⛔️ Support chat error: \(error)")
+            state = .error(Localization.errorMessage)
+        }
+    }
+}
+
+// MARK: - Localization
+//
+private extension SupportChatViewModel {
+    enum Localization {
+        static let greetingMessage = NSLocalizedString(
+            "supportChatViewModel.greetingMessage",
+            value: "Hello! I'm your Woo Mobile Support Bot. Is there anything I can help you with today?",
+            comment: "Initial greeting message from the AI support bot"
+        )
+        static let errorMessage = NSLocalizedString(
+            "supportChatViewModel.errorMessage",
+            value: "Something went wrong. Please try again.",
+            comment: "Error message shown when sending a support chat message fails"
+        )
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -409,6 +409,60 @@ struct ConnectivityToolViewModelTests {
         #expect(actions.contains(where: { $0.id == ConnectivityToolViewModel.NotificationFailedAction.viewDetails.id }))
     }
 
+    // MARK: - isBotChatSupported
+
+    @Test func test_isBotChatSupported_when_feature_flag_enabled_and_wpcom_authenticated_then_returns_true() {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.aiSupportChat] = true
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        // When
+        let sut = ConnectivityToolViewModel(
+            session: SessionManager.makeForTesting(authenticated: true),
+            stores: stores,
+            featureFlagService: featureFlagService
+        )
+
+        // Then
+        #expect(sut.isBotChatSupported == true)
+    }
+
+    @Test func test_isBotChatSupported_when_feature_flag_disabled_then_returns_false() {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.aiSupportChat] = false
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        // When
+        let sut = ConnectivityToolViewModel(
+            session: SessionManager.makeForTesting(authenticated: true),
+            stores: stores,
+            featureFlagService: featureFlagService
+        )
+
+        // Then
+        #expect(sut.isBotChatSupported == false)
+    }
+
+    @Test func test_isBotChatSupported_when_authenticated_without_wpcom_then_returns_false() {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.aiSupportChat] = true
+        let session = SessionManager.makeForTesting(authenticated: true, isWPCom: false)
+        let stores = MockStoresManager(sessionManager: session)
+
+        // When
+        let sut = ConnectivityToolViewModel(
+            session: session,
+            stores: stores,
+            featureFlagService: featureFlagService
+        )
+
+        // Then
+        #expect(sut.isBotChatSupported == false)
+    }
+
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## Description
Adds a chat interface to the Connectivity Tool that allows users to interact with an AI support bot. The bot guides users through troubleshooting before connecting them with human support.

## Changes
- Add `SupportChatView` and `SupportChatViewModel` for the chat interface
- Add `SupportChatMessageRow` for rendering chat messages with markdown support
- Integrate chat button into ConnectivityTool, shown only when user is authenticated with WPCOM
- Hide human support option until all connectivity checks complete
- Use new draft bot endpoint for AI responses

## Test Steps
1. Open the Connectivity Tool from Help & Support
2. Verify the "Chat with Support" button appears after all checks are done (requires WPCOM authentication) 
3. Tap to open the chat interface
4. Send a message and verify bot responds
5. If logged in without WPCom: Verify bot chat entry point is not available and human support option appears only after all checks complete.

## Screenshots


https://github.com/user-attachments/assets/836e5f7e-1a1c-43e1-9c95-1e0ad372ef8c




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.