### PR TITLE
Woo Mobile AI: Wire up REST tool dispatch with retries

### DIFF
--- a/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
@@ -1,7 +1,6 @@
 public enum HTTPStatusClassification {
-    /// Sentinel for transport-level failures (no HTTP response: dropped
-    /// connection, DNS, timeout). Mapped to the network error kind so the
-    /// retry policy treats it like a 5xx instead of a hard error.
+    /// Sentinel for transport-level failures: no HTTP response (dropped
+    /// connection, DNS, timeout).
     public static let transportFailure: Int = 0
 
     public static func isSuccess(_ statusCode: Int) -> Bool {

--- a/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
@@ -1,0 +1,33 @@
+/// Maps HTTP status codes to the assistant's typed error vocabulary so the
+/// retry policy and tool executors share one classifier. Centralising the
+/// mapping keeps the "what counts as auth vs upstream vs validation" rule
+/// out of every tool body.
+public enum HTTPStatusClassification {
+    /// Sentinel used by `WCRESTClient` for transport-level failures (no HTTP
+    /// response - dropped connection, DNS, timeout). Treated as retryable
+    /// network kind by the policy.
+    public static let transportFailure: Int = 0
+
+    public static func isSuccess(_ statusCode: Int) -> Bool {
+        (200..<300).contains(statusCode)
+    }
+
+    public static func errorKind(forStatusCode statusCode: Int) -> AssistantErrorKind {
+        switch statusCode {
+        case transportFailure:
+            return .network
+        case 401, 403:
+            return .auth
+        case 408:
+            return .timeout
+        case 429:
+            return .rateLimit
+        case 400..<500:
+            return .invalidToolCall
+        case 500..<600:
+            return .upstreamFailure
+        default:
+            return .unknown
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
@@ -1,11 +1,7 @@
-/// Maps HTTP status codes to the assistant's typed error vocabulary so the
-/// retry policy and tool executors share one classifier. Centralising the
-/// mapping keeps the "what counts as auth vs upstream vs validation" rule
-/// out of every tool body.
 public enum HTTPStatusClassification {
-    /// Sentinel used by `WCRESTClient` for transport-level failures (no HTTP
-    /// response - dropped connection, DNS, timeout). Treated as retryable
-    /// network kind by the policy.
+    /// Sentinel for transport-level failures (no HTTP response: dropped
+    /// connection, DNS, timeout). Mapped to the network error kind so the
+    /// retry policy treats it like a 5xx instead of a hard error.
     public static let transportFailure: Int = 0
 
     public static func isSuccess(_ statusCode: Int) -> Bool {

--- a/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/HTTPStatusClassification.swift
@@ -17,8 +17,6 @@ public enum HTTPStatusClassification {
             return .timeout
         case 429:
             return .rateLimit
-        case 400..<500:
-            return .invalidToolCall
         case 500..<600:
             return .upstreamFailure
         default:

--- a/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Decision-only retry policy for `WCRESTClient` requests. Pure value type so
+/// the policy can be unit-tested without sleeping or running networking.
+///
+/// Two rules drive the decision:
+///   1. Transient transport faults (connection drop, 5xx, 429) are retryable.
+///      4xx (except 429) and auth are not - they will not become 2xx if we
+///      try again with the same payload.
+///   2. Non-idempotent methods (POST, PUT, PATCH, DELETE) never auto-retry.
+///      Idempotency keys land in a follow-up change; until then we refuse to
+///      double-charge a customer because the network blipped.
+public struct RESTRetryPolicy: Sendable, Equatable {
+    public let maxRetries: Int
+    public let backoff: [TimeInterval]
+
+    public init(maxRetries: Int = 2,
+                backoff: [TimeInterval] = [0.2, 0.8]) {
+        self.maxRetries = maxRetries
+        self.backoff = backoff
+    }
+
+    /// Default policy per the assistant transport spec: two retries with 200ms
+    /// then 800ms backoff. Three attempts total at most.
+    public static let `default` = RESTRetryPolicy()
+
+    public func shouldRetry(method: String, statusCode: Int, attempt: Int) -> Bool {
+        guard attempt < maxRetries else { return false }
+        guard isIdempotent(method: method) else { return false }
+        return isRetryableStatus(statusCode)
+    }
+
+    public func delay(forAttempt attempt: Int) -> TimeInterval {
+        guard attempt >= 0, attempt < backoff.count else {
+            return backoff.last ?? 0
+        }
+        return backoff[attempt]
+    }
+
+    private func isIdempotent(method: String) -> Bool {
+        switch method.uppercased() {
+        case "GET", "HEAD", "OPTIONS":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func isRetryableStatus(_ statusCode: Int) -> Bool {
+        switch statusCode {
+        case HTTPStatusClassification.transportFailure, 408, 429:
+            return true
+        case 500..<600:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-/// Decision-only retry policy for `WCRESTClient` requests.
-///
 /// Writes (POST, PUT, PATCH) never auto-retry. A duplicate write reaching the
 /// upstream could double-charge or duplicate inventory mutations, and the
 /// runtime can't tell whether the first attempt landed when the transport

--- a/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
@@ -1,15 +1,10 @@
 import Foundation
 
-/// Decision-only retry policy for `WCRESTClient` requests. Pure value type so
-/// the policy can be unit-tested without sleeping or running networking.
+/// Decision-only retry policy for `WCRESTClient` requests.
 ///
-/// Two rules drive the decision:
-///   1. Transient transport faults (connection drop, 5xx, 429) are retryable.
-///      4xx (except 429) and auth are not - they will not become 2xx if we
-///      try again with the same payload.
-///   2. Non-idempotent methods (POST, PUT, PATCH, DELETE) never auto-retry.
-///      Without an idempotency key the same write reaching the upstream twice
-///      would risk double-billing or duplicate inventory mutations.
+/// Non-idempotent methods (POST, PUT, PATCH, DELETE) never auto-retry: without
+/// an idempotency key the same write reaching the upstream twice could double
+/// charge or duplicate inventory mutations.
 public struct RESTRetryPolicy: Sendable, Equatable {
     public let maxRetries: Int
     public let backoff: [TimeInterval]
@@ -20,8 +15,6 @@ public struct RESTRetryPolicy: Sendable, Equatable {
         self.backoff = backoff
     }
 
-    /// Default policy per the assistant transport spec: two retries with 200ms
-    /// then 800ms backoff. Three attempts total at most.
     public static let `default` = RESTRetryPolicy()
 
     public func shouldRetry(method: String, statusCode: Int, attempt: Int) -> Bool {

--- a/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
@@ -8,8 +8,8 @@ import Foundation
 ///      4xx (except 429) and auth are not - they will not become 2xx if we
 ///      try again with the same payload.
 ///   2. Non-idempotent methods (POST, PUT, PATCH, DELETE) never auto-retry.
-///      Idempotency keys land in a follow-up change; until then we refuse to
-///      double-charge a customer because the network blipped.
+///      Without an idempotency key the same write reaching the upstream twice
+///      would risk double-billing or duplicate inventory mutations.
 public struct RESTRetryPolicy: Sendable, Equatable {
     public let maxRetries: Int
     public let backoff: [TimeInterval]

--- a/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTRetryPolicy.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// Decision-only retry policy for `WCRESTClient` requests.
 ///
-/// Non-idempotent methods (POST, PUT, PATCH, DELETE) never auto-retry: without
-/// an idempotency key the same write reaching the upstream twice could double
-/// charge or duplicate inventory mutations.
+/// Writes (POST, PUT, PATCH) never auto-retry. A duplicate write reaching the
+/// upstream could double-charge or duplicate inventory mutations, and the
+/// runtime can't tell whether the first attempt landed when the transport
+/// drops mid-flight.
 public struct RESTRetryPolicy: Sendable, Equatable {
     public let maxRetries: Int
     public let backoff: [TimeInterval]

--- a/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
@@ -1,9 +1,7 @@
 import Foundation
 
-/// `ToolRegistry` whose tools call into the merchant's WooCommerce REST API
-/// through `WCRESTClient`. Unknown tool names short-circuit to
-/// `.failed(kind: .invalidToolCall)` so callers never need a typo guard
-/// before dispatch.
+/// Unknown tool names short-circuit to `.failed(kind: .invalidToolCall)` so
+/// callers never need a typo guard before dispatch.
 public struct RESTToolRegistry: ToolRegistry {
     private let client: WCRESTClient
     private let tools: [String: RESTTool]

--- a/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
@@ -1,12 +1,9 @@
 import Foundation
 
-/// Concrete `ToolRegistry` whose tools call into the merchant's WooCommerce
-/// REST API through `WCRESTClient`. Constructable empty so the dispatch loop
-/// works without any tools registered.
-///
-/// Unknown tool names short-circuit to `.failed(kind: .invalidToolCall)` so
-/// the orchestrator never has to guard against typos before dispatch - one
-/// classification path, one place errors live.
+/// `ToolRegistry` whose tools call into the merchant's WooCommerce REST API
+/// through `WCRESTClient`. Unknown tool names short-circuit to
+/// `.failed(kind: .invalidToolCall)` so callers never need a typo guard
+/// before dispatch.
 public struct RESTToolRegistry: ToolRegistry {
     private let client: WCRESTClient
     private let tools: [String: RESTTool]
@@ -31,10 +28,6 @@ public struct RESTToolRegistry: ToolRegistry {
     }
 }
 
-/// Pairs an `AITool` schema with the `@Sendable` async executor that runs
-/// when the model calls it. The executor returns a fully-formed `ToolResult`
-/// rather than throwing so retry classification, safety rejections, and
-/// confirmation flows live behind one return type.
 public struct RESTTool: Sendable {
     public let definition: AITool
     public let executor: @Sendable (_ arguments: String, _ client: WCRESTClient) async -> ToolResult

--- a/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
@@ -1,9 +1,8 @@
 import Foundation
 
 /// Concrete `ToolRegistry` whose tools call into the merchant's WooCommerce
-/// REST API through `WCRESTClient`. Constructable empty so this PR proves the
-/// dispatch loop end-to-end; the real read and write tools register through
-/// the same surface in follow-up work.
+/// REST API through `WCRESTClient`. Constructable empty so the dispatch loop
+/// works without any tools registered.
 ///
 /// Unknown tool names short-circuit to `.failed(kind: .invalidToolCall)` so
 /// the orchestrator never has to guard against typos before dispatch - one

--- a/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RESTToolRegistry.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Concrete `ToolRegistry` whose tools call into the merchant's WooCommerce
+/// REST API through `WCRESTClient`. Constructable empty so this PR proves the
+/// dispatch loop end-to-end; the real read and write tools register through
+/// the same surface in follow-up work.
+///
+/// Unknown tool names short-circuit to `.failed(kind: .invalidToolCall)` so
+/// the orchestrator never has to guard against typos before dispatch - one
+/// classification path, one place errors live.
+public struct RESTToolRegistry: ToolRegistry {
+    private let client: WCRESTClient
+    private let tools: [String: RESTTool]
+
+    public init(client: WCRESTClient, tools: [RESTTool] = []) {
+        self.client = client
+        self.tools = Dictionary(uniqueKeysWithValues: tools.map { ($0.definition.name, $0) })
+    }
+
+    public func availableTools() async throws -> [AITool] {
+        tools.values.map { $0.definition }
+    }
+
+    public func execute(name: String, arguments: String) async -> ToolResult {
+        guard let tool = tools[name] else {
+            return .failed(.init(toolName: name,
+                                 toolCallID: "",
+                                 kind: .invalidToolCall,
+                                 reason: "Unknown tool: \(name)"))
+        }
+        return await tool.executor(arguments, client)
+    }
+}
+
+/// Pairs an `AITool` schema with the `@Sendable` async executor that runs
+/// when the model calls it. The executor returns a fully-formed `ToolResult`
+/// rather than throwing so retry classification, safety rejections, and
+/// confirmation flows live behind one return type.
+public struct RESTTool: Sendable {
+    public let definition: AITool
+    public let executor: @Sendable (_ arguments: String, _ client: WCRESTClient) async -> ToolResult
+
+    public init(definition: AITool,
+                executor: @escaping @Sendable (_ arguments: String, _ client: WCRESTClient) async -> ToolResult) {
+        self.definition = definition
+        self.executor = executor
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/RetryingWCRESTClient.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RetryingWCRESTClient.swift
@@ -3,11 +3,11 @@ import Foundation
 public struct RetryingWCRESTClient: WCRESTClient {
     private let inner: WCRESTClient
     private let policy: RESTRetryPolicy
-    private let sleep: @Sendable (TimeInterval) async -> Void
+    private let sleep: @Sendable (TimeInterval) async throws -> Void
 
     public init(inner: WCRESTClient,
                 policy: RESTRetryPolicy = .default,
-                sleep: @escaping @Sendable (TimeInterval) async -> Void = Self.realSleep) {
+                sleep: @escaping @Sendable (TimeInterval) async throws -> Void = Self.realSleep) {
         self.inner = inner
         self.policy = policy
         self.sleep = sleep
@@ -33,13 +33,17 @@ public struct RetryingWCRESTClient: WCRESTClient {
                                      attempt: attempt) else {
                 return response
             }
-            await sleep(policy.delay(forAttempt: attempt))
+            do {
+                try await sleep(policy.delay(forAttempt: attempt))
+            } catch {
+                return WCRESTResponse(data: Data(), statusCode: HTTPStatusClassification.transportFailure)
+            }
             attempt += 1
         }
     }
 
-    public static let realSleep: @Sendable (TimeInterval) async -> Void = { interval in
+    public static let realSleep: @Sendable (TimeInterval) async throws -> Void = { interval in
         let nanoseconds = UInt64(max(0, interval) * 1_000_000_000)
-        try? await Task.sleep(nanoseconds: nanoseconds)
+        try await Task.sleep(nanoseconds: nanoseconds)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/RetryingWCRESTClient.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RetryingWCRESTClient.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// `WCRESTClient` wrapper that re-issues retryable requests per `RESTRetryPolicy`.
+/// The inner client and the sleep are injected so tests can drive the loop
+/// without real networking or wall-clock waits.
+public struct RetryingWCRESTClient: WCRESTClient {
+    private let inner: WCRESTClient
+    private let policy: RESTRetryPolicy
+    private let sleep: @Sendable (TimeInterval) async -> Void
+
+    public init(inner: WCRESTClient,
+                policy: RESTRetryPolicy = .default,
+                sleep: @escaping @Sendable (TimeInterval) async -> Void = Self.realSleep) {
+        self.inner = inner
+        self.policy = policy
+        self.sleep = sleep
+    }
+
+    public func request(method: String,
+                        path: String,
+                        query: [String: String]?,
+                        body: Data?,
+                        headers: [String: String]?) async -> WCRESTResponse {
+        var attempt = 0
+        while true {
+            let response = await inner.request(method: method,
+                                               path: path,
+                                               query: query,
+                                               body: body,
+                                               headers: headers)
+            if HTTPStatusClassification.isSuccess(response.statusCode) {
+                return response
+            }
+            guard policy.shouldRetry(method: method,
+                                     statusCode: response.statusCode,
+                                     attempt: attempt) else {
+                return response
+            }
+            await sleep(policy.delay(forAttempt: attempt))
+            attempt += 1
+        }
+    }
+
+    public static let realSleep: @Sendable (TimeInterval) async -> Void = { interval in
+        let nanoseconds = UInt64(max(0, interval) * 1_000_000_000)
+        try? await Task.sleep(nanoseconds: nanoseconds)
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/RetryingWCRESTClient.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/RetryingWCRESTClient.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-/// `WCRESTClient` wrapper that re-issues retryable requests per `RESTRetryPolicy`.
-/// The inner client and the sleep are injected so tests can drive the loop
-/// without real networking or wall-clock waits.
 public struct RetryingWCRESTClient: WCRESTClient {
     private let inner: WCRESTClient
     private let policy: RESTRetryPolicy

--- a/Modules/Sources/WooAIAssistant/Tools/WCRESTClient.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/WCRESTClient.swift
@@ -1,14 +1,13 @@
 import Foundation
 
-/// Transport surface every REST tool calls into. The protocol is deliberately
-/// thin so the production adaptor can sit on the existing Networking module
-/// (app password, WPCOM bearer, Jetpack tunnel) and the headless harness can
-/// swap in a `URLSession`-only implementation without dragging dependencies
-/// into the assistant module.
+/// Transport surface every REST tool calls into. Deliberately thin so the
+/// production adaptor can sit on the existing Networking module (app password,
+/// WPCOM bearer, Jetpack tunnel) and the headless harness can swap in a
+/// `URLSession`-only implementation without dragging dependencies into the
+/// assistant module.
 ///
-/// Non-2xx responses are returned, not thrown - executors map status codes to
-/// `ToolResult.failed` so retry policy and error classification stay in one
-/// place rather than spread across `do/catch` blocks.
+/// Non-2xx responses are returned, not thrown, so retry policy and error
+/// classification stay in one place rather than spread across `do/catch`.
 public protocol WCRESTClient: Sendable {
     func request(method: String,
                  path: String,
@@ -17,12 +16,11 @@ public protocol WCRESTClient: Sendable {
                  headers: [String: String]?) async -> WCRESTResponse
 }
 
-/// Outcome of a single REST request. `statusCode == 0` is reserved for
-/// transport failures (no HTTP response - dropped connection, DNS, timeout)
-/// so executors and retry policy treat them like 5xx without a separate
-/// throwing path.
 public struct WCRESTResponse: Sendable, Equatable {
     public let data: Data
+    /// `0` is reserved for transport failures (no HTTP response: dropped
+    /// connection, DNS, timeout) so executors and retry policy treat them
+    /// like 5xx without a separate throwing path.
     public let statusCode: Int
     public let headers: [String: String]
 

--- a/Modules/Sources/WooAIAssistant/Tools/WCRESTClient.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/WCRESTClient.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Transport surface every REST tool calls into. The protocol is deliberately
+/// thin so the production adaptor can sit on the existing Networking module
+/// (app password, WPCOM bearer, Jetpack tunnel) and the headless harness can
+/// swap in a `URLSession`-only implementation without dragging dependencies
+/// into the assistant module.
+///
+/// Non-2xx responses are returned, not thrown - executors map status codes to
+/// `ToolResult.failed` so retry policy and error classification stay in one
+/// place rather than spread across `do/catch` blocks.
+public protocol WCRESTClient: Sendable {
+    func request(method: String,
+                 path: String,
+                 query: [String: String]?,
+                 body: Data?,
+                 headers: [String: String]?) async -> WCRESTResponse
+}
+
+/// Outcome of a single REST request. `statusCode == 0` is reserved for
+/// transport failures (no HTTP response - dropped connection, DNS, timeout)
+/// so executors and retry policy treat them like 5xx without a separate
+/// throwing path.
+public struct WCRESTResponse: Sendable, Equatable {
+    public let data: Data
+    public let statusCode: Int
+    public let headers: [String: String]
+
+    public init(data: Data, statusCode: Int, headers: [String: String] = [:]) {
+        self.data = data
+        self.statusCode = statusCode
+        self.headers = headers
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/WCRESTClient.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/WCRESTClient.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-/// Transport surface every REST tool calls into. Deliberately thin so the
-/// production adaptor can sit on the existing Networking module (app password,
-/// WPCOM bearer, Jetpack tunnel) and the headless harness can swap in a
-/// `URLSession`-only implementation without dragging dependencies into the
-/// assistant module.
-///
-/// Non-2xx responses are returned, not thrown, so retry policy and error
-/// classification stay in one place rather than spread across `do/catch`.
+/// Non-2xx responses return as `WCRESTResponse`, never throw.
 public protocol WCRESTClient: Sendable {
     func request(method: String,
                  path: String,

--- a/Modules/Tests/WooAIAssistantTests/Tools/RESTRetryPolicyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/RESTRetryPolicyTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct RESTRetryPolicyTests {
+    @Test
+    func test_shouldRetry_when_get_and_5xx_then_retries_until_max() {
+        // Given
+        let policy = RESTRetryPolicy.default
+
+        // When / Then
+        #expect(policy.shouldRetry(method: "GET", statusCode: 500, attempt: 0))
+        #expect(policy.shouldRetry(method: "GET", statusCode: 502, attempt: 1))
+        #expect(!policy.shouldRetry(method: "GET", statusCode: 503, attempt: 2))
+    }
+
+    @Test
+    func test_shouldRetry_when_get_and_4xx_then_does_not_retry() {
+        // Given
+        let policy = RESTRetryPolicy.default
+
+        // When / Then
+        #expect(!policy.shouldRetry(method: "GET", statusCode: 400, attempt: 0))
+        #expect(!policy.shouldRetry(method: "GET", statusCode: 401, attempt: 0))
+        #expect(!policy.shouldRetry(method: "GET", statusCode: 403, attempt: 0))
+        #expect(!policy.shouldRetry(method: "GET", statusCode: 404, attempt: 0))
+    }
+
+    @Test
+    func test_shouldRetry_when_get_and_429_then_retries() {
+        // Given
+        let policy = RESTRetryPolicy.default
+
+        // When / Then
+        #expect(policy.shouldRetry(method: "GET", statusCode: 429, attempt: 0))
+    }
+
+    @Test
+    func test_shouldRetry_when_post_then_never_retries() {
+        // Given
+        let policy = RESTRetryPolicy.default
+
+        // When / Then - writes are non-idempotent without an idempotency key.
+        #expect(!policy.shouldRetry(method: "POST", statusCode: 500, attempt: 0))
+        #expect(!policy.shouldRetry(method: "PUT", statusCode: 503, attempt: 0))
+        #expect(!policy.shouldRetry(method: "PATCH", statusCode: 429, attempt: 0))
+        #expect(!policy.shouldRetry(method: "DELETE", statusCode: 502, attempt: 0))
+    }
+
+    @Test
+    func test_shouldRetry_when_transport_failure_then_retries_for_idempotent_methods() {
+        // Given
+        let policy = RESTRetryPolicy.default
+        let transport = HTTPStatusClassification.transportFailure
+
+        // When / Then
+        #expect(policy.shouldRetry(method: "GET", statusCode: transport, attempt: 0))
+        #expect(!policy.shouldRetry(method: "POST", statusCode: transport, attempt: 0))
+    }
+
+    @Test
+    func test_delay_returns_configured_backoff_per_attempt() {
+        // Given
+        let policy = RESTRetryPolicy.default
+
+        // When / Then
+        #expect(policy.delay(forAttempt: 0) == 0.2)
+        #expect(policy.delay(forAttempt: 1) == 0.8)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/RESTRetryPolicyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/RESTRetryPolicyTests.swift
@@ -40,7 +40,7 @@ struct RESTRetryPolicyTests {
         // Given
         let policy = RESTRetryPolicy.default
 
-        // When / Then - writes are non-idempotent without an idempotency key.
+        // When / Then
         #expect(!policy.shouldRetry(method: "POST", statusCode: 500, attempt: 0))
         #expect(!policy.shouldRetry(method: "PUT", statusCode: 503, attempt: 0))
         #expect(!policy.shouldRetry(method: "PATCH", statusCode: 429, attempt: 0))

--- a/Modules/Tests/WooAIAssistantTests/Tools/RESTToolRegistryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/RESTToolRegistryTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct RESTToolRegistryTests {
+    @Test
+    func test_execute_when_tool_unknown_then_returns_validationError() async {
+        // Given
+        let registry = RESTToolRegistry(client: NoopWCRESTClient(), tools: [])
+
+        // When
+        let result = await registry.execute(name: "missing_tool", arguments: "{}")
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected .failed, got \(result)")
+            return
+        }
+        #expect(failed.toolName == "missing_tool")
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("missing_tool"))
+    }
+
+    @Test
+    func test_execute_when_executor_returns_success_then_payload_passes_through() async {
+        // Given
+        let structured = AnyCodableJSON.object([
+            "count": .int(2),
+            "ids": .array([.int(3551), .int(3548)])
+        ])
+        let tool = RESTTool(
+            definition: AITool(name: "orders_list",
+                               description: "List orders",
+                               parametersSchema: .object([:])),
+            executor: { _, _ in
+                .success(.init(toolName: "orders_list",
+                               toolCallID: "call_1",
+                               structured: structured))
+            }
+        )
+        let registry = RESTToolRegistry(client: NoopWCRESTClient(), tools: [tool])
+
+        // When
+        let result = await registry.execute(name: "orders_list", arguments: "{}")
+
+        // Then
+        guard case .success(let success) = result else {
+            Issue.record("expected .success, got \(result)")
+            return
+        }
+        #expect(success.toolName == "orders_list")
+        #expect(success.toolCallID == "call_1")
+        #expect(success.structured == structured)
+        #expect(success.uiStructured == nil)
+    }
+
+    @Test
+    func test_execute_passes_arguments_and_client_to_executor() async {
+        // Given
+        let recorder = ExecutorRecorder()
+        let probingClient = ProbingWCRESTClient()
+        let tool = RESTTool(
+            definition: AITool(name: "orders_get",
+                               description: "Get one",
+                               parametersSchema: .object([:])),
+            executor: { arguments, client in
+                await recorder.record(arguments: arguments)
+                _ = await client.request(method: "GET",
+                                         path: "wc/v3/orders/3551",
+                                         query: nil,
+                                         body: nil,
+                                         headers: nil)
+                return .success(.init(toolName: "orders_get",
+                                      toolCallID: "call_2",
+                                      structured: .object(["ok": .bool(true)])))
+            }
+        )
+        let registry = RESTToolRegistry(client: probingClient, tools: [tool])
+
+        // When
+        _ = await registry.execute(name: "orders_get", arguments: #"{"id":3551}"#)
+
+        // Then
+        #expect(await recorder.recordedArguments == #"{"id":3551}"#)
+        #expect(await probingClient.callCount == 1)
+        #expect(await probingClient.recordedPaths == ["wc/v3/orders/3551"])
+    }
+
+    @Test
+    func test_availableTools_returns_registered_definitions() async throws {
+        // Given
+        let listTool = RESTTool(
+            definition: AITool(name: "orders_list",
+                               description: "List",
+                               parametersSchema: .object([:])),
+            executor: { _, _ in .failed(.init(toolName: "orders_list",
+                                              toolCallID: "",
+                                              kind: .toolFailed,
+                                              reason: "stub")) }
+        )
+        let getTool = RESTTool(
+            definition: AITool(name: "orders_get",
+                               description: "Get",
+                               parametersSchema: .object([:])),
+            executor: { _, _ in .failed(.init(toolName: "orders_get",
+                                              toolCallID: "",
+                                              kind: .toolFailed,
+                                              reason: "stub")) }
+        )
+        let registry = RESTToolRegistry(client: NoopWCRESTClient(), tools: [listTool, getTool])
+
+        // When
+        let definitions = try await registry.availableTools()
+
+        // Then
+        #expect(Set(definitions.map { $0.name }) == ["orders_list", "orders_get"])
+    }
+
+    @Test
+    func test_availableTools_when_empty_then_returns_empty_array() async throws {
+        // Given
+        let registry = RESTToolRegistry(client: NoopWCRESTClient())
+
+        // When
+        let definitions = try await registry.availableTools()
+
+        // Then
+        #expect(definitions.isEmpty)
+    }
+}
+
+// MARK: - Test doubles
+
+private struct NoopWCRESTClient: WCRESTClient {
+    func request(method: String,
+                 path: String,
+                 query: [String: String]?,
+                 body: Data?,
+                 headers: [String: String]?) async -> WCRESTResponse {
+        WCRESTResponse(data: Data(), statusCode: 200)
+    }
+}
+
+private actor ExecutorRecorder {
+    private(set) var recordedArguments: String?
+
+    func record(arguments: String) {
+        recordedArguments = arguments
+    }
+}
+
+private final class ProbingWCRESTClient: WCRESTClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _callCount = 0
+    private var _recordedPaths: [String] = []
+
+    var callCount: Int {
+        get async {
+            lock.lock(); defer { lock.unlock() }
+            return _callCount
+        }
+    }
+
+    var recordedPaths: [String] {
+        get async {
+            lock.lock(); defer { lock.unlock() }
+            return _recordedPaths
+        }
+    }
+
+    func request(method: String,
+                 path: String,
+                 query: [String: String]?,
+                 body: Data?,
+                 headers: [String: String]?) async -> WCRESTResponse {
+        lock.lock()
+        _callCount += 1
+        _recordedPaths.append(path)
+        lock.unlock()
+        return WCRESTResponse(data: Data(), statusCode: 200)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/RESTToolRegistryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/RESTToolRegistryTests.swift
@@ -149,34 +149,17 @@ private actor ExecutorRecorder {
     }
 }
 
-private final class ProbingWCRESTClient: WCRESTClient, @unchecked Sendable {
-    private let lock = NSLock()
-    private var _callCount = 0
-    private var _recordedPaths: [String] = []
-
-    var callCount: Int {
-        get async {
-            lock.lock(); defer { lock.unlock() }
-            return _callCount
-        }
-    }
-
-    var recordedPaths: [String] {
-        get async {
-            lock.lock(); defer { lock.unlock() }
-            return _recordedPaths
-        }
-    }
+private actor ProbingWCRESTClient: WCRESTClient {
+    private(set) var callCount = 0
+    private(set) var recordedPaths: [String] = []
 
     func request(method: String,
                  path: String,
                  query: [String: String]?,
                  body: Data?,
                  headers: [String: String]?) async -> WCRESTResponse {
-        lock.lock()
-        _callCount += 1
-        _recordedPaths.append(path)
-        lock.unlock()
+        callCount += 1
+        recordedPaths.append(path)
         return WCRESTResponse(data: Data(), statusCode: 200)
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -148,7 +148,7 @@ struct WCRESTClientRetryTests {
     }
 
     @Test
-    func test_request_when_cancelled_during_backoff_then_returns_transportFailure_promptly() async {
+    func test_request_when_sleep_throws_cancellation_then_returns_transport_failure() async {
         // Given
         let stub = StubWCRESTClient(responses: [
             .status(503),
@@ -156,27 +156,17 @@ struct WCRESTClientRetryTests {
         ])
         let client = RetryingWCRESTClient(inner: stub,
                                           policy: RESTRetryPolicy(maxRetries: 2, backoff: [60, 60]),
-                                          sleep: { interval in
-            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
-        })
+                                          sleep: { _ in throw CancellationError() })
 
         // When
-        let task = Task {
-            await client.request(method: "GET",
-                                 path: "wc/v3/orders",
-                                 query: nil,
-                                 body: nil,
-                                 headers: nil)
-        }
-        try? await Task.sleep(nanoseconds: 50_000_000)
-        task.cancel()
-        let start = Date()
-        let response = await task.value
-        let elapsed = Date().timeIntervalSince(start)
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/orders",
+                                            query: nil,
+                                            body: nil,
+                                            headers: nil)
 
         // Then
         #expect(response.statusCode == HTTPStatusClassification.transportFailure)
-        #expect(elapsed < 5)
         #expect(stub.callCount == 1)
     }
 

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -102,8 +102,8 @@ struct WCRESTClientRetryTests {
 
     @Test
     func test_request_when_post_returns_5xx_then_does_not_retry() async {
-        // Given - writes are non-idempotent until idempotency keys land, so a
-        // failed POST must not auto-retry even on a normally-retryable status.
+        // Given - writes are non-idempotent here, so a failed POST must not
+        // auto-retry even on a normally-retryable status.
         let stub = StubWCRESTClient(responses: [.status(503)])
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -31,7 +31,7 @@ struct WCRESTClientRetryTests {
     }
 
     @Test
-    func test_request_when_4xx_then_does_not_retry_and_returns_transportError() async {
+    func test_request_when_other_4xx_then_does_not_retry_and_kind_is_unknown() async {
         // Given
         let stub = StubWCRESTClient(responses: [.status(404)])
         let recorder = SleepRecorder()
@@ -50,7 +50,7 @@ struct WCRESTClientRetryTests {
         #expect(response.statusCode == 404)
         #expect(stub.callCount == 1)
         #expect(await recorder.delays.isEmpty)
-        #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .invalidToolCall)
+        #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .unknown)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -102,8 +102,7 @@ struct WCRESTClientRetryTests {
 
     @Test
     func test_request_when_post_returns_5xx_then_does_not_retry() async {
-        // Given - writes are non-idempotent here, so a failed POST must not
-        // auto-retry even on a normally-retryable status.
+        // Given
         let stub = StubWCRESTClient(responses: [.status(503)])
         let recorder = SleepRecorder()
         let client = RetryingWCRESTClient(inner: stub,

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -25,7 +25,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == 503)
-        #expect(stub.callCount == 3)
+        #expect(await stub.callCount == 3)
         #expect(await recorder.delays == [0.2, 0.8])
         #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .upstreamFailure)
     }
@@ -48,7 +48,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == 404)
-        #expect(stub.callCount == 1)
+        #expect(await stub.callCount == 1)
         #expect(await recorder.delays.isEmpty)
         #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .unknown)
     }
@@ -70,7 +70,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == 401)
-        #expect(stub.callCount == 1)
+        #expect(await stub.callCount == 1)
         #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .auth)
     }
 
@@ -95,7 +95,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == 200)
-        #expect(stub.callCount == 2)
+        #expect(await stub.callCount == 2)
         #expect(await recorder.delays == [0.2])
         #expect(HTTPStatusClassification.errorKind(forStatusCode: 429) == .rateLimit)
     }
@@ -118,7 +118,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == 503)
-        #expect(stub.callCount == 1)
+        #expect(await stub.callCount == 1)
         #expect(await recorder.delays.isEmpty)
     }
 
@@ -143,7 +143,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == 200)
-        #expect(stub.callCount == 2)
+        #expect(await stub.callCount == 2)
         #expect(await recorder.delays == [0.2])
     }
 
@@ -167,7 +167,7 @@ struct WCRESTClientRetryTests {
 
         // Then
         #expect(response.statusCode == HTTPStatusClassification.transportFailure)
-        #expect(stub.callCount == 1)
+        #expect(await stub.callCount == 1)
     }
 
     @Test
@@ -187,14 +187,14 @@ struct WCRESTClientRetryTests {
                                            "X-Trace": "trace-7"])
 
         // Then
-        #expect(stub.recordedHeaders.first?["Idempotency-Key"] == "abc-123")
-        #expect(stub.recordedHeaders.first?["X-Trace"] == "trace-7")
+        #expect(await stub.recordedHeaders.first?["Idempotency-Key"] == "abc-123")
+        #expect(await stub.recordedHeaders.first?["X-Trace"] == "trace-7")
     }
 }
 
 // MARK: - Test doubles
 
-private final class StubWCRESTClient: WCRESTClient, @unchecked Sendable {
+private actor StubWCRESTClient: WCRESTClient {
     enum Scripted {
         case status(Int)
         case response(WCRESTResponse)
@@ -203,7 +203,6 @@ private final class StubWCRESTClient: WCRESTClient, @unchecked Sendable {
     private var responses: [Scripted]
     private(set) var callCount = 0
     private(set) var recordedHeaders: [[String: String]] = []
-    private let lock = NSLock()
 
     init(responses: [Scripted]) {
         self.responses = responses
@@ -214,8 +213,6 @@ private final class StubWCRESTClient: WCRESTClient, @unchecked Sendable {
                  query: [String: String]?,
                  body: Data?,
                  headers: [String: String]?) async -> WCRESTResponse {
-        lock.lock()
-        defer { lock.unlock() }
         callCount += 1
         recordedHeaders.append(headers ?? [:])
         let scripted = responses.isEmpty ? .status(500) : responses.removeFirst()

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct WCRESTClientRetryTests {
+    @Test
+    func test_request_when_5xx_then_retries_twice_then_returns_transportError() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [
+            .status(503),
+            .status(503),
+            .status(503)
+        ])
+        let recorder = SleepRecorder()
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: recorder.record)
+
+        // When
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/orders",
+                                            query: nil,
+                                            body: nil,
+                                            headers: nil)
+
+        // Then
+        #expect(response.statusCode == 503)
+        #expect(stub.callCount == 3)
+        #expect(await recorder.delays == [0.2, 0.8])
+        #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .upstreamFailure)
+    }
+
+    @Test
+    func test_request_when_4xx_then_does_not_retry_and_returns_transportError() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [.status(404)])
+        let recorder = SleepRecorder()
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: recorder.record)
+
+        // When
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/orders/9999",
+                                            query: nil,
+                                            body: nil,
+                                            headers: nil)
+
+        // Then
+        #expect(response.statusCode == 404)
+        #expect(stub.callCount == 1)
+        #expect(await recorder.delays.isEmpty)
+        #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .invalidToolCall)
+    }
+
+    @Test
+    func test_request_when_401_then_kind_is_auth() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [.status(401)])
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: { _ in })
+
+        // When
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/orders",
+                                            query: nil,
+                                            body: nil,
+                                            headers: nil)
+
+        // Then
+        #expect(response.statusCode == 401)
+        #expect(stub.callCount == 1)
+        #expect(HTTPStatusClassification.errorKind(forStatusCode: response.statusCode) == .auth)
+    }
+
+    @Test
+    func test_request_when_429_then_retries_and_kind_is_rateLimit() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [
+            .status(429),
+            .status(200)
+        ])
+        let recorder = SleepRecorder()
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: recorder.record)
+
+        // When
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/orders",
+                                            query: nil,
+                                            body: nil,
+                                            headers: nil)
+
+        // Then
+        #expect(response.statusCode == 200)
+        #expect(stub.callCount == 2)
+        #expect(await recorder.delays == [0.2])
+        #expect(HTTPStatusClassification.errorKind(forStatusCode: 429) == .rateLimit)
+    }
+
+    @Test
+    func test_request_when_post_returns_5xx_then_does_not_retry() async {
+        // Given - writes are non-idempotent until idempotency keys land, so a
+        // failed POST must not auto-retry even on a normally-retryable status.
+        let stub = StubWCRESTClient(responses: [.status(503)])
+        let recorder = SleepRecorder()
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: recorder.record)
+
+        // When
+        let response = await client.request(method: "POST",
+                                            path: "wc/v3/orders/3551",
+                                            query: nil,
+                                            body: Data("{}".utf8),
+                                            headers: nil)
+
+        // Then
+        #expect(response.statusCode == 503)
+        #expect(stub.callCount == 1)
+        #expect(await recorder.delays.isEmpty)
+    }
+
+    @Test
+    func test_request_when_transport_failure_then_retries_then_succeeds() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [
+            .status(HTTPStatusClassification.transportFailure),
+            .status(200)
+        ])
+        let recorder = SleepRecorder()
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: recorder.record)
+
+        // When
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/orders",
+                                            query: nil,
+                                            body: nil,
+                                            headers: nil)
+
+        // Then
+        #expect(response.statusCode == 200)
+        #expect(stub.callCount == 2)
+        #expect(await recorder.delays == [0.2])
+    }
+
+    @Test
+    func test_request_passes_idempotencyKey_header_through_unchanged() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [.status(200)])
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: .default,
+                                          sleep: { _ in })
+
+        // When
+        _ = await client.request(method: "POST",
+                                 path: "wc/v3/orders/3551",
+                                 query: nil,
+                                 body: Data("{\"status\":\"completed\"}".utf8),
+                                 headers: ["Idempotency-Key": "abc-123",
+                                           "X-Trace": "trace-7"])
+
+        // Then
+        #expect(stub.recordedHeaders.first?["Idempotency-Key"] == "abc-123")
+        #expect(stub.recordedHeaders.first?["X-Trace"] == "trace-7")
+    }
+}
+
+// MARK: - Test doubles
+
+private final class StubWCRESTClient: WCRESTClient, @unchecked Sendable {
+    enum Scripted {
+        case status(Int)
+        case response(WCRESTResponse)
+    }
+
+    private var responses: [Scripted]
+    private(set) var callCount = 0
+    private(set) var recordedHeaders: [[String: String]] = []
+    private let lock = NSLock()
+
+    init(responses: [Scripted]) {
+        self.responses = responses
+    }
+
+    func request(method: String,
+                 path: String,
+                 query: [String: String]?,
+                 body: Data?,
+                 headers: [String: String]?) async -> WCRESTResponse {
+        lock.lock()
+        defer { lock.unlock() }
+        callCount += 1
+        recordedHeaders.append(headers ?? [:])
+        let scripted = responses.isEmpty ? .status(500) : responses.removeFirst()
+        switch scripted {
+        case .status(let code):
+            return WCRESTResponse(data: Data(), statusCode: code)
+        case .response(let response):
+            return response
+        }
+    }
+}
+
+private actor SleepRecorder {
+    private(set) var delays: [TimeInterval] = []
+
+    func record(_ interval: TimeInterval) async {
+        delays.append(interval)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/WCRESTClientRetryTests.swift
@@ -148,6 +148,39 @@ struct WCRESTClientRetryTests {
     }
 
     @Test
+    func test_request_when_cancelled_during_backoff_then_returns_transportFailure_promptly() async {
+        // Given
+        let stub = StubWCRESTClient(responses: [
+            .status(503),
+            .status(200)
+        ])
+        let client = RetryingWCRESTClient(inner: stub,
+                                          policy: RESTRetryPolicy(maxRetries: 2, backoff: [60, 60]),
+                                          sleep: { interval in
+            try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+        })
+
+        // When
+        let task = Task {
+            await client.request(method: "GET",
+                                 path: "wc/v3/orders",
+                                 query: nil,
+                                 body: nil,
+                                 headers: nil)
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+        let start = Date()
+        let response = await task.value
+        let elapsed = Date().timeIntervalSince(start)
+
+        // Then
+        #expect(response.statusCode == HTTPStatusClassification.transportFailure)
+        #expect(elapsed < 5)
+        #expect(stub.callCount == 1)
+    }
+
+    @Test
     func test_request_passes_idempotencyKey_header_through_unchanged() async {
         // Given
         let stub = StubWCRESTClient(responses: [.status(200)])
@@ -208,7 +241,7 @@ private final class StubWCRESTClient: WCRESTClient, @unchecked Sendable {
 private actor SleepRecorder {
     private(set) var delays: [TimeInterval] = []
 
-    func record(_ interval: TimeInterval) async {
+    func record(_ interval: TimeInterval) async throws {
         delays.append(interval)
     }
 }

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -9,14 +9,12 @@ import enum WooAIAssistant.HTTPStatusClassification
 import struct WooAIAssistant.WCRESTResponse
 import protocol WooAIAssistant.WCRESTClient
 
-/// Implements `WCRESTClient` on top of the existing `Networking.Network`. Using
 /// `JetpackRequest(availableAsRESTRequest: true)` routes the same way other
 /// remotes do: WPCOM-tunneled with the bearer token, or upgraded to a direct
 /// app-password REST call when the site supports it.
 ///
-/// `Network` is not declared `Sendable`, but the app constructs a single
-/// instance at launch and never mutates it; treating the adaptor as `Sendable`
-/// is sound at this integration boundary.
+/// `Network` isn't declared `Sendable`, but the production instance is
+/// constructed once at launch and treated as thread-safe across the app.
 struct WCRESTClientAdaptor: @unchecked Sendable, WCRESTClient {
     private let network: Network
     private let siteID: Int64
@@ -34,9 +32,8 @@ struct WCRESTClientAdaptor: @unchecked Sendable, WCRESTClient {
         let httpMethod = HTTPMethod(rawValue: method.uppercased())
         let (apiVersion, subpath) = Self.splitAPIVersion(from: path)
         let parameters = Self.parameters(forMethod: httpMethod, query: query, body: body)
-        // `JetpackRequest` has no slot for arbitrary headers; auth headers are
-        // injected downstream by the network layer. Caller-supplied headers
-        // (e.g. `Idempotency-Key`) are intentionally dropped at this boundary.
+        // `JetpackRequest` has no header slot; caller-supplied headers
+        // (e.g. `Idempotency-Key`) are dropped at this boundary.
         _ = headers
 
         let jetpackRequest = JetpackRequest(wooApiVersion: apiVersion,

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -47,8 +47,13 @@ struct WCRESTClientAdaptor: @unchecked Sendable, WCRESTClient {
             let (data, _) = try await network.responseDataAndHeaders(for: jetpackRequest)
             return WCRESTResponse(data: data, statusCode: 200)
         } catch let error as NetworkError {
+            if case .timeout = error {
+                return WCRESTResponse(data: error.responseData ?? Data(), statusCode: 408)
+            }
             return WCRESTResponse(data: error.responseData ?? Data(),
                                   statusCode: error.responseCode ?? HTTPStatusClassification.transportFailure)
+        } catch let error as URLError where error.code == .timedOut {
+            return WCRESTResponse(data: Data(), statusCode: 408)
         } catch {
             return WCRESTResponse(data: Data(), statusCode: HTTPStatusClassification.transportFailure)
         }

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -13,7 +13,11 @@ import protocol WooAIAssistant.WCRESTClient
 /// `JetpackRequest(availableAsRESTRequest: true)` routes the same way other
 /// remotes do: WPCOM-tunneled with the bearer token, or upgraded to a direct
 /// app-password REST call when the site supports it.
-struct WCRESTClientAdaptor: WCRESTClient {
+///
+/// `Network` is not declared `Sendable`, but the app constructs a single
+/// instance at launch and never mutates it; treating the adaptor as `Sendable`
+/// is sound at this integration boundary.
+struct WCRESTClientAdaptor: @unchecked Sendable, WCRESTClient {
     private let network: Network
     private let siteID: Int64
 

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -8,6 +8,7 @@ import struct Alamofire.HTTPMethod
 import enum WooAIAssistant.HTTPStatusClassification
 import struct WooAIAssistant.WCRESTResponse
 import protocol WooAIAssistant.WCRESTClient
+import CocoaLumberjackSwift
 
 /// `JetpackRequest(availableAsRESTRequest: true)` routes the same way other
 /// remotes do: WPCOM-tunneled with the bearer token, or upgraded to a direct
@@ -80,7 +81,12 @@ struct WCRESTClientAdaptor: @unchecked Sendable, WCRESTClient {
         switch method {
         case .post, .put, .patch:
             guard let body, !body.isEmpty else { return nil }
-            return (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
+            do {
+                return try JSONSerialization.jsonObject(with: body) as? [String: Any]
+            } catch {
+                DDLogError("⛔️ WCRESTClientAdaptor failed to deserialize request body as JSON: \(error)")
+                return nil
+            }
         default:
             guard let query, !query.isEmpty else { return nil }
             return query.reduce(into: [String: Any]()) { dict, pair in

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -5,6 +5,7 @@ import enum NetworkingCore.NetworkError
 import enum NetworkingCore.WooAPIVersion
 import protocol NetworkingCore.Network
 import struct Alamofire.HTTPMethod
+import enum WooAIAssistant.HTTPStatusClassification
 import struct WooAIAssistant.WCRESTResponse
 import protocol WooAIAssistant.WCRESTClient
 
@@ -46,15 +47,11 @@ struct WCRESTClientAdaptor: WCRESTClient {
             return WCRESTResponse(data: data, statusCode: 200)
         } catch let error as NetworkError {
             return WCRESTResponse(data: error.responseData ?? Data(),
-                                  statusCode: error.responseCode ?? Self.transportFailure)
+                                  statusCode: error.responseCode ?? HTTPStatusClassification.transportFailure)
         } catch {
-            return WCRESTResponse(data: Data(), statusCode: Self.transportFailure)
+            return WCRESTResponse(data: Data(), statusCode: HTTPStatusClassification.transportFailure)
         }
     }
-
-    /// Mirror of the module's `HTTPStatusClassification.transportFailure`
-    /// kept local so this adaptor avoids importing the module's internals.
-    private static let transportFailure: Int = 0
 
     private static func splitAPIVersion(from path: String) -> (apiVersion: WooAPIVersion, subpath: String) {
         let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Networking
+import struct NetworkingCore.JetpackRequest
+import enum NetworkingCore.NetworkError
+import enum NetworkingCore.WooAPIVersion
+import protocol NetworkingCore.Network
+import struct Alamofire.HTTPMethod
+import struct WooAIAssistant.WCRESTResponse
+import protocol WooAIAssistant.WCRESTClient
+
+/// Implements `WCRESTClient` on top of the existing `Networking.Network`. Using
+/// `JetpackRequest(availableAsRESTRequest: true)` routes the same way other
+/// remotes do: WPCOM-tunneled with the bearer token, or upgraded to a direct
+/// app-password REST call when the site supports it.
+struct WCRESTClientAdaptor: WCRESTClient {
+    private let network: Network
+    private let siteID: Int64
+
+    init(network: Network, siteID: Int64) {
+        self.network = network
+        self.siteID = siteID
+    }
+
+    func request(method: String,
+                 path: String,
+                 query: [String: String]?,
+                 body: Data?,
+                 headers: [String: String]?) async -> WCRESTResponse {
+        let httpMethod = HTTPMethod(rawValue: method.uppercased())
+        let (apiVersion, subpath) = Self.splitAPIVersion(from: path)
+        let parameters = Self.parameters(forMethod: httpMethod, query: query, body: body)
+        // `JetpackRequest` has no slot for arbitrary headers; auth headers are
+        // injected downstream by the network layer. Caller-supplied headers
+        // (e.g. `Idempotency-Key`) are intentionally dropped at this boundary.
+        _ = headers
+
+        let jetpackRequest = JetpackRequest(wooApiVersion: apiVersion,
+                                            method: httpMethod,
+                                            siteID: siteID,
+                                            path: subpath,
+                                            parameters: parameters,
+                                            availableAsRESTRequest: true)
+
+        do {
+            let (data, _) = try await network.responseDataAndHeaders(for: jetpackRequest)
+            return WCRESTResponse(data: data, statusCode: 200)
+        } catch let error as NetworkError {
+            return WCRESTResponse(data: error.responseData ?? Data(),
+                                  statusCode: error.responseCode ?? Self.transportFailure)
+        } catch {
+            return WCRESTResponse(data: Data(), statusCode: Self.transportFailure)
+        }
+    }
+
+    /// Mirror of the module's `HTTPStatusClassification.transportFailure`
+    /// kept local so this adaptor avoids importing the module's internals.
+    private static let transportFailure: Int = 0
+
+    private static func splitAPIVersion(from path: String) -> (apiVersion: WooAPIVersion, subpath: String) {
+        let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        let prefixes: [(String, WooAPIVersion)] = [
+            ("wc-analytics/", .wcAnalytics),
+            ("wc/v4/", .mark4),
+            ("wc/v3/", .mark3),
+            ("wc/v2/", .mark2),
+            ("wc/v1/", .mark1)
+        ]
+        for (prefix, version) in prefixes where trimmed.hasPrefix(prefix) {
+            return (version, String(trimmed.dropFirst(prefix.count)))
+        }
+        return (.mark3, trimmed)
+    }
+
+    private static func parameters(forMethod method: HTTPMethod,
+                                   query: [String: String]?,
+                                   body: Data?) -> [String: Any]? {
+        switch method {
+        case .post, .put, .patch:
+            guard let body, !body.isEmpty else { return nil }
+            return (try? JSONSerialization.jsonObject(with: body)) as? [String: Any]
+        default:
+            guard let query, !query.isEmpty else { return nil }
+            return query.reduce(into: [String: Any]()) { dict, pair in
+                dict[pair.key] = pair.value
+            }
+        }
+    }
+}
+
+private extension NetworkError {
+    var responseData: Data? {
+        switch self {
+        case .notFound(let response), .timeout(let response), .unacceptableStatusCode(_, let response):
+            return response
+        case .invalidURL, .invalidCookieNonce:
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
WOOMOB-2865

## Summary

Wires up REST tool dispatch for the WooAI Assistant. Adds the transport seam (`WCRESTClient`), retry policy, and the registry that dispatches tools by name. The production adaptor in the app target reuses the existing `Networking.Network` stack rather than introducing a parallel HTTP layer.

## Architecture (reuse, not rebuild)

```
RESTToolRegistry -> WCRESTClient (Sendable protocol, in module)
                       |
              WCRESTClientAdaptor
              (app target, wraps Networking.Network)
                       |
              Networking.Network -> Alamofire, app-password auth,
                                    WPCOM bearer, Jetpack tunnel
```

The module-level `WCRESTClient` protocol is intentionally thin so production reuses the app's networking via an adaptor, and the headless harness can swap in a `URLSession`-only implementation without dragging dependencies into the assistant module.

## What this introduces

- `WCRESTClient` - Sendable async protocol with `request(method:path:query:body:headers:)` returning a populated `WCRESTResponse` (no throw on non-2xx).
- `HTTPStatusClassification` - status code to `AssistantErrorKind` mapping (401/403=auth, 408=timeout, 429=rateLimit, 5xx=upstreamFailure, 0=network sentinel, other=unknown). Aligned with the cross-platform error taxonomy.
- `RESTRetryPolicy` - decision-only value type. Max 2 retries, 200ms+800ms backoff. Idempotent methods only (GET/HEAD/OPTIONS); writes never auto-retry.
- `RetryingWCRESTClient` - wrapper consuming any `WCRESTClient` plus a `RESTRetryPolicy`. Cancellation propagates through the retry sleep.
- `RESTToolRegistry` - concrete `ToolRegistry`, ships empty, dispatches by tool name; unknown names short-circuit to `.failed(kind: .invalidToolCall)`.
- `WCRESTClientAdaptor` (app target) - bridges `Networking.Network` + `JetpackRequest(availableAsRESTRequest: true)` to the module's `WCRESTClient` protocol. Routes the same way other remotes do; `URLError.timedOut` and `NetworkError.timeout` route through HTTP 408.
- 19 Swift Testing cases covering retry decisions, status classification, deterministic cancellation, and registry dispatch.

## Tests

- CI should build.
- Doesn't introduce any user-visible changes; the new adaptor has no call sites yet.

## Known limitation

`JetpackRequest` has no header slot. The adaptor accepts `headers:` per the protocol but drops them at the boundary, so `Idempotency-Key` doesn't reach the wire. Extending `JetpackRequest.customHeaders` in NetworkingCore is tracked on WOOMOB-2867.

---
- [x] I have considered if this change warrants user-facing release notes and decided no - the module has no call sites yet.