### PR TITLE
[RSM] Build POS custom amount form as a full-screen modal

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -288,13 +288,13 @@ private extension CartView {
 }
 
 private struct CartAddCustomAmountButton: View {
-    let onTap: () -> Void
+    static let tip = AddCustomAmountTip()
 
-    @State private var tip = AddCustomAmountTip()
+    let onTap: () -> Void
 
     var body: some View {
         Button(action: {
-            tip.invalidate(reason: .actionPerformed)
+            Self.tip.invalidate(reason: .actionPerformed)
             onTap()
         }) {
             Image(systemName: "plus")
@@ -303,7 +303,7 @@ private struct CartAddCustomAmountButton: View {
                 .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
                 .accessibilityLabel(Localization.addCustomAmountAccessibilityLabel)
         }
-        .popoverTip(tip, arrowEdge: .top)
+        .popoverTip(Self.tip, arrowEdge: .top)
         .accessibilityIdentifier("pos-add-custom-amount-header-button")
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -5,6 +5,7 @@ import WooFoundation
 struct CartView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posCurrencyProvider) private var currencyProvider
     private let viewHelper = CartViewHelper()
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -63,8 +64,14 @@ struct CartView: View {
             .posModal(isPresented: $showBarcodeScanningModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
             }
-            .posModal(isPresented: $showAddCustomAmountSheet) {
-                AddCustomAmountView(isPresented: $showAddCustomAmountSheet)
+            .posFullScreenCover(isPresented: $showAddCustomAmountSheet) {
+                AddCustomAmountView(
+                    isPresented: $showAddCustomAmountSheet,
+                    currencySettings: currencyProvider.currencySettings,
+                    onSubmit: { _ in
+                        // Real wiring lands on the next branch.
+                    }
+                )
             }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountFormViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountFormViewModel.swift
@@ -31,9 +31,6 @@ final class AddCustomAmountFormViewModel {
         self.numberFormatter = formatter
     }
 
-    /// Updates `amount` after running the raw user input through
-    /// `CurrencyInputSanitizer`. Invalid input (extra decimals, multiple
-    /// separators, etc.) is rejected and the current value is kept.
     func setAmount(_ rawInput: String) {
         guard let sanitized = sanitizer.sanitize(rawInput) else { return }
         amount = sanitized

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountFormViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountFormViewModel.swift
@@ -1,0 +1,75 @@
+import Foundation
+import WooFoundation
+
+struct POSCustomAmountInput: Equatable {
+    let name: String
+    let amount: String
+    let isTaxable: Bool
+}
+
+@Observable
+final class AddCustomAmountFormViewModel {
+    var amount: String = ""
+    var name: String = ""
+    var isTaxable: Bool = true
+
+    let currencySymbol: String
+    let sanitizer: CurrencyInputSanitizer
+    private let numberFormatter: NumberFormatter
+
+    init(currencySettings: CurrencySettings) {
+        self.sanitizer = CurrencyInputSanitizer(currencySettings: currencySettings)
+        self.currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.generatesDecimalNumbers = true
+        formatter.groupingSeparator = currencySettings.groupingSeparator
+        formatter.decimalSeparator = currencySettings.decimalSeparator
+        formatter.minimumFractionDigits = currencySettings.fractionDigits
+        formatter.maximumFractionDigits = currencySettings.fractionDigits
+        self.numberFormatter = formatter
+    }
+
+    /// Updates `amount` after running the raw user input through
+    /// `CurrencyInputSanitizer`. Invalid input (extra decimals, multiple
+    /// separators, etc.) is rejected and the current value is kept.
+    func setAmount(_ rawInput: String) {
+        guard let sanitized = sanitizer.sanitize(rawInput) else { return }
+        amount = sanitized
+    }
+
+    var isAddEnabled: Bool {
+        guard let value = parsedAmount else { return false }
+        return value > 0
+    }
+
+    func resolvedInput() -> POSCustomAmountInput? {
+        guard isAddEnabled else { return nil }
+        return POSCustomAmountInput(
+            name: resolvedName,
+            amount: amount,
+            isTaxable: isTaxable
+        )
+    }
+
+    var resolvedName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? Localization.defaultName : trimmed
+    }
+
+    private var parsedAmount: Decimal? {
+        let trimmed = amount.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return numberFormatter.number(from: trimmed)?.decimalValue
+    }
+}
+
+private extension AddCustomAmountFormViewModel {
+    enum Localization {
+        static let defaultName = NSLocalizedString(
+            "pos.addCustomAmount.defaultName",
+            value: "Custom amount",
+            comment: "Default name used for a Point of Sale custom amount when the merchant leaves the name field empty.")
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
@@ -1,52 +1,191 @@
 import SwiftUI
+import WooFoundation
 
 struct AddCustomAmountView: View {
     @Binding var isPresented: Bool
-    @Environment(\.posModalParentSize) private var parentSize
+    let onSubmit: (POSCustomAmountInput) -> Void
+
+    @State private var viewModel: AddCustomAmountFormViewModel
+    @FocusState private var isAmountFocused: Bool
+    @FocusState private var isNameFocused: Bool
+
+    private var amountBinding: Binding<String> {
+        Binding(
+            get: { viewModel.amount },
+            set: { viewModel.setAmount($0) }
+        )
+    }
+
+    init(isPresented: Binding<Bool>,
+         currencySettings: CurrencySettings,
+         onSubmit: @escaping (POSCustomAmountInput) -> Void) {
+        self._isPresented = isPresented
+        self.onSubmit = onSubmit
+        self._viewModel = State(wrappedValue: AddCustomAmountFormViewModel(currencySettings: currencySettings))
+    }
 
     var body: some View {
-        VStack(spacing: POSSpacing.large) {
-            Text(Localization.title)
-                .font(.posHeadingBold)
-                .foregroundColor(.posOnSurface)
+        VStack(spacing: 0) {
+            POSPageHeaderView(
+                title: Localization.title,
+                backButtonConfiguration: .init(
+                    state: .enabled,
+                    action: { isPresented = false },
+                    buttonIcon: "xmark"
+                )
+            )
 
-            Text(Localization.comingSoon)
+            ScrollView {
+                VStack(alignment: .leading, spacing: POSSpacing.xLarge) {
+                    amountSection
+                        .padding(.top, POSSpacing.xLarge)
+
+                    Divider()
+
+                    taxesRow
+
+                    Divider()
+
+                    nameSection
+
+                    Spacer(minLength: POSSpacing.xxLarge)
+                }
+                .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
+            }
+            .scrollDismissesKeyboard(.interactively)
+
+            addButton
+                .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
+                .padding(.vertical, POSPadding.medium)
+        }
+        .background(Color.posSurfaceBright.ignoresSafeArea())
+    }
+
+    private var amountSection: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.small) {
+            Text(Localization.amountLabel)
                 .font(.posBodyMediumRegular())
                 .foregroundColor(.posOnSurfaceVariantLowest)
-                .multilineTextAlignment(.center)
+
+            ZStack {
+                TextField("", text: amountBinding)
+                    .keyboardType(.decimalPad)
+                    .focused($isAmountFocused)
+                    .opacity(0)
+                    .accessibilityHidden(true)
+
+                HStack(spacing: POSSpacing.xSmall) {
+                    Text(viewModel.currencySymbol)
+                        .font(.posHeadingBold)
+                        .foregroundColor(.posOnSurface)
+
+                    Text(viewModel.amount.isEmpty ? "0" : viewModel.amount)
+                        .font(.posHeadingBold)
+                        .foregroundColor(viewModel.amount.isEmpty ? .posOnSurfaceVariantLowest : .posOnSurface)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(POSPadding.large)
+            .background(Color.posSurfaceContainerLowest)
+            .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.large.value))
+            .contentShape(Rectangle())
+            .onTapGesture { focusAmountField() }
         }
-        .posModalCloseButton(action: {
-            isPresented = false
-        })
-        .padding(POSPadding.xLarge)
-        .background(Color.posSurfaceBright)
-        .frame(
-            maxWidth: parentSize.width * Constants.parentWidthRatio,
-            maxHeight: parentSize.height * Constants.parentHeightRatio
-        )
+    }
+
+    private func focusAmountField() {
+        // Force a focus cycle (false → true) so a fresh tap always re-presents
+        // the popover — without this, dismissing the keyboard by tapping
+        // outside leaves `@FocusState` out of sync and a second tap does
+        // nothing. Also explicitly clear the name field's focus so the
+        // QWERTY keyboard fully tears down before the decimal-pad opens.
+        isNameFocused = false
+        isAmountFocused = false
+        DispatchQueue.main.async {
+            isAmountFocused = true
+        }
+    }
+
+    private var taxesRow: some View {
+        Toggle(isOn: $viewModel.isTaxable) {
+            Text(Localization.chargeTaxes)
+                .font(.posBodyLargeRegular())
+                .foregroundColor(.posOnSurface)
+        }
+        .tint(.posPrimary)
+        .padding(.vertical, POSPadding.small)
+    }
+
+    private var nameSection: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.small) {
+            Text(Localization.nameLabel)
+                .font(.posBodyMediumRegular())
+                .foregroundColor(.posOnSurfaceVariantLowest)
+
+            TextField(Localization.namePlaceholder, text: $viewModel.name)
+                .font(.posBodyLargeRegular())
+                .foregroundColor(.posOnSurface)
+                .focused($isNameFocused)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.sentences)
+                .submitLabel(.done)
+                .onSubmit(submit)
+                .padding(.vertical, POSPadding.small)
+        }
+    }
+
+    private var addButton: some View {
+        Button(action: submit) {
+            Text(Localization.addButton)
+        }
+        .buttonStyle(POSFilledButtonStyle(size: .normal))
+        .frame(maxWidth: .infinity)
+        .disabled(!viewModel.isAddEnabled)
+        .accessibilityIdentifier("pos-add-custom-amount-submit-button")
+    }
+
+    private func submit() {
+        guard let input = viewModel.resolvedInput() else { return }
+        onSubmit(input)
+        isPresented = false
     }
 }
 
 private extension AddCustomAmountView {
-    enum Constants {
-        static let parentWidthRatio: CGFloat = 0.5
-        static let parentHeightRatio: CGFloat = 0.5
-    }
-
     enum Localization {
         static let title = NSLocalizedString(
             "pos.addCustomAmount.title",
+            value: "Custom amount",
+            comment: "Title of the full-screen Point of Sale form for adding a custom amount to the order.")
+        static let amountLabel = NSLocalizedString(
+            "pos.addCustomAmount.amountLabel",
+            value: "Amount",
+            comment: "Label above the amount field in the Point of Sale add custom amount form.")
+        static let chargeTaxes = NSLocalizedString(
+            "pos.addCustomAmount.chargeTaxes",
+            value: "Charge taxes",
+            comment: "Title of the taxable toggle in the Point of Sale add custom amount form.")
+        static let nameLabel = NSLocalizedString(
+            "pos.addCustomAmount.nameLabel",
+            value: "Name",
+            comment: "Label above the name field in the Point of Sale add custom amount form.")
+        static let namePlaceholder = NSLocalizedString(
+            "pos.addCustomAmount.namePlaceholder",
+            value: "Custom amount",
+            comment: "Placeholder for the name field in the Point of Sale add custom amount form.")
+        static let addButton = NSLocalizedString(
+            "pos.addCustomAmount.addButton",
             value: "Add custom amount",
-            comment: "Title of the sheet for adding a custom amount to the Point of Sale cart.")
-        static let comingSoon = NSLocalizedString(
-            "pos.addCustomAmount.comingSoon",
-            value: "The custom amount form is coming soon.",
-            comment: "Placeholder text shown on the Point of Sale add custom amount sheet while the form is under development.")
+            comment: "Primary button in the Point of Sale add custom amount form that adds the amount to the order.")
     }
 }
 
 #if DEBUG
 #Preview {
-    AddCustomAmountView(isPresented: .constant(true))
+    AddCustomAmountView(
+        isPresented: .constant(true),
+        currencySettings: CurrencySettings(),
+        onSubmit: { _ in }
+    )
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
@@ -94,11 +94,6 @@ struct AddCustomAmountView: View {
     }
 
     private func focusAmountField() {
-        // Force a focus cycle (false → true) so a fresh tap always re-presents
-        // the popover — without this, dismissing the keyboard by tapping
-        // outside leaves `@FocusState` out of sync and a second tap does
-        // nothing. Also explicitly clear the name field's focus so the
-        // QWERTY keyboard fully tears down before the decimal-pad opens.
         isNameFocused = false
         isAmountFocused = false
         DispatchQueue.main.async {
@@ -115,10 +110,6 @@ struct AddCustomAmountView: View {
         .tint(.posPrimary)
         .padding(.vertical, POSPadding.small)
         .onChange(of: viewModel.isTaxable) { _, _ in
-            // Tapping the toggle dismisses the amount popover, but on iPad iOS
-            // sometimes "demotes" it to the docked decimal pad instead of
-            // closing the keyboard. Explicitly clear focus so the keyboard
-            // actually goes away.
             isAmountFocused = false
             isNameFocused = false
         }

--- a/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Custom Amount/AddCustomAmountView.swift
@@ -114,6 +114,14 @@ struct AddCustomAmountView: View {
         }
         .tint(.posPrimary)
         .padding(.vertical, POSPadding.small)
+        .onChange(of: viewModel.isTaxable) { _, _ in
+            // Tapping the toggle dismisses the amount popover, but on iPad iOS
+            // sometimes "demotes" it to the docked decimal pad instead of
+            // closing the keyboard. Explicitly clear focus so the keyboard
+            // actually goes away.
+            isAmountFocused = false
+            isNameFocused = false
+        }
     }
 
     private var nameSection: some View {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -176,7 +176,11 @@ public struct PointOfSaleEntryPointView: View {
             }
         }
         .task {
-            try? Tips.configure()
+            do {
+                try Tips.configure()
+            } catch {
+                DDLogError("⛔️ Failed to configure TipKit: \(error)")
+            }
 
             // We create the posModel in a task, not init, to avoid creating multiple copies during the view's lifecycle.
             // Confusingly, init can be called more than once, but `task` matches the lifecycle.

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import SwiftUI
 import TipKit
 import class WooFoundation.CurrencyFormatter

--- a/Modules/Tests/PointOfSaleTests/Presentation/Custom Amount/AddCustomAmountFormViewModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/Custom Amount/AddCustomAmountFormViewModelTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+import WooFoundation
+@testable import PointOfSale
+
+struct AddCustomAmountFormViewModelTests {
+    private let currencySettings = CurrencySettings(
+        currencyCode: .USD,
+        currencyPosition: .left,
+        thousandSeparator: ",",
+        decimalSeparator: ".",
+        numberOfDecimals: 2
+    )
+
+    @Test func test_isAddEnabled_when_amount_is_empty_then_false() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When, Then
+        #expect(sut.isAddEnabled == false)
+    }
+
+    @Test func test_isAddEnabled_when_amount_is_zero_then_false() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = "0.00"
+
+        // Then
+        #expect(sut.isAddEnabled == false)
+    }
+
+    @Test func test_isAddEnabled_when_amount_is_positive_then_true() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = "10.00"
+
+        // Then
+        #expect(sut.isAddEnabled == true)
+    }
+
+    @Test func test_resolvedInput_when_amount_is_invalid_then_returns_nil() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = ""
+
+        // Then
+        #expect(sut.resolvedInput() == nil)
+    }
+
+    @Test func test_resolvedInput_when_amount_valid_and_name_empty_then_returns_default_name() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = "12.50"
+        sut.name = ""
+
+        // Then
+        let input = try #require(sut.resolvedInput())
+        #expect(input.name == "Custom amount")
+        #expect(input.amount == "12.50")
+        #expect(input.isTaxable == true)
+    }
+
+    @Test func test_resolvedInput_when_name_has_whitespace_only_then_uses_default_name() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = "5.00"
+        sut.name = "   "
+
+        // Then
+        let input = try #require(sut.resolvedInput())
+        #expect(input.name == "Custom amount")
+    }
+
+    @Test func test_resolvedInput_when_name_is_provided_then_uses_trimmed_name() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = "5.00"
+        sut.name = "  Service fee  "
+
+        // Then
+        let input = try #require(sut.resolvedInput())
+        #expect(input.name == "Service fee")
+    }
+
+    @Test func test_resolvedInput_when_isTaxable_is_false_then_input_reflects_it() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.amount = "5.00"
+        sut.isTaxable = false
+
+        // Then
+        let input = try #require(sut.resolvedInput())
+        #expect(input.isTaxable == false)
+    }
+
+    @Test func test_isTaxable_default_is_true() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When, Then
+        #expect(sut.isTaxable == true)
+    }
+
+    @Test func test_setAmount_when_input_is_valid_then_updates_amount() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+
+        // When
+        sut.setAmount("12.34")
+
+        // Then
+        #expect(sut.amount == "12.34")
+    }
+
+    @Test func test_setAmount_when_input_is_invalid_then_keeps_previous_amount() async throws {
+        // Given
+        let sut = AddCustomAmountFormViewModel(currencySettings: currencySettings)
+        sut.setAmount("12.34")
+
+        // When — too many decimals for a 2-fraction-digit currency
+        sut.setAmount("12.345")
+
+        // Then
+        #expect(sut.amount == "12.34")
+    }
+}


### PR DESCRIPTION
## Description
Stacks on top of [#16970](https://github.com/woocommerce/woocommerce-ios/pull/16970) — replaces the placeholder sheet that PR introduced with the real Point of Sale custom amount form.

- **Full-screen presentation** via `posFullScreenCover`. POS principles call out amount entry as a focused-input flow that should take the whole screen, not a centered modal.
- **Hero amount field** with the iPad number-pad popover. The `TextField` is hidden behind a styled `Text` (mirroring the IPP `FormattableAmountTextField` trick) so users tap the visible display, which programmatically focuses the field. Avoids a series of iOS 26 popover-vs-docked-keyboard quirks we hit with a visible TextField.
- **Charge taxes toggle** (default on). Only flips the fee line's `taxStatus` — actual tax math runs server-side.
- **Optional name field** that falls back to "Custom amount" when empty.
- **Primary CTA** disabled until the amount is greater than zero.
- **X close icon** in the header (modal semantics, not in-place navigation).

`AddCustomAmountFormViewModel` (`@Observable`) is the single source of truth for the form. It owns the `CurrencyInputSanitizer`, exposes `setAmount(_:)`, `isAddEnabled`, and produces a `POSCustomAmountInput` on submit. The view binds the hidden `TextField` directly to that view model — no duplicated state.

Submission is wired to a no-op callback at the cart level for now. The `Cart.customAmounts` model extension and order-sync wiring land on the next branch.

This PR targets the [homescreen entry-point branch](https://github.com/woocommerce/woocommerce-ios/pull/16970) so the diff stays scoped to the form work; it auto-rebases onto `trunk` once that one merges.

## Test Steps
On a `localDeveloper` or `alpha` build:
- [ ] Open Point of Sale → tap the `+` icon in the cart header → the full-screen form appears with the X close icon, "Custom amount" title, and an "Amount" hero field.
- [ ] Tap the amount hero — the iPad numeric popover opens. Type a value; verify only digits and the store's decimal separator are accepted, and that the visible display updates.
- [ ] Type a value with too many decimals (e.g. `1.234` for a 2-fraction-digit currency); verify the input is rejected and the previous valid value remains.
- [ ] Tap the amount field, then tap outside, then tap the amount field again — the popover should reopen reliably.
- [ ] Toggle "Charge taxes" off; verify the toggle updates without affecting the amount value.
- [ ] Tap the name field — the standard keyboard appears. Tap back into the amount; the popover should replace the standard keyboard.
- [ ] Verify "Add custom amount" is disabled when the amount is empty or zero, and enabled with any positive amount.
- [ ] Tap "Add custom amount" — the sheet dismisses and returns to the cart (no cart mutation yet — that's the next branch).
- [ ] Tap the X close icon — the sheet dismisses without firing submit.
- [ ] Run the POS unit tests: `AddCustomAmountFormViewModelTests` (11 cases) should all pass.

On an App Store build (flag off):
- [ ] No `+` button in the cart header → no way to reach the form. Cart looks identical to trunk.

## Screenshots
N/A — design previews to follow.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.