### PR TITLE
Add issue picker and diagnostics flow to AI support chat

### DIFF
--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -189,6 +189,7 @@ public typealias SupportChatMessage = Networking.SupportChatMessage
 public typealias SupportChatMessageContext = Networking.SupportChatMessageContext
 public typealias SupportChatSource = Networking.SupportChatSource
 public typealias SupportChatFlags = Networking.SupportChatFlags
+public typealias SupportChatRole = Networking.SupportChatRole
 public typealias SystemPlugin = Networking.SystemPlugin
 public typealias SystemStatus = Networking.SystemStatus
 public typealias SystemStatusReport = Networking.SystemStatusReport

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -226,6 +226,7 @@ final class ConnectivityToolViewModel {
         context["ios_version"] = UIDevice.current.systemVersion
 
         return SupportChatViewModel(
+            entryPoint: .connectivityTool,
             initialContext: context,
             onContactHumanSupport: onContactHumanSupport
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -481,8 +481,7 @@ private extension HelpAndSupportViewController {
                 self?.navigateToContactSupport(transcript: transcript)
             }
         )
-        let supportChatView = SupportChatView(viewModel: viewModel)
-        let controller = UIHostingController(rootView: supportChatView)
+        let controller = SupportChatHostingController(viewModel: viewModel)
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -510,6 +510,7 @@ private extension HelpAndSupportViewController {
     private func resumeChat(for summary: SupportChatSummary) {
         let chatViewModel = SupportChatViewModel(
             botSlug: summary.botSlug,
+            entryPoint: .chatHistory,
             chatID: summary.chatID,
             onContactHumanSupport: { [weak self] _ in
                 self?.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -76,7 +76,8 @@ final class HelpAndSupportViewController: UIViewController {
         isMacCatalyst: isMacCatalyst,
         hasLoginSiteURL: loginSiteURL != nil,
         developerFFPanelEnabled: !ServiceLocator.stores.isAuthenticated
-            && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel)
+            && ServiceLocator.featureFlagService.isFeatureFlagEnabled(.loggedOutFFPanel),
+        isAISupportChatEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
     )
 
     private var isMacCatalyst: Bool {
@@ -234,6 +235,8 @@ private extension HelpAndSupportViewController {
             configureSiteCompatibility(cell: cell)
         case let cell as ValueOneTableViewCell where row == .featureFlags:
             configureFeatureFlags(cell: cell)
+        case let cell as ValueOneTableViewCell where row == .aiSupportChat:
+            configureAISupportChat(cell: cell)
         default:
             fatalError()
         }
@@ -317,6 +320,23 @@ private extension HelpAndSupportViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = "Override Feature Flags"
         cell.detailTextLabel?.text = "Toggle local feature flags"
+    }
+
+    /// AI Support Chat cell
+    ///
+    func configureAISupportChat(cell: ValueOneTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = NSLocalizedString(
+            "helpAndSupport.aiSupportChat.title",
+            value: "Chat with Support",
+            comment: "Title for the AI support chat row on the Help screen"
+        )
+        cell.detailTextLabel?.text = NSLocalizedString(
+            "helpAndSupport.aiSupportChat.subtitle",
+            value: "Get help from our AI assistant",
+            comment: "Subtitle for the AI support chat row on the Help screen"
+        )
     }
 
     func refreshViewContent() {
@@ -432,6 +452,25 @@ private extension HelpAndSupportViewController {
         navigationController?.pushViewController(controller, animated: true)
     }
 
+    /// AI Support Chat action
+    ///
+    func aiSupportChatWasPressed() {
+        let viewModel = SupportChatViewModel(
+            entryPoint: .helpAndSupport,
+            onContactHumanSupport: { [weak self] transcript in
+                self?.navigateToContactSupport(transcript: transcript)
+            }
+        )
+        let supportChatView = SupportChatView(viewModel: viewModel)
+        let controller = UIHostingController(rootView: supportChatView)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
+    private func navigateToContactSupport(transcript: String) {
+        let viewController = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag))
+        viewController.show(from: self)
+    }
+
     @objc func dismissWasPressed() {
         dismiss(animated: true, completion: nil)
     }
@@ -488,6 +527,8 @@ extension HelpAndSupportViewController: UITableViewDelegate {
             siteCompatibilityWasPressed()
         case .featureFlags:
             featureFlagsWasPressed()
+        case .aiSupportChat:
+            aiSupportChatWasPressed()
         }
     }
 }
@@ -509,6 +550,7 @@ private struct Section {
 enum HelpAndSupportRow: CaseIterable {
     case helpCenter
     case contactSupport
+    case aiSupportChat
     case contactEmail
     case applicationLog
     case systemStatusReport
@@ -517,7 +559,8 @@ enum HelpAndSupportRow: CaseIterable {
 
     var type: UITableViewCell.Type {
         switch self {
-        case .helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport, .siteCompatibility, .featureFlags:
+        case .helpCenter, .contactSupport, .aiSupportChat, .contactEmail, .applicationLog,
+             .systemStatusReport, .siteCompatibility, .featureFlags:
             return ValueOneTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -7,17 +7,20 @@ struct HelpAndSupportViewModel {
     private let isMacCatalyst: Bool
     private let hasLoginSiteURL: Bool
     private let developerFFPanelEnabled: Bool
+    private let isAISupportChatEnabled: Bool
 
     init(isAuthenticated: Bool,
          isZendeskEnabled: Bool,
          isMacCatalyst: Bool,
          hasLoginSiteURL: Bool = false,
-         developerFFPanelEnabled: Bool = false) {
+         developerFFPanelEnabled: Bool = false,
+         isAISupportChatEnabled: Bool = false) {
         self.isAuthenticated = isAuthenticated
         self.isZendeskEnabled = isZendeskEnabled
         self.isMacCatalyst = isMacCatalyst
         self.developerFFPanelEnabled = developerFFPanelEnabled
         self.hasLoginSiteURL = hasLoginSiteURL
+        self.isAISupportChatEnabled = isAISupportChatEnabled
     }
 
     func getRows() -> [HelpAndSupportRow] {
@@ -32,6 +35,9 @@ struct HelpAndSupportViewModel {
         var rows: [HelpAndSupportRow] = [.helpCenter, .contactSupport, .contactEmail, .applicationLog]
         if isAuthenticated {
             rows.append(.systemStatusReport)
+        }
+        if isAuthenticated && isAISupportChatEnabled {
+            rows.append(.aiSupportChat)
         }
         if !isAuthenticated && hasLoginSiteURL {
             rows.append(.siteCompatibility)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -7,6 +7,9 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
 
     private let viewModel: SupportChatViewModel
 
+    /// Retains the Jetpack setup coordinator while the flow is active.
+    private var jetpackSetupCoordinator: JetpackSetupCoordinator?
+
     init(viewModel: SupportChatViewModel) {
         self.viewModel = viewModel
         let view = SupportChatView(viewModel: viewModel)
@@ -14,6 +17,10 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
 
         self.hidesBottomBarWhenPushed = true
         self.title = Localization.title
+
+        viewModel.onStartJetpackSetup = { [weak self] in
+            self?.startJetpackSetup()
+        }
     }
 
     @available(*, unavailable)
@@ -24,6 +31,16 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.largeTitleDisplayMode = .never
+    }
+
+    private func startJetpackSetup() {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else { return }
+        let coordinator = JetpackSetupCoordinator(site: site, rootViewController: self, onCompletion: { [weak self] in
+            self?.viewModel.replaceActionWithRetry()
+            self?.jetpackSetupCoordinator = nil
+        })
+        jetpackSetupCoordinator = coordinator
+        coordinator.startSetup()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import enum Networking.SupportChatRole
 
 /// Shared layout constants for the support chat UI.
 ///
@@ -22,14 +23,23 @@ enum SupportChatLayout {
     }
 }
 
-/// A chat bubble component that displays a single message.
+/// Shared constant for maximum bubble width.
+///
+extension SupportChatLayout {
+    static var maxBubbleWidth: CGFloat {
+        UIScreen.main.bounds.width * maxBubbleWidthRatio
+    }
+}
+
+/// A chat bubble component that displays a single text message.
 ///
 struct SupportChatMessageRow: View {
-    let message: SupportChatViewModel.ChatMessage
+    let role: SupportChatRole
+    let text: String
 
     var body: some View {
         HStack {
-            if message.role == .user {
+            if role == .user {
                 Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
             }
 
@@ -39,7 +49,7 @@ struct SupportChatMessageRow: View {
                 .foregroundColor(bubbleForeground)
                 .cornerRadius(SupportChatLayout.bubbleCornerRadius)
 
-            if message.role == .bot {
+            if role == .bot {
                 Spacer(minLength: UIScreen.main.bounds.width * (1 - SupportChatLayout.maxBubbleWidthRatio))
             }
         }
@@ -47,16 +57,16 @@ struct SupportChatMessageRow: View {
 
     @ViewBuilder
     private var messageText: some View {
-        switch message.role {
+        switch role {
         case .user:
-            Text(message.content)
+            Text(text)
         case .bot, .unknown:
-            Text(.init(message.content))
+            Text(.init(text))
         }
     }
 
     private var bubbleBackground: Color {
-        switch message.role {
+        switch role {
         case .user:
             return Color(.accent)
         case .bot, .unknown:
@@ -65,7 +75,7 @@ struct SupportChatMessageRow: View {
     }
 
     private var bubbleForeground: Color {
-        switch message.role {
+        switch role {
         case .user:
             return .white
         case .bot, .unknown:
@@ -112,14 +122,16 @@ struct TypingIndicatorRow: View {
 
 #Preview("User Message") {
     SupportChatMessageRow(
-        message: .init(role: .user, content: "How do I fix my connection issue?")
+        role: .user,
+        text: "How do I fix my connection issue?"
     )
     .padding()
 }
 
 #Preview("Assistant Message") {
     SupportChatMessageRow(
-        message: .init(role: .bot, content: "I can help you troubleshoot your connection. Let's start by checking a few things.")
+        role: .bot,
+        text: "I can help you troubleshoot your connection. Let's start by checking a few things."
     )
     .padding()
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
@@ -70,7 +70,7 @@ struct SupportChatMessageRow: View {
         case .user:
             return Color(.accent)
         case .bot, .unknown:
-            return Color(.systemGray5)
+            return Color(.listForeground(modal: false))
         }
     }
 
@@ -102,7 +102,7 @@ struct TypingIndicatorRow: View {
                 }
             }
             .padding(SupportChatLayout.bubblePadding)
-            .background(Color(.systemGray5))
+            .background(Color(.listForeground(modal: false)))
             .cornerRadius(SupportChatLayout.bubbleCornerRadius)
 
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatMessageRow.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import enum Networking.SupportChatRole
+import enum Yosemite.SupportChatRole
 
 /// Shared layout constants for the support chat UI.
 ///

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -109,26 +109,20 @@ struct SupportChatView: View {
         VStack(alignment: .leading, spacing: Layout.bubbleSpacing) {
             Text(Localization.issuePickerHeader)
                 .font(.body)
-                .foregroundStyle(Color(.secondaryLabel))
+                .foregroundStyle(Color(.text))
 
             ForEach(issues, id: \.self) { issue in
-                Button {
+                Button(issue.displayName) {
                     Task {
                         await viewModel.selectIssue(issue)
                     }
-                } label: {
-                    Text(issue.displayName)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(Layout.issueButtonPadding)
-                        .background(Color(.tertiarySystemBackground))
-                        .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(SecondaryButtonStyle())
                 .disabled(viewModel.selectedIssue != nil)
             }
         }
         .padding(SupportChatLayout.bubblePadding)
-        .background(Color(.secondarySystemBackground))
+        .background(Colors.botBubbleBackground)
         .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
         .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
     }
@@ -150,7 +144,7 @@ struct SupportChatView: View {
             }
         }
         .padding(SupportChatLayout.bubblePadding)
-        .background(Color(.secondarySystemBackground))
+        .background(Colors.botBubbleBackground)
         .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
         .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
     }
@@ -167,21 +161,13 @@ struct SupportChatView: View {
                     .font(.body)
             }
 
-            Button {
+            Button(Localization.continueToChat) {
                 viewModel.proceedToChat()
-            } label: {
-                Text(Localization.continueToChat)
-                    .font(.body.weight(.medium))
-                    .frame(maxWidth: .infinity)
-                    .padding(Layout.issueButtonPadding)
-                    .background(Color.accentColor)
-                    .foregroundStyle(Color.white)
-                    .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(SecondaryButtonStyle())
         }
         .padding(SupportChatLayout.bubblePadding)
-        .background(Color(.secondarySystemBackground))
+        .background(Colors.botBubbleBackground)
         .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
         .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
     }
@@ -214,22 +200,14 @@ struct SupportChatView: View {
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isExecutingAction))
             } else {
-                Button {
+                Button(Localization.continueToChat) {
                     viewModel.proceedToChat()
-                } label: {
-                    Text(Localization.continueToChat)
-                        .font(.body.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                        .padding(Layout.issueButtonPadding)
-                        .background(Color(.tertiarySystemBackground))
-                        .foregroundStyle(Color(.label))
-                        .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(SecondaryButtonStyle())
             }
         }
         .padding(SupportChatLayout.bubblePadding)
-        .background(Color(.secondarySystemBackground))
+        .background(Colors.botBubbleBackground)
         .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
         .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
     }
@@ -318,11 +296,13 @@ struct SupportChatView: View {
 private extension SupportChatView {
     enum Layout {
         static let bubbleSpacing: CGFloat = 8
-        static let issueButtonPadding: CGFloat = 12
-        static let issueButtonRadius: CGFloat = 8
         static let progressSpacing: CGFloat = 8
         static let resultsSpacing: CGFloat = 12
         static let resultIconSpacing: CGFloat = 6
+    }
+
+    enum Colors {
+        static let botBubbleBackground = Color(.listForeground(modal: false))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -7,15 +7,16 @@ struct SupportChatView: View {
     @FocusState private var isInputFocused: Bool
 
     var body: some View {
-        VStack(spacing: 0) {
-            messageList
-
-            if viewModel.shouldPromptHumanSupport {
-                humanSupportBanner
-            } else {
-                Divider()
-
-                inputArea
+        Group {
+            switch viewModel.phase {
+            case .issuePicker:
+                issuePickerView
+            case .runningDiagnostics:
+                diagnosticsProgressView
+            case .showingResults:
+                resultsView
+            case .chatting:
+                chatView
             }
         }
         .background(Color(.listBackground))
@@ -38,6 +39,124 @@ struct SupportChatView: View {
                 }
             }
         )
+    }
+
+    // MARK: - Issue Picker
+
+    private var issuePickerView: some View {
+        List {
+            Section {
+                ForEach(SupportIssueType.allCases, id: \.self) { issue in
+                    Button {
+                        Task {
+                            await viewModel.selectIssue(issue)
+                        }
+                    } label: {
+                        Text(issue.displayName)
+                            .foregroundStyle(Color(.label))
+                    }
+                }
+            } header: {
+                Text(Localization.issuePickerHeader)
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Diagnostics Progress
+
+    private var diagnosticsProgressView: some View {
+        VStack(spacing: Layout.progressSpacing) {
+            ProgressView()
+                .scaleEffect(Layout.progressScale)
+
+            Text(Localization.runningDiagnostics)
+                .font(.headline)
+
+            if let issue = viewModel.selectedIssue {
+                Text(issue.displayName)
+                    .font(.subheadline)
+                    .foregroundStyle(Color(.secondaryLabel))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Results View
+
+    private var resultsView: some View {
+        ScrollView {
+            VStack(spacing: Layout.resultsSpacing) {
+                ForEach(viewModel.diagnosticResults, id: \.test) { result in
+                    resultCard(for: result)
+                }
+
+                proceedToChatButton
+            }
+            .padding()
+        }
+    }
+
+    private func resultCard(for result: SupportDiagnosticsService.Result) -> some View {
+        VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+            HStack {
+                Image(systemName: result.isSuccess ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(result.isSuccess ? Color.green : Color.red)
+
+                Text(result.test.title)
+                    .font(.headline)
+
+                Spacer()
+            }
+
+            if !result.isSuccess {
+                if let errorMessage = result.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .foregroundStyle(Color(.secondaryLabel))
+                }
+
+                if let action = result.suggestedAction {
+                    Button {
+                        Task {
+                            await viewModel.executeAction(action)
+                        }
+                    } label: {
+                        Label(action.title, systemImage: action.systemImage)
+                    }
+                    .buttonStyle(SecondaryButtonStyle())
+                }
+            }
+        }
+        .padding()
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: Layout.cardCornerRadius))
+    }
+
+    private var proceedToChatButton: some View {
+        Button {
+            viewModel.proceedToChat()
+        } label: {
+            Text(Localization.continueToChat)
+        }
+        .buttonStyle(PrimaryButtonStyle())
+        .padding(.top)
+    }
+
+    // MARK: - Chat View
+
+    private var chatView: some View {
+        VStack(spacing: 0) {
+            messageList
+
+            if viewModel.shouldPromptHumanSupport {
+                humanSupportBanner
+            } else {
+                Divider()
+
+                inputArea
+            }
+        }
         .onAppear {
             viewModel.showGreeting()
         }
@@ -139,8 +258,20 @@ struct SupportChatView: View {
     }
 }
 
+// MARK: - Layout Constants
+
+private extension SupportChatView {
+    enum Layout {
+        static let progressSpacing: CGFloat = 16
+        static let progressScale: CGFloat = 1.5
+        static let resultsSpacing: CGFloat = 16
+        static let cardSpacing: CGFloat = 12
+        static let cardCornerRadius: CGFloat = 12
+    }
+}
+
 // MARK: - Localization
-//
+
 private extension SupportChatView {
     enum Localization {
         static let title = NSLocalizedString(
@@ -173,17 +304,42 @@ private extension SupportChatView {
             value: "Contact Support",
             comment: "Button to contact human support from the chat"
         )
+        static let issuePickerHeader = NSLocalizedString(
+            "supportChatView.issuePickerHeader",
+            value: "What are you having trouble with?",
+            comment: "Header for the issue picker in support chat"
+        )
+        static let runningDiagnostics = NSLocalizedString(
+            "supportChatView.runningDiagnostics",
+            value: "Running diagnostics...",
+            comment: "Message shown while running diagnostics in support chat"
+        )
+        static let continueToChat = NSLocalizedString(
+            "supportChatView.continueToChat",
+            value: "Continue to Chat",
+            comment: "Button to proceed from diagnostics results to chat"
+        )
     }
 }
 
-#Preview {
+#Preview("Issue Picker") {
     NavigationStack {
         SupportChatView(
             viewModel: SupportChatViewModel(
+                entryPoint: .helpAndSupport,
                 onContactHumanSupport: { _ in }
             )
         )
-        .navigationTitle("Chat with Support")
-        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview("Chat") {
+    NavigationStack {
+        SupportChatView(
+            viewModel: SupportChatViewModel(
+                entryPoint: .connectivityTool,
+                onContactHumanSupport: { _ in }
+            )
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -138,43 +138,21 @@ struct SupportChatView: View {
     private func diagnosticsProgressBubble(
         steps: [(test: SupportDiagnosticsService.Test, status: SupportChatViewModel.TestStatus)]
     ) -> some View {
-        VStack(alignment: .leading, spacing: Layout.resultRowSpacing) {
-            ForEach(steps, id: \.test) { step in
-                HStack(alignment: .top, spacing: Layout.resultIconSpacing) {
-                    statusIcon(for: step.status)
-                        .font(.body)
+        HStack(alignment: .center, spacing: Layout.resultIconSpacing) {
+            let currentStep = steps.first { $0.status == .running } ?? steps.first { $0.status == .pending }
+            if let step = currentStep {
+                ProgressView()
+                    .controlSize(.small)
 
-                    Text(step.test.title)
-                        .font(.body)
-                        .foregroundStyle(step.status == .pending ? Color(.tertiaryLabel) : Color(.label))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                Text(step.test.title)
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(SupportChatLayout.bubblePadding)
         .background(Color(.secondarySystemBackground))
         .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
         .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
-    }
-
-    private func statusIcon(for status: SupportChatViewModel.TestStatus) -> some View {
-        VStack {
-            switch status {
-            case .pending:
-                Image(systemName: "circle")
-                    .foregroundStyle(Color(.tertiaryLabel))
-            case .running:
-                ProgressView()
-                    .controlSize(.small)
-            case .passed:
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(Color.green)
-            case .failed:
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundStyle(Color.red)
-            }
-        }
-        .frame(width: Layout.resultIconSize)
     }
 
     // MARK: - Diagnostics Success Bubble
@@ -344,9 +322,7 @@ private extension SupportChatView {
         static let issueButtonRadius: CGFloat = 8
         static let progressSpacing: CGFloat = 8
         static let resultsSpacing: CGFloat = 12
-        static let resultRowSpacing: CGFloat = 8
         static let resultIconSpacing: CGFloat = 6
-        static let resultIconSize: CGFloat = 24
     }
 }
 
@@ -406,7 +382,7 @@ private extension SupportChatView {
         )
         static let allChecksPassed = NSLocalizedString(
             "supportChatView.allChecksPassed",
-            value: "All checks completed with no issues",
+            value: "All checks completed with no issues.",
             comment: "Message shown when all diagnostic checks pass"
         )
         static let resumedChatHeader = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -104,7 +104,7 @@ struct SupportChatView: View {
     private func issuePickerBubble(issues: [SupportIssueType]) -> some View {
         VStack(alignment: .leading, spacing: Layout.bubbleSpacing) {
             Text(Localization.issuePickerHeader)
-                .font(.subheadline)
+                .font(.body)
                 .foregroundStyle(Color(.secondaryLabel))
 
             ForEach(issues, id: \.self) { issue in
@@ -229,14 +229,8 @@ struct SupportChatView: View {
                     }
                 } label: {
                     Label(action.title, systemImage: action.systemImage)
-                        .font(.body.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                        .padding(Layout.issueButtonPadding)
-                        .background(Color.accentColor)
-                        .foregroundStyle(Color.white)
-                        .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isExecutingAction))
             } else {
                 Button {
                     viewModel.proceedToChat()

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -7,140 +7,27 @@ struct SupportChatView: View {
     @FocusState private var isInputFocused: Bool
 
     var body: some View {
-        Group {
-            switch viewModel.phase {
-            case .issuePicker:
-                issuePickerView
-            case .runningDiagnostics:
-                diagnosticsProgressView
-            case .showingResults:
-                resultsView
-            case .chatting:
-                chatView
-            }
-        }
-        .background(Color(.listBackground))
-        .navigationTitle(Localization.title)
-        .navigationBarTitleDisplayMode(.inline)
-        .alert(
-            Localization.errorTitle,
-            isPresented: .init(
-                get: { viewModel.state != .idle && viewModel.state != .sending },
-                set: { if !$0 { viewModel.dismissError() } }
-            ),
-            actions: {
-                Button(Localization.ok) {
-                    viewModel.dismissError()
-                }
-            },
-            message: {
-                if case .error(let message) = viewModel.state {
-                    Text(message)
-                }
-            }
-        )
-    }
-
-    // MARK: - Issue Picker
-
-    private var issuePickerView: some View {
-        List {
-            Section {
-                ForEach(SupportIssueType.allCases, id: \.self) { issue in
-                    Button {
-                        Task {
-                            await viewModel.selectIssue(issue)
-                        }
-                    } label: {
-                        Text(issue.displayName)
-                            .foregroundStyle(Color(.label))
+        chatView
+            .background(Color(.listBackground))
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .alert(
+                Localization.errorTitle,
+                isPresented: .init(
+                    get: { viewModel.state != .idle && viewModel.state != .sending },
+                    set: { if !$0 { viewModel.dismissError() } }
+                ),
+                actions: {
+                    Button(Localization.ok) {
+                        viewModel.dismissError()
+                    }
+                },
+                message: {
+                    if case .error(let message) = viewModel.state {
+                        Text(message)
                     }
                 }
-            } header: {
-                Text(Localization.issuePickerHeader)
-            }
-        }
-        .listStyle(.insetGrouped)
-    }
-
-    // MARK: - Diagnostics Progress
-
-    private var diagnosticsProgressView: some View {
-        VStack(spacing: Layout.progressSpacing) {
-            ProgressView()
-                .scaleEffect(Layout.progressScale)
-
-            Text(Localization.runningDiagnostics)
-                .font(.headline)
-
-            if let issue = viewModel.selectedIssue {
-                Text(issue.displayName)
-                    .font(.subheadline)
-                    .foregroundStyle(Color(.secondaryLabel))
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    // MARK: - Results View
-
-    private var resultsView: some View {
-        ScrollView {
-            VStack(spacing: Layout.resultsSpacing) {
-                ForEach(viewModel.diagnosticResults, id: \.test) { result in
-                    resultCard(for: result)
-                }
-
-                proceedToChatButton
-            }
-            .padding()
-        }
-    }
-
-    private func resultCard(for result: SupportDiagnosticsService.Result) -> some View {
-        VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-            HStack {
-                Image(systemName: result.isSuccess ? "checkmark.circle.fill" : "xmark.circle.fill")
-                    .foregroundStyle(result.isSuccess ? Color.green : Color.red)
-
-                Text(result.test.title)
-                    .font(.headline)
-
-                Spacer()
-            }
-
-            if !result.isSuccess {
-                if let errorMessage = result.errorMessage {
-                    Text(errorMessage)
-                        .font(.subheadline)
-                        .foregroundStyle(Color(.secondaryLabel))
-                }
-
-                if let action = result.suggestedAction {
-                    Button {
-                        Task {
-                            await viewModel.executeAction(action)
-                        }
-                    } label: {
-                        Label(action.title, systemImage: action.systemImage)
-                    }
-                    .buttonStyle(SecondaryButtonStyle())
-                }
-            }
-        }
-        .padding()
-        .background(Color(.secondarySystemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: Layout.cardCornerRadius))
-    }
-
-    private var proceedToChatButton: some View {
-        Button {
-            viewModel.proceedToChat()
-        } label: {
-            Text(Localization.continueToChat)
-        }
-        .buttonStyle(PrimaryButtonStyle())
-        .padding(.top)
+            )
     }
 
     // MARK: - Chat View
@@ -151,7 +38,7 @@ struct SupportChatView: View {
 
             if viewModel.shouldPromptHumanSupport {
                 humanSupportBanner
-            } else {
+            } else if viewModel.shouldShowInputArea {
                 Divider()
 
                 inputArea
@@ -167,9 +54,9 @@ struct SupportChatView: View {
     private var messageList: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(spacing: SupportChatLayout.messageSpacing) {
+                LazyVStack(alignment: .leading, spacing: SupportChatLayout.messageSpacing) {
                     ForEach(viewModel.messages) { message in
-                        SupportChatMessageRow(message: message)
+                        messageRow(for: message)
                             .id(message.id)
                     }
 
@@ -190,6 +77,185 @@ struct SupportChatView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func messageRow(for message: SupportChatViewModel.ChatMessage) -> some View {
+        switch message.content {
+        case .text(let text):
+            SupportChatMessageRow(role: message.role, text: text)
+
+        case .issuePicker(let issues):
+            issuePickerBubble(issues: issues)
+
+        case .diagnosticsProgress(let steps):
+            diagnosticsProgressBubble(steps: steps)
+
+        case .diagnosticsSuccess:
+            diagnosticsSuccessBubble()
+
+        case .diagnosticsFailure(let result):
+            diagnosticsFailureBubble(result: result)
+        }
+    }
+
+    // MARK: - Issue Picker Bubble
+
+    private func issuePickerBubble(issues: [SupportIssueType]) -> some View {
+        VStack(alignment: .leading, spacing: Layout.bubbleSpacing) {
+            Text(Localization.issuePickerHeader)
+                .font(.subheadline)
+                .foregroundStyle(Color(.secondaryLabel))
+
+            ForEach(issues, id: \.self) { issue in
+                Button {
+                    Task {
+                        await viewModel.selectIssue(issue)
+                    }
+                } label: {
+                    Text(issue.displayName)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(Layout.issueButtonPadding)
+                        .background(Color(.tertiarySystemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
+                }
+                .buttonStyle(.plain)
+                .disabled(viewModel.selectedIssue != nil)
+            }
+        }
+        .padding(SupportChatLayout.bubblePadding)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
+        .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
+    }
+
+    // MARK: - Diagnostics Progress Bubble
+
+    private func diagnosticsProgressBubble(
+        steps: [(test: SupportDiagnosticsService.Test, status: SupportChatViewModel.TestStatus)]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Layout.resultRowSpacing) {
+            ForEach(steps, id: \.test) { step in
+                HStack(alignment: .top, spacing: Layout.resultIconSpacing) {
+                    statusIcon(for: step.status)
+                        .font(.body)
+
+                    Text(step.test.title)
+                        .font(.body)
+                        .foregroundStyle(step.status == .pending ? Color(.tertiaryLabel) : Color(.label))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding(SupportChatLayout.bubblePadding)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
+        .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
+    }
+
+    private func statusIcon(for status: SupportChatViewModel.TestStatus) -> some View {
+        VStack {
+            switch status {
+            case .pending:
+                Image(systemName: "circle")
+                    .foregroundStyle(Color(.tertiaryLabel))
+            case .running:
+                ProgressView()
+                    .controlSize(.small)
+            case .passed:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.green)
+            case .failed:
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(Color.red)
+            }
+        }
+        .frame(width: Layout.resultIconSize)
+    }
+
+    // MARK: - Diagnostics Success Bubble
+
+    private func diagnosticsSuccessBubble() -> some View {
+        VStack(alignment: .leading, spacing: Layout.resultsSpacing) {
+            HStack(alignment: .top, spacing: Layout.resultIconSpacing) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(Color.green)
+
+                Text(Localization.allChecksPassed)
+                    .font(.body)
+            }
+
+            Button {
+                viewModel.proceedToChat()
+            } label: {
+                Text(Localization.continueToChat)
+                    .font(.body.weight(.medium))
+                    .frame(maxWidth: .infinity)
+                    .padding(Layout.issueButtonPadding)
+                    .background(Color.accentColor)
+                    .foregroundStyle(Color.white)
+                    .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(SupportChatLayout.bubblePadding)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
+        .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
+    }
+
+    // MARK: - Diagnostics Failure Bubble
+
+    private func diagnosticsFailureBubble(result: SupportDiagnosticsService.Result) -> some View {
+        VStack(alignment: .leading, spacing: Layout.resultsSpacing) {
+            HStack(alignment: .top, spacing: Layout.resultIconSpacing) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(Color.red)
+
+                Text(result.test.title)
+                    .font(.body.weight(.semibold))
+            }
+
+            if let errorMessage = result.errorMessage {
+                Text(errorMessage)
+                    .font(.body)
+                    .foregroundStyle(Color(.secondaryLabel))
+            }
+
+            if let action = result.suggestedAction {
+                Button {
+                    Task {
+                        await viewModel.executeAction(action)
+                    }
+                } label: {
+                    Label(action.title, systemImage: action.systemImage)
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(Layout.issueButtonPadding)
+                        .background(Color.accentColor)
+                        .foregroundStyle(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
+                }
+                .buttonStyle(.plain)
+            } else {
+                Button {
+                    viewModel.proceedToChat()
+                } label: {
+                    Text(Localization.continueToChat)
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(Layout.issueButtonPadding)
+                        .background(Color(.tertiarySystemBackground))
+                        .foregroundStyle(Color(.label))
+                        .clipShape(RoundedRectangle(cornerRadius: Layout.issueButtonRadius))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(SupportChatLayout.bubblePadding)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: SupportChatLayout.bubbleCornerRadius))
+        .frame(maxWidth: SupportChatLayout.maxBubbleWidth)
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy) {
@@ -262,11 +328,14 @@ struct SupportChatView: View {
 
 private extension SupportChatView {
     enum Layout {
-        static let progressSpacing: CGFloat = 16
-        static let progressScale: CGFloat = 1.5
-        static let resultsSpacing: CGFloat = 16
-        static let cardSpacing: CGFloat = 12
-        static let cardCornerRadius: CGFloat = 12
+        static let bubbleSpacing: CGFloat = 8
+        static let issueButtonPadding: CGFloat = 12
+        static let issueButtonRadius: CGFloat = 8
+        static let progressSpacing: CGFloat = 8
+        static let resultsSpacing: CGFloat = 12
+        static let resultRowSpacing: CGFloat = 8
+        static let resultIconSpacing: CGFloat = 6
+        static let resultIconSize: CGFloat = 24
     }
 }
 
@@ -306,8 +375,8 @@ private extension SupportChatView {
         )
         static let issuePickerHeader = NSLocalizedString(
             "supportChatView.issuePickerHeader",
-            value: "What are you having trouble with?",
-            comment: "Header for the issue picker in support chat"
+            value: "Hello! I'm your Woo Mobile Support Bot. What are you having trouble with today?",
+            comment: "Greeting and header for the issue picker in support chat"
         )
         static let runningDiagnostics = NSLocalizedString(
             "supportChatView.runningDiagnostics",
@@ -318,6 +387,16 @@ private extension SupportChatView {
             "supportChatView.continueToChat",
             value: "Continue to Chat",
             comment: "Button to proceed from diagnostics results to chat"
+        )
+        static let diagnosticsComplete = NSLocalizedString(
+            "supportChatView.diagnosticsComplete",
+            value: "Diagnostics Complete",
+            comment: "Header shown when diagnostics have finished running"
+        )
+        static let allChecksPassed = NSLocalizedString(
+            "supportChatView.allChecksPassed",
+            value: "All checks completed with no issues",
+            comment: "Message shown when all diagnostic checks pass"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -130,6 +130,7 @@ final class SupportChatViewModel {
     }
 
     private(set) var hasProceededToChat: Bool = false
+    private(set) var isExecutingAction: Bool = false
 
     var inputText: String = ""
 
@@ -244,6 +245,9 @@ final class SupportChatViewModel {
     /// Executes a fix action and re-runs the relevant test.
     ///
     func executeAction(_ action: SupportDiagnosticsService.Action) async {
+        isExecutingAction = true
+        defer { isExecutingAction = false }
+
         do {
             switch action {
             case .enableAnalytics:
@@ -272,10 +276,44 @@ final class SupportChatViewModel {
     /// Re-runs a specific test and updates the results.
     ///
     private func rerunTest(_ test: SupportDiagnosticsService.Test) async {
+        // Find the failure message and convert it to progress state
+        guard let messageIndex = messages.lastIndex(where: {
+            if case .diagnosticsFailure = $0.content { return true }
+            return false
+        }) else { return }
+
+        let messageId = messages[messageIndex].id
+
+        // Show progress state with the test running
+        let progressSteps: [(test: SupportDiagnosticsService.Test, status: TestStatus)] = [(test, .running)]
+        messages[messageIndex] = ChatMessage(
+            id: messageId,
+            role: .bot,
+            content: .diagnosticsProgress(progressSteps)
+        )
+
+        // Run the test
         let newResults = await diagnosticsService.runTests([test])
-        if let newResult = newResults.first,
-           let index = diagnosticResults.firstIndex(where: { $0.test == test }) {
+        guard let newResult = newResults.first else { return }
+
+        // Update diagnostic results
+        if let index = diagnosticResults.firstIndex(where: { $0.test == test }) {
             diagnosticResults[index] = newResult
+        }
+
+        // Update message with result
+        if newResult.isSuccess {
+            messages[messageIndex] = ChatMessage(
+                id: messageId,
+                role: .bot,
+                content: .diagnosticsSuccess
+            )
+        } else {
+            messages[messageIndex] = ChatMessage(
+                id: messageId,
+                role: .bot,
+                content: .diagnosticsFailure(newResult)
+            )
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -275,10 +275,40 @@ final class SupportChatViewModel {
                    UIApplication.shared.canOpenURL(selectedURL) {
                     await UIApplication.shared.open(selectedURL)
                 }
+                replaceActionWithRetry(for: .notifications)
+
+            case .retryDiagnostic(let test):
+                await rerunTest(test)
             }
         } catch {
             DDLogError("⛔️ Failed to execute action \(action): \(error)")
         }
+    }
+
+    /// Replaces the current failure action with a retry action for the given test.
+    ///
+    private func replaceActionWithRetry(for test: SupportDiagnosticsService.Test) {
+        guard let messageIndex = messages.lastIndex(where: {
+            if case .diagnosticsFailure = $0.content { return true }
+            return false
+        }),
+              case .diagnosticsFailure(let result) = messages[messageIndex].content else {
+            return
+        }
+
+        let updatedResult = SupportDiagnosticsService.Result(
+            test: result.test,
+            isSuccess: result.isSuccess,
+            errorMessage: result.errorMessage,
+            technicalDetails: result.technicalDetails,
+            suggestedAction: .retryDiagnostic(test)
+        )
+
+        messages[messageIndex] = ChatMessage(
+            id: messages[messageIndex].id,
+            role: .bot,
+            content: .diagnosticsFailure(updatedResult)
+        )
     }
 
     /// Re-runs a specific test and updates the results.

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import UIKit
 import Yosemite
 import enum Networking.SupportChatRole
 import protocol WooFoundation.Analytics
@@ -9,6 +10,22 @@ import protocol WooFoundation.Analytics
 @MainActor
 @Observable
 final class SupportChatViewModel {
+
+    /// Entry point for opening the support chat.
+    ///
+    enum EntryPoint {
+        case helpAndSupport   // Shows issue picker first
+        case connectivityTool // Goes directly to chat (context already provided)
+    }
+
+    /// Current phase of the support chat flow.
+    ///
+    enum Phase: Equatable {
+        case issuePicker
+        case runningDiagnostics
+        case showingResults
+        case chatting
+    }
 
     /// Represents the current state of the chat.
     ///
@@ -47,33 +64,141 @@ final class SupportChatViewModel {
 
     // MARK: - Published State
 
+    private(set) var phase: Phase
+    private(set) var selectedIssue: SupportIssueType?
+    private(set) var diagnosticResults: [SupportDiagnosticsService.Result] = []
     private(set) var messages: [ChatMessage] = []
     private(set) var state: State = .idle
     private(set) var shouldPromptHumanSupport: Bool = false
+
+    /// URL to open when a fix action requires opening settings.
+    ///
+    private(set) var selectedURL: URL?
+
+    /// Set to true when the user needs to start Jetpack setup.
+    ///
+    private(set) var shouldStartJetpackSetup: Bool = false
 
     var inputText: String = ""
 
     // MARK: - Private Properties
 
     private var chatID: Int64?
+    private let entryPoint: EntryPoint
     private let botSlug: String
     private let stores: StoresManager
+    private var diagnosticsContext: [String: Any]?
     private let initialContext: [String: Any]?
     private let onContactHumanSupport: (_ transcript: String) -> Void
+    private let diagnosticsService: SupportDiagnosticsService
 
     // MARK: - Initialization
 
     init(botSlug: String = "woo-workflow-support_mobile_inapp",
+         entryPoint: EntryPoint = .helpAndSupport,
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,
+         diagnosticsService: SupportDiagnosticsService? = nil,
          onContactHumanSupport: @escaping (_ transcript: String) -> Void) {
         self.botSlug = botSlug
+        self.entryPoint = entryPoint
         self.stores = stores
         self.initialContext = initialContext
+        self.diagnosticsService = diagnosticsService ?? SupportDiagnosticsService()
         self.onContactHumanSupport = onContactHumanSupport
+
+        // Set initial phase based on entry point
+        switch entryPoint {
+        case .helpAndSupport:
+            self.phase = .issuePicker
+        case .connectivityTool:
+            self.phase = .chatting
+        }
     }
 
-    // MARK: - Actions
+    // MARK: - Issue Selection & Diagnostics
+
+    /// Selects an issue type and runs diagnostics if needed.
+    ///
+    func selectIssue(_ issue: SupportIssueType) async {
+        selectedIssue = issue
+
+        // "Other" skips diagnostics and goes directly to chat
+        guard issue != .other else {
+            phase = .chatting
+            return
+        }
+
+        phase = .runningDiagnostics
+        diagnosticResults = await diagnosticsService.runTests(for: issue)
+        phase = .showingResults
+    }
+
+    /// Executes a fix action and re-runs the relevant test.
+    ///
+    func executeAction(_ action: SupportDiagnosticsService.Action) async {
+        do {
+            switch action {
+            case .enableAnalytics:
+                try await diagnosticsService.enableAnalytics()
+                await rerunTest(.analyticsSetting)
+
+            case .registerDevice:
+                try await diagnosticsService.registerDevice()
+                await rerunTest(.notifications)
+
+            case .enableOrderNotifications(let settings):
+                try await diagnosticsService.enableOrderNotifications(settings: settings)
+                await rerunTest(.notifications)
+
+            case .setupJetpack:
+                shouldStartJetpackSetup = true
+
+            case .openNotificationSettings:
+                selectedURL = diagnosticsService.openNotificationSettings()
+            }
+        } catch {
+            DDLogError("⛔️ Failed to execute action \(action): \(error)")
+        }
+    }
+
+    /// Re-runs a specific test and updates the results.
+    ///
+    private func rerunTest(_ test: SupportDiagnosticsService.Test) async {
+        let newResults = await diagnosticsService.runTests([test])
+        if let newResult = newResults.first,
+           let index = diagnosticResults.firstIndex(where: { $0.test == test }) {
+            diagnosticResults[index] = newResult
+        }
+    }
+
+    /// Proceeds from results screen to chat, building context from diagnostics.
+    ///
+    func proceedToChat() {
+        // Build context from diagnostic results
+        var context: [String: Any] = initialContext ?? [:]
+
+        if let issue = selectedIssue {
+            context["issue_type"] = String(describing: issue)
+        }
+
+        if let troubleshootingDescription = SupportDiagnosticsService.troubleshootingDescription(from: diagnosticResults) {
+            context["troubleshooting_results"] = troubleshootingDescription
+        }
+
+        if let site = stores.sessionManager.defaultSite {
+            context["site_id"] = site.siteID
+            context["site_url"] = site.url
+        }
+
+        context["app_version"] = Bundle.main.marketingVersion
+        context["ios_version"] = UIDevice.current.systemVersion
+
+        diagnosticsContext = context
+        phase = .chatting
+    }
+
+    // MARK: - Chat Actions
 
     func showGreeting() {
         guard messages.isEmpty else { return }
@@ -97,7 +222,13 @@ final class SupportChatViewModel {
         inputText = ""
         state = .sending
 
-        let context = chatID == nil ? initialContext : nil
+        // Use diagnostics context on first message, then nil for subsequent messages
+        let context: [String: Any]? = {
+            if chatID == nil {
+                return diagnosticsContext ?? initialContext
+            }
+            return nil
+        }()
 
         let action = SupportChatAction.sendMessage(
             botSlug: botSlug,

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -110,9 +110,6 @@ final class SupportChatViewModel {
     private(set) var state: State = .idle
     private(set) var shouldPromptHumanSupport: Bool = false
 
-    /// Set to true when the user needs to start Jetpack setup.
-    ///
-    private(set) var shouldStartJetpackSetup: Bool = false
 
     /// Whether the input area should be shown.
     /// Hidden during issue picker and diagnostics phases.
@@ -145,6 +142,7 @@ final class SupportChatViewModel {
     private var diagnosticsContext: [String: Any]?
     private let initialContext: [String: Any]?
     private let onContactHumanSupport: (_ transcript: String) -> Void
+    var onStartJetpackSetup: () -> Void
     private let diagnosticsService: SupportDiagnosticsService
 
     // MARK: - Initialization
@@ -155,7 +153,8 @@ final class SupportChatViewModel {
          initialContext: [String: Any]? = nil,
          diagnosticsService: SupportDiagnosticsService? = nil,
          chatID: Int64? = nil,
-         onContactHumanSupport: @escaping (_ transcript: String) -> Void) {
+         onContactHumanSupport: @escaping (_ transcript: String) -> Void,
+         onStartJetpackSetup: @escaping () -> Void = {}) {
         self.botSlug = botSlug
         self.entryPoint = entryPoint
         self.stores = stores
@@ -164,6 +163,7 @@ final class SupportChatViewModel {
         self.chatID = chatID
         self.isResumedChat = chatID != nil
         self.onContactHumanSupport = onContactHumanSupport
+        self.onStartJetpackSetup = onStartJetpackSetup
     }
 
     // MARK: - Issue Selection & Diagnostics
@@ -268,26 +268,26 @@ final class SupportChatViewModel {
                 await rerunTest(.notifications)
 
             case .setupJetpack:
-                shouldStartJetpackSetup = true
+                onStartJetpackSetup()
 
             case .openNotificationSettings:
                 if let selectedURL = diagnosticsService.openNotificationSettings(),
                    UIApplication.shared.canOpenURL(selectedURL) {
                     await UIApplication.shared.open(selectedURL)
                 }
-                replaceActionWithRetry(for: .notifications)
+                replaceActionWithRetry()
 
-            case .retryDiagnostic(let test):
-                await rerunTest(test)
+            case .retryDiagnostics:
+                await rerunAllTests()
             }
         } catch {
             DDLogError("⛔️ Failed to execute action \(action): \(error)")
         }
     }
 
-    /// Replaces the current failure action with a retry action for the given test.
+    /// Replaces the current failure action with a retry action.
     ///
-    private func replaceActionWithRetry(for test: SupportDiagnosticsService.Test) {
+    func replaceActionWithRetry() {
         guard let messageIndex = messages.lastIndex(where: {
             if case .diagnosticsFailure = $0.content { return true }
             return false
@@ -301,7 +301,7 @@ final class SupportChatViewModel {
             isSuccess: result.isSuccess,
             errorMessage: result.errorMessage,
             technicalDetails: result.technicalDetails,
-            suggestedAction: .retryDiagnostic(test)
+            suggestedAction: .retryDiagnostics
         )
 
         messages[messageIndex] = ChatMessage(
@@ -351,6 +351,84 @@ final class SupportChatViewModel {
                 id: messageId,
                 role: .bot,
                 content: .diagnosticsFailure(newResult)
+            )
+        }
+    }
+
+    /// Re-runs all tests for the selected issue.
+    ///
+    private func rerunAllTests() async {
+        guard let tests = selectedIssue?.testsToRun else { return }
+
+        // Find the failure message to update
+        guard let messageIndex = messages.lastIndex(where: {
+            if case .diagnosticsFailure = $0.content { return true }
+            return false
+        }) else { return }
+
+        let messageId = messages[messageIndex].id
+
+        // Clear previous results
+        diagnosticResults = []
+
+        // Initialize progress with all tests pending
+        var testStatuses: [(test: SupportDiagnosticsService.Test, status: TestStatus)] = tests.map { ($0, .pending) }
+        messages[messageIndex] = ChatMessage(
+            id: messageId,
+            role: .bot,
+            content: .diagnosticsProgress(testStatuses)
+        )
+
+        // Run each test sequentially, updating progress
+        var failedResult: SupportDiagnosticsService.Result?
+
+        for (index, test) in tests.enumerated() {
+            // Mark current test as running
+            testStatuses[index].status = .running
+            messages[messageIndex] = ChatMessage(
+                id: messageId,
+                role: .bot,
+                content: .diagnosticsProgress(testStatuses)
+            )
+
+            // Run the test
+            let results = await diagnosticsService.runTests([test])
+            guard let result = results.first else { continue }
+
+            diagnosticResults.append(result)
+
+            if result.isSuccess {
+                testStatuses[index].status = .passed
+            } else {
+                testStatuses[index].status = .failed(result.errorMessage)
+                failedResult = result
+                messages[messageIndex] = ChatMessage(
+                    id: messageId,
+                    role: .bot,
+                    content: .diagnosticsProgress(testStatuses)
+                )
+                break
+            }
+
+            messages[messageIndex] = ChatMessage(
+                id: messageId,
+                role: .bot,
+                content: .diagnosticsProgress(testStatuses)
+            )
+        }
+
+        // Replace progress with final result
+        if let failure = failedResult {
+            messages[messageIndex] = ChatMessage(
+                id: messageId,
+                role: .bot,
+                content: .diagnosticsFailure(failure)
+            )
+        } else {
+            messages[messageIndex] = ChatMessage(
+                id: messageId,
+                role: .bot,
+                content: .diagnosticsSuccess
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -16,6 +16,7 @@ final class SupportChatViewModel {
     enum EntryPoint {
         case helpAndSupport   // Shows issue picker first
         case connectivityTool // Goes directly to chat (context already provided)
+        case chatHistory      // Resuming a prior conversation from history
     }
 
     /// Represents the current state of the chat.
@@ -109,10 +110,6 @@ final class SupportChatViewModel {
     private(set) var state: State = .idle
     private(set) var shouldPromptHumanSupport: Bool = false
 
-    /// URL to open when a fix action requires opening settings.
-    ///
-    private(set) var selectedURL: URL?
-
     /// Set to true when the user needs to start Jetpack setup.
     ///
     private(set) var shouldStartJetpackSetup: Bool = false
@@ -122,7 +119,7 @@ final class SupportChatViewModel {
     ///
     var shouldShowInputArea: Bool {
         switch entryPoint {
-        case .connectivityTool:
+        case .connectivityTool, .chatHistory:
             return true
         case .helpAndSupport:
             return hasProceededToChat
@@ -153,7 +150,7 @@ final class SupportChatViewModel {
     // MARK: - Initialization
 
     init(botSlug: String = "woo-workflow-support_mobile_inapp",
-         entryPoint: EntryPoint = .helpAndSupport,
+         entryPoint: EntryPoint,
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,
          diagnosticsService: SupportDiagnosticsService? = nil,
@@ -274,7 +271,10 @@ final class SupportChatViewModel {
                 shouldStartJetpackSetup = true
 
             case .openNotificationSettings:
-                selectedURL = diagnosticsService.openNotificationSettings()
+                if let selectedURL = diagnosticsService.openNotificationSettings(),
+                   UIApplication.shared.canOpenURL(selectedURL) {
+                    await UIApplication.shared.open(selectedURL)
+                }
             }
         } catch {
             DDLogError("⛔️ Failed to execute action \(action): \(error)")
@@ -362,7 +362,6 @@ final class SupportChatViewModel {
 
         // Resumed chats skip the greeting — the merchant is continuing a prior conversation.
         guard chatID == nil else { return }
-        state = .sending
 
         switch entryPoint {
         case .helpAndSupport:
@@ -374,9 +373,14 @@ final class SupportChatViewModel {
             messages.append(pickerMessage)
 
         case .connectivityTool:
+            state = .sending
             // Show standard greeting for connectivity tool entry
             let greetingMessage = ChatMessage(role: .bot, text: Localization.greetingMessage)
             messages.append(greetingMessage)
+
+        case .chatHistory:
+            // Chat history loads via resumeIfNeeded() — no greeting needed
+            break
         }
     }
 
@@ -507,7 +511,7 @@ final class SupportChatViewModel {
         switch result {
         case .success(let response):
             let rehydrated: [ChatMessage] = response.messages.compactMap { message in
-                switch message.role {       
+                switch message.role {
                 case .user:
                     return ChatMessage(role: .user, text: message.content)
                 case .bot:

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -146,7 +146,7 @@ final class SupportChatViewModel {
 
     // MARK: - Initialization
 
-    init(botSlug: String = "woo-workflow-support_mobile_inapp",
+    init(botSlug: String = "woo-workflow-support_mobile_inapp_all_users",
          entryPoint: EntryPoint,
          stores: StoresManager = ServiceLocator.stores,
          initialContext: [String: Any]? = nil,

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -2,7 +2,6 @@ import Foundation
 import Observation
 import UIKit
 import Yosemite
-import enum Networking.SupportChatRole
 import protocol WooFoundation.Analytics
 
 /// View model for the AI support chat interface.

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -18,15 +18,6 @@ final class SupportChatViewModel {
         case connectivityTool // Goes directly to chat (context already provided)
     }
 
-    /// Current phase of the support chat flow.
-    ///
-    enum Phase: Equatable {
-        case issuePicker
-        case runningDiagnostics
-        case showingResults
-        case chatting
-    }
-
     /// Represents the current state of the chat.
     ///
     enum State: Equatable {
@@ -46,25 +37,72 @@ final class SupportChatViewModel {
         }
     }
 
+    /// Progress state for a diagnostic test.
+    ///
+    enum TestStatus: Equatable {
+        case pending
+        case running
+        case passed
+        case failed(String?) // error message
+    }
+
+    /// Content types for chat messages.
+    ///
+    enum MessageContent: Equatable {
+        case text(String)
+        case issuePicker([SupportIssueType])
+        /// Shows step-by-step progress: list of (test, status) pairs
+        case diagnosticsProgress([(test: SupportDiagnosticsService.Test, status: TestStatus)])
+        /// All tests passed - show simple success message
+        case diagnosticsSuccess
+        /// A test failed - show failure with optional action
+        case diagnosticsFailure(SupportDiagnosticsService.Result)
+
+        static func == (lhs: MessageContent, rhs: MessageContent) -> Bool {
+            switch (lhs, rhs) {
+            case (.text(let l), .text(let r)):
+                return l == r
+            case (.issuePicker(let l), .issuePicker(let r)):
+                return l == r
+            case (.diagnosticsProgress(let l), .diagnosticsProgress(let r)):
+                return l.map { $0.test } == r.map { $0.test } &&
+                       l.map { $0.status } == r.map { $0.status }
+            case (.diagnosticsSuccess, .diagnosticsSuccess):
+                return true
+            case (.diagnosticsFailure(let l), .diagnosticsFailure(let r)):
+                return l == r
+            default:
+                return false
+            }
+        }
+    }
+
     /// A message in the chat thread (local UI model).
     ///
     struct ChatMessage: Identifiable, Equatable {
         let id: UUID
         let role: SupportChatRole
-        let content: String
+        let content: MessageContent
         let timestamp: Date
 
-        init(id: UUID = UUID(), role: SupportChatRole, content: String, timestamp: Date = Date()) {
+        init(id: UUID = UUID(), role: SupportChatRole, content: MessageContent, timestamp: Date = Date()) {
             self.id = id
             self.role = role
             self.content = content
+            self.timestamp = timestamp
+        }
+
+        /// Convenience initializer for text messages.
+        init(id: UUID = UUID(), role: SupportChatRole, text: String, timestamp: Date = Date()) {
+            self.id = id
+            self.role = role
+            self.content = .text(text)
             self.timestamp = timestamp
         }
     }
 
     // MARK: - Published State
 
-    private(set) var phase: Phase
     private(set) var selectedIssue: SupportIssueType?
     private(set) var diagnosticResults: [SupportDiagnosticsService.Result] = []
     private(set) var messages: [ChatMessage] = []
@@ -78,6 +116,20 @@ final class SupportChatViewModel {
     /// Set to true when the user needs to start Jetpack setup.
     ///
     private(set) var shouldStartJetpackSetup: Bool = false
+
+    /// Whether the input area should be shown.
+    /// Hidden during issue picker and diagnostics phases.
+    ///
+    var shouldShowInputArea: Bool {
+        switch entryPoint {
+        case .connectivityTool:
+            return true
+        case .helpAndSupport:
+            return hasProceededToChat
+        }
+    }
+
+    private(set) var hasProceededToChat: Bool = false
 
     var inputText: String = ""
 
@@ -106,14 +158,6 @@ final class SupportChatViewModel {
         self.initialContext = initialContext
         self.diagnosticsService = diagnosticsService ?? SupportDiagnosticsService()
         self.onContactHumanSupport = onContactHumanSupport
-
-        // Set initial phase based on entry point
-        switch entryPoint {
-        case .helpAndSupport:
-            self.phase = .issuePicker
-        case .connectivityTool:
-            self.phase = .chatting
-        }
     }
 
     // MARK: - Issue Selection & Diagnostics
@@ -123,15 +167,78 @@ final class SupportChatViewModel {
     func selectIssue(_ issue: SupportIssueType) async {
         selectedIssue = issue
 
-        // "Other" skips diagnostics and goes directly to chat
-        guard issue != .other else {
-            phase = .chatting
+        // Add user's selection as a message
+        let userMessage = ChatMessage(role: .user, text: issue.displayName)
+        messages.append(userMessage)
+
+        // "Other" skips diagnostics and shows greeting
+        guard issue != .other, let tests = issue.testsToRun else {
+            let greetingMessage = ChatMessage(role: .bot, text: Localization.greetingMessage)
+            messages.append(greetingMessage)
+            hasProceededToChat = true
             return
         }
 
-        phase = .runningDiagnostics
-        diagnosticResults = await diagnosticsService.runTests(for: issue)
-        phase = .showingResults
+        // Initialize progress with all tests pending
+        var testStatuses: [(test: SupportDiagnosticsService.Test, status: TestStatus)] = tests.map { ($0, .pending) }
+        let progressMessage = ChatMessage(role: .bot, content: .diagnosticsProgress(testStatuses))
+        messages.append(progressMessage)
+        let progressIndex = messages.count - 1
+
+        // Run each test sequentially, updating progress
+        var failedResult: SupportDiagnosticsService.Result?
+
+        for (index, test) in tests.enumerated() {
+            // Mark current test as running
+            testStatuses[index].status = .running
+            messages[progressIndex] = ChatMessage(
+                id: messages[progressIndex].id,
+                role: .bot,
+                content: .diagnosticsProgress(testStatuses)
+            )
+
+            // Run the test
+            let results = await diagnosticsService.runTests([test])
+            guard let result = results.first else { continue }
+
+            diagnosticResults.append(result)
+
+            if result.isSuccess {
+                testStatuses[index].status = .passed
+            } else {
+                testStatuses[index].status = .failed(result.errorMessage)
+                failedResult = result
+                // Update progress to show failure
+                messages[progressIndex] = ChatMessage(
+                    id: messages[progressIndex].id,
+                    role: .bot,
+                    content: .diagnosticsProgress(testStatuses)
+                )
+                break
+            }
+
+            // Update progress
+            messages[progressIndex] = ChatMessage(
+                id: messages[progressIndex].id,
+                role: .bot,
+                content: .diagnosticsProgress(testStatuses)
+            )
+        }
+
+        // Replace progress with final result
+        if let failure = failedResult {
+            messages[progressIndex] = ChatMessage(
+                id: messages[progressIndex].id,
+                role: .bot,
+                content: .diagnosticsFailure(failure)
+            )
+        } else {
+            messages[progressIndex] = ChatMessage(
+                id: messages[progressIndex].id,
+                role: .bot,
+                content: .diagnosticsSuccess
+            )
+        }
     }
 
     /// Executes a fix action and re-runs the relevant test.
@@ -172,7 +279,7 @@ final class SupportChatViewModel {
         }
     }
 
-    /// Proceeds from results screen to chat, building context from diagnostics.
+    /// Proceeds from diagnostics results to chat, building context from diagnostics.
     ///
     func proceedToChat() {
         // Build context from diagnostic results
@@ -195,20 +302,31 @@ final class SupportChatViewModel {
         context["ios_version"] = UIDevice.current.systemVersion
 
         diagnosticsContext = context
-        phase = .chatting
+
+        // Add greeting message to continue chat
+        let greetingMessage = ChatMessage(role: .bot, text: Localization.postDiagnosticsGreeting)
+        messages.append(greetingMessage)
+        hasProceededToChat = true
     }
 
     // MARK: - Chat Actions
 
     func showGreeting() {
         guard messages.isEmpty else { return }
-        state = .sending
 
-        Task {
-            try? await Task.sleep(for: .seconds(1))
-            let greetingMessage = ChatMessage(role: .bot, content: Localization.greetingMessage)
+        switch entryPoint {
+        case .helpAndSupport:
+            // Show issue picker as first message
+            let pickerMessage = ChatMessage(
+                role: .bot,
+                content: .issuePicker(SupportIssueType.allCases)
+            )
+            messages.append(pickerMessage)
+
+        case .connectivityTool:
+            // Show standard greeting for connectivity tool entry
+            let greetingMessage = ChatMessage(role: .bot, text: Localization.greetingMessage)
             messages.append(greetingMessage)
-            state = .idle
         }
     }
 
@@ -217,7 +335,7 @@ final class SupportChatViewModel {
         guard !trimmedText.isEmpty else { return }
         guard state != .sending else { return }
 
-        let userMessage = ChatMessage(role: .user, content: trimmedText)
+        let userMessage = ChatMessage(role: .user, text: trimmedText)
         messages.append(userMessage)
         inputText = ""
         state = .sending
@@ -251,7 +369,7 @@ final class SupportChatViewModel {
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
 
-        return messages.map { message in
+        return messages.compactMap { message -> String? in
             let roleName: String
             switch message.role {
             case .user: roleName = "User"
@@ -259,7 +377,23 @@ final class SupportChatViewModel {
             case .unknown: roleName = "Unknown"
             }
             let timestamp = dateFormatter.string(from: message.timestamp)
-            return "[\(timestamp)] \(roleName): \(message.content)"
+
+            let contentText: String
+            switch message.content {
+            case .text(let text):
+                contentText = text
+            case .issuePicker:
+                contentText = "[Issue picker shown]"
+            case .diagnosticsProgress(let steps):
+                let summary = steps.map { "\($0.test.title): \($0.status)" }.joined(separator: ", ")
+                contentText = "[Running diagnostics: \(summary)]"
+            case .diagnosticsSuccess:
+                contentText = "[All diagnostics passed]"
+            case .diagnosticsFailure(let result):
+                contentText = "[Diagnostics failed: \(result.test.title) - \(result.errorMessage ?? "Unknown error")]"
+            }
+
+            return "[\(timestamp)] \(roleName): \(contentText)"
         }.joined(separator: "\n\n")
     }
 
@@ -277,7 +411,7 @@ final class SupportChatViewModel {
             if let lastBotMessage = response.messages.last(where: { $0.role == .bot }) {
                 let assistantMessage = ChatMessage(
                     role: .bot,
-                    content: lastBotMessage.content
+                    text: lastBotMessage.content
                 )
                 messages.append(assistantMessage)
 
@@ -303,6 +437,11 @@ private extension SupportChatViewModel {
             "supportChatViewModel.greetingMessage",
             value: "Hello! I'm your Woo Mobile Support Bot. Is there anything I can help you with today?",
             comment: "Initial greeting message from the AI support bot"
+        )
+        static let postDiagnosticsGreeting = NSLocalizedString(
+            "supportChatViewModel.postDiagnosticsGreeting",
+            value: "Please describe your issue in more detail so I can help.",
+            comment: "Message prompting user to describe their issue after diagnostics"
         )
         static let errorMessage = NSLocalizedString(
             "supportChatViewModel.errorMessage",

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -120,12 +120,19 @@ final class SupportDiagnosticsService {
 
     /// Result of a diagnostic test.
     ///
-    struct Result {
+    struct Result: Equatable {
         let test: Test
         let isSuccess: Bool
         let errorMessage: String?
         let technicalDetails: String?
         let suggestedAction: Action?
+
+        static func == (lhs: Result, rhs: Result) -> Bool {
+            lhs.test == rhs.test &&
+            lhs.isSuccess == rhs.isSuccess &&
+            lhs.errorMessage == rhs.errorMessage &&
+            lhs.suggestedAction == rhs.suggestedAction
+        }
 
         static func success(test: Test) -> Result {
             Result(test: test, isSuccess: true, errorMessage: nil, technicalDetails: nil, suggestedAction: nil)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -62,19 +62,18 @@ final class SupportDiagnosticsService {
         case enableOrderNotifications(settings: NotificationSettings)
         case setupJetpack
         case openNotificationSettings
-        case retryDiagnostic(Test)
+        case retryDiagnostics
 
         static func == (lhs: Action, rhs: Action) -> Bool {
             switch (lhs, rhs) {
             case (.enableAnalytics, .enableAnalytics),
                  (.registerDevice, .registerDevice),
                  (.setupJetpack, .setupJetpack),
-                 (.openNotificationSettings, .openNotificationSettings):
+                 (.openNotificationSettings, .openNotificationSettings),
+                 (.retryDiagnostics, .retryDiagnostics):
                 return true
             case (.enableOrderNotifications, .enableOrderNotifications):
                 return true
-            case (.retryDiagnostic(let lhsTest), .retryDiagnostic(let rhsTest)):
-                return lhsTest == rhsTest
             default:
                 return false
             }
@@ -92,8 +91,8 @@ final class SupportDiagnosticsService {
                 return Localization.Action.setupJetpack
             case .openNotificationSettings:
                 return Localization.Action.openSettings
-            case .retryDiagnostic:
-                return Localization.Action.retryDiagnostic
+            case .retryDiagnostics:
+                return Localization.Action.retryDiagnostics
             }
         }
 
@@ -105,7 +104,7 @@ final class SupportDiagnosticsService {
                 return "bolt.fill"
             case .openNotificationSettings:
                 return "gear"
-            case .retryDiagnostic:
+            case .retryDiagnostics:
                 return "arrow.clockwise"
             }
         }
@@ -631,10 +630,10 @@ private extension SupportDiagnosticsService {
                 value: "Open Settings",
                 comment: "Action button to open device notification settings"
             )
-            static let retryDiagnostic = NSLocalizedString(
-                "supportDiagnosticsService.action.retryDiagnostic",
+            static let retryDiagnostics = NSLocalizedString(
+                "supportDiagnosticsService.action.retryDiagnostics",
                 value: "Retry",
-                comment: "Action button to retry a diagnostic test"
+                comment: "Action button to retry diagnostic tests"
             )
         }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -62,6 +62,7 @@ final class SupportDiagnosticsService {
         case enableOrderNotifications(settings: NotificationSettings)
         case setupJetpack
         case openNotificationSettings
+        case retryDiagnostic(Test)
 
         static func == (lhs: Action, rhs: Action) -> Bool {
             switch (lhs, rhs) {
@@ -72,6 +73,8 @@ final class SupportDiagnosticsService {
                 return true
             case (.enableOrderNotifications, .enableOrderNotifications):
                 return true
+            case (.retryDiagnostic(let lhsTest), .retryDiagnostic(let rhsTest)):
+                return lhsTest == rhsTest
             default:
                 return false
             }
@@ -89,6 +92,8 @@ final class SupportDiagnosticsService {
                 return Localization.Action.setupJetpack
             case .openNotificationSettings:
                 return Localization.Action.openSettings
+            case .retryDiagnostic:
+                return Localization.Action.retryDiagnostic
             }
         }
 
@@ -100,6 +105,8 @@ final class SupportDiagnosticsService {
                 return "bolt.fill"
             case .openNotificationSettings:
                 return "gear"
+            case .retryDiagnostic:
+                return "arrow.clockwise"
             }
         }
     }
@@ -623,6 +630,11 @@ private extension SupportDiagnosticsService {
                 "supportDiagnosticsService.action.openSettings",
                 value: "Open Settings",
                 comment: "Action button to open device notification settings"
+            )
+            static let retryDiagnostic = NSLocalizedString(
+                "supportDiagnosticsService.action.retryDiagnostic",
+                value: "Retry",
+                comment: "Action button to retry a diagnostic test"
             )
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -6,64 +6,98 @@ import Yosemite
 @MainActor
 struct SupportChatViewModelTests {
 
-    // MARK: - Initial Phase Tests
+    // MARK: - Greeting Tests
 
-    @Test func test_init_when_entryPoint_is_helpAndSupport_then_phase_is_issuePicker() {
-        // Given / When
+    @Test func test_showGreeting_when_entryPoint_is_helpAndSupport_then_shows_issue_picker() {
+        // Given
         let sut = makeSUT(entryPoint: .helpAndSupport)
 
+        // When
+        sut.showGreeting()
+
         // Then
-        #expect(sut.phase == .issuePicker)
+        #expect(sut.messages.count == 1)
+        if case .issuePicker = sut.messages.first?.content {
+            // Success
+        } else {
+            Issue.record("Expected issue picker message")
+        }
     }
 
-    @Test func test_init_when_entryPoint_is_connectivityTool_then_phase_is_chatting() {
-        // Given / When
+    @Test func test_showGreeting_when_entryPoint_is_connectivityTool_then_shows_text_greeting() {
+        // Given
         let sut = makeSUT(entryPoint: .connectivityTool)
 
+        // When
+        sut.showGreeting()
+
         // Then
-        #expect(sut.phase == .chatting)
+        #expect(sut.messages.count == 1)
+        if case .text = sut.messages.first?.content {
+            // Success
+        } else {
+            Issue.record("Expected text greeting message")
+        }
     }
 
     // MARK: - Issue Selection Tests
 
-    @Test func test_selectIssue_when_other_then_skips_diagnostics_and_goes_to_chatting() async {
+    @Test func test_selectIssue_when_other_then_skips_diagnostics_and_shows_greeting() async {
         // Given
         let sut = makeSUT()
+        sut.showGreeting()
 
         // When
         await sut.selectIssue(.other)
 
         // Then
-        #expect(sut.phase == .chatting)
         #expect(sut.selectedIssue == .other)
         #expect(sut.diagnosticResults.isEmpty)
+        // Should have: issue picker, user selection, greeting
+        #expect(sut.messages.count == 3)
     }
 
-    @Test func test_selectIssue_when_specific_issue_then_runs_diagnostics_and_shows_results() async {
+    @Test func test_selectIssue_when_specific_issue_then_runs_diagnostics_and_shows_final_result() async {
         // Given
         let sut = makeSUT()
+        sut.showGreeting()
 
         // When
         await sut.selectIssue(.loadingAnalytics)
 
         // Then
-        #expect(sut.phase == .showingResults)
         #expect(sut.selectedIssue == .loadingAnalytics)
         #expect(sut.diagnosticResults.isEmpty == false)
+        // Should have: issue picker, user selection, final result (success or failure)
+        #expect(sut.messages.count == 3)
+        let lastContent = sut.messages.last?.content
+        let isValidFinalState = {
+            if case .diagnosticsSuccess = lastContent { return true }
+            if case .diagnosticsFailure = lastContent { return true }
+            return false
+        }()
+        #expect(isValidFinalState, "Expected diagnosticsSuccess or diagnosticsFailure message")
     }
 
     // MARK: - Proceed to Chat Tests
 
-    @Test func test_proceedToChat_transitions_to_chatting_phase() async {
+    @Test func test_proceedToChat_appends_greeting_message() async {
         // Given
         let sut = makeSUT()
+        sut.showGreeting()
         await sut.selectIssue(.loadingOrders)
+        let messageCountBeforeProceed = sut.messages.count
 
         // When
         sut.proceedToChat()
 
         // Then
-        #expect(sut.phase == .chatting)
+        #expect(sut.messages.count == messageCountBeforeProceed + 1)
+        if case .text = sut.messages.last?.content {
+            // Success
+        } else {
+            Issue.record("Expected text greeting after proceeding to chat")
+        }
     }
 
     // MARK: - Execute Action Tests

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import Foundation
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+struct SupportChatViewModelTests {
+
+    // MARK: - Initial Phase Tests
+
+    @Test func test_init_when_entryPoint_is_helpAndSupport_then_phase_is_issuePicker() {
+        // Given / When
+        let sut = makeSUT(entryPoint: .helpAndSupport)
+
+        // Then
+        #expect(sut.phase == .issuePicker)
+    }
+
+    @Test func test_init_when_entryPoint_is_connectivityTool_then_phase_is_chatting() {
+        // Given / When
+        let sut = makeSUT(entryPoint: .connectivityTool)
+
+        // Then
+        #expect(sut.phase == .chatting)
+    }
+
+    // MARK: - Issue Selection Tests
+
+    @Test func test_selectIssue_when_other_then_skips_diagnostics_and_goes_to_chatting() async {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        await sut.selectIssue(.other)
+
+        // Then
+        #expect(sut.phase == .chatting)
+        #expect(sut.selectedIssue == .other)
+        #expect(sut.diagnosticResults.isEmpty)
+    }
+
+    @Test func test_selectIssue_when_specific_issue_then_runs_diagnostics_and_shows_results() async {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        await sut.selectIssue(.loadingAnalytics)
+
+        // Then
+        #expect(sut.phase == .showingResults)
+        #expect(sut.selectedIssue == .loadingAnalytics)
+        #expect(sut.diagnosticResults.isEmpty == false)
+    }
+
+    // MARK: - Proceed to Chat Tests
+
+    @Test func test_proceedToChat_transitions_to_chatting_phase() async {
+        // Given
+        let sut = makeSUT()
+        await sut.selectIssue(.loadingOrders)
+
+        // When
+        sut.proceedToChat()
+
+        // Then
+        #expect(sut.phase == .chatting)
+    }
+
+    // MARK: - Execute Action Tests
+
+    @Test func test_executeAction_enableAnalytics_calls_service() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveAnalyticsSetting(_, onCompletion):
+                onCompletion(.success(false))
+            case let .enableAnalyticsSetting(_, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let diagnosticsService = SupportDiagnosticsService(stores: stores)
+        let sut = makeSUT(stores: stores, diagnosticsService: diagnosticsService)
+
+        // Run analytics test to get the failure result
+        await sut.selectIssue(.loadingAnalytics)
+
+        // When
+        await sut.executeAction(.enableAnalytics)
+
+        // Then - action executed without error (test would fail if service threw)
+    }
+
+    @Test func test_executeAction_openNotificationSettings_sets_selectedURL() async {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        await sut.executeAction(.openNotificationSettings)
+
+        // Then
+        #expect(sut.selectedURL != nil)
+    }
+
+    @Test func test_executeAction_setupJetpack_sets_shouldStartJetpackSetup() async {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        await sut.executeAction(.setupJetpack)
+
+        // Then
+        #expect(sut.shouldStartJetpackSetup == true)
+    }
+
+    // MARK: - Test Helpers
+
+    private func makeSUT(
+        entryPoint: SupportChatViewModel.EntryPoint = .helpAndSupport,
+        stores: StoresManager? = nil,
+        diagnosticsService: SupportDiagnosticsService? = nil
+    ) -> SupportChatViewModel {
+        let stores = stores ?? MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        return SupportChatViewModel(
+            entryPoint: entryPoint,
+            stores: stores,
+            diagnosticsService: diagnosticsService,
+            onContactHumanSupport: { _ in }
+        )
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -102,28 +102,6 @@ struct SupportChatViewModelTests {
         #expect(sut.hasProceededToChat == true)
     }
 
-    @Test func test_selectIssue_when_specific_issue_then_runs_diagnostics_and_shows_final_result() async {
-        // Given
-        let sut = makeSUT()
-        sut.showGreeting()
-
-        // When
-        await sut.selectIssue(.loadingAnalytics)
-
-        // Then
-        #expect(sut.selectedIssue == .loadingAnalytics)
-        #expect(sut.diagnosticResults.isEmpty == false)
-        // Should have: issue picker, user selection, final result (success or failure)
-        #expect(sut.messages.count == 3)
-        let lastContent = sut.messages.last?.content
-        let isValidFinalState = {
-            if case .diagnosticsSuccess = lastContent { return true }
-            if case .diagnosticsFailure = lastContent { return true }
-            return false
-        }()
-        #expect(isValidFinalState, "Expected diagnosticsSuccess or diagnosticsFailure message")
-    }
-
     // MARK: - Proceed to Chat Tests
 
     @Test func test_proceedToChat_appends_greeting_message() async {
@@ -203,7 +181,7 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
-    @Test func test_executeAction_openNotificationSettings_sets_selectedURL() async {
+    @Test func test_executeAction_openNotificationSettings_completes_without_error() async {
         // Given
         let sut = makeSUT()
 
@@ -211,19 +189,19 @@ struct SupportChatViewModelTests {
         await sut.executeAction(.openNotificationSettings)
 
         // Then
-        #expect(sut.selectedURL != nil)
         #expect(sut.isExecutingAction == false)
     }
 
-    @Test func test_executeAction_setupJetpack_sets_shouldStartJetpackSetup() async {
+    @Test func test_executeAction_setupJetpack_calls_onStartJetpackSetup() async {
         // Given
-        let sut = makeSUT()
+        var callbackCalled = false
+        let sut = makeSUT(onStartJetpackSetup: { callbackCalled = true })
 
         // When
         await sut.executeAction(.setupJetpack)
 
         // Then
-        #expect(sut.shouldStartJetpackSetup == true)
+        #expect(callbackCalled == true)
         #expect(sut.isExecutingAction == false)
     }
 
@@ -232,14 +210,17 @@ struct SupportChatViewModelTests {
     private func makeSUT(
         entryPoint: SupportChatViewModel.EntryPoint = .helpAndSupport,
         stores: StoresManager? = nil,
-        diagnosticsService: SupportDiagnosticsService? = nil
+        diagnosticsService: SupportDiagnosticsService? = nil,
+        onStartJetpackSetup: @escaping () -> Void = {}
     ) -> SupportChatViewModel {
         let stores = stores ?? MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        return SupportChatViewModel(
+        let viewModel = SupportChatViewModel(
             entryPoint: entryPoint,
             stores: stores,
             diagnosticsService: diagnosticsService,
             onContactHumanSupport: { _ in }
         )
+        viewModel.onStartJetpackSetup = onStartJetpackSetup
+        return viewModel
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -40,6 +40,50 @@ struct SupportChatViewModelTests {
         }
     }
 
+    // MARK: - Input Area Visibility Tests
+
+    @Test func test_shouldShowInputArea_when_entryPoint_is_connectivityTool_then_returns_true() {
+        // Given
+        let sut = makeSUT(entryPoint: .connectivityTool)
+
+        // Then
+        #expect(sut.shouldShowInputArea == true)
+    }
+
+    @Test func test_shouldShowInputArea_when_entryPoint_is_helpAndSupport_and_not_proceeded_then_returns_false() {
+        // Given
+        let sut = makeSUT(entryPoint: .helpAndSupport)
+        sut.showGreeting()
+
+        // Then
+        #expect(sut.shouldShowInputArea == false)
+    }
+
+    @Test func test_shouldShowInputArea_when_proceeded_to_chat_then_returns_true() async {
+        // Given
+        let sut = makeSUT(entryPoint: .helpAndSupport)
+        sut.showGreeting()
+        await sut.selectIssue(.loadingOrders)
+
+        // When
+        sut.proceedToChat()
+
+        // Then
+        #expect(sut.shouldShowInputArea == true)
+    }
+
+    @Test func test_shouldShowInputArea_when_other_selected_then_returns_true() async {
+        // Given
+        let sut = makeSUT(entryPoint: .helpAndSupport)
+        sut.showGreeting()
+
+        // When
+        await sut.selectIssue(.other)
+
+        // Then
+        #expect(sut.shouldShowInputArea == true)
+    }
+
     // MARK: - Issue Selection Tests
 
     @Test func test_selectIssue_when_other_then_skips_diagnostics_and_shows_greeting() async {
@@ -55,6 +99,7 @@ struct SupportChatViewModelTests {
         #expect(sut.diagnosticResults.isEmpty)
         // Should have: issue picker, user selection, greeting
         #expect(sut.messages.count == 3)
+        #expect(sut.hasProceededToChat == true)
     }
 
     @Test func test_selectIssue_when_specific_issue_then_runs_diagnostics_and_shows_final_result() async {
@@ -100,16 +145,33 @@ struct SupportChatViewModelTests {
         }
     }
 
+    @Test func test_proceedToChat_sets_hasProceededToChat() async {
+        // Given
+        let sut = makeSUT()
+        sut.showGreeting()
+        await sut.selectIssue(.loadingOrders)
+        #expect(sut.hasProceededToChat == false)
+
+        // When
+        sut.proceedToChat()
+
+        // Then
+        #expect(sut.hasProceededToChat == true)
+    }
+
     // MARK: - Execute Action Tests
 
-    @Test func test_executeAction_enableAnalytics_calls_service() async {
+    @Test func test_executeAction_enableAnalytics_calls_service_and_reruns_test() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        var enableAnalyticsCalled = false
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             switch action {
             case let .retrieveAnalyticsSetting(_, onCompletion):
-                onCompletion(.success(false))
+                // Return false first (disabled), then true after enabling
+                onCompletion(.success(enableAnalyticsCalled))
             case let .enableAnalyticsSetting(_, onCompletion):
+                enableAnalyticsCalled = true
                 onCompletion(.success(()))
             default:
                 break
@@ -117,14 +179,28 @@ struct SupportChatViewModelTests {
         }
         let diagnosticsService = SupportDiagnosticsService(stores: stores)
         let sut = makeSUT(stores: stores, diagnosticsService: diagnosticsService)
+        sut.showGreeting()
 
         // Run analytics test to get the failure result
         await sut.selectIssue(.loadingAnalytics)
 
+        // Verify we have a failure message
+        let hasFailureMessage = sut.messages.contains {
+            if case .diagnosticsFailure = $0.content { return true }
+            return false
+        }
+        #expect(hasFailureMessage, "Expected diagnostics failure message before executing action")
+
         // When
         await sut.executeAction(.enableAnalytics)
 
-        // Then - action executed without error (test would fail if service threw)
+        // Then - should have success message after rerun
+        let hasSuccessMessage = sut.messages.contains {
+            if case .diagnosticsSuccess = $0.content { return true }
+            return false
+        }
+        #expect(hasSuccessMessage, "Expected diagnostics success message after executing action")
+        #expect(sut.isExecutingAction == false)
     }
 
     @Test func test_executeAction_openNotificationSettings_sets_selectedURL() async {
@@ -136,6 +212,7 @@ struct SupportChatViewModelTests {
 
         // Then
         #expect(sut.selectedURL != nil)
+        #expect(sut.isExecutingAction == false)
     }
 
     @Test func test_executeAction_setupJetpack_sets_shouldStartJetpackSetup() async {
@@ -147,6 +224,7 @@ struct SupportChatViewModelTests {
 
         // Then
         #expect(sut.shouldStartJetpackSetup == true)
+        #expect(sut.isExecutingAction == false)
     }
 
     // MARK: - Test Helpers


### PR DESCRIPTION
Closes WOOMOB-2934

## Summary
- Adds issue picker as the entry point when opening support chat from Help & Support
- Users select from: Loading orders, Loading products, Loading analytics, Receiving notifications, or Other
- For specific issues, runs targeted diagnostics with step-by-step progress indicators
- Shows diagnostic results with suggested fix actions (e.g., "Enable Analytics")
- Fix actions show loading state and re-run the relevant test after completion
- "Other" skips diagnostics and goes directly to chat
- Connectivity Tool entry point bypasses issue picker and shows greeting directly

## Test steps
- [x] Navigate to Settings > Help > Chat with Support
- [x] Verify issue picker appears with 5 options
- [x] Select "Loading orders" - verify 4 diagnostic tests run with progress indicators
- [x] If a test fails, verify fix action button appears with loading state when tapped for cases where actionable suggestions are available (e.g. disabled analytics module, disabled push notifications, no Jetpack plugin when checking push notifications etc.)
- [x] Tap "Continue to Chat" - verify chat input appears and diagnostics remain visible
- [x] Start new chat, select "Other" - verify it skips diagnostics and shows greeting
- [x] Open chat from Connectivity Tool - verify no issue picker, goes directly to chat

## Screenshot

https://github.com/user-attachments/assets/db2cb369-fcc8-4f7a-8144-fbff1714402e

