### PR TITLE
[WOOMOB-2811] Introduce metric catalog for store widgets

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/MetricCellView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricCellView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Reusable cell that renders a single metric on the home-screen widget.
+///
+/// Accepts any `MetricPresentable` so the view is testable with stubs and size/family-specific
+/// formatting can be swapped by changing the presenter, not the cell. When the metric exposes
+/// a `tapURL`, the cell becomes a `Link` so the system handles the deep-link.
+///
+struct MetricCellView: View {
+    let metric: any MetricPresentable
+
+    var body: some View {
+        if let url = metric.tapURL {
+            Link(destination: url) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+            Text(metric.title)
+                .statTitleStyle()
+
+            Text(metric.formattedValue)
+                .statValueStyle()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private extension MetricCellView {
+    enum Layout {
+        static let cardSpacing = 2.0
+    }
+}
+
+// MARK: - Previews
+#if DEBUG
+struct MetricCellView_Previews: PreviewProvider {
+    private struct PreviewMetric: MetricPresentable {
+        let title: String
+        let formattedValue: String
+    }
+
+    static var previews: some View {
+        MetricCellView(metric: PreviewMetric(title: "Total sales", formattedValue: "$12.3k"))
+            .padding()
+            .background(Color(.brand))
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -10,10 +10,10 @@ import WidgetKit
 struct StoreInfoMetricsView: View {
     let entryData: StoreInfoData
 
-    @Environment(\.sizeCategory) var category
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
-    var accessibilityCategory: ContentSizeCategory {
-        return .extraLarge
+    var accessibilityDynamicTypeSize: DynamicTypeSize {
+        return .xLarge
     }
 
     var body: some View {
@@ -30,7 +30,7 @@ struct StoreInfoMetricsView: View {
                     .statRangeStyle()
             }
 
-            if category > accessibilityCategory {
+            if dynamicTypeSize > accessibilityDynamicTypeSize {
                 MetricsAccessibilityCard(entryData: entryData)
             } else {
                 StoreInfoMetricsCard(metrics: entryData.metrics)
@@ -75,7 +75,7 @@ struct StoreInfoMetricsCard: View {
         }
     }
 
-    enum Layout {
+    private enum Layout {
         static let metricsPerRow = 2
     }
 }
@@ -153,7 +153,7 @@ struct StoreInfoMetricsView_Previews: PreviewProvider {
 
         StoreInfoMetricsView(entryData: exampleData)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
-            .environment(\.sizeCategory, .extraExtraLarge)
+            .environment(\.dynamicTypeSize, .xxLarge)
             .previewDisplayName("XXL font")
     }
 }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+import WidgetKit
+
+/// Medium home-screen widget view driven by the metric catalog.
+///
+/// Companion to the legacy `StoreInfoView`; both render the same widget family but consume
+/// different shapes off `StoreInfoData`. Selection happens in `StoreInfoHomescreenWidget`
+/// based on `useMetricsHomescreenWidget`.
+///
+struct StoreInfoMetricsView: View {
+    let entryData: StoreInfoData
+
+    @Environment(\.sizeCategory) var category
+
+    var accessibilityCategory: ContentSizeCategory {
+        return .extraLarge
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+                HStack {
+                    Text(entryData.name)
+                        .storeNameStyle()
+                    Spacer()
+                    Text(entryData.range)
+                        .statRangeStyle()
+                }
+                Text(Localization.updatedAt(entryData.updatedTime))
+                    .statRangeStyle()
+            }
+
+            if category > accessibilityCategory {
+                MetricsAccessibilityCard(entryData: entryData)
+            } else {
+                StoreInfoMetricsCard(metrics: entryData.metrics)
+            }
+        }
+        .padding(.horizontal)
+        .widgetBackground(backgroundView: Color(.brand))
+    }
+}
+
+/// Renders an ordered list of metrics in a 2-column grid for the medium widget.
+/// Operates on the presentation protocol so the layout is decoupled from
+/// the concrete `StoreInfoMetric` type.
+///
+struct StoreInfoMetricsCard: View {
+    let metrics: [any MetricPresentable]
+
+    /// Chunks metrics into rows of two for the medium widget layout.
+    ///
+    private var rows: [[any MetricPresentable]] {
+        stride(from: 0, to: metrics.count, by: Layout.metricsPerRow).map { start in
+            Array(metrics[start..<min(start + Layout.metricsPerRow, metrics.count)])
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: StoreInfoMetricsView.Layout.sectionSpacing) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack {
+                    ForEach(Array(row.enumerated()), id: \.offset) { _, metric in
+                        MetricCellView(metric: metric)
+                    }
+                    // Pad the last row so a trailing cell keeps the grid alignment
+                    // when the row has fewer metrics than the slot count.
+                    if row.count < Layout.metricsPerRow {
+                        ForEach(0..<(Layout.metricsPerRow - row.count), id: \.self) { _ in
+                            Color.clear.frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    enum Layout {
+        static let metricsPerRow = 2
+    }
+}
+
+/// Accessibility card for `StoreInfoMetricsView`. Shows only revenue and a `View More` button.
+///
+private struct MetricsAccessibilityCard: View {
+    let entryData: StoreInfoData
+
+    var body: some View {
+        let revenue = entryData.metric(of: .revenue)
+        Group {
+            VStack(alignment: .leading, spacing: StoreInfoMetricsView.Layout.cardSpacing) {
+                Text(revenue.title)
+                    .statTitleStyle()
+
+                Text(revenue.formattedValue)
+                    .statValueStyle()
+            }
+
+            Text(StoreInfoMetricsView.Localization.viewMore)
+                .statButtonStyle()
+        }
+    }
+}
+
+// MARK: - Constants
+
+extension StoreInfoMetricsView {
+    enum Localization {
+        static let viewMore = AppLocalizedString(
+            "storeWidgets.infoView.viewMore",
+            value: "View More",
+            comment: "Title for the button indicator to display more stats in the Today's Stat widget when using accessibility fonts."
+        )
+        static func updatedAt(_ updatedTime: String) -> LocalizedString {
+            let format = AppLocalizedString("storeWidgets.infoView.updatedAt",
+                                            value: "As of %1$@",
+                                            comment: "Displays the time when the widget was last updated. %1$@ is the time to render.")
+            return LocalizedString.localizedStringWithFormat(format, updatedTime)
+        }
+    }
+
+    enum Layout {
+        static let sectionSpacing = 8.0
+        static let cardSpacing = 2.0
+    }
+}
+
+// MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
+
+struct StoreInfoMetricsView_Previews: PreviewProvider {
+    static var exampleData = StoreInfoData(
+        range: "Today",
+        name: "Ernest Shop",
+        revenue: "$123,456,789",
+        revenueCompact: "$123M",
+        visitors: "67",
+        orders: "23",
+        conversion: "34%",
+        updatedTime: "10:24 PM",
+        metrics: [
+            .init(type: .revenue, value: .currency(123_456_789, CurrencySettings())),
+            .init(type: .visitors, value: .count(67)),
+            .init(type: .orders, value: .count(23)),
+            .init(type: .conversion, value: .percentage(23.0 / 67.0))
+        ]
+    )
+
+    static var previews: some View {
+        StoreInfoMetricsView(entryData: exampleData)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+
+        StoreInfoMetricsView(entryData: exampleData)
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.sizeCategory, .extraExtraLarge)
+            .previewDisplayName("XXL font")
+    }
+}
+#endif

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -1,15 +1,19 @@
 import SwiftUI
 import WidgetKit
 
-/// Local routing flag for the medium home-screen widget.
+/// Routing flag for the medium home-screen widget.
 ///
 /// `false`: render the legacy `StoreInfoView` / `StatsCard` (consumes pre-formatted String fields).
 /// `true`: render the metric-catalog driven `StoreInfoMetricsView` / `StoreInfoMetricsCard`.
 ///
-/// Hard-coded for now so the new path can be exercised in dev without affecting shipped builds.
-/// A later step will read the same intent from App Group `UserDefaults` so the main app can flip it.
+/// Mirrored into the App Group by `StoreWidgetsFeatureFlagSynchronizer` from the local
+/// `FeatureFlag.configurableStoreStatsWidgets` (enabled by default on local/alpha builds, off on
+/// App Store). View-level gating: the widget kind / supported families never change, so flipping
+/// the flag does not orphan installed tiles — only the rendered body switches.
 ///
-private let useMetricsHomescreenWidget = false
+private var useMetricsHomescreenWidget: Bool {
+    UserDefaults.group?.configurableStoreStatsWidgetsEnabled ?? false
+}
 
 /// Entry point for StoreInfo Home Screen Widget
 ///

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -1,6 +1,16 @@
 import SwiftUI
 import WidgetKit
 
+/// Local routing flag for the medium home-screen widget.
+///
+/// `false`: render the legacy `StoreInfoView` / `StatsCard` (consumes pre-formatted String fields).
+/// `true`: render the metric-catalog driven `StoreInfoMetricsView` / `StoreInfoMetricsCard`.
+///
+/// Hard-coded for now so the new path can be exercised in dev without affecting shipped builds.
+/// A later step will read the same intent from App Group `UserDefaults` so the main app can flip it.
+///
+private let useMetricsHomescreenWidget = false
+
 /// Entry point for StoreInfo Home Screen Widget
 ///
 struct StoreInfoHomescreenWidget: View {
@@ -14,12 +24,19 @@ struct StoreInfoHomescreenWidget: View {
         case .error:
             UnableToFetchView()
         case .data(let data):
-            StoreInfoView(entryData: data)
+            if useMetricsHomescreenWidget {
+                StoreInfoMetricsView(entryData: data)
+            } else {
+                StoreInfoView(entryData: data)
+            }
         }
     }
 }
 
-/// StoreInfo Widget View
+/// StoreInfo Widget View (legacy path).
+///
+/// Reads the pre-formatted String fields off `StoreInfoData`. Kept side-by-side with
+/// `StoreInfoMetricsView` while the metric catalog is being validated end-to-end.
 ///
 private struct StoreInfoView: View {
     // Stats data to render
@@ -59,7 +76,7 @@ private struct StoreInfoView: View {
     }
 }
 
-/// Stats card sub view.
+/// Stats card sub view (legacy path).
 /// To be used inside `StoreInfoView`.
 ///
 private struct StatsCard: View {
@@ -269,14 +286,22 @@ private extension UnableToFetchView {
 import class WooFoundation.CurrencySettings
 
 struct StoreWidgets_Previews: PreviewProvider {
-    static var exampleData = StoreInfoData(range: "Today",
-                                           name: "Ernest Shop",
-                                           revenue: StoreInfoFormatter.formattedAmountString(for: Decimal(123456789), with: CurrencySettings()),
-                                           revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: Decimal(123456789), with: CurrencySettings()),
-                                           visitors: "67",
-                                           orders: "23",
-                                           conversion: "34%",
-                                           updatedTime: "10:24 PM")
+    static var exampleData = StoreInfoData(
+        range: "Today",
+        name: "Ernest Shop",
+        revenue: "$123,456,789",
+        revenueCompact: "$123M",
+        visitors: "67",
+        orders: "23",
+        conversion: "34%",
+        updatedTime: "10:24 PM",
+        metrics: [
+            .init(type: .revenue, value: .currency(123_456_789, CurrencySettings())),
+            .init(type: .visitors, value: .count(67)),
+            .init(type: .orders, value: .count(23)),
+            .init(type: .conversion, value: .percentage(23.0 / 67.0))
+        ]
+    )
 
     static var previews: some View {
         StoreInfoView(entryData: exampleData)

--- a/WooCommerce/StoreWidgets/MetricPresentable.swift
+++ b/WooCommerce/StoreWidgets/MetricPresentable.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Presentation-layer protocol consumed by `MetricCellView`.
+///
+/// Decouples the cell view from `StoreInfoMetric`, so previews and tests can provide
+/// arbitrary conforming stubs without constructing the full metric type.
+///
+protocol MetricPresentable {
+    var title: String { get }
+    var formattedValue: String { get }
+    /// URL the cell should deep-link to when tapped. `nil` means non-tappable.
+    var tapURL: URL? { get }
+}
+
+extension MetricPresentable {
+    var tapURL: URL? { nil }
+}
+
+// MARK: - StoreInfoMetric
+
+/// Format policy (v1): currency values use the compact form (e.g. `$12k`) on all surfaces.
+/// Size-specific formatting (full on `.systemLarge`, compact on `.systemSmall`) is a later
+/// refinement — swap in a size-aware formatter, not a different cell.
+///
+extension StoreInfoMetric: MetricPresentable {
+    var title: String {
+        type.displayName
+    }
+
+    var formattedValue: String {
+        switch value {
+        case .currency(let amount, let currencySettings):
+            return StoreInfoFormatter.formattedAmountCompactString(
+                for: amount,
+                with: currencySettings
+            )
+        case .count(let count):
+            return NumberFormatter.localizedString(from: NSNumber(value: count), number: .decimal)
+        case .percentage(let ratio):
+            return StoreInfoFormatter.formattedConversionString(
+                for: ratio
+            )
+        case .unavailable:
+            return StoreInfoFormatter.Constants.valuePlaceholderText
+        }
+    }
+
+    var tapURL: URL? {
+        switch type {
+        case .orders:
+            return WooConstants.URLs.ordersScreen.asURL()
+        case .revenue, .netSales, .itemsSold, .visitors, .conversion, .averageOrderValue:
+            return nil
+        }
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -16,7 +16,10 @@ final class StoreInfoDataService {
     ///
     struct Stats {
         let revenue: Decimal
+        let netRevenue: Decimal
+        let averageOrderValue: Decimal
         let totalOrders: Int
+        let totalItemsSold: Int
         let totalVisitors: Int?
         let conversion: Double?
     }
@@ -68,7 +71,10 @@ final class StoreInfoDataService {
             // Assemble stats data
             let conversion = siteStats.visitors > 0 ? Double(revenueAndOrders.totals.totalOrders) / Double(siteStats.visitors) : 0
             return Stats(revenue: revenueAndOrders.totals.grossRevenue,
+                         netRevenue: revenueAndOrders.totals.netRevenue,
+                         averageOrderValue: revenueAndOrders.totals.averageOrderValue,
                          totalOrders: revenueAndOrders.totals.totalOrders,
+                         totalItemsSold: revenueAndOrders.totals.totalItemsSold,
                          totalVisitors: siteStats.visitors,
                          conversion: min(conversion, 1))
 
@@ -86,7 +92,10 @@ final class StoreInfoDataService {
     private func todayStatsWithoutVisitors(for storeID: Int64) async throws -> Stats {
         let revenueAndOrders = try await fetchTodaysRevenueAndOrders(for: storeID)
         return Stats(revenue: revenueAndOrders.totals.grossRevenue,
+                     netRevenue: revenueAndOrders.totals.netRevenue,
+                     averageOrderValue: revenueAndOrders.totals.averageOrderValue,
                      totalOrders: revenueAndOrders.totals.totalOrders,
+                     totalItemsSold: revenueAndOrders.totals.totalItemsSold,
                      totalVisitors: nil,
                      conversion: nil)
     }

--- a/WooCommerce/StoreWidgets/StoreInfoMetric.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoMetric.swift
@@ -1,0 +1,24 @@
+import Foundation
+import WooFoundationCore
+
+/// Resolved raw value for a single metric at a given time range.
+///
+/// The case carries everything the presentation layer needs to format the value —
+/// currency-typed metrics therefore include the `CurrencySettings` that produced them.
+/// `.unavailable` means the data source couldn't produce a value
+/// (e.g. `visitors` for a non-WPCOM site, or a metric whose fetcher isn't wired yet).
+///
+enum StoreInfoMetricValue: Equatable {
+    case currency(Decimal, CurrencySettings?)
+    case count(Int)
+    /// Ratio in the 0.0 – 1.0 range.
+    case percentage(Double)
+    case unavailable
+}
+
+/// A metric entry — the catalog type paired with its resolved value.
+///
+struct StoreInfoMetric: Equatable {
+    let type: StoreInfoMetricType
+    let value: StoreInfoMetricValue
+}

--- a/WooCommerce/StoreWidgets/StoreInfoMetricType.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoMetricType.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Catalog of metrics that store widgets can surface.
+///
+/// The raw value is a stable, persistence-safe identifier — it is written into App Group storage
+/// and (later) into `AppIntentConfiguration` options. Do not rename cases without a migration.
+///
+enum StoreInfoMetricType: String, CaseIterable, Hashable {
+    // ⚠️ Don't rename these raw values without a migration —
+    // they are persisted to App Group storage and AppIntent configuration.
+    case revenue
+    case netSales
+    case orders
+    case itemsSold
+    case visitors
+    case conversion
+    case averageOrderValue
+
+    /// Localized user-facing title rendered in the metric cell.
+    ///
+    var displayName: String {
+        switch self {
+        case .revenue: return Localization.revenue
+        case .netSales: return Localization.netSales
+        case .orders: return Localization.orders
+        case .itemsSold: return Localization.itemsSold
+        case .visitors: return Localization.visitors
+        case .conversion: return Localization.conversion
+        case .averageOrderValue: return Localization.averageOrderValue
+        }
+    }
+
+    /// How the raw metric value should be formatted for display.
+    ///
+    enum Unit {
+        case currency
+        case count
+        case percentage
+    }
+
+    var unit: Unit {
+        switch self {
+        case .revenue, .netSales, .averageOrderValue: return .currency
+        case .orders, .itemsSold, .visitors: return .count
+        case .conversion: return .percentage
+        }
+    }
+
+    /// Whether the metric's data source requires WPCOM/Jetpack endpoints.
+    /// Used by the metric picker to filter options for self-hosted users.
+    ///
+    var requiresWPCom: Bool {
+        switch self {
+        case .visitors, .conversion: return true
+        case .revenue, .netSales, .orders, .itemsSold, .averageOrderValue: return false
+        }
+    }
+}
+
+// MARK: - Localization
+
+private extension StoreInfoMetricType {
+    // Keys here intentionally reuse the previous per-view keys where the English value
+    // is unchanged, so existing GlotPress translations carry over without a regression.
+    // Truly new metrics (netSales, itemsSold, averageOrderValue) use new `storeWidgets.metric.*` keys.
+    enum Localization {
+        static let revenue = AppLocalizedString(
+            "storeWidgets.infoView.totalSales",
+            value: "Total sales",
+            comment: "Revenue metric title — gross revenue including taxes and shipping."
+        )
+        static let netSales = AppLocalizedString(
+            "storeWidgets.metric.netSales",
+            value: "Net sales",
+            comment: "Net sales metric title — revenue excluding tax, shipping, and refunds."
+        )
+        static let orders = AppLocalizedString(
+            "storeWidgets.infoView.orders",
+            value: "Orders",
+            comment: "Orders metric title for the store info widget."
+        )
+        static let itemsSold = AppLocalizedString(
+            "storeWidgets.metric.itemsSold",
+            value: "Items sold",
+            comment: "Items sold metric title — total units sold in the period."
+        )
+        static let visitors = AppLocalizedString(
+            "storeWidgets.infoView.visitors",
+            value: "Visitors",
+            comment: "Visitors metric title for the store info widget."
+        )
+        static let conversion = AppLocalizedString(
+            "storeWidgets.infoView.conversion",
+            value: "Conversion",
+            comment: "Conversion rate metric title for the store info widget."
+        )
+        static let averageOrderValue = AppLocalizedString(
+            "storeWidgets.metric.averageOrderValue",
+            value: "Average order value",
+            comment: "Average order value (AOV) metric title for the store info widget."
+        )
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -21,6 +21,11 @@ enum StoreInfoEntry: TimelineEntry {
 
 /// Type that represents the the widget state data.
 ///
+/// Field shape matches trunk so the legacy `StoreInfoView` / `StatsCard` and the lock-screen
+/// widgets keep building unchanged. The metric catalog (`metrics`) is defaulted so callers
+/// that only need the legacy String fields don't have to populate it. The main provider
+/// populates both shapes; view selection is controlled by `useMetricsHomescreenWidget`.
+///
 struct StoreInfoData {
     /// Eg: Today, Weekly, Monthly, Yearly
     ///
@@ -53,6 +58,29 @@ struct StoreInfoData {
     /// Time when the widget was last refreshed (eg: 10.24PM)
     ///
     var updatedTime: String
+
+    /// Resolved metric entries for the new metric-catalog driven path. Ordering here is
+    /// the source of truth; metric-driven views render entries in this order. Currency-typed
+    /// metrics carry their own `CurrencySettings`, so this struct doesn't need a global one.
+    ///
+    var metrics: [StoreInfoMetric] = []
+}
+
+extension StoreInfoData {
+    /// Returns the entry for the given metric type, or an `.unavailable` placeholder
+    /// if the metric isn't present in the current data set.
+    ///
+    /// A miss is treated as a wiring bug (provider didn't include an expected metric);
+    /// `assertionFailure` catches it in debug, while production falls through to the
+    /// placeholder so the widget still renders as `-` instead of crashing.
+    ///
+    func metric(of type: StoreInfoMetricType) -> StoreInfoMetric {
+        if let metric = metrics.first(where: { $0.type == type }) {
+            return metric
+        }
+        assertionFailure("StoreInfoData missing expected metric: \(type.rawValue)")
+        return StoreInfoMetric(type: type, value: .unavailable)
+    }
 }
 
 /// Type that provides data entries to the widget system.
@@ -162,40 +190,66 @@ private extension StoreInfoProvider {
     /// Redacted entry with sample data. If dependencies are available - store name and currency settings will be used.
     ///
     static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
-        StoreInfoEntry.data(.init(range: Localization.today,
-                                  name: dependencies?.storeName ?? Localization.myShop,
-                                  revenue: StoreInfoFormatter.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
-                                  revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: 132.234, with: dependencies?.storeCurrencySettings),
-                                  visitors: "67",
-                                  orders: "23",
-                                  conversion: StoreInfoFormatter.formattedConversionString(for: 23/67),
-                                  updatedTime: StoreInfoFormatter.currentFormattedTime()))
+        let currencySettings = dependencies?.storeCurrencySettings ?? CurrencySettings()
+        let revenueAmount: Decimal = 132.234
+        let metrics: [StoreInfoMetric] = [
+            StoreInfoMetric(type: .revenue, value: .currency(revenueAmount, currencySettings)),
+            StoreInfoMetric(type: .visitors, value: .count(67)),
+            StoreInfoMetric(type: .orders, value: .count(23)),
+            StoreInfoMetric(type: .conversion, value: .percentage(23.0 / 67.0))
+        ]
+        return .data(.init(
+            range: Localization.today,
+            name: dependencies?.storeName ?? Localization.myShop,
+            revenue: StoreInfoFormatter.formattedAmountString(for: revenueAmount, with: currencySettings),
+            revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: revenueAmount, with: currencySettings),
+            visitors: "67",
+            orders: "23",
+            conversion: StoreInfoFormatter.formattedConversionString(for: 23.0 / 67.0),
+            updatedTime: StoreInfoFormatter.currentFormattedTime(),
+            metrics: metrics
+        ))
     }
 
     /// Real data entry.
     ///
     static func dataEntry(for todayStats: StoreInfoDataService.Stats, with dependencies: Dependencies) -> StoreInfoEntry {
-        let visitors: String = {
+        let currencySettings = dependencies.storeCurrencySettings
+        let visitorsValue: StoreInfoMetricValue = todayStats.totalVisitors.map { .count($0) } ?? .unavailable
+        let conversionValue: StoreInfoMetricValue = todayStats.conversion.map { .percentage($0) } ?? .unavailable
+
+        // Today's medium-widget preset. A later ticket will let users pick this list.
+        let metrics: [StoreInfoMetric] = [
+            .init(type: .revenue, value: .currency(todayStats.revenue, currencySettings)),
+            .init(type: .visitors, value: visitorsValue),
+            .init(type: .orders, value: .count(todayStats.totalOrders)),
+            .init(type: .conversion, value: conversionValue)
+        ]
+
+        let visitorsString: String = {
             if let visitors = todayStats.totalVisitors {
                 return "\(visitors)"
             }
             return StoreInfoFormatter.Constants.valuePlaceholderText
         }()
-        let conversion: String = {
+        let conversionString: String = {
             if let conversion = todayStats.conversion {
                 return StoreInfoFormatter.formattedConversionString(for: conversion)
             }
             return StoreInfoFormatter.Constants.valuePlaceholderText
         }()
-        return StoreInfoEntry.data(.init(range: Localization.today,
-                                         name: dependencies.storeName,
-                                         revenue: StoreInfoFormatter.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
-                                         revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: todayStats.revenue,
-                                                                                                         with: dependencies.storeCurrencySettings),
-                                         visitors: visitors,
-                                         orders: "\(todayStats.totalOrders)",
-                                         conversion: conversion,
-                                         updatedTime: StoreInfoFormatter.currentFormattedTime()))
+
+        return .data(.init(
+            range: Localization.today,
+            name: dependencies.storeName,
+            revenue: StoreInfoFormatter.formattedAmountString(for: todayStats.revenue, with: currencySettings),
+            revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: todayStats.revenue, with: currencySettings),
+            visitors: visitorsString,
+            orders: "\(todayStats.totalOrders)",
+            conversion: conversionString,
+            updatedTime: StoreInfoFormatter.currentFormattedTime(),
+            metrics: metrics
+        ))
     }
 
     enum Localization {

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -4,17 +4,30 @@ import SwiftUI
 /// Main StoreInfo Widget type.
 ///
 struct StoreInfoWidget: Widget {
+    /// Bundle-level gate for the configurable widget surface. Reads the App Group mirror written
+    /// by `StoreWidgetsFeatureFlagSynchronizer` from the local
+    /// `FeatureFlag.configurableStoreStatsWidgets`. When enabled, the new home-screen sizes
+    /// (`.systemSmall`, `.systemLarge`) are exposed in the widget gallery alongside the existing
+    /// `.systemMedium`. Adding sizes is a one-way decision once shipped enabled to App Store.
+    ///
+    /// `supportedFamilies` is evaluated when iOS launches the widget extension process — not on
+    /// every timeline reload — so changes propagate non-deterministically (next extension
+    /// relaunch).
+    ///
     private var supportedFamilies: [WidgetFamily] {
-        if #available(iOSApplicationExtension 16.0, *) {
-            return [
-                .accessoryInline,
-                .accessoryRectangular,
-                .accessoryCircular,
-                .systemMedium
-            ]
-        } else {
-            return [.systemMedium]
+        guard #available(iOSApplicationExtension 16.0, *) else {
+            return .wooFallbackFamilies
         }
+
+        /// Temporary developer flag
+        /// Will be removed before feature rollout
+        let isConfigurableEnabled = UserDefaults.group?.configurableStoreStatsWidgetsEnabled ?? false
+
+        if isConfigurableEnabled {
+            return .wooDefaultFamilies + .wooConfigurableFamilies
+        }
+
+        return .wooDefaultFamilies
     }
 
     var body: some WidgetConfiguration {
@@ -25,6 +38,21 @@ struct StoreInfoWidget: Widget {
         .description(Localization.description)
         .supportedFamilies(supportedFamilies)
     }
+}
+
+/// Widget family constants
+private extension Array where Element == WidgetFamily {
+    static let wooFallbackFamilies: [WidgetFamily] = [.systemMedium]
+    static let wooConfigurableFamilies: [WidgetFamily] = [
+        .systemSmall,
+        .systemLarge
+    ]
+    static let wooDefaultFamilies: [WidgetFamily] = [
+        .accessoryInline,
+        .accessoryRectangular,
+        .accessoryCircular,
+        .systemMedium
+    ]
 }
 
 /// Entry view for StoreInfo Widget UI
@@ -42,7 +70,10 @@ private struct StoreInfoWidgetEntryView: View {
                 StoreInfoRectangularWidget(entry: entry)
             case .accessoryCircular:
                 StoreInfoCircularWidget(entry: entry)
-            case .systemMedium:
+            case .systemMedium, .systemSmall, .systemLarge:
+                // `.systemSmall` and `.systemLarge` only enter `supportedFamilies` when the
+                // configurable-widgets FF is on, so reaching them implies the metric-driven path.
+                // Layouts dedicated to these sizes will land in Tickets #7 / #8.
                 StoreInfoHomescreenWidget(entry: entry)
             default:
                 EmptyView()


### PR DESCRIPTION
## Description

Foundational refactor of the Woo store widgets onto a metric catalog + presentation protocol. Lays the typed plumbing for the metric-driven medium widget alongside the existing one — **no user-visible difference**: the legacy `StoreInfoView` / `StatsCard` keeps rendering by default, and the new metric-driven path ships behind a local boolean.

### What's added

- `StoreInfoMetricType` — catalog enum with stable raw-string identifiers, localized display names, a presentation `Unit` (currency / count / percentage), and a `requiresWPCom` flag the metric picker can use to filter options for self-hosted users. The catalog has 7 entries — revenue, net sales, orders, items sold, visitors, conversion, AOV — matching the metric set Shopify exposes on its large analytics widget except for sessions, which Jetpack does not expose.
- `StoreInfoMetricValue` — typed value: `.currency(Decimal, CurrencySettings?)`, `.count(Int)`, `.percentage(Double)`, `.unavailable`. Currency settings ride along on the value so the metric is self-sufficient for formatting.
- `StoreInfoMetric` — `{ type, value }` entry. Conforms to `MetricPresentable` via an extension that owns the format policy and exposes an optional `tapURL` for cells that deep-link.
- `MetricCellView` — universal cell that renders any `MetricPresentable`. Wraps its content in a `Link` when the metric exposes a `tapURL`.
- `StoreInfoMetricsView` / `StoreInfoMetricsCard` — new metric-driven medium-widget rendering. Operates on `[any MetricPresentable]` and chunks rows of two; the orders deep-link is preserved via `MetricPresentable.tapURL` rather than a special case in the layout.

### What's wired

- `StoreInfoData` gets a defaulted `metrics: [StoreInfoMetric] = []` field alongside its existing pre-formatted String fields. The provider populates both shapes in `dataEntry` / `placeholderEntry`. A `metric(of:)` accessor exposes catalog entries with an `assertionFailure` tripwire for missing entries.
- `StoreInfoHomescreenWidget` reads a file-scope `useMetricsHomescreenWidget` boolean and routes the medium widget body between the legacy `StoreInfoView` and the new `StoreInfoMetricsView`. Defaults to the legacy path. Flipping the bool is enough to exercise the new layout end-to-end in dev. Production gating via App Group `UserDefaults` written by the main app is a follow-up.
- `StoreInfoDataService.Stats` is extended with `netRevenue`, `averageOrderValue`, and `totalItemsSold`. These come for free off the same `OrderStatsRemoteV4` response the widget already fetches — `OrderStatsV4Totals` decodes them today; the widget service was just dropping them.
- The provider's `dataEntry` builds the medium widget's preset (revenue / visitors / orders / conversion) into `data.metrics` for the metric-driven path. The catalog metrics not yet surfaced in the medium widget (net sales, AOV, items sold) are populated on `Stats` only — they're observable from the data layer ahead of the larger widget layouts that will surface them in the UI.

### What's not touched

- The legacy `StoreInfoView` and `StatsCard` are unchanged from trunk and remain the default rendering path. They keep consuming the pre-formatted String fields.
- All three lock-screen widgets (`StoreInfoCircularWidget`, `StoreInfoInlineWidget`, `StoreInfoRectangularWidget`) and their localization keys are bit-identical to trunk.
- No translation regression: existing GlotPress translations for the metric titles carry over because the new catalog reuses the per-view keys (`storeWidgets.infoView.totalSales`, `.visitors`, `.orders`, `.conversion`) where the English value is unchanged. Genuinely new metrics (`netSales`, `itemsSold`, `averageOrderValue`) use new `storeWidgets.metric.*` keys.

### Notes for reviewers

- **Watch App.** `StoreInfoFormatter.swift` is shared with the Woo Watch App target; this PR doesn't touch it. Metric-aware formatting lives on `StoreInfoMetric`'s `MetricPresentable` extension instead. The Watch App is the only other consumer of `StoreInfoDataService.Stats` and only reads `revenue` / `totalVisitors` / `conversion`, so the additive struct extension is safe.
- **Self-hosted parity.** Of the 7 catalog metrics, only `visitors` and `conversion` require WPCOM/Jetpack. Self-hosted merchants will get 5 of 7 metrics with real values; the other 2 resolve to `.unavailable` and render as `-`, which matches today's behaviour.
- **Type-safe entry split is a follow-up.** A future cleanup will split `StoreInfoEntry` into `.data(StoreInfoData)` and `.metricsData(StoreInfoMetricsData)` so the metrics path no longer relies on defaulted fields and the view layer doesn't read a flag. Postponed deliberately to keep this PR's blast radius minimal.

Tracking: WOOMOB-2811.

## Test Steps

This PR ships with the metric-catalog wired but **off by default**. Default flow should be indistinguishable from trunk; the flag flip exercises the new path.

### Default (legacy path)

1. Long-press the home screen, add the **Today** widget at medium size for an account that has data.
2. Verify the four cells (Total sales, Visitors, Orders, Conversion) render identical values to trunk.
3. Tap the Orders cell — should still deep-link to the orders list.
4. For a self-hosted (non-Jetpack) account, verify the Visitors and Conversion cells render `-` as before.
5. Add each lock-screen variant (rectangular / inline / circular) — revenue should render identically to trunk.
6. Switch the device to an XXL accessibility font size and confirm the medium widget falls back to the existing accessibility card (revenue + "View More").

### Metric-driven path

7. Flip `useMetricsHomescreenWidget = true` in `WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift` and rebuild.
8. Re-add the medium widget and repeat steps 2–4. Cell values should match the legacy path; layout should be the chunked 2-column grid produced by `StoreInfoMetricsCard`.
9. Confirm the Orders cell still deep-links via `MetricPresentable.tapURL`.
10. Verify the accessibility card (XXL font) renders revenue title + value via `MetricsAccessibilityCard`.

## Screenshots

N/A — no user-visible change in the default path.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
