### PR TITLE
Add ai_skip tag and attachments when escalating from AI support chat

### DIFF
--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -37,6 +37,7 @@ public struct SupportChatResponse: Decodable, Equatable {
 /// Role of a message sender in a support chat thread.
 ///
 public enum SupportChatRole: String, Decodable, Equatable {
+    case user
     case bot
     case unknown
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -99,18 +99,30 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         coordinator.startSetup()
     }
 
-    private func showContactSupportForm(sourceTag: String? = nil, additionalTags: [String] = []) {
-        let attachments: [ZendeskAttachment] = {
-            guard let troubleshootingDescription = self.viewModel.troubleshootingDescription(),
-                  let data = troubleshootingDescription.data(using: .utf8) else { return [] }
-            return [
-                ZendeskAttachment(
-                    data: data,
-                    filename: "connectivitytest_log.txt",
-                    contentType: "text/plain"
-                )
-            ]
-        }()
+    private func showContactSupportForm(sourceTag: String? = nil,
+                                         additionalTags: [String] = [],
+                                         chatTranscript: String? = nil) {
+        var attachments: [ZendeskAttachment] = []
+
+        if let troubleshootingDescription = viewModel.troubleshootingDescription(),
+           let data = troubleshootingDescription.data(using: .utf8) {
+            attachments.append(ZendeskAttachment(
+                data: data,
+                filename: "connectivitytest_log.txt",
+                contentType: "text/plain"
+            ))
+        }
+
+        if let transcript = chatTranscript,
+           !transcript.isEmpty,
+           let data = transcript.data(using: .utf8) {
+            attachments.append(ZendeskAttachment(
+                data: data,
+                filename: "support_chat_transcript.txt",
+                contentType: "text/plain"
+            ))
+        }
+
         let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(sourceTag: sourceTag,
                                                                                               additionalTags: additionalTags,
                                                                                               attachments: attachments))
@@ -120,10 +132,11 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     }
 
     private func showSupportChat() {
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] transcript in
             self?.navigationController?.popViewController(animated: true)
             self?.showContactSupportForm(sourceTag: Constants.aiChatEscalationSourceTag,
-                                         additionalTags: Constants.aiChatEscalationAdditionalTags)
+                                         additionalTags: Constants.aiChatEscalationAdditionalTags,
+                                         chatTranscript: transcript)
         }
 
         let chatController = SupportChatHostingController(viewModel: chatViewModel)

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -99,7 +99,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         coordinator.startSetup()
     }
 
-    private func showContactSupportForm() {
+    private func showContactSupportForm(sourceTag: String? = nil, additionalTags: [String] = []) {
         let attachments: [ZendeskAttachment] = {
             guard let troubleshootingDescription = self.viewModel.troubleshootingDescription(),
                   let data = troubleshootingDescription.data(using: .utf8) else { return [] }
@@ -111,7 +111,9 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
                 )
             ]
         }()
-        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(attachments: attachments))
+        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(sourceTag: sourceTag,
+                                                                                              additionalTags: additionalTags,
+                                                                                              attachments: attachments))
         supportController.show(from: self)
 
         ServiceLocator.analytics.track(event: .ConnectivityTool.contactSupportTapped())
@@ -120,11 +122,19 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     private func showSupportChat() {
         let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] in
             self?.navigationController?.popViewController(animated: true)
-            self?.showContactSupportForm()
+            self?.showContactSupportForm(sourceTag: Constants.aiChatEscalationSourceTag,
+                                         additionalTags: Constants.aiChatEscalationAdditionalTags)
         }
 
         let chatController = SupportChatHostingController(viewModel: chatViewModel)
         chatController.show(from: self)
+    }
+}
+
+private extension ConnectivityToolViewController {
+    enum Constants {
+        static let aiChatEscalationSourceTag = "in_app_support_escalate"
+        static let aiChatEscalationAdditionalTags = ["ai_skip"]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -210,7 +210,7 @@ final class ConnectivityToolViewModel {
     /// Creates a SupportChatViewModel with the current troubleshooting context.
     ///
     @MainActor
-    func makeSupportChatViewModel(onContactHumanSupport: @escaping () -> Void) -> SupportChatViewModel {
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping (_ transcript: String) -> Void) -> SupportChatViewModel {
         var context: [String: Any] = [:]
 
         if let troubleshootingDescription = troubleshootingDescription() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -52,6 +52,10 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let sourceTag: String?
 
+    /// Additional tags to include in the support request.
+    ///
+    private let additionalTags: [String]
+
     /// Handles the communication with Zendesk.
     ///
     private let zendeskProvider: ZendeskManagerProtocol
@@ -97,6 +101,7 @@ public final class SupportFormViewModel: ObservableObject {
 
     init(areas: [Area] = wooSupportAreas(),
          sourceTag: String? = nil,
+         additionalTags: [String] = [],
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics,
          applicationLogsProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
@@ -104,6 +109,7 @@ public final class SupportFormViewModel: ObservableObject {
          attachments: [ZendeskAttachment] = []) {
         self.areas = areas
         self.sourceTag = sourceTag
+        self.additionalTags = additionalTags
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
         self.applicationLogsProvider = applicationLogsProvider
@@ -163,14 +169,15 @@ public final class SupportFormViewModel: ObservableObject {
         }
     }
 
-    /// Joins the selected area tags with the source tag(if available).
+    /// Joins the selected area tags with the source tag and additional tags.
     ///
     func assembleTags() -> [String] {
         guard let area else { return [] }
-        guard let sourceTag, sourceTag.isNotEmpty else {
-            return area.datasource.tags
+        var tags = area.datasource.tags
+        if let sourceTag, sourceTag.isNotEmpty {
+            tags.append(sourceTag)
         }
-        return area.datasource.tags + [sourceTag]
+        return tags + additionalTags
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
@@ -39,7 +39,7 @@ struct SupportChatMessageRow: View {
                 .foregroundColor(bubbleForeground)
                 .cornerRadius(SupportChatLayout.bubbleCornerRadius)
 
-            if message.role == .assistant {
+            if message.role == .bot {
                 Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
             }
         }
@@ -50,7 +50,7 @@ struct SupportChatMessageRow: View {
         switch message.role {
         case .user:
             Text(message.content)
-        case .assistant:
+        case .bot, .unknown:
             Text(.init(message.content))
         }
     }
@@ -59,7 +59,7 @@ struct SupportChatMessageRow: View {
         switch message.role {
         case .user:
             return Color(.accent)
-        case .assistant:
+        case .bot, .unknown:
             return Color(.systemGray5)
         }
     }
@@ -68,7 +68,7 @@ struct SupportChatMessageRow: View {
         switch message.role {
         case .user:
             return .white
-        case .assistant:
+        case .bot, .unknown:
             return Color(.label)
         }
     }
@@ -119,7 +119,7 @@ struct TypingIndicatorRow: View {
 
 #Preview("Assistant Message") {
     SupportChatMessageRow(
-        message: .init(role: .assistant, content: "I can help you troubleshoot your connection. Let's start by checking a few things.")
+        message: .init(role: .bot, content: "I can help you troubleshoot your connection. Let's start by checking a few things.")
     )
     .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -180,7 +180,7 @@ private extension SupportChatView {
     NavigationStack {
         SupportChatView(
             viewModel: SupportChatViewModel(
-                onContactHumanSupport: {}
+                onContactHumanSupport: { _ in }
             )
         )
         .navigationTitle("Chat with Support")

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import Yosemite
+import enum Networking.SupportChatRole
 import protocol WooFoundation.Analytics
 
 /// View model for the AI support chat interface.
@@ -32,16 +33,11 @@ final class SupportChatViewModel {
     ///
     struct ChatMessage: Identifiable, Equatable {
         let id: UUID
-        let role: Role
+        let role: SupportChatRole
         let content: String
         let timestamp: Date
 
-        enum Role {
-            case user
-            case assistant
-        }
-
-        init(id: UUID = UUID(), role: Role, content: String, timestamp: Date = Date()) {
+        init(id: UUID = UUID(), role: SupportChatRole, content: String, timestamp: Date = Date()) {
             self.id = id
             self.role = role
             self.content = content
@@ -63,14 +59,14 @@ final class SupportChatViewModel {
     private let botSlug: String
     private let stores: StoresManager
     private let initialContext: [String: Any]?
-    private let onContactHumanSupport: () -> Void
+    private let onContactHumanSupport: (_ transcript: String) -> Void
 
     // MARK: - Initialization
 
     init(botSlug: String = "woo-workflow-support_mobile_inapp",
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,
-         onContactHumanSupport: @escaping () -> Void) {
+         onContactHumanSupport: @escaping (_ transcript: String) -> Void) {
         self.botSlug = botSlug
         self.stores = stores
         self.initialContext = initialContext
@@ -85,7 +81,7 @@ final class SupportChatViewModel {
 
         Task {
             try? await Task.sleep(for: .seconds(1))
-            let greetingMessage = ChatMessage(role: .assistant, content: Localization.greetingMessage)
+            let greetingMessage = ChatMessage(role: .bot, content: Localization.greetingMessage)
             messages.append(greetingMessage)
             state = .idle
         }
@@ -116,7 +112,24 @@ final class SupportChatViewModel {
     }
 
     func contactHumanSupport() {
-        onContactHumanSupport()
+        onContactHumanSupport(generateTranscript())
+    }
+
+    private func generateTranscript() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .short
+        dateFormatter.timeStyle = .short
+
+        return messages.map { message in
+            let roleName: String
+            switch message.role {
+            case .user: roleName = "User"
+            case .bot: roleName = "Bot"
+            case .unknown: roleName = "Unknown"
+            }
+            let timestamp = dateFormatter.string(from: message.timestamp)
+            return "[\(timestamp)] \(roleName): \(message.content)"
+        }.joined(separator: "\n\n")
     }
 
     func dismissError() {
@@ -132,7 +145,7 @@ final class SupportChatViewModel {
 
             if let lastBotMessage = response.messages.last(where: { $0.role == .bot }) {
                 let assistantMessage = ChatMessage(
-                    role: .assistant,
+                    role: .bot,
                     content: lastBotMessage.content
                 )
                 messages.append(assistantMessage)


### PR DESCRIPTION
## Description
When users escalate from the AI support chat to human support, this PR:

1. **Adds Zendesk tags** to prevent AI auto-response:
   - `in_app_support_escalate` as source tag
   - `ai_skip` as additional tag

2. **Attaches context files** to help support agents:
   - Connectivity test log (`connectivitytest_log.txt`)
   - AI chat transcript (`support_chat_transcript.txt`)

3. **Refactors** `SupportFormViewModel` to accept `additionalTags` parameter without changing existing call sites.

4. **Unifies** `SupportChatRole` enum - removes duplicate `ChatMessage.Role` in favor of the Networking layer's `SupportChatRole`.

## Test Steps
1. Open the Connectivity Tool from Help & Support.
2. Start a chat with the AI support bot.
3. Send a few messages to build a conversation, then send one with "This is not helpful" to trigger human support.
4. When the "Contact Human Support" option appears, tap it.
5. Fill out the support form and submit.
6. Verify in Zendesk that:
   - Tags include `in_app_support_escalate` and `ai_skip`.
   - No additional AI response is triggered in the chat.
   - Attachments include both the connectivity log and chat transcript.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.