### PR TITLE
Woo Mobile AI: Add feature flag and eligibility checker

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -107,6 +107,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return !buildConfig.isProduction
         case .aiSupportChat:
             return !buildConfig.isProduction
+        case .wooAIAssistant:
+            return !buildConfig.isProduction
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -223,4 +223,8 @@ public enum FeatureFlag: Int, CaseIterable {
     /// Enables the AI-powered support chat
     ///
     case aiSupportChat
+
+    /// Enables the WooAI Assistant tab and chat experience.
+    ///
+    case wooAIAssistant
 }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -224,7 +224,7 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case aiSupportChat
 
-    /// Enables the WooAI Assistant tab and chat experience.
+    /// Enables the WooAI Assistant.
     ///
     case wooAIAssistant
 }

--- a/WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift
@@ -1,0 +1,20 @@
+import Experiments
+import Foundation
+
+/// Gates whether the WooAI Assistant feature is available to the current user.
+///
+/// PR A1 establishes the gate. Subsequent PRs in the WooAI Assistant
+/// sequence will introduce module code, UI, and entry points - all
+/// behind this checker.
+struct AIAssistantEligibilityChecker {
+    private let featureFlagService: FeatureFlagService
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.featureFlagService = featureFlagService
+    }
+
+    /// `true` when the WooAI Assistant feature flag is enabled for the current build.
+    var isEligible: Bool {
+        featureFlagService.isFeatureFlagEnabled(.wooAIAssistant)
+    }
+}

--- a/WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift
@@ -1,11 +1,7 @@
 import Experiments
 import Foundation
 
-/// Gates whether the WooAI Assistant feature is available to the current user.
-///
-/// PR A1 establishes the gate. Subsequent PRs in the WooAI Assistant
-/// sequence will introduce module code, UI, and entry points - all
-/// behind this checker.
+/// Gates the WooAI Assistant feature behind its feature flag.
 struct AIAssistantEligibilityChecker {
     private let featureFlagService: FeatureFlagService
 
@@ -13,7 +9,6 @@ struct AIAssistantEligibilityChecker {
         self.featureFlagService = featureFlagService
     }
 
-    /// `true` when the WooAI Assistant feature flag is enabled for the current build.
     var isEligible: Bool {
         featureFlagService.isFeatureFlagEnabled(.wooAIAssistant)
     }

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
@@ -1,0 +1,34 @@
+import Experiments
+import Testing
+@testable import WooCommerce
+
+struct AIAssistantEligibilityCheckerTests {
+
+    @Test
+    func test_isEligible_when_flag_enabled_then_returns_true() {
+        // Given
+        let flagService = MockFeatureFlagService()
+        flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
+
+        // When
+        let result = sut.isEligible
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test
+    func test_isEligible_when_flag_disabled_then_returns_false() {
+        // Given
+        let flagService = MockFeatureFlagService()
+        flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = false
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
+
+        // When
+        let result = sut.isEligible
+
+        // Then
+        #expect(result == false)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `wooAIAssistant` feature flag and an `AIAssistantEligibilityChecker` that consults it.

## What this PR introduces

- `FeatureFlag.wooAIAssistant` in `Modules/Sources/Experiments/FeatureFlag.swift`.
- `DefaultFeatureFlagService` mapping - returns `!buildConfig.isProduction`, so it is on for `localDeveloper` / `alpha` / `appStoreBeta` and off for `appStore`.
- `AIAssistantEligibilityChecker` in `WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift` - exposes `var isEligible: Bool`.
- Swift Testing coverage in `WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift`.

## Test plan

1. CI builds the WooCommerce scheme without errors.
2. CI builds the PointOfSale scheme without errors.
3. `WooCommerceTests/AIAssistantEligibilityCheckerTests` passes.
4. SwiftLint passes.
5. Manually verify the new flag appears in the in-app feature flag override panel on a non-production build.

## Links

- WOOMOB-2856

---
- [x] I have considered if this change warrants user-facing release notes and decided no - the flag ships disabled in production.