### PR TITLE
WOOMOB-2927: Performance card order type bottom sheet

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -147,6 +147,11 @@ public enum WooAnalyticsStat: String {
     case dashboardStatsCustomRangeEditButtonTapped = "dashboard_stats_custom_range_edit_button_tapped"
     case dashboardStatsCustomRangeInteracted = "dashboard_stats_custom_range_interacted"
 
+    // MARK: Performance card order type bottom sheet
+    case dashboardMainStatsOrderTypeChevronTapped = "dashboard_main_stats_order_type_chevron_tapped"
+    case dashboardMainStatsOrderTypeSelected = "dashboard_main_stats_order_type_selected"
+    case dashboardMainStatsOrderTypeUpdateFailed = "dashboard_main_stats_order_type_update_failed"
+
     // MARK: Dashboard Stats v3/v4 Events
     //
     case dashboardNewStatsAvailabilityBannerCancelTapped = "dashboard_new_stats_availability_banner_cancel_tapped"

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -147,10 +147,10 @@ public enum WooAnalyticsStat: String {
     case dashboardStatsCustomRangeEditButtonTapped = "dashboard_stats_custom_range_edit_button_tapped"
     case dashboardStatsCustomRangeInteracted = "dashboard_stats_custom_range_interacted"
 
-    // MARK: Performance card order type bottom sheet
-    case dashboardMainStatsOrderTypeChevronTapped = "dashboard_main_stats_order_type_chevron_tapped"
-    case dashboardMainStatsOrderTypeSelected = "dashboard_main_stats_order_type_selected"
-    case dashboardMainStatsOrderTypeUpdateFailed = "dashboard_main_stats_order_type_update_failed"
+    // MARK: Performance card order date type bottom sheet
+    case dashboardStatsOrderDateTypeSelectorTapped = "dashboard_stats_order_date_type_selector_tapped"
+    case dashboardStatsOrderDateTypeSelected = "dashboard_stats_order_date_type_selected"
+    case dashboardStatsOrderDateTypeUpdateFailed = "dashboard_stats_order_date_type_update_failed"
 
     // MARK: Dashboard Stats v3/v4 Events
     //

--- a/Modules/Sources/Yosemite/Model/Enums/AnalyticsOrderDateType+Cache.swift
+++ b/Modules/Sources/Yosemite/Model/Enums/AnalyticsOrderDateType+Cache.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Storage
+
+public extension AnalyticsOrderDateType {
+    /// Reads the cached analytics order date type for the given site from local storage.
+    /// Returns `nil` when no value has been persisted yet for this site, or when the
+    /// stored value can't be mapped to a known case.
+    ///
+    /// `SettingStoreMethods.retrieveAnalyticsOrderDateType` and
+    /// `updateAnalyticsOrderDateType` write the value to `Storage.SiteSetting` on every
+    /// successful network call, so callers can use this helper to seed UI state
+    /// synchronously on launch and avoid a flash of the backend default while the
+    /// network round-trip is in flight.
+    static func cachedValue(siteID: Int64, storageManager: StorageManagerType) -> AnalyticsOrderDateType? {
+        guard let value = storageManager.viewStorage.loadSiteSetting(siteID: siteID, settingID: cachedSettingID)?.value else {
+            return nil
+        }
+        return AnalyticsOrderDateType(rawValue: value)
+    }
+
+    /// Mirrors `SiteSettingsRemote.Constants.analyticsOrderDateTypeSettingID`. Kept in
+    /// sync manually because the Networking constant is private to that file.
+    private static var cachedSettingID: String { "woocommerce_date_type" }
+}

--- a/Modules/Tests/YosemiteTests/Model/Enums/AnalyticsOrderDateTypeCacheTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/Enums/AnalyticsOrderDateTypeCacheTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import YosemiteTestHelpers
+@testable import Yosemite
+@testable import Networking
+
+@MainActor
+struct AnalyticsOrderDateTypeCacheTests {
+    private let siteID: Int64 = 134
+
+    @Test
+    func cachedValue_when_no_setting_persisted_then_returns_nil() {
+        // Given — empty storage.
+        let storageManager = MockStorageManager()
+
+        // When
+        let cached = AnalyticsOrderDateType.cachedValue(siteID: siteID, storageManager: storageManager)
+
+        // Then
+        #expect(cached == nil)
+    }
+
+    @Test
+    func cachedValue_when_setting_persisted_then_returns_matching_case() {
+        // Given
+        let storageManager = MockStorageManager()
+        let stored = SiteSetting.fake().copy(siteID: siteID,
+                                             settingID: "woocommerce_date_type",
+                                             value: AnalyticsOrderDateType.completed.rawValue,
+                                             settingGroupKey: "wc_admin")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: stored)
+
+        // When
+        let cached = AnalyticsOrderDateType.cachedValue(siteID: siteID, storageManager: storageManager)
+
+        // Then
+        #expect(cached == .completed)
+    }
+
+    @Test
+    func cachedValue_when_persisted_value_is_unknown_then_returns_nil() {
+        // Given — a stored setting whose raw value can't be mapped to a known case.
+        let storageManager = MockStorageManager()
+        let stored = SiteSetting.fake().copy(siteID: siteID,
+                                             settingID: "woocommerce_date_type",
+                                             value: "garbage_value",
+                                             settingGroupKey: "wc_admin")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: stored)
+
+        // When
+        let cached = AnalyticsOrderDateType.cachedValue(siteID: siteID, storageManager: storageManager)
+
+        // Then
+        #expect(cached == nil)
+    }
+
+    @Test
+    func cachedValue_when_setting_belongs_to_other_site_then_returns_nil() {
+        // Given
+        let storageManager = MockStorageManager()
+        let stored = SiteSetting.fake().copy(siteID: siteID + 1,
+                                             settingID: "woocommerce_date_type",
+                                             value: AnalyticsOrderDateType.allOrders.rawValue,
+                                             settingGroupKey: "wc_admin")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: stored)
+
+        // When
+        let cached = AnalyticsOrderDateType.cachedValue(siteID: siteID, storageManager: storageManager)
+
+        // Then
+        #expect(cached == nil)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.7
 -----
+- [*] Performance card: pick which order date type drives the totals (paid, placed, or completed) from a bottom sheet. [https://github.com/woocommerce/woocommerce-ios/pull/16988]
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
 - [*] POS: Update empty orders state copy and replace "Learn more" with "Refresh" [https://github.com/woocommerce/woocommerce-ios/pull/16961]
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -1,5 +1,6 @@
 import Foundation
 import enum Yosemite.StatsTimeRangeV4
+import enum Yosemite.AnalyticsOrderDateType
 import struct Yosemite.Site
 
 extension WooAnalyticsEvent {
@@ -10,6 +11,7 @@ extension WooAnalyticsEvent {
             static let localTimezone = "local_timezone"
             static let storeTimezone = "store_timezone"
             static let siteConnectionType = "site_connection_type"
+            static let orderType = "order_type"
         }
 
         /// Tracked once per session when the site connection type is identified on the dashboard.
@@ -53,6 +55,41 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .dashboardStoreTimezoneDifferFromDevice,
                                      properties: [Keys.storeTimezone: storeTimezoneText,
                                                   Keys.localTimezone: localTimezoneText])
+        }
+
+        // MARK: Order type bottom sheet
+
+        /// Tracked when the merchant taps the chevron next to the order type label on the Performance card.
+        static func performanceCardOrderTypeChevronTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardMainStatsOrderTypeChevronTapped, properties: [:])
+        }
+
+        /// Tracked when the merchant selects an order type from the bottom sheet.
+        /// - Parameter orderType: The selected order type.
+        static func performanceCardOrderTypeSelected(_ orderType: AnalyticsOrderDateType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardMainStatsOrderTypeSelected,
+                              properties: [Keys.orderType: orderType.analyticsValue])
+        }
+
+        /// Tracked when updating the order type setting fails.
+        /// - Parameter error: The error reported by the data layer.
+        static func performanceCardOrderTypeUpdateFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardMainStatsOrderTypeUpdateFailed,
+                              properties: [:],
+                              error: error)
+        }
+    }
+}
+
+private extension AnalyticsOrderDateType {
+    var analyticsValue: String {
+        switch self {
+        case .paid:
+            return "paid"
+        case .allOrders:
+            return "all_orders"
+        case .completed:
+            return "completed"
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -11,8 +11,14 @@ extension WooAnalyticsEvent {
             static let localTimezone = "local_timezone"
             static let storeTimezone = "store_timezone"
             static let siteConnectionType = "site_connection_type"
-            static let orderType = "order_type"
+            static let type = "type"
+            static let option = "option"
         }
+
+        /// Shared `type` value for all stats card events. Mirrors the Android
+        /// `trackEventForStatsCard` helper so the iOS and Android pipelines emit
+        /// the same `type` discriminator for dashboard stats events.
+        private static let statsCardType = "dashboard_stats"
 
         /// Tracked once per session when the site connection type is identified on the dashboard.
         /// - Parameter siteConnectionType: the type of connection for the site.
@@ -57,39 +63,30 @@ extension WooAnalyticsEvent {
                                                   Keys.localTimezone: localTimezoneText])
         }
 
-        // MARK: Order type bottom sheet
+        // MARK: Order date type bottom sheet
 
-        /// Tracked when the merchant taps the chevron next to the order type label on the Performance card.
-        static func performanceCardOrderTypeChevronTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .dashboardMainStatsOrderTypeChevronTapped, properties: [:])
+        /// Tracked when the merchant taps the order date type label / selector on the Performance card.
+        static func performanceCardOrderDateTypeSelectorTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsOrderDateTypeSelectorTapped,
+                              properties: [Keys.type: statsCardType])
         }
 
-        /// Tracked when the merchant selects an order type from the bottom sheet.
-        /// - Parameter orderType: The selected order type.
-        static func performanceCardOrderTypeSelected(_ orderType: AnalyticsOrderDateType) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .dashboardMainStatsOrderTypeSelected,
-                              properties: [Keys.orderType: orderType.analyticsValue])
+        /// Tracked when the merchant picks an order date type and the API update succeeds.
+        /// Only fire on successful save — Android emits this event on success only.
+        /// - Parameter orderType: The newly applied order date type.
+        static func performanceCardOrderDateTypeSelected(_ orderType: AnalyticsOrderDateType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsOrderDateTypeSelected,
+                              properties: [Keys.type: statsCardType,
+                                           Keys.option: orderType.rawValue])
         }
 
-        /// Tracked when updating the order type setting fails.
+        /// Tracked when updating the order date type setting fails. iOS-only: not part of the
+        /// shared cross-platform plan, kept as a diagnostic counterpart to the success event.
         /// - Parameter error: The error reported by the data layer.
-        static func performanceCardOrderTypeUpdateFailed(error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .dashboardMainStatsOrderTypeUpdateFailed,
-                              properties: [:],
+        static func performanceCardOrderDateTypeUpdateFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsOrderDateTypeUpdateFailed,
+                              properties: [Keys.type: statsCardType],
                               error: error)
-        }
-    }
-}
-
-private extension AnalyticsOrderDateType {
-    var analyticsValue: String {
-        switch self {
-        case .paid:
-            return "paid"
-        case .allOrders:
-            return "all_orders"
-        case .completed:
-            return "completed"
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+import enum Yosemite.AnalyticsOrderDateType
+
+/// Bottom sheet that lets the merchant choose which order date type the Performance card uses.
+/// Backed by the `woocommerce_date_type` site setting.
+struct PerformanceCardOrderTypeBottomSheet: View {
+    @ObservedObject var viewModel: StorePerformanceViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// The order type whose update is currently in flight, if any.
+    /// Used to render an inline progress indicator next to the row being saved
+    /// and to disable other rows while a save is in progress.
+    @State private var updatingType: AnalyticsOrderDateType?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text(Localization.title)
+                    .font(.title3.weight(.semibold))
+                    .padding(.top, Layout.titleTopPadding)
+
+                Text(Localization.description)
+                    .font(.body.weight(.regular))
+                    .padding(.top, Layout.titleToDescriptionSpacing)
+
+                VStack(alignment: .leading, spacing: Layout.rowSpacing) {
+                    ForEach(AnalyticsOrderDateType.allCases, id: \.rawValue) { type in
+                        Button {
+                            handleSelection(of: type)
+                        } label: {
+                            row(for: type)
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(updatingType != nil)
+                        .accessibilityIdentifier("performance-order-type-\(type.rawValue)")
+                    }
+                }
+                .padding(.top, Layout.descriptionToOptionsSpacing)
+
+                Text(Localization.footer)
+                    .font(.footnote.weight(.regular))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, Layout.optionsToFooterSpacing)
+
+                if viewModel.orderTypeUpdateError != nil {
+                    HStack(spacing: Layout.errorSpacing) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundStyle(Color(.error))
+                        Text(Localization.updateError)
+                            .footnoteStyle(isError: true)
+                    }
+                    .padding(.top, Layout.errorTopSpacing)
+                }
+            }
+            .padding(.horizontal, Layout.horizontalPadding)
+            .padding(.bottom, Layout.bottomPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    private func handleSelection(of type: AnalyticsOrderDateType) {
+        // Tapping the currently-selected row just dismisses; nothing to save.
+        if viewModel.orderType == type {
+            dismiss()
+            return
+        }
+        Task { @MainActor in
+            updatingType = type
+            await viewModel.didSelectOrderType(type)
+            updatingType = nil
+            if viewModel.orderTypeUpdateError == nil {
+                dismiss()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(for type: AnalyticsOrderDateType) -> some View {
+        let isSelected = viewModel.orderType == type
+        let isUpdating = updatingType == type
+        HStack(alignment: .top, spacing: Layout.rowCheckmarkSpacing) {
+            VStack(alignment: .leading, spacing: Layout.rowTitleSubtitleSpacing) {
+                Text(type.localizedTitle)
+                    .font(.body.weight(.regular))
+                    .foregroundStyle(.primary)
+                Text(type.localizedDescription)
+                    .font(.subheadline.weight(.regular))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            trailingAccessory(isSelected: isSelected, isUpdating: isUpdating)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func trailingAccessory(isSelected: Bool, isUpdating: Bool) -> some View {
+        if isUpdating {
+            ProgressView()
+                .progressViewStyle(.circular)
+        } else if isSelected {
+            Image(uiImage: .checkmarkStyledImage)
+        }
+    }
+}
+
+extension AnalyticsOrderDateType {
+    /// User-facing title for the Performance card order label and bottom sheet rows.
+    var localizedTitle: String {
+        switch self {
+        case .paid:
+            return PerformanceCardOrderTypeBottomSheet.Localization.paidTitle
+        case .allOrders:
+            return PerformanceCardOrderTypeBottomSheet.Localization.placedTitle
+        case .completed:
+            return PerformanceCardOrderTypeBottomSheet.Localization.completedTitle
+        }
+    }
+
+    /// Short description shown beneath each option in the bottom sheet.
+    var localizedDescription: String {
+        switch self {
+        case .paid:
+            return PerformanceCardOrderTypeBottomSheet.Localization.paidDescription
+        case .allOrders:
+            return PerformanceCardOrderTypeBottomSheet.Localization.placedDescription
+        case .completed:
+            return PerformanceCardOrderTypeBottomSheet.Localization.completedDescription
+        }
+    }
+}
+
+extension PerformanceCardOrderTypeBottomSheet {
+    enum Layout {
+        static let horizontalPadding: CGFloat = 16
+        static let titleTopPadding: CGFloat = 29
+        static let titleToDescriptionSpacing: CGFloat = 16
+        static let descriptionToOptionsSpacing: CGFloat = 32
+        static let optionsToFooterSpacing: CGFloat = 24
+        static let bottomPadding: CGFloat = 24
+        static let rowSpacing: CGFloat = 20
+        static let rowTitleSubtitleSpacing: CGFloat = 3
+        static let rowCheckmarkSpacing: CGFloat = 12
+        static let errorSpacing: CGFloat = 8
+        static let errorTopSpacing: CGFloat = 16
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.title.v2",
+            value: "Order date type",
+            comment: "Title of the bottom sheet that lets the merchant choose which order date type to include in dashboard analytics."
+        )
+        static let description = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.description.v2",
+            value: "Choose which orders to include in your performance metrics for the selected time range.",
+            comment: "Description shown below the title of the order type bottom sheet on the dashboard Performance card."
+        )
+        static let footer = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.footer",
+            value: "This is a store-wide setting, which also controls the “Date type” option in WooCommerce admin analytics settings.",
+            comment: "Clarification text shown below the order type options on the dashboard Performance card bottom sheet."
+        )
+        static let updateError = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.updateError",
+            value: "Couldn't update the order type. Please try again.",
+            comment: "Inline error shown when saving the analytics order type setting fails."
+        )
+        static let paidTitle = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.paidTitle",
+            value: "Paid orders",
+            comment: "Order type option that counts orders by the date they were paid."
+        )
+        static let paidDescription = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.paidDescription.v2",
+            value: "Count orders on the date the order was paid.",
+            comment: "Description of the paid orders option in the dashboard Performance card bottom sheet."
+        )
+        static let placedTitle = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.placedTitle",
+            value: "Placed orders",
+            comment: "Order type option that counts orders by the date they were placed (created)."
+        )
+        static let placedDescription = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.placedDescription",
+            value: "Count orders on the date they were placed or created.",
+            comment: "Description of the placed orders option in the dashboard Performance card bottom sheet."
+        )
+        static let completedTitle = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.completedTitle",
+            value: "Completed orders",
+            comment: "Order type option that counts orders by the date they were marked as completed."
+        )
+        static let completedDescription = NSLocalizedString(
+            "performanceCardOrderTypeBottomSheet.completedDescription.v2",
+            value: "Count orders on the date they were marked as completed.",
+            comment: "Description of the completed orders option in the dashboard Performance card bottom sheet."
+        )
+    }
+}
+
+#Preview("Default") {
+    Color.gray
+        .sheet(isPresented: .constant(true)) {
+            PerformanceCardOrderTypeBottomSheet(
+                viewModel: StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init())
+            )
+        }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
@@ -7,50 +7,12 @@ struct PerformanceCardOrderTypeBottomSheet: View {
     @ObservedObject var viewModel: StorePerformanceViewModel
     @Environment(\.dismiss) private var dismiss
 
-    /// The order type whose update is currently in flight, if any.
-    /// Used to render an inline progress indicator next to the row being saved
-    /// and to disable other rows while a save is in progress.
-    @State private var updatingType: AnalyticsOrderDateType?
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
-                Text(Localization.title)
-                    .font(.title3.weight(.semibold))
-                    .padding(.top, Layout.titleTopPadding)
-
-                Text(Localization.description)
-                    .font(.body.weight(.regular))
-                    .padding(.top, Layout.titleToDescriptionSpacing)
-
-                VStack(alignment: .leading, spacing: Layout.rowSpacing) {
-                    ForEach(AnalyticsOrderDateType.allCases, id: \.rawValue) { type in
-                        Button {
-                            handleSelection(of: type)
-                        } label: {
-                            row(for: type)
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(updatingType != nil)
-                        .accessibilityIdentifier("performance-order-type-\(type.rawValue)")
-                    }
-                }
-                .padding(.top, Layout.descriptionToOptionsSpacing)
-
-                if viewModel.orderTypeUpdateError != nil {
-                    HStack(spacing: Layout.errorSpacing) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .foregroundStyle(Color(.error))
-                        Text(Localization.updateError)
-                            .footnoteStyle(isError: true)
-                    }
-                    .padding(.top, Layout.errorTopSpacing)
-                }
-
-                Text(Localization.footer)
-                    .font(.footnote.weight(.regular))
-                    .foregroundStyle(.secondary)
-                    .padding(.top, Layout.optionsToFooterSpacing)
+                header
+                typeSelector
+                footer
             }
             .padding(.horizontal, Layout.horizontalPadding)
             .padding(.bottom, Layout.bottomPadding)
@@ -60,20 +22,55 @@ struct PerformanceCardOrderTypeBottomSheet: View {
         .presentationDragIndicator(.visible)
     }
 
-    private func handleSelection(of type: AnalyticsOrderDateType) {
-        // Tapping the currently-selected row just dismisses; nothing to save.
-        if viewModel.orderType == type {
-            dismiss()
-            return
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(Localization.title)
+                .font(.title3.weight(.semibold))
+                .padding(.top, Layout.titleTopPadding)
+
+            Text(Localization.description)
+                .font(.body.weight(.regular))
+                .padding(.top, Layout.titleToDescriptionSpacing)
         }
+    }
+
+    private var typeSelector: some View {
+        VStack(alignment: .leading, spacing: Layout.rowSpacing) {
+            ForEach(AnalyticsOrderDateType.allCases, id: \.rawValue) { type in
+                Button {
+                    handleSelection(of: type)
+                } label: {
+                    row(for: type)
+                }
+                .buttonStyle(.plain)
+                .disabled(viewModel.updatingOrderType != nil)
+                .accessibilityIdentifier("performance-order-type-\(type.rawValue)")
+            }
+        }
+        .padding(.top, Layout.descriptionToOptionsSpacing)
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if viewModel.orderTypeUpdateError != nil {
+            HStack(spacing: Layout.errorSpacing) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(Color(.error))
+                Text(Localization.updateError)
+                    .footnoteStyle(isError: true)
+            }
+            .padding(.top, Layout.errorTopSpacing)
+        }
+
+        Text(Localization.footer)
+            .font(.footnote.weight(.regular))
+            .foregroundStyle(.secondary)
+            .padding(.top, Layout.optionsToFooterSpacing)
+    }
+
+    private func handleSelection(of type: AnalyticsOrderDateType) {
         Task { @MainActor in
-            updatingType = type
-            await viewModel.didSelectOrderType(type)
-            updatingType = nil
-            // Dismiss only if the save actually took effect on the view model.
-            // If the save failed (or the server returned a value that doesn't match), the sheet stays
-            // open so the inline error block remains visible.
-            if viewModel.orderType == type {
+            if await viewModel.handleOrderTypeSelection(type) {
                 dismiss()
             }
         }
@@ -82,7 +79,7 @@ struct PerformanceCardOrderTypeBottomSheet: View {
     @ViewBuilder
     private func row(for type: AnalyticsOrderDateType) -> some View {
         let isSelected = viewModel.orderType == type
-        let isUpdating = updatingType == type
+        let isUpdating = viewModel.updatingOrderType == type
         HStack(alignment: .top, spacing: Layout.rowCheckmarkSpacing) {
             VStack(alignment: .leading, spacing: Layout.rowTitleSubtitleSpacing) {
                 Text(type.localizedTitle)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
@@ -70,7 +70,10 @@ struct PerformanceCardOrderTypeBottomSheet: View {
             updatingType = type
             await viewModel.didSelectOrderType(type)
             updatingType = nil
-            if viewModel.orderTypeUpdateError == nil {
+            // Dismiss only if the save actually took effect on the view model.
+            // If the save failed (or the server returned a value that doesn't match), the sheet stays
+            // open so the inline error block remains visible.
+            if viewModel.orderType == type {
                 dismiss()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardOrderTypeBottomSheet.swift
@@ -37,11 +37,6 @@ struct PerformanceCardOrderTypeBottomSheet: View {
                 }
                 .padding(.top, Layout.descriptionToOptionsSpacing)
 
-                Text(Localization.footer)
-                    .font(.footnote.weight(.regular))
-                    .foregroundStyle(.secondary)
-                    .padding(.top, Layout.optionsToFooterSpacing)
-
                 if viewModel.orderTypeUpdateError != nil {
                     HStack(spacing: Layout.errorSpacing) {
                         Image(systemName: "exclamationmark.triangle")
@@ -51,12 +46,17 @@ struct PerformanceCardOrderTypeBottomSheet: View {
                     }
                     .padding(.top, Layout.errorTopSpacing)
                 }
+
+                Text(Localization.footer)
+                    .font(.footnote.weight(.regular))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, Layout.optionsToFooterSpacing)
             }
             .padding(.horizontal, Layout.horizontalPadding)
             .padding(.bottom, Layout.bottomPadding)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.fraction(Layout.preferredDetentFraction), .large])
         .presentationDragIndicator(.visible)
     }
 
@@ -83,7 +83,7 @@ struct PerformanceCardOrderTypeBottomSheet: View {
         HStack(alignment: .top, spacing: Layout.rowCheckmarkSpacing) {
             VStack(alignment: .leading, spacing: Layout.rowTitleSubtitleSpacing) {
                 Text(type.localizedTitle)
-                    .font(.body.weight(.regular))
+                    .font(.body.weight(.medium))
                     .foregroundStyle(.primary)
                 Text(type.localizedDescription)
                     .font(.subheadline.weight(.regular))
@@ -137,8 +137,8 @@ extension PerformanceCardOrderTypeBottomSheet {
     enum Layout {
         static let horizontalPadding: CGFloat = 16
         static let titleTopPadding: CGFloat = 29
-        static let titleToDescriptionSpacing: CGFloat = 16
-        static let descriptionToOptionsSpacing: CGFloat = 32
+        static let titleToDescriptionSpacing: CGFloat = 10
+        static let descriptionToOptionsSpacing: CGFloat = 24
         static let optionsToFooterSpacing: CGFloat = 24
         static let bottomPadding: CGFloat = 24
         static let rowSpacing: CGFloat = 20
@@ -146,6 +146,9 @@ extension PerformanceCardOrderTypeBottomSheet {
         static let rowCheckmarkSpacing: CGFloat = 12
         static let errorSpacing: CGFloat = 8
         static let errorTopSpacing: CGFloat = 16
+        /// Custom default detent — a bit bigger than `.medium` so that the entire
+        /// content (including the footer text) is visible without forcing a swipe to `.large`.
+        static let preferredDetentFraction: CGFloat = 0.65
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -261,15 +261,16 @@ private extension StorePerformanceView {
                 viewModel.trackOrderTypeChevronTapped()
                 showingOrderTypePicker = true
             } label: {
-                HStack(spacing: Layout.orderTypeChevronSpacing) {
+                HStack(alignment: .center, spacing: Layout.orderTypeChevronSpacing) {
                     Text(viewModel.orderType.localizedTitle)
                         .font(Font(StyleManager.statsTitleFont))
-                        .lineLimit(1)
+                        .lineLimit(2)
                         .minimumScaleFactor(Layout.orderTypeLabelMinScale)
+                        .multilineTextAlignment(.center)
                     Image(systemName: "chevron.down")
                         .font(.caption2)
                         .foregroundStyle(Color(.textSubtle))
-                }
+                }.padding(.leading)
             }
             .buttonStyle(.plain)
             .accessibilityIdentifier("performance-order-type-button")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -7,6 +7,7 @@ import struct Yosemite.DashboardCard
 struct StorePerformanceView: View {
     @ObservedObject private var viewModel: StorePerformanceViewModel
     @State private var showingCustomRangePicker = false
+    @State private var showingOrderTypePicker = false
 
     private var statsValueColor: Color {
         guard viewModel.hasRevenue else {
@@ -83,6 +84,9 @@ struct StorePerformanceView: View {
                 viewModel.trackCustomRangeEvent(.DashboardCustomRange.customRangeConfirmed(isEditing: viewModel.timeRange.isCustomTimeRange))
                 viewModel.didSelectTimeRange(.custom(from: start, to: end))
             })
+        }
+        .sheet(isPresented: $showingOrderTypePicker) {
+            PerformanceCardOrderTypeBottomSheet(viewModel: viewModel)
         }
         .onAppear {
             viewModel.onViewAppear()
@@ -183,10 +187,8 @@ private extension StorePerformanceView {
 
                 HStack(alignment: .bottom) {
                     Group {
-                        statsItemView(title: Localization.orders,
-                                      value: viewModel.orderStatsText,
-                                      redactMode: .none)
-                        .frame(maxWidth: .infinity)
+                        ordersStatsItemView
+                            .frame(maxWidth: .infinity)
 
                         statsItemView(title: Localization.visitors,
                                       value: viewModel.visitorStatsText,
@@ -245,6 +247,36 @@ private extension StorePerformanceView {
             viewModel.trackInteraction()
             onCustomRangeRedactedViewTap()
         }
+    }
+
+    /// "Orders" stats column with the order date type selector affordance.
+    /// Tapping the title or chevron opens the order type bottom sheet.
+    var ordersStatsItemView: some View {
+        VStack(spacing: Layout.contentVerticalSpacing) {
+            Text(viewModel.orderStatsText)
+                .font(Font(StyleManager.statsFont))
+                .foregroundStyle(statsValueColor)
+            Button {
+                viewModel.trackInteraction()
+                viewModel.trackOrderTypeChevronTapped()
+                showingOrderTypePicker = true
+            } label: {
+                HStack(spacing: Layout.orderTypeChevronSpacing) {
+                    Text(viewModel.orderType.localizedTitle)
+                        .font(Font(StyleManager.statsTitleFont))
+                        .lineLimit(1)
+                        .minimumScaleFactor(Layout.orderTypeLabelMinScale)
+                    Image(systemName: "chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(Color(.textSubtle))
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("performance-order-type-button")
+            .accessibilityHint(Localization.orderTypeAccessibilityHint)
+            .disabled(viewModel.syncingData || viewModel.isUpdatingOrderType)
+        }
+        .contentShape(Rectangle())
     }
 
     func statValueRedactedView(withIcon: Bool) -> some View {
@@ -334,6 +366,8 @@ private extension StorePerformanceView {
         static let redactedViewIconOffset = CGSize(width: 16, height: 0)
         static let hideIconVerticalPadding: CGFloat = 8
         static let emptyViewSpacing: CGFloat = 24
+        static let orderTypeChevronSpacing: CGFloat = 4
+        static let orderTypeLabelMinScale: CGFloat = 0.7
     }
 
     enum Localization {
@@ -361,6 +395,11 @@ private extension StorePerformanceView {
             "storePerformanceView.orders",
             value: "Orders",
             comment: "Orders stat label on dashboard - should be plural."
+        )
+        static let orderTypeAccessibilityHint = NSLocalizedString(
+            "storePerformanceView.orderTypeAccessibilityHint",
+            value: "Opens a bottom sheet to change which orders are included in your performance totals.",
+            comment: "Accessibility hint for the order type chevron button on the dashboard Performance card."
         )
         static let visitors = NSLocalizedString(
             "storePerformanceView.visitors",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -275,7 +275,7 @@ private extension StorePerformanceView {
             .buttonStyle(.plain)
             .accessibilityIdentifier("performance-order-type-button")
             .accessibilityHint(Localization.orderTypeAccessibilityHint)
-            .disabled(viewModel.syncingData || viewModel.isUpdatingOrderType)
+            .disabled(viewModel.syncingData || viewModel.updatingOrderType != nil)
         }
         .contentShape(Rectangle())
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -258,7 +258,7 @@ private extension StorePerformanceView {
                 .foregroundStyle(statsValueColor)
             Button {
                 viewModel.trackInteraction()
-                viewModel.trackOrderTypeChevronTapped()
+                viewModel.trackOrderDateTypeSelectorTapped()
                 showingOrderTypePicker = true
             } label: {
                 HStack(alignment: .center, spacing: Layout.orderTypeChevronSpacing) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -43,8 +43,10 @@ final class StorePerformanceViewModel: ObservableObject {
     /// while the value is being loaded for the first time.
     @Published private(set) var orderType: AnalyticsOrderDateType = .paid
 
-    /// `true` while an order type update is in flight.
-    @Published private(set) var isUpdatingOrderType = false
+    /// The order type whose update is currently in flight, if any. Used by the bottom sheet to render
+    /// an inline progress indicator next to the row being saved and to disable other rows while a
+    /// save is in progress.
+    @Published private(set) var updatingOrderType: AnalyticsOrderDateType?
 
     /// Set when the most recent order type update fails. Cleared when a save succeeds or when the
     /// merchant initiates a new selection.
@@ -256,16 +258,33 @@ final class StorePerformanceViewModel: ObservableObject {
         analytics.track(event: .Dashboard.performanceCardOrderDateTypeSelectorTapped())
     }
 
+    /// Handles the merchant tapping a row in the order date type bottom sheet.
+    ///
+    /// Returns `true` when the bottom sheet should dismiss:
+    /// - the tapped option is already selected (no save round-trip needed), or
+    /// - the save succeeded.
+    ///
+    /// Returns `false` when the save failed so the sheet stays open and the inline error remains visible.
+    @MainActor
+    func handleOrderTypeSelection(_ newOrderType: AnalyticsOrderDateType) async -> Bool {
+        // Tapping the currently-selected row just dismisses; nothing to save.
+        if orderType == newOrderType {
+            return true
+        }
+        await updateOrderType(newOrderType)
+        // Dismiss only if the save actually took effect on the view model.
+        return orderType == newOrderType
+    }
+
     /// Updates the analytics order date type setting and refreshes dashboard stats.
-    /// No-op if `newOrderType` matches the current selection.
     /// On failure, sets `orderTypeUpdateError` so the bottom sheet can present an inline error.
     @MainActor
-    func didSelectOrderType(_ newOrderType: AnalyticsOrderDateType) async {
-        guard !isUpdatingOrderType, orderType != newOrderType else { return }
+    private func updateOrderType(_ newOrderType: AnalyticsOrderDateType) async {
+        guard updatingOrderType == nil else { return }
         hasUserSelectedOrderType = true
-        isUpdatingOrderType = true
+        updatingOrderType = newOrderType
         orderTypeUpdateError = nil
-        defer { isUpdatingOrderType = false }
+        defer { updatingOrderType = nil }
         do {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 let action = SettingAction.updateAnalyticsOrderDateType(siteID: siteID, value: newOrderType) { result in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -266,6 +266,11 @@ final class StorePerformanceViewModel: ObservableObject {
                 }
                 stores.dispatch(action)
             }
+            // Defensive: the API should echo back the value we just sent. If it doesn't, treat the
+            // response as a failure so the sheet surfaces an error instead of silently advancing.
+            guard saved == newOrderType else {
+                throw OrderTypeUpdateError.unexpectedSavedValue(expected: newOrderType, received: saved)
+            }
             orderType = saved
             // Server-side filter changed: invalidate the cached timestamp so the next sync hits the network.
             DashboardTimestampStore.removeTimestamp(for: .performance, at: timeRange.timestampRange)
@@ -276,6 +281,10 @@ final class StorePerformanceViewModel: ObservableObject {
             analytics.track(event: .Dashboard.performanceCardOrderTypeUpdateFailed(error: error))
         }
     }
+}
+
+private enum OrderTypeUpdateError: Error {
+    case unexpectedSavedValue(expected: AnalyticsOrderDateType, received: AnalyticsOrderDateType)
 }
 
 // MARK: - Data for `StorePerformanceView`

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -50,6 +50,10 @@ final class StorePerformanceViewModel: ObservableObject {
     /// merchant initiates a new selection.
     @Published var orderTypeUpdateError: Error?
 
+    /// Tracks whether the merchant has manually picked an order type during this session.
+    /// Prevents a late-arriving initial `loadOrderType` from clobbering a user selection.
+    private var hasUserSelectedOrderType = false
+
     let siteID: Int64
     let siteTimezone: TimeZone
     private let stores: StoresManager
@@ -250,6 +254,7 @@ final class StorePerformanceViewModel: ObservableObject {
     @MainActor
     func didSelectOrderType(_ newOrderType: AnalyticsOrderDateType) async {
         guard !isUpdatingOrderType, orderType != newOrderType else { return }
+        hasUserSelectedOrderType = true
         analytics.track(event: .Dashboard.performanceCardOrderTypeSelected(newOrderType))
         isUpdatingOrderType = true
         orderTypeUpdateError = nil
@@ -452,6 +457,9 @@ private extension StorePerformanceViewModel {
                 }
                 stores.dispatch(action)
             }
+            // If the merchant already changed the order type while the initial fetch was in flight,
+            // honor their selection rather than overwriting it with the stale server value.
+            guard !hasUserSelectedOrderType else { return }
             orderType = dateType
         } catch {
             DDLogWarn("⚠️ Could not fetch analytics order date type, falling back to default: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -279,19 +279,14 @@ final class StorePerformanceViewModel: ObservableObject {
         orderTypeUpdateError = nil
         defer { isUpdatingOrderType = false }
         do {
-            let saved: AnalyticsOrderDateType = try await withCheckedThrowingContinuation { continuation in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 let action = SettingAction.updateAnalyticsOrderDateType(siteID: siteID, value: newOrderType) { result in
                     continuation.resume(with: result)
                 }
                 stores.dispatch(action)
             }
-            // Defensive: the API should echo back the value we just sent. If it doesn't, treat the
-            // response as a failure so the sheet surfaces an error instead of silently advancing.
-            guard saved == newOrderType else {
-                throw OrderTypeUpdateError.unexpectedSavedValue(expected: newOrderType, received: saved)
-            }
-            orderType = saved
-            cacheOrderType(saved)
+            orderType = newOrderType
+            cacheOrderType(newOrderType)
             // Server-side filter changed: invalidate the cached timestamp so the next sync hits the network.
             DashboardTimestampStore.removeTimestamp(for: .performance, at: timeRange.timestampRange)
             await reloadDataIfNeeded(forceRefresh: true)
@@ -301,10 +296,6 @@ final class StorePerformanceViewModel: ObservableObject {
             analytics.track(event: .Dashboard.performanceCardOrderTypeUpdateFailed(error: error))
         }
     }
-}
-
-private enum OrderTypeUpdateError: Error {
-    case unexpectedSavedValue(expected: AnalyticsOrderDateType, received: AnalyticsOrderDateType)
 }
 
 // MARK: - Data for `StorePerformanceView`

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -251,9 +251,9 @@ final class StorePerformanceViewModel: ObservableObject {
         usageTracksEventEmitter.interacted()
     }
 
-    /// Tracks the chevron tap on the Performance card order type label.
-    func trackOrderTypeChevronTapped() {
-        analytics.track(event: .Dashboard.performanceCardOrderTypeChevronTapped())
+    /// Tracks the tap on the Performance card order date type selector label.
+    func trackOrderDateTypeSelectorTapped() {
+        analytics.track(event: .Dashboard.performanceCardOrderDateTypeSelectorTapped())
     }
 
     /// Updates the analytics order date type setting and refreshes dashboard stats.
@@ -263,7 +263,6 @@ final class StorePerformanceViewModel: ObservableObject {
     func didSelectOrderType(_ newOrderType: AnalyticsOrderDateType) async {
         guard !isUpdatingOrderType, orderType != newOrderType else { return }
         hasUserSelectedOrderType = true
-        analytics.track(event: .Dashboard.performanceCardOrderTypeSelected(newOrderType))
         isUpdatingOrderType = true
         orderTypeUpdateError = nil
         defer { isUpdatingOrderType = false }
@@ -275,13 +274,15 @@ final class StorePerformanceViewModel: ObservableObject {
                 stores.dispatch(action)
             }
             orderType = newOrderType
+            // Tracked only after a successful API update — matches Android, where the event fires on save success.
+            analytics.track(event: .Dashboard.performanceCardOrderDateTypeSelected(newOrderType))
             // Server-side filter changed: invalidate the cached timestamp so the next sync hits the network.
             DashboardTimestampStore.removeTimestamp(for: .performance, at: timeRange.timestampRange)
             await reloadDataIfNeeded(forceRefresh: true)
         } catch {
             DDLogError("⛔️ Error updating analytics order date type: \(error)")
             orderTypeUpdateError = error
-            analytics.track(event: .Dashboard.performanceCardOrderTypeUpdateFailed(error: error))
+            analytics.track(event: .Dashboard.performanceCardOrderDateTypeUpdateFailed(error: error))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -62,6 +62,7 @@ final class StorePerformanceViewModel: ObservableObject {
     private let currencySettings: CurrencySettings
     private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
     private let analytics: Analytics
+    private let userDefaults: UserDefaults
 
     private var periodViewModel: StoreStatsPeriodViewModel?
     private(set) var chartViewModel: StoreStatsChartViewModel?
@@ -114,7 +115,8 @@ final class StorePerformanceViewModel: ObservableObject {
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         userDefaults: UserDefaults = .standard) {
         self.siteID = siteID
         self.stores = stores
         self.siteTimezone = siteTimezone
@@ -123,6 +125,15 @@ final class StorePerformanceViewModel: ObservableObject {
         self.currencySettings = currencySettings
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.analytics = analytics
+        self.userDefaults = userDefaults
+
+        // Seed from the per-site cache to avoid showing the default (.paid) for the network round-trip
+        // when the merchant has previously saved a different value. `loadOrderType` still runs and
+        // reconciles with the server.
+        if let cachedRaw = userDefaults.string(forKey: Self.orderTypeCacheKey(for: siteID)),
+           let cached = AnalyticsOrderDateType(rawValue: cachedRaw) {
+            self.orderType = cached
+        }
 
         observeSyncingCompletion()
         observeData()
@@ -135,6 +146,14 @@ final class StorePerformanceViewModel: ObservableObject {
         Task { @MainActor in
             await loadOrderType()
         }
+    }
+
+    private static func orderTypeCacheKey(for siteID: Int64) -> String {
+        "performanceCard.orderType.\(siteID)"
+    }
+
+    private func cacheOrderType(_ value: AnalyticsOrderDateType) {
+        userDefaults.set(value.rawValue, forKey: Self.orderTypeCacheKey(for: siteID))
     }
 
     func didSelectTimeRange(_ newTimeRange: StatsTimeRangeV4) {
@@ -272,6 +291,7 @@ final class StorePerformanceViewModel: ObservableObject {
                 throw OrderTypeUpdateError.unexpectedSavedValue(expected: newOrderType, received: saved)
             }
             orderType = saved
+            cacheOrderType(saved)
             // Server-side filter changed: invalidate the cached timestamp so the next sync hits the network.
             DashboardTimestampStore.removeTimestamp(for: .performance, at: timeRange.timestampRange)
             await reloadDataIfNeeded(forceRefresh: true)
@@ -470,6 +490,7 @@ private extension StorePerformanceViewModel {
             // honor their selection rather than overwriting it with the stale server value.
             guard !hasUserSelectedOrderType else { return }
             orderType = dateType
+            cacheOrderType(dateType)
         } catch {
             DDLogWarn("⚠️ Could not fetch analytics order date type, falling back to default: \(error)")
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -62,7 +62,6 @@ final class StorePerformanceViewModel: ObservableObject {
     private let currencySettings: CurrencySettings
     private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
     private let analytics: Analytics
-    private let userDefaults: UserDefaults
 
     private var periodViewModel: StoreStatsPeriodViewModel?
     private(set) var chartViewModel: StoreStatsChartViewModel?
@@ -115,8 +114,7 @@ final class StorePerformanceViewModel: ObservableObject {
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
-         analytics: Analytics = ServiceLocator.analytics,
-         userDefaults: UserDefaults = .standard) {
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.siteTimezone = siteTimezone
@@ -125,13 +123,12 @@ final class StorePerformanceViewModel: ObservableObject {
         self.currencySettings = currencySettings
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.analytics = analytics
-        self.userDefaults = userDefaults
 
-        // Seed from the per-site cache to avoid showing the default (.paid) for the network round-trip
-        // when the merchant has previously saved a different value. `loadOrderType` still runs and
-        // reconciles with the server.
-        if let cachedRaw = userDefaults.string(forKey: Self.orderTypeCacheKey(for: siteID)),
-           let cached = AnalyticsOrderDateType(rawValue: cachedRaw) {
+        // Seed from the locally cached SiteSetting (written by SettingStoreMethods on every
+        // successful retrieve/update) to avoid showing the default `.paid` for the network
+        // round-trip when the merchant has previously saved a different value. `loadOrderType`
+        // still runs and reconciles with the server.
+        if let cached = AnalyticsOrderDateType.cachedValue(siteID: siteID, storageManager: storageManager) {
             self.orderType = cached
         }
 
@@ -146,14 +143,6 @@ final class StorePerformanceViewModel: ObservableObject {
         Task { @MainActor in
             await loadOrderType()
         }
-    }
-
-    private static func orderTypeCacheKey(for siteID: Int64) -> String {
-        "performanceCard.orderType.\(siteID)"
-    }
-
-    private func cacheOrderType(_ value: AnalyticsOrderDateType) {
-        userDefaults.set(value.rawValue, forKey: Self.orderTypeCacheKey(for: siteID))
     }
 
     func didSelectTimeRange(_ newTimeRange: StatsTimeRangeV4) {
@@ -286,7 +275,6 @@ final class StorePerformanceViewModel: ObservableObject {
                 stores.dispatch(action)
             }
             orderType = newOrderType
-            cacheOrderType(newOrderType)
             // Server-side filter changed: invalidate the cached timestamp so the next sync hits the network.
             DashboardTimestampStore.removeTimestamp(for: .performance, at: timeRange.timestampRange)
             await reloadDataIfNeeded(forceRefresh: true)
@@ -481,7 +469,6 @@ private extension StorePerformanceViewModel {
             // honor their selection rather than overwriting it with the stale server value.
             guard !hasUserSelectedOrderType else { return }
             orderType = dateType
-            cacheOrderType(dateType)
         } catch {
             DDLogWarn("⚠️ Could not fetch analytics order date type, falling back to default: \(error)")
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -39,6 +39,17 @@ final class StorePerformanceViewModel: ObservableObject {
 
     @Published private(set) var loadingError: Error?
 
+    /// Currently applied analytics order date type. Defaults to `.paid` (the WooCommerce backend default)
+    /// while the value is being loaded for the first time.
+    @Published private(set) var orderType: AnalyticsOrderDateType = .paid
+
+    /// `true` while an order type update is in flight.
+    @Published private(set) var isUpdatingOrderType = false
+
+    /// Set when the most recent order type update fails. Cleared when a save succeeds or when the
+    /// merchant initiates a new selection.
+    @Published var orderTypeUpdateError: Error?
+
     let siteID: Int64
     let siteTimezone: TimeZone
     private let stores: StoresManager
@@ -115,6 +126,10 @@ final class StorePerformanceViewModel: ObservableObject {
 
         Task { @MainActor in
             self.timeRange = await loadLastTimeRange() ?? .today
+        }
+
+        Task { @MainActor in
+            await loadOrderType()
         }
     }
 
@@ -222,6 +237,39 @@ final class StorePerformanceViewModel: ObservableObject {
     func onViewAppear() {
         /// tracks `used_analytics`
         usageTracksEventEmitter.interacted()
+    }
+
+    /// Tracks the chevron tap on the Performance card order type label.
+    func trackOrderTypeChevronTapped() {
+        analytics.track(event: .Dashboard.performanceCardOrderTypeChevronTapped())
+    }
+
+    /// Updates the analytics order date type setting and refreshes dashboard stats.
+    /// No-op if `newOrderType` matches the current selection.
+    /// On failure, sets `orderTypeUpdateError` so the bottom sheet can present an inline error.
+    @MainActor
+    func didSelectOrderType(_ newOrderType: AnalyticsOrderDateType) async {
+        guard !isUpdatingOrderType, orderType != newOrderType else { return }
+        analytics.track(event: .Dashboard.performanceCardOrderTypeSelected(newOrderType))
+        isUpdatingOrderType = true
+        orderTypeUpdateError = nil
+        defer { isUpdatingOrderType = false }
+        do {
+            let saved: AnalyticsOrderDateType = try await withCheckedThrowingContinuation { continuation in
+                let action = SettingAction.updateAnalyticsOrderDateType(siteID: siteID, value: newOrderType) { result in
+                    continuation.resume(with: result)
+                }
+                stores.dispatch(action)
+            }
+            orderType = saved
+            // Server-side filter changed: invalidate the cached timestamp so the next sync hits the network.
+            DashboardTimestampStore.removeTimestamp(for: .performance, at: timeRange.timestampRange)
+            await reloadDataIfNeeded(forceRefresh: true)
+        } catch {
+            DDLogError("⛔️ Error updating analytics order date type: \(error)")
+            orderTypeUpdateError = error
+            analytics.track(event: .Dashboard.performanceCardOrderTypeUpdateFailed(error: error))
+        }
     }
 }
 
@@ -389,6 +437,24 @@ private extension StorePerformanceViewModel {
                 continuation.resume(returning: timeRange)
             }
             stores.dispatch(action)
+        }
+    }
+
+    /// Loads the current analytics order date type from the backend. Falls back to the existing
+    /// `orderType` value (default `.paid`) if the request fails — the merchant still gets a usable
+    /// default and can re-open the bottom sheet to retry.
+    @MainActor
+    func loadOrderType() async {
+        do {
+            let dateType: AnalyticsOrderDateType = try await withCheckedThrowingContinuation { continuation in
+                let action = SettingAction.retrieveAnalyticsOrderDateType(siteID: siteID) { result in
+                    continuation.resume(with: result)
+                }
+                stores.dispatch(action)
+            }
+            orderType = dateType
+        } catch {
+            DDLogWarn("⚠️ Could not fetch analytics order date type, falling back to default: \(error)")
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -18,14 +18,9 @@ final class StorePerformanceViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         storageManager = MockStorageManager()
-        // The view model caches the analytics order type per siteID in UserDefaults to avoid a
-        // flash of the default value on launch. Tests share `siteID: 123`, so wipe the cache here
-        // to keep order-type tests deterministic.
-        UserDefaults.standard.removeObject(forKey: "performanceCard.orderType.123")
     }
 
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: "performanceCard.orderType.123")
         storageManager = nil
         super.tearDown()
     }
@@ -372,6 +367,26 @@ final class StorePerformanceViewModelTests: XCTestCase {
     // MARK: - Order type bottom sheet
 
     @MainActor
+    func test_orderType_when_cached_SiteSetting_exists_then_seeded_synchronously_on_init() {
+        // Given — a previously persisted analytics order date type for this site.
+        let cachedSetting = SiteSetting.fake().copy(siteID: 123,
+                                                    settingID: "woocommerce_date_type",
+                                                    value: AnalyticsOrderDateType.allOrders.rawValue,
+                                                    settingGroupKey: "wc_admin")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: cachedSetting)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+
+        // When
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
+
+        // Then — the cached value seeds `orderType` synchronously, before any network round-trip.
+        XCTAssertEqual(viewModel.orderType, .allOrders)
+    }
+
+    @MainActor
     func test_orderType_when_loadOrderType_succeeds_then_value_is_published() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -385,10 +400,13 @@ final class StorePerformanceViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
 
         // Then
-        XCTAssertEqual(viewModel.orderType, .paid) // initial fallback
+        XCTAssertEqual(viewModel.orderType, .paid) // initial fallback (no cached SiteSetting)
         waitUntil {
             viewModel.orderType == .completed
         }
@@ -408,7 +426,10 @@ final class StorePerformanceViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
 
         // Then — orderType remains the default `.paid` after failed fetch
         XCTAssertEqual(viewModel.orderType, .paid)
@@ -429,7 +450,10 @@ final class StorePerformanceViewModelTests: XCTestCase {
                 break
             }
         }
-        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
 
         // When
         await viewModel.didSelectOrderType(.paid)
@@ -468,7 +492,10 @@ final class StorePerformanceViewModelTests: XCTestCase {
                 break
             }
         }
-        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
 
         // When
         await viewModel.didSelectOrderType(.completed)
@@ -495,7 +522,10 @@ final class StorePerformanceViewModelTests: XCTestCase {
                 break
             }
         }
-        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
 
         // When
         await viewModel.didSelectOrderType(.allOrders)
@@ -536,6 +566,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         }
         let viewModel = StorePerformanceViewModel(siteID: 123,
                                                   stores: stores,
+                                                  storageManager: storageManager,
                                                   usageTracksEventEmitter: .init(),
                                                   analytics: analytics)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -10,7 +10,7 @@ import YosemiteTestHelpers
 
 
 final class StorePerformanceViewModelTests: XCTestCase {
-    private var storageManager: StorageManagerType!
+    private var storageManager: MockStorageManager!
     private var storage: StorageType {
         storageManager.viewStorage
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -436,7 +436,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_didSelectOrderType_when_value_matches_current_then_no_action_dispatched() async {
+    func test_handleOrderTypeSelection_when_value_matches_current_then_no_action_dispatched_and_returns_true() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         var updateActionDispatched = false
@@ -456,15 +456,16 @@ final class StorePerformanceViewModelTests: XCTestCase {
                                                   usageTracksEventEmitter: .init())
 
         // When
-        await viewModel.didSelectOrderType(.paid)
+        let shouldDismiss = await viewModel.handleOrderTypeSelection(.paid)
 
         // Then
+        XCTAssertTrue(shouldDismiss)
         XCTAssertFalse(updateActionDispatched)
         XCTAssertNil(viewModel.orderTypeUpdateError)
     }
 
     @MainActor
-    func test_didSelectOrderType_when_save_succeeds_then_orderType_is_updated_and_error_is_nil() async {
+    func test_handleOrderTypeSelection_when_save_succeeds_then_orderType_is_updated_and_returns_true() async {
         // Given
         var receivedValue: AnalyticsOrderDateType?
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -498,17 +499,18 @@ final class StorePerformanceViewModelTests: XCTestCase {
                                                   usageTracksEventEmitter: .init())
 
         // When
-        await viewModel.didSelectOrderType(.completed)
+        let shouldDismiss = await viewModel.handleOrderTypeSelection(.completed)
 
         // Then
+        XCTAssertTrue(shouldDismiss)
         XCTAssertEqual(receivedValue, .completed)
         XCTAssertEqual(viewModel.orderType, .completed)
         XCTAssertNil(viewModel.orderTypeUpdateError)
-        XCTAssertFalse(viewModel.isUpdatingOrderType)
+        XCTAssertNil(viewModel.updatingOrderType)
     }
 
     @MainActor
-    func test_didSelectOrderType_when_save_fails_then_error_is_set_and_orderType_is_unchanged() async {
+    func test_handleOrderTypeSelection_when_save_fails_then_error_is_set_and_returns_false() async {
         // Given
         let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -528,16 +530,68 @@ final class StorePerformanceViewModelTests: XCTestCase {
                                                   usageTracksEventEmitter: .init())
 
         // When
-        await viewModel.didSelectOrderType(.allOrders)
+        let shouldDismiss = await viewModel.handleOrderTypeSelection(.allOrders)
 
         // Then
+        XCTAssertFalse(shouldDismiss)
         XCTAssertEqual(viewModel.orderType, .paid)
         XCTAssertEqual(viewModel.orderTypeUpdateError as? NetworkError, expectedError)
-        XCTAssertFalse(viewModel.isUpdatingOrderType)
+        XCTAssertNil(viewModel.updatingOrderType)
     }
 
     @MainActor
-    func test_didSelectOrderType_when_save_succeeds_then_tracks_selected_event_with_type_and_option() async throws {
+    func test_handleOrderTypeSelection_while_save_is_in_flight_then_updatingOrderType_reflects_new_type() async {
+        // Given — hold the update-action completion so the save suspends mid-flight.
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var pendingUpdateCompletion: ((Result<Void, Error>) -> Void)?
+        let updateActionDispatched = expectation(description: "update action dispatched")
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case let .updateAnalyticsOrderDateType(_, _, onCompletion):
+                pendingUpdateCompletion = onCompletion
+                updateActionDispatched.fulfill()
+            default:
+                break
+            }
+        }
+        // Stub stats actions so the post-save reload doesn't hang.
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveStats(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteVisitStats(_, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
+        XCTAssertNil(viewModel.updatingOrderType)
+
+        // When — kick off the selection; it suspends waiting on `pendingUpdateCompletion`.
+        let task = Task { @MainActor in
+            await viewModel.handleOrderTypeSelection(.completed)
+        }
+        await fulfillment(of: [updateActionDispatched], timeout: 1)
+
+        // Then — while the save is in flight, the in-flight type is exposed for the bottom sheet row spinner.
+        XCTAssertEqual(viewModel.updatingOrderType, .completed)
+
+        // Cleanup — release the suspended save and verify the in-flight state clears.
+        pendingUpdateCompletion?(.success(()))
+        _ = await task.value
+        XCTAssertNil(viewModel.updatingOrderType)
+    }
+
+    @MainActor
+    func test_handleOrderTypeSelection_when_save_succeeds_then_tracks_selected_event_with_type_and_option() async throws {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
@@ -571,7 +625,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
                                                   analytics: analytics)
 
         // When
-        await viewModel.didSelectOrderType(.allOrders)
+        _ = await viewModel.handleOrderTypeSelection(.allOrders)
 
         // Then
         let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "dashboard_stats_order_date_type_selected" }))
@@ -581,7 +635,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_didSelectOrderType_when_save_fails_then_does_not_track_selected_event() async {
+    func test_handleOrderTypeSelection_when_save_fails_then_does_not_track_selected_event() async {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
@@ -603,7 +657,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
                                                   analytics: analytics)
 
         // When
-        await viewModel.didSelectOrderType(.completed)
+        _ = await viewModel.handleOrderTypeSelection(.completed)
 
         // Then
         XCTAssertFalse(analyticsProvider.receivedEvents.contains("dashboard_stats_order_date_type_selected"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -450,7 +450,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
                 onCompletion(.success(.paid))
             case let .updateAnalyticsOrderDateType(_, value, onCompletion):
                 receivedValue = value
-                onCompletion(.success(value))
+                onCompletion(.success(()))
             default:
                 break
             }
@@ -516,8 +516,8 @@ final class StorePerformanceViewModelTests: XCTestCase {
             switch action {
             case .retrieveAnalyticsOrderDateType(_, let onCompletion):
                 onCompletion(.success(.paid))
-            case let .updateAnalyticsOrderDateType(_, value, onCompletion):
-                onCompletion(.success(value))
+            case .updateAnalyticsOrderDateType(_, _, let onCompletion):
+                onCompletion(.success(()))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -364,6 +364,199 @@ final class StorePerformanceViewModelTests: XCTestCase {
         XCTAssertEqual(properties?["type"], "performance")
     }
 
+    // MARK: - Order type bottom sheet
+
+    @MainActor
+    func test_orderType_when_loadOrderType_succeeds_then_value_is_published() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveAnalyticsOrderDateType(_, onCompletion):
+                onCompletion(.success(.completed))
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+
+        // Then
+        XCTAssertEqual(viewModel.orderType, .paid) // initial fallback
+        waitUntil {
+            viewModel.orderType == .completed
+        }
+    }
+
+    @MainActor
+    func test_orderType_when_loadOrderType_fails_then_value_falls_back_to_paid() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveAnalyticsOrderDateType(_, onCompletion):
+                onCompletion(.failure(NetworkError.unacceptableStatusCode(statusCode: 500)))
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+
+        // Then — orderType remains the default `.paid` after failed fetch
+        XCTAssertEqual(viewModel.orderType, .paid)
+    }
+
+    @MainActor
+    func test_didSelectOrderType_when_value_matches_current_then_no_action_dispatched() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var updateActionDispatched = false
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case .updateAnalyticsOrderDateType:
+                updateActionDispatched = true
+            default:
+                break
+            }
+        }
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+
+        // When
+        await viewModel.didSelectOrderType(.paid)
+
+        // Then
+        XCTAssertFalse(updateActionDispatched)
+        XCTAssertNil(viewModel.orderTypeUpdateError)
+    }
+
+    @MainActor
+    func test_didSelectOrderType_when_save_succeeds_then_orderType_is_updated_and_error_is_nil() async {
+        // Given
+        var receivedValue: AnalyticsOrderDateType?
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case let .updateAnalyticsOrderDateType(_, value, onCompletion):
+                receivedValue = value
+                onCompletion(.success(value))
+            default:
+                break
+            }
+        }
+        // Stub stats actions so reloadDataIfNeeded(forceRefresh:) doesn't hang.
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveStats(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteVisitStats(_, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+
+        // When
+        await viewModel.didSelectOrderType(.completed)
+
+        // Then
+        XCTAssertEqual(receivedValue, .completed)
+        XCTAssertEqual(viewModel.orderType, .completed)
+        XCTAssertNil(viewModel.orderTypeUpdateError)
+        XCTAssertFalse(viewModel.isUpdatingOrderType)
+    }
+
+    @MainActor
+    func test_didSelectOrderType_when_save_fails_then_error_is_set_and_orderType_is_unchanged() async {
+        // Given
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case .updateAnalyticsOrderDateType(_, _, let onCompletion):
+                onCompletion(.failure(expectedError))
+            default:
+                break
+            }
+        }
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+
+        // When
+        await viewModel.didSelectOrderType(.allOrders)
+
+        // Then
+        XCTAssertEqual(viewModel.orderType, .paid)
+        XCTAssertEqual(viewModel.orderTypeUpdateError as? NetworkError, expectedError)
+        XCTAssertFalse(viewModel.isUpdatingOrderType)
+    }
+
+    @MainActor
+    func test_didSelectOrderType_tracks_selected_event_with_order_type_property() async throws {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case let .updateAnalyticsOrderDateType(_, value, onCompletion):
+                onCompletion(.success(value))
+            default:
+                break
+            }
+        }
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveStats(_, _, _, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteVisitStats(_, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  usageTracksEventEmitter: .init(),
+                                                  analytics: analytics)
+
+        // When
+        await viewModel.didSelectOrderType(.allOrders)
+
+        // Then
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "dashboard_main_stats_order_type_selected" }))
+        let properties = analyticsProvider.receivedProperties[index] as? [String: AnyHashable]
+        XCTAssertEqual(properties?["order_type"], "all_orders")
+    }
+
+    @MainActor
+    func test_trackOrderTypeChevronTapped_tracks_chevron_event() throws {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let viewModel = StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init(), analytics: analytics)
+
+        // When
+        viewModel.trackOrderTypeChevronTapped()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("dashboard_main_stats_order_type_chevron_tapped"))
+    }
+
     @MainActor
     func test_given_existing_cached_data_when_timestamp_is_fresh_then_cached_data_is_shown() async {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -18,9 +18,14 @@ final class StorePerformanceViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         storageManager = MockStorageManager()
+        // The view model caches the analytics order type per siteID in UserDefaults to avoid a
+        // flash of the default value on launch. Tests share `siteID: 123`, so wipe the cache here
+        // to keep order-type tests deterministic.
+        UserDefaults.standard.removeObject(forKey: "performanceCard.orderType.123")
     }
 
     override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "performanceCard.orderType.123")
         storageManager = nil
         super.tearDown()
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -537,7 +537,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_didSelectOrderType_tracks_selected_event_with_order_type_property() async throws {
+    func test_didSelectOrderType_when_save_succeeds_then_tracks_selected_event_with_type_and_option() async throws {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
@@ -574,23 +574,56 @@ final class StorePerformanceViewModelTests: XCTestCase {
         await viewModel.didSelectOrderType(.allOrders)
 
         // Then
-        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "dashboard_main_stats_order_type_selected" }))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "dashboard_stats_order_date_type_selected" }))
         let properties = analyticsProvider.receivedProperties[index] as? [String: AnyHashable]
-        XCTAssertEqual(properties?["order_type"], "all_orders")
+        XCTAssertEqual(properties?["type"], "dashboard_stats")
+        XCTAssertEqual(properties?["option"], "date_created")
     }
 
     @MainActor
-    func test_trackOrderTypeChevronTapped_tracks_chevron_event() throws {
+    func test_didSelectOrderType_when_save_fails_then_does_not_track_selected_event() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case .updateAnalyticsOrderDateType(_, _, let onCompletion):
+                onCompletion(.failure(NetworkError.unacceptableStatusCode(statusCode: 500)))
+            default:
+                break
+            }
+        }
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init(),
+                                                  analytics: analytics)
+
+        // When
+        await viewModel.didSelectOrderType(.completed)
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("dashboard_stats_order_date_type_selected"))
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("dashboard_stats_order_date_type_update_failed"))
+    }
+
+    @MainActor
+    func test_trackOrderDateTypeSelectorTapped_tracks_selector_event_with_type_property() throws {
         // Given
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init(), analytics: analytics)
 
         // When
-        viewModel.trackOrderTypeChevronTapped()
+        viewModel.trackOrderDateTypeSelectorTapped()
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("dashboard_main_stats_order_type_chevron_tapped"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "dashboard_stats_order_date_type_selector_tapped" }))
+        let properties = analyticsProvider.receivedProperties[index] as? [String: AnyHashable]
+        XCTAssertEqual(properties?["type"], "dashboard_stats")
     }
 
     @MainActor


### PR DESCRIPTION
WOOMOB-2926

## Description

Adds the merchant-facing UI for choosing which order date type the Performance card uses for revenue totals.

The "Orders" stats column on the Performance card now shows the active order type (Paid orders / Placed orders / Completed orders) with a chevron-down. Tapping it opens a bottom sheet with the three options. The label wraps to two lines if needed (longer copy like "Completed orders") and only shrinks at extreme Dynamic Type sizes.

The bottom sheet matches Figma 9090-18390: title, body description, three rows with a trailing checkmark on the active selection, and a footer explaining this setting is store-wide. While a save is in flight the row's checkmark is replaced with a small spinner — same pattern Android shipped in [woocommerce-android#15750](https://github.com/woocommerce/woocommerce-android/pull/15750). On a failed save, an inline error block appears between the rows and the footer; the sheet stays open. Tapping the currently-selected row dismisses immediately without a save round-trip.

A few non-obvious decisions worth flagging:

- **Cached value seeds the view model synchronously on launch.** #16987 already persists the setting to CoreData via the standard `SiteSetting` upsert. A new synchronous reader (`AnalyticsOrderDateType.cachedValue(siteID:storageManager:)`) reads it back in `init` so the dashboard doesn't briefly show "Paid orders" (the backend default) for the network round-trip every launch. The async load still runs and reconciles if the value diverged externally.
- **"All orders" → "Placed orders".** renamed from initial Figma design. "all" was misleading. Final copy was confirmed in p1777358770060539-slack-C03L1NF1EA3.

## Tracking events

| Event name | Triggered when | Properties (key → values) |
|------------|----------------|--------------------------|
| `DASHBOARD_STATS_ORDER_DATE_TYPE_SELECTOR_TAPPED` ([PR 15750](https://github.com/woocommerce/woocommerce-android/pull/15750)) | User taps the **order date type label** under the order count to open the bottom sheet | `type` → `dashboard_stats` |
| `DASHBOARD_STATS_ORDER_DATE_TYPE_SELECTED` ([PR 15750](https://github.com/woocommerce/woocommerce-android/pull/15750)) | User picks an order date type in the bottom sheet **and the API update succeeds** (not fired on tap, only on successful save) | `type` → `dashboard_stats`<br>`option` → `date_paid` \| `date_created` \| `date_completed` |

## Demo

https://github.com/user-attachments/assets/2664cfcb-7af9-420e-8259-e4dcf9346aae

## Bottom Sheet Screenshots

Progress | Failure
--- | ---
<img width="538" height="717" alt="Progress" src="https://github.com/user-attachments/assets/b9165aad-14fb-47ba-b438-b3c08d9d0ec0" /> | <img width="537" height="712" alt="Failure" src="https://github.com/user-attachments/assets/95f2548c-7c45-4499-8b55-e686e58b8cb1" />

## Test Steps

- Open Dashboard. The Performance card shows the order type label with a chevron under the order count. Make sure to select time interval with orders.
- Tap the chevron → sheet opens at the default detent with the full footer visible without scrolling. Selected row has a checkmark.
- Pick a different option → spinner on that row → sheet dismisses → card label updates → chart refreshes.
- Turn off Wi-Fi mid-save (or Proxyman breakpoint + abort) → inline error appears between the rows and the footer; sheet stays open.
- Tap the already-selected row → dismisses immediately, no save.
- Save a non-default option, terminate the app, relaunch → dashboard immediately shows the saved label with no flash of "Paid orders".
- Confirm Tracks events fire for chevron tap, selection, and update failure.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Will be added with WOOMOB-2925 for the unified user-facing change set.)