### PR TITLE
Woo Mobile AI: Add module skeleton

### DIFF
--- a/Modules/.swiftpm/xcode/xcshareddata/xcschemes/WooAIAssistant.xcscheme
+++ b/Modules/.swiftpm/xcode/xcshareddata/xcschemes/WooAIAssistant.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WooAIAssistant"
+               BuildableName = "WooAIAssistant"
+               BlueprintName = "WooAIAssistant"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Tests/WooAIAssistantTests/WooAIAssistant.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WooAIAssistant"
+            BuildableName = "WooAIAssistant"
+            BlueprintName = "WooAIAssistant"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -272,11 +272,7 @@ let package = Package(
         ),
         .target(
             name: "WooAIAssistant",
-            dependencies: [
-                "Experiments",
-                "WooFoundation",
-                "Yosemite",
-            ]
+            dependencies: []
         ),
         .target(
             name: "NetworkingTestsResponsesFixtures",
@@ -364,8 +360,6 @@ let package = Package(
             name: "WooAIAssistantTests",
             dependencies: [
                 .target(name: "WooAIAssistant"),
-                "TestKit",
-                "WooFoundation",
             ]
         ),
         .binaryTarget(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -83,6 +83,10 @@ let package = Package(
             name: "PointOfSale",
             targets: ["PointOfSale"]
         ),
+        .library(
+            name: "WooAIAssistant",
+            targets: ["WooAIAssistant"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire", from: "5.2.0"),
@@ -267,6 +271,14 @@ let package = Package(
             resources: [.process("Resources")]
         ),
         .target(
+            name: "WooAIAssistant",
+            dependencies: [
+                "Experiments",
+                "WooFoundation",
+                "Yosemite",
+            ]
+        ),
+        .target(
             name: "NetworkingTestsResponsesFixtures",
             path: "Tests/NetworkingTestsResponsesFixtures",
             resources: [.process("Responses")]
@@ -346,6 +358,14 @@ let package = Package(
                 "Fakes",
                 "TestKit",
                 "WooFoundation"
+            ]
+        ),
+        .testTarget(
+            name: "WooAIAssistantTests",
+            dependencies: [
+                .target(name: "WooAIAssistant"),
+                "TestKit",
+                "WooFoundation",
             ]
         ),
         .binaryTarget(
@@ -439,6 +459,7 @@ enum XcodeSupport {
                     "WPMediaPicker",
                     "Yosemite",
                     "PointOfSale",
+                    "WooAIAssistant",
                     .product(name: "Alamofire", package: "Alamofire"),
                     .product(name: "Algorithms", package: "swift-algorithms"),
                     .product(name: "AutomatticAbout", package: "AutomatticAbout-swift"),

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
@@ -1,0 +1,7 @@
+/// Pinned model + prompt + tool catalog versions. Treat as a release tuple:
+/// changing any of the three is a behavior change worth a smoke run.
+public enum AssistantConfiguration {
+    public static let chatModel = "gpt-4o-mini"
+    public static let promptVersion = "v1"
+    public static let toolCatalogVersion = "v1"
+}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantAnalyticsProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantAnalyticsProviding.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Analytics surface the assistant module uses. Generic by design - typed
 /// event constructors land in a later PR alongside the Tracks catalog.
 public protocol AssistantAnalyticsProviding: Sendable {

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantAnalyticsProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantAnalyticsProviding.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Analytics surface the assistant module uses. Generic by design - typed
+/// event constructors land in a later PR alongside the Tracks catalog.
+public protocol AssistantAnalyticsProviding: Sendable {
+    func track(event: String, properties: [String: String])
+}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantAnalyticsProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantAnalyticsProviding.swift
@@ -1,5 +1,4 @@
-/// Analytics surface the assistant module uses. Generic by design - typed
-/// event constructors land in a later PR alongside the Tracks catalog.
+/// Analytics surface the assistant module uses.
 public protocol AssistantAnalyticsProviding: Sendable {
     func track(event: String, properties: [String: String])
 }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
@@ -2,5 +2,6 @@
 public protocol AssistantDependencyProviding: Sendable {
     var analytics: AssistantAnalyticsProviding { get }
     var externalNavigation: AssistantExternalNavigationProviding { get }
+    var externalViews: AssistantExternalViewProviding { get }
     var jwtProvider: AssistantJWTProviding { get }
 }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Aggregate DI the app target supplies when mounting the assistant.
 /// Mirrors the pattern established by `POSDependencyProviding` in PointOfSale.
 public protocol AssistantDependencyProviding: Sendable {

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Aggregate DI the app target supplies when mounting the assistant.
+/// Mirrors the pattern established by `POSDependencyProviding` in PointOfSale.
+public protocol AssistantDependencyProviding: Sendable {
+    var analytics: AssistantAnalyticsProviding { get }
+    var externalNavigation: AssistantExternalNavigationProviding { get }
+    var externalViews: AssistantExternalViewProviding { get }
+    var jwtProvider: AssistantJWTProviding { get }
+}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
@@ -1,5 +1,4 @@
 /// Aggregate DI the app target supplies when mounting the assistant.
-/// Mirrors the pattern established by `POSDependencyProviding` in PointOfSale.
 public protocol AssistantDependencyProviding: Sendable {
     var analytics: AssistantAnalyticsProviding { get }
     var externalNavigation: AssistantExternalNavigationProviding { get }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantDependencyProviding.swift
@@ -5,6 +5,5 @@ import Foundation
 public protocol AssistantDependencyProviding: Sendable {
     var analytics: AssistantAnalyticsProviding { get }
     var externalNavigation: AssistantExternalNavigationProviding { get }
-    var externalViews: AssistantExternalViewProviding { get }
     var jwtProvider: AssistantJWTProviding { get }
 }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalNavigationProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalNavigationProviding.swift
@@ -1,6 +1,4 @@
 /// Native-screen navigation the assistant delegates to the app target.
-/// Keeping it as a protocol means the module never imports the main app -
-/// tests stub it, previews mock it.
 public protocol AssistantExternalNavigationProviding: Sendable {
     func openOrder(siteID: Int64, orderID: Int64)
     func openProduct(siteID: Int64, productID: Int64)

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalNavigationProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalNavigationProviding.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Native-screen navigation the assistant delegates to the app target.
 /// Keeping it as a protocol means the module never imports the main app -
 /// tests stub it, previews mock it.

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalNavigationProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalNavigationProviding.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Native-screen navigation the assistant delegates to the app target.
+/// Keeping it as a protocol means the module never imports the main app -
+/// tests stub it, previews mock it.
+public protocol AssistantExternalNavigationProviding: Sendable {
+    func openOrder(siteID: Int64, orderID: Int64)
+    func openProduct(siteID: Int64, productID: Int64)
+    func openCustomer(siteID: Int64, customerID: Int64)
+}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalViewProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalViewProviding.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-/// Bridge for SwiftUI views the assistant embeds from the app target.
-/// Empty in v1 - concrete view types land alongside the renderer PR.
-public protocol AssistantExternalViewProviding: Sendable {}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalViewProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalViewProviding.swift
@@ -1,0 +1,2 @@
+/// Bridge for SwiftUI views the assistant embeds from the app target.
+public protocol AssistantExternalViewProviding: Sendable {}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalViewProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantExternalViewProviding.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+/// Bridge for SwiftUI views the assistant embeds from the app target.
+/// Empty in v1 - concrete view types land alongside the renderer PR.
+public protocol AssistantExternalViewProviding: Sendable {}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
@@ -1,5 +1,4 @@
-/// Mints the WPCOM AI JWT the assistant transport layer presents on every
-/// upstream request. The app target wraps the existing token-fetch path.
+/// Mints the WPCOM AI JWT the assistant transport layer presents on every upstream request.
 public protocol AssistantJWTProviding: Sendable {
     func currentJWT() async throws -> String
 }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Mints the WPCOM AI JWT the assistant transport layer presents on every
+/// upstream request. The app target wraps the existing token-fetch path.
+public protocol AssistantJWTProviding: Sendable {
+    func currentJWT() async throws -> String
+}

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Mints the WPCOM AI JWT the assistant transport layer presents on every
 /// upstream request. The app target wraps the existing token-fetch path.
 public protocol AssistantJWTProviding: Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/AITool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AITool.swift
@@ -1,0 +1,12 @@
+/// Catalog entry the orchestrator hands to the model so it knows what tools exist.
+public struct AITool: Sendable {
+    public let name: String
+    public let description: String
+    public let parametersSchema: AnyCodableJSON
+
+    public init(name: String, description: String, parametersSchema: AnyCodableJSON) {
+        self.name = name
+        self.description = description
+        self.parametersSchema = parametersSchema
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-/// Sealed `Sendable` JSON value used for tool result envelopes and JSON Schema fragments.
-/// Explicit cases avoid the `@unchecked Sendable` that an `Any`-backed type would force on
-/// every actor-isolated tool result.
+/// Sealed `Sendable` JSON value for tool parameter schemas and tool result envelopes.
+///
+/// Tool inputs and outputs are untyped JSON whose shape varies per tool, and results
+/// are re-serialized to the model's next turn. We need one value type that round-trips
+/// arbitrary JSON across actor boundaries. Explicit enum cases keep `Sendable`
+/// type-safe; an `Any`-backed type would force `@unchecked Sendable` on every result.
 public enum AnyCodableJSON: Codable, Sendable, Equatable {
     case null
     case bool(Bool)

--- a/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// A `Sendable` JSON value type. WooAIAssistant cannot use the existing
+/// `NetworkingCore.AnyCodable` because that type is `Any`-backed, which
+/// forces `@unchecked Sendable` on every actor-isolated tool result.
+/// Sealed enum with explicit cases keeps Sendable type-safe.
+///
 /// Loosely-typed JSON value that round-trips through `Codable`. Used for
 /// tool result envelopes and JSON Schema fragments where the inner shape
 /// is per-tool and we don't want to define a Swift type per variant.
@@ -29,7 +34,7 @@ public enum AnyCodableJSON: Codable, Sendable, Equatable {
         } else if let value = try? container.decode([String: AnyCodableJSON].self) {
             self = .object(value)
         } else {
-            self = .null
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unrecognized JSON value")
         }
     }
 

--- a/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Loosely-typed JSON value that round-trips through `Codable`. Used for
+/// tool result envelopes and JSON Schema fragments where the inner shape
+/// is per-tool and we don't want to define a Swift type per variant.
+public enum AnyCodableJSON: Codable, Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case int(Int64)
+    case double(Double)
+    case string(String)
+    case array([AnyCodableJSON])
+    case object([String: AnyCodableJSON])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int64.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([AnyCodableJSON].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: AnyCodableJSON].self) {
+            self = .object(value)
+        } else {
+            self = .null
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .bool(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AnyCodableJSON.swift
@@ -1,13 +1,8 @@
 import Foundation
 
-/// A `Sendable` JSON value type. WooAIAssistant cannot use the existing
-/// `NetworkingCore.AnyCodable` because that type is `Any`-backed, which
-/// forces `@unchecked Sendable` on every actor-isolated tool result.
-/// Sealed enum with explicit cases keeps Sendable type-safe.
-///
-/// Loosely-typed JSON value that round-trips through `Codable`. Used for
-/// tool result envelopes and JSON Schema fragments where the inner shape
-/// is per-tool and we don't want to define a Swift type per variant.
+/// Sealed `Sendable` JSON value used for tool result envelopes and JSON Schema fragments.
+/// Explicit cases avoid the `@unchecked Sendable` that an `Any`-backed type would force on
+/// every actor-isolated tool result.
 public enum AnyCodableJSON: Codable, Sendable, Equatable {
     case null
     case bool(Bool)

--- a/Modules/Sources/WooAIAssistant/Tools/AssistantErrorKind.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AssistantErrorKind.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Typed kinds the transport layer and orchestrator classify errors into.
 /// Surfaced through `ToolResult.Failed.kind`, transport telemetry, and the
 /// confirmation/retry decisions higher layers make.

--- a/Modules/Sources/WooAIAssistant/Tools/AssistantErrorKind.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AssistantErrorKind.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Typed kinds the transport layer and orchestrator classify errors into.
+/// Surfaced through `ToolResult.Failed.kind`, transport telemetry, and the
+/// confirmation/retry decisions higher layers make.
+public enum AssistantErrorKind: String, Sendable, Codable {
+    case network
+    case auth
+    case rateLimit          = "rate_limit"
+    case timeout
+    case upstreamFailure    = "upstream_failure"
+    case toolFailed         = "tool_failed"
+    case invalidToolCall    = "invalid_tool_call"
+    case outcomeUnknown     = "outcome_unknown"
+    case cancelled
+    case unknown
+}

--- a/Modules/Sources/WooAIAssistant/Tools/ToolRegistry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/ToolRegistry.swift
@@ -1,0 +1,6 @@
+/// Single dispatch surface every executor implements. `execute` returns a typed `ToolResult`
+/// rather than throwing, so error classification is part of the contract not a side effect.
+public protocol ToolRegistry: Sendable {
+    func availableTools() async throws -> [AITool]
+    func execute(name: String, arguments: String) async -> ToolResult
+}

--- a/Modules/Sources/WooAIAssistant/Tools/ToolResult.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/ToolResult.swift
@@ -41,15 +41,18 @@ public enum ToolResult: Sendable {
     public struct Failed: Sendable {
         public let toolName: String
         public let toolCallID: String
+        public let kind: AssistantErrorKind
         public let reason: String
         public let code: String?
 
         public init(toolName: String,
                     toolCallID: String,
+                    kind: AssistantErrorKind,
                     reason: String,
                     code: String? = nil) {
             self.toolName = toolName
             self.toolCallID = toolCallID
+            self.kind = kind
             self.reason = reason
             self.code = code
         }

--- a/Modules/Sources/WooAIAssistant/Tools/ToolResult.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/ToolResult.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Result of a single tool dispatch. Sealed so every executor commits to
+/// one of the four shapes; the orchestrator pattern-matches without
+/// stringly-typed status fields, and tools never `throw` past this point.
+public enum ToolResult: Sendable {
+    /// Successful execution. `structured` is the compact, model-visible
+    /// summary; `uiStructured` is the optional full render payload that
+    /// stays app-side and never re-enters model context.
+    case success(Success)
+
+    /// Tool ran but the operation logically failed (NotFound, validation,
+    /// HTTP 4xx). Surfaced to the model as `{"error":..., "reason":...}`.
+    case failed(Failed)
+
+    /// Tool was rejected by safety policy before dispatch (e.g. unconfirmed
+    /// destructive write). Distinct from `.failed` so analytics can split.
+    case rejectedBySafety(SafetyRejection)
+
+    /// Confirmation flow was started; the loop resumes after the user
+    /// confirms or cancels. Carries the proposal payload for the UI.
+    case awaitingConfirmation(ConfirmationProposal)
+
+    public struct Success: Sendable {
+        public let toolName: String
+        public let toolCallID: String
+        public let structured: AnyCodableJSON
+        public let uiStructured: UIStructured?
+
+        public init(toolName: String,
+                    toolCallID: String,
+                    structured: AnyCodableJSON,
+                    uiStructured: UIStructured? = nil) {
+            self.toolName = toolName
+            self.toolCallID = toolCallID
+            self.structured = structured
+            self.uiStructured = uiStructured
+        }
+    }
+
+    public struct Failed: Sendable {
+        public let toolName: String
+        public let toolCallID: String
+        public let reason: String
+        public let code: String?
+
+        public init(toolName: String,
+                    toolCallID: String,
+                    reason: String,
+                    code: String? = nil) {
+            self.toolName = toolName
+            self.toolCallID = toolCallID
+            self.reason = reason
+            self.code = code
+        }
+    }
+
+    public struct SafetyRejection: Sendable {
+        public let toolName: String
+        public let toolCallID: String
+        public let reason: String
+
+        public init(toolName: String, toolCallID: String, reason: String) {
+            self.toolName = toolName
+            self.toolCallID = toolCallID
+            self.reason = reason
+        }
+    }
+
+    public struct ConfirmationProposal: Sendable {
+        public let toolName: String
+        public let toolCallID: String
+        public let proposal: AnyCodableJSON
+
+        public init(toolName: String, toolCallID: String, proposal: AnyCodableJSON) {
+            self.toolName = toolName
+            self.toolCallID = toolCallID
+            self.proposal = proposal
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/ToolResult.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/ToolResult.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Result of a single tool dispatch. Sealed so every executor commits to
 /// one of the four shapes; the orchestrator pattern-matches without
 /// stringly-typed status fields, and tools never `throw` past this point.

--- a/Modules/Sources/WooAIAssistant/Tools/UIStructured.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/UIStructured.swift
@@ -9,8 +9,8 @@ public struct UIStructured: Sendable, Equatable {
     }
 }
 
-/// One card the renderer will draw. `element` is the family-typed render
-/// JSON (full entity for `order` / `product` / `customer` v1 families).
+/// One card the renderer will draw. `element` is the family-typed render JSON
+/// (the full entity for `order`, `product`, and `customer` families).
 public struct RenderedCardPayload: Sendable, Equatable {
     public let family: CardFamilyID
     public let id: Int64
@@ -23,8 +23,8 @@ public struct RenderedCardPayload: Sendable, Equatable {
     }
 }
 
-/// Card families the v1 renderer supports. Coupon / review / refund land
-/// in a v2 PR; the catalog is intentionally narrow for the first cut.
+/// Card families the renderer supports. Kept intentionally narrow so each
+/// family has a hand-written renderer rather than a generic JSON walker.
 public enum CardFamilyID: String, Sendable, Codable, Equatable {
     case order
     case product

--- a/Modules/Sources/WooAIAssistant/Tools/UIStructured.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/UIStructured.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Render payload a tool can attach to a successful result. Lives app-side
+/// only - the orchestrator must never serialize it back into model context,
+/// or the model starts parroting the same JSON the renderer is drawing.
+public struct UIStructured: Sendable, Equatable {
+    public let cards: [RenderedCardPayload]
+
+    public init(cards: [RenderedCardPayload]) {
+        self.cards = cards
+    }
+}
+
+/// One card the renderer will draw. `element` is the family-typed render
+/// JSON (full entity for `order` / `product` / `customer` v1 families).
+public struct RenderedCardPayload: Sendable, Equatable {
+    public let family: CardFamilyID
+    public let id: Int64
+    public let element: AnyCodableJSON
+
+    public init(family: CardFamilyID, id: Int64, element: AnyCodableJSON) {
+        self.family = family
+        self.id = id
+        self.element = element
+    }
+}
+
+/// Card families the v1 renderer supports. Coupon / review / refund land
+/// in a v2 PR; the catalog is intentionally narrow for the first cut.
+public enum CardFamilyID: String, Sendable, Codable, Equatable {
+    case order
+    case product
+    case customer
+}

--- a/Modules/Sources/WooAIAssistant/Tools/UIStructured.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/UIStructured.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 /// Render payload a tool can attach to a successful result. Lives app-side
 /// only - the orchestrator must never serialize it back into model context,
 /// or the model starts parroting the same JSON the renderer is drawing.

--- a/Modules/Sources/WooAIAssistant/WooAIAssistant.swift
+++ b/Modules/Sources/WooAIAssistant/WooAIAssistant.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-/// Module marker. Public types live in their own files; this exists so the
-/// target has at least one source file before subsequent commits add real
-/// content.
-public enum WooAIAssistant {}

--- a/Modules/Sources/WooAIAssistant/WooAIAssistant.swift
+++ b/Modules/Sources/WooAIAssistant/WooAIAssistant.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Module marker. Public types live in their own files; this exists so the
+/// target has at least one source file before subsequent commits add real
+/// content.
+public enum WooAIAssistant {}

--- a/Modules/Tests/WooAIAssistantTests/Configuration/AssistantConfigurationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Configuration/AssistantConfigurationTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import WooAIAssistant
+
+struct AssistantConfigurationTests {
+    @Test
+    func test_assistantConfiguration_when_inspected_then_pins_release_triple() {
+        #expect(AssistantConfiguration.chatModel == "gpt-4o-mini")
+        #expect(AssistantConfiguration.promptVersion == "v1")
+        #expect(AssistantConfiguration.toolCatalogVersion == "v1")
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/AIToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/AIToolTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct AIToolTests {
+    @Test
+    func test_aiTool_when_constructed_then_exposes_name_description_and_schema() {
+        // Given
+        let schema: AnyCodableJSON = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "site_id": .object(["type": .string("integer")]),
+                "order_id": .object(["type": .string("integer")])
+            ]),
+            "required": .array([.string("site_id"), .string("order_id")])
+        ])
+
+        // When
+        let tool = AITool(name: "orders_get",
+                          description: "Fetch a single order by ID",
+                          parametersSchema: schema)
+
+        // Then
+        #expect(tool.name == "orders_get")
+        #expect(tool.description == "Fetch a single order by ID")
+        #expect(tool.parametersSchema == schema)
+    }
+
+    @Test
+    func test_aiTool_when_parametersSchema_round_trips_through_json_then_preserves_shape() throws {
+        // Given
+        let schema: AnyCodableJSON = .object([
+            "type": .string("object"),
+            "properties": .object([
+                "query": .object(["type": .string("string")])
+            ])
+        ])
+        let tool = AITool(name: "products_search", description: "Search products", parametersSchema: schema)
+
+        // When
+        let data = try JSONEncoder().encode(tool.parametersSchema)
+        let decoded = try JSONDecoder().decode(AnyCodableJSON.self, from: data)
+
+        // Then
+        #expect(decoded == schema)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/AssistantErrorKindTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/AssistantErrorKindTests.swift
@@ -6,7 +6,9 @@ struct AssistantErrorKindTests {
     @Test
     func test_assistantErrorKind_when_decoded_from_snake_case_then_matches_enum_case() throws {
         // Given
-        let json = Data(#"["network","auth","rate_limit","timeout","upstream_failure","tool_failed","invalid_tool_call","outcome_unknown","cancelled","unknown"]"#.utf8)
+        let raws = ["network", "auth", "rate_limit", "timeout", "upstream_failure",
+                    "tool_failed", "invalid_tool_call", "outcome_unknown", "cancelled", "unknown"]
+        let json = try JSONEncoder().encode(raws)
 
         // When
         let decoded = try JSONDecoder().decode([AssistantErrorKind].self, from: json)

--- a/Modules/Tests/WooAIAssistantTests/Tools/AssistantErrorKindTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/AssistantErrorKindTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct AssistantErrorKindTests {
+    @Test
+    func test_assistantErrorKind_when_decoded_from_snake_case_then_matches_enum_case() throws {
+        // Given
+        let json = Data(#"["network","auth","rate_limit","timeout","upstream_failure","tool_failed","invalid_tool_call","outcome_unknown","cancelled","unknown"]"#.utf8)
+
+        // When
+        let decoded = try JSONDecoder().decode([AssistantErrorKind].self, from: json)
+
+        // Then
+        #expect(decoded == [
+            .network,
+            .auth,
+            .rateLimit,
+            .timeout,
+            .upstreamFailure,
+            .toolFailed,
+            .invalidToolCall,
+            .outcomeUnknown,
+            .cancelled,
+            .unknown
+        ])
+    }
+
+    @Test
+    func test_assistantErrorKind_when_encoded_then_emits_snake_case_strings() throws {
+        // Given
+        let cases: [AssistantErrorKind] = [.rateLimit, .upstreamFailure, .invalidToolCall, .outcomeUnknown]
+
+        // When
+        let data = try JSONEncoder().encode(cases)
+        let stringified = try #require(String(data: data, encoding: .utf8))
+
+        // Then
+        #expect(stringified == #"["rate_limit","upstream_failure","invalid_tool_call","outcome_unknown"]"#)
+    }
+
+    @Test
+    func test_assistantErrorKind_when_outcomeUnknown_then_distinct_from_unknown() {
+        #expect(AssistantErrorKind.outcomeUnknown != AssistantErrorKind.unknown)
+        #expect(AssistantErrorKind.outcomeUnknown.rawValue == "outcome_unknown")
+        #expect(AssistantErrorKind.unknown.rawValue == "unknown")
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/ToolResultTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/ToolResultTests.swift
@@ -157,6 +157,36 @@ struct ToolResultTests {
     }
 
     @Test
+    func test_anyCodableJSON_when_decoding_integer_versus_decimal_then_preserves_distinction() throws {
+        // Given
+        let integerJSON = Data("1".utf8)
+        let decimalJSON = Data("1.0".utf8)
+
+        // When
+        let decodedInteger = try JSONDecoder().decode(AnyCodableJSON.self, from: integerJSON)
+        let decodedDecimal = try JSONDecoder().decode(AnyCodableJSON.self, from: decimalJSON)
+        let reencodedInteger = String(data: try JSONEncoder().encode(decodedInteger), encoding: .utf8)
+        let reencodedDecimal = String(data: try JSONEncoder().encode(decodedDecimal), encoding: .utf8)
+        let reencodedExplicitDouble = String(data: try JSONEncoder().encode(AnyCodableJSON.double(1.0)), encoding: .utf8)
+        let reencodedExplicitFractional = String(data: try JSONEncoder().encode(AnyCodableJSON.double(1.5)), encoding: .utf8)
+
+        // Then
+        // JSON `1` decodes as `.int(1)` and re-encodes as `1`.
+        #expect(decodedInteger == .int(1))
+        #expect(reencodedInteger == "1")
+
+        // JSON `1.0` decodes as `.int(1)` because `Int64` decoding accepts integral floats and
+        // is tried before `Double`. Re-encodes as `1`. Pinned to surface intentional changes.
+        #expect(decodedDecimal == .int(1))
+        #expect(reencodedDecimal == "1")
+
+        // Explicit `.double(1.0)` encoder output is also `1` (JSONEncoder drops trailing `.0`).
+        // Non-integral doubles keep their decimal form.
+        #expect(reencodedExplicitDouble == "1")
+        #expect(reencodedExplicitFractional == "1.5")
+    }
+
+    @Test
     func test_renderedCardPayload_when_round_tripped_through_uiStructured_then_preserves_all_fields() {
         // Given
         let element = AnyCodableJSON.object([

--- a/Modules/Tests/WooAIAssistantTests/Tools/ToolResultTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/ToolResultTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct ToolResultTests {
+    @Test
+    func test_toolResult_when_success_then_carries_structured_and_optional_uiStructured() {
+        // Given
+        let structured = AnyCodableJSON.object([
+            "count": .int(2),
+            "ids": .array([.int(3551), .int(3548)])
+        ])
+        let uiStructured = UIStructured(cards: [
+            RenderedCardPayload(family: .order, id: 3551, element: .object(["id": .int(3551)]))
+        ])
+
+        // When
+        let result: ToolResult = .success(.init(
+            toolName: "show_cards",
+            toolCallID: "call_1",
+            structured: structured,
+            uiStructured: uiStructured
+        ))
+
+        // Then
+        guard case .success(let success) = result else {
+            Issue.record("expected .success, got \(result)")
+            return
+        }
+        #expect(success.toolName == "show_cards")
+        #expect(success.toolCallID == "call_1")
+        #expect(success.structured == structured)
+        #expect(success.uiStructured?.cards.count == 1)
+        #expect(success.uiStructured?.cards.first?.family == .order)
+        #expect(success.uiStructured?.cards.first?.id == 3551)
+    }
+
+    @Test
+    func test_toolResult_when_success_without_uiStructured_then_uiStructured_is_nil() {
+        // Given / When
+        let result: ToolResult = .success(.init(
+            toolName: "orders_list",
+            toolCallID: "call_2",
+            structured: .object(["count": .int(0)])
+        ))
+
+        // Then
+        guard case .success(let success) = result else {
+            Issue.record("expected .success, got \(result)")
+            return
+        }
+        #expect(success.uiStructured == nil)
+    }
+
+    @Test
+    func test_toolResult_when_failed_then_carries_kind_reason_code() {
+        // Given / When
+        let result: ToolResult = .failed(.init(
+            toolName: "orders_get",
+            toolCallID: "call_3",
+            kind: .upstreamFailure,
+            reason: "HTTP 502 from upstream",
+            code: "bad_gateway"
+        ))
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(failed.toolName == "orders_get")
+        #expect(failed.toolCallID == "call_3")
+        #expect(failed.kind == .upstreamFailure)
+        #expect(failed.reason == "HTTP 502 from upstream")
+        #expect(failed.code == "bad_gateway")
+    }
+
+    @Test
+    func test_toolResult_when_failed_without_code_then_code_is_nil() {
+        // Given / When
+        let result: ToolResult = .failed(.init(
+            toolName: "orders_get",
+            toolCallID: "call_4",
+            kind: .network,
+            reason: "offline"
+        ))
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(failed.code == nil)
+    }
+
+    @Test
+    func test_toolResult_when_rejectedBySafety_then_carries_reason() {
+        // Given / When
+        let result: ToolResult = .rejectedBySafety(.init(
+            toolName: "orders_update",
+            toolCallID: "call_5",
+            reason: "destructive write requires confirmation"
+        ))
+
+        // Then
+        guard case .rejectedBySafety(let rejection) = result else {
+            Issue.record("expected .rejectedBySafety, got \(result)")
+            return
+        }
+        #expect(rejection.toolName == "orders_update")
+        #expect(rejection.reason == "destructive write requires confirmation")
+    }
+
+    @Test
+    func test_toolResult_when_awaitingConfirmation_then_carries_proposal() {
+        // Given
+        let proposal = AnyCodableJSON.object([
+            "tool": .string("orders_update"),
+            "id": .int(3551),
+            "changes": .object(["status": .string("completed")])
+        ])
+
+        // When
+        let result: ToolResult = .awaitingConfirmation(.init(
+            toolName: "orders_update",
+            toolCallID: "call_6",
+            proposal: proposal
+        ))
+
+        // Then
+        guard case .awaitingConfirmation(let confirmation) = result else {
+            Issue.record("expected .awaitingConfirmation, got \(result)")
+            return
+        }
+        #expect(confirmation.toolName == "orders_update")
+        #expect(confirmation.proposal == proposal)
+    }
+
+    @Test
+    func test_anyCodableJSON_when_encoded_to_json_then_round_trips_back() throws {
+        // Given
+        let original: AnyCodableJSON = .object([
+            "id": .int(3551),
+            "total": .double(99.99),
+            "currency": .string("USD"),
+            "paid": .bool(true),
+            "tags": .array([.string("urgent"), .string("vip")]),
+            "billing_address": .null
+        ])
+
+        // When
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AnyCodableJSON.self, from: data)
+
+        // Then
+        #expect(decoded == original)
+    }
+
+    @Test
+    func test_renderedCardPayload_when_round_tripped_through_uiStructured_then_preserves_all_fields() {
+        // Given
+        let element = AnyCodableJSON.object([
+            "id": .int(3551),
+            "status": .string("processing")
+        ])
+        let payload = RenderedCardPayload(family: .order, id: 3551, element: element)
+
+        // When
+        let envelope = UIStructured(cards: [payload])
+
+        // Then
+        let card = envelope.cards.first
+        #expect(card?.family == .order)
+        #expect(card?.id == 3551)
+        #expect(card?.element == element)
+    }
+
+    @Test
+    func test_cardFamilyID_when_decoded_from_json_then_matches_enum_case() throws {
+        // Given
+        let json = Data(#"["order","product","customer"]"#.utf8)
+
+        // When
+        let decoded = try JSONDecoder().decode([CardFamilyID].self, from: json)
+
+        // Then
+        #expect(decoded == [.order, .product, .customer])
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/WooAIAssistant.xctestplan
+++ b/Modules/Tests/WooAIAssistantTests/WooAIAssistant.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "B3C9F42D-1E5D-46A8-9F3B-5DEE9A1B7C20",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "performanceAntipatternCheckerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "WooAIAssistantTests",
+        "name" : "WooAIAssistantTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Modules/Tests/WooAIAssistantTests/WooAIAssistantTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/WooAIAssistantTests.swift
@@ -1,9 +1,0 @@
-import Testing
-@testable import WooAIAssistant
-
-struct WooAIAssistantTests {
-    @Test
-    func test_module_marker_exists() {
-        _ = WooAIAssistant.self
-    }
-}

--- a/Modules/Tests/WooAIAssistantTests/WooAIAssistantTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/WooAIAssistantTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import WooAIAssistant
+
+struct WooAIAssistantTests {
+    @Test
+    func test_module_marker_exists() {
+        _ = WooAIAssistant.self
+    }
+}

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -124,6 +124,13 @@
         "identifier" : "PointOfSaleTests",
         "name" : "PointOfSaleTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "WooAIAssistantTests",
+        "name" : "WooAIAssistantTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
WOOMOB-2863

## Summary

Sets up the `WooAIAssistant` SPM module and the foundational types every later piece keys off: a sealed `ToolResult` envelope, typed `AssistantErrorKind`, `AnyCodableJSON` for arbitrary tool JSON across actor boundaries, the `ToolRegistry` protocol, and the DI protocols the app target conforms to.

## What this introduces

- New `WooAIAssistant` SPM target and paired `WooAIAssistantTests`.
- `ToolResult` (4-case sealed enum), `AssistantErrorKind` (10 cases), `AnyCodableJSON`, `UIStructured`, `RenderedCardPayload`, `CardFamilyID`.
- `ToolRegistry` and `AITool`.
- `AssistantConfiguration` pinning model + prompt + tool-catalog versions.
- DI protocols: `AssistantDependencyProviding`, `AssistantAnalyticsProviding`, `AssistantJWTProviding`, `AssistantExternalNavigationProviding`, `AssistantExternalViewProviding`.
- 16 Swift Testing cases covering encoding, equality, distinct error kinds, and configuration pinning.

## Tests

- CI should build.
- Doesn't introduce any changes to the main app.

---
- [x] I have considered if this change warrants user-facing release notes and decided no - the module has no call sites yet.