### PR TITLE
[RSM] Render POS custom amounts in order details

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -218,15 +218,9 @@ private extension POSOrderDetailsView {
     @ViewBuilder
     func customAmountRow(customAmount: POSOrderCustomAmount) -> some View {
         HStack(alignment: .center, spacing: POSSpacing.medium) {
-            ZStack {
-                Color.posSurfaceContainerLow
-
-                Image(systemName: "tag")
-                    .font(.posButtonSymbolMedium)
-                    .foregroundColor(.posOnSurface)
-            }
-            .frame(width: Constants.productImageSize, height: Constants.productImageSize)
-            .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
+            CustomAmountAvatar(name: customAmount.name)
+                .frame(width: Constants.productImageSize, height: Constants.productImageSize)
+                .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
 
             Text(customAmount.name)
                 .font(.posBodyLargeBold)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import struct WooFoundation.WooAnalyticsEvent
 import struct Yosemite.POSOrder
+import struct Yosemite.POSOrderCustomAmount
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderRefund
 import struct Yosemite.POSRefundItem
@@ -56,6 +57,9 @@ struct POSOrderDetailsView: View {
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
                     if !orderListModel.ordersController.displayedLineItems.isEmpty {
                         productsSection(orderListModel.ordersController.displayedLineItems)
+                    }
+                    if !order.customAmounts.isEmpty {
+                        customAmountsSection(order.customAmounts)
                     }
                     if shouldShowDedicatedRefundsSection && orderListModel.ordersController.isLoadingOrderRefunds {
                         ghostRefundedProductsSection
@@ -183,6 +187,57 @@ private extension POSOrderDetailsView {
         .padding(POSPadding.medium)
         .background(Color.posSurfaceContainerLowest)
         .posItemCardBorderStyles()
+    }
+
+    @ViewBuilder
+    func customAmountsSection(_ customAmounts: [POSOrderCustomAmount]) -> some View {
+        VStack(alignment: .leading, spacing: POSSpacing.medium) {
+            Text(Localization.customAmountsTitle)
+                .font(.posBodyXLargeRegular)
+                .foregroundStyle(Color.posOnSurface)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: POSSpacing.small) {
+                ForEach(Array(customAmounts.enumerated()), id: \.element.id) { index, customAmount in
+                    customAmountRow(customAmount: customAmount)
+
+                    if index < customAmounts.count - 1 {
+                        divider
+                    }
+                }
+            }
+        }
+        .padding(POSPadding.medium)
+        .background(Color.posSurfaceContainerLowest)
+        .posItemCardBorderStyles()
+    }
+
+    @ViewBuilder
+    func customAmountRow(customAmount: POSOrderCustomAmount) -> some View {
+        HStack(alignment: .center, spacing: POSSpacing.medium) {
+            ZStack {
+                Color.posSurfaceContainerLow
+
+                Image(systemName: "tag")
+                    .font(.posButtonSymbolMedium)
+                    .foregroundColor(.posOnSurface)
+            }
+            .frame(width: Constants.productImageSize, height: Constants.productImageSize)
+            .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
+
+            Text(customAmount.name)
+                .font(.posBodyLargeBold)
+                .foregroundStyle(Color.posOnSurface)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            Text(customAmount.formattedTotal)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(Color.posOnSurface)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Localization.customAmountRowAccessibilityLabel(name: customAmount.name, total: customAmount.formattedTotal))
     }
 
     @ViewBuilder
@@ -532,6 +587,21 @@ private enum Localization {
         value: "Refunded products",
         comment: "Section title for the refunded products list in order details"
     )
+
+    static let customAmountsTitle = NSLocalizedString(
+        "pos.orderDetailsView.customAmountsTitle",
+        value: "Custom amounts",
+        comment: "Section title for the custom amounts list in order details"
+    )
+
+    static func customAmountRowAccessibilityLabel(name: String, total: String) -> String {
+        let format = NSLocalizedString(
+            "pos.orderDetailsView.customAmountRow.accessibilityLabel",
+            value: "%1$@, %2$@",
+            comment: "Accessibility label for a custom amount row. %1$@ is the name, %2$@ is the formatted total."
+        )
+        return String(format: format, name, total)
+    }
 
     static func refundTitle(_ number: Int) -> String {
         let format = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -58,6 +58,9 @@ struct POSOrderDetailsView: View {
                     if !orderListModel.ordersController.displayedLineItems.isEmpty {
                         productsSection(orderListModel.ordersController.displayedLineItems)
                     }
+                    // Fee refunds are out of scope for this PR. When they land, this read should
+                    // move to a `displayedCustomAmounts` computed property on the controller that
+                    // mirrors `displayedLineItems` and filters refunded fees out by id.
                     if !order.customAmounts.isEmpty {
                         customAmountsSection(order.customAmounts)
                     }

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -24,6 +24,7 @@ import enum Yosemite.PointOfSaleBarcodeScanError
 import Combine
 import struct Yosemite.PaymentIntent
 import struct Yosemite.POSOrder
+import struct Yosemite.POSOrderCustomAmount
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderRefund
 import struct Yosemite.POSRefund
@@ -314,6 +315,9 @@ struct POSPreviewHelpers {
                         OrderItemAttribute(metaID: 2, name: "Type", value: "Loose Leaf")
                     ]
                 )
+            ],
+            customAmounts: [
+                POSOrderCustomAmount(id: 1, name: "Service fee", formattedTotal: "$5.00")
             ],
             refunds: [],
             formattedDiscountTotal: "$0.00",

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -85,6 +85,7 @@ extension Yosemite.POSOrder {
         paymentMethodID: CopiableProp<String> = .copy,
         paymentMethodTitle: CopiableProp<String> = .copy,
         lineItems: CopiableProp<[POSOrderItem]> = .copy,
+        customAmounts: CopiableProp<[POSOrderCustomAmount]> = .copy,
         refunds: CopiableProp<[POSOrderRefund]> = .copy,
         formattedDiscountTotal: NullableCopiableProp<String> = .copy,
         formattedTotalTax: CopiableProp<String> = .copy,
@@ -104,6 +105,7 @@ extension Yosemite.POSOrder {
         let paymentMethodID = paymentMethodID ?? self.paymentMethodID
         let paymentMethodTitle = paymentMethodTitle ?? self.paymentMethodTitle
         let lineItems = lineItems ?? self.lineItems
+        let customAmounts = customAmounts ?? self.customAmounts
         let refunds = refunds ?? self.refunds
         let formattedDiscountTotal = formattedDiscountTotal ?? self.formattedDiscountTotal
         let formattedTotalTax = formattedTotalTax ?? self.formattedTotalTax
@@ -124,6 +126,7 @@ extension Yosemite.POSOrder {
             paymentMethodID: paymentMethodID,
             paymentMethodTitle: paymentMethodTitle,
             lineItems: lineItems,
+            customAmounts: customAmounts,
             refunds: refunds,
             formattedDiscountTotal: formattedDiscountTotal,
             formattedTotalTax: formattedTotalTax,

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrder.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrder.swift
@@ -18,6 +18,7 @@ public struct POSOrder: Equatable, Hashable, Identifiable, GeneratedCopiable {
     public let paymentMethodID: String
     public let paymentMethodTitle: String
     public let lineItems: [POSOrderItem]
+    public let customAmounts: [POSOrderCustomAmount]
     public let refunds: [POSOrderRefund]
     public let formattedDiscountTotal: String?
     public let formattedTotalTax: String
@@ -41,6 +42,7 @@ public struct POSOrder: Equatable, Hashable, Identifiable, GeneratedCopiable {
                 paymentMethodID: String,
                 paymentMethodTitle: String,
                 lineItems: [POSOrderItem] = [],
+                customAmounts: [POSOrderCustomAmount] = [],
                 refunds: [POSOrderRefund] = [],
                 formattedDiscountTotal: String?,
                 formattedTotalTax: String,
@@ -59,6 +61,7 @@ public struct POSOrder: Equatable, Hashable, Identifiable, GeneratedCopiable {
         self.paymentMethodID = paymentMethodID
         self.paymentMethodTitle = paymentMethodTitle
         self.lineItems = lineItems
+        self.customAmounts = customAmounts
         self.refunds = refunds
         self.formattedDiscountTotal = formattedDiscountTotal
         self.formattedTotalTax = formattedTotalTax

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderCustomAmount.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderCustomAmount.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct POSOrderCustomAmount: Equatable, Hashable, Identifiable {
+    public let id: Int64
+    public let name: String
+    public let formattedTotal: String
+
+    public init(id: Int64, name: String, formattedTotal: String) {
+        self.id = id
+        self.name = name
+        self.formattedTotal = formattedTotal
+    }
+}

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import class WooFoundationCore.CurrencyFormatter
 import struct NetworkingCore.Order
+import struct NetworkingCore.OrderFeeLine
 import struct NetworkingCore.OrderItem
 import struct NetworkingCore.OrderItemAttribute
 import struct NetworkingCore.OrderRefundCondensed
@@ -22,6 +23,10 @@ struct POSOrderMapper {
         let customerEmail = order.billingAddress?.email
 
         let posLineItems = try order.items.map { try map(orderItem: $0, currency: order.currency) }
+
+        let posCustomAmounts = order.fees
+            .filter { !$0.isDeleted }
+            .map { map(fee: $0, currency: order.currency) }
 
         let posRefunds = order.refunds.map { map(orderRefund: $0, currency: order.currency) }
 
@@ -56,6 +61,7 @@ struct POSOrderMapper {
             paymentMethodID: order.paymentMethodID,
             paymentMethodTitle: order.paymentMethodTitle,
             lineItems: posLineItems,
+            customAmounts: posCustomAmounts,
             refunds: posRefunds,
             formattedDiscountTotal: formattedDiscountTotal,
             formattedTotalTax: currencyFormatter.formatAmount(order.totalTax, with: order.currency) ?? "",
@@ -91,6 +97,14 @@ struct POSOrderMapper {
             formattedTotal: formattedTotal,
             imageSrc: orderItem.image?.src,
             attributes: orderItem.attributes
+        )
+    }
+
+    private func map(fee: OrderFeeLine, currency: String) -> POSOrderCustomAmount {
+        POSOrderCustomAmount(
+            id: fee.feeID,
+            name: fee.name ?? "",
+            formattedTotal: currencyFormatter.formatAmount(fee.total, with: currency) ?? fee.total
         )
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -101,10 +101,16 @@ struct POSOrderMapper {
     }
 
     private func map(fee: OrderFeeLine, currency: String) -> POSOrderCustomAmount {
-        POSOrderCustomAmount(
+        // `fee.name` is `String?` for decoder safety; in practice the WC API always
+        // sets a name for live fee lines. Fall back to a localized placeholder so a
+        // nil/blank value (e.g. malformed payload, fees created via another client)
+        // doesn't render as a row with no left-side text.
+        let trimmedName = (fee.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedName = trimmedName.isEmpty ? Localization.defaultFeeName : trimmedName
+        return POSOrderCustomAmount(
             id: fee.feeID,
-            name: fee.name ?? "",
-            formattedTotal: currencyFormatter.formatAmount(fee.total, with: currency) ?? fee.total
+            name: resolvedName,
+            formattedTotal: currencyFormatter.formatAmount(fee.total, with: currency) ?? ""
         )
     }
 
@@ -113,6 +119,16 @@ struct POSOrderMapper {
             refundID: orderRefund.refundID,
             formattedTotal: currencyFormatter.formatAmount(orderRefund.total, with: currency) ?? "",
             reason: orderRefund.reason
+        )
+    }
+}
+
+private extension POSOrderMapper {
+    enum Localization {
+        static let defaultFeeName = NSLocalizedString(
+            "pos.orderMapper.defaultFeeName",
+            value: "Custom amount",
+            comment: "Fallback label shown for a fee on a Point of Sale order whose name is missing or blank."
         )
     }
 }

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -142,6 +142,54 @@ struct POSOrderMapperTests {
         // Then
         #expect(result.formattedNetAmount == "$10.99")
     }
+
+    // MARK: - Custom Amounts
+
+    @Test
+    func customAmounts_are_mapped_from_active_order_fees() throws {
+        // Given
+        let fee = OrderFeeLine.fake().copy(feeID: 42, name: "Service fee", total: "10.00")
+        let order = makeOrder(currency: "USD", fees: [fee])
+
+        // When
+        let result = try sut.map(order: order)
+
+        // Then
+        #expect(result.customAmounts.count == 1)
+        let mapped = try #require(result.customAmounts.first)
+        #expect(mapped.id == 42)
+        #expect(mapped.name == "Service fee")
+        #expect(mapped.formattedTotal == "$10.00")
+    }
+
+    @Test
+    func customAmounts_skip_deleted_fee_lines() throws {
+        // Given
+        let liveFee = OrderFeeLine.fake().copy(feeID: 1, name: "Tip", total: "5.00")
+        let deletedFee = OrderFactory.deletedFeeLine(OrderFeeLine.fake().copy(feeID: 2, name: "Removed", total: "8.00"))
+        let order = makeOrder(currency: "USD", fees: [liveFee, deletedFee])
+
+        // When
+        let result = try sut.map(order: order)
+
+        // Then
+        #expect(result.customAmounts.count == 1)
+        #expect(result.customAmounts.first?.name == "Tip")
+    }
+
+    @Test
+    func customAmounts_use_empty_name_when_fee_line_has_no_name() throws {
+        // Given
+        let fee = OrderFeeLine.fake().copy(feeID: 1, name: nil, total: "3.00")
+        let order = makeOrder(currency: "USD", fees: [fee])
+
+        // When
+        let result = try sut.map(order: order)
+
+        // Then
+        let firstName = try #require(result.customAmounts.first?.name)
+        #expect(firstName.isEmpty)
+    }
 }
 
 // MARK: - Test Helpers
@@ -158,7 +206,8 @@ private extension POSOrderMapperTests {
         totalTax: String = "2.50",
         currency: String = "USD",
         refunds: [OrderRefundCondensed] = [],
-        items: [OrderItem] = []
+        items: [OrderItem] = [],
+        fees: [OrderFeeLine] = []
     ) -> NetworkingCore.Order {
         return NetworkingCore.Order.fake().copy(
             orderID: orderID,
@@ -171,7 +220,8 @@ private extension POSOrderMapperTests {
             total: total,
             totalTax: totalTax,
             items: items.isEmpty ? [makeOrderItem()] : items,
-            refunds: refunds
+            refunds: refunds,
+            fees: fees
         )
     }
 

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -178,7 +178,7 @@ struct POSOrderMapperTests {
     }
 
     @Test
-    func customAmounts_use_empty_name_when_fee_line_has_no_name() throws {
+    func customAmounts_use_default_name_when_fee_line_has_no_name() throws {
         // Given
         let fee = OrderFeeLine.fake().copy(feeID: 1, name: nil, total: "3.00")
         let order = makeOrder(currency: "USD", fees: [fee])
@@ -186,9 +186,22 @@ struct POSOrderMapperTests {
         // When
         let result = try sut.map(order: order)
 
+        // Then - falls back to a localized "Custom amount" placeholder so the row
+        // never renders with empty left-side text.
+        #expect(result.customAmounts.first?.name == "Custom amount")
+    }
+
+    @Test
+    func customAmounts_use_default_name_when_fee_line_name_is_blank() throws {
+        // Given
+        let fee = OrderFeeLine.fake().copy(feeID: 1, name: "   ", total: "3.00")
+        let order = makeOrder(currency: "USD", fees: [fee])
+
+        // When
+        let result = try sut.map(order: order)
+
         // Then
-        let firstName = try #require(result.customAmounts.first?.name)
-        #expect(firstName.isEmpty)
+        #expect(result.customAmounts.first?.name == "Custom amount")
     }
 }
 


### PR DESCRIPTION
## Description
Stacks on top of [#16998](https://github.com/woocommerce/woocommerce-ios/pull/16998). Adds a "Custom amounts" section to the Point of Sale order details so a merchant can see the fee lines they added during the sale, alongside the products section.

### Yosemite
- New `POSOrderCustomAmount` value type carrying the fee's id, name, and pre-formatted total.
- `POSOrder` gains a `customAmounts: [POSOrderCustomAmount]` array (defaulting to `[]`, so existing callers are unaffected) and the Copiable codegen is regenerated to include it.
- `POSOrderMapper` maps the order's active fee lines (skipping deleted ones) into `POSOrderCustomAmount`s, formatting the total via the existing currency formatter.

### PointOfSale
- `POSOrderDetailsView` renders a `customAmountsSection` between the products section and the refunds section when the order has any custom amounts. Each row shows the fee's name and formatted total with a tag icon, matching the visual rhythm of the products section.
- `POSPreviewHelpers.makePreviewOrder` includes a sample custom amount so the section is visible in SwiftUI previews.

Refunds for fee lines stay out of scope and will land separately.

## Test Steps
On a `localDeveloper` or `alpha` build (custom amounts flag on):

1. Place a POS order with at least one product and at least one custom amount.
2. Open the order from Orders. The Custom amounts section appears between Products and Refunds, showing each fee's name and formatted total.
3. Open an existing order without custom amounts. The section does not render.

## Screenshots
See the feature walkthrough video and design rationale in the feature announcement post.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.