### PR TITLE
Fix POS test hangs by replacing fragile async-mock patterns

### DIFF
--- a/Modules/Tests/CLAUDE.md
+++ b/Modules/Tests/CLAUDE.md
@@ -38,25 +38,24 @@ Organize tests into three logical blocks with comments:
 ## Async Testing Patterns
 These patterns target modern Swift concurrency when using the Swift Testing framework.
 
-### 1. Continuations for Mock Callbacks
-Use `withCheckedContinuation` to wait for mock method invocations:
+### Choosing a pattern
+
+| Situation | Use |
+|---|---|
+| Want to assert intermediate SUT state during an in-flight async call | Mock callback hook (see Mocks section) |
+| Same as above, and the trigger awaits to completion in the test body | `confirmation()` wrapping the hook |
+| Want to wait until an `@Observable` property reaches a value | `withCheckedContinuation` + `withObservationTracking` |
+| Mock hook can fire more than once and you only want to act on the first | `fireOnce` (see `Modules/Tests/PointOfSaleTests/Helpers/FireOnce.swift`) |
+| Combine subscription / observation re-establishment that may emit multiple events | `fireOnce` |
+
+If the test contains `var resumed = false` to dedupe a callback, use `fireOnce` instead — the manual flag is racy when the closure runs off the test's actor.
+
+### `confirmation()` for intermediate state observation
+
+When the trigger is awaitable AND the hook fires before the trigger returns:
 
 ```swift
-await withCheckedContinuation { continuation in
-    cardPresentPaymentService.onCollectPaymentCalled = {
-        continuation.resume()
-    }
-
-    // When
-    cardPresentPaymentService.connectedReader = .init(name: "Reader", batteryLevel: 0.7)
-}
-```
-
-### 2. `confirmation()` for Intermediate State Observation
-Use when testing state changes during an async operation:
-
-```swift
-await confirmation() { confirmation in
+await confirmation { confirmation in
     catalogService.onLoadCatalogCalled = {
         #expect(sut.isLoading == true)
         confirmation()
@@ -67,8 +66,9 @@ await confirmation() { confirmation in
 }
 ```
 
-### 3. `withObservationTracking` for @Observable Properties
-Use `withCheckedContinuation` + `withObservationTracking` to wait for `@Observable` state changes. This works for both sync and async methods:
+### `withObservationTracking` for `@Observable` properties
+
+Wait for a property to reach a target value:
 
 ```swift
 await withCheckedContinuation { continuation in
@@ -88,10 +88,20 @@ await withCheckedContinuation { continuation in
 }
 ```
 
-**Key points:**
-- `withObservationTracking` detects property changes deterministically (no polling)
-- Wrap the state check in `Task { @MainActor in }` because `onChange` fires with `willSet` semantics
-- The continuation suspends until the expected state is reached
+`withObservationTracking` is one-shot. If multiple state changes are expected before reaching the target, use `fireOnce` so the same closure can re-establish observation.
+
+### `fireOnce` for multi-fire callbacks
+
+When the SUT can trigger the same hook from more than one path (e.g., parallel observation handlers or multiple Tasks), the hook's `resume()` must be idempotent. Use `fireOnce` (the bug behind PR #16984 was a manual `var resumed = false` dedupe racing across actors):
+
+```swift
+await fireOnce { fire in
+    coordinator.onPerformIncrementalSyncCalled = { fire() }
+    Task { @MainActor in await sut.checkOut() }
+}
+```
+
+The first call to `fire` resumes the underlying continuation; later calls are silent no-ops. Locking is internal, so the hook is safe to invoke from any actor.
 
 ## Mocks
 
@@ -118,7 +128,7 @@ final class MockOrderService: OrderServiceProtocol {
 
 ### Mock Callback Hooks for In-Flight Observation
 
-When a test needs to assert state or mutate the SUT *while* it is awaiting the mock, expose a synchronous callback that the mock fires inside its body:
+When a test needs to assert state or mutate the SUT *while* it is awaiting the mock, expose a callback that the mock fires inside its body:
 
 ```swift
 final class MockRefundsService: RefundsServiceProtocol {
@@ -133,7 +143,12 @@ final class MockRefundsService: RefundsServiceProtocol {
 }
 ```
 
-The hook runs on the same actor as the SUT, so the test can call `sut.selectOrder(otherOrder)` or assert `sut.isLoading == true` synchronously, then the mock returns and the SUT proceeds. No `Task`, no continuations, no race surface.
+The hook runs on the same actor as the SUT, so the test can call `sut.selectOrder(otherOrder)` or assert `sut.isLoading == true` synchronously inside the hook, then the mock returns and the SUT proceeds. No `Task`, no continuations, no race surface.
+
+**When to mark the hook `@MainActor`:**
+- The hook's body needs to call `@MainActor`-isolated SUT methods or read `@Observable` state — **required**.
+- The hook only calls `fire()` from `fireOnce` and does no other work — optional, but match the type the SUT expects so closure literals don't need explicit isolation at the call site.
+- Pin the **mock method itself** to `@MainActor` whenever the hook is `@MainActor`. That way the closure invocation is a same-actor call, no implicit hop, no need for `MainActor.run`.
 
 For tests where the in-flight body itself needs to do async work, make the hook async:
 
@@ -145,6 +160,8 @@ func syncOrder(...) async throws -> Order {
     ...
 }
 ```
+
+If the hook can fire more than once (multiple SUT paths, observation re-emits), wrap the test's wait in `fireOnce` (see Async Testing Patterns above).
 
 ### Anti-Pattern: Mock Suspension via `awaitX` / `resumeX`
 
@@ -166,11 +183,22 @@ func service(...) async {
 }
 ```
 
-The two continuations are written and read from different actors, so the test's `resumeService()` can fire before the mock has stored the suspension continuation. The `?.resume()` no-ops on a still-nil reference and the mock waits on a continuation no one will resume — the test hangs forever (3-hour CI burns; see #16980). Fixing it with `@MainActor` only paper-overs the race; use the callback hook pattern instead.
+Why this hangs:
+
+1. Test (on main) calls `await awaitServiceCall()`, stores its continuation on the mock, suspends.
+2. SUT (on a Task in the cooperative pool) calls `service(...)`. Because the mock is non-isolated (no `@MainActor` annotation on the method), this call hops off main onto the pool.
+3. From the pool, the mock executes `callSignalContinuation?.resume()`. That schedules the test to resume on main.
+4. The test wakes on main and calls `resumeService()` — but the mock's pool thread hasn't yet executed `await withCheckedContinuation`, so `suspensionContinuation` is still `nil`. `?.resume()` silently no-ops.
+5. The mock's pool thread finally reaches the `withCheckedContinuation`, stores the continuation, and parks. Nobody will ever resume it.
+6. Test hangs until the job-level timeout (was 3 hours; see #16980).
+
+Pinning the mock method to `@MainActor` removes the hop and makes the test pass, but only because main-actor source-order happens to schedule the writes before the reads. It papers over the underlying contract — the mock and the test are sharing mutable continuation state across actor isolation domains, which Swift's concurrency model does not guarantee to serialize. Use the callback hook pattern instead — the mock fires the hook **before returning**, so the test does its in-flight work inside the hook, with no second continuation in the picture. If the hook can fire more than once, wrap the wait in `fireOnce` (`Modules/Tests/PointOfSaleTests/Helpers/FireOnce.swift`).
 
 ### Cap Suite Runtime With `.timeLimit`
 
-Add `@Suite(.timeLimit(.minutes(5)))` to any test suite that uses async patterns (continuations, callback hooks, `withObservationTracking`). If a regression in this category lands, it surfaces as a failed test in seconds instead of consuming a job-level timeout.
+Add `@Suite(.timeLimit(.minutes(5)))` to any test suite that uses async patterns (continuations, callback hooks, `withObservationTracking`). A regression in this category fails as a single test in minutes instead of consuming a job-level timeout (the bug behind #16980 burned a 3-hour CI slot before this trait was in place).
+
+Five minutes is the recommended cap because (a) Swift Testing's `.timeLimit` only accepts minute granularity, (b) any well-written test in this codebase finishes in well under a minute even on a loaded simulator, and (c) one minute is too aggressive for the slowest legitimate tests (Core Data migrations, simulator boot, contended cooperative pool under heavy parallel load) and would produce false failures. Don't drop the cap to 1 minute "to fail faster" without first confirming no legitimate test in the suite needs the headroom.
 
 ## Test Data Factories
 Use static factory methods for consistent test data:

--- a/Modules/Tests/CLAUDE.md
+++ b/Modules/Tests/CLAUDE.md
@@ -38,24 +38,25 @@ Organize tests into three logical blocks with comments:
 ## Async Testing Patterns
 These patterns target modern Swift concurrency when using the Swift Testing framework.
 
-### Choosing a pattern
-
-| Situation | Use |
-|---|---|
-| Want to assert intermediate SUT state during an in-flight async call | Mock callback hook (see Mocks section) |
-| Same as above, and the trigger awaits to completion in the test body | `confirmation()` wrapping the hook |
-| Want to wait until an `@Observable` property reaches a value | `withCheckedContinuation` + `withObservationTracking` |
-| Mock hook can fire more than once and you only want to act on the first | `fireOnce` (see `Modules/Tests/PointOfSaleTests/Helpers/FireOnce.swift`) |
-| Combine subscription / observation re-establishment that may emit multiple events | `fireOnce` |
-
-If the test contains `var resumed = false` to dedupe a callback, use `fireOnce` instead — the manual flag is racy when the closure runs off the test's actor.
-
-### `confirmation()` for intermediate state observation
-
-When the trigger is awaitable AND the hook fires before the trigger returns:
+### 1. Continuations for Mock Callbacks
+Use `withCheckedContinuation` to wait for mock method invocations:
 
 ```swift
-await confirmation { confirmation in
+await withCheckedContinuation { continuation in
+    cardPresentPaymentService.onCollectPaymentCalled = {
+        continuation.resume()
+    }
+
+    // When
+    cardPresentPaymentService.connectedReader = .init(name: "Reader", batteryLevel: 0.7)
+}
+```
+
+### 2. `confirmation()` for Intermediate State Observation
+Use when testing state changes during an async operation:
+
+```swift
+await confirmation() { confirmation in
     catalogService.onLoadCatalogCalled = {
         #expect(sut.isLoading == true)
         confirmation()
@@ -66,9 +67,8 @@ await confirmation { confirmation in
 }
 ```
 
-### `withObservationTracking` for `@Observable` properties
-
-Wait for a property to reach a target value:
+### 3. `withObservationTracking` for @Observable Properties
+Use `withCheckedContinuation` + `withObservationTracking` to wait for `@Observable` state changes. This works for both sync and async methods:
 
 ```swift
 await withCheckedContinuation { continuation in
@@ -88,20 +88,10 @@ await withCheckedContinuation { continuation in
 }
 ```
 
-`withObservationTracking` is one-shot. If multiple state changes are expected before reaching the target, use `fireOnce` so the same closure can re-establish observation.
-
-### `fireOnce` for multi-fire callbacks
-
-When the SUT can trigger the same hook from more than one path (e.g., parallel observation handlers or multiple Tasks), the hook's `resume()` must be idempotent. Use `fireOnce` (the bug behind PR #16984 was a manual `var resumed = false` dedupe racing across actors):
-
-```swift
-await fireOnce { fire in
-    coordinator.onPerformIncrementalSyncCalled = { fire() }
-    Task { @MainActor in await sut.checkOut() }
-}
-```
-
-The first call to `fire` resumes the underlying continuation; later calls are silent no-ops. Locking is internal, so the hook is safe to invoke from any actor.
+**Key points:**
+- `withObservationTracking` detects property changes deterministically (no polling)
+- Wrap the state check in `Task { @MainActor in }` because `onChange` fires with `willSet` semantics
+- The continuation suspends until the expected state is reached
 
 ## Mocks
 
@@ -128,77 +118,41 @@ final class MockOrderService: OrderServiceProtocol {
 
 ### Mock Callback Hooks for In-Flight Observation
 
-When a test needs to assert state or mutate the SUT *while* it is awaiting the mock, expose a callback that the mock fires inside its body:
+When a test needs to assert state or mutate the SUT *while* it is awaiting the mock, expose a callback that the mock fires inside its body, before returning:
 
 ```swift
 final class MockRefundsService: RefundsServiceProtocol {
-    var loadOrderRefundsResultToReturn: [POSOrderRefund] = []
-    var onLoadOrderRefundsCalled: (@MainActor (POSOrder) -> Void)?
+    var resultToReturn: [Refund] = []
+    var onLoadCalled: (@MainActor (Order) -> Void)?
 
     @MainActor
-    func loadOrderRefunds(for order: POSOrder) async throws -> [POSOrderRefund] {
-        onLoadOrderRefundsCalled?(order)
-        return loadOrderRefundsResultToReturn
+    func load(for order: Order) async throws -> [Refund] {
+        onLoadCalled?(order)
+        return resultToReturn
     }
 }
 ```
 
-The hook runs on the same actor as the SUT, so the test can call `sut.selectOrder(otherOrder)` or assert `sut.isLoading == true` synchronously inside the hook, then the mock returns and the SUT proceeds. No `Task`, no continuations, no race surface.
-
-**When to mark the hook `@MainActor`:**
-- The hook's body needs to call `@MainActor`-isolated SUT methods or read `@Observable` state — **required**.
-- The hook only calls `fire()` from `fireOnce` and does no other work — optional, but match the type the SUT expects so closure literals don't need explicit isolation at the call site.
-- Pin the **mock method itself** to `@MainActor` whenever the hook is `@MainActor`. That way the closure invocation is a same-actor call, no implicit hop, no need for `MainActor.run`.
+The hook runs on the same actor as the SUT, so the test can synchronously mutate state or assert intermediate values inside the hook, then the mock returns and the SUT proceeds. No `Task`, no continuations, no race surface. Mark the hook `@MainActor` whenever the SUT it touches is `@MainActor`-isolated, and pin the mock method itself to `@MainActor` to keep the invocation a same-actor call.
 
 For tests where the in-flight body itself needs to do async work, make the hook async:
 
 ```swift
-var onSyncOrderCalled: (@MainActor () async -> Void)?
+var onSyncCalled: (@MainActor () async -> Void)?
 
-func syncOrder(...) async throws -> Order {
-    await onSyncOrderCalled?()
+func sync(...) async throws {
+    await onSyncCalled?()
     ...
 }
 ```
 
-If the hook can fire more than once (multiple SUT paths, observation re-emits), wrap the test's wait in `fireOnce` (see Async Testing Patterns above).
-
 ### Anti-Pattern: Mock Suspension via `awaitX` / `resumeX`
 
-Do not write mocks that hold themselves open with one continuation while signalling readiness through a second one:
-
-```swift
-// DON'T
-var shouldSuspend = false
-func awaitServiceCall() async { ... stores call signal continuation ... }
-func resumeService() { ... resumes suspension continuation ... }
-
-func service(...) async {
-    callSignalContinuation?.resume()                 // signal "I've been called"
-    if shouldSuspend {
-        await withCheckedContinuation { cont in
-            suspensionContinuation = cont            // park HERE — too late
-        }
-    }
-}
-```
-
-Why this hangs:
-
-1. Test (on main) calls `await awaitServiceCall()`, stores its continuation on the mock, suspends.
-2. SUT (on a Task in the cooperative pool) calls `service(...)`. Because the mock is non-isolated (no `@MainActor` annotation on the method), this call hops off main onto the pool.
-3. From the pool, the mock executes `callSignalContinuation?.resume()`. That schedules the test to resume on main.
-4. The test wakes on main and calls `resumeService()` — but the mock's pool thread hasn't yet executed `await withCheckedContinuation`, so `suspensionContinuation` is still `nil`. `?.resume()` silently no-ops.
-5. The mock's pool thread finally reaches the `withCheckedContinuation`, stores the continuation, and parks. Nobody will ever resume it.
-6. Test hangs until the job-level timeout (was 3 hours; see #16980).
-
-Pinning the mock method to `@MainActor` removes the hop and makes the test pass, but only because main-actor source-order happens to schedule the writes before the reads. It papers over the underlying contract — the mock and the test are sharing mutable continuation state across actor isolation domains, which Swift's concurrency model does not guarantee to serialize. Use the callback hook pattern instead — the mock fires the hook **before returning**, so the test does its in-flight work inside the hook, with no second continuation in the picture. If the hook can fire more than once, wrap the wait in `fireOnce` (`Modules/Tests/PointOfSaleTests/Helpers/FireOnce.swift`).
+Do not write mocks that hold themselves open with one continuation while signalling readiness through a second one. The two continuations are written and read from different actors, so the test's `resumeX` can fire before the mock has stored the suspension continuation, leaving the mock parked on a continuation no one will resume — the test hangs. Use the callback hook pattern above instead.
 
 ### Cap Suite Runtime With `.timeLimit`
 
-Add `@Suite(.timeLimit(.minutes(5)))` to any test suite that uses async patterns (continuations, callback hooks, `withObservationTracking`). A regression in this category fails as a single test in minutes instead of consuming a job-level timeout (the bug behind #16980 burned a 3-hour CI slot before this trait was in place).
-
-Five minutes is the recommended cap because (a) Swift Testing's `.timeLimit` only accepts minute granularity, (b) any well-written test in this codebase finishes in well under a minute even on a loaded simulator, and (c) one minute is too aggressive for the slowest legitimate tests (Core Data migrations, simulator boot, contended cooperative pool under heavy parallel load) and would produce false failures. Don't drop the cap to 1 minute "to fail faster" without first confirming no legitimate test in the suite needs the headroom.
+Add `@Suite(.timeLimit(.minutes(5)))` to test suites that use async patterns (continuations, callback hooks, `withObservationTracking`). A regression in this category fails as a single test in minutes instead of consuming a job-level timeout. Five minutes is recommended because Swift Testing's `.timeLimit` only accepts minute granularity, well-written tests finish in well under a minute, and one minute is too tight for the slowest legitimate tests (Core Data migrations, simulator boot, contended cooperative pool under heavy parallel load).
 
 ## Test Data Factories
 Use static factory methods for consistent test data:

--- a/Modules/Tests/CLAUDE.md
+++ b/Modules/Tests/CLAUDE.md
@@ -116,25 +116,61 @@ final class MockOrderService: OrderServiceProtocol {
 }
 ```
 
-### Continuation-Based Mocks for Async Control
+### Mock Callback Hooks for In-Flight Observation
+
+When a test needs to assert state or mutate the SUT *while* it is awaiting the mock, expose a synchronous callback that the mock fires inside its body:
+
 ```swift
 final class MockRefundsService: RefundsServiceProtocol {
-    private var continuation: CheckedContinuation<Void, Never>?
+    var loadOrderRefundsResultToReturn: [POSOrderRefund] = []
+    var onLoadOrderRefundsCalled: (@MainActor (POSOrder) -> Void)?
 
-    var shouldSuspend = false
-
-    func awaitServiceCall() async {
-        await withCheckedContinuation { cont in
-            continuation = cont
-        }
-    }
-
-    func resumeService() {
-        continuation?.resume()
-        continuation = nil
+    @MainActor
+    func loadOrderRefunds(for order: POSOrder) async throws -> [POSOrderRefund] {
+        onLoadOrderRefundsCalled?(order)
+        return loadOrderRefundsResultToReturn
     }
 }
 ```
+
+The hook runs on the same actor as the SUT, so the test can call `sut.selectOrder(otherOrder)` or assert `sut.isLoading == true` synchronously, then the mock returns and the SUT proceeds. No `Task`, no continuations, no race surface.
+
+For tests where the in-flight body itself needs to do async work, make the hook async:
+
+```swift
+var onSyncOrderCalled: (@MainActor () async -> Void)?
+
+func syncOrder(...) async throws -> Order {
+    await onSyncOrderCalled?()
+    ...
+}
+```
+
+### Anti-Pattern: Mock Suspension via `awaitX` / `resumeX`
+
+Do not write mocks that hold themselves open with one continuation while signalling readiness through a second one:
+
+```swift
+// DON'T
+var shouldSuspend = false
+func awaitServiceCall() async { ... stores call signal continuation ... }
+func resumeService() { ... resumes suspension continuation ... }
+
+func service(...) async {
+    callSignalContinuation?.resume()                 // signal "I've been called"
+    if shouldSuspend {
+        await withCheckedContinuation { cont in
+            suspensionContinuation = cont            // park HERE — too late
+        }
+    }
+}
+```
+
+The two continuations are written and read from different actors, so the test's `resumeService()` can fire before the mock has stored the suspension continuation. The `?.resume()` no-ops on a still-nil reference and the mock waits on a continuation no one will resume — the test hangs forever (3-hour CI burns; see #16980). Fixing it with `@MainActor` only paper-overs the race; use the callback hook pattern instead.
+
+### Cap Suite Runtime With `.timeLimit`
+
+Add `@Suite(.timeLimit(.minutes(5)))` to any test suite that uses async patterns (continuations, callback hooks, `withObservationTracking`). If a regression in this category lands, it surfaces as a failed test in seconds instead of consuming a job-level timeout.
 
 ## Test Data Factories
 Use static factory methods for consistent test data:

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1232,11 +1232,11 @@ final class POSOrderListControllerTests {
 
     @MainActor
     @Test func test_loadOrderRefunds_when_selected_order_changes_during_fetch_then_discards_stale_result() async throws {
-        // Given: Select Order A and start loading its refunds
+        // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
         let orderA = makeOrder(id: 1, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        let orderB = makeOrder(id: 2, refunds: [POSOrderRefund(refundID: 2, formattedTotal: "-$5.00")])
         sut.selectOrder(orderA)
-        refundsService.shouldSuspendLoadOrderRefunds = true
         refundsService.loadOrderRefundsResultToReturn = [
             POSOrderRefund(refundID: 1, formattedTotal: "-$10.00", items: [
                 POSRefundItem(refundedItemID: 1,
@@ -1247,22 +1247,14 @@ final class POSOrderListControllerTests {
                               imageSrc: nil)
             ])
         ]
-
-        // Start the fetch. Await until mock confirms it's been called and is suspended
-        let loadTask = Task { @MainActor in
-            await sut.loadOrderRefunds()
+        refundsService.onLoadOrderRefundsCalled = { [weak sut] _ in
+            sut?.selectOrder(orderB)
         }
-        await refundsService.awaitLoadOrderRefundsCall()
 
-        // When: Switch to Order B while fetch is genuinely in-flight
-        let orderB = makeOrder(id: 2, refunds: [POSOrderRefund(refundID: 2, formattedTotal: "-$5.00")])
-        sut.selectOrder(orderB)
+        // When
+        await sut.loadOrderRefunds()
 
-        // Resume Order A's fetch — it should complete but discard the result
-        refundsService.resumeLoadOrderRefunds()
-        await loadTask.value
-
-        // Then: selectedOrder should still be Order B, not overwritten by Order A's result
+        // Then
         #expect(sut.selectedOrder?.id == 2)
         #expect(sut.selectedOrder?.refunds.flatMap { $0.items }.isEmpty == true)
     }
@@ -1275,18 +1267,16 @@ final class POSOrderListControllerTests {
         let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
 
-        // When — refunds are still loading
-        refundsService.shouldSuspendLoadOrderRefunds = true
-        let loadTask = Task { @MainActor in
-            await sut.loadOrderRefunds()
+        var displayedLineItemsCountWhileLoading: Int?
+        refundsService.onLoadOrderRefundsCalled = { [weak sut] _ in
+            displayedLineItemsCountWhileLoading = sut?.displayedLineItems.count
         }
-        await refundsService.awaitLoadOrderRefundsCall()
+
+        // When
+        await sut.loadOrderRefunds()
 
         // Then
-        #expect(sut.displayedLineItems.count == 2)
-
-        refundsService.resumeLoadOrderRefunds()
-        await loadTask.value
+        #expect(displayedLineItemsCountWhileLoading == 2)
     }
 
     @MainActor

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -17,6 +17,7 @@ import struct Yosemite.POSOrderRefund
 import class WooFoundation.CurrencySettings
 import class WooFoundation.CurrencyFormatter
 
+@Suite(.timeLimit(.minutes(5)))
 final class POSOrderListControllerTests {
     private let orderListService = MockPOSOrderListService()
     private let refundsService = MockPOSRefundsService()

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -57,10 +57,8 @@ struct POSPaymentModelTests {
         #expect(service.collectPaymentWasCalled == false)
 
         // Connect the reader and wait for the Combine chain to trigger collectPayment
-        await withCheckedContinuation { continuation in
-            service.onCollectPaymentCalled = {
-                continuation.resume()
-            }
+        await fireOnce { fire in
+            service.onCollectPaymentCalled = { fire() }
             service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         }
 
@@ -680,13 +678,11 @@ struct POSPaymentModelTests {
 
         // Wait for cardReaderConnectionStatus to update, proving the Combine
         // chain fully processed the connection event.
-        await withCheckedContinuation { continuation in
+        await fireOnce { fire in
             withObservationTracking {
                 _ = sut.cardReaderConnectionStatus
             } onChange: {
-                Task { @MainActor in
-                    continuation.resume()
-                }
+                Task { @MainActor in fire() }
             }
             service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         }
@@ -1000,10 +996,8 @@ struct POSPaymentModelTests {
         // Then: subscription should be restored - connecting a reader triggers payment
         #expect(service.collectPaymentWasCalled == false)
 
-        await withCheckedContinuation { continuation in
-            service.onCollectPaymentCalled = {
-                continuation.resume()
-            }
+        await fireOnce { fire in
+            service.onCollectPaymentCalled = { fire() }
             service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         }
 
@@ -1043,10 +1037,8 @@ struct POSPaymentModelTests {
         let sut = makePaymentController(cardPresentPaymentService: service)
 
         // When
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = {
-                continuation.resume()
-            }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             sut.connectCardReader()
             sut.connectCardReader()
         }
@@ -1063,21 +1055,15 @@ struct POSPaymentModelTests {
         let sut = makePaymentController(cardPresentPaymentService: service)
 
         // When - first connect call completes
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = {
-                continuation.resume()
-                service.onConnectReaderCalled = nil
-            }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             sut.connectCardReader()
         }
         #expect(service.connectReaderCallCount == 1)
 
         // When - second connect call after first completed
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = {
-                continuation.resume()
-                service.onConnectReaderCalled = nil
-            }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             sut.connectCardReader()
         }
 
@@ -1092,16 +1078,33 @@ struct POSPaymentModelTests {
         let service = MockCardPresentPaymentService()
         let sut = makePaymentController(cardPresentPaymentService: service)
 
-        // When/Then
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        // When/Then: while the first call's mock body is running, a second
+        // call hits the SUT's task guard and is skipped.
+        await fireOnce { fire in
             service.onConnectReaderCalled = {
                 sut.connectCardReader()
                 #expect(service.connectReaderCallCount == 1)
-                continuation.resume()
-                service.onConnectReaderCalled = nil
+                fire()
             }
             sut.connectCardReader()
         }
+
+        // After the first connect propagates to cardReaderConnectionStatus,
+        // verify no observer reactions caused a spurious re-call.
+        let reader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.85)
+        await fireOnce { fire in
+            withObservationTracking {
+                _ = sut.cardReaderConnectionStatus
+            } onChange: {
+                Task { @MainActor in
+                    if case .connected = sut.cardReaderConnectionStatus {
+                        fire()
+                    }
+                }
+            }
+            service.connectedReader = reader
+        }
+        #expect(service.connectReaderCallCount == 1)
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -1084,44 +1084,23 @@ struct POSPaymentModelTests {
         #expect(service.connectReaderCallCount == 2)
     }
 
-    @Test("connectCardReader blocks second call while first is suspended in the service")
+    @Test("connectCardReader skips a second call while the first is in flight")
     @MainActor
-    func test_connectCardReader_when_second_call_while_first_suspended_then_blocks_second() async {
+    func test_connectCardReader_when_called_again_while_in_flight_then_skips_second() async {
         // Given
         let service = MockCardPresentPaymentService()
-        service.shouldSuspendConnectReader = true
         let sut = makePaymentController(cardPresentPaymentService: service)
 
-        // When - first call suspends inside connectReader
-        await withCheckedContinuation { continuation in
+        // When/Then
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             service.onConnectReaderCalled = {
+                sut.connectCardReader()
+                #expect(service.connectReaderCallCount == 1)
                 continuation.resume()
                 service.onConnectReaderCalled = nil
             }
             sut.connectCardReader()
         }
-        #expect(service.connectReaderCallCount == 1)
-
-        sut.connectCardReader()
-        #expect(service.connectReaderCallCount == 1)
-
-        let reader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.85)
-        await withCheckedContinuation { continuation in
-            withObservationTracking {
-                _ = sut.cardReaderConnectionStatus
-            } onChange: {
-                Task { @MainActor in
-                    if case .connected = sut.cardReaderConnectionStatus {
-                        continuation.resume()
-                    }
-                }
-            }
-            service.resumeConnectReader(with: .connected(reader))
-            service.connectedReader = reader
-        }
-
-        // Then
-        #expect(service.connectReaderCallCount == 1)
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -6,6 +6,7 @@ import struct Yosemite.Address
 import protocol Yosemite.PaymentCaptureCelebrationProtocol
 @testable import PointOfSale
 
+@Suite(.timeLimit(.minutes(5)))
 struct POSPaymentModelTests {
 
     // MARK: - Init

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -60,51 +60,20 @@ struct PointOfSaleOrderControllerTests {
                                              receiptSender: mockReceiptSender,
                                              currencySettingsProvider: MockCurrencySettingsProvider(),
                                              analytics: MockPOSAnalytics())
+        mockOrderService.orderToReturn = MockOrders().sampleOrder()
 
-        // Block the sync so it doesn't complete until we manually resume it
-        mockOrderService.blockNextSync()
-
-        // Start the first sync in a detached task so it runs concurrently
-        let firstSyncTask = Task.detached {
-            await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 1)]), retryHandler: {})
+        mockOrderService.onSyncOrderCalled = { [weak sut] in
+            #expect(sut?.orderState.isSyncing == true)
+            await sut?.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 2),
+                                                              makeItem(quantity: 5)]),
+                                 retryHandler: {})
         }
 
-        // Wait for the order state to actually become syncing
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            @Sendable func observeOrderState() {
-                withObservationTracking {
-                    _ = sut.orderState
-                } onChange: {
-                    Task { @MainActor in
-                        if sut.orderState.isSyncing {
-                            continuation.resume()
-                        } else {
-                            observeOrderState()
-                        }
-                    }
-                }
-            }
-            observeOrderState()
-        }
+        // When
+        _ = await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 1)]), retryHandler: {})
 
-        // Verify the state is actually syncing
-        #expect(sut.orderState.isSyncing == true)
-        #expect(mockOrderService.syncOrderWasCalled == true)
-
-        // Reset the flag after confirming the sync has started
-        mockOrderService.syncOrderWasCalled = false
-
-        // When - try to sync while the first sync is still in progress
-        await sut.syncOrder(for: Cart(purchasableItems: [makeItem(quantity: 2),
-                                                          makeItem(quantity: 5)]),
-                            retryHandler: {})
-
-        // Then - the second sync should have been skipped
-        #expect(mockOrderService.syncOrderWasCalled == false)
-
-        // Cleanup - allow the first sync to complete
-        mockOrderService.resumeBlockedSync()
-        _ = await firstSyncTask.result
+        // Then
+        #expect(mockOrderService.syncOrderCallCount == 1)
     }
 
     @Test func syncOrder_with_no_previous_order_calls_orderService() async throws {

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -15,6 +15,7 @@ import enum Networking.DotcomError
 import enum Networking.NetworkError
 import struct Yosemite.POSItemIdentifier
 
+@Suite(.timeLimit(.minutes(5)))
 struct PointOfSaleOrderControllerTests {
     let mockOrderService = MockPOSOrderService()
     let mockReceiptSender = MockPOSReceiptSender()

--- a/Modules/Tests/PointOfSaleTests/Helpers/FireOnce.swift
+++ b/Modules/Tests/PointOfSaleTests/Helpers/FireOnce.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Awaits a single mock-callback fire and ignores any duplicates.
+///
+/// Pass `fire` to whatever hook the test installs; the first call resumes the
+/// underlying continuation, subsequent calls are no-ops. The dedupe is
+/// thread-safe so the hook can be invoked from any actor.
+///
+/// ```swift
+/// await fireOnce { fire in
+///     coordinator.onPerformIncrementalSyncCalled = { fire() }
+///     Task { @MainActor in await sut.checkOut() }
+/// }
+/// ```
+@MainActor
+func fireOnce(_ body: (_ fire: @escaping @Sendable () -> Void) -> Void) async {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let lock = NSLock()
+        nonisolated(unsafe) var fired = false
+        body {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !fired else { return }
+            fired = true
+            continuation.resume()
+        }
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
@@ -29,8 +29,6 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
 
     var cancelPaymentCalled = false
     var connectReaderCallCount = 0
-    private var connectReaderContinuation: CheckedContinuation<CardPresentPaymentReaderConnectionResult, Error>?
-    var shouldSuspendConnectReader = false
     var connectReaderResult: CardPresentPaymentReaderConnectionResult = .connected(
         CardPresentPaymentCardReader(name: "Test reader", batteryLevel: 0.85)
     )
@@ -51,22 +49,7 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
     func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult {
         connectReaderCallCount += 1
         onConnectReaderCalled?()
-        if shouldSuspendConnectReader {
-            return try await withCheckedThrowingContinuation { continuation in
-                connectReaderContinuation = continuation
-            }
-        }
         return connectReaderResult
-    }
-
-    func resumeConnectReader(with result: CardPresentPaymentReaderConnectionResult) {
-        connectReaderContinuation?.resume(returning: result)
-        connectReaderContinuation = nil
-    }
-
-    func failConnectReader(with error: Error) {
-        connectReaderContinuation?.resume(throwing: error)
-        connectReaderContinuation = nil
     }
 
     func disconnectReader() async {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderService.swift
@@ -10,37 +10,22 @@ class MockPOSOrderService: POSOrderServiceProtocol {
     var resultToReturn: Result<Void, Error> = .success(())
 
     var syncOrderWasCalled = false
+    var syncOrderCallCount = 0
     var updateOrderWasCalled = false
     var spySyncOrderCurrency: CurrencyCode?
     var spyCashPaymentChangeDueAmount: String?
 
-    // For controlling sync timing in tests
-    private var syncContinuation: CheckedContinuation<Void, Never>?
-    private var shouldBlockSync = false
-
-    /// Blocks the next sync operation until `resumeBlockedSync()` is called
-    func blockNextSync() {
-        shouldBlockSync = true
-    }
-
-    /// Resumes a blocked sync operation
-    func resumeBlockedSync() {
-        syncContinuation?.resume()
-        syncContinuation = nil
-        shouldBlockSync = false
-    }
+    var onSyncOrderCalled: (@MainActor () async -> Void)?
 
     func syncOrder(cart: Yosemite.POSCart,
                    currency: CurrencyCode) async throws -> Yosemite.Order {
         syncOrderWasCalled = true
+        syncOrderCallCount += 1
         spySyncOrderCurrency = currency
 
-        if shouldBlockSync {
-            shouldBlockSync = false // Only block the first call
-            await withCheckedContinuation { continuation in
-                syncContinuation = continuation
-            }
-        } else if simulateSyncing {
+        await onSyncOrderCalled?()
+
+        if simulateSyncing {
             try await Task.sleep(nanoseconds: UInt64(1 * Double(NSEC_PER_SEC)))
         }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSRefundsService.swift
@@ -5,33 +5,8 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
     var providePointOfSaleRefundsResultToReturn: Yosemite.POSRefundsResult = POSRefundsResult(refunds: [], isFullyRefunded: false, supportsAutomaticRefund: true)
     var errorToThrow: Error?
 
-    private var continuation: CheckedContinuation<Yosemite.POSOrder, Never>?
-
-    var shouldSuspendProvidePointOfSaleRefunds = false
-    private var refundsContinuation: CheckedContinuation<Void, Never>?
-
-    func awaitProvidePointOfSaleRefundsCall() async -> Yosemite.POSOrder {
-        await withCheckedContinuation { cont in
-            continuation = cont
-        }
-    }
-
-    func resumeProvidePointOfSaleRefunds() {
-        refundsContinuation?.resume()
-        refundsContinuation = nil
-    }
-
     func providePointOfSaleRefunds(for order: Yosemite.POSOrder) async throws -> Yosemite.POSRefundsResult {
         spyProvidePointOfSaleRefundsOrder = order
-        continuation?.resume(returning: order)
-        continuation = nil
-
-        if shouldSuspendProvidePointOfSaleRefunds {
-            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                refundsContinuation = cont
-            }
-        }
-
         if let error = errorToThrow { throw error }
         return providePointOfSaleRefundsResultToReturn
     }
@@ -48,32 +23,15 @@ final class MockPOSRefundsService: POSRefundsServiceProtocol {
         return calculator.calculateRefundAmounts(for: items, numberOfDecimals: 2)
     }
 
+    // MARK: - loadOrderRefunds
+
     var loadOrderRefundsResultToReturn: [POSOrderRefund] = []
     var loadOrderRefundsErrorToThrow: Error?
-    var shouldSuspendLoadOrderRefunds = false
-    private var loadOrderRefundsContinuation: CheckedContinuation<Void, Never>?
-    private var loadOrderRefundsCallContinuation: CheckedContinuation<Void, Never>?
+    var onLoadOrderRefundsCalled: (@MainActor (Yosemite.POSOrder) -> Void)?
 
-    func awaitLoadOrderRefundsCall() async {
-        await withCheckedContinuation { continuation in
-            loadOrderRefundsCallContinuation = continuation
-        }
-    }
-
-    func resumeLoadOrderRefunds() {
-        loadOrderRefundsContinuation?.resume()
-        loadOrderRefundsContinuation = nil
-    }
-
+    @MainActor
     func loadOrderRefunds(for order: Yosemite.POSOrder) async throws -> [POSOrderRefund] {
-        loadOrderRefundsCallContinuation?.resume()
-        loadOrderRefundsCallContinuation = nil
-
-        if shouldSuspendLoadOrderRefunds {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                loadOrderRefundsContinuation = continuation
-            }
-        }
+        onLoadOrderRefundsCalled?(order)
         if let error = loadOrderRefundsErrorToThrow {
             throw error
         }

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -655,11 +655,10 @@ struct PointOfSaleAggregateModelTests {
             #expect(cardPresentPaymentService.collectPaymentWasCalled == false)
 
             await withCheckedContinuation { continuation in
-                var resumed = false
+                let once = OnceFlag()
                 cardPresentPaymentService.onCollectPaymentCalled = {
-                    if !resumed {
+                    if once.tryFire() {
                         continuation.resume()
-                        resumed = true
                     }
                 }
 
@@ -723,11 +722,10 @@ struct PointOfSaleAggregateModelTests {
             cardPresentPaymentService.collectPaymentWasCalled = false
 
             await withCheckedContinuation { continuation in
-                var resumed = false
+                let once = OnceFlag()
                 cardPresentPaymentService.onCollectPaymentCalled = {
-                    if !resumed {
+                    if once.tryFire() {
                         continuation.resume()
-                        resumed = true
                     }
                 }
 
@@ -884,15 +882,14 @@ struct PointOfSaleAggregateModelTests {
 
             // When card payment succeeds
             await withCheckedContinuation { continuation in
-                var resumed = false
+                let once = OnceFlag()
                 coordinator.onPerformIncrementalSyncCalled = {
-                    if !resumed {
+                    if once.tryFire() {
                         continuation.resume()
-                        resumed = true
                     }
                 }
 
-                Task {
+                Task { @MainActor in
                     await sut.checkOut()
                 }
             }
@@ -905,15 +902,14 @@ struct PointOfSaleAggregateModelTests {
 
             // When cash payment succeeds
             await withCheckedContinuation { continuation in
-                var resumed = false
+                let once = OnceFlag()
                 coordinator.onPerformIncrementalSyncCalled = {
-                    if !resumed {
+                    if once.tryFire() {
                         continuation.resume()
-                        resumed = true
                     }
                 }
 
-                Task {
+                Task { @MainActor in
                     try await sut.collectCashPayment(changeDueAmount: "0.00")
                 }
             }
@@ -1123,15 +1119,15 @@ struct PointOfSaleAggregateModelTests {
 
             // Then: set the callback before checkOut so it fires when the fire-and-forget Task runs
             await withCheckedContinuation { continuation in
-                var resumed = false
+                let once = OnceFlag()
                 catalogSyncCoordinator.onPerformIncrementalSyncCalled = {
-                    guard !resumed else { return }
-                    resumed = true
-                    continuation.resume()
+                    if once.tryFire() {
+                        continuation.resume()
+                    }
                 }
 
                 // When
-                Task { await sut.checkOut() }
+                Task { @MainActor in await sut.checkOut() }
             }
             #expect(catalogSyncCoordinator.performIncrementalSyncInvocationCount >= 1)
             #expect(catalogSyncCoordinator.performIncrementalSyncSiteID == siteID)
@@ -1277,4 +1273,17 @@ private func makePointOfSaleAggregateModel(
         catalogSyncCoordinator: catalogSyncCoordinator,
         sunsetWarningChecker: sunsetWarningChecker
     )
+}
+
+private final class OnceFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fired = false
+
+    func tryFire() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !fired else { return false }
+        fired = true
+        return true
+    }
 }

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -15,6 +15,7 @@ import enum Yosemite.POSItemType
 import Combine
 
 @MainActor
+@Suite(.timeLimit(.minutes(5)))
 struct PointOfSaleAggregateModelTests {
     @MainActor struct OrderStageTests {
         @Test func inits_with_building_order_stage() async throws {

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -654,13 +654,8 @@ struct PointOfSaleAggregateModelTests {
             await sut.checkOut()
             #expect(cardPresentPaymentService.collectPaymentWasCalled == false)
 
-            await withCheckedContinuation { continuation in
-                let once = OnceFlag()
-                cardPresentPaymentService.onCollectPaymentCalled = {
-                    if once.tryFire() {
-                        continuation.resume()
-                    }
-                }
+            await fireOnce { fire in
+                cardPresentPaymentService.onCollectPaymentCalled = { fire() }
 
                 // When: the card reader connects
                 cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
@@ -721,13 +716,8 @@ struct PointOfSaleAggregateModelTests {
             await cardPresentPaymentService.disconnectReader()
             cardPresentPaymentService.collectPaymentWasCalled = false
 
-            await withCheckedContinuation { continuation in
-                let once = OnceFlag()
-                cardPresentPaymentService.onCollectPaymentCalled = {
-                    if once.tryFire() {
-                        continuation.resume()
-                    }
-                }
+            await fireOnce { fire in
+                cardPresentPaymentService.onCollectPaymentCalled = { fire() }
 
                 // When: the card reader is reconnected
                 cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
@@ -881,14 +871,8 @@ struct PointOfSaleAggregateModelTests {
             orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$1.00", orderTotalDecimal: 1)
 
             // When card payment succeeds
-            await withCheckedContinuation { continuation in
-                let once = OnceFlag()
-                coordinator.onPerformIncrementalSyncCalled = {
-                    if once.tryFire() {
-                        continuation.resume()
-                    }
-                }
-
+            await fireOnce { fire in
+                coordinator.onPerformIncrementalSyncCalled = { fire() }
                 Task { @MainActor in
                     await sut.checkOut()
                 }
@@ -901,14 +885,8 @@ struct PointOfSaleAggregateModelTests {
             coordinator.performIncrementalSyncSiteID = 0
 
             // When cash payment succeeds
-            await withCheckedContinuation { continuation in
-                let once = OnceFlag()
-                coordinator.onPerformIncrementalSyncCalled = {
-                    if once.tryFire() {
-                        continuation.resume()
-                    }
-                }
-
+            await fireOnce { fire in
+                coordinator.onPerformIncrementalSyncCalled = { fire() }
                 Task { @MainActor in
                     try await sut.collectCashPayment(changeDueAmount: "0.00")
                 }
@@ -1118,13 +1096,8 @@ struct PointOfSaleAggregateModelTests {
             sut.addToCart(makePurchasableItem(price: "10.00"))
 
             // Then: set the callback before checkOut so it fires when the fire-and-forget Task runs
-            await withCheckedContinuation { continuation in
-                let once = OnceFlag()
-                catalogSyncCoordinator.onPerformIncrementalSyncCalled = {
-                    if once.tryFire() {
-                        continuation.resume()
-                    }
-                }
+            await fireOnce { fire in
+                catalogSyncCoordinator.onPerformIncrementalSyncCalled = { fire() }
 
                 // When
                 Task { @MainActor in await sut.checkOut() }
@@ -1273,17 +1246,4 @@ private func makePointOfSaleAggregateModel(
         catalogSyncCoordinator: catalogSyncCoordinator,
         sunsetWarningChecker: sunsetWarningChecker
     )
-}
-
-private final class OnceFlag: @unchecked Sendable {
-    private let lock = NSLock()
-    private var fired = false
-
-    func tryFire() -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        guard !fired else { return false }
-        fired = true
-        return true
-    }
 }


### PR DESCRIPTION
## What broke

Build [#36375](https://buildkite.com/automattic/woocommerce-ios/builds/36375) (microscope unit tests) hung for the full ~3-hour CI timeout on the POS suite. PR #16980 had previously fixed one instance of the same shape by pinning a mock to `@MainActor`. This PR fixes the underlying class of bugs: the test infrastructure had several patterns that were timing-sensitive and only flaked under heavy parallel CI load.

## Problems found and how they're fixed

| Problem | Where | Fix |
|---|---|---|
| Mock parks on one continuation while signalling readiness through another. The signal can fire before the suspension continuation is stored, so the mock waits on a continuation no one resumes → permanent hang. | `MockPOSRefundsService`, `MockCardPresentPaymentService`, `MockPOSOrderService` | Drop the suspending pattern. The mock fires a synchronous (or async) callback hook from inside its body. The test does its in-flight work inside the hook, where the SUT's await is still pending. No second continuation, no race. |
| Tests dedupe multi-fire callbacks with `var resumed = false` captured by a closure. The closure runs on the cooperative pool while the test runs on main, so the read-then-write is not atomic — duplicate fires can double-resume the continuation or miss the signal entirely. | 5 sites in `PointOfSaleAggregateModelTests`, several more in `POSPaymentModelTests` | New `fireOnce` test helper wraps `withCheckedContinuation` with a thread-safe single-shot resume. Call sites are now one-liners. |
| `Task { await sut.checkOut() }` ran on the unisolated cooperative pool. Under contention the Task could be deferred long enough to exceed any timeout. | `PointOfSaleAggregateModelTests` | Wrap with `Task { @MainActor in await sut.checkOut() }` so the work runs on the same actor as the test. |
| No upper bound on test runtime, so a deadlocked continuation consumed the full job-level timeout (~3h). | All POS suites with async tests | `@Suite(.timeLimit(.minutes(5)))` on the four affected suites. Future regressions in this category fail in minutes, not hours. |
| `Modules/Tests/CLAUDE.md` recommended the suspending-mock pattern. | `Modules/Tests/CLAUDE.md` | Replaced with guidance on the callback-hook pattern; called the suspending pattern an anti-pattern with reference to this PR. |

## What `fireOnce` looks like

```swift
await fireOnce { fire in
    coordinator.onPerformIncrementalSyncCalled = { fire() }
    Task { @MainActor in await sut.checkOut() }
}
```

The closure receives a `fire` you pass to whatever hook the test installs. The first call resumes; later calls are silently dropped. Thread-safe.

## Audit

Every mock in `Modules/Tests/PointOfSaleTests/Mocks/` was reviewed for the suspending-mock anti-pattern; all three sites that had it are addressed.

## Test plan

- [x] `POSOrderListControllerTests` × 1000 iterations — no failures.
- [x] `POSPaymentModelTests` × 500 iterations — no failures.
- [x] `PointOfSaleOrderControllerTests` × 500 iterations — no failures.
- [x] `PointOfSaleAggregateModelTests` × 500 iterations — no failures.
- [x] `POSPaymentModelTests + PointOfSaleAggregateModelTests` × 500 iterations after `fireOnce` rewrite — no failures.
- [x] Repro the original hang on trunk: 9th iteration of `POSOrderListControllerTests` hung indefinitely (killed at 2 min). With this PR: 1000 iterations / 70,000 tests pass in ~45 s.
- [x] SwiftLint clean.
- [ ] CI green.

## Notes

- `PointOfSaleBarcodeScannerSetupFlowManagerTests` has a separate, unrelated parallel-execution flake. Out of scope for this PR.

---
- [x] I have considered if this change warrants user-facing release notes — no, internal test infrastructure only.