### PR TITLE
Woo Mobile AI: Add two-level safety policy with confirmation flow

### DIFF
--- a/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
@@ -8,12 +8,9 @@
 public struct DefaultSafetyPolicy: SafetyPolicy {
 
     private let isReadOnly: @Sendable () -> Bool
-    private let previewBuilder: @Sendable (String, String) -> String
 
-    public init(isReadOnly: @escaping @Sendable () -> Bool,
-                previewBuilder: @escaping @Sendable (String, String) -> String = ToolPreviews.defaultBuilder) {
+    public init(isReadOnly: @escaping @Sendable () -> Bool) {
         self.isReadOnly = isReadOnly
-        self.previewBuilder = previewBuilder
     }
 
     public func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision {
@@ -24,7 +21,7 @@ public struct DefaultSafetyPolicy: SafetyPolicy {
             if isReadOnly() {
                 return .block(reason: readOnlyBlockMessage(for: name))
             }
-            return .requireConfirmation(preview: previewBuilder(name, arguments))
+            return .requireConfirmation(preview: ToolPreviews.defaultBuilder(name, arguments))
         }
     }
 

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
@@ -1,22 +1,12 @@
-/// `isReadOnly` is closure-injected because the toggle lives in app-target
-/// Labs settings; the assistant module stays UI-agnostic and the host wires
-/// the closure at construction.
 public struct DefaultSafetyPolicy: SafetyPolicy {
 
-    private let isReadOnly: @Sendable () -> Bool
-
-    public init(isReadOnly: @escaping @Sendable () -> Bool) {
-        self.isReadOnly = isReadOnly
-    }
+    public init() {}
 
     public func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision {
         switch tool.safetyLevel {
         case .safe:
             return .execute
         case .unsafe:
-            if isReadOnly() {
-                return .block(reason: "Read-only mode is on - the assistant can't run '\(name)'. Toggle it off in Labs settings to allow this change.")
-            }
             return .requireConfirmation(preview: ToolPreviews.defaultBuilder(name, arguments))
         }
     }

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
@@ -1,0 +1,34 @@
+/// Default policy that keys off `AIToolSafetyLevel` plus the read-only Labs toggle.
+///
+/// `isReadOnly` is closure-injected (not read directly) because the toggle lives
+/// in app-target Labs settings; the assistant module stays UI-agnostic and the
+/// host wires the closure at construction. Every `.unsafe` write requires
+/// confirmation: there is no auto-execute path for mutations regardless of
+/// shape, so the merchant always taps through.
+public struct DefaultSafetyPolicy: SafetyPolicy {
+
+    private let isReadOnly: @Sendable () -> Bool
+    private let previewBuilder: @Sendable (String, String) -> String
+
+    public init(isReadOnly: @escaping @Sendable () -> Bool,
+                previewBuilder: @escaping @Sendable (String, String) -> String = ToolPreviews.defaultBuilder) {
+        self.isReadOnly = isReadOnly
+        self.previewBuilder = previewBuilder
+    }
+
+    public func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision {
+        switch tool.safetyLevel {
+        case .safe:
+            return .execute
+        case .unsafe:
+            if isReadOnly() {
+                return .block(reason: readOnlyBlockMessage(for: name))
+            }
+            return .requireConfirmation(preview: previewBuilder(name, arguments))
+        }
+    }
+
+    private func readOnlyBlockMessage(for name: String) -> String {
+        "Read-only mode is on - the assistant can't run '\(name)'. Toggle it off in Labs settings to allow this change."
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
@@ -1,10 +1,6 @@
-/// Default policy that keys off `AIToolSafetyLevel` plus the read-only Labs toggle.
-///
-/// `isReadOnly` is closure-injected (not read directly) because the toggle lives
-/// in app-target Labs settings; the assistant module stays UI-agnostic and the
-/// host wires the closure at construction. Every `.unsafe` write requires
-/// confirmation: there is no auto-execute path for mutations regardless of
-/// shape, so the merchant always taps through.
+/// `isReadOnly` is closure-injected because the toggle lives in app-target
+/// Labs settings; the assistant module stays UI-agnostic and the host wires
+/// the closure at construction.
 public struct DefaultSafetyPolicy: SafetyPolicy {
 
     private let isReadOnly: @Sendable () -> Bool

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
@@ -19,13 +19,9 @@ public struct DefaultSafetyPolicy: SafetyPolicy {
             return .execute
         case .unsafe:
             if isReadOnly() {
-                return .block(reason: readOnlyBlockMessage(for: name))
+                return .block(reason: "Read-only mode is on - the assistant can't run '\(name)'. Toggle it off in Labs settings to allow this change.")
             }
             return .requireConfirmation(preview: ToolPreviews.defaultBuilder(name, arguments))
         }
-    }
-
-    private func readOnlyBlockMessage(for name: String) -> String {
-        "Read-only mode is on - the assistant can't run '\(name)'. Toggle it off in Labs settings to allow this change."
     }
 }

--- a/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
@@ -1,0 +1,23 @@
+/// Decides what to do with a tool call the LLM wants to dispatch.
+///
+/// The orchestrator consults the policy before calling the tool. The policy
+/// returns a `SafetyDecision` for each call; `requireConfirmation` suspends the
+/// loop until the merchant confirms or cancels via the orchestrator's confirm
+/// pathway, and `block` synthesizes an error tool result without dispatching.
+public protocol SafetyPolicy: Sendable {
+    func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision
+}
+
+public enum SafetyDecision: Equatable, Sendable {
+    /// Dispatch the tool immediately.
+    case execute
+
+    /// Pause the loop, emit a confirmation event to the UI, wait for the
+    /// merchant's tap. `preview` is the short line shown on the confirmation
+    /// card (e.g. "Set order #42 to processing").
+    case requireConfirmation(preview: String)
+
+    /// Synthesize an error tool result with `reason` and feed it back to the
+    /// LLM so it can explain to the merchant. No dispatch, no UI prompt.
+    case block(reason: String)
+}

--- a/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
@@ -1,6 +1,5 @@
 /// `requireConfirmation` suspends the orchestrator loop until the merchant
-/// confirms or cancels via the confirm pathway; `block` synthesizes an error
-/// tool result fed back to the LLM without dispatching.
+/// confirms or cancels via the confirm pathway.
 public protocol SafetyPolicy: Sendable {
     func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision
 }
@@ -11,6 +10,4 @@ public enum SafetyDecision: Equatable, Sendable {
     /// `preview` is the short line shown on the confirmation card
     /// (e.g. "Set order #42 to processing").
     case requireConfirmation(preview: String)
-
-    case block(reason: String)
 }

--- a/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
@@ -1,23 +1,16 @@
-/// Decides what to do with a tool call the LLM wants to dispatch.
-///
-/// The orchestrator consults the policy before calling the tool. The policy
-/// returns a `SafetyDecision` for each call; `requireConfirmation` suspends the
-/// loop until the merchant confirms or cancels via the orchestrator's confirm
-/// pathway, and `block` synthesizes an error tool result without dispatching.
+/// `requireConfirmation` suspends the orchestrator loop until the merchant
+/// confirms or cancels via the confirm pathway; `block` synthesizes an error
+/// tool result fed back to the LLM without dispatching.
 public protocol SafetyPolicy: Sendable {
     func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision
 }
 
 public enum SafetyDecision: Equatable, Sendable {
-    /// Dispatch the tool immediately.
     case execute
 
-    /// Pause the loop, emit a confirmation event to the UI, wait for the
-    /// merchant's tap. `preview` is the short line shown on the confirmation
-    /// card (e.g. "Set order #42 to processing").
+    /// `preview` is the short line shown on the confirmation card
+    /// (e.g. "Set order #42 to processing").
     case requireConfirmation(preview: String)
 
-    /// Synthesize an error tool result with `reason` and feed it back to the
-    /// LLM so it can explain to the merchant. No dispatch, no UI prompt.
     case block(reason: String)
 }

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -1,19 +1,8 @@
 import Foundation
 import CocoaLumberjackSwift
 
-/// Human-readable one-liners shown on the confirmation card. Keeps the
-/// confirmation UX honest: the merchant sees "Update product #7: price -> $24.99"
-/// instead of `products_update {"id":7,"regular_price":"24.99"}`.
-///
-/// Each known tool decodes its own args struct and builds a sentence. Unknown
-/// tools fall through to a compact generic preview so adding a new tool never
-/// breaks the confirmation path - the preview just looks worse until a builder
-/// lands here.
 public enum ToolPreviews {
 
-    /// Default preview builder plugged into `DefaultSafetyPolicy`. Routes by
-    /// tool name; falls back to a truncated args string for anything it
-    /// doesn't recognize.
     public static let defaultBuilder: @Sendable (String, String) -> String = { name, arguments in
         switch name {
         case OrdersUpdateTool.name:
@@ -30,8 +19,6 @@ public enum ToolPreviews {
             return genericPreview(name: name, arguments: arguments)
         }
     }
-
-    // MARK: - Per-tool previews
 
     private static func ordersUpdate(arguments: String) -> String {
         struct A: Decodable {
@@ -157,10 +144,7 @@ public enum ToolPreviews {
         return "Update variation #\(vid) of product #\(pid): \(summary)"
     }
 
-    // MARK: - Helpers
-
-    /// Order statuses that trigger a customer email on transition. Used to
-    /// enrich the preview so the merchant knows an email is coming.
+    /// Order statuses that trigger a customer email on transition.
     private static let customerNotifyingStatuses: Set<String> = [
         "processing", "completed", "cancelled", "refunded", "on-hold"
     ]
@@ -175,8 +159,6 @@ public enum ToolPreviews {
         }
     }
 
-    /// Last-resort preview for tools without a dedicated builder. Truncates
-    /// to keep the card readable.
     private static func genericPreview(name: String, arguments: String) -> String {
         let args = arguments.count > 80
             ? String(arguments.prefix(80)) + "..."

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -69,7 +69,9 @@ public enum ToolPreviews {
         }
         var changes: [String] = []
         if let status = patch.status {
-            changes.append(String.localizedStringWithFormat(Localization.changeStatus, status))
+            let baseChange = String.localizedStringWithFormat(Localization.changeStatus, status)
+            let suffix = customerNotifyingStatuses.contains(status) ? Localization.emailsCustomersSuffix : ""
+            changes.append(baseChange + suffix)
         }
         if patch.customer_note != nil { changes.append(Localization.changeCustomerNote) }
         if let email = patch.billing_email {
@@ -292,7 +294,12 @@ public enum ToolPreviews {
         static let emailsCustomerSuffix = NSLocalizedString(
             "ai.assistant.preview.suffix.emails_customer",
             value: " (emails the customer)",
-            comment: "Trailing suffix appended to an order-status confirmation preview when the new status triggers a customer email. Includes the leading space."
+            comment: "Trailing suffix appended to a single-order status confirmation preview when the new status triggers a customer email. Includes the leading space."
+        )
+        static let emailsCustomersSuffix = NSLocalizedString(
+            "ai.assistant.preview.suffix.emails_customers",
+            value: " (emails customers)",
+            comment: "Trailing suffix appended to a bulk-order status confirmation preview when the new status triggers customer emails for each affected order. Includes the leading space."
         )
 
         static let changeEditFields = NSLocalizedString(

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CocoaLumberjackSwift
 
 /// Human-readable one-liners shown on the confirmation card. Keeps the
 /// confirmation UX honest: the merchant sees "Update product #7: price -> $24.99"
@@ -166,7 +167,12 @@ public enum ToolPreviews {
 
     private static func decode<T: Decodable>(_ type: T.Type, from json: String) -> T? {
         guard let data = json.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(type, from: data)
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            DDLogError("ToolPreviews failed to decode \(type): \(error)")
+            return nil
+        }
     }
 
     /// Last-resort preview for tools without a dedicated builder. Truncates

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// Human-readable one-liners shown on the confirmation card. Keeps the
+/// confirmation UX honest: the merchant sees "Update product #7: price -> $24.99"
+/// instead of `products_update {"id":7,"regular_price":"24.99"}`.
+///
+/// Each known tool decodes its own args struct and builds a sentence. Unknown
+/// tools fall through to a compact generic preview so adding a new tool never
+/// breaks the confirmation path - the preview just looks worse until a builder
+/// lands here.
+public enum ToolPreviews {
+
+    /// Default preview builder plugged into `DefaultSafetyPolicy`. Routes by
+    /// tool name; falls back to a truncated args string for anything it
+    /// doesn't recognize.
+    public static let defaultBuilder: @Sendable (String, String) -> String = { name, arguments in
+        switch name {
+        case OrdersUpdateTool.name:
+            return ordersUpdate(arguments: arguments)
+        case OrdersBulkUpdateTool.name:
+            return ordersBulkUpdate(arguments: arguments)
+        case ProductsUpdateTool.name:
+            return productsUpdate(arguments: arguments)
+        case ProductsBulkUpdateTool.name:
+            return productsBulkUpdate(arguments: arguments)
+        case ProductVariationsUpdateTool.name:
+            return productVariationsUpdate(arguments: arguments)
+        default:
+            return genericPreview(name: name, arguments: arguments)
+        }
+    }
+
+    // MARK: - Per-tool previews
+
+    private static func ordersUpdate(arguments: String) -> String {
+        struct A: Decodable {
+            let id: Int?
+            let status: String?
+            let customer_note: String?
+            let billing_email: String?
+        }
+        guard let a = decode(A.self, from: arguments), let id = a.id else {
+            return "Update an order"
+        }
+        var changes: [String] = []
+        if let status = a.status {
+            let note = customerNotifyingStatuses.contains(status) ? " (emails the customer)" : ""
+            changes.append("status -> \(status)\(note)")
+        }
+        if a.customer_note != nil { changes.append("customer note updated") }
+        if let email = a.billing_email { changes.append("billing email -> \(email)") }
+        if changes.isEmpty {
+            return "Update order #\(id)"
+        }
+        if changes.count == 1, a.status != nil {
+            return "Set order #\(id) to \(changes[0].replacingOccurrences(of: "status -> ", with: ""))"
+        }
+        return "Update order #\(id): \(changes.joined(separator: ", "))"
+    }
+
+    private static func ordersBulkUpdate(arguments: String) -> String {
+        struct A: Decodable {
+            let ids: [Int]?
+            let patch: Patch?
+            struct Patch: Decodable {
+                let status: String?
+                let customer_note: String?
+                let billing_email: String?
+            }
+        }
+        guard let a = decode(A.self, from: arguments),
+              let ids = a.ids, let patch = a.patch else {
+            return "Update many orders"
+        }
+        var changes: [String] = []
+        if let status = patch.status { changes.append("status -> \(status)") }
+        if patch.customer_note != nil { changes.append("customer note updated") }
+        if let email = patch.billing_email { changes.append("billing email -> \(email)") }
+        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
+        let noun = ids.count == 1 ? "order" : "orders"
+        return "Update \(ids.count) \(noun): \(summary)"
+    }
+
+    private static func productsUpdate(arguments: String) -> String {
+        struct A: Decodable {
+            let id: Int?
+            let name: String?
+            let regular_price: String?
+            let sale_price: String?
+            let stock_quantity: Int?
+            let status: String?
+        }
+        guard let a = decode(A.self, from: arguments), let id = a.id else {
+            return "Update a product"
+        }
+        var changes: [String] = []
+        if let name = a.name { changes.append("name -> \(name)") }
+        if let price = a.regular_price { changes.append("price -> $\(price)") }
+        if let sale = a.sale_price { changes.append("sale -> \(sale.isEmpty ? "off" : "$\(sale)")") }
+        if let stock = a.stock_quantity { changes.append("stock -> \(stock)") }
+        if let status = a.status { changes.append("status -> \(status)") }
+        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
+        return "Update product #\(id): \(summary)"
+    }
+
+    private static func productsBulkUpdate(arguments: String) -> String {
+        struct A: Decodable {
+            let ids: [Int]?
+            let patch: Patch?
+            struct Patch: Decodable {
+                let name: String?
+                let regular_price: String?
+                let sale_price: String?
+                let stock_quantity: Int?
+                let status: String?
+            }
+        }
+        guard let a = decode(A.self, from: arguments),
+              let ids = a.ids, let patch = a.patch else {
+            return "Update many products"
+        }
+        var changes: [String] = []
+        if let name = patch.name { changes.append("name -> \(name)") }
+        if let price = patch.regular_price { changes.append("price -> $\(price)") }
+        if let sale = patch.sale_price { changes.append("sale -> \(sale.isEmpty ? "off" : "$\(sale)")") }
+        if let stock = patch.stock_quantity { changes.append("stock -> \(stock)") }
+        if let status = patch.status { changes.append("status -> \(status)") }
+        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
+        let noun = ids.count == 1 ? "product" : "products"
+        return "Update \(ids.count) \(noun): \(summary)"
+    }
+
+    private static func productVariationsUpdate(arguments: String) -> String {
+        struct A: Decodable {
+            let product_id: Int?
+            let id: Int?
+            let regular_price: String?
+            let sale_price: String?
+            let stock_quantity: Int?
+            let stock_status: String?
+            let sku: String?
+            let status: String?
+        }
+        guard let a = decode(A.self, from: arguments),
+              let pid = a.product_id, let vid = a.id else {
+            return "Update product variation"
+        }
+        var changes: [String] = []
+        if let price = a.regular_price { changes.append("price -> $\(price)") }
+        if let sale = a.sale_price { changes.append("sale -> \(sale.isEmpty ? "off" : "$\(sale)")") }
+        if let stock = a.stock_quantity { changes.append("stock -> \(stock)") }
+        if let stockStatus = a.stock_status { changes.append("stock status -> \(stockStatus)") }
+        if let sku = a.sku { changes.append("sku -> \(sku)") }
+        if let status = a.status { changes.append("status -> \(status)") }
+        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
+        return "Update variation #\(vid) of product #\(pid): \(summary)"
+    }
+
+    // MARK: - Helpers
+
+    /// Order statuses that trigger a customer email on transition. Used to
+    /// enrich the preview so the merchant knows an email is coming.
+    private static let customerNotifyingStatuses: Set<String> = [
+        "processing", "completed", "cancelled", "refunded", "on-hold"
+    ]
+
+    private static func decode<T: Decodable>(_ type: T.Type, from json: String) -> T? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    /// Last-resort preview for tools without a dedicated builder. Truncates
+    /// to keep the card readable.
+    private static func genericPreview(name: String, arguments: String) -> String {
+        let args = arguments.count > 80
+            ? String(arguments.prefix(80)) + "..."
+            : arguments
+        return "\(name) \(args)"
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -28,22 +28,29 @@ public enum ToolPreviews {
             let billing_email: String?
         }
         guard let a = decode(A.self, from: arguments), let id = a.id else {
-            return "Update an order"
+            return Localization.ordersUpdateFallback
         }
+
+        // Status-only path: special "Set order #X to Y" wording.
+        if let status = a.status, a.customer_note == nil, a.billing_email == nil {
+            let suffix = customerNotifyingStatuses.contains(status) ? Localization.emailsCustomerSuffix : ""
+            return String.localizedStringWithFormat(Localization.ordersUpdateStatusOnly, id, status) + suffix
+        }
+
         var changes: [String] = []
         if let status = a.status {
-            let note = customerNotifyingStatuses.contains(status) ? " (emails the customer)" : ""
-            changes.append("status -> \(status)\(note)")
+            let suffix = customerNotifyingStatuses.contains(status) ? Localization.emailsCustomerSuffix : ""
+            changes.append(String.localizedStringWithFormat(Localization.changeStatus, status) + suffix)
         }
-        if a.customer_note != nil { changes.append("customer note updated") }
-        if let email = a.billing_email { changes.append("billing email -> \(email)") }
+        if a.customer_note != nil { changes.append(Localization.changeCustomerNote) }
+        if let email = a.billing_email {
+            changes.append(String.localizedStringWithFormat(Localization.changeBillingEmail, email))
+        }
+
         if changes.isEmpty {
-            return "Update order #\(id)"
+            return String.localizedStringWithFormat(Localization.ordersUpdateNoChanges, id)
         }
-        if changes.count == 1, a.status != nil {
-            return "Set order #\(id) to \(changes[0].replacingOccurrences(of: "status -> ", with: ""))"
-        }
-        return "Update order #\(id): \(changes.joined(separator: ", "))"
+        return String.localizedStringWithFormat(Localization.ordersUpdateFull, id, changes.joined(separator: ", "))
     }
 
     private static func ordersBulkUpdate(arguments: String) -> String {
@@ -58,15 +65,19 @@ public enum ToolPreviews {
         }
         guard let a = decode(A.self, from: arguments),
               let ids = a.ids, let patch = a.patch else {
-            return "Update many orders"
+            return Localization.ordersBulkUpdateFallback
         }
         var changes: [String] = []
-        if let status = patch.status { changes.append("status -> \(status)") }
-        if patch.customer_note != nil { changes.append("customer note updated") }
-        if let email = patch.billing_email { changes.append("billing email -> \(email)") }
-        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
-        let noun = ids.count == 1 ? "order" : "orders"
-        return "Update \(ids.count) \(noun): \(summary)"
+        if let status = patch.status {
+            changes.append(String.localizedStringWithFormat(Localization.changeStatus, status))
+        }
+        if patch.customer_note != nil { changes.append(Localization.changeCustomerNote) }
+        if let email = patch.billing_email {
+            changes.append(String.localizedStringWithFormat(Localization.changeBillingEmail, email))
+        }
+        let summary = changes.isEmpty ? Localization.changeEditFields : changes.joined(separator: ", ")
+        let format = ids.count == 1 ? Localization.ordersBulkUpdateSingular : Localization.ordersBulkUpdatePlural
+        return String.localizedStringWithFormat(format, ids.count, summary)
     }
 
     private static func productsUpdate(arguments: String) -> String {
@@ -79,16 +90,15 @@ public enum ToolPreviews {
             let status: String?
         }
         guard let a = decode(A.self, from: arguments), let id = a.id else {
-            return "Update a product"
+            return Localization.productsUpdateFallback
         }
-        var changes: [String] = []
-        if let name = a.name { changes.append("name -> \(name)") }
-        if let price = a.regular_price { changes.append("price -> $\(price)") }
-        if let sale = a.sale_price { changes.append("sale -> \(sale.isEmpty ? "off" : "$\(sale)")") }
-        if let stock = a.stock_quantity { changes.append("stock -> \(stock)") }
-        if let status = a.status { changes.append("status -> \(status)") }
-        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
-        return "Update product #\(id): \(summary)"
+        let changes = productChanges(name: a.name,
+                                     regularPrice: a.regular_price,
+                                     salePrice: a.sale_price,
+                                     stockQuantity: a.stock_quantity,
+                                     status: a.status)
+        let summary = changes.isEmpty ? Localization.changeEditFields : changes.joined(separator: ", ")
+        return String.localizedStringWithFormat(Localization.productsUpdateFull, id, summary)
     }
 
     private static func productsBulkUpdate(arguments: String) -> String {
@@ -105,17 +115,16 @@ public enum ToolPreviews {
         }
         guard let a = decode(A.self, from: arguments),
               let ids = a.ids, let patch = a.patch else {
-            return "Update many products"
+            return Localization.productsBulkUpdateFallback
         }
-        var changes: [String] = []
-        if let name = patch.name { changes.append("name -> \(name)") }
-        if let price = patch.regular_price { changes.append("price -> $\(price)") }
-        if let sale = patch.sale_price { changes.append("sale -> \(sale.isEmpty ? "off" : "$\(sale)")") }
-        if let stock = patch.stock_quantity { changes.append("stock -> \(stock)") }
-        if let status = patch.status { changes.append("status -> \(status)") }
-        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
-        let noun = ids.count == 1 ? "product" : "products"
-        return "Update \(ids.count) \(noun): \(summary)"
+        let changes = productChanges(name: patch.name,
+                                     regularPrice: patch.regular_price,
+                                     salePrice: patch.sale_price,
+                                     stockQuantity: patch.stock_quantity,
+                                     status: patch.status)
+        let summary = changes.isEmpty ? Localization.changeEditFields : changes.joined(separator: ", ")
+        let format = ids.count == 1 ? Localization.productsBulkUpdateSingular : Localization.productsBulkUpdatePlural
+        return String.localizedStringWithFormat(format, ids.count, summary)
     }
 
     private static func productVariationsUpdate(arguments: String) -> String {
@@ -131,17 +140,55 @@ public enum ToolPreviews {
         }
         guard let a = decode(A.self, from: arguments),
               let pid = a.product_id, let vid = a.id else {
-            return "Update product variation"
+            return Localization.productVariationsUpdateFallback
         }
         var changes: [String] = []
-        if let price = a.regular_price { changes.append("price -> $\(price)") }
-        if let sale = a.sale_price { changes.append("sale -> \(sale.isEmpty ? "off" : "$\(sale)")") }
-        if let stock = a.stock_quantity { changes.append("stock -> \(stock)") }
-        if let stockStatus = a.stock_status { changes.append("stock status -> \(stockStatus)") }
-        if let sku = a.sku { changes.append("sku -> \(sku)") }
-        if let status = a.status { changes.append("status -> \(status)") }
-        let summary = changes.isEmpty ? "edit fields" : changes.joined(separator: ", ")
-        return "Update variation #\(vid) of product #\(pid): \(summary)"
+        if let price = a.regular_price {
+            changes.append(String.localizedStringWithFormat(Localization.changeRegularPrice, price))
+        }
+        if let sale = a.sale_price {
+            changes.append(sale.isEmpty ? Localization.changeSaleOff
+                                        : String.localizedStringWithFormat(Localization.changeSalePrice, sale))
+        }
+        if let stock = a.stock_quantity {
+            changes.append(String.localizedStringWithFormat(Localization.changeStockQuantity, stock))
+        }
+        if let stockStatus = a.stock_status {
+            changes.append(String.localizedStringWithFormat(Localization.changeStockStatus, stockStatus))
+        }
+        if let sku = a.sku {
+            changes.append(String.localizedStringWithFormat(Localization.changeSku, sku))
+        }
+        if let status = a.status {
+            changes.append(String.localizedStringWithFormat(Localization.changeStatus, status))
+        }
+        let summary = changes.isEmpty ? Localization.changeEditFields : changes.joined(separator: ", ")
+        return String.localizedStringWithFormat(Localization.productVariationsUpdateFull, vid, pid, summary)
+    }
+
+    private static func productChanges(name: String?,
+                                       regularPrice: String?,
+                                       salePrice: String?,
+                                       stockQuantity: Int?,
+                                       status: String?) -> [String] {
+        var changes: [String] = []
+        if let name = name {
+            changes.append(String.localizedStringWithFormat(Localization.changeName, name))
+        }
+        if let price = regularPrice {
+            changes.append(String.localizedStringWithFormat(Localization.changeRegularPrice, price))
+        }
+        if let sale = salePrice {
+            changes.append(sale.isEmpty ? Localization.changeSaleOff
+                                        : String.localizedStringWithFormat(Localization.changeSalePrice, sale))
+        }
+        if let stock = stockQuantity {
+            changes.append(String.localizedStringWithFormat(Localization.changeStockQuantity, stock))
+        }
+        if let status = status {
+            changes.append(String.localizedStringWithFormat(Localization.changeStatus, status))
+        }
+        return changes
     }
 
     /// Order statuses that trigger a customer email on transition.
@@ -164,5 +211,144 @@ public enum ToolPreviews {
             ? String(arguments.prefix(80)) + "..."
             : arguments
         return "\(name) \(args)"
+    }
+
+    private enum Localization {
+        static let ordersUpdateFallback = NSLocalizedString(
+            "ai.assistant.preview.orders_update.fallback",
+            value: "Update an order",
+            comment: "Confirmation card preview shown when the orders_update tool call cannot be parsed."
+        )
+        static let ordersUpdateNoChanges = NSLocalizedString(
+            "ai.assistant.preview.orders_update.no_changes",
+            value: "Update order #%1$d",
+            comment: "Confirmation card preview when only the order id is known. %1$d is the order number."
+        )
+        static let ordersUpdateStatusOnly = NSLocalizedString(
+            "ai.assistant.preview.orders_update.status_only",
+            value: "Set order #%1$d to %2$@",
+            comment: "Confirmation card preview when only the status changes on an order. %1$d is the order number, %2$@ is the new status."
+        )
+        static let ordersUpdateFull = NSLocalizedString(
+            "ai.assistant.preview.orders_update.full",
+            value: "Update order #%1$d: %2$@",
+            comment: "Confirmation card preview for a multi-field order update. %1$d is the order number, %2$@ is a comma-separated change list."
+        )
+
+        static let ordersBulkUpdateFallback = NSLocalizedString(
+            "ai.assistant.preview.orders_bulk_update.fallback",
+            value: "Update many orders",
+            comment: "Confirmation card preview when the orders_bulk_update tool call cannot be parsed."
+        )
+        static let ordersBulkUpdateSingular = NSLocalizedString(
+            "ai.assistant.preview.orders_bulk_update.singular",
+            value: "Update %1$d order: %2$@",
+            comment: "Singular bulk-orders confirmation preview. %1$d is the count (1), %2$@ is a comma-separated change list."
+        )
+        static let ordersBulkUpdatePlural = NSLocalizedString(
+            "ai.assistant.preview.orders_bulk_update.plural",
+            value: "Update %1$d orders: %2$@",
+            comment: "Plural bulk-orders confirmation preview. %1$d is the count, %2$@ is a comma-separated change list."
+        )
+
+        static let productsUpdateFallback = NSLocalizedString(
+            "ai.assistant.preview.products_update.fallback",
+            value: "Update a product",
+            comment: "Confirmation card preview when the products_update tool call cannot be parsed."
+        )
+        static let productsUpdateFull = NSLocalizedString(
+            "ai.assistant.preview.products_update.full",
+            value: "Update product #%1$d: %2$@",
+            comment: "Confirmation card preview for a product update. %1$d is the product id, %2$@ is a comma-separated change list."
+        )
+
+        static let productsBulkUpdateFallback = NSLocalizedString(
+            "ai.assistant.preview.products_bulk_update.fallback",
+            value: "Update many products",
+            comment: "Confirmation card preview when the products_bulk_update tool call cannot be parsed."
+        )
+        static let productsBulkUpdateSingular = NSLocalizedString(
+            "ai.assistant.preview.products_bulk_update.singular",
+            value: "Update %1$d product: %2$@",
+            comment: "Singular bulk-products confirmation preview. %1$d is the count (1), %2$@ is a comma-separated change list."
+        )
+        static let productsBulkUpdatePlural = NSLocalizedString(
+            "ai.assistant.preview.products_bulk_update.plural",
+            value: "Update %1$d products: %2$@",
+            comment: "Plural bulk-products confirmation preview. %1$d is the count, %2$@ is a comma-separated change list."
+        )
+
+        static let productVariationsUpdateFallback = NSLocalizedString(
+            "ai.assistant.preview.product_variations_update.fallback",
+            value: "Update product variation",
+            comment: "Confirmation card preview when the product_variations_update tool call cannot be parsed."
+        )
+        static let productVariationsUpdateFull = NSLocalizedString(
+            "ai.assistant.preview.product_variations_update.full",
+            value: "Update variation #%1$d of product #%2$d: %3$@",
+            comment: "Confirmation card preview for a variation update. %1$d is the variation id, %2$d is the parent product id, %3$@ is a comma-separated change list."
+        )
+
+        static let emailsCustomerSuffix = NSLocalizedString(
+            "ai.assistant.preview.suffix.emails_customer",
+            value: " (emails the customer)",
+            comment: "Trailing suffix appended to an order-status confirmation preview when the new status triggers a customer email. Includes the leading space."
+        )
+
+        static let changeEditFields = NSLocalizedString(
+            "ai.assistant.preview.change.edit_fields",
+            value: "edit fields",
+            comment: "Generic change description used when no specific field can be enumerated."
+        )
+        static let changeName = NSLocalizedString(
+            "ai.assistant.preview.change.name",
+            value: "name -> %1$@",
+            comment: "Change description for a name field. %1$@ is the new name."
+        )
+        static let changeRegularPrice = NSLocalizedString(
+            "ai.assistant.preview.change.regular_price",
+            value: "price -> $%1$@",
+            comment: "Change description for the regular price. %1$@ is the new price as a string."
+        )
+        static let changeSalePrice = NSLocalizedString(
+            "ai.assistant.preview.change.sale_price",
+            value: "sale -> $%1$@",
+            comment: "Change description for the sale price. %1$@ is the new sale price as a string."
+        )
+        static let changeSaleOff = NSLocalizedString(
+            "ai.assistant.preview.change.sale_off",
+            value: "sale -> off",
+            comment: "Change description when the sale price is being cleared (turned off)."
+        )
+        static let changeStockQuantity = NSLocalizedString(
+            "ai.assistant.preview.change.stock_quantity",
+            value: "stock -> %1$d",
+            comment: "Change description for stock quantity. %1$d is the new quantity."
+        )
+        static let changeStockStatus = NSLocalizedString(
+            "ai.assistant.preview.change.stock_status",
+            value: "stock status -> %1$@",
+            comment: "Change description for stock status (e.g. instock, outofstock). %1$@ is the new value."
+        )
+        static let changeSku = NSLocalizedString(
+            "ai.assistant.preview.change.sku",
+            value: "sku -> %1$@",
+            comment: "Change description for SKU. %1$@ is the new SKU."
+        )
+        static let changeStatus = NSLocalizedString(
+            "ai.assistant.preview.change.status",
+            value: "status -> %1$@",
+            comment: "Change description for a status field. %1$@ is the new status."
+        )
+        static let changeCustomerNote = NSLocalizedString(
+            "ai.assistant.preview.change.customer_note",
+            value: "customer note updated",
+            comment: "Change description when an order's customer note is being modified (the note text itself is not shown)."
+        )
+        static let changeBillingEmail = NSLocalizedString(
+            "ai.assistant.preview.change.billing_email",
+            value: "billing email -> %1$@",
+            comment: "Change description for billing email. %1$@ is the new email address."
+        )
     }
 }

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -294,12 +294,12 @@ public enum ToolPreviews {
         static let emailsCustomerSuffix = NSLocalizedString(
             "ai.assistant.preview.suffix.emails_customer",
             value: " (emails the customer)",
-            comment: "Trailing suffix appended to a single-order status confirmation preview when the new status triggers a customer email. Includes the leading space."
+            comment: "Suffix on a single-order status preview when the status triggers a customer email. Leading space included."
         )
         static let emailsCustomersSuffix = NSLocalizedString(
             "ai.assistant.preview.suffix.emails_customers",
             value: " (emails customers)",
-            comment: "Trailing suffix appended to a bulk-order status confirmation preview when the new status triggers customer emails for each affected order. Includes the leading space."
+            comment: "Suffix on a bulk-order status preview when the status triggers customer emails. Leading space included."
         )
 
         static let changeEditFields = NSLocalizedString(
@@ -313,14 +313,14 @@ public enum ToolPreviews {
             comment: "Change description for a name field. %1$@ is the new name."
         )
         static let changeRegularPrice = NSLocalizedString(
-            "ai.assistant.preview.change.regular_price",
-            value: "price -> $%1$@",
-            comment: "Change description for the regular price. %1$@ is the new price as a string."
+            "ai.assistant.preview.change.regular_price.no_currency",
+            value: "price -> %1$@",
+            comment: "Regular price change. %1$@ is the raw amount; no currency symbol because store currency varies."
         )
         static let changeSalePrice = NSLocalizedString(
-            "ai.assistant.preview.change.sale_price",
-            value: "sale -> $%1$@",
-            comment: "Change description for the sale price. %1$@ is the new sale price as a string."
+            "ai.assistant.preview.change.sale_price.no_currency",
+            value: "sale -> %1$@",
+            comment: "Sale price change. %1$@ is the raw amount; no currency symbol because store currency varies."
         )
         static let changeSaleOff = NSLocalizedString(
             "ai.assistant.preview.change.sale_off",

--- a/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ToolPreviews.swift
@@ -172,7 +172,7 @@ public enum ToolPreviews {
                                        stockQuantity: Int?,
                                        status: String?) -> [String] {
         var changes: [String] = []
-        if let name = name {
+        if let name {
             changes.append(String.localizedStringWithFormat(Localization.changeName, name))
         }
         if let price = regularPrice {
@@ -185,7 +185,7 @@ public enum ToolPreviews {
         if let stock = stockQuantity {
             changes.append(String.localizedStringWithFormat(Localization.changeStockQuantity, stock))
         }
-        if let status = status {
+        if let status {
             changes.append(String.localizedStringWithFormat(Localization.changeStatus, status))
         }
         return changes
@@ -286,7 +286,7 @@ public enum ToolPreviews {
         static let productVariationsUpdateFull = NSLocalizedString(
             "ai.assistant.preview.product_variations_update.full",
             value: "Update variation #%1$d of product #%2$d: %3$@",
-            comment: "Confirmation card preview for a variation update. %1$d is the variation id, %2$d is the parent product id, %3$@ is a comma-separated change list."
+            comment: "Variation update preview. %1$d is the variation id, %2$d the parent product id, %3$@ the change list."
         )
 
         static let emailsCustomerSuffix = NSLocalizedString(

--- a/Modules/Sources/WooAIAssistant/Tools/AITool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AITool.swift
@@ -16,14 +16,12 @@ public struct AITool: Sendable {
     }
 }
 
-/// Two-level safety classification consumed by `SafetyPolicy` to decide whether
-/// a tool call may dispatch immediately, requires confirmation, or must block.
 /// Cross-platform-aligned with the Android client; richer taxonomies were
 /// considered and rejected to keep the merchant-facing contract uniform.
 public enum AIToolSafetyLevel: Equatable, Sendable {
-    /// Side-effect-free or render-only. Always dispatches.
+    /// Side-effect-free or render-only.
     case safe
 
-    /// Mutates store data. Requires confirmation, or blocks under read-only mode.
+    /// Mutates store data.
     case unsafe
 }

--- a/Modules/Sources/WooAIAssistant/Tools/AITool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/AITool.swift
@@ -3,10 +3,27 @@ public struct AITool: Sendable {
     public let name: String
     public let description: String
     public let parametersSchema: AnyCodableJSON
+    public let safetyLevel: AIToolSafetyLevel
 
-    public init(name: String, description: String, parametersSchema: AnyCodableJSON) {
+    public init(name: String,
+                description: String,
+                parametersSchema: AnyCodableJSON,
+                safetyLevel: AIToolSafetyLevel) {
         self.name = name
         self.description = description
         self.parametersSchema = parametersSchema
+        self.safetyLevel = safetyLevel
     }
+}
+
+/// Two-level safety classification consumed by `SafetyPolicy` to decide whether
+/// a tool call may dispatch immediately, requires confirmation, or must block.
+/// Cross-platform-aligned with the Android client; richer taxonomies were
+/// considered and rejected to keep the merchant-facing contract uniform.
+public enum AIToolSafetyLevel: Equatable, Sendable {
+    /// Side-effect-free or render-only. Always dispatches.
+    case safe
+
+    /// Mutates store data. Requires confirmation, or blocks under read-only mode.
+    case unsafe
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
@@ -35,7 +35,8 @@ public enum AnalyticsOrdersTool {
                 ])
             ]),
             "required": .array([.string("after"), .string("before")])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
@@ -40,7 +40,8 @@ public enum AnalyticsRevenueTool {
                 ])
             ]),
             "required": .array([.string("after"), .string("before")])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Customers/CustomersListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Customers/CustomersListTool.swift
@@ -53,7 +53,8 @@ public enum CustomersListTool {
                     "description": .string("Max items; clamped 1-50, default 20.")
                 ])
             ])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
@@ -43,7 +43,8 @@ public enum OrdersBulkUpdateTool {
                 ])
             ]),
             "required": .array([.string("ids"), .string("patch")])
-        ])
+        ]),
+        safetyLevel: .unsafe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersGetTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersGetTool.swift
@@ -26,7 +26,8 @@ public enum OrdersGetTool {
                 ])
             ]),
             "required": .array([.string("id")])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListTool.swift
@@ -69,7 +69,8 @@ public enum OrdersListTool {
                     "description": .string("Max items; clamped 1-50, default 20.")
                 ])
             ])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersUpdateTool.swift
@@ -39,7 +39,8 @@ public enum OrdersUpdateTool {
                 ])
             ]),
             "required": .array([.string("id")])
-        ])
+        ]),
+        safetyLevel: .unsafe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsListTool.swift
@@ -34,7 +34,8 @@ public enum ProductVariationsListTool {
                 ])
             ]),
             "required": .array([.string("product_id")])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsUpdateTool.swift
@@ -45,7 +45,8 @@ public enum ProductVariationsUpdateTool {
                 ])
             ]),
             "required": .array([.string("product_id"), .string("id")])
-        ])
+        ]),
+        safetyLevel: .unsafe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsBulkUpdateTool.swift
@@ -46,7 +46,8 @@ public enum ProductsBulkUpdateTool {
                 ])
             ]),
             "required": .array([.string("ids"), .string("patch")])
-        ])
+        ]),
+        safetyLevel: .unsafe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsGetTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsGetTool.swift
@@ -26,7 +26,8 @@ public enum ProductsGetTool {
                 ])
             ]),
             "required": .array([.string("id")])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -67,7 +67,8 @@ public enum ProductsListTool {
                     "description": .string("Max items; clamped 1-50, default 20.")
                 ])
             ])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
@@ -43,7 +43,8 @@ public enum ProductsUpdateTool {
                 ])
             ]),
             "required": .array([.string("id")])
-        ])
+        ]),
+        safetyLevel: .unsafe
     )
 
     private struct Args: Decodable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/ShowCardsTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/ShowCardsTool.swift
@@ -53,7 +53,8 @@ public enum ShowCardsTool {
                     ])
                 ])
             ])
-        ])
+        ]),
+        safetyLevel: .safe
     )
 
     private static let executor: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultSafetyPolicyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultSafetyPolicyTests.swift
@@ -10,7 +10,7 @@ struct DefaultSafetyPolicyTests {
                           description: "List orders",
                           parametersSchema: .object([:]),
                           safetyLevel: .safe)
-        let policy = DefaultSafetyPolicy(isReadOnly: { true })
+        let policy = DefaultSafetyPolicy()
 
         // When
         let decision = policy.decision(for: tool.name, arguments: "{}", tool: tool)
@@ -20,13 +20,13 @@ struct DefaultSafetyPolicyTests {
     }
 
     @Test
-    func test_decision_when_tool_unsafe_and_readOnlyOff_then_requireConfirmation_with_preview() {
+    func test_decision_when_tool_unsafe_then_requireConfirmation_with_preview() {
         // Given
         let tool = AITool(name: "orders_update",
                           description: "Update an order",
                           parametersSchema: .object([:]),
                           safetyLevel: .unsafe)
-        let policy = DefaultSafetyPolicy(isReadOnly: { false })
+        let policy = DefaultSafetyPolicy()
 
         // When
         let decision = policy.decision(for: tool.name,
@@ -40,28 +40,5 @@ struct DefaultSafetyPolicyTests {
         }
         #expect(preview.isEmpty == false)
         #expect(preview.contains("42"))
-    }
-
-    @Test
-    func test_decision_when_tool_unsafe_and_readOnlyOn_then_block_with_message() {
-        // Given
-        let tool = AITool(name: "products_update",
-                          description: "Update a product",
-                          parametersSchema: .object([:]),
-                          safetyLevel: .unsafe)
-        let policy = DefaultSafetyPolicy(isReadOnly: { true })
-
-        // When
-        let decision = policy.decision(for: tool.name,
-                                       arguments: #"{"id":7,"regular_price":"19.99"}"#,
-                                       tool: tool)
-
-        // Then
-        guard case .block(let reason) = decision else {
-            Issue.record("expected .block, got \(decision)")
-            return
-        }
-        let lower = reason.lowercased()
-        #expect(lower.contains("read-only") || lower.contains("labs"))
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultSafetyPolicyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultSafetyPolicyTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct DefaultSafetyPolicyTests {
+    @Test
+    func test_decision_when_tool_safe_then_execute() {
+        // Given
+        let tool = AITool(name: "orders_list",
+                          description: "List orders",
+                          parametersSchema: .object([:]),
+                          safetyLevel: .safe)
+        let policy = DefaultSafetyPolicy(isReadOnly: { true })
+
+        // When
+        let decision = policy.decision(for: tool.name, arguments: "{}", tool: tool)
+
+        // Then
+        #expect(decision == .execute)
+    }
+
+    @Test
+    func test_decision_when_tool_unsafe_and_readOnlyOff_then_requireConfirmation_with_preview() {
+        // Given
+        let tool = AITool(name: "orders_update",
+                          description: "Update an order",
+                          parametersSchema: .object([:]),
+                          safetyLevel: .unsafe)
+        let policy = DefaultSafetyPolicy(isReadOnly: { false })
+
+        // When
+        let decision = policy.decision(for: tool.name,
+                                       arguments: #"{"id":42,"status":"processing"}"#,
+                                       tool: tool)
+
+        // Then
+        guard case .requireConfirmation(let preview) = decision else {
+            Issue.record("expected .requireConfirmation, got \(decision)")
+            return
+        }
+        #expect(preview.isEmpty == false)
+        #expect(preview.contains("42"))
+    }
+
+    @Test
+    func test_decision_when_tool_unsafe_and_readOnlyOn_then_block_with_message() {
+        // Given
+        let tool = AITool(name: "products_update",
+                          description: "Update a product",
+                          parametersSchema: .object([:]),
+                          safetyLevel: .unsafe)
+        let policy = DefaultSafetyPolicy(isReadOnly: { true })
+
+        // When
+        let decision = policy.decision(for: tool.name,
+                                       arguments: #"{"id":7,"regular_price":"19.99"}"#,
+                                       tool: tool)
+
+        // Then
+        guard case .block(let reason) = decision else {
+            Issue.record("expected .block, got \(decision)")
+            return
+        }
+        let lower = reason.lowercased()
+        #expect(lower.contains("read-only") || lower.contains("labs"))
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct ToolPreviewsTests {
+    @Test
+    func test_ordersUpdate_preview_when_status_set_to_processing_then_includes_email_note() {
+        // Given
+        let arguments = #"{"id":42,"status":"processing"}"#
+
+        // When
+        let preview = ToolPreviews.defaultBuilder(OrdersUpdateTool.name, arguments)
+
+        // Then
+        #expect(preview == "Set order #42 to processing (emails the customer)")
+    }
+
+    @Test
+    func test_ordersBulkUpdate_preview_when_status_change_for_many_then_pluralizes_and_summarizes() {
+        // Given
+        let arguments = #"{"ids":[1,2,3,4,5],"patch":{"status":"completed"}}"#
+
+        // When
+        let preview = ToolPreviews.defaultBuilder(OrdersBulkUpdateTool.name, arguments)
+
+        // Then
+        #expect(preview == "Update 5 orders: status -> completed")
+    }
+
+    @Test
+    func test_productsUpdate_preview_when_price_and_stock_set_then_lists_changes_in_order() {
+        // Given
+        let arguments = #"{"id":7,"regular_price":"24.99","stock_quantity":100}"#
+
+        // When
+        let preview = ToolPreviews.defaultBuilder(ProductsUpdateTool.name, arguments)
+
+        // Then
+        #expect(preview == "Update product #7: price -> $24.99, stock -> 100")
+    }
+
+    @Test
+    func test_productsBulkUpdate_preview_when_one_id_then_uses_singular_noun() {
+        // Given
+        let arguments = #"{"ids":[10],"patch":{"status":"draft"}}"#
+
+        // When
+        let preview = ToolPreviews.defaultBuilder(ProductsBulkUpdateTool.name, arguments)
+
+        // Then
+        #expect(preview == "Update 1 product: status -> draft")
+    }
+
+    @Test
+    func test_productVariationsUpdate_preview_when_price_set_then_names_variation_and_parent() {
+        // Given
+        let arguments = #"{"product_id":7,"id":15,"regular_price":"19.99"}"#
+
+        // When
+        let preview = ToolPreviews.defaultBuilder(ProductVariationsUpdateTool.name, arguments)
+
+        // Then
+        #expect(preview == "Update variation #15 of product #7: price -> $19.99")
+    }
+
+    @Test
+    func test_genericPreview_when_unknown_tool_name_then_returns_truncated_args() {
+        // Given a tool name not in the routing table and arguments longer than 80 chars
+        let longArgs = String(repeating: "a", count: 100)
+
+        // When
+        let preview = ToolPreviews.defaultBuilder("future_unknown_tool", longArgs)
+
+        // Then
+        let expectedTruncated = String(repeating: "a", count: 80) + "..."
+        #expect(preview == "future_unknown_tool \(expectedTruncated)")
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
@@ -12,13 +12,13 @@ struct ToolPreviewsTests {
          "Update 5 orders: status -> completed (emails customers)"),
         (ProductsUpdateTool.name,
          #"{"id":7,"regular_price":"24.99","stock_quantity":100}"#,
-         "Update product #7: price -> $24.99, stock -> 100"),
+         "Update product #7: price -> 24.99, stock -> 100"),
         (ProductsBulkUpdateTool.name,
          #"{"ids":[10],"patch":{"status":"draft"}}"#,
          "Update 1 product: status -> draft"),
         (ProductVariationsUpdateTool.name,
          #"{"product_id":7,"id":15,"regular_price":"19.99"}"#,
-         "Update variation #15 of product #7: price -> $19.99")
+         "Update variation #15 of product #7: price -> 19.99")
     ])
     func test_defaultBuilder_when_known_tool_then_returns_readable_preview(
         toolName: String,

--- a/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
@@ -3,69 +3,38 @@ import Testing
 @testable import WooAIAssistant
 
 struct ToolPreviewsTests {
-    @Test
-    func test_ordersUpdate_preview_when_status_set_to_processing_then_includes_email_note() {
-        // Given
-        let arguments = #"{"id":42,"status":"processing"}"#
-
+    @Test(arguments: [
+        (OrdersUpdateTool.name,
+         #"{"id":42,"status":"processing"}"#,
+         "Set order #42 to processing (emails the customer)"),
+        (OrdersBulkUpdateTool.name,
+         #"{"ids":[1,2,3,4,5],"patch":{"status":"completed"}}"#,
+         "Update 5 orders: status -> completed"),
+        (ProductsUpdateTool.name,
+         #"{"id":7,"regular_price":"24.99","stock_quantity":100}"#,
+         "Update product #7: price -> $24.99, stock -> 100"),
+        (ProductsBulkUpdateTool.name,
+         #"{"ids":[10],"patch":{"status":"draft"}}"#,
+         "Update 1 product: status -> draft"),
+        (ProductVariationsUpdateTool.name,
+         #"{"product_id":7,"id":15,"regular_price":"19.99"}"#,
+         "Update variation #15 of product #7: price -> $19.99")
+    ])
+    func test_defaultBuilder_when_known_tool_then_returns_readable_preview(
+        toolName: String,
+        argumentsJSON: String,
+        expected: String
+    ) {
         // When
-        let preview = ToolPreviews.defaultBuilder(OrdersUpdateTool.name, arguments)
+        let preview = ToolPreviews.defaultBuilder(toolName, argumentsJSON)
 
         // Then
-        #expect(preview == "Set order #42 to processing (emails the customer)")
-    }
-
-    @Test
-    func test_ordersBulkUpdate_preview_when_status_change_for_many_then_pluralizes_and_summarizes() {
-        // Given
-        let arguments = #"{"ids":[1,2,3,4,5],"patch":{"status":"completed"}}"#
-
-        // When
-        let preview = ToolPreviews.defaultBuilder(OrdersBulkUpdateTool.name, arguments)
-
-        // Then
-        #expect(preview == "Update 5 orders: status -> completed")
-    }
-
-    @Test
-    func test_productsUpdate_preview_when_price_and_stock_set_then_lists_changes_in_order() {
-        // Given
-        let arguments = #"{"id":7,"regular_price":"24.99","stock_quantity":100}"#
-
-        // When
-        let preview = ToolPreviews.defaultBuilder(ProductsUpdateTool.name, arguments)
-
-        // Then
-        #expect(preview == "Update product #7: price -> $24.99, stock -> 100")
-    }
-
-    @Test
-    func test_productsBulkUpdate_preview_when_one_id_then_uses_singular_noun() {
-        // Given
-        let arguments = #"{"ids":[10],"patch":{"status":"draft"}}"#
-
-        // When
-        let preview = ToolPreviews.defaultBuilder(ProductsBulkUpdateTool.name, arguments)
-
-        // Then
-        #expect(preview == "Update 1 product: status -> draft")
-    }
-
-    @Test
-    func test_productVariationsUpdate_preview_when_price_set_then_names_variation_and_parent() {
-        // Given
-        let arguments = #"{"product_id":7,"id":15,"regular_price":"19.99"}"#
-
-        // When
-        let preview = ToolPreviews.defaultBuilder(ProductVariationsUpdateTool.name, arguments)
-
-        // Then
-        #expect(preview == "Update variation #15 of product #7: price -> $19.99")
+        #expect(preview == expected)
     }
 
     @Test
     func test_genericPreview_when_unknown_tool_name_then_returns_truncated_args() {
-        // Given a tool name not in the routing table and arguments longer than 80 chars
+        // Given
         let longArgs = String(repeating: "a", count: 100)
 
         // When

--- a/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/ToolPreviewsTests.swift
@@ -9,7 +9,7 @@ struct ToolPreviewsTests {
          "Set order #42 to processing (emails the customer)"),
         (OrdersBulkUpdateTool.name,
          #"{"ids":[1,2,3,4,5],"patch":{"status":"completed"}}"#,
-         "Update 5 orders: status -> completed"),
+         "Update 5 orders: status -> completed (emails customers)"),
         (ProductsUpdateTool.name,
          #"{"id":7,"regular_price":"24.99","stock_quantity":100}"#,
          "Update product #7: price -> $24.99, stock -> 100"),

--- a/Modules/Tests/WooAIAssistantTests/Tools/AIToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/AIToolTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct AIToolTests {
     @Test
-    func test_aiTool_when_constructed_then_exposes_name_description_and_schema() {
+    func test_aiTool_when_constructed_then_exposes_name_description_schema_and_safetyLevel() {
         // Given
         let schema: AnyCodableJSON = .object([
             "type": .string("object"),
@@ -18,12 +18,14 @@ struct AIToolTests {
         // When
         let tool = AITool(name: "orders_get",
                           description: "Fetch a single order by ID",
-                          parametersSchema: schema)
+                          parametersSchema: schema,
+                          safetyLevel: .safe)
 
         // Then
         #expect(tool.name == "orders_get")
         #expect(tool.description == "Fetch a single order by ID")
         #expect(tool.parametersSchema == schema)
+        #expect(tool.safetyLevel == .safe)
     }
 
     @Test
@@ -35,7 +37,10 @@ struct AIToolTests {
                 "query": .object(["type": .string("string")])
             ])
         ])
-        let tool = AITool(name: "products_search", description: "Search products", parametersSchema: schema)
+        let tool = AITool(name: "products_search",
+                          description: "Search products",
+                          parametersSchema: schema,
+                          safetyLevel: .safe)
 
         // When
         let data = try JSONEncoder().encode(tool.parametersSchema)

--- a/Modules/Tests/WooAIAssistantTests/Tools/RESTToolRegistryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/RESTToolRegistryTests.swift
@@ -32,7 +32,8 @@ struct RESTToolRegistryTests {
         let tool = RESTTool(
             definition: AITool(name: "orders_list",
                                description: "List orders",
-                               parametersSchema: .object([:])),
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe),
             executor: { _, _ in
                 .success(.init(toolName: "orders_list", structured: structured))
             }
@@ -58,7 +59,8 @@ struct RESTToolRegistryTests {
         let tool = RESTTool(
             definition: AITool(name: "orders_get",
                                description: "Get",
-                               parametersSchema: .object([:])),
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe),
             executor: { _, _ in
                 .failed(.init(toolName: "orders_get",
                               toolCallID: "executor_emitted",
@@ -87,7 +89,8 @@ struct RESTToolRegistryTests {
         let tool = RESTTool(
             definition: AITool(name: "orders_get",
                                description: "Get one",
-                               parametersSchema: .object([:])),
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe),
             executor: { arguments, client in
                 await recorder.record(arguments: arguments)
                 _ = await client.request(method: "GET",
@@ -114,13 +117,15 @@ struct RESTToolRegistryTests {
         let listTool = RESTTool(
             definition: AITool(name: "orders_list",
                                description: "List",
-                               parametersSchema: .object([:])),
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe),
             executor: { _, _ in .failed(.init(toolName: "orders_list", kind: .toolFailed, reason: "stub")) }
         )
         let getTool = RESTTool(
             definition: AITool(name: "orders_get",
                                description: "Get",
-                               parametersSchema: .object([:])),
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe),
             executor: { _, _ in .failed(.init(toolName: "orders_get", kind: .toolFailed, reason: "stub")) }
         )
         let registry = RESTToolRegistry(client: NoopWCRESTClient(), tools: [listTool, getTool])


### PR DESCRIPTION
[WOOMOB-2869](https://linear.app/a8c/issue/WOOMOB-2869/woo-mobile-ai-add-two-level-safety-policy-with-confirmation-flow)

Depends on #16996 - when that merges, this PR rebases to trunk automatically.

## Description

Adds the safety policy that gates every tool call before dispatch. Two levels:
- `safe` (auto-execute): every read tool plus `show_cards`
- `unsafe` (requires confirmation): every write tool

`SafetyPolicy.decision(for:arguments:tool:)` returns one of two outcomes:
- `.execute` for `safe` tools
- `.requireConfirmation(preview:)` for `unsafe` tools

`ToolPreviews` builds the human-readable confirmation text shown on the confirmation card. Five known-tool builders (orders update, orders bulk update, products update, products bulk update, product variations update) plus a generic fallback that truncates raw arguments at 80 chars for any unknown tool. All preview strings are localized via `NSLocalizedString` with reverse-DNS keys and positional placeholders. Decode failures log via `DDLogError` and fall back to the generic preview.

`AITool` gains a `safetyLevel: AIToolSafetyLevel` field; all 14 existing tool definitions declare their level. The field is non-defaulted so the compiler enforces declarations at every call site.

## Test Steps

1. Build the `WooAIAssistant` scheme and run its test plan. All 156 tests across 33 suites should pass.

## Tests

CI should build and `WooAIAssistantTests` should pass. Doesn't introduce any changes to the main app target. The new types ship behind the existing `wooAIAssistant` feature flag.