### PR TITLE
[AI Support Chat] Store/access local AI chat history

### DIFF
--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -37,7 +37,6 @@ public struct SupportChatResponse: Decodable, Equatable {
 /// Role of a message sender in a support chat thread.
 ///
 public enum SupportChatRole: String, Decodable, Equatable {
-    case user
     case bot
     case user
     case unknown

--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -38,6 +38,7 @@ public struct SupportChatResponse: Decodable, Equatable {
 ///
 public enum SupportChatRole: String, Decodable, Equatable {
     case bot
+    case user
     case unknown
 
     public init(from decoder: Decoder) throws {

--- a/Modules/Sources/Networking/Remote/SupportChatRemote.swift
+++ b/Modules/Sources/Networking/Remote/SupportChatRemote.swift
@@ -16,6 +16,15 @@ public protocol SupportChatRemoteProtocol {
                      message: String,
                      chatID: Int64?,
                      context: [String: Any]?) async throws -> SupportChatResponse
+
+    /// Fetches an existing chat thread by id, returning every turn (user + bot).
+    ///
+    /// - Parameters:
+    ///   - botSlug: Assistant slug the chat was created against.
+    ///   - chatID: Identifier returned by a previous `sendMessage` call.
+    /// - Returns: The full thread in `ts`-ascending order.
+    func fetchChat(botSlug: String,
+                   chatID: Int64) async throws -> SupportChatResponse
 }
 
 /// Remote for the support chat endpoint (`/wpcom/v2/odie/chat/{bot_slug}`).
@@ -43,6 +52,16 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
                                     path: path,
                                     parameters: parameters,
                                     encoding: JSONEncoding.default)
+        let mapper = SupportChatResponseMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    public func fetchChat(botSlug: String,
+                          chatID: Int64) async throws -> SupportChatResponse {
+        let path = "\(Path.chat)/\(botSlug)/\(chatID)"
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
+                                    method: .get,
+                                    path: path)
         let mapper = SupportChatResponseMapper()
         return try await enqueue(request, mapper: mapper)
     }

--- a/Modules/Sources/Storage/Extensions/StorageType+SupportChat.swift
+++ b/Modules/Sources/Storage/Extensions/StorageType+SupportChat.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+// MARK: - StoredSupportChat helpers
+//
+public extension StorageType {
+
+    /// Returns the single `StoredSupportChat` with the given `chatID`, if any.
+    ///
+    func loadSupportChat(chatID: Int64) -> StoredSupportChat? {
+        let predicate = NSPredicate(format: "chatID == %lld", chatID)
+        return firstObject(ofType: StoredSupportChat.self, matching: predicate)
+    }
+
+    /// Returns the `StoredSupportChat` entries for a site, newest first.
+    ///
+    func loadSupportChats(siteID: Int64) -> [StoredSupportChat] {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        let descriptor = NSSortDescriptor(key: "updatedAt", ascending: false)
+        return allObjects(ofType: StoredSupportChat.self, matching: predicate, sortedBy: [descriptor])
+    }
+
+    /// Deletes the `StoredSupportChat` with the given `chatID`, if present.
+    ///
+    func deleteSupportChat(chatID: Int64) {
+        guard let chat = loadSupportChat(chatID: chatID) else {
+            return
+        }
+        deleteObject(chat)
+    }
+}

--- a/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
@@ -16,4 +16,59 @@ public enum SupportChatAction: Action {
                      chatID: Int64?,
                      context: [String: Any]?,
                      completion: (Result<SupportChatResponse, Error>) -> Void)
+
+    /// Fetches the full transcript of an existing chat so the UI can rehydrate a resumed session.
+    ///
+    /// - Parameters:
+    ///   - botSlug: Assistant slug the chat was created against.
+    ///   - chatID: Identifier returned by a previous `sendMessage`.
+    ///   - completion: Called on the main thread with every turn (user + bot) in ascending order.
+    case fetchChat(botSlug: String,
+                   chatID: Int64,
+                   completion: (Result<SupportChatResponse, Error>) -> Void)
+
+    /// Persists a new chat bookmark so the merchant can revisit it later.
+    ///
+    /// Called once per chat, typically after the first successful `sendMessage` response.
+    /// No-op if a row with `chatID` already exists.
+    ///
+    /// - Parameters:
+    ///   - chatID: Identifier returned by the assistant.
+    ///   - siteID: Primary scoping key. Must be non-zero for post-login chats.
+    ///   - wpcomUserID: Secondary identifier. Pass `0` for non-WPCom-authenticated users.
+    ///   - botSlug: Assistant slug backing the chat.
+    ///   - firstUserMessage: Used to derive the chat's title. Trimmed and clamped to 50 chars.
+    ///   - onCompletion: Delivered on the main thread. `nil` on success.
+    case registerChat(chatID: Int64,
+                      siteID: Int64,
+                      wpcomUserID: Int64,
+                      botSlug: String,
+                      firstUserMessage: String,
+                      onCompletion: (Error?) -> Void)
+
+    /// Bumps the `updatedAt` timestamp for an existing chat so it surfaces at the top of history.
+    ///
+    /// Idempotent: if no row exists for `chatID`, completes without error.
+    ///
+    /// - Parameters:
+    ///   - chatID: Identifier of the chat to bump.
+    ///   - onCompletion: Delivered on the main thread. `nil` on success.
+    case touchChat(chatID: Int64,
+                   onCompletion: (Error?) -> Void)
+
+    /// Loads all locally-persisted chat bookmarks for a site, sorted newest first.
+    ///
+    /// - Parameters:
+    ///   - siteID: Scoping key.
+    ///   - onCompletion: Delivered on the main thread with the list of summaries.
+    case loadChatHistory(siteID: Int64,
+                         onCompletion: (Result<[SupportChatSummary], Error>) -> Void)
+
+    /// Deletes a single chat bookmark from local storage.
+    ///
+    /// - Parameters:
+    ///   - chatID: Identifier of the chat to delete.
+    ///   - onCompletion: Delivered on the main thread. `nil` on success.
+    case deleteChat(chatID: Int64,
+                    onCompletion: (Error?) -> Void)
 }

--- a/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
@@ -38,23 +38,23 @@ public enum SupportChatAction: Action {
     ///   - wpcomUserID: Secondary identifier. Pass `0` for non-WPCom-authenticated users.
     ///   - botSlug: Assistant slug backing the chat.
     ///   - firstUserMessage: Used to derive the chat's title. Trimmed and clamped to 50 chars.
-    ///   - onCompletion: Delivered on the main thread. `nil` on success.
+    ///   - onCompletion: Delivered on the main thread once the row is persisted.
     case registerChat(chatID: Int64,
                       siteID: Int64,
                       wpcomUserID: Int64,
                       botSlug: String,
                       firstUserMessage: String,
-                      onCompletion: (Error?) -> Void)
+                      onCompletion: () -> Void)
 
     /// Bumps the `updatedAt` timestamp for an existing chat so it surfaces at the top of history.
     ///
-    /// Idempotent: if no row exists for `chatID`, completes without error.
+    /// Idempotent: if no row exists for `chatID`, completes without doing anything.
     ///
     /// - Parameters:
     ///   - chatID: Identifier of the chat to bump.
-    ///   - onCompletion: Delivered on the main thread. `nil` on success.
+    ///   - onCompletion: Delivered on the main thread once the bump is persisted.
     case touchChat(chatID: Int64,
-                   onCompletion: (Error?) -> Void)
+                   onCompletion: () -> Void)
 
     /// Loads all locally-persisted chat bookmarks for a site, sorted newest first.
     ///
@@ -62,13 +62,13 @@ public enum SupportChatAction: Action {
     ///   - siteID: Scoping key.
     ///   - onCompletion: Delivered on the main thread with the list of summaries.
     case loadChatHistory(siteID: Int64,
-                         onCompletion: (Result<[SupportChatSummary], Error>) -> Void)
+                         onCompletion: ([SupportChatSummary]) -> Void)
 
     /// Deletes a single chat bookmark from local storage.
     ///
     /// - Parameters:
     ///   - chatID: Identifier of the chat to delete.
-    ///   - onCompletion: Delivered on the main thread. `nil` on success.
+    ///   - onCompletion: Delivered on the main thread once the row is removed.
     case deleteChat(chatID: Int64,
-                    onCompletion: (Error?) -> Void)
+                    onCompletion: () -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
@@ -15,13 +15,13 @@ struct MockSupportChatActionHandler: MockActionHandler {
         case let .fetchChat(_, _, completion):
             completion(.success(Self.emptyResponse))
         case let .registerChat(_, _, _, _, _, onCompletion):
-            onCompletion(nil)
+            onCompletion()
         case let .touchChat(_, onCompletion):
-            onCompletion(nil)
+            onCompletion()
         case let .loadChatHistory(_, onCompletion):
-            onCompletion(.success([]))
+            onCompletion([])
         case let .deleteChat(_, onCompletion):
-            onCompletion(nil)
+            onCompletion()
         }
     }
 

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Networking
+import Storage
+
+struct MockSupportChatActionHandler: MockActionHandler {
+    typealias ActionType = SupportChatAction
+
+    let objectGraph: MockObjectGraph
+    let storageManager: StorageManagerType
+
+    func handle(action: ActionType) {
+        switch action {
+        case let .sendMessage(_, _, _, _, completion):
+            completion(.success(Self.emptyResponse))
+        case let .fetchChat(_, _, completion):
+            completion(.success(Self.emptyResponse))
+        case let .registerChat(_, _, _, _, _, onCompletion):
+            onCompletion(nil)
+        case let .touchChat(_, onCompletion):
+            onCompletion(nil)
+        case let .loadChatHistory(_, onCompletion):
+            onCompletion(.success([]))
+        case let .deleteChat(_, onCompletion):
+            onCompletion(nil)
+        }
+    }
+
+    private static let emptyResponse = SupportChatResponse(
+        chatID: 0,
+        sessionID: "",
+        botSlug: "",
+        botVersion: "",
+        messages: []
+    )
+}

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -43,6 +43,7 @@ public class MockStoresManager: StoresManager {
     private let justInTimeMessageActionHandler: MockJustInTimeMessageActionHandler
     private let shippingMethodActionHandler: MockShippingMethodActionHandler
     private let couponActionHandler: MockCouponActionHandler
+    private let supportChatActionHandler: MockSupportChatActionHandler
 
 
 
@@ -79,6 +80,7 @@ public class MockStoresManager: StoresManager {
         justInTimeMessageActionHandler = MockJustInTimeMessageActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         shippingMethodActionHandler = MockShippingMethodActionHandler(objectGraph: objectGraph, storageManager: storageManager)
         couponActionHandler = MockCouponActionHandler(objectGraph: objectGraph, storageManager: storageManager)
+        supportChatActionHandler = MockSupportChatActionHandler(objectGraph: objectGraph, storageManager: storageManager)
     }
 
     /// Accessor for whether the user is logged in (spoiler: they always will be when mocking)
@@ -163,6 +165,8 @@ public class MockStoresManager: StoresManager {
             shippingMethodActionHandler.handle(action: action)
         case let action as CouponAction:
             couponActionHandler.handle(action: action)
+        case let action as SupportChatAction:
+            supportChatActionHandler.handle(action: action)
         case let action as FeatureFlagAction:
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):

--- a/Modules/Sources/Yosemite/Model/Storage/StoredSupportChat+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/StoredSupportChat+ReadOnlyConvertible.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Storage
+
+
+// MARK: - Storage.StoredSupportChat: ReadOnlyConvertible
+//
+extension Storage.StoredSupportChat: ReadOnlyConvertible {
+
+    /// Updates the `Storage.StoredSupportChat` from the ReadOnly representation (`Yosemite.SupportChatSummary`).
+    ///
+    public func update(with summary: Yosemite.SupportChatSummary) {
+        chatID = summary.chatID
+        siteID = summary.siteID
+        wpcomUserID = summary.wpcomUserID
+        botSlug = summary.botSlug
+        title = summary.title
+        createdAt = summary.createdAt
+        updatedAt = summary.updatedAt
+    }
+
+    /// Returns a ReadOnly (`Yosemite.SupportChatSummary`) version of the `Storage.StoredSupportChat`.
+    ///
+    public func toReadOnly() -> Yosemite.SupportChatSummary {
+        SupportChatSummary(chatID: chatID,
+                           siteID: siteID,
+                           wpcomUserID: wpcomUserID,
+                           botSlug: botSlug ?? "",
+                           title: title,
+                           createdAt: createdAt ?? Date(),
+                           updatedAt: updatedAt ?? Date())
+    }
+}

--- a/Modules/Sources/Yosemite/Model/SupportChatSummary.swift
+++ b/Modules/Sources/Yosemite/Model/SupportChatSummary.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// A lightweight bookmark for a support chat conversation, used by the chat history UI.
+///
+/// Persisted locally in Core Data so the merchant can revisit a previous conversation,
+/// share its `chatID` with human support, or continue it by reusing the `chatID` on a new
+/// message. Message bodies are not stored locally — the assistant holds the canonical thread.
+///
+public struct SupportChatSummary: Equatable {
+    public let chatID: Int64
+    public let siteID: Int64
+    public let wpcomUserID: Int64
+    public let botSlug: String
+    public let title: String?
+    public let createdAt: Date
+    public let updatedAt: Date
+
+    public init(chatID: Int64,
+                siteID: Int64,
+                wpcomUserID: Int64,
+                botSlug: String,
+                title: String?,
+                createdAt: Date,
+                updatedAt: Date) {
+        self.chatID = chatID
+        self.siteID = siteID
+        self.wpcomUserID = wpcomUserID
+        self.botSlug = botSlug
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
@@ -100,7 +100,7 @@ private extension SupportChatStore {
                       wpcomUserID: Int64,
                       botSlug: String,
                       firstUserMessage: String,
-                      onCompletion: @escaping (Error?) -> Void) {
+                      onCompletion: @escaping () -> Void) {
         let title = Self.deriveTitle(from: firstUserMessage)
         let now = Date()
 
@@ -118,11 +118,11 @@ private extension SupportChatStore {
             chat.createdAt = now
             chat.updatedAt = now
         }, completion: {
-            onCompletion(nil)
+            onCompletion()
         }, on: .main)
     }
 
-    func touchChat(chatID: Int64, onCompletion: @escaping (Error?) -> Void) {
+    func touchChat(chatID: Int64, onCompletion: @escaping () -> Void) {
         let now = Date()
         storageManager.performAndSave({ storage in
             guard let chat = storage.loadSupportChat(chatID: chatID) else {
@@ -131,23 +131,23 @@ private extension SupportChatStore {
             }
             chat.updatedAt = now
         }, completion: {
-            onCompletion(nil)
+            onCompletion()
         }, on: .main)
     }
 
     func loadChatHistory(siteID: Int64,
-                         onCompletion: @escaping (Result<[SupportChatSummary], Error>) -> Void) {
+                         onCompletion: @escaping ([SupportChatSummary]) -> Void) {
         let summaries = storageManager.viewStorage
             .loadSupportChats(siteID: siteID)
             .map { $0.toReadOnly() }
-        onCompletion(.success(summaries))
+        onCompletion(summaries)
     }
 
-    func deleteChat(chatID: Int64, onCompletion: @escaping (Error?) -> Void) {
+    func deleteChat(chatID: Int64, onCompletion: @escaping () -> Void) {
         storageManager.performAndSave({ storage in
             storage.deleteSupportChat(chatID: chatID)
         }, completion: {
-            onCompletion(nil)
+            onCompletion()
         }, on: .main)
     }
 }

--- a/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
@@ -1,8 +1,9 @@
 import Foundation
 import Networking
-import protocol Storage.StorageManagerType
+import Storage
 
-/// Handles `SupportChatAction` by delegating to the `SupportChatRemote`.
+/// Handles `SupportChatAction` by delegating to the `SupportChatRemote` (network) and the
+/// `StorageManager` (local chat history).
 ///
 public final class SupportChatStore: Store {
     private let remote: SupportChatRemoteProtocol
@@ -34,11 +35,26 @@ public final class SupportChatStore: Store {
         switch action {
         case let .sendMessage(botSlug, message, chatID, context, completion):
             sendMessage(botSlug: botSlug, message: message, chatID: chatID, context: context, completion: completion)
+        case let .fetchChat(botSlug, chatID, completion):
+            fetchChat(botSlug: botSlug, chatID: chatID, completion: completion)
+        case let .registerChat(chatID, siteID, wpcomUserID, botSlug, firstUserMessage, onCompletion):
+            registerChat(chatID: chatID,
+                         siteID: siteID,
+                         wpcomUserID: wpcomUserID,
+                         botSlug: botSlug,
+                         firstUserMessage: firstUserMessage,
+                         onCompletion: onCompletion)
+        case let .touchChat(chatID, onCompletion):
+            touchChat(chatID: chatID, onCompletion: onCompletion)
+        case let .loadChatHistory(siteID, onCompletion):
+            loadChatHistory(siteID: siteID, onCompletion: onCompletion)
+        case let .deleteChat(chatID, onCompletion):
+            deleteChat(chatID: chatID, onCompletion: onCompletion)
         }
     }
 }
 
-// MARK: - Private Methods
+// MARK: - Network
 //
 private extension SupportChatStore {
     func sendMessage(botSlug: String,
@@ -58,5 +74,97 @@ private extension SupportChatStore {
                 completion(result)
             }
         }
+    }
+
+    func fetchChat(botSlug: String,
+                   chatID: Int64,
+                   completion: @escaping (Result<SupportChatResponse, Error>) -> Void) {
+        Task {
+            let result = await Result {
+                try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+            }
+
+            await MainActor.run {
+                completion(result)
+            }
+        }
+    }
+}
+
+// MARK: - Local history
+//
+private extension SupportChatStore {
+
+    func registerChat(chatID: Int64,
+                      siteID: Int64,
+                      wpcomUserID: Int64,
+                      botSlug: String,
+                      firstUserMessage: String,
+                      onCompletion: @escaping (Error?) -> Void) {
+        let title = Self.deriveTitle(from: firstUserMessage)
+        let now = Date()
+
+        storageManager.performAndSave({ storage in
+            // No-op if a row already exists for this chatID (duplicate dispatch or retry).
+            guard storage.loadSupportChat(chatID: chatID) == nil else {
+                return
+            }
+            let chat = storage.insertNewObject(ofType: StoredSupportChat.self)
+            chat.chatID = chatID
+            chat.siteID = siteID
+            chat.wpcomUserID = wpcomUserID
+            chat.botSlug = botSlug
+            chat.title = title
+            chat.createdAt = now
+            chat.updatedAt = now
+        }, completion: {
+            onCompletion(nil)
+        }, on: .main)
+    }
+
+    func touchChat(chatID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        let now = Date()
+        storageManager.performAndSave({ storage in
+            guard let chat = storage.loadSupportChat(chatID: chatID) else {
+                // Idempotent — row may have been deleted between turns.
+                return
+            }
+            chat.updatedAt = now
+        }, completion: {
+            onCompletion(nil)
+        }, on: .main)
+    }
+
+    func loadChatHistory(siteID: Int64,
+                         onCompletion: @escaping (Result<[SupportChatSummary], Error>) -> Void) {
+        let summaries = storageManager.viewStorage
+            .loadSupportChats(siteID: siteID)
+            .map { $0.toReadOnly() }
+        onCompletion(.success(summaries))
+    }
+
+    func deleteChat(chatID: Int64, onCompletion: @escaping (Error?) -> Void) {
+        storageManager.performAndSave({ storage in
+            storage.deleteSupportChat(chatID: chatID)
+        }, completion: {
+            onCompletion(nil)
+        }, on: .main)
+    }
+}
+
+// MARK: - Helpers
+//
+private extension SupportChatStore {
+    /// Trims whitespace and clamps `message` to 50 characters, preserving Unicode scalars.
+    /// Returns `nil` if the resulting string is empty.
+    static func deriveTitle(from message: String) -> String? {
+        let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let maxLength = 50
+        if trimmed.count <= maxLength {
+            return trimmed
+        }
+        let endIndex = trimmed.index(trimmed.startIndex, offsetBy: maxLength)
+        return String(trimmed[..<endIndex])
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -225,4 +225,91 @@ struct SupportChatRemoteTests {
                                          context: nil)
         }
     }
+
+    // MARK: - fetchChat
+
+    @Test func fetchChat_issues_get_request_to_chat_path() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4522824
+
+        // When
+        _ = try? await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? DotcomRequest)
+        #expect(request.path == "odie/chat/\(botSlug)/\(chatID)")
+        #expect(request.method == .get)
+    }
+
+    @Test func fetchChat_when_response_is_valid_then_returns_every_turn_in_order() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4522824
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)",
+                                 filename: "support-chat-fetch-chat")
+
+        // When
+        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+
+        // Then
+        #expect(response.chatID == chatID)
+        #expect(response.messages.count == 4)
+        #expect(response.messages.map(\.role) == [.user, .bot, .user, .bot])
+    }
+
+    @Test func fetchChat_when_response_contains_user_role_then_decodes_as_user_case() async throws {
+        // Given — GET surfaces user turns (POST only returns bot), so `.user` must decode cleanly.
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4522824
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)",
+                                 filename: "support-chat-fetch-chat")
+
+        // When
+        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+
+        // Then
+        let firstMessage = try #require(response.messages.first)
+        #expect(firstMessage.role == .user)
+        #expect(firstMessage.content == "Smoke test for GET endpoint — ignore.")
+    }
+
+    @Test func fetchChat_when_user_message_context_lacks_flags_and_sources_then_decodes_failsafe() async throws {
+        // Given — user messages carry a different `context` shape than bot messages (no flags/sources).
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4522824
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)",
+                                 filename: "support-chat-fetch-chat")
+
+        // When
+        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+
+        // Then — the failsafe decoder produces empty sources + nil flags rather than throwing.
+        let userMessageContext = try #require(response.messages.first?.context)
+        #expect(userMessageContext.sources.isEmpty)
+        #expect(userMessageContext.flags == nil)
+    }
+
+    @Test func fetchChat_when_no_response_stubbed_then_throws_notFound() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+
+        // When / Then
+        await #expect(throws: NetworkError.notFound()) {
+            try await remote.fetchChat(botSlug: botSlug, chatID: 4522824)
+        }
+    }
+
+    @Test func fetchChat_when_network_errors_then_propagates_error() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4522824
+        network.simulateError(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)",
+                              error: NetworkError.timeout())
+
+        // When / Then
+        await #expect(throws: NetworkError.timeout()) {
+            try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-fetch-chat.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-fetch-chat.json
@@ -1,0 +1,90 @@
+{
+    "chat_id": 4522824,
+    "wpcom_user_id": 2002,
+    "external_id": null,
+    "external_id_provider": null,
+    "session_id": "aa11bb22-cc33-dd44-ee55-ff6677889900",
+    "bot_slug": "woo-chat-allusers",
+    "bot_version": "1.4.3",
+    "created_at": "2026-04-24 09:04:29",
+    "zendesk_ticket_id": null,
+    "messages": [
+        {
+            "message_id": 18644627,
+            "role": "user",
+            "content": "Smoke test for GET endpoint — ignore.",
+            "created_at": "2026-04-24 09:04:29",
+            "context": {
+                "message": "Smoke test for GET endpoint — ignore.",
+                "wpcom_user_id": 2002,
+                "wpcom_user_name": "testuser",
+                "user_paid_support_eligibility": {
+                    "is_user_eligible": true,
+                    "is_chat_restricted": false,
+                    "wapuu_assistant_enabled": true,
+                    "support_level": "p2-plus",
+                    "user_field_flow_name": null
+                }
+            },
+            "ts": 1777021469
+        },
+        {
+            "message_id": 18644640,
+            "role": "bot",
+            "content": "Hi there! How can I help?",
+            "created_at": "2026-04-24 09:04:35",
+            "context": {
+                "sources": [
+                    {
+                        "title": "Placeholder Source",
+                        "url": "https://example.com/docs/source-a",
+                        "heading": "Excerpt",
+                        "content": "Chunk of source text."
+                    }
+                ],
+                "flags": {
+                    "forward_to_human_support": false,
+                    "canned_response": false,
+                    "logged_in": false,
+                    "branch": "default"
+                }
+            },
+            "ts": 1777021475
+        },
+        {
+            "message_id": 18644655,
+            "role": "user",
+            "content": "Follow-up turn to seed history.",
+            "created_at": "2026-04-24 09:04:48",
+            "context": {
+                "message": "Follow-up turn to seed history.",
+                "wpcom_user_id": 2002,
+                "wpcom_user_name": "testuser",
+                "user_paid_support_eligibility": {
+                    "is_user_eligible": true,
+                    "is_chat_restricted": false,
+                    "wapuu_assistant_enabled": true,
+                    "support_level": "p2-plus",
+                    "user_field_flow_name": null
+                }
+            },
+            "ts": 1777021488
+        },
+        {
+            "message_id": 18644670,
+            "role": "bot",
+            "content": "I'm here to help with any WooCommerce questions.",
+            "created_at": "2026-04-24 09:04:57",
+            "context": {
+                "sources": [],
+                "flags": {
+                    "forward_to_human_support": false,
+                    "canned_response": false,
+                    "logged_in": false,
+                    "branch": "default"
+                }
+            },
+            "ts": 1777021497
+        }
+    ]
+}

--- a/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
@@ -1,0 +1,39 @@
+import Foundation
+@testable import Networking
+
+/// Mock for `SupportChatRemoteProtocol`.
+///
+final class MockSupportChatRemote: SupportChatRemoteProtocol {
+    private var sendMessageResult: Result<SupportChatResponse, Error>?
+    private var fetchChatResult: Result<SupportChatResponse, Error>?
+
+    private(set) var sendMessageInvocations: [(botSlug: String, message: String, chatID: Int64?)] = []
+    private(set) var fetchChatInvocations: [(botSlug: String, chatID: Int64)] = []
+
+    func whenSendingMessage(thenReturn result: Result<SupportChatResponse, Error>) {
+        sendMessageResult = result
+    }
+
+    func whenFetchingChat(thenReturn result: Result<SupportChatResponse, Error>) {
+        fetchChatResult = result
+    }
+
+    func sendMessage(botSlug: String,
+                     message: String,
+                     chatID: Int64?,
+                     context: [String: Any]?) async throws -> SupportChatResponse {
+        sendMessageInvocations.append((botSlug, message, chatID))
+        guard let result = sendMessageResult else {
+            throw NetworkError.timeout()
+        }
+        return try result.get()
+    }
+
+    func fetchChat(botSlug: String, chatID: Int64) async throws -> SupportChatResponse {
+        fetchChatInvocations.append((botSlug, chatID))
+        guard let result = fetchChatResult else {
+            throw NetworkError.timeout()
+        }
+        return try result.get()
+    }
+}

--- a/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
@@ -1,0 +1,349 @@
+import Foundation
+import Testing
+import YosemiteTestHelpers
+@testable import Networking
+@testable import Storage
+@testable import Yosemite
+
+@MainActor
+struct SupportChatStoreTests {
+    private let dispatcher: Dispatcher
+    private let storageManager: MockStorageManager
+    private let network: MockNetwork
+    private let remote: MockSupportChatRemote
+
+    private var viewStorage: StorageType { storageManager.viewStorage }
+    private var storedChatCount: Int { viewStorage.countObjects(ofType: StoredSupportChat.self) }
+
+    private let sampleSiteID: Int64 = 134
+    private let sampleWPComUserID: Int64 = 9001
+    private let sampleBotSlug = "woo-chat-allusers"
+
+    init() {
+        dispatcher = Dispatcher()
+        storageManager = MockStorageManager()
+        network = MockNetwork()
+        remote = MockSupportChatRemote()
+    }
+
+    private func makeStore() -> SupportChatStore {
+        SupportChatStore(dispatcher: dispatcher,
+                         storageManager: storageManager,
+                         network: network,
+                         remote: remote)
+    }
+
+    // MARK: - registerChat
+
+    @Test func registerChat_inserts_a_row_with_all_fields_populated() async throws {
+        // Given
+        let store = makeStore()
+        let chatID: Int64 = 4242
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "How do I configure shipping?",
+                                                          onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+
+        // Then
+        #expect(error == nil)
+        #expect(storedChatCount == 1)
+        let stored = try #require(viewStorage.loadSupportChat(chatID: chatID))
+        #expect(stored.chatID == chatID)
+        #expect(stored.siteID == sampleSiteID)
+        #expect(stored.wpcomUserID == sampleWPComUserID)
+        #expect(stored.botSlug == sampleBotSlug)
+        #expect(stored.title == "How do I configure shipping?")
+        #expect(stored.createdAt != nil)
+        #expect(stored.updatedAt != nil)
+    }
+
+    @Test func registerChat_when_row_already_exists_then_does_not_insert_duplicate() async throws {
+        // Given — one row already persisted
+        let store = makeStore()
+        let chatID: Int64 = 4242
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "first",
+                                                          onCompletion: { _ in continuation.resume() }))
+        }
+        #expect(storedChatCount == 1)
+
+        // When — register again with the same chatID but a different message
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "second",
+                                                          onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+
+        // Then — still one row, original title preserved.
+        #expect(error == nil)
+        #expect(storedChatCount == 1)
+        let stored = try #require(viewStorage.loadSupportChat(chatID: chatID))
+        #expect(stored.title == "first")
+    }
+
+    @Test func registerChat_clamps_long_first_user_message_to_50_chars_and_trims() async throws {
+        // Given
+        let store = makeStore()
+        let longMessage = "   " + String(repeating: "a", count: 80) + "   "
+
+        // When
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: 1,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: longMessage,
+                                                          onCompletion: { _ in continuation.resume() }))
+        }
+
+        // Then — leading/trailing whitespace trimmed, then clamped to 50 chars.
+        let stored = try #require(viewStorage.loadSupportChat(chatID: 1))
+        let title = try #require(stored.title)
+        #expect(title.count == 50)
+        #expect(title == String(repeating: "a", count: 50))
+    }
+
+    // MARK: - touchChat
+
+    @Test func touchChat_bumps_updatedAt_on_existing_row() async throws {
+        // Given — register a chat, capture its initial updatedAt.
+        let store = makeStore()
+        let chatID: Int64 = 4242
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "hi",
+                                                          onCompletion: { _ in continuation.resume() }))
+        }
+        let initialUpdatedAt = try #require(viewStorage.loadSupportChat(chatID: chatID)?.updatedAt)
+
+        // Sleep a beat so the new timestamp is materially different.
+        try await Task.sleep(for: .milliseconds(20))
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.touchChat(chatID: chatID, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+
+        // Then
+        #expect(error == nil)
+        let bumpedUpdatedAt = try #require(viewStorage.loadSupportChat(chatID: chatID)?.updatedAt)
+        #expect(bumpedUpdatedAt > initialUpdatedAt)
+    }
+
+    @Test func touchChat_when_row_does_not_exist_then_completes_without_error() async {
+        // Given
+        let store = makeStore()
+
+        // When — touch a chatID that was never registered.
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.touchChat(chatID: 9999, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+
+        // Then — idempotent: no error, no row created.
+        #expect(error == nil)
+        #expect(storedChatCount == 0)
+    }
+
+    // MARK: - loadChatHistory
+
+    @Test func loadChatHistory_returns_rows_sorted_by_updatedAt_descending() async throws {
+        // Given — three rows on the same site with distinct updatedAt timestamps.
+        let store = makeStore()
+        for chatID in Int64(1)...Int64(3) {
+            await withCheckedContinuation { continuation in
+                store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                              siteID: sampleSiteID,
+                                                              wpcomUserID: sampleWPComUserID,
+                                                              botSlug: sampleBotSlug,
+                                                              firstUserMessage: "chat \(chatID)",
+                                                              onCompletion: { _ in continuation.resume() }))
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        let summaries = try result.get()
+        #expect(summaries.map(\.chatID) == [3, 2, 1])
+    }
+
+    @Test func loadChatHistory_filters_by_siteID() async throws {
+        // Given — rows on two different sites.
+        let store = makeStore()
+        let otherSiteID: Int64 = 999
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: 1,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "ours",
+                                                          onCompletion: { _ in continuation.resume() }))
+        }
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: 2,
+                                                          siteID: otherSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "theirs",
+                                                          onCompletion: { _ in continuation.resume() }))
+        }
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then — only the row scoped to sampleSiteID is returned.
+        let summaries = try result.get()
+        #expect(summaries.map(\.chatID) == [1])
+    }
+
+    @Test func loadChatHistory_when_no_rows_then_returns_empty() async throws {
+        // Given
+        let store = makeStore()
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        let summaries = try result.get()
+        #expect(summaries.isEmpty)
+    }
+
+    // MARK: - deleteChat
+
+    @Test func deleteChat_removes_the_row() async throws {
+        // Given
+        let store = makeStore()
+        let chatID: Int64 = 4242
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          firstUserMessage: "hi",
+                                                          onCompletion: { _ in continuation.resume() }))
+        }
+        #expect(storedChatCount == 1)
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.deleteChat(chatID: chatID, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+
+        // Then
+        #expect(error == nil)
+        #expect(storedChatCount == 0)
+    }
+
+    @Test func deleteChat_when_row_does_not_exist_then_completes_without_error() async {
+        // Given
+        let store = makeStore()
+
+        // When
+        let error = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.deleteChat(chatID: 9999, onCompletion: { error in
+                continuation.resume(returning: error)
+            }))
+        }
+
+        // Then — idempotent.
+        #expect(error == nil)
+    }
+
+    // MARK: - fetchChat
+
+    @Test func fetchChat_forwards_to_remote_with_botSlug_and_chatID() async throws {
+        // Given
+        let store = makeStore()
+        remote.whenFetchingChat(thenReturn: .success(.fake()))
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.fetchChat(botSlug: sampleBotSlug,
+                                                       chatID: 4242,
+                                                       completion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        #expect(remote.fetchChatInvocations.count == 1)
+        let invocation = try #require(remote.fetchChatInvocations.first)
+        #expect(invocation.botSlug == sampleBotSlug)
+        #expect(invocation.chatID == 4242)
+    }
+
+    @Test func fetchChat_propagates_remote_errors() async {
+        // Given
+        let store = makeStore()
+        remote.whenFetchingChat(thenReturn: .failure(NetworkError.timeout()))
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.fetchChat(botSlug: sampleBotSlug,
+                                                       chatID: 4242,
+                                                       completion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        switch result {
+        case .success:
+            Issue.record("Expected fetchChat to propagate a failure")
+        case .failure(let error):
+            #expect(error is NetworkError)
+        }
+    }
+}
+
+// MARK: - Test helper
+//
+private extension SupportChatResponse {
+    static func fake() -> SupportChatResponse {
+        SupportChatResponse(chatID: 4242,
+                            sessionID: "session",
+                            botSlug: "woo-chat-allusers",
+                            botVersion: "1.4.3",
+                            messages: [])
+    }
+}

--- a/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
@@ -41,19 +41,16 @@ struct SupportChatStoreTests {
         let chatID: Int64 = 4242
 
         // When
-        let error = await withCheckedContinuation { continuation in
+        await withCheckedContinuation { continuation in
             store.onAction(SupportChatAction.registerChat(chatID: chatID,
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "How do I configure shipping?",
-                                                          onCompletion: { error in
-                continuation.resume(returning: error)
-            }))
+                                                          onCompletion: { continuation.resume() }))
         }
 
         // Then
-        #expect(error == nil)
         #expect(storedChatCount == 1)
         let stored = try #require(viewStorage.loadSupportChat(chatID: chatID))
         #expect(stored.chatID == chatID)
@@ -75,24 +72,21 @@ struct SupportChatStoreTests {
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "first",
-                                                          onCompletion: { _ in continuation.resume() }))
+                                                          onCompletion: { continuation.resume() }))
         }
         #expect(storedChatCount == 1)
 
         // When — register again with the same chatID but a different message
-        let error = await withCheckedContinuation { continuation in
+        await withCheckedContinuation { continuation in
             store.onAction(SupportChatAction.registerChat(chatID: chatID,
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "second",
-                                                          onCompletion: { error in
-                continuation.resume(returning: error)
-            }))
+                                                          onCompletion: { continuation.resume() }))
         }
 
         // Then — still one row, original title preserved.
-        #expect(error == nil)
         #expect(storedChatCount == 1)
         let stored = try #require(viewStorage.loadSupportChat(chatID: chatID))
         #expect(stored.title == "first")
@@ -110,7 +104,7 @@ struct SupportChatStoreTests {
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: longMessage,
-                                                          onCompletion: { _ in continuation.resume() }))
+                                                          onCompletion: { continuation.resume() }))
         }
 
         // Then — leading/trailing whitespace trimmed, then clamped to 50 chars.
@@ -132,7 +126,7 @@ struct SupportChatStoreTests {
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "hi",
-                                                          onCompletion: { _ in continuation.resume() }))
+                                                          onCompletion: { continuation.resume() }))
         }
         let initialUpdatedAt = try #require(viewStorage.loadSupportChat(chatID: chatID)?.updatedAt)
 
@@ -140,14 +134,11 @@ struct SupportChatStoreTests {
         try await Task.sleep(for: .milliseconds(20))
 
         // When
-        let error = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.touchChat(chatID: chatID, onCompletion: { error in
-                continuation.resume(returning: error)
-            }))
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.touchChat(chatID: chatID, onCompletion: { continuation.resume() }))
         }
 
         // Then
-        #expect(error == nil)
         let bumpedUpdatedAt = try #require(viewStorage.loadSupportChat(chatID: chatID)?.updatedAt)
         #expect(bumpedUpdatedAt > initialUpdatedAt)
     }
@@ -157,14 +148,11 @@ struct SupportChatStoreTests {
         let store = makeStore()
 
         // When — touch a chatID that was never registered.
-        let error = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.touchChat(chatID: 9999, onCompletion: { error in
-                continuation.resume(returning: error)
-            }))
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.touchChat(chatID: 9999, onCompletion: { continuation.resume() }))
         }
 
-        // Then — idempotent: no error, no row created.
-        #expect(error == nil)
+        // Then — idempotent: no row created.
         #expect(storedChatCount == 0)
     }
 
@@ -180,20 +168,19 @@ struct SupportChatStoreTests {
                                                               wpcomUserID: sampleWPComUserID,
                                                               botSlug: sampleBotSlug,
                                                               firstUserMessage: "chat \(chatID)",
-                                                              onCompletion: { _ in continuation.resume() }))
+                                                              onCompletion: { continuation.resume() }))
             }
             try await Task.sleep(for: .milliseconds(10))
         }
 
         // When
-        let result = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { result in
-                continuation.resume(returning: result)
+        let summaries = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { summaries in
+                continuation.resume(returning: summaries)
             }))
         }
 
         // Then
-        let summaries = try result.get()
         #expect(summaries.map(\.chatID) == [3, 2, 1])
     }
 
@@ -207,7 +194,7 @@ struct SupportChatStoreTests {
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "ours",
-                                                          onCompletion: { _ in continuation.resume() }))
+                                                          onCompletion: { continuation.resume() }))
         }
         await withCheckedContinuation { continuation in
             store.onAction(SupportChatAction.registerChat(chatID: 2,
@@ -215,34 +202,32 @@ struct SupportChatStoreTests {
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "theirs",
-                                                          onCompletion: { _ in continuation.resume() }))
+                                                          onCompletion: { continuation.resume() }))
         }
 
         // When
-        let result = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { result in
-                continuation.resume(returning: result)
+        let summaries = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { summaries in
+                continuation.resume(returning: summaries)
             }))
         }
 
         // Then — only the row scoped to sampleSiteID is returned.
-        let summaries = try result.get()
         #expect(summaries.map(\.chatID) == [1])
     }
 
-    @Test func loadChatHistory_when_no_rows_then_returns_empty() async throws {
+    @Test func loadChatHistory_when_no_rows_then_returns_empty() async {
         // Given
         let store = makeStore()
 
         // When
-        let result = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { result in
-                continuation.resume(returning: result)
+        let summaries = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.loadChatHistory(siteID: sampleSiteID, onCompletion: { summaries in
+                continuation.resume(returning: summaries)
             }))
         }
 
         // Then
-        let summaries = try result.get()
         #expect(summaries.isEmpty)
     }
 
@@ -258,19 +243,16 @@ struct SupportChatStoreTests {
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
                                                           firstUserMessage: "hi",
-                                                          onCompletion: { _ in continuation.resume() }))
+                                                          onCompletion: { continuation.resume() }))
         }
         #expect(storedChatCount == 1)
 
         // When
-        let error = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.deleteChat(chatID: chatID, onCompletion: { error in
-                continuation.resume(returning: error)
-            }))
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.deleteChat(chatID: chatID, onCompletion: { continuation.resume() }))
         }
 
         // Then
-        #expect(error == nil)
         #expect(storedChatCount == 0)
     }
 
@@ -279,14 +261,12 @@ struct SupportChatStoreTests {
         let store = makeStore()
 
         // When
-        let error = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.deleteChat(chatID: 9999, onCompletion: { error in
-                continuation.resume(returning: error)
-            }))
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.deleteChat(chatID: 9999, onCompletion: { continuation.resume() }))
         }
 
         // Then — idempotent.
-        #expect(error == nil)
+        #expect(storedChatCount == 0)
     }
 
     // MARK: - fetchChat

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -76,7 +76,8 @@ final class HelpAndSupportViewController: UIViewController {
         isMacCatalyst: isMacCatalyst,
         hasLoginSiteURL: loginSiteURL != nil,
         developerFFPanelEnabled: !ServiceLocator.stores.isAuthenticated
-            && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
+            && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel),
+        isAIChatEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
     )
 
     private var isMacCatalyst: Bool {
@@ -234,6 +235,8 @@ private extension HelpAndSupportViewController {
             configureSiteCompatibility(cell: cell)
         case let cell as ValueOneTableViewCell where row == .featureFlags:
             configureFeatureFlags(cell: cell)
+        case let cell as ValueOneTableViewCell where row == .chatHistory:
+            configureChatHistory(cell: cell)
         default:
             fatalError()
         }
@@ -317,6 +320,23 @@ private extension HelpAndSupportViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = "Override Feature Flags"
         cell.detailTextLabel?.text = "Toggle local feature flags"
+    }
+
+    /// Chat History cell
+    ///
+    func configureChatHistory(cell: ValueOneTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString(
+            "helpAndSupport.chatHistory.title",
+            value: "Chat History",
+            comment: "Title for the support chat history row on the Help screen"
+        )
+        cell.detailTextLabel?.text = NSLocalizedString(
+            "helpAndSupport.chatHistory.subtitle",
+            value: "Revisit past support conversations",
+            comment: "Subtitle for the support chat history row on the Help screen"
+        )
     }
 
     func refreshViewContent() {
@@ -432,6 +452,34 @@ private extension HelpAndSupportViewController {
         navigationController?.pushViewController(controller, animated: true)
     }
 
+    /// Chat History action
+    ///
+    func chatHistoryWasPressed() {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return
+        }
+        let historyViewModel = SupportChatHistoryViewModel(siteID: siteID)
+        let rootView = SupportChatHistoryView(viewModel: historyViewModel) { [weak self] summary in
+            self?.resumeChat(for: summary)
+        }
+        let controller = UIHostingController(rootView: rootView)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
+    /// Pushes the support chat UI seeded with a prior `chatID` so the conversation
+    /// continues on the assistant's side when the merchant sends the next message.
+    private func resumeChat(for summary: SupportChatSummary) {
+        let chatViewModel = SupportChatViewModel(
+            botSlug: summary.botSlug,
+            chatID: summary.chatID,
+            onContactHumanSupport: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            }
+        )
+        let controller = SupportChatHostingController(viewModel: chatViewModel)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     @objc func dismissWasPressed() {
         dismiss(animated: true, completion: nil)
     }
@@ -488,6 +536,8 @@ extension HelpAndSupportViewController: UITableViewDelegate {
             siteCompatibilityWasPressed()
         case .featureFlags:
             featureFlagsWasPressed()
+        case .chatHistory:
+            chatHistoryWasPressed()
         }
     }
 }
@@ -514,10 +564,11 @@ enum HelpAndSupportRow: CaseIterable {
     case systemStatusReport
     case siteCompatibility
     case featureFlags
+    case chatHistory
 
     var type: UITableViewCell.Type {
         switch self {
-        case .helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport, .siteCompatibility, .featureFlags:
+        case .helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport, .siteCompatibility, .featureFlags, .chatHistory:
             return ValueOneTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -472,7 +472,7 @@ private extension HelpAndSupportViewController {
         let chatViewModel = SupportChatViewModel(
             botSlug: summary.botSlug,
             chatID: summary.chatID,
-            onContactHumanSupport: { [weak self] in
+            onContactHumanSupport: { [weak self] _ in
                 self?.navigationController?.popViewController(animated: true)
             }
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -7,17 +7,20 @@ struct HelpAndSupportViewModel {
     private let isMacCatalyst: Bool
     private let hasLoginSiteURL: Bool
     private let developerFFPanelEnabled: Bool
+    private let isAIChatEnabled: Bool
 
     init(isAuthenticated: Bool,
          isZendeskEnabled: Bool,
          isMacCatalyst: Bool,
          hasLoginSiteURL: Bool = false,
-         developerFFPanelEnabled: Bool = false) {
+         developerFFPanelEnabled: Bool = false,
+         isAIChatEnabled: Bool = false) {
         self.isAuthenticated = isAuthenticated
         self.isZendeskEnabled = isZendeskEnabled
         self.isMacCatalyst = isMacCatalyst
         self.developerFFPanelEnabled = developerFFPanelEnabled
         self.hasLoginSiteURL = hasLoginSiteURL
+        self.isAIChatEnabled = isAIChatEnabled
     }
 
     func getRows() -> [HelpAndSupportRow] {
@@ -35,6 +38,9 @@ struct HelpAndSupportViewModel {
         }
         if !isAuthenticated && hasLoginSiteURL {
             rows.append(.siteCompatibility)
+        }
+        if isAuthenticated && isAIChatEnabled {
+            rows.append(.chatHistory)
         }
         return rows
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryRow.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import Yosemite
+
+/// A single row in the chat history list — title (or fallback) plus a relative date.
+///
+struct SupportChatHistoryRow: View {
+    let summary: SupportChatSummary
+
+    private static let dateFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(summary.title ?? Localization.untitledFallback)
+                .font(.body)
+                .lineLimit(1)
+            Text(Self.dateFormatter.localizedString(for: summary.updatedAt, relativeTo: Date()))
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private extension SupportChatHistoryRow {
+    enum Localization {
+        static let untitledFallback = NSLocalizedString(
+            "supportChatHistoryRow.untitledFallback",
+            value: "Untitled chat",
+            comment: "Fallback title for a support chat history row when no title was captured"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import Yosemite
+
+/// List of previously-stored support chats. Supports swipe-to-delete and tap-to-resume.
+///
+struct SupportChatHistoryView: View {
+    @State private var viewModel: SupportChatHistoryViewModel
+
+    /// Called when the merchant taps a chat to resume it. The host is responsible
+    /// for presenting the chat UI seeded with the given `chatID`.
+    private let onSelect: (SupportChatSummary) -> Void
+
+    init(viewModel: SupportChatHistoryViewModel,
+         onSelect: @escaping (SupportChatSummary) -> Void) {
+        self._viewModel = State(wrappedValue: viewModel)
+        self.onSelect = onSelect
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.summaries.isEmpty {
+                emptyState
+            } else {
+                list
+            }
+        }
+        .navigationTitle(Localization.title)
+        .task {
+            viewModel.load()
+        }
+    }
+
+    private var list: some View {
+        List {
+            ForEach(viewModel.summaries, id: \.chatID) { summary in
+                Button {
+                    onSelect(summary)
+                } label: {
+                    SupportChatHistoryRow(summary: summary)
+                }
+                .buttonStyle(.plain)
+            }
+            .onDelete { indexSet in
+                viewModel.delete(at: indexSet)
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text(Localization.emptyState)
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+private extension SupportChatHistoryView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "supportChatHistoryView.title",
+            value: "Chat History",
+            comment: "Navigation title for the support chat history screen"
+        )
+        static let emptyState = NSLocalizedString(
+            "supportChatHistoryView.emptyState",
+            value: "You haven't chatted with support yet.",
+            comment: "Empty state message shown when there are no stored support chats"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryViewModel.swift
@@ -19,13 +19,8 @@ final class SupportChatHistoryViewModel {
     }
 
     func load() {
-        let action = SupportChatAction.loadChatHistory(siteID: siteID) { [weak self] result in
-            switch result {
-            case .success(let summaries):
-                self?.summaries = summaries
-            case .failure(let error):
-                DDLogError("⛔️ Failed to load support chat history: \(error)")
-            }
+        let action = SupportChatAction.loadChatHistory(siteID: siteID) { [weak self] summaries in
+            self?.summaries = summaries
         }
         stores.dispatch(action)
     }
@@ -37,7 +32,7 @@ final class SupportChatHistoryViewModel {
         summaries.remove(atOffsets: indexSet)
 
         for chatID in chatIDsToDelete {
-            let action = SupportChatAction.deleteChat(chatID: chatID, onCompletion: { _ in })
+            let action = SupportChatAction.deleteChat(chatID: chatID, onCompletion: {})
             stores.dispatch(action)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/History/SupportChatHistoryViewModel.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Observation
+import Yosemite
+
+/// View model backing the chat history list. Loads persisted chat bookmarks
+/// for the current site and supports swipe-to-delete.
+///
+@MainActor
+@Observable
+final class SupportChatHistoryViewModel {
+    private(set) var summaries: [SupportChatSummary] = []
+
+    private let stores: StoresManager
+    private let siteID: Int64
+
+    init(stores: StoresManager = ServiceLocator.stores, siteID: Int64) {
+        self.stores = stores
+        self.siteID = siteID
+    }
+
+    func load() {
+        let action = SupportChatAction.loadChatHistory(siteID: siteID) { [weak self] result in
+            switch result {
+            case .success(let summaries):
+                self?.summaries = summaries
+            case .failure(let error):
+                DDLogError("⛔️ Failed to load support chat history: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    func delete(at indexSet: IndexSet) {
+        let chatIDsToDelete = indexSet.map { summaries[$0].chatID }
+
+        // Remove from the local array first for snappy UI; the dispatched action is fire-and-forget.
+        summaries.remove(atOffsets: indexSet)
+
+        for chatID in chatIDsToDelete {
+            let action = SupportChatAction.deleteChat(chatID: chatID, onCompletion: { _ in })
+            stores.dispatch(action)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -40,6 +40,7 @@ struct SupportChatView: View {
         )
         .onAppear {
             viewModel.showGreeting()
+            viewModel.resumeIfNeeded()
         }
     }
 
@@ -49,6 +50,10 @@ struct SupportChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: SupportChatLayout.messageSpacing) {
+                    if viewModel.isResumedChat {
+                        resumedChatHeader
+                    }
+
                     ForEach(viewModel.messages) { message in
                         SupportChatMessageRow(message: message)
                             .id(message.id)
@@ -81,6 +86,19 @@ struct SupportChatView: View {
                 proxy.scrollTo(lastMessage.id, anchor: .bottom)
             }
         }
+    }
+
+    // MARK: - Resumed Chat Header
+
+    private var resumedChatHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "clock.arrow.circlepath")
+            Text(Localization.resumedChatHeader)
+        }
+        .font(.caption)
+        .foregroundColor(Color(.secondaryLabel))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 4)
     }
 
     // MARK: - Human Support Banner
@@ -172,6 +190,11 @@ private extension SupportChatView {
             "supportChatView.contactSupport",
             value: "Contact Support",
             comment: "Button to contact human support from the chat"
+        )
+        static let resumedChatHeader = NSLocalizedString(
+            "supportChatView.resumedChatHeader",
+            value: "Continuing previous conversation",
+            comment: "Inline separator shown at the top of a chat that was opened from history, signalling that prior messages follow"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -205,7 +205,7 @@ final class SupportChatViewModel {
                 case .user:
                     return ChatMessage(role: .user, content: message.content)
                 case .bot:
-                    return ChatMessage(role: .assistant, content: message.content)
+                    return ChatMessage(role: .bot, content: message.content)
                 case .unknown:
                     return nil
                 }
@@ -237,11 +237,11 @@ final class SupportChatViewModel {
                                                        wpcomUserID: wpcomUserID,
                                                        botSlug: botSlug,
                                                        firstUserMessage: firstUserMessage,
-                                                       onCompletion: { _ in })
+                                                       onCompletion: {})
             stores.dispatch(action)
         } else {
             let action = SupportChatAction.touchChat(chatID: response.chatID,
-                                                    onCompletion: { _ in })
+                                                    onCompletion: {})
             stores.dispatch(action)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -55,6 +55,11 @@ final class SupportChatViewModel {
     private(set) var state: State = .idle
     private(set) var shouldPromptHumanSupport: Bool = false
 
+    /// `true` when the view model was seeded with a prior `chatID` — i.e. the merchant
+    /// tapped a history row rather than starting fresh. Drives the "Continuing conversation"
+    /// header in the chat surface.
+    let isResumedChat: Bool
+
     var inputText: String = ""
 
     // MARK: - Private Properties
@@ -70,10 +75,13 @@ final class SupportChatViewModel {
     init(botSlug: String = "woo-workflow-support_mobile_inapp",
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,
+         chatID: Int64? = nil,
          onContactHumanSupport: @escaping () -> Void) {
         self.botSlug = botSlug
         self.stores = stores
         self.initialContext = initialContext
+        self.chatID = chatID
+        self.isResumedChat = chatID != nil
         self.onContactHumanSupport = onContactHumanSupport
     }
 
@@ -81,6 +89,8 @@ final class SupportChatViewModel {
 
     func showGreeting() {
         guard messages.isEmpty else { return }
+        // Resumed chats skip the greeting — the merchant is continuing a prior conversation.
+        guard chatID == nil else { return }
         state = .sending
 
         Task {
@@ -89,6 +99,19 @@ final class SupportChatViewModel {
             messages.append(greetingMessage)
             state = .idle
         }
+    }
+
+    /// Fetches the prior transcript for a resumed chat and populates `messages`.
+    /// No-op for fresh chats or if messages have already been loaded.
+    func resumeIfNeeded() {
+        guard let chatID else { return }
+        guard messages.isEmpty else { return }
+        state = .sending
+
+        let action = SupportChatAction.fetchChat(botSlug: botSlug, chatID: chatID) { [weak self] result in
+            self?.handleFetchChatResult(result)
+        }
+        stores.dispatch(action)
     }
 
     func sendMessage() {
@@ -102,6 +125,8 @@ final class SupportChatViewModel {
         state = .sending
 
         let context = chatID == nil ? initialContext : nil
+        let wasNewChat = chatID == nil
+        let firstUserMessage = trimmedText
 
         let action = SupportChatAction.sendMessage(
             botSlug: botSlug,
@@ -109,7 +134,9 @@ final class SupportChatViewModel {
             chatID: chatID,
             context: context
         ) { [weak self] result in
-            self?.handleSendMessageResult(result)
+            self?.handleSendMessageResult(result,
+                                          wasNewChat: wasNewChat,
+                                          firstUserMessage: firstUserMessage)
         }
 
         stores.dispatch(action)
@@ -125,10 +152,15 @@ final class SupportChatViewModel {
 
     // MARK: - Private Methods
 
-    private func handleSendMessageResult(_ result: Result<SupportChatResponse, Error>) {
+    private func handleSendMessageResult(_ result: Result<SupportChatResponse, Error>,
+                                         wasNewChat: Bool,
+                                         firstUserMessage: String) {
         switch result {
         case .success(let response):
             chatID = response.chatID
+            persistChatBookmark(wasNewChat: wasNewChat,
+                                response: response,
+                                firstUserMessage: firstUserMessage)
 
             if let lastBotMessage = response.messages.last(where: { $0.role == .bot }) {
                 let assistantMessage = ChatMessage(
@@ -149,6 +181,57 @@ final class SupportChatViewModel {
             state = .error(Localization.errorMessage)
         }
     }
+
+    /// Maps a fetched transcript into local `ChatMessage` values. Unknown roles are dropped
+    /// rather than rendered as garbage; ordering from the server (ts-ascending) is preserved.
+    private func handleFetchChatResult(_ result: Result<SupportChatResponse, Error>) {
+        switch result {
+        case .success(let response):
+            let rehydrated: [ChatMessage] = response.messages.compactMap { message in
+                switch message.role {
+                case .user:
+                    return ChatMessage(role: .user, content: message.content)
+                case .bot:
+                    return ChatMessage(role: .assistant, content: message.content)
+                case .unknown:
+                    return nil
+                }
+            }
+            messages = rehydrated
+            state = .idle
+
+        case .failure(let error):
+            DDLogError("⛔️ Support chat resume error: \(error)")
+            // Fail soft: the merchant can still send a new message into the existing chatID;
+            // they just won't see the prior transcript. Surface as a retry-able error.
+            state = .error(Localization.resumeErrorMessage)
+        }
+    }
+
+    /// Persists a local bookmark for the chat so it appears in the chat history UI.
+    /// Fire-and-forget: we don't surface storage errors to the user.
+    private func persistChatBookmark(wasNewChat: Bool,
+                                     response: SupportChatResponse,
+                                     firstUserMessage: String) {
+        if wasNewChat {
+            guard let siteID = stores.sessionManager.defaultStoreID else {
+                // No site context — skip silently. Pre-login / non-WPCom flows aren't persisted yet.
+                return
+            }
+            let wpcomUserID = stores.sessionManager.defaultAccountID ?? -1
+            let action = SupportChatAction.registerChat(chatID: response.chatID,
+                                                       siteID: siteID,
+                                                       wpcomUserID: wpcomUserID,
+                                                       botSlug: botSlug,
+                                                       firstUserMessage: firstUserMessage,
+                                                       onCompletion: { _ in })
+            stores.dispatch(action)
+        } else {
+            let action = SupportChatAction.touchChat(chatID: response.chatID,
+                                                    onCompletion: { _ in })
+            stores.dispatch(action)
+        }
+    }
 }
 
 // MARK: - Localization
@@ -164,6 +247,11 @@ private extension SupportChatViewModel {
             "supportChatViewModel.errorMessage",
             value: "Something went wrong. Please try again.",
             comment: "Error message shown when sending a support chat message fails"
+        )
+        static let resumeErrorMessage = NSLocalizedString(
+            "supportChatViewModel.resumeErrorMessage",
+            value: "We couldn't load the previous conversation. You can still send a new message.",
+            comment: "Error message shown when loading a prior support chat transcript fails on resume"
         )
     }
 }


### PR DESCRIPTION
## Description

Adds local chat history for the AI support chat: persists a bookmark per chat in Core Data, exposes a "Chat History" entry under Settings → Help, and lets the merchant resume any prior chat (rehydrates the full transcript via the `GET /odie/chat/{slug}/{chat_id}` endpoint and threads the next message into the same `chat_id` server-side).        


| 1 | 2 | 3 |
|--------|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-04-28 at 10 56 48" src="https://github.com/user-attachments/assets/d43139b9-bee0-4a8a-a4af-92777b1ededc" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-04-28 at 10 56 51" src="https://github.com/user-attachments/assets/27385501-2c67-4271-beeb-92205d143704" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-04-28 at 10 56 54" src="https://github.com/user-attachments/assets/6e32a4a1-0191-4a67-a2e1-c2d2360e856d" /> | 


## Test Steps
- With `aiSupportChat` flag on, and logged with an authenticated account
- Start a troubleshoot AI chat
- Navigate to Settings > Help > See Chat History
- Confirm chat is there and can be accessed by tapping, opening it rehydrates previous content and scrolls automatically to last conversation point
- Slide left to delete chat

## Screenshots

<img width="148" height="320" alt="Simulator Screen Recording - iPhone 16 Pro Max - Logged wpcom a8c - 2026-04-28 at 10 52 18" src="https://github.com/user-attachments/assets/4821b6c2-19d0-4265-830d-fa7c6df3db6f" />