### PR TITLE
Add `lint:build_settings` rake task

### DIFF
--- a/.buildkite/commands/lint-build-settings.sh
+++ b/.buildkite/commands/lint-build-settings.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+# `lint:xcode_build_settings` runs a SwiftPM tool from `BuildSettingsPolice/`.
+# Resolve its dependencies up front so the Buildkite cache can pick them up
+# and subsequent runs check out the repo fast.
+echo "--- :swift: Setting up Swift Packages"
+pushd "$(dirname "${BASH_SOURCE[0]}")/../../BuildSettingsPolice"
+install_swiftpm_dependencies
+popd
+
+echo "--- :sleuth_or_spy: Linting Xcode Build Settings"
+bundle exec rake lint:xcode_build_settings

--- a/.buildkite/commands/lint-build-settings.sh
+++ b/.buildkite/commands/lint-build-settings.sh
@@ -13,5 +13,5 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/../../BuildSettingsPolice"
 install_swiftpm_dependencies
 popd
 
-echo "--- :sleuth_or_spy: Linting Xcode Build Settings"
+echo "--- :xcode: Linting Xcode Build Settings"
 bundle exec rake lint:xcode_build_settings

--- a/.buildkite/commands/lint-build-settings.sh
+++ b/.buildkite/commands/lint-build-settings.sh
@@ -14,4 +14,13 @@ install_swiftpm_dependencies
 popd
 
 echo "--- :xcode: Linting Xcode Build Settings"
-bundle exec rake lint:xcode_build_settings
+status=0
+bundle exec rake lint:xcode_build_settings || status=$?
+
+if [ "$status" -ne 0 ]; then
+  # Expand this collapsed log group so reviewers see the violations
+  # without having to click into the job.
+  # https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
+  echo "^^^ +++"
+  exit "$status"
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,7 +123,7 @@ steps:
               context: Check Package.resolved
 
       # Runs on the `mac` queue because the underlying tool uses SwiftPM.
-      - label: ":sleuth_or_spy: Lint Xcode Build Settings"
+      - label: ":xcode: Lint Xcode Build Settings"
         command: .buildkite/commands/lint-build-settings.sh
         plugins: [$CI_TOOLKIT]
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,6 +122,14 @@ steps:
           - github_commit_status:
               context: Check Package.resolved
 
+      # Runs on the `mac` queue because the underlying tool uses SwiftPM.
+      - label: ":sleuth_or_spy: Lint Xcode Build Settings"
+        command: .buildkite/commands/lint-build-settings.sh
+        plugins: [$CI_TOOLKIT]
+        notify:
+          - github_commit_status:
+              context: Lint Xcode Build Settings
+
   #################
   # UI Tests
   #################

--- a/BuildSettingsPolice/Empty.swift
+++ b/BuildSettingsPolice/Empty.swift
@@ -1,0 +1,2 @@
+// Here only to satisfy SwiftPM requirement.
+// See https://github.com/nicklockwood/SwiftFormat#1-create-a-buildtools-folder-and-packageswift

--- a/BuildSettingsPolice/Package.resolved
+++ b/BuildSettingsPolice/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "79c68527271a3334df0c27b914b2548271f921e07c07055f0dcef14957b11d92",
+  "originHash" : "4711e08639a5b07d1f2bf3112aadda298f2f458d36dd142a2365cc54b45717ac",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,7 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/xcode-build-settings-police.git",
       "state" : {
-        "revision" : "932eb94dca30a3b2efeaf1a46e3022cd6ed94808"
+        "revision" : "8bd833c18a9396cecf381eaad2cfc34cde4d66ba"
       }
     },
     {
@@ -50,7 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mokagio/XcodeProj-Tuist.git",
       "state" : {
-        "revision" : "956d02f29c984edcadcc2313ce057e5fc66ddc0e"
+        "revision" : "c4bd95e55682918544ffb9bae568743acf236bf7"
       }
     }
   ],

--- a/BuildSettingsPolice/Package.resolved
+++ b/BuildSettingsPolice/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ac552bbb7c707319683b7f9bf416f8e808e0fa8a34f361501993240482bf09b6",
+  "originHash" : "79c68527271a3334df0c27b914b2548271f921e07c07055f0dcef14957b11d92",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,16 +42,15 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/xcode-build-settings-police.git",
       "state" : {
-        "revision" : "a0538abe3a2b56e6dda7a08c440fe79603fc1b34"
+        "revision" : "932eb94dca30a3b2efeaf1a46e3022cd6ed94808"
       }
     },
     {
-      "identity" : "xcodeproj",
+      "identity" : "xcodeproj-tuist",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tuist/XcodeProj.git",
+      "location" : "https://github.com/mokagio/XcodeProj-Tuist.git",
       "state" : {
-        "revision" : "7dbe497dd963b6b29622b13711aa9a156e362ba5",
-        "version" : "9.11.0"
+        "revision" : "956d02f29c984edcadcc2313ce057e5fc66ddc0e"
       }
     }
   ],

--- a/BuildSettingsPolice/Package.resolved
+++ b/BuildSettingsPolice/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "527245b6a47858fe07f911401642963c1baaf6b9def103e826bc0610aadedd6b",
+  "originHash" : "ac552bbb7c707319683b7f9bf416f8e808e0fa8a34f361501993240482bf09b6",
   "pins" : [
     {
       "identity" : "aexml",
@@ -42,7 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/xcode-build-settings-police.git",
       "state" : {
-        "revision" : "872287e2e01daf6d3574acf9a41c19ec4e0e6529"
+        "revision" : "a0538abe3a2b56e6dda7a08c440fe79603fc1b34"
       }
     },
     {

--- a/BuildSettingsPolice/Package.resolved
+++ b/BuildSettingsPolice/Package.resolved
@@ -1,0 +1,59 @@
+{
+  "originHash" : "527245b6a47858fe07f911401642963c1baaf6b9def103e826bc0610aadedd6b",
+  "pins" : [
+    {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "xcode-build-settings-police",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/xcode-build-settings-police.git",
+      "state" : {
+        "revision" : "872287e2e01daf6d3574acf9a41c19ec4e0e6529"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/XcodeProj.git",
+      "state" : {
+        "revision" : "7dbe497dd963b6b29622b13711aa9a156e362ba5",
+        "version" : "9.11.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/BuildSettingsPolice/Package.swift
+++ b/BuildSettingsPolice/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     name: "BuildSettingsPolice",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "a0538abe3a2b56e6dda7a08c440fe79603fc1b34")
+        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "932eb94dca30a3b2efeaf1a46e3022cd6ed94808")
     ],
     targets: [.target(name: "BuildSettingsPoliceRunner", path: "")]
 )

--- a/BuildSettingsPolice/Package.swift
+++ b/BuildSettingsPolice/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     name: "BuildSettingsPolice",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "932eb94dca30a3b2efeaf1a46e3022cd6ed94808")
+        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "8bd833c18a9396cecf381eaad2cfc34cde4d66ba")
     ],
     targets: [.target(name: "BuildSettingsPoliceRunner", path: "")]
 )

--- a/BuildSettingsPolice/Package.swift
+++ b/BuildSettingsPolice/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+// `build-settings-police` lives in its own SwiftPM package — separate from
+// `BuildTools/` — because it depends on `XcodeProj` 9.x while Sourcery 2.3.0
+// (in `BuildTools/`) exact-pins `XcodeProj` 8.24.6 and is not yet on Swift 6,
+// so the two graphs cannot be resolved together.
+//
+// Track https://github.com/krzysztofzablocki/Sourcery/issues/1457 — once a new
+// Sourcery release lands with a loosened `XcodeProj` constraint, this package
+// can be folded back into `BuildTools/`.
+let package = Package(
+    name: "BuildSettingsPolice",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "872287e2e01daf6d3574acf9a41c19ec4e0e6529")
+    ],
+    targets: [.target(name: "BuildSettingsPoliceRunner", path: "")]
+)

--- a/BuildSettingsPolice/Package.swift
+++ b/BuildSettingsPolice/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     name: "BuildSettingsPolice",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "872287e2e01daf6d3574acf9a41c19ec4e0e6529")
+        .package(url: "https://github.com/Automattic/xcode-build-settings-police.git", revision: "a0538abe3a2b56e6dda7a08c440fe79603fc1b34")
     ],
     targets: [.target(name: "BuildSettingsPoliceRunner", path: "")]
 )

--- a/Rakefile
+++ b/Rakefile
@@ -117,5 +117,7 @@ def run_in_build_tools(cmd:)
 end
 
 def run_in_swift_package(dir:, cmd:)
-  sh "pushd #{dir} && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && #{cmd} && popd"
+  sh "pushd #{dir} && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && #{cmd} && popd" do |ok, status|
+    exit(status.exitstatus || 1) unless ok
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -108,5 +108,9 @@ end
 
 # We could use more idiomatic Ruby here, with `Dir.chdir`, but leaving as raw shell commands for when we'll drop Ruby and rake for tooling.
 def run_in_build_tools(cmd:)
-  sh "pushd BuildTools && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && #{cmd} && popd"
+  run_in_swift_package(dir: 'BuildTools', cmd: cmd)
+end
+
+def run_in_swift_package(dir:, cmd:)
+  sh "pushd #{dir} && export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && #{cmd} && popd"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -70,6 +70,11 @@ namespace :lint do
   task :autocorrect do
     swiftlint(additional_args: ['--fix'])
   end
+
+  desc 'Check the Xcode project for inline build settings'
+  task :build_settings do
+    run_in_swift_package(dir: 'BuildSettingsPolice', cmd: 'swift run -c release build-settings-police check ../WooCommerce/WooCommerce.xcodeproj --project')
+  end
 end
 
 desc 'Open the project in Xcode'

--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ namespace :lint do
   end
 
   desc 'Check the Xcode project for inline build settings'
-  task :build_settings do
+  task :xcode_build_settings do
     run_in_swift_package(dir: 'BuildSettingsPolice', cmd: 'swift run -c release build-settings-police check ../WooCommerce/WooCommerce.xcodeproj --project')
   end
 end


### PR DESCRIPTION
## Summary

- Adds `lint:build_settings` rake task that runs [`xcode-build-settings-police`](https://github.com/Automattic/xcode-build-settings-police) `check ... --project` against `WooCommerce.xcodeproj`.
- The tool is consumed via a new sibling `BuildSettingsPolice/` SwiftPM package (SwiftFormat-style) rather than `BuildTools/`.
  Sourcery 2.3.0 (in `BuildTools/`) exact-pins `XcodeProj` 8.24.6 and isn't on Swift 6, while `xcode-build-settings-police` requires `XcodeProj` 9.x — so the two dep graphs can't resolve together.
- The package's top-of-file comment links https://github.com/krzysztofzablocki/Sourcery/issues/1457 to monitor.
  Once Sourcery cuts a release that loosens the pin, this package can be folded back into `BuildTools/`.

## Status

<!-- purple -->
> [!IMPORTANT]  
> The task currently fails by design.

Each of the three project-level configurations (Debug, Release, Release-Alpha) carries ~50 inline build settings that need to migrate to xcconfig files.
That migration is the follow-up — the task going green will mean the project is clean.

## Test plan

- [ ] `bundle exec rake lint:build_settings` builds the tool and reports the expected violations
- [ ] Rake propagates the tool's non-zero exit as task failure
- [ ] Existing tasks (`rake lint`, `rake lint:autocorrect`, `rake generate`) are unaffected

---

Generated with the help of Claude Code, https://code.claude.com