### PR TITLE
[WOOMOB-2808] Add configurable store widgets feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -99,6 +99,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return false
         case .clientSideDashboardBanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .configurableStoreStatsWidgets:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ageRangeRequirementsCompliance:
             return false
         case .ciabBookingReschedule:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -207,6 +207,10 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case clientSideDashboardBanner
 
+    /// Enables configurable store stats widgets
+    ///
+    case configurableStoreStatsWidgets
+
     /// Enables age range verification features
     /// https://developer.apple.com/news/?id=2ezb6jhj
     ///

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -83,6 +83,9 @@ extension UserDefaults {
 
         /// Debug override for the minimum WooCommerce plugin version required for WPCom connection setup
         case debugMinWooVersionForSelfDrivenPushNotifications
+
+        /// Whether configurable store stats widgets are enabled
+        case configurableStoreStatsWidgetsEnabled
     }
 }
 
@@ -90,6 +93,19 @@ extension UserDefaults {
     /// User defaults instance ready to be shared between extensions of the same group.
     ///
     static let group = UserDefaults(suiteName: WooConstants.sharedUserDefaultsSuiteName)
+}
+
+extension UserDefaults {
+    /// Whether configurable store stats widgets are enabled.
+    ///
+    var configurableStoreStatsWidgetsEnabled: Bool {
+        get {
+            object(forKey: .configurableStoreStatsWidgetsEnabled) ?? false
+        }
+        set {
+            set(newValue, forKey: .configurableStoreStatsWidgetsEnabled)
+        }
+    }
 }
 
 

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -20,6 +20,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let coordinator = AppCoordinator(window: window)
         self.appCoordinator = coordinator
         coordinator.start()
+        StoreWidgetsFeatureFlagSynchronizer.sync()
 
         // Scene-scoped initializations that need UI
         setupNoticePresenter()

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -77,6 +77,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Cache onboarding state to speed IPP process, then silently connect to Tap to Pay if previously connected, to speed up IPP
         AppDelegate.shared.refreshCardPresentPaymentsOnboardingIfNeeded()
+        StoreWidgetsFeatureFlagSynchronizer.sync()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/WooCommerce/Classes/Tools/StoreWidgetsFeatureFlagSynchronizer.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgetsFeatureFlagSynchronizer.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Experiments
+import class WidgetKit.WidgetCenter
+
+enum StoreWidgetsFeatureFlagSynchronizer {
+    static func sync() {
+        guard let userDefaults = UserDefaults.group else { return }
+
+        let isEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.configurableStoreStatsWidgets)
+        let currentValue: Bool? = userDefaults.object(forKey: .configurableStoreStatsWidgetsEnabled)
+        guard currentValue != isEnabled else { return }
+
+        userDefaults.configurableStoreStatsWidgetsEnabled = isEnabled
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/OverrideFeatureFlagsView.swift
@@ -62,6 +62,7 @@ struct OverrideFeatureFlagsView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     ServiceLocator.featureFlagOverrideStore.removeAllOverrides()
+                    StoreWidgetsFeatureFlagSynchronizer.sync()
                     refreshID = UUID()
                 } label: {
                     Text("Reset All")
@@ -132,6 +133,7 @@ fileprivate struct FeatureFlagRow: View {
                     } else {
                         overrideValue = newValue
                         ServiceLocator.featureFlagOverrideStore.setOverrideValue(newValue, for: featureFlag)
+                        StoreWidgetsFeatureFlagSynchronizer.sync()
                     }
                 }
             )) { EmptyView() }
@@ -139,8 +141,9 @@ fileprivate struct FeatureFlagRow: View {
     }
 
     private func resetValue() {
-            overrideValue = nil
-            ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
+        overrideValue = nil
+        ServiceLocator.featureFlagOverrideStore.setOverrideValue(nil, for: featureFlag)
+        StoreWidgetsFeatureFlagSynchronizer.sync()
     }
 }
 


### PR DESCRIPTION
## Description
Adds a local feature flag for configurable store stats widgets and mirrors the resolved value into app-group UserDefaults so the widget extension can gate future widget registration without affecting existing widgets.

The flag is enabled by default for local developer and alpha builds, remains disabled for App Store builds, and uses the existing local override flow where available.

There are no user-facing changes in this PR. This is initial groundwork for the RSM project.

### What's added

- `FeatureFlag.configurableStoreStatsWidgets` — local feature flag for the new configurable store stats widgets.
- `UserDefaults.Key.configurableStoreStatsWidgetsEnabled` — shared app-group key that the widget extension can read synchronously.
- `UserDefaults.configurableStoreStatsWidgetsEnabled` — typed convenience helper for app and widget extension code.
- `StoreWidgetsFeatureFlagSynchronizer` — app-side synchronizer that resolves the effective local feature flag value, mirrors it into app-group defaults, and reloads WidgetKit timelines only when the stored value changes.

### What's wired

- `DefaultFeatureFlagService` enables the flag by default for local developer and alpha builds. App Store builds remain disabled and continue to avoid local overrides through the existing `ServiceLocator` setup.
- `SceneDelegate.sceneWillEnterForeground(_:)` refreshes the mirrored app-group value when the app returns to the foreground.
- `OverrideFeatureFlagsView` refreshes the mirrored app-group value immediately after setting, resetting, or clearing local feature flag overrides.

### What's unchanged

- Existing store widgets remain registered unconditionally. This PR only prepares the boolean gate for future configurable widget registration.
- No new widget UI or user-facing widget behavior is introduced in this PR.

### Options Considered

- Remote feature flag: this was not a good fit for the widget registration gate because WidgetKit needs the extension to decide which widgets are available from local state. A remote flag would require async/network-backed app state and could leave the app and widget extension out of sync, especially before the app has launched or refreshed remote values.
- Custom build flag or widget-only flag: this would keep the gate local, but it would add separate build configuration plumbing and would not reuse the existing debug-panel override flow. It also increases the chance that the app-side configuration UI and widget extension registration drift from each other.
- Local feature flag mirrored to app-group defaults: this keeps the source of truth in the existing app feature flag system, supports local overrides where they already exist, keeps App Store disabled through the existing non-overridable setup, and gives the widget extension a simple synchronous boolean to read.

Part of: WOOMOB-2808

## Test Steps
This is a no-user-visible-change refactor. Sanity flow:

1. Launch a local developer or alpha build.
2. Open the feature flag override panel.
3. Verify `configurableStoreStatsWidgets` is enabled by default.
4. Toggle or reset the override.
5. Verify `UserDefaults.group?.configurableStoreStatsWidgetsEnabled` reflects the effective value.
6. Verify existing widgets remain available.

## Screenshots
<img width="589" height="1280" alt="Simulator Screenshot - 26 2 iPhone 17 Pro - 2026-04-27 at 18 07 33 Large" src="https://github.com/user-attachments/assets/c2b40238-bd33-43dd-b847-0a13c6215678" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.