### PR TITLE
Woo Mobile AI: Add chat schema

### DIFF
--- a/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
+++ b/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
@@ -56,7 +56,6 @@ enum OpenAIChat {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(role, forKey: .role)
             if role == .assistant && toolCalls?.isEmpty == false {
-                // Empty string, NOT null and NOT omitted.
                 try container.encode(content ?? "", forKey: .content)
             } else {
                 try container.encodeIfPresent(content, forKey: .content)
@@ -64,34 +63,19 @@ enum OpenAIChat {
             try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
             try container.encodeIfPresent(toolCallID, forKey: .toolCallID)
         }
-
-        static func system(_ text: String) -> Message {
-            Message(role: .system, content: text)
-        }
-        static func user(_ text: String) -> Message {
-            Message(role: .user, content: text)
-        }
-        static func assistant(_ text: String) -> Message {
-            Message(role: .assistant, content: text)
-        }
-        static func assistant(toolCalls: [ToolCall]) -> Message {
-            Message(role: .assistant, toolCalls: toolCalls)
-        }
-        static func tool(callID: String, content: String) -> Message {
-            Message(role: .tool, content: content, toolCallID: callID)
-        }
     }
 
-    /// Assistant-emitted request to invoke a function. `arguments` is a JSON
-    /// string the caller must parse against the tool's declared schema.
+    /// `arguments` is a JSON string the caller must parse against the tool's
+    /// declared schema; OpenAI sends arguments as a serialised string rather
+    /// than an inline object.
     struct ToolCall: Codable, Sendable, Equatable {
         let id: String
         let type: String
         let function: FunctionCall
 
-        init(id: String, function: FunctionCall, type: String = "function") {
+        init(id: String, function: FunctionCall) {
             self.id = id
-            self.type = type
+            self.type = "function"
             self.function = function
         }
     }
@@ -99,11 +83,6 @@ enum OpenAIChat {
     struct FunctionCall: Codable, Sendable, Equatable {
         let name: String
         let arguments: String
-
-        init(name: String, arguments: String) {
-            self.name = name
-            self.arguments = arguments
-        }
     }
 
     /// `parameters` is a JSON Schema object describing the function's
@@ -113,8 +92,8 @@ enum OpenAIChat {
         let type: String
         let function: FunctionDefinition
 
-        init(function: FunctionDefinition, type: String = "function") {
-            self.type = type
+        init(function: FunctionDefinition) {
+            self.type = "function"
             self.function = function
         }
     }
@@ -123,12 +102,6 @@ enum OpenAIChat {
         let name: String
         let description: String
         let parameters: AnyCodableJSON
-
-        init(name: String, description: String, parameters: AnyCodableJSON) {
-            self.name = name
-            self.description = description
-            self.parameters = parameters
-        }
     }
 
     /// Encoded-only; `jetpack-ai-query` never returns `tool_choice`.
@@ -199,28 +172,12 @@ enum OpenAIChat {
         let model: String?
         let choices: [Choice]
         let usage: Usage?
-
-        init(id: String? = nil,
-             model: String? = nil,
-             choices: [Choice],
-             usage: Usage? = nil) {
-            self.id = id
-            self.model = model
-            self.choices = choices
-            self.usage = usage
-        }
     }
 
     struct Choice: Decodable, Sendable, Equatable {
         let index: Int
         let message: Message
         let finishReason: FinishReason?
-
-        init(index: Int, message: Message, finishReason: FinishReason? = nil) {
-            self.index = index
-            self.message = message
-            self.finishReason = finishReason
-        }
 
         enum CodingKeys: String, CodingKey {
             case index, message

--- a/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
+++ b/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
@@ -1,0 +1,331 @@
+import Foundation
+
+/// OpenAI-compatible chat-completion wire types.
+///
+/// Both `jetpack-ai-query` and `ai-api-proxy/v1/chat/completions` accept this
+/// shape verbatim, so a single set of types covers today's backend and the
+/// expected future swap. Tool calling follows the OpenAI spec
+/// (`finish_reason: "tool_calls"`, `tool_calls[i].function.{name,arguments}`).
+public enum OpenAIChat {
+
+    // MARK: - Roles
+
+    public enum Role: String, Codable, Sendable {
+        case system
+        case user
+        case assistant
+        case tool
+    }
+
+    // MARK: - Messages
+
+    /// One message in the chat history. Field validity depends on `role`:
+    /// - `.system` / `.user`: `content` set; `toolCalls` and `toolCallID` nil.
+    /// - `.assistant`: either `content` set (text response) OR `toolCalls`
+    ///   set (model wants to call functions). Never both populated together
+    ///   in a real response, but both fields exist for round-tripping.
+    /// - `.tool`: `content` is the tool result (typically a JSON string),
+    ///   `toolCallID` references the originating assistant tool call.
+    public struct Message: Codable, Sendable, Equatable {
+        public let role: Role
+        public let content: String?
+        public let toolCalls: [ToolCall]?
+        public let toolCallID: String?
+
+        public init(role: Role,
+                    content: String? = nil,
+                    toolCalls: [ToolCall]? = nil,
+                    toolCallID: String? = nil) {
+            self.role = role
+            self.content = content
+            self.toolCalls = toolCalls
+            self.toolCallID = toolCallID
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case role
+            case content
+            case toolCalls = "tool_calls"
+            case toolCallID = "tool_call_id"
+        }
+
+        /// Custom encoder so an assistant turn carrying `tool_calls` still
+        /// emits a present, non-null `content` field. jetpack-ai-query's
+        /// pre-filter rejects `"content": null` AND an omitted `content`
+        /// key with `jetpack_ai_error: Invalid message format`; it accepts
+        /// an empty string. OpenAI's downstream model ignores `content`
+        /// when `tool_calls` is set, so the empty string is cosmetic but
+        /// required to satisfy the proxy's validator. Verified empirically
+        /// via a live probe of the endpoint (probes E1/E2: `""` and
+        /// `"Calling tool"` both return 200 against an otherwise-failing
+        /// body).
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(role, forKey: .role)
+            if role == .assistant && toolCalls?.isEmpty == false {
+                // Empty string, NOT null and NOT omitted.
+                try container.encode(content ?? "", forKey: .content)
+            } else {
+                try container.encodeIfPresent(content, forKey: .content)
+            }
+            try container.encodeIfPresent(toolCalls, forKey: .toolCalls)
+            try container.encodeIfPresent(toolCallID, forKey: .toolCallID)
+        }
+
+        public static func system(_ text: String) -> Message {
+            Message(role: .system, content: text)
+        }
+        public static func user(_ text: String) -> Message {
+            Message(role: .user, content: text)
+        }
+        public static func assistant(_ text: String) -> Message {
+            Message(role: .assistant, content: text)
+        }
+        public static func assistant(toolCalls: [ToolCall]) -> Message {
+            Message(role: .assistant, toolCalls: toolCalls)
+        }
+        public static func tool(callID: String, content: String) -> Message {
+            Message(role: .tool, content: content, toolCallID: callID)
+        }
+    }
+
+    // MARK: - Tool calls
+
+    /// Assistant-emitted request to invoke a function. `arguments` is a JSON
+    /// string the caller must parse against the tool's declared schema.
+    public struct ToolCall: Codable, Sendable, Equatable {
+        public let id: String
+        public let type: String
+        public let function: FunctionCall
+
+        public init(id: String, function: FunctionCall, type: String = "function") {
+            self.id = id
+            self.type = type
+            self.function = function
+        }
+    }
+
+    public struct FunctionCall: Codable, Sendable, Equatable {
+        public let name: String
+        public let arguments: String
+
+        public init(name: String, arguments: String) {
+            self.name = name
+            self.arguments = arguments
+        }
+    }
+
+    // MARK: - Tool definitions (request side)
+
+    /// Function declaration sent in the `tools` array of a request. The
+    /// `parameters` field is a JSON Schema object describing the function's
+    /// argument shape - encoded as `AnyCodableJSON` so any valid schema
+    /// round-trips.
+    public struct ToolDefinition: Codable, Sendable, Equatable {
+        public let type: String
+        public let function: FunctionDefinition
+
+        public init(function: FunctionDefinition, type: String = "function") {
+            self.type = type
+            self.function = function
+        }
+    }
+
+    public struct FunctionDefinition: Codable, Sendable, Equatable {
+        public let name: String
+        public let description: String
+        public let parameters: AnyCodableJSON
+
+        public init(name: String, description: String, parameters: AnyCodableJSON) {
+            self.name = name
+            self.description = description
+            self.parameters = parameters
+        }
+    }
+
+    /// Wire-level `tool_choice` parameter. OpenAI accepts `"auto"`,
+    /// `"required"`, or a specific-function object. Used by the
+    /// orchestrator to pin `respond` on forced follow-up turns when the
+    /// model emitted plain text instead of calling the terminal tool.
+    public enum ToolChoice: Encodable, Sendable, Equatable {
+        case auto
+        case required
+        case function(name: String)
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .auto:
+                try container.encode("auto")
+            case .required:
+                try container.encode("required")
+            case .function(let name):
+                try container.encode(SpecificFunctionChoice(
+                    type: "function",
+                    function: .init(name: name)
+                ))
+            }
+        }
+
+        private struct SpecificFunctionChoice: Encodable {
+            let type: String
+            let function: FunctionName
+            struct FunctionName: Encodable { let name: String }
+        }
+    }
+
+    // MARK: - Request
+
+    public struct Request: Encodable, Sendable {
+        public let messages: [Message]
+        public let tools: [ToolDefinition]?
+        public let toolChoice: ToolChoice?
+        public let model: String?
+        public let stream: Bool
+        public let feature: String
+        public let temperature: Double?
+        public let maxTokens: Int?
+
+        public init(messages: [Message],
+                    tools: [ToolDefinition]? = nil,
+                    toolChoice: ToolChoice? = nil,
+                    model: String? = nil,
+                    stream: Bool = false,
+                    feature: String,
+                    temperature: Double? = nil,
+                    maxTokens: Int? = nil) {
+            self.messages = messages
+            self.tools = tools
+            self.toolChoice = toolChoice
+            self.model = model
+            self.stream = stream
+            self.feature = feature
+            self.temperature = temperature
+            self.maxTokens = maxTokens
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case messages, tools, model, stream, feature, temperature
+            case toolChoice = "tool_choice"
+            case maxTokens = "max_tokens"
+        }
+    }
+
+    // MARK: - Response (non-streaming)
+
+    public struct Response: Decodable, Sendable, Equatable {
+        public let id: String?
+        public let model: String?
+        public let choices: [Choice]
+        public let usage: Usage?
+
+        public init(id: String? = nil,
+                    model: String? = nil,
+                    choices: [Choice],
+                    usage: Usage? = nil) {
+            self.id = id
+            self.model = model
+            self.choices = choices
+            self.usage = usage
+        }
+    }
+
+    public struct Choice: Decodable, Sendable, Equatable {
+        public let index: Int
+        public let message: Message
+        public let finishReason: FinishReason?
+
+        public init(index: Int, message: Message, finishReason: FinishReason? = nil) {
+            self.index = index
+            self.message = message
+            self.finishReason = finishReason
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case index, message
+            case finishReason = "finish_reason"
+        }
+    }
+
+    /// `finish_reason` value from the API. Decode falls back to `.stop` for
+    /// unknown strings so a future server-side enum addition does not break
+    /// in-flight responses; the orchestrator inspects `tool_calls` directly
+    /// for tool-driven turns and treats anything else as a terminal stop.
+    public enum FinishReason: String, Sendable, Equatable {
+        case stop
+        case toolCalls = "tool_calls"
+        case length
+        case contentFilter = "content_filter"
+        case functionCall = "function_call"
+    }
+
+    public struct Usage: Decodable, Sendable, Equatable {
+        public let promptTokens: Int?
+        public let completionTokens: Int?
+        public let totalTokens: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case promptTokens = "prompt_tokens"
+            case completionTokens = "completion_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+
+    // MARK: - Streaming chunk (SSE)
+
+    /// Streaming chunk in the OpenAI SSE format. Multiple chunks build up a
+    /// single response; tool-call arguments arrive as fragments and must be
+    /// concatenated by index across chunks.
+    public struct Chunk: Decodable, Sendable, Equatable {
+        public let id: String?
+        public let model: String?
+        public let choices: [ChunkChoice]
+        public let usage: Usage?
+    }
+
+    public struct ChunkChoice: Decodable, Sendable, Equatable {
+        public let index: Int
+        public let delta: Delta
+        public let finishReason: FinishReason?
+
+        enum CodingKeys: String, CodingKey {
+            case index, delta
+            case finishReason = "finish_reason"
+        }
+    }
+
+    public struct Delta: Decodable, Sendable, Equatable {
+        public let role: Role?
+        public let content: String?
+        public let toolCalls: [ToolCallDelta]?
+
+        enum CodingKeys: String, CodingKey {
+            case role, content
+            case toolCalls = "tool_calls"
+        }
+    }
+
+    /// Partial tool call fragment streamed inside a `Delta`. `index` identifies
+    /// which tool call this fragment belongs to (0-based across the response).
+    /// All other fields are present in the first fragment and absent in
+    /// subsequent fragments that only carry more `arguments` characters.
+    public struct ToolCallDelta: Decodable, Sendable, Equatable {
+        public let index: Int
+        public let id: String?
+        public let type: String?
+        public let function: FunctionDelta?
+    }
+
+    public struct FunctionDelta: Decodable, Sendable, Equatable {
+        public let name: String?
+        public let arguments: String?
+    }
+}
+
+extension OpenAIChat.FinishReason: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = OpenAIChat.FinishReason(rawValue: raw) ?? .stop
+    }
+}

--- a/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
+++ b/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
@@ -6,18 +6,14 @@ import Foundation
 /// shape verbatim, so a single set of types covers today's backend and the
 /// expected future swap. Tool calling follows the OpenAI spec
 /// (`finish_reason: "tool_calls"`, `tool_calls[i].function.{name,arguments}`).
-public enum OpenAIChat {
+enum OpenAIChat {
 
-    // MARK: - Roles
-
-    public enum Role: String, Codable, Sendable {
+    enum Role: String, Codable, Sendable {
         case system
         case user
         case assistant
         case tool
     }
-
-    // MARK: - Messages
 
     /// One message in the chat history. Field validity depends on `role`:
     /// - `.system` / `.user`: `content` set; `toolCalls` and `toolCallID` nil.
@@ -26,16 +22,16 @@ public enum OpenAIChat {
     ///   in a real response, but both fields exist for round-tripping.
     /// - `.tool`: `content` is the tool result (typically a JSON string),
     ///   `toolCallID` references the originating assistant tool call.
-    public struct Message: Codable, Sendable, Equatable {
-        public let role: Role
-        public let content: String?
-        public let toolCalls: [ToolCall]?
-        public let toolCallID: String?
+    struct Message: Codable, Sendable, Equatable {
+        let role: Role
+        let content: String?
+        let toolCalls: [ToolCall]?
+        let toolCallID: String?
 
-        public init(role: Role,
-                    content: String? = nil,
-                    toolCalls: [ToolCall]? = nil,
-                    toolCallID: String? = nil) {
+        init(role: Role,
+             content: String? = nil,
+             toolCalls: [ToolCall]? = nil,
+             toolCallID: String? = nil) {
             self.role = role
             self.content = content
             self.toolCalls = toolCalls
@@ -55,11 +51,8 @@ public enum OpenAIChat {
         /// key with `jetpack_ai_error: Invalid message format`; it accepts
         /// an empty string. OpenAI's downstream model ignores `content`
         /// when `tool_calls` is set, so the empty string is cosmetic but
-        /// required to satisfy the proxy's validator. Verified empirically
-        /// via a live probe of the endpoint (probes E1/E2: `""` and
-        /// `"Calling tool"` both return 200 against an otherwise-failing
-        /// body).
-        public func encode(to encoder: Encoder) throws {
+        /// required to satisfy the proxy's validator.
+        func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(role, forKey: .role)
             if role == .assistant && toolCalls?.isEmpty == false {
@@ -72,87 +65,79 @@ public enum OpenAIChat {
             try container.encodeIfPresent(toolCallID, forKey: .toolCallID)
         }
 
-        public static func system(_ text: String) -> Message {
+        static func system(_ text: String) -> Message {
             Message(role: .system, content: text)
         }
-        public static func user(_ text: String) -> Message {
+        static func user(_ text: String) -> Message {
             Message(role: .user, content: text)
         }
-        public static func assistant(_ text: String) -> Message {
+        static func assistant(_ text: String) -> Message {
             Message(role: .assistant, content: text)
         }
-        public static func assistant(toolCalls: [ToolCall]) -> Message {
+        static func assistant(toolCalls: [ToolCall]) -> Message {
             Message(role: .assistant, toolCalls: toolCalls)
         }
-        public static func tool(callID: String, content: String) -> Message {
+        static func tool(callID: String, content: String) -> Message {
             Message(role: .tool, content: content, toolCallID: callID)
         }
     }
 
-    // MARK: - Tool calls
-
     /// Assistant-emitted request to invoke a function. `arguments` is a JSON
     /// string the caller must parse against the tool's declared schema.
-    public struct ToolCall: Codable, Sendable, Equatable {
-        public let id: String
-        public let type: String
-        public let function: FunctionCall
+    struct ToolCall: Codable, Sendable, Equatable {
+        let id: String
+        let type: String
+        let function: FunctionCall
 
-        public init(id: String, function: FunctionCall, type: String = "function") {
+        init(id: String, function: FunctionCall, type: String = "function") {
             self.id = id
             self.type = type
             self.function = function
         }
     }
 
-    public struct FunctionCall: Codable, Sendable, Equatable {
-        public let name: String
-        public let arguments: String
+    struct FunctionCall: Codable, Sendable, Equatable {
+        let name: String
+        let arguments: String
 
-        public init(name: String, arguments: String) {
+        init(name: String, arguments: String) {
             self.name = name
             self.arguments = arguments
         }
     }
 
-    // MARK: - Tool definitions (request side)
+    /// `parameters` is a JSON Schema object describing the function's
+    /// argument shape. Stored as `AnyCodableJSON` so any valid schema
+    /// round-trips without bespoke decoding per tool.
+    struct ToolDefinition: Codable, Sendable, Equatable {
+        let type: String
+        let function: FunctionDefinition
 
-    /// Function declaration sent in the `tools` array of a request. The
-    /// `parameters` field is a JSON Schema object describing the function's
-    /// argument shape - encoded as `AnyCodableJSON` so any valid schema
-    /// round-trips.
-    public struct ToolDefinition: Codable, Sendable, Equatable {
-        public let type: String
-        public let function: FunctionDefinition
-
-        public init(function: FunctionDefinition, type: String = "function") {
+        init(function: FunctionDefinition, type: String = "function") {
             self.type = type
             self.function = function
         }
     }
 
-    public struct FunctionDefinition: Codable, Sendable, Equatable {
-        public let name: String
-        public let description: String
-        public let parameters: AnyCodableJSON
+    struct FunctionDefinition: Codable, Sendable, Equatable {
+        let name: String
+        let description: String
+        let parameters: AnyCodableJSON
 
-        public init(name: String, description: String, parameters: AnyCodableJSON) {
+        init(name: String, description: String, parameters: AnyCodableJSON) {
             self.name = name
             self.description = description
             self.parameters = parameters
         }
     }
 
-    /// Wire-level `tool_choice` parameter. OpenAI accepts `"auto"`,
-    /// `"required"`, or a specific-function object. Used by the
-    /// orchestrator to pin `respond` on forced follow-up turns when the
-    /// model emitted plain text instead of calling the terminal tool.
-    public enum ToolChoice: Encodable, Sendable, Equatable {
+    /// Encoded-only; `jetpack-ai-query` never returns `tool_choice`.
+    enum ToolChoice: Encodable, Sendable, Equatable {
         case auto
         case required
         case function(name: String)
 
-        public func encode(to encoder: Encoder) throws {
+        func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
             case .auto:
@@ -174,26 +159,24 @@ public enum OpenAIChat {
         }
     }
 
-    // MARK: - Request
+    struct Request: Encodable, Sendable {
+        let messages: [Message]
+        let tools: [ToolDefinition]?
+        let toolChoice: ToolChoice?
+        let model: String?
+        let stream: Bool
+        let feature: String
+        let temperature: Double?
+        let maxTokens: Int?
 
-    public struct Request: Encodable, Sendable {
-        public let messages: [Message]
-        public let tools: [ToolDefinition]?
-        public let toolChoice: ToolChoice?
-        public let model: String?
-        public let stream: Bool
-        public let feature: String
-        public let temperature: Double?
-        public let maxTokens: Int?
-
-        public init(messages: [Message],
-                    tools: [ToolDefinition]? = nil,
-                    toolChoice: ToolChoice? = nil,
-                    model: String? = nil,
-                    stream: Bool = false,
-                    feature: String,
-                    temperature: Double? = nil,
-                    maxTokens: Int? = nil) {
+        init(messages: [Message],
+             tools: [ToolDefinition]? = nil,
+             toolChoice: ToolChoice? = nil,
+             model: String? = nil,
+             stream: Bool = false,
+             feature: String,
+             temperature: Double? = nil,
+             maxTokens: Int? = nil) {
             self.messages = messages
             self.tools = tools
             self.toolChoice = toolChoice
@@ -211,18 +194,16 @@ public enum OpenAIChat {
         }
     }
 
-    // MARK: - Response (non-streaming)
+    struct Response: Decodable, Sendable, Equatable {
+        let id: String?
+        let model: String?
+        let choices: [Choice]
+        let usage: Usage?
 
-    public struct Response: Decodable, Sendable, Equatable {
-        public let id: String?
-        public let model: String?
-        public let choices: [Choice]
-        public let usage: Usage?
-
-        public init(id: String? = nil,
-                    model: String? = nil,
-                    choices: [Choice],
-                    usage: Usage? = nil) {
+        init(id: String? = nil,
+             model: String? = nil,
+             choices: [Choice],
+             usage: Usage? = nil) {
             self.id = id
             self.model = model
             self.choices = choices
@@ -230,12 +211,12 @@ public enum OpenAIChat {
         }
     }
 
-    public struct Choice: Decodable, Sendable, Equatable {
-        public let index: Int
-        public let message: Message
-        public let finishReason: FinishReason?
+    struct Choice: Decodable, Sendable, Equatable {
+        let index: Int
+        let message: Message
+        let finishReason: FinishReason?
 
-        public init(index: Int, message: Message, finishReason: FinishReason? = nil) {
+        init(index: Int, message: Message, finishReason: FinishReason? = nil) {
             self.index = index
             self.message = message
             self.finishReason = finishReason
@@ -247,22 +228,24 @@ public enum OpenAIChat {
         }
     }
 
-    /// `finish_reason` value from the API. Decode falls back to `.stop` for
-    /// unknown strings so a future server-side enum addition does not break
-    /// in-flight responses; the orchestrator inspects `tool_calls` directly
-    /// for tool-driven turns and treats anything else as a terminal stop.
-    public enum FinishReason: String, Sendable, Equatable {
+    /// `finish_reason` value from the API. Unknown strings decode to `.other`
+    /// so a future server-side enum addition does not break in-flight
+    /// responses; matches Android's `FinishReason.OTHER` for cross-platform
+    /// parity. Callers that need to react only to a terminal stop should
+    /// match `.stop` explicitly.
+    enum FinishReason: String, Sendable, Equatable {
         case stop
         case toolCalls = "tool_calls"
         case length
         case contentFilter = "content_filter"
         case functionCall = "function_call"
+        case other
     }
 
-    public struct Usage: Decodable, Sendable, Equatable {
-        public let promptTokens: Int?
-        public let completionTokens: Int?
-        public let totalTokens: Int?
+    struct Usage: Decodable, Sendable, Equatable {
+        let promptTokens: Int?
+        let completionTokens: Int?
+        let totalTokens: Int?
 
         enum CodingKeys: String, CodingKey {
             case promptTokens = "prompt_tokens"
@@ -271,22 +254,19 @@ public enum OpenAIChat {
         }
     }
 
-    // MARK: - Streaming chunk (SSE)
-
-    /// Streaming chunk in the OpenAI SSE format. Multiple chunks build up a
-    /// single response; tool-call arguments arrive as fragments and must be
-    /// concatenated by index across chunks.
-    public struct Chunk: Decodable, Sendable, Equatable {
-        public let id: String?
-        public let model: String?
-        public let choices: [ChunkChoice]
-        public let usage: Usage?
+    /// Multiple chunks build up a single response; tool-call arguments arrive
+    /// as fragments and must be concatenated by index across chunks.
+    struct Chunk: Decodable, Sendable, Equatable {
+        let id: String?
+        let model: String?
+        let choices: [ChunkChoice]
+        let usage: Usage?
     }
 
-    public struct ChunkChoice: Decodable, Sendable, Equatable {
-        public let index: Int
-        public let delta: Delta
-        public let finishReason: FinishReason?
+    struct ChunkChoice: Decodable, Sendable, Equatable {
+        let index: Int
+        let delta: Delta
+        let finishReason: FinishReason?
 
         enum CodingKeys: String, CodingKey {
             case index, delta
@@ -294,10 +274,10 @@ public enum OpenAIChat {
         }
     }
 
-    public struct Delta: Decodable, Sendable, Equatable {
-        public let role: Role?
-        public let content: String?
-        public let toolCalls: [ToolCallDelta]?
+    struct Delta: Decodable, Sendable, Equatable {
+        let role: Role?
+        let content: String?
+        let toolCalls: [ToolCallDelta]?
 
         enum CodingKeys: String, CodingKey {
             case role, content
@@ -305,27 +285,26 @@ public enum OpenAIChat {
         }
     }
 
-    /// Partial tool call fragment streamed inside a `Delta`. `index` identifies
-    /// which tool call this fragment belongs to (0-based across the response).
-    /// All other fields are present in the first fragment and absent in
-    /// subsequent fragments that only carry more `arguments` characters.
-    public struct ToolCallDelta: Decodable, Sendable, Equatable {
-        public let index: Int
-        public let id: String?
-        public let type: String?
-        public let function: FunctionDelta?
+    /// All fields except `index` are present only in the first fragment of a
+    /// given tool call. Subsequent fragments carry just `index` and a slice
+    /// of `function.arguments` to be concatenated by the consumer.
+    struct ToolCallDelta: Decodable, Sendable, Equatable {
+        let index: Int
+        let id: String?
+        let type: String?
+        let function: FunctionDelta?
     }
 
-    public struct FunctionDelta: Decodable, Sendable, Equatable {
-        public let name: String?
-        public let arguments: String?
+    struct FunctionDelta: Decodable, Sendable, Equatable {
+        let name: String?
+        let arguments: String?
     }
 }
 
 extension OpenAIChat.FinishReason: Decodable {
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)
-        self = OpenAIChat.FinishReason(rawValue: raw) ?? .stop
+        self = OpenAIChat.FinishReason(rawValue: raw) ?? .other
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/AI/OpenAIChatTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/AI/OpenAIChatTests.swift
@@ -26,7 +26,7 @@ struct OpenAIChatTests {
     @Test
     func test_response_decode_when_choices_empty_then_does_not_crash() throws {
         // Given
-        let json = """
+        let json = try #require("""
         {
           "id": "chatcmpl-1",
           "model": "gpt-4o-mini",
@@ -37,7 +37,7 @@ struct OpenAIChatTests {
             "total_tokens": 12
           }
         }
-        """.data(using: .utf8) ?? Data()
+        """.data(using: .utf8))
 
         // When
         let response = try JSONDecoder().decode(OpenAIChat.Response.self, from: json)
@@ -48,9 +48,33 @@ struct OpenAIChatTests {
     }
 
     @Test
+    func test_chunk_decode_when_choices_empty_then_does_not_crash() throws {
+        // Given
+        let json = try #require("""
+        {
+          "id": "chatcmpl-3",
+          "model": "gpt-4o-mini",
+          "choices": [],
+          "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 1,
+            "total_tokens": 10
+          }
+        }
+        """.data(using: .utf8))
+
+        // When
+        let chunk = try JSONDecoder().decode(OpenAIChat.Chunk.self, from: json)
+
+        // Then
+        #expect(chunk.choices.isEmpty)
+        #expect(chunk.usage?.totalTokens == 10)
+    }
+
+    @Test
     func test_chunk_decode_when_tool_call_delta_only_arguments_then_index_assigns_correctly() throws {
         // Given
-        let json = """
+        let json = try #require("""
         {
           "id": "chatcmpl-2",
           "model": "gpt-4o-mini",
@@ -68,7 +92,7 @@ struct OpenAIChatTests {
             }
           ]
         }
-        """.data(using: .utf8) ?? Data()
+        """.data(using: .utf8))
 
         // When
         let chunk = try JSONDecoder().decode(OpenAIChat.Chunk.self, from: json)
@@ -85,7 +109,7 @@ struct OpenAIChatTests {
     @Test
     func test_finishReason_when_unknown_string_then_decodes_to_other() throws {
         // Given
-        let json = "\"some_future_value\"".data(using: .utf8) ?? Data()
+        let json = try #require("\"some_future_value\"".data(using: .utf8))
 
         // When
         let finishReason = try JSONDecoder().decode(OpenAIChat.FinishReason.self, from: json)
@@ -105,5 +129,40 @@ struct OpenAIChatTests {
 
         // Then
         #expect(decoded == original)
+    }
+
+    @Test
+    func test_request_encode_uses_snake_case_keys_and_omits_nil_fields() throws {
+        // Given
+        let request = OpenAIChat.Request(
+            messages: [.init(role: .user, content: "hi")],
+            tools: [
+                .init(function: .init(name: "orders_list",
+                                      description: "List orders",
+                                      parameters: .object([:])))
+            ],
+            toolChoice: .auto,
+            model: "gpt-4o-mini",
+            stream: true,
+            feature: "woo-ai-assistant",
+            maxTokens: 256
+        )
+
+        // When
+        let data = try JSONEncoder().encode(request)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        // Then
+        #expect(json["tool_choice"] as? String == "auto")
+        #expect(json["max_tokens"] as? Int == 256)
+        #expect(json["model"] as? String == "gpt-4o-mini")
+        #expect(json["stream"] as? Bool == true)
+        #expect(json["feature"] as? String == "woo-ai-assistant")
+        #expect(json["temperature"] == nil)
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        #expect(messages.first?["role"] as? String == "user")
+        let tools = try #require(json["tools"] as? [[String: Any]])
+        let toolFunction = try #require(tools.first?["function"] as? [String: Any])
+        #expect(toolFunction["name"] as? String == "orders_list")
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/AI/OpenAIChatTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/AI/OpenAIChatTests.swift
@@ -83,7 +83,7 @@ struct OpenAIChatTests {
     }
 
     @Test
-    func test_finishReason_when_unknown_string_then_decodes_to_stop() throws {
+    func test_finishReason_when_unknown_string_then_decodes_to_other() throws {
         // Given
         let json = "\"some_future_value\"".data(using: .utf8) ?? Data()
 
@@ -91,7 +91,7 @@ struct OpenAIChatTests {
         let finishReason = try JSONDecoder().decode(OpenAIChat.FinishReason.self, from: json)
 
         // Then
-        #expect(finishReason == .stop)
+        #expect(finishReason == .other)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/AI/OpenAIChatTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/AI/OpenAIChatTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct OpenAIChatTests {
+
+    @Test
+    func test_message_encode_when_assistant_with_tool_calls_then_content_is_empty_string() throws {
+        // Given
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "orders_get", arguments: "{}")
+        )
+        let message = OpenAIChat.Message(role: .assistant, content: nil, toolCalls: [toolCall])
+
+        // When
+        let data = try JSONEncoder().encode(message)
+        let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        // Then
+        let content = try #require(json["content"] as? String)
+        #expect(content.isEmpty)
+        #expect(json["tool_calls"] != nil)
+    }
+
+    @Test
+    func test_response_decode_when_choices_empty_then_does_not_crash() throws {
+        // Given
+        let json = """
+        {
+          "id": "chatcmpl-1",
+          "model": "gpt-4o-mini",
+          "choices": [],
+          "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 0,
+            "total_tokens": 12
+          }
+        }
+        """.data(using: .utf8) ?? Data()
+
+        // When
+        let response = try JSONDecoder().decode(OpenAIChat.Response.self, from: json)
+
+        // Then
+        #expect(response.choices.isEmpty)
+        #expect(response.usage?.promptTokens == 12)
+    }
+
+    @Test
+    func test_chunk_decode_when_tool_call_delta_only_arguments_then_index_assigns_correctly() throws {
+        // Given
+        let json = """
+        {
+          "id": "chatcmpl-2",
+          "model": "gpt-4o-mini",
+          "choices": [
+            {
+              "index": 0,
+              "delta": {
+                "tool_calls": [
+                  {
+                    "index": 0,
+                    "function": { "arguments": "{\\"site_id\\":1}" }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+        """.data(using: .utf8) ?? Data()
+
+        // When
+        let chunk = try JSONDecoder().decode(OpenAIChat.Chunk.self, from: json)
+
+        // Then
+        let choice = try #require(chunk.choices.first)
+        let toolCallDelta = try #require(choice.delta.toolCalls?.first)
+        #expect(toolCallDelta.index == 0)
+        #expect(toolCallDelta.id == nil)
+        #expect(toolCallDelta.function?.name == nil)
+        #expect(toolCallDelta.function?.arguments == "{\"site_id\":1}")
+    }
+
+    @Test
+    func test_finishReason_when_unknown_string_then_decodes_to_stop() throws {
+        // Given
+        let json = "\"some_future_value\"".data(using: .utf8) ?? Data()
+
+        // When
+        let finishReason = try JSONDecoder().decode(OpenAIChat.FinishReason.self, from: json)
+
+        // Then
+        #expect(finishReason == .stop)
+    }
+
+    @Test
+    func test_roundTrip_when_message_with_text_then_decodes_back_equal() throws {
+        // Given
+        let original = OpenAIChat.Message(role: .assistant, content: "hi")
+
+        // When
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(OpenAIChat.Message.self, from: data)
+
+        // Then
+        #expect(decoded == original)
+    }
+}


### PR DESCRIPTION
[WOOMOB-2873](https://linear.app/a8c/issue/WOOMOB-2873/woo-mobile-ai-add-a-generic-json-value-type-and-openai-chat-schema)

## Description

Adds the `OpenAIChat` namespace - the wire types every chat backend uses (`Message`, `ToolCall`, `ToolDefinition`, `ToolChoice`, `Request`, `Response`, `Chunk`, `FinishReason`). Pure data; no transport or business logic. The namespace is module-internal; nothing in the app target imports it directly.

Wire-format guards baked in:
- `Message.encode` writes `content: ""` (empty string) when an assistant turn carries `tool_calls`. The `jetpack-ai-query` pre-filter rejects both `"content": null` and an omitted key with `jetpack_ai_error: Invalid message format`.
- `FinishReason` decodes unknown strings to `.other` so a server-side enum addition does not break in-flight responses.
- `ToolCall` and `ToolDefinition` always emit `"type": "function"`; the field is hard-coded so callers cannot accidentally drift from the OpenAI tool-calling spec.

## Live verification

Ran a throwaway integration test against the live `jetpack-ai-query` endpoint to sanity-check the new types end-to-end (test deleted after the run):

- **Encode**: `OpenAIChat.Request` / `Message` / `Role` encoded by `JSONEncoder` are accepted by the proxy (HTTP 200). Snake-case `CodingKeys` (`max_tokens`, `tool_call_id`, `finish_reason`) and nil-field omission both verified by the wire round-trip.
- **Decode**: a real `gpt-4o-mini` response decoded cleanly through `OpenAIChat.Response` -> `Choice.finishReason = .stop`, `Usage.totalTokens` mapped via snake_case, `Message.role = .assistant`, `Message.content` populated.
- **Custom encoder branch** (`Message.encode(to:)` when `role == .assistant && toolCalls?.isEmpty == false`): the encoder writes `"content": ""` and the proxy accepts it (HTTP 200). The alternative `"content": null` shape is rejected with HTTP 400 `Invalid message format`, confirming the doc-comment rationale on the encoder.

Streaming chunks (`Chunk`, `ToolCallDelta`), error envelopes, and tool-call response decoding stay covered by unit tests until live streaming ships.

## Test Steps

1. Build the `WooAIAssistant` scheme and run its test plan. All 126 tests across 26 suites should pass.
2. SwiftLint passes on touched files.

## Tests

CI should build and `WooAIAssistantTests` should pass. Doesn't introduce any changes to the main app target. The new types ship behind the existing `wooAIAssistant` feature flag.