### PR TITLE
Woo Mobile AI: Add Jetpack AI chat client and JWT cache

### DIFF
--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
@@ -1,10 +1,7 @@
-/// Pinned model + prompt + tool catalog versions plus the upstream feature name.
-/// Treat as a release tuple: changing any of the four is a behavior change worth a smoke run.
+// Pinned release tuple: changing any field is a behavior change worth a smoke run.
 public enum AssistantConfiguration {
     public static let chatModel = "gpt-4o-mini"
     public static let promptVersion = "v1"
     public static let toolCatalogVersion = "v1"
-    /// `feature` parameter the WPCOM jetpack-ai-query proxy stamps on every upstream call;
-    /// also the analytics correlation key the eventual telemetry pipeline keys on.
     public static let featureName = "woo-ai-assistant"
 }

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
@@ -1,4 +1,5 @@
-// Pinned release tuple: changing any field is a behavior change worth a smoke run.
+// Pinned release identity. Changing chatModel, promptVersion, or toolCatalogVersion
+// is a behavior change worth a smoke run; featureName is the proxy routing slug.
 public enum AssistantConfiguration {
     public static let chatModel = "gpt-4o-mini"
     public static let promptVersion = "v1"

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
@@ -1,7 +1,10 @@
-/// Pinned model + prompt + tool catalog versions. Treat as a release tuple:
-/// changing any of the three is a behavior change worth a smoke run.
+/// Pinned model + prompt + tool catalog versions plus the upstream feature name.
+/// Treat as a release tuple: changing any of the four is a behavior change worth a smoke run.
 public enum AssistantConfiguration {
     public static let chatModel = "gpt-4o-mini"
     public static let promptVersion = "v1"
     public static let toolCatalogVersion = "v1"
+    /// `feature` parameter the WPCOM jetpack-ai-query proxy stamps on every upstream call;
+    /// also the analytics correlation key the eventual telemetry pipeline keys on.
+    public static let featureName = "woo-ai-assistant"
 }

--- a/Modules/Sources/WooAIAssistant/Networking/CachedJWT+Localization.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/CachedJWT+Localization.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension CachedJWT {
+    enum Localization {
+        static let invalidJWT = NSLocalizedString(
+            "ai.assistant.networking.jwt.invalid",
+            value: "The assistant authentication token is invalid.",
+            comment: "Shown when the JWT minted by the proxy is malformed or missing required fields. Diagnostic detail is logged via DDLogError."
+        )
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient+Localization.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient+Localization.swift
@@ -12,5 +12,10 @@ extension JetpackAIQueryClient {
             value: "The assistant returned an error (HTTP %1$d).",
             comment: "Fallback shown when the chat transport hits a non-2xx status without a structured error envelope. %1$d is the HTTP status code."
         )
+        static let invalidStreamPayload = NSLocalizedString(
+            "ai.assistant.networking.invalid_stream_payload",
+            value: "The assistant returned an unexpected stream payload.",
+            comment: "Surfaced when an SSE data frame fails to decode as a chat chunk or known error envelope."
+        )
     }
 }

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient+Localization.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient+Localization.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension JetpackAIQueryClient {
+    enum Localization {
+        static let nonHTTPResponse = NSLocalizedString(
+            "ai.assistant.networking.non_http_response",
+            value: "The assistant returned an unexpected response.",
+            comment: "Surfaced when the chat transport receives a non-HTTP URLResponse from the WPCOM proxy."
+        )
+        static let httpFailureFallback = NSLocalizedString(
+            "ai.assistant.networking.http_failure",
+            value: "The assistant returned an error (HTTP %1$d).",
+            comment: "Fallback shown when the chat transport hits a non-2xx status without a structured error envelope. %1$d is the HTTP status code."
+        )
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -48,7 +48,13 @@ struct JetpackAIQueryClient: AIChatService {
 
     private static func urlSessionStreamingTransport(_ session: URLSession) -> StreamingHTTPTransport {
         return { request in
-            let (bytes, response) = try await session.bytes(for: request)
+            let bytes: URLSession.AsyncBytes
+            let response: URLResponse
+            do {
+                (bytes, response) = try await session.bytes(for: request)
+            } catch let urlError as URLError {
+                throw Self.mapURLError(urlError)
+            }
             guard let http = response as? HTTPURLResponse else {
                 throw AssistantError(kind: .network, message: Localization.nonHTTPResponse)
             }
@@ -70,6 +76,8 @@ struct JetpackAIQueryClient: AIChatService {
                             continuation.yield(buffer)
                         }
                         continuation.finish()
+                    } catch let urlError as URLError {
+                        continuation.finish(throwing: Self.mapURLError(urlError))
                     } catch {
                         continuation.finish(throwing: error)
                     }
@@ -81,6 +89,23 @@ struct JetpackAIQueryClient: AIChatService {
             }
             return (stream, http)
         }
+    }
+
+    static func mapURLError(_ error: URLError) -> AssistantError {
+        let kind: AssistantErrorKind
+        switch error.code {
+        case .timedOut:
+            kind = .timeout
+        case .cancelled:
+            kind = .cancelled
+        default:
+            // Catch-all to .network mirrors Android's IOException -> NETWORK mapping; the orchestrator
+            // would otherwise collapse these to .unknown via the AssistantError-typed catch only.
+            kind = .network
+        }
+        return AssistantError(kind: kind,
+                              code: String(error.code.rawValue),
+                              message: error.localizedDescription)
     }
 
     func streamTurn(messages: [OpenAIChat.Message],

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -35,7 +35,7 @@ struct JetpackAIQueryClient: AIChatService {
         return { request in
             let (bytes, response) = try await session.bytes(for: request)
             guard let http = response as? HTTPURLResponse else {
-                throw AssistantError(kind: .network, message: "Non-HTTP response.")
+                throw AssistantError(kind: .network, message: Localization.nonHTTPResponse)
             }
             // Cancelling only the wrapping Swift Task leaves the URL loader holding the
             // socket; an idle SSE connection never produces a cancellation through the
@@ -178,7 +178,8 @@ struct JetpackAIQueryClient: AIChatService {
             for try await chunk in byteStream {
                 buffer.append(chunk)
             }
-            let reason = Self.envelopeReason(from: buffer) ?? "jetpack-ai-query returned HTTP \(http.statusCode)."
+            let fallback = String.localizedStringWithFormat(Localization.httpFailureFallback, http.statusCode)
+            let reason = Self.envelopeReason(from: buffer) ?? fallback
             throw AssistantError(kind: HTTPStatusClassification.errorKind(forStatusCode: http.statusCode),
                                  code: String(http.statusCode),
                                  message: reason)

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -37,9 +37,8 @@ struct JetpackAIQueryClient: AIChatService {
             guard let http = response as? HTTPURLResponse else {
                 throw AssistantError(kind: .network, message: Localization.nonHTTPResponse)
             }
-            // Cancelling only the wrapping Swift Task leaves the URL loader holding the
-            // socket; an idle SSE connection never produces a cancellation through the
-            // byte iterator. Cancel the URL task too.
+            // Cancelling only the Swift Task leaves the URL loader holding the socket;
+            // an idle SSE connection never throws via the byte iterator.
             let urlSessionTask = bytes.task
             let stream = AsyncThrowingStream<Data, Error> { continuation in
                 let task = Task {
@@ -90,9 +89,8 @@ struct JetpackAIQueryClient: AIChatService {
         }
     }
 
-    // 401 before any event lands → invalidate JWT + retry once. Replaying after an event
-    // crosses the seam would emit a duplicate prefix or a torn tool call. Android applies
-    // the same gate for 401 only; 403 is treated as terminal.
+    // Replaying after an event crosses the seam would emit a duplicate prefix or a torn
+    // tool call, so 401 retry only fires before any event has been yielded.
     private func runWithAuthRetry(messages: [OpenAIChat.Message],
                                   tools: [OpenAIChat.ToolDefinition]?,
                                   toolChoice: OpenAIChat.ToolChoice?,
@@ -124,7 +122,6 @@ struct JetpackAIQueryClient: AIChatService {
         return error.code == "401"
     }
 
-    // 429 retries (3 attempts, 2s + 4s) only run before any event crosses the seam.
     private func runWithRateLimitRetry(messages: [OpenAIChat.Message],
                                        tools: [OpenAIChat.ToolDefinition]?,
                                        toolChoice: OpenAIChat.ToolChoice?,
@@ -169,10 +166,8 @@ struct JetpackAIQueryClient: AIChatService {
                                        jwt: jwt)
         let (byteStream, http) = try await streamingTransport(request)
 
-        // jetpack-ai-query validates before opening the stream, so a non-2xx body is
-        // a single JSON error payload (the proxy uses the same wrapped shape for HTTP
-        // failures and soft failures). The HTTP status drives retry classification;
-        // the envelope's text just enriches the message for the consumer.
+        // jetpack-ai-query validates before opening the stream, so a non-2xx body is a
+        // single JSON error payload, not SSE frames.
         if !(200..<300).contains(http.statusCode) {
             var buffer = Data()
             for try await chunk in byteStream {
@@ -189,8 +184,8 @@ struct JetpackAIQueryClient: AIChatService {
         var toolCallBuffers: [Int: ToolCallAssembly] = [:]
         var toolCallOrder: [Int] = []
         var finishReason: OpenAIChat.FinishReason?
-        // Multi-byte UTF-8 chars that straddle a chunk boundary fail `String(data:encoding:)`
-        // and the chunk would be dropped wholesale. Carry up to 3 trailing bytes forward.
+        // Carry up to 3 trailing bytes when a multi-byte UTF-8 char straddles a chunk;
+        // otherwise `String(data:encoding:)` drops the whole chunk.
         var pendingBytes = Data()
 
         for try await rawChunk in byteStream {
@@ -242,8 +237,7 @@ struct JetpackAIQueryClient: AIChatService {
         if trimmed.isEmpty || trimmed == "[DONE]" { return }
         guard let data = trimmed.data(using: .utf8) else { return }
 
-        // Some soft errors come back as 200 + a wrapped envelope (no `choices`). Surface
-        // as a typed error as long as nothing has crossed the seam yet.
+        // Soft errors can ship as 200 + envelope; surface as a typed error before any event lands.
         if await bridge.didEmitAnyEvent == false, let envelope = Self.decodeWrappedError(from: data) {
             throw WrappedEnvelopeError(assistantError: envelope)
         }
@@ -299,9 +293,7 @@ struct JetpackAIQueryClient: AIChatService {
         func markEmitted() { didEmitAnyEvent = true }
     }
 
-    // Source-tagging wrapper: envelope-derived AssistantErrors travel inside this so the
-    // HTTP retry guards (which key on `error.code`) skip them. `streamTurn` unwraps it
-    // before yielding the inner AssistantError to the consumer.
+    // Wraps envelope errors so they bypass the HTTP retry guards keyed on `error.code`.
     private struct WrappedEnvelopeError: Error {
         let assistantError: AssistantError
     }

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -1,0 +1,433 @@
+import Foundation
+
+/// Streaming HTTP transport. Returns a byte stream alongside the status response
+/// so the caller can parse SSE frames incrementally on 2xx, or drain the (small)
+/// JSON error body on non-2xx. Production uses URLSession; tests pass a closure
+/// that records the request and returns canned bytes.
+typealias StreamingHTTPTransport = @Sendable (URLRequest) async throws -> (AsyncThrowingStream<Data, Error>, HTTPURLResponse)
+
+/// Calls `POST /wpcom/v2/jetpack-ai-query` with an OpenAI-shape body.
+///
+/// Auth: `Authorization: Bearer <Jetpack AI JWT>`. The JWT is minted per
+/// site by `AssistantJWTProviding` and rotated on expiry; this client just
+/// asks for one before each call and asks the provider to invalidate when
+/// the upstream rejects it.
+///
+/// Streaming-only: the `feature` / `model` / `stream=true` parameters are
+/// pinned at construction from `AssistantConfiguration` so callers can't
+/// accidentally drift the wire shape per call.
+struct JetpackAIQueryClient: AIChatService {
+
+    /// Sleep hook so the 429-backoff branch is testable without `Task.sleep`
+    /// burning real wall-clock seconds. Production uses `Task.sleep(nanoseconds:)`.
+    typealias Sleep = @Sendable (UInt64) async throws -> Void
+
+    private let endpoint: URL
+    private let jwtProvider: AssistantJWTProviding
+    private let streamingTransport: StreamingHTTPTransport
+    private let sleep: Sleep
+
+    init(jwtProvider: AssistantJWTProviding,
+         endpoint: URL = URL(string: "https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query")!,
+         streamingTransport: StreamingHTTPTransport? = nil,
+         sleep: Sleep? = nil) {
+        self.jwtProvider = jwtProvider
+        self.endpoint = endpoint
+        self.streamingTransport = streamingTransport ?? Self.urlSessionStreamingTransport(Self.sharedLLMSession)
+        self.sleep = sleep ?? { nanoseconds in try await Task.sleep(nanoseconds: nanoseconds) }
+    }
+
+    /// One URLSession per process for all LLM calls. Dedicated so we can raise the
+    /// per-host connection cap (URLSession.shared caps at 6/host) without affecting
+    /// other Networking-module call paths. 64 matches what URLSession itself uses
+    /// on iOS when explicitly raised; 120s/180s timeouts cover the long tail of
+    /// model thinking before any byte is delivered.
+    private static let sharedLLMSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.httpMaximumConnectionsPerHost = 64
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 180
+        return URLSession(configuration: config)
+    }()
+
+    /// Streaming transport backed by URLSession's AsyncBytes. Yields 4 KB `Data`
+    /// chunks so the SSE parser can drain frames as soon as they arrive.
+    static func urlSessionStreamingTransport(_ session: URLSession) -> StreamingHTTPTransport {
+        return { request in
+            let (bytes, response) = try await session.bytes(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw AssistantError(kind: .network, message: "Non-HTTP response.")
+            }
+            // Cancelling just the wrapping Swift Task isn't enough - URLSession keeps the
+            // socket open waiting for data, and an idle SSE connection never produces a
+            // cancellation error through `for try await byte in bytes`. Cancel the URL
+            // task too so the socket closes and resources release.
+            let urlSessionTask = bytes.task
+            let stream = AsyncThrowingStream<Data, Error> { continuation in
+                let task = Task {
+                    var buffer = Data()
+                    do {
+                        for try await byte in bytes {
+                            buffer.append(byte)
+                            if buffer.count >= 4096 {
+                                continuation.yield(buffer)
+                                buffer.removeAll(keepingCapacity: true)
+                            }
+                        }
+                        if !buffer.isEmpty {
+                            continuation.yield(buffer)
+                        }
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { _ in
+                    task.cancel()
+                    urlSessionTask.cancel()
+                }
+            }
+            return (stream, http)
+        }
+    }
+
+    func streamTurn(messages: [OpenAIChat.Message],
+                    tools: [OpenAIChat.ToolDefinition]?,
+                    toolChoice: OpenAIChat.ToolChoice?) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    try await self.runWithAuthRetry(messages: messages,
+                                                    tools: tools,
+                                                    toolChoice: toolChoice,
+                                                    continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Outer envelope. Wraps the inner streaming call so a 401/403 error received before
+    /// any chunk is yielded triggers exactly one JWT-invalidate-and-retry. After the first
+    /// `ChatStreamEvent` is delivered to the consumer we never retry - that would emit a
+    /// duplicate prefix or a torn tool call. The 429 backoff lives one layer in
+    /// (`runWithRateLimitRetry`) so the two retries nest cleanly.
+    private func runWithAuthRetry(messages: [OpenAIChat.Message],
+                                  tools: [OpenAIChat.ToolDefinition]?,
+                                  toolChoice: OpenAIChat.ToolChoice?,
+                                  continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation) async throws {
+        var authAttempt = 0
+        while true {
+            let bridge = StreamBridge()
+            do {
+                try await runWithRateLimitRetry(messages: messages,
+                                                tools: tools,
+                                                toolChoice: toolChoice,
+                                                bridge: bridge,
+                                                continuation: continuation)
+                return
+            } catch let error as AssistantError {
+                if await shouldRetryAuth(error: error, bridge: bridge, attempt: authAttempt) {
+                    authAttempt += 1
+                    await jwtProvider.invalidate()
+                    continue
+                }
+                throw error
+            }
+        }
+    }
+
+    private func shouldRetryAuth(error: AssistantError, bridge: StreamBridge, attempt: Int) async -> Bool {
+        guard attempt < 1 else { return false }
+        guard await bridge.didEmitAnyEvent == false else { return false }
+        guard let code = error.code, code == "401" || code == "403" else { return false }
+        return true
+    }
+
+    /// Inner envelope. 429 retries (3 attempts, 2s + 4s backoff) only run before any event
+    /// has been yielded - once the consumer has seen a delta we cannot replay safely. The
+    /// rate-limit ceiling exists because jetpack-ai-query throttles aggressively under
+    /// parallel smoke load and a brief wait usually clears it.
+    private func runWithRateLimitRetry(messages: [OpenAIChat.Message],
+                                       tools: [OpenAIChat.ToolDefinition]?,
+                                       toolChoice: OpenAIChat.ToolChoice?,
+                                       bridge: StreamBridge,
+                                       continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation) async throws {
+        var attempt = 0
+        while true {
+            do {
+                try await sendStreaming(messages: messages,
+                                        tools: tools,
+                                        toolChoice: toolChoice,
+                                        bridge: bridge,
+                                        continuation: continuation)
+                return
+            } catch let error as AssistantError {
+                if await shouldRetryRateLimit(error: error, bridge: bridge, attempt: attempt) {
+                    let delaySeconds: UInt64 = attempt == 0 ? 2 : 4
+                    try await sleep(delaySeconds * 1_000_000_000)
+                    attempt += 1
+                    continue
+                }
+                throw error
+            }
+        }
+    }
+
+    private func shouldRetryRateLimit(error: AssistantError, bridge: StreamBridge, attempt: Int) async -> Bool {
+        guard attempt < 2 else { return false }
+        guard await bridge.didEmitAnyEvent == false else { return false }
+        return error.code == "429"
+    }
+
+    private func sendStreaming(messages: [OpenAIChat.Message],
+                               tools: [OpenAIChat.ToolDefinition]?,
+                               toolChoice: OpenAIChat.ToolChoice?,
+                               bridge: StreamBridge,
+                               continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation) async throws {
+        let jwt = try await jwtProvider.currentJWT()
+        let request = try buildRequest(messages: messages,
+                                       tools: tools,
+                                       toolChoice: toolChoice,
+                                       jwt: jwt)
+        let (byteStream, http) = try await streamingTransport(request)
+
+        // Non-2xx: jetpack-ai-query validates BEFORE opening the stream, so the body is
+        // a single JSON error payload (no SSE frames). Drain it fully and run through
+        // the standard validate + wrapped-envelope decoder.
+        if !(200..<300).contains(http.statusCode) {
+            var buffer = Data()
+            for try await chunk in byteStream {
+                buffer.append(chunk)
+            }
+            try Self.validate(http: http, body: buffer)
+            if let envelope = Self.decodeWrappedError(from: buffer) {
+                throw envelope
+            }
+            throw AssistantError(kind: Self.errorKind(forStatus: http.statusCode),
+                                 code: String(http.statusCode),
+                                 message: "jetpack-ai-query returned HTTP \(http.statusCode).")
+        }
+
+        var parser = SSEParser()
+        var firstDecodedChunkSeen = false
+        var toolCallBuffers: [Int: ToolCallAssembly] = [:]
+        var toolCallOrder: [Int] = []
+        var finishReason: OpenAIChat.FinishReason?
+        // Multi-byte UTF-8 chars that straddle a chunk boundary fail `String(data:encoding:)`
+        // and the entire chunk is dropped, manifesting as "the assistant skips characters"
+        // on emoji / non-ASCII content. Carry up to 3 trailing bytes forward.
+        var pendingBytes = Data()
+
+        for try await rawChunk in byteStream {
+            pendingBytes.append(rawChunk)
+            let (decoded, remainder) = Self.decodeUTF8WithBoundaryCarry(pendingBytes)
+            pendingBytes = remainder
+            guard let text = decoded, !text.isEmpty else { continue }
+            let events = parser.feed(text)
+            for event in events {
+                let trimmed = event.data.trimmingCharacters(in: .whitespaces)
+                if trimmed == "[DONE]" { continue }
+                guard let data = trimmed.data(using: .utf8) else { continue }
+
+                // Some soft errors come back as HTTP 200 with a wrapped JSON envelope that
+                // looks NOTHING like an SSE chunk (no `choices` field). Surface as typed
+                // error before we waste a JSON decode against the chunk shape.
+                if !firstDecodedChunkSeen, let envelope = Self.decodeWrappedError(from: data) {
+                    throw envelope
+                }
+                firstDecodedChunkSeen = true
+
+                guard let chunk = try? JSONDecoder().decode(OpenAIChat.Chunk.self, from: data) else { continue }
+                guard let choice = chunk.choices.first else { continue }
+
+                if let text = choice.delta.content, !text.isEmpty {
+                    await bridge.markEmitted()
+                    continuation.yield(.textDelta(text))
+                }
+                if let deltaCalls = choice.delta.toolCalls {
+                    for delta in deltaCalls {
+                        apply(delta: delta, to: &toolCallBuffers, order: &toolCallOrder)
+                    }
+                }
+                if let reason = choice.finishReason {
+                    finishReason = reason
+                }
+            }
+        }
+        // Flush any trailing event the buffer held onto. If the stream cut mid-multibyte
+        // we just drop the partial tail (no valid codepoint to emit).
+        if !pendingBytes.isEmpty,
+           let tail = String(data: pendingBytes, encoding: .utf8),
+           !tail.isEmpty {
+            _ = parser.feed(tail)
+        }
+        for event in parser.finish() {
+            let trimmed = event.data.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed == "[DONE]" { continue }
+            if let data = trimmed.data(using: .utf8),
+               let chunk = try? JSONDecoder().decode(OpenAIChat.Chunk.self, from: data),
+               let choice = chunk.choices.first {
+                if let text = choice.delta.content, !text.isEmpty {
+                    await bridge.markEmitted()
+                    continuation.yield(.textDelta(text))
+                }
+                if let deltaCalls = choice.delta.toolCalls {
+                    for delta in deltaCalls {
+                        apply(delta: delta, to: &toolCallBuffers, order: &toolCallOrder)
+                    }
+                }
+                if let reason = choice.finishReason {
+                    finishReason = reason
+                }
+            }
+        }
+
+        for index in toolCallOrder {
+            guard let asm = toolCallBuffers[index], let id = asm.id, let name = asm.name else { continue }
+            await bridge.markEmitted()
+            continuation.yield(.toolCall(OpenAIChat.ToolCall(id: id,
+                                                             function: .init(name: name,
+                                                                             arguments: asm.arguments))))
+        }
+        await bridge.markEmitted()
+        continuation.yield(.completed(finishReason))
+    }
+
+    private func buildRequest(messages: [OpenAIChat.Message],
+                              tools: [OpenAIChat.ToolDefinition]?,
+                              toolChoice: OpenAIChat.ToolChoice?,
+                              jwt: String) throws -> URLRequest {
+        var urlRequest = URLRequest(url: endpoint)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+        let body = OpenAIChat.Request(messages: messages,
+                                      tools: tools,
+                                      toolChoice: toolChoice,
+                                      model: AssistantConfiguration.chatModel,
+                                      stream: true,
+                                      feature: AssistantConfiguration.featureName)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        urlRequest.httpBody = try encoder.encode(body)
+        return urlRequest
+    }
+
+    /// Accumulator for streaming tool-call fragments. OpenAI streams the skeleton
+    /// (`id` / `type` / `function.name`) in the first delta and the arguments as
+    /// string chunks across subsequent deltas, keyed by `tool_calls[<index>]`.
+    private struct ToolCallAssembly {
+        var id: String?
+        var type: String?
+        var name: String?
+        var arguments: String = ""
+    }
+
+    /// Tracks whether the consumer has observed any event, so retry envelopes
+    /// can short-circuit once a partial response has crossed the seam.
+    private actor StreamBridge {
+        private(set) var didEmitAnyEvent = false
+        func markEmitted() { didEmitAnyEvent = true }
+    }
+
+    /// Try to decode `buffer` as UTF-8 in one shot. If that fails, back off by up
+    /// to 3 bytes (max length of a UTF-8 sequence minus 1) searching for a valid
+    /// prefix - those last bytes are the start of a codepoint that'll complete on
+    /// the next network chunk.
+    static func decodeUTF8WithBoundaryCarry(_ buffer: Data) -> (decoded: String?, remainder: Data) {
+        if let full = String(data: buffer, encoding: .utf8) {
+            return (full, Data())
+        }
+        for backoff in 1...min(3, buffer.count) {
+            let split = buffer.count - backoff
+            let prefix = buffer.prefix(split)
+            if let decoded = String(data: prefix, encoding: .utf8) {
+                return (decoded, buffer.suffix(from: split))
+            }
+        }
+        return (nil, buffer)
+    }
+
+    private func apply(delta: OpenAIChat.ToolCallDelta,
+                       to buffers: inout [Int: ToolCallAssembly],
+                       order: inout [Int]) {
+        var asm = buffers[delta.index] ?? ToolCallAssembly()
+        if asm.id == nil, let id = delta.id { asm.id = id }
+        if asm.type == nil, let type = delta.type { asm.type = type }
+        if asm.name == nil, let name = delta.function?.name { asm.name = name }
+        if let args = delta.function?.arguments { asm.arguments.append(args) }
+        buffers[delta.index] = asm
+        if !order.contains(delta.index) { order.append(delta.index) }
+    }
+
+    /// Wrapped-error envelope returned by jetpack-ai-query for soft failures
+    /// (context overflow, moderation, downstream JSON-schema rejection). HTTP
+    /// status is usually 200 - the real error lives in the body.
+    private struct WrappedError: Decodable {
+        let code: String
+        let message: String
+        let data: ErrorData?
+
+        struct ErrorData: Decodable {
+            let status: Int?
+        }
+    }
+
+    /// Returns an `AssistantError` if the body decodes as a wrapped error envelope.
+    /// Returns nil when both `code` and `message` are not populated, which keeps
+    /// successful chat-completion responses (no top-level `code`) from being
+    /// misclassified.
+    static func decodeWrappedError(from data: Data) -> AssistantError? {
+        let envelope: WrappedError
+        do {
+            envelope = try JSONDecoder().decode(WrappedError.self, from: data)
+        } catch {
+            return nil
+        }
+        guard !envelope.code.isEmpty, !envelope.message.isEmpty else {
+            return nil
+        }
+        let httpStatus = envelope.data?.status
+        let codeString = httpStatus.map(String.init)
+        let kind = httpStatus.map(errorKind(forStatus:)) ?? .upstreamFailure
+        return AssistantError(kind: kind,
+                              code: codeString,
+                              message: "[\(envelope.code)] \(envelope.message)")
+    }
+
+    static func validate(http: HTTPURLResponse, body: Data) throws {
+        if http.statusCode == 401 || http.statusCode == 403 {
+            throw AssistantError(kind: .auth,
+                                 code: String(http.statusCode),
+                                 message: "Authentication to jetpack-ai-query failed (HTTP \(http.statusCode)).")
+        }
+        if http.statusCode == 429 {
+            throw AssistantError(kind: .rateLimit,
+                                 code: "429",
+                                 message: "Rate-limited by jetpack-ai-query. Please try again shortly.")
+        }
+        if !(200..<300).contains(http.statusCode) {
+            let snippet = String(data: body.prefix(300), encoding: .utf8) ?? ""
+            throw AssistantError(kind: errorKind(forStatus: http.statusCode),
+                                 code: String(http.statusCode),
+                                 message: "jetpack-ai-query returned HTTP \(http.statusCode): \(snippet)")
+        }
+    }
+
+    private static func errorKind(forStatus status: Int) -> AssistantErrorKind {
+        switch status {
+        case 401, 403: return .auth
+        case 429: return .rateLimit
+        case 408: return .timeout
+        case 400..<500: return .upstreamFailure
+        case 500..<600: return .upstreamFailure
+        default: return .unknown
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CocoaLumberjackSwift
 import NetworkingCore
 
 typealias StreamingHTTPTransport = @Sendable (URLRequest) async throws -> (AsyncThrowingStream<Data, Error>, HTTPURLResponse)
@@ -205,7 +206,14 @@ struct JetpackAIQueryClient: AIChatService {
         if !pendingBytes.isEmpty,
            let tail = String(data: pendingBytes, encoding: .utf8),
            !tail.isEmpty {
-            _ = parser.feed(tail)
+            for event in parser.feed(tail) {
+                try await handle(event: event,
+                                 bridge: bridge,
+                                 continuation: continuation,
+                                 buffers: &toolCallBuffers,
+                                 order: &toolCallOrder,
+                                 finishReason: &finishReason)
+            }
         }
         for event in parser.finish() {
             try await handle(event: event,
@@ -217,13 +225,15 @@ struct JetpackAIQueryClient: AIChatService {
         }
 
         for index in toolCallOrder {
-            guard let asm = toolCallBuffers[index], let id = asm.id, let name = asm.name else { continue }
+            guard let asm = toolCallBuffers[index], let id = asm.id, let name = asm.name else {
+                DDLogError("⛔️ Skipping tool call at index \(index): id or name absent.")
+                continue
+            }
             await bridge.markEmitted()
             continuation.yield(.toolCall(OpenAIChat.ToolCall(id: id,
                                                              function: .init(name: name,
                                                                              arguments: asm.arguments))))
         }
-        await bridge.markEmitted()
         continuation.yield(.completed(finishReason))
     }
 
@@ -331,20 +341,21 @@ struct JetpackAIQueryClient: AIChatService {
         struct ErrorData: Decodable {
             let status: Int?
         }
+
+        var formattedReason: String { "[\(code)] \(message)" }
     }
 
     static func decodeWrappedError(from data: Data) -> AssistantError? {
         guard let envelope = decodeEnvelope(from: data) else { return nil }
         let httpStatus = envelope.data?.status
-        let codeString = httpStatus.map(String.init)
         let kind = httpStatus.map(HTTPStatusClassification.errorKind(forStatusCode:)) ?? .upstreamFailure
         return AssistantError(kind: kind,
-                              code: codeString,
-                              message: "[\(envelope.code)] \(envelope.message)")
+                              code: httpStatus.map(String.init),
+                              message: envelope.formattedReason)
     }
 
     static func envelopeReason(from data: Data) -> String? {
-        decodeEnvelope(from: data).map { "[\($0.code)] \($0.message)" }
+        decodeEnvelope(from: data)?.formattedReason
     }
 
     private static func decodeEnvelope(from data: Data) -> WrappedError? {

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -21,8 +21,7 @@ struct JetpackAIQueryClient: AIChatService {
         self.sleep = sleep ?? { nanoseconds in try await Task.sleep(nanoseconds: nanoseconds) }
     }
 
-    // 64 conns/host (URLSession.shared caps at 6) + long timeouts cover the
-    // long tail of model thinking before any byte is delivered.
+    // httpMaximumConnectionsPerHost overrides URLSession.shared's 6-conn cap.
     private static let sharedLLMSession: URLSession = {
         let config = URLSessionConfiguration.default
         config.httpMaximumConnectionsPerHost = 64
@@ -31,7 +30,7 @@ struct JetpackAIQueryClient: AIChatService {
         return URLSession(configuration: config)
     }()
 
-    static func urlSessionStreamingTransport(_ session: URLSession) -> StreamingHTTPTransport {
+    private static func urlSessionStreamingTransport(_ session: URLSession) -> StreamingHTTPTransport {
         return { request in
             let (bytes, response) = try await session.bytes(for: request)
             guard let http = response as? HTTPURLResponse else {
@@ -80,6 +79,8 @@ struct JetpackAIQueryClient: AIChatService {
                                                     toolChoice: toolChoice,
                                                     continuation: continuation)
                     continuation.finish()
+                } catch let envelope as WrappedEnvelopeError {
+                    continuation.finish(throwing: envelope.assistantError)
                 } catch {
                     continuation.finish(throwing: error)
                 }
@@ -88,8 +89,9 @@ struct JetpackAIQueryClient: AIChatService {
         }
     }
 
-    // 401/403 before any event lands → invalidate JWT + retry once. Once an event
-    // crosses the seam, retrying would emit a duplicate prefix or torn tool call.
+    // 401 before any event lands → invalidate JWT + retry once. Replaying after an event
+    // crosses the seam would emit a duplicate prefix or a torn tool call. Android applies
+    // the same gate for 401 only; 403 is treated as terminal.
     private func runWithAuthRetry(messages: [OpenAIChat.Message],
                                   tools: [OpenAIChat.ToolDefinition]?,
                                   toolChoice: OpenAIChat.ToolChoice?,
@@ -116,10 +118,9 @@ struct JetpackAIQueryClient: AIChatService {
     }
 
     private func shouldRetryAuth(error: AssistantError, bridge: StreamBridge, attempt: Int) async -> Bool {
-        guard attempt < 1 else { return false }
+        guard attempt == 0 else { return false }
         guard await bridge.didEmitAnyEvent == false else { return false }
-        guard let code = error.code, code == "401" || code == "403" else { return false }
-        return true
+        return error.code == "401"
     }
 
     // 429 retries (3 attempts, 2s + 4s) only run before any event crosses the seam.
@@ -168,23 +169,21 @@ struct JetpackAIQueryClient: AIChatService {
         let (byteStream, http) = try await streamingTransport(request)
 
         // jetpack-ai-query validates before opening the stream, so a non-2xx body is
-        // a single JSON error payload, not SSE frames.
+        // a single JSON error payload (the proxy uses the same wrapped shape for HTTP
+        // failures and soft failures). The HTTP status drives retry classification;
+        // the envelope's text just enriches the message for the consumer.
         if !(200..<300).contains(http.statusCode) {
             var buffer = Data()
             for try await chunk in byteStream {
                 buffer.append(chunk)
             }
-            try Self.validate(http: http, body: buffer)
-            if let envelope = Self.decodeWrappedError(from: buffer) {
-                throw envelope
-            }
-            throw AssistantError(kind: Self.errorKind(forStatus: http.statusCode),
+            let reason = Self.envelopeReason(from: buffer) ?? "jetpack-ai-query returned HTTP \(http.statusCode)."
+            throw AssistantError(kind: HTTPStatusClassification.errorKind(forStatusCode: http.statusCode),
                                  code: String(http.statusCode),
-                                 message: "jetpack-ai-query returned HTTP \(http.statusCode).")
+                                 message: reason)
         }
 
         var parser = SSEParser()
-        var firstDecodedChunkSeen = false
         var toolCallBuffers: [Int: ToolCallAssembly] = [:]
         var toolCallOrder: [Int] = []
         var finishReason: OpenAIChat.FinishReason?
@@ -197,34 +196,13 @@ struct JetpackAIQueryClient: AIChatService {
             let (decoded, remainder) = Self.decodeUTF8WithBoundaryCarry(pendingBytes)
             pendingBytes = remainder
             guard let text = decoded, !text.isEmpty else { continue }
-            let events = parser.feed(text)
-            for event in events {
-                let trimmed = event.data.trimmingCharacters(in: .whitespaces)
-                if trimmed == "[DONE]" { continue }
-                guard let data = trimmed.data(using: .utf8) else { continue }
-
-                // Some soft errors come back as 200 + a wrapped envelope (no `choices`).
-                // Surface as a typed error before attempting the chunk decode.
-                if !firstDecodedChunkSeen, let envelope = Self.decodeWrappedError(from: data) {
-                    throw envelope
-                }
-                firstDecodedChunkSeen = true
-
-                guard let chunk = try? JSONDecoder().decode(OpenAIChat.Chunk.self, from: data) else { continue }
-                guard let choice = chunk.choices.first else { continue }
-
-                if let text = choice.delta.content, !text.isEmpty {
-                    await bridge.markEmitted()
-                    continuation.yield(.textDelta(text))
-                }
-                if let deltaCalls = choice.delta.toolCalls {
-                    for delta in deltaCalls {
-                        apply(delta: delta, to: &toolCallBuffers, order: &toolCallOrder)
-                    }
-                }
-                if let reason = choice.finishReason {
-                    finishReason = reason
-                }
+            for event in parser.feed(text) {
+                try await handle(event: event,
+                                 bridge: bridge,
+                                 continuation: continuation,
+                                 buffers: &toolCallBuffers,
+                                 order: &toolCallOrder,
+                                 finishReason: &finishReason)
             }
         }
         if !pendingBytes.isEmpty,
@@ -233,24 +211,12 @@ struct JetpackAIQueryClient: AIChatService {
             _ = parser.feed(tail)
         }
         for event in parser.finish() {
-            let trimmed = event.data.trimmingCharacters(in: .whitespaces)
-            if trimmed.isEmpty || trimmed == "[DONE]" { continue }
-            if let data = trimmed.data(using: .utf8),
-               let chunk = try? JSONDecoder().decode(OpenAIChat.Chunk.self, from: data),
-               let choice = chunk.choices.first {
-                if let text = choice.delta.content, !text.isEmpty {
-                    await bridge.markEmitted()
-                    continuation.yield(.textDelta(text))
-                }
-                if let deltaCalls = choice.delta.toolCalls {
-                    for delta in deltaCalls {
-                        apply(delta: delta, to: &toolCallBuffers, order: &toolCallOrder)
-                    }
-                }
-                if let reason = choice.finishReason {
-                    finishReason = reason
-                }
-            }
+            try await handle(event: event,
+                             bridge: bridge,
+                             continuation: continuation,
+                             buffers: &toolCallBuffers,
+                             order: &toolCallOrder,
+                             finishReason: &finishReason)
         }
 
         for index in toolCallOrder {
@@ -262,6 +228,39 @@ struct JetpackAIQueryClient: AIChatService {
         }
         await bridge.markEmitted()
         continuation.yield(.completed(finishReason))
+    }
+
+    private func handle(event: SSEParser.Event,
+                        bridge: StreamBridge,
+                        continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation,
+                        buffers: inout [Int: ToolCallAssembly],
+                        order: inout [Int],
+                        finishReason: inout OpenAIChat.FinishReason?) async throws {
+        let trimmed = event.data.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty || trimmed == "[DONE]" { return }
+        guard let data = trimmed.data(using: .utf8) else { return }
+
+        // Some soft errors come back as 200 + a wrapped envelope (no `choices`). Surface
+        // as a typed error as long as nothing has crossed the seam yet.
+        if await bridge.didEmitAnyEvent == false, let envelope = Self.decodeWrappedError(from: data) {
+            throw WrappedEnvelopeError(assistantError: envelope)
+        }
+
+        guard let chunk = try? JSONDecoder().decode(OpenAIChat.Chunk.self, from: data) else { return }
+        guard let choice = chunk.choices.first else { return }
+
+        if let text = choice.delta.content, !text.isEmpty {
+            await bridge.markEmitted()
+            continuation.yield(.textDelta(text))
+        }
+        if let deltaCalls = choice.delta.toolCalls {
+            for delta in deltaCalls {
+                apply(delta: delta, to: &buffers, order: &order)
+            }
+        }
+        if let reason = choice.finishReason {
+            finishReason = reason
+        }
     }
 
     private func buildRequest(messages: [OpenAIChat.Message],
@@ -288,7 +287,6 @@ struct JetpackAIQueryClient: AIChatService {
 
     private struct ToolCallAssembly {
         var id: String?
-        var type: String?
         var name: String?
         var arguments: String = ""
     }
@@ -296,6 +294,13 @@ struct JetpackAIQueryClient: AIChatService {
     private actor StreamBridge {
         private(set) var didEmitAnyEvent = false
         func markEmitted() { didEmitAnyEvent = true }
+    }
+
+    // Source-tagging wrapper: envelope-derived AssistantErrors travel inside this so the
+    // HTTP retry guards (which key on `error.code`) skip them. `streamTurn` unwraps it
+    // before yielding the inner AssistantError to the consumer.
+    private struct WrappedEnvelopeError: Error {
+        let assistantError: AssistantError
     }
 
     static func decodeUTF8WithBoundaryCarry(_ buffer: Data) -> (decoded: String?, remainder: Data) {
@@ -317,7 +322,6 @@ struct JetpackAIQueryClient: AIChatService {
                        order: inout [Int]) {
         var asm = buffers[delta.index] ?? ToolCallAssembly()
         if asm.id == nil, let id = delta.id { asm.id = id }
-        if asm.type == nil, let type = delta.type { asm.type = type }
         if asm.name == nil, let name = delta.function?.name { asm.name = name }
         if let args = delta.function?.arguments { asm.arguments.append(args) }
         buffers[delta.index] = asm
@@ -334,55 +338,28 @@ struct JetpackAIQueryClient: AIChatService {
         }
     }
 
-    // jetpack-ai-query wraps soft failures (context overflow, moderation, schema
-    // rejection) as `{code, message, data:{status}}` over HTTP 200. Both fields
-    // must be populated so a successful chat response (no top-level `code`)
-    // doesn't get misclassified.
     static func decodeWrappedError(from data: Data) -> AssistantError? {
+        guard let envelope = decodeEnvelope(from: data) else { return nil }
+        let httpStatus = envelope.data?.status
+        let codeString = httpStatus.map(String.init)
+        let kind = httpStatus.map(HTTPStatusClassification.errorKind(forStatusCode:)) ?? .upstreamFailure
+        return AssistantError(kind: kind,
+                              code: codeString,
+                              message: "[\(envelope.code)] \(envelope.message)")
+    }
+
+    static func envelopeReason(from data: Data) -> String? {
+        decodeEnvelope(from: data).map { "[\($0.code)] \($0.message)" }
+    }
+
+    private static func decodeEnvelope(from data: Data) -> WrappedError? {
         let envelope: WrappedError
         do {
             envelope = try JSONDecoder().decode(WrappedError.self, from: data)
         } catch {
             return nil
         }
-        guard !envelope.code.isEmpty, !envelope.message.isEmpty else {
-            return nil
-        }
-        let httpStatus = envelope.data?.status
-        let codeString = httpStatus.map(String.init)
-        let kind = httpStatus.map(errorKind(forStatus:)) ?? .upstreamFailure
-        return AssistantError(kind: kind,
-                              code: codeString,
-                              message: "[\(envelope.code)] \(envelope.message)")
-    }
-
-    static func validate(http: HTTPURLResponse, body: Data) throws {
-        if http.statusCode == 401 || http.statusCode == 403 {
-            throw AssistantError(kind: .auth,
-                                 code: String(http.statusCode),
-                                 message: "Authentication to jetpack-ai-query failed (HTTP \(http.statusCode)).")
-        }
-        if http.statusCode == 429 {
-            throw AssistantError(kind: .rateLimit,
-                                 code: "429",
-                                 message: "Rate-limited by jetpack-ai-query. Please try again shortly.")
-        }
-        if !(200..<300).contains(http.statusCode) {
-            let snippet = String(data: body.prefix(300), encoding: .utf8) ?? ""
-            throw AssistantError(kind: errorKind(forStatus: http.statusCode),
-                                 code: String(http.statusCode),
-                                 message: "jetpack-ai-query returned HTTP \(http.statusCode): \(snippet)")
-        }
-    }
-
-    private static func errorKind(forStatus status: Int) -> AssistantErrorKind {
-        switch status {
-        case 401, 403: return .auth
-        case 429: return .rateLimit
-        case 408: return .timeout
-        case 400..<500: return .upstreamFailure
-        case 500..<600: return .upstreamFailure
-        default: return .unknown
-        }
+        guard !envelope.code.isEmpty, !envelope.message.isEmpty else { return nil }
+        return envelope
     }
 }

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -13,7 +13,7 @@ struct JetpackAIQueryClient: AIChatService {
     private let sleep: Sleep
 
     init(jwtProvider: AssistantJWTProviding,
-         endpoint: URL = URL(string: "https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query")!,
+         endpoint: URL = URL(string: Settings.wordpressApiBaseURL + "wpcom/v2/jetpack-ai-query")!,
          streamingTransport: StreamingHTTPTransport? = nil,
          sleep: Sleep? = nil) {
         self.jwtProvider = jwtProvider

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -14,13 +14,27 @@ struct JetpackAIQueryClient: AIChatService {
     private let sleep: Sleep
 
     init(jwtProvider: AssistantJWTProviding,
-         endpoint: URL = URL(string: Settings.wordpressApiBaseURL + "wpcom/v2/jetpack-ai-query")!,
+         endpoint: URL? = nil,
          streamingTransport: StreamingHTTPTransport? = nil,
          sleep: Sleep? = nil) {
         self.jwtProvider = jwtProvider
-        self.endpoint = endpoint
+        self.endpoint = endpoint ?? Self.defaultEndpoint()
         self.streamingTransport = streamingTransport ?? Self.urlSessionStreamingTransport(Self.sharedLLMSession)
         self.sleep = sleep ?? { nanoseconds in try await Task.sleep(nanoseconds: nanoseconds) }
+    }
+
+    private static let endpointPath = "wpcom/v2/jetpack-ai-query"
+
+    // Compose against `Settings.wordpressApiBaseURL` so launch-arg overrides
+    // (`mocked-wpcom-api`, `wpcom-api-base-url=...`) reroute the chat traffic too.
+    // Falls back to the production URL if the dynamic base is somehow malformed.
+    private static func defaultEndpoint() -> URL {
+        if let base = URL(string: Settings.wordpressApiBaseURL),
+           let composed = URL(string: endpointPath, relativeTo: base)?.absoluteURL {
+            return composed
+        }
+        DDLogError("⛔️ Settings.wordpressApiBaseURL malformed: \(Settings.wordpressApiBaseURL); falling back.")
+        return URL(string: "https://public-api.wordpress.com/\(endpointPath)") ?? URL(fileURLWithPath: "/")
     }
 
     // httpMaximumConnectionsPerHost overrides URLSession.shared's 6-conn cap.

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NetworkingCore
 
 typealias StreamingHTTPTransport = @Sendable (URLRequest) async throws -> (AsyncThrowingStream<Data, Error>, HTTPURLResponse)
 
@@ -272,6 +273,7 @@ struct JetpackAIQueryClient: AIChatService {
         urlRequest.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        urlRequest.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
         let body = OpenAIChat.Request(messages: messages,
                                       tools: tools,

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -1,25 +1,9 @@
 import Foundation
 
-/// Streaming HTTP transport. Returns a byte stream alongside the status response
-/// so the caller can parse SSE frames incrementally on 2xx, or drain the (small)
-/// JSON error body on non-2xx. Production uses URLSession; tests pass a closure
-/// that records the request and returns canned bytes.
 typealias StreamingHTTPTransport = @Sendable (URLRequest) async throws -> (AsyncThrowingStream<Data, Error>, HTTPURLResponse)
 
-/// Calls `POST /wpcom/v2/jetpack-ai-query` with an OpenAI-shape body.
-///
-/// Auth: `Authorization: Bearer <Jetpack AI JWT>`. The JWT is minted per
-/// site by `AssistantJWTProviding` and rotated on expiry; this client just
-/// asks for one before each call and asks the provider to invalidate when
-/// the upstream rejects it.
-///
-/// Streaming-only: the `feature` / `model` / `stream=true` parameters are
-/// pinned at construction from `AssistantConfiguration` so callers can't
-/// accidentally drift the wire shape per call.
 struct JetpackAIQueryClient: AIChatService {
 
-    /// Sleep hook so the 429-backoff branch is testable without `Task.sleep`
-    /// burning real wall-clock seconds. Production uses `Task.sleep(nanoseconds:)`.
     typealias Sleep = @Sendable (UInt64) async throws -> Void
 
     private let endpoint: URL
@@ -37,11 +21,8 @@ struct JetpackAIQueryClient: AIChatService {
         self.sleep = sleep ?? { nanoseconds in try await Task.sleep(nanoseconds: nanoseconds) }
     }
 
-    /// One URLSession per process for all LLM calls. Dedicated so we can raise the
-    /// per-host connection cap (URLSession.shared caps at 6/host) without affecting
-    /// other Networking-module call paths. 64 matches what URLSession itself uses
-    /// on iOS when explicitly raised; 120s/180s timeouts cover the long tail of
-    /// model thinking before any byte is delivered.
+    // 64 conns/host (URLSession.shared caps at 6) + long timeouts cover the
+    // long tail of model thinking before any byte is delivered.
     private static let sharedLLMSession: URLSession = {
         let config = URLSessionConfiguration.default
         config.httpMaximumConnectionsPerHost = 64
@@ -50,18 +31,15 @@ struct JetpackAIQueryClient: AIChatService {
         return URLSession(configuration: config)
     }()
 
-    /// Streaming transport backed by URLSession's AsyncBytes. Yields 4 KB `Data`
-    /// chunks so the SSE parser can drain frames as soon as they arrive.
     static func urlSessionStreamingTransport(_ session: URLSession) -> StreamingHTTPTransport {
         return { request in
             let (bytes, response) = try await session.bytes(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw AssistantError(kind: .network, message: "Non-HTTP response.")
             }
-            // Cancelling just the wrapping Swift Task isn't enough - URLSession keeps the
-            // socket open waiting for data, and an idle SSE connection never produces a
-            // cancellation error through `for try await byte in bytes`. Cancel the URL
-            // task too so the socket closes and resources release.
+            // Cancelling only the wrapping Swift Task leaves the URL loader holding the
+            // socket; an idle SSE connection never produces a cancellation through the
+            // byte iterator. Cancel the URL task too.
             let urlSessionTask = bytes.task
             let stream = AsyncThrowingStream<Data, Error> { continuation in
                 let task = Task {
@@ -110,11 +88,8 @@ struct JetpackAIQueryClient: AIChatService {
         }
     }
 
-    /// Outer envelope. Wraps the inner streaming call so a 401/403 error received before
-    /// any chunk is yielded triggers exactly one JWT-invalidate-and-retry. After the first
-    /// `ChatStreamEvent` is delivered to the consumer we never retry - that would emit a
-    /// duplicate prefix or a torn tool call. The 429 backoff lives one layer in
-    /// (`runWithRateLimitRetry`) so the two retries nest cleanly.
+    // 401/403 before any event lands → invalidate JWT + retry once. Once an event
+    // crosses the seam, retrying would emit a duplicate prefix or torn tool call.
     private func runWithAuthRetry(messages: [OpenAIChat.Message],
                                   tools: [OpenAIChat.ToolDefinition]?,
                                   toolChoice: OpenAIChat.ToolChoice?,
@@ -147,10 +122,7 @@ struct JetpackAIQueryClient: AIChatService {
         return true
     }
 
-    /// Inner envelope. 429 retries (3 attempts, 2s + 4s backoff) only run before any event
-    /// has been yielded - once the consumer has seen a delta we cannot replay safely. The
-    /// rate-limit ceiling exists because jetpack-ai-query throttles aggressively under
-    /// parallel smoke load and a brief wait usually clears it.
+    // 429 retries (3 attempts, 2s + 4s) only run before any event crosses the seam.
     private func runWithRateLimitRetry(messages: [OpenAIChat.Message],
                                        tools: [OpenAIChat.ToolDefinition]?,
                                        toolChoice: OpenAIChat.ToolChoice?,
@@ -195,9 +167,8 @@ struct JetpackAIQueryClient: AIChatService {
                                        jwt: jwt)
         let (byteStream, http) = try await streamingTransport(request)
 
-        // Non-2xx: jetpack-ai-query validates BEFORE opening the stream, so the body is
-        // a single JSON error payload (no SSE frames). Drain it fully and run through
-        // the standard validate + wrapped-envelope decoder.
+        // jetpack-ai-query validates before opening the stream, so a non-2xx body is
+        // a single JSON error payload, not SSE frames.
         if !(200..<300).contains(http.statusCode) {
             var buffer = Data()
             for try await chunk in byteStream {
@@ -218,8 +189,7 @@ struct JetpackAIQueryClient: AIChatService {
         var toolCallOrder: [Int] = []
         var finishReason: OpenAIChat.FinishReason?
         // Multi-byte UTF-8 chars that straddle a chunk boundary fail `String(data:encoding:)`
-        // and the entire chunk is dropped, manifesting as "the assistant skips characters"
-        // on emoji / non-ASCII content. Carry up to 3 trailing bytes forward.
+        // and the chunk would be dropped wholesale. Carry up to 3 trailing bytes forward.
         var pendingBytes = Data()
 
         for try await rawChunk in byteStream {
@@ -233,9 +203,8 @@ struct JetpackAIQueryClient: AIChatService {
                 if trimmed == "[DONE]" { continue }
                 guard let data = trimmed.data(using: .utf8) else { continue }
 
-                // Some soft errors come back as HTTP 200 with a wrapped JSON envelope that
-                // looks NOTHING like an SSE chunk (no `choices` field). Surface as typed
-                // error before we waste a JSON decode against the chunk shape.
+                // Some soft errors come back as 200 + a wrapped envelope (no `choices`).
+                // Surface as a typed error before attempting the chunk decode.
                 if !firstDecodedChunkSeen, let envelope = Self.decodeWrappedError(from: data) {
                     throw envelope
                 }
@@ -258,8 +227,6 @@ struct JetpackAIQueryClient: AIChatService {
                 }
             }
         }
-        // Flush any trailing event the buffer held onto. If the stream cut mid-multibyte
-        // we just drop the partial tail (no valid codepoint to emit).
         if !pendingBytes.isEmpty,
            let tail = String(data: pendingBytes, encoding: .utf8),
            !tail.isEmpty {
@@ -319,9 +286,6 @@ struct JetpackAIQueryClient: AIChatService {
         return urlRequest
     }
 
-    /// Accumulator for streaming tool-call fragments. OpenAI streams the skeleton
-    /// (`id` / `type` / `function.name`) in the first delta and the arguments as
-    /// string chunks across subsequent deltas, keyed by `tool_calls[<index>]`.
     private struct ToolCallAssembly {
         var id: String?
         var type: String?
@@ -329,17 +293,11 @@ struct JetpackAIQueryClient: AIChatService {
         var arguments: String = ""
     }
 
-    /// Tracks whether the consumer has observed any event, so retry envelopes
-    /// can short-circuit once a partial response has crossed the seam.
     private actor StreamBridge {
         private(set) var didEmitAnyEvent = false
         func markEmitted() { didEmitAnyEvent = true }
     }
 
-    /// Try to decode `buffer` as UTF-8 in one shot. If that fails, back off by up
-    /// to 3 bytes (max length of a UTF-8 sequence minus 1) searching for a valid
-    /// prefix - those last bytes are the start of a codepoint that'll complete on
-    /// the next network chunk.
     static func decodeUTF8WithBoundaryCarry(_ buffer: Data) -> (decoded: String?, remainder: Data) {
         if let full = String(data: buffer, encoding: .utf8) {
             return (full, Data())
@@ -366,9 +324,6 @@ struct JetpackAIQueryClient: AIChatService {
         if !order.contains(delta.index) { order.append(delta.index) }
     }
 
-    /// Wrapped-error envelope returned by jetpack-ai-query for soft failures
-    /// (context overflow, moderation, downstream JSON-schema rejection). HTTP
-    /// status is usually 200 - the real error lives in the body.
     private struct WrappedError: Decodable {
         let code: String
         let message: String
@@ -379,10 +334,10 @@ struct JetpackAIQueryClient: AIChatService {
         }
     }
 
-    /// Returns an `AssistantError` if the body decodes as a wrapped error envelope.
-    /// Returns nil when both `code` and `message` are not populated, which keeps
-    /// successful chat-completion responses (no top-level `code`) from being
-    /// misclassified.
+    // jetpack-ai-query wraps soft failures (context overflow, moderation, schema
+    // rejection) as `{code, message, data:{status}}` over HTTP 200. Both fields
+    // must be populated so a successful chat response (no top-level `code`)
+    // doesn't get misclassified.
     static func decodeWrappedError(from data: Data) -> AssistantError? {
         let envelope: WrappedError
         do {

--- a/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/JetpackAIQueryClient.swift
@@ -266,7 +266,16 @@ struct JetpackAIQueryClient: AIChatService {
             throw WrappedEnvelopeError(assistantError: envelope)
         }
 
-        guard let chunk = try? JSONDecoder().decode(OpenAIChat.Chunk.self, from: data) else { return }
+        // Past the [DONE]/empty/envelope filters this should decode as a chat chunk; surface a
+        // decode failure as `invalidStream` instead of swallowing so a corrupted frame can't let
+        // the turn finish silently with whatever partial content already streamed.
+        let chunk: OpenAIChat.Chunk
+        do {
+            chunk = try JSONDecoder().decode(OpenAIChat.Chunk.self, from: data)
+        } catch {
+            DDLogError("⛔️ Malformed SSE chunk dropped: \(error.localizedDescription)")
+            throw AssistantError(kind: .invalidStream, message: Localization.invalidStreamPayload)
+        }
         guard let choice = chunk.choices.first else { return }
 
         if let text = choice.delta.content, !text.isEmpty {

--- a/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
@@ -1,8 +1,10 @@
 import Foundation
 
-// Single-flight is automatic via actor isolation: concurrent callers serialize on
-// `currentJWT()`, so the second caller observes the freshly-minted token rather
-// than triggering a second mint.
+// Concurrent `currentJWT()` callers share one in-flight mint via a stored Task.
+// Plain actor isolation isn't enough: `await mint(...)` suspends, the actor lets the
+// next caller re-enter, that caller sees the still-unset cache and starts a second
+// mint. Holding a Task<String, Error> while the first call is in flight makes
+// followers await the same value.
 public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
 
     public typealias Mint = @Sendable (Int64) async throws -> String
@@ -10,6 +12,7 @@ public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
     private let blogID: Int64
     private let mint: Mint
     private var cached: CachedJWT?
+    private var inflight: Task<String, Error>?
 
     public init(blogID: Int64, mint: @escaping Mint) {
         self.blogID = blogID
@@ -20,9 +23,16 @@ public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
         if let cached, cached.matchesBlog(blogID), !cached.isExpired {
             return cached.token
         }
-        let fresh = try await mint(blogID)
-        let parsed = try CachedJWT(token: fresh)
-        cached = parsed
+        if let inflight {
+            return try await inflight.value
+        }
+        let blogID = self.blogID
+        let mint = self.mint
+        let task = Task<String, Error> { try await mint(blogID) }
+        inflight = task
+        defer { inflight = nil }
+        let fresh = try await task.value
+        cached = try CachedJWT(token: fresh)
         return fresh
     }
 
@@ -66,8 +76,11 @@ struct CachedJWT: Equatable, Sendable {
         blogID == id
     }
 
+    // Expire 60s early so a token whose true `exp` is just past `now` doesn't get
+    // shipped on a request that the proxy will then reject. Mirrors typical
+    // clock-skew margin and avoids 401-then-retry cycles at the boundary.
     var isExpired: Bool {
-        Date() >= expiresAt
+        Date() >= expiresAt.addingTimeInterval(-60)
     }
 
     // JWT payload is base64url (`-_` instead of `+/`) with padding elided.

--- a/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CocoaLumberjackSwift
 
 // Concurrent `currentJWT()` callers share one in-flight mint via a stored Task.
 // Plain actor isolation isn't enough: `await mint(...)` suspends, the actor lets the
@@ -49,23 +50,28 @@ struct CachedJWT: Equatable, Sendable {
     init(token: String) throws {
         let segments = token.split(separator: ".", omittingEmptySubsequences: false)
         guard segments.count == 3 else {
-            throw AssistantError(kind: .auth, message: "Jetpack AI JWT does not have three segments.")
+            DDLogError("⛔️ Jetpack AI JWT does not have three segments")
+            throw AssistantError(kind: .auth, message: Localization.invalidJWT)
         }
         let payloadSegment = String(segments[1])
         guard let payloadData = Self.base64URLDecode(payloadSegment) else {
-            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is not valid base64url.")
+            DDLogError("⛔️ Jetpack AI JWT payload is not valid base64url")
+            throw AssistantError(kind: .auth, message: Localization.invalidJWT)
         }
         let decoded: Payload
         do {
             decoded = try JSONDecoder().decode(Payload.self, from: payloadData)
         } catch {
-            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is not valid JSON: \(error).")
+            DDLogError("⛔️ Jetpack AI JWT payload is not valid JSON: \(error)")
+            throw AssistantError(kind: .auth, message: Localization.invalidJWT)
         }
         guard let blogID = decoded.blogID else {
-            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is missing blog_id.")
+            DDLogError("⛔️ Jetpack AI JWT payload is missing blog_id")
+            throw AssistantError(kind: .auth, message: Localization.invalidJWT)
         }
         guard let exp = decoded.exp else {
-            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is missing exp.")
+            DDLogError("⛔️ Jetpack AI JWT payload is missing exp")
+            throw AssistantError(kind: .auth, message: Localization.invalidJWT)
         }
         self.token = token
         self.blogID = blogID

--- a/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
@@ -26,7 +26,13 @@ public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
         }
         let blogID = self.blogID
         let mint = self.mint
-        let task = Task<String, Error> { try await mint(blogID) }
+        // Validate inside the Task body so concurrent sharers all see the same
+        // throw if the proxy ever returns a malformed JWT.
+        let task = Task<String, Error> {
+            let fresh = try await mint(blogID)
+            _ = try CachedJWT(token: fresh)
+            return fresh
+        }
         inflight = task
         defer { inflight = nil }
         let fresh = try await task.value
@@ -34,6 +40,9 @@ public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
         return fresh
     }
 
+    // Clears the cache. An in-flight mint started before invalidate is allowed
+    // to complete and write the fresh token; that's the desired outcome - a
+    // concurrent caller pays the network cost once and everyone benefits.
     public func invalidate() async {
         cached = nil
     }

--- a/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-/// Caches a Jetpack AI JWT in process and refreshes it on expiry / blog mismatch.
-///
-/// Single-flight is automatic via actor isolation: only one task runs inside the actor
-/// at a time, so concurrent callers serialize on `currentJWT()` and the second caller
-/// observes the freshly-minted token in the cache instead of triggering a second mint.
+// Single-flight is automatic via actor isolation: concurrent callers serialize on
+// `currentJWT()`, so the second caller observes the freshly-minted token rather
+// than triggering a second mint.
 public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
 
     public typealias Mint = @Sendable (Int64) async throws -> String
@@ -33,9 +31,6 @@ public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
     }
 }
 
-/// Decoded view of a Jetpack AI JWT. The provider only needs `blog_id` and `exp`
-/// from the payload to decide whether to reuse or refresh; signature is verified
-/// upstream by the proxy on each request, not here.
 struct CachedJWT: Equatable, Sendable {
     let token: String
     let blogID: Int64
@@ -75,8 +70,7 @@ struct CachedJWT: Equatable, Sendable {
         Date() >= expiresAt
     }
 
-    /// JWT payload uses base64url (`-_` instead of `+/`) and elides padding.
-    /// Convert to standard base64 and pad before handing to `Data(base64Encoded:)`.
+    // JWT payload is base64url (`-_` instead of `+/`) with padding elided.
     private static func base64URLDecode(_ input: String) -> Data? {
         var base64 = input
             .replacingOccurrences(of: "-", with: "+")

--- a/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Caches a Jetpack AI JWT in process and refreshes it on expiry / blog mismatch.
+///
+/// Single-flight is automatic via actor isolation: only one task runs inside the actor
+/// at a time, so concurrent callers serialize on `currentJWT()` and the second caller
+/// observes the freshly-minted token in the cache instead of triggering a second mint.
+public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
+
+    public typealias Mint = @Sendable (Int64) async throws -> String
+
+    private let blogID: Int64
+    private let mint: Mint
+    private var cached: CachedJWT?
+
+    public init(blogID: Int64, mint: @escaping Mint) {
+        self.blogID = blogID
+        self.mint = mint
+    }
+
+    public func currentJWT() async throws -> String {
+        if let cached, cached.matchesBlog(blogID), !cached.isExpired {
+            return cached.token
+        }
+        let fresh = try await mint(blogID)
+        let parsed = try CachedJWT(token: fresh)
+        cached = parsed
+        return fresh
+    }
+
+    public func invalidate() async {
+        cached = nil
+    }
+}
+
+/// Decoded view of a Jetpack AI JWT. The provider only needs `blog_id` and `exp`
+/// from the payload to decide whether to reuse or refresh; signature is verified
+/// upstream by the proxy on each request, not here.
+struct CachedJWT: Equatable, Sendable {
+    let token: String
+    let blogID: Int64
+    let expiresAt: Date
+
+    init(token: String) throws {
+        let segments = token.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3 else {
+            throw AssistantError(kind: .auth, message: "Jetpack AI JWT does not have three segments.")
+        }
+        let payloadSegment = String(segments[1])
+        guard let payloadData = Self.base64URLDecode(payloadSegment) else {
+            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is not valid base64url.")
+        }
+        let decoded: Payload
+        do {
+            decoded = try JSONDecoder().decode(Payload.self, from: payloadData)
+        } catch {
+            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is not valid JSON: \(error).")
+        }
+        guard let blogID = decoded.blogID else {
+            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is missing blog_id.")
+        }
+        guard let exp = decoded.exp else {
+            throw AssistantError(kind: .auth, message: "Jetpack AI JWT payload is missing exp.")
+        }
+        self.token = token
+        self.blogID = blogID
+        self.expiresAt = Date(timeIntervalSince1970: TimeInterval(exp))
+    }
+
+    func matchesBlog(_ id: Int64) -> Bool {
+        blogID == id
+    }
+
+    var isExpired: Bool {
+        Date() >= expiresAt
+    }
+
+    /// JWT payload uses base64url (`-_` instead of `+/`) and elides padding.
+    /// Convert to standard base64 and pad before handing to `Data(base64Encoded:)`.
+    private static func base64URLDecode(_ input: String) -> Data? {
+        var base64 = input
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: base64)
+    }
+
+    private struct Payload: Decodable {
+        let blogID: Int64?
+        let exp: Int64?
+
+        enum CodingKeys: String, CodingKey {
+            case blogID = "blog_id"
+            case exp
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
+++ b/Modules/Sources/WooAIAssistant/Networking/WpComJetpackAIJWTProvider.swift
@@ -1,11 +1,8 @@
 import Foundation
 import CocoaLumberjackSwift
 
-// Concurrent `currentJWT()` callers share one in-flight mint via a stored Task.
-// Plain actor isolation isn't enough: `await mint(...)` suspends, the actor lets the
-// next caller re-enter, that caller sees the still-unset cache and starts a second
-// mint. Holding a Task<String, Error> while the first call is in flight makes
-// followers await the same value.
+// Single-flight via a stored in-flight Task. Actor isolation alone isn't enough:
+// `await mint(...)` suspends, lets a second caller see the unset cache, and double-mints.
 public actor WpComJetpackAIJWTProvider: AssistantJWTProviding {
 
     public typealias Mint = @Sendable (Int64) async throws -> String
@@ -82,14 +79,11 @@ struct CachedJWT: Equatable, Sendable {
         blogID == id
     }
 
-    // Expire 60s early so a token whose true `exp` is just past `now` doesn't get
-    // shipped on a request that the proxy will then reject. Mirrors typical
-    // clock-skew margin and avoids 401-then-retry cycles at the boundary.
+    // 60s clock-skew margin avoids 401-then-retry cycles at the expiry boundary.
     var isExpired: Bool {
         Date() >= expiresAt.addingTimeInterval(-60)
     }
 
-    // JWT payload is base64url (`-_` instead of `+/`) with padding elided.
     private static func base64URLDecode(_ input: String) -> Data? {
         var base64 = input
             .replacingOccurrences(of: "-", with: "+")

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
@@ -1,4 +1,13 @@
 /// Mints the WPCOM AI JWT the assistant transport layer presents on every upstream request.
+/// `invalidate()` lets the chat client throw away a token the upstream reported as expired
+/// before its `exp` (clock skew or revocation) so the next `currentJWT()` mints fresh.
 public protocol AssistantJWTProviding: Sendable {
     func currentJWT() async throws -> String
+    func invalidate() async
+}
+
+public extension AssistantJWTProviding {
+    /// No-op default so non-caching stubs (in-memory test doubles, app-password adaptors)
+    /// don't have to implement an invalidation hook they have nothing to invalidate.
+    func invalidate() async {}
 }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
@@ -4,5 +4,6 @@ public protocol AssistantJWTProviding: Sendable {
 }
 
 public extension AssistantJWTProviding {
+    // Default for non-caching conformers (e.g. test stubs) that have no token to drop.
     func invalidate() async {}
 }

--- a/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
+++ b/Modules/Sources/WooAIAssistant/Protocols/AssistantJWTProviding.swift
@@ -1,13 +1,8 @@
-/// Mints the WPCOM AI JWT the assistant transport layer presents on every upstream request.
-/// `invalidate()` lets the chat client throw away a token the upstream reported as expired
-/// before its `exp` (clock skew or revocation) so the next `currentJWT()` mints fresh.
 public protocol AssistantJWTProviding: Sendable {
     func currentJWT() async throws -> String
     func invalidate() async
 }
 
 public extension AssistantJWTProviding {
-    /// No-op default so non-caching stubs (in-memory test doubles, app-password adaptors)
-    /// don't have to implement an invalidation hook they have nothing to invalidate.
     func invalidate() async {}
 }

--- a/Modules/Tests/WooAIAssistantTests/Configuration/AssistantConfigurationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Configuration/AssistantConfigurationTests.swift
@@ -3,9 +3,10 @@ import Testing
 
 struct AssistantConfigurationTests {
     @Test
-    func test_assistantConfiguration_when_inspected_then_pins_release_triple() {
+    func test_pinned_constants_match_documented_values() {
         #expect(AssistantConfiguration.chatModel == "gpt-4o-mini")
         #expect(AssistantConfiguration.promptVersion == "v1")
         #expect(AssistantConfiguration.toolCatalogVersion == "v1")
+        #expect(AssistantConfiguration.featureName == "woo-ai-assistant")
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Networking/CachedJWTTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/CachedJWTTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct CachedJWTTests {
+
+    @Test
+    func test_init_when_token_has_one_segment_then_throws_auth_error() {
+        // When / Then
+        #expect(throws: AssistantError.self) {
+            _ = try CachedJWT(token: "only-one-segment")
+        }
+    }
+
+    @Test
+    func test_init_when_token_payload_is_not_base64url_then_throws_auth_error() {
+        // When / Then
+        #expect(throws: AssistantError.self) {
+            _ = try CachedJWT(token: "header.\u{1F600}.signature")
+        }
+    }
+
+    @Test
+    func test_init_when_token_payload_is_not_json_then_throws_auth_error() {
+        // Given the literal "not-json" in base64url
+        let header = Self.base64URLEncode(Data("header".utf8))
+        let payload = Self.base64URLEncode(Data("not-json".utf8))
+        let token = "\(header).\(payload).signature"
+
+        // When / Then
+        #expect(throws: AssistantError.self) {
+            _ = try CachedJWT(token: token)
+        }
+    }
+
+    @Test
+    func test_init_when_payload_missing_blog_id_then_throws_auth_error() {
+        // Given
+        let token = Self.makeToken(payload: "{\"exp\":\(Int(Date().timeIntervalSince1970) + 3600)}")
+
+        // When / Then
+        #expect(throws: AssistantError.self) {
+            _ = try CachedJWT(token: token)
+        }
+    }
+
+    @Test
+    func test_init_when_payload_missing_exp_then_throws_auth_error() {
+        // Given
+        let token = Self.makeToken(payload: "{\"blog_id\":12345}")
+
+        // When / Then
+        #expect(throws: AssistantError.self) {
+            _ = try CachedJWT(token: token)
+        }
+    }
+
+    @Test
+    func test_init_when_payload_well_formed_then_extracts_blog_id_and_expiry() throws {
+        // Given
+        let exp = Int(Date().timeIntervalSince1970) + 3600
+        let token = Self.makeToken(payload: "{\"blog_id\":42,\"exp\":\(exp)}")
+
+        // When
+        let cached = try CachedJWT(token: token)
+
+        // Then
+        #expect(cached.blogID == 42)
+        #expect(cached.expiresAt.timeIntervalSince1970 == TimeInterval(exp))
+        #expect(cached.matchesBlog(42))
+    }
+
+    private static func makeToken(payload: String) -> String {
+        let header = base64URLEncode(Data(#"{"alg":"HS256","typ":"JWT"}"#.utf8))
+        let payloadEncoded = base64URLEncode(Data(payload.utf8))
+        return "\(header).\(payloadEncoded).signature"
+    }
+
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -165,6 +165,93 @@ struct JetpackAIQueryClientTests {
         #expect(textDeltas.joined() == "after refresh")
     }
 
+    @Test
+    func test_streamTurn_when_401_repeats_then_surfaces_error_after_one_retry() async throws {
+        // Given
+        let unauthorizedBody = Data(#"{"code":"jetpack_ai_unauthorized","message":"unauthorized"}"#.utf8)
+        let jwtProvider = ScriptedJWTProvider(tokens: ["t1", "t2", "t3"])
+        let transport = ScriptedTransport(scenarios: [
+            .errorBody(status: 401, body: unauthorizedBody),
+            .errorBody(status: 401, body: unauthorizedBody)
+        ])
+        let client = JetpackAIQueryClient(jwtProvider: jwtProvider,
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected the second 401 to surface.")
+        } catch let error as AssistantError {
+            #expect(error.code == "401")
+        }
+        #expect(await transport.callCount == 2)
+        #expect(await jwtProvider.invalidateCount == 1)
+    }
+
+    @Test
+    func test_streamTurn_when_429_repeats_three_times_then_surfaces_after_two_retries() async throws {
+        // Given
+        let scenarios: [TransportScenario] = (0..<3).map { _ in
+            .errorBody(status: 429, body: rateLimitedBody())
+        }
+        let transport = ScriptedTransport(scenarios: scenarios)
+        let sleepRecorder = SleepRecorder()
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: sleepRecorder.handler)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected the third 429 to surface.")
+        } catch let error as AssistantError {
+            #expect(error.code == "429")
+        }
+        #expect(await transport.callCount == 3)
+        #expect(await sleepRecorder.delays == [2_000_000_000, 4_000_000_000])
+    }
+
+    @Test
+    func test_streamTurn_when_503_then_surfaces_without_retry() async throws {
+        // Given
+        let body = Data("upstream is down".utf8)
+        let transport = ScriptedTransport(scenarios: [.errorBody(status: 503, body: body)])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected 503 to surface.")
+        } catch let error as AssistantError {
+            #expect(error.code == "503")
+            #expect(error.kind == .upstreamFailure)
+        }
+        #expect(await transport.callCount == 1)
+    }
+
+    @Test
+    func test_streamTurn_when_wrapped_envelope_arrives_after_keepalive_then_throws_typed_AssistantError() async throws {
+        // Given
+        let envelope = #"{"code":"context_too_long","message":"context overflow","data":{"status":413}}"#
+        let frames = ":\n\n:\n\ndata: \(envelope)\n\n"
+        let transport = ScriptedTransport(scenarios: [.successChunks([Data(frames.utf8)])])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected wrapped envelope to surface even after keepalive comments.")
+        } catch let error as AssistantError {
+            #expect(error.code == "413")
+            #expect(error.message.contains("context_too_long"))
+        }
+    }
+
     private func makeClient(streamingResult: TransportScenario) -> JetpackAIQueryClient {
         let transport = ScriptedTransport(scenarios: [streamingResult])
         return JetpackAIQueryClient(jwtProvider: stubJWTProvider(),

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct JetpackAIQueryClientTests {
+
+    // MARK: - 1. Streaming with split chunks
+
+    @Test
+    func test_streamTurn_when_streaming_with_split_chunks_then_assembles_text_in_order() async throws {
+        // Given
+        let frames = [
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"lo, w\"}}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"orld!\"}}]}\n\n",
+            "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        ]
+        // Splits crafted to land mid-frame and mid-line, exercising the parser's buffering.
+        let chunks = chunkifyAwkwardly(frames.joined())
+        let client = makeClient(streamingResult: .successChunks(chunks))
+
+        // When
+        let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        let textDeltas = events.compactMap { event -> String? in
+            if case .textDelta(let text) = event { return text }
+            return nil
+        }
+        #expect(textDeltas.joined() == "Hello, world!")
+        if case .completed(let reason) = events.last {
+            #expect(reason == .stop)
+        } else {
+            Issue.record("Expected last event to be completed.")
+        }
+    }
+
+    // MARK: - 2. 429 retry with backoff
+
+    @Test
+    func test_streamTurn_when_429_then_retries_with_backoff() async throws {
+        // Given
+        let successFrames = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+        let scenarios: [TransportScenario] = [
+            .errorBody(status: 429, body: rateLimitedBody()),
+            .errorBody(status: 429, body: rateLimitedBody()),
+            .successChunks([Data(successFrames.utf8)])
+        ]
+        let transport = ScriptedTransport(scenarios: scenarios)
+        let sleepRecorder = SleepRecorder()
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: sleepRecorder.handler)
+
+        // When
+        let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        #expect(await transport.callCount == 3)
+        let textDeltas = events.compactMap { event -> String? in
+            if case .textDelta(let text) = event { return text }
+            return nil
+        }
+        #expect(textDeltas.joined() == "ok")
+        let recordedDelays = await sleepRecorder.delays
+        // 2s + 4s backoff = 2_000_000_000 + 4_000_000_000 nanoseconds.
+        #expect(recordedDelays == [2_000_000_000, 4_000_000_000])
+    }
+
+    // MARK: - 3. Wrapped-error envelope on HTTP 200
+
+    @Test
+    func test_streamTurn_when_wrapped_error_envelope_then_throws_typed_AssistantError() async throws {
+        // Given
+        let envelope = #"{"code":"context_too_long","message":"Conversation exceeded the model context.","data":{"status":413}}"#
+        let frame = "data: \(envelope)\n\n"
+        let transport = ScriptedTransport(scenarios: [.successChunks([Data(frame.utf8)])])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected wrapped envelope to surface as AssistantError.")
+        } catch let error as AssistantError {
+            #expect(error.code == "413")
+            #expect(error.message.contains("context_too_long"))
+        }
+    }
+
+    // MARK: - 4. Tool-calling assistant message encodes empty content
+
+    @Test
+    func test_streamTurn_when_assistant_message_carries_tool_calls_then_encodes_empty_content_string() async throws {
+        // Given
+        let toolCall = OpenAIChat.ToolCall(id: "call_1", function: .init(name: "orders_get", arguments: "{}"))
+        let assistantMessage = OpenAIChat.Message(role: .assistant, content: nil, toolCalls: [toolCall])
+        let toolMessage = OpenAIChat.Message(role: .tool, content: "{}", toolCalls: nil, toolCallID: "call_1")
+        let frame = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"done\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+        let transport = ScriptedTransport(scenarios: [.successChunks([Data(frame.utf8)])])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When
+        _ = try await collect(client.streamTurn(messages: [userMessage(), assistantMessage, toolMessage],
+                                                tools: nil,
+                                                toolChoice: nil))
+
+        // Then
+        let captured = try #require(await transport.lastRequest)
+        let body = try #require(captured.httpBody)
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
+        let messages = try #require(json["messages"] as? [[String: Any]])
+        let assistantOnWire = try #require(messages.first(where: { $0["role"] as? String == "assistant" }))
+        let content = try #require(assistantOnWire["content"] as? String)
+        #expect(content.isEmpty)
+        #expect(assistantOnWire["tool_calls"] != nil)
+    }
+
+    // MARK: - 5. UTF-8 boundary carry
+
+    @Test
+    func test_streamTurn_when_utf8_boundary_split_then_recovers_full_character() async throws {
+        // Given
+        // Rocket emoji U+1F680 encodes to 4 bytes: F0 9F 9A 80. Frame is split inside
+        // the emoji's byte sequence so the first chunk has only its leading bytes.
+        let prefix = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi "
+        let suffix = "!\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+        let emojiBytes: [UInt8] = [0xF0, 0x9F, 0x9A, 0x80]
+        var firstChunk = Data(prefix.utf8)
+        firstChunk.append(contentsOf: emojiBytes.prefix(2))
+        var secondChunk = Data()
+        secondChunk.append(contentsOf: emojiBytes.suffix(2))
+        secondChunk.append(Data(suffix.utf8))
+        let transport = ScriptedTransport(scenarios: [.successChunks([firstChunk, secondChunk])])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When
+        let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        let textDeltas = events.compactMap { event -> String? in
+            if case .textDelta(let text) = event { return text }
+            return nil
+        }
+        #expect(textDeltas.joined() == "Hi \u{1F680}!")
+    }
+
+    // MARK: - 6. 401 pre-data invalidates JWT and retries once
+
+    @Test
+    func test_streamTurn_when_401_pre_data_then_invalidates_jwt_and_retries_once() async throws {
+        // Given
+        let successFrames = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"after refresh\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+        let jwtProvider = ScriptedJWTProvider(tokens: ["stale-token", "fresh-token"])
+        let transport = ScriptedTransport(scenarios: [
+            .errorBody(status: 401, body: Data(#"{"code":"jetpack_ai_unauthorized","message":"unauthorized"}"#.utf8)),
+            .successChunks([Data(successFrames.utf8)])
+        ])
+        let client = JetpackAIQueryClient(jwtProvider: jwtProvider,
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When
+        let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        #expect(await transport.callCount == 2)
+        #expect(await jwtProvider.invalidateCount == 1)
+        #expect(await jwtProvider.handedOut == ["stale-token", "fresh-token"])
+        let textDeltas = events.compactMap { event -> String? in
+            if case .textDelta(let text) = event { return text }
+            return nil
+        }
+        #expect(textDeltas.joined() == "after refresh")
+    }
+
+    // MARK: - Helpers
+
+    private func makeClient(streamingResult: TransportScenario) -> JetpackAIQueryClient {
+        let transport = ScriptedTransport(scenarios: [streamingResult])
+        return JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                    streamingTransport: transport.handler,
+                                    sleep: noOpSleep)
+    }
+
+    private func userMessage() -> OpenAIChat.Message {
+        OpenAIChat.Message(role: .user, content: "ping")
+    }
+
+    private func collect(_ stream: AsyncThrowingStream<ChatStreamEvent, Error>) async throws -> [ChatStreamEvent] {
+        var events: [ChatStreamEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        return events
+    }
+
+    private func chunkifyAwkwardly(_ string: String) -> [Data] {
+        let bytes = Array(string.utf8)
+        var chunks: [Data] = []
+        var index = 0
+        let breakpoints = [7, 19, 47, 83]
+        for breakpoint in breakpoints where breakpoint < bytes.count {
+            chunks.append(Data(bytes[index..<breakpoint]))
+            index = breakpoint
+        }
+        if index < bytes.count {
+            chunks.append(Data(bytes[index..<bytes.count]))
+        }
+        return chunks
+    }
+
+    private func rateLimitedBody() -> Data {
+        Data(#"{"code":"jetpack_ai_rate_limited","message":"too many requests","data":{"status":429}}"#.utf8)
+    }
+
+    private func stubJWTProvider() -> AssistantJWTProviding {
+        FixedJWTProvider(token: "stub-token")
+    }
+
+    private var noOpSleep: JetpackAIQueryClient.Sleep {
+        { _ in }
+    }
+}
+
+// MARK: - Test doubles
+
+/// Records the bytes the client passes to `sleep`. Calls produce no real wait.
+private actor SleepRecorder {
+    private(set) var delays: [UInt64] = []
+
+    nonisolated var handler: JetpackAIQueryClient.Sleep {
+        { @Sendable nanoseconds in
+            await self.record(nanoseconds)
+        }
+    }
+
+    private func record(_ nanoseconds: UInt64) {
+        delays.append(nanoseconds)
+    }
+}
+
+/// Returns a fixed token forever; ignores `invalidate()`. Suitable for tests
+/// that don't exercise the auth-retry path.
+private struct FixedJWTProvider: AssistantJWTProviding {
+    let token: String
+    func currentJWT() async throws -> String { token }
+}
+
+/// Mints from a scripted list and counts invalidations. Used by the 401-retry
+/// test to assert the client asked the provider to invalidate exactly once.
+private actor ScriptedJWTProvider: AssistantJWTProviding {
+    private var tokens: [String]
+    private(set) var invalidateCount = 0
+    private(set) var handedOut: [String] = []
+
+    init(tokens: [String]) {
+        self.tokens = tokens
+    }
+
+    func currentJWT() async throws -> String {
+        guard !tokens.isEmpty else {
+            throw AssistantError(kind: .auth, message: "scripted provider exhausted")
+        }
+        let next = tokens.removeFirst()
+        handedOut.append(next)
+        return next
+    }
+
+    func invalidate() async {
+        invalidateCount += 1
+    }
+}
+
+/// One scenario per call to the streaming transport. The scripted transport
+/// returns scenarios in order and records every request the client built.
+private enum TransportScenario {
+    case successChunks([Data])
+    case errorBody(status: Int, body: Data)
+}
+
+private actor ScriptedTransport {
+    private var scenarios: [TransportScenario]
+    private(set) var callCount = 0
+    private(set) var lastRequest: URLRequest?
+
+    init(scenarios: [TransportScenario]) {
+        self.scenarios = scenarios
+    }
+
+    nonisolated var handler: StreamingHTTPTransport {
+        { @Sendable request in
+            try await self.handle(request: request)
+        }
+    }
+
+    private func handle(request: URLRequest) async throws -> (AsyncThrowingStream<Data, Error>, HTTPURLResponse) {
+        callCount += 1
+        lastRequest = request
+        guard !scenarios.isEmpty else {
+            throw AssistantError(kind: .network, message: "scripted transport exhausted")
+        }
+        let scenario = scenarios.removeFirst()
+        switch scenario {
+        case .successChunks(let chunks):
+            let stream = AsyncThrowingStream<Data, Error> { continuation in
+                for chunk in chunks {
+                    continuation.yield(chunk)
+                }
+                continuation.finish()
+            }
+            let http = HTTPURLResponse(url: request.url ?? URL(string: "https://test.invalid")!,
+                                       statusCode: 200,
+                                       httpVersion: nil,
+                                       headerFields: nil)!
+            return (stream, http)
+        case .errorBody(let status, let body):
+            let stream = AsyncThrowingStream<Data, Error> { continuation in
+                continuation.yield(body)
+                continuation.finish()
+            }
+            let http = HTTPURLResponse(url: request.url ?? URL(string: "https://test.invalid")!,
+                                       statusCode: status,
+                                       httpVersion: nil,
+                                       headerFields: nil)!
+            return (stream, http)
+        }
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -344,6 +344,27 @@ struct JetpackAIQueryClientTests {
         }
     }
 
+    @Test
+    func test_streamTurn_when_data_frame_neither_chunk_nor_envelope_then_throws_invalidStream() async throws {
+        // Given
+        // Non-empty JSON that misses `choices` (so it won't decode as `OpenAIChat.Chunk`) and misses
+        // `code`/`message` (so it won't decode as a wrapped error envelope). Without the typed
+        // surface we'd silently drop this frame and let the turn complete with a partial response.
+        let frame = #"data: {"some":"unexpected","payload":42}"# + "\n\n"
+        let transport = ScriptedTransport(scenarios: [.successChunks([Data(frame.utf8)])])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected malformed SSE chunk to surface as AssistantError(.invalidStream).")
+        } catch let error as AssistantError {
+            #expect(error.kind == .invalidStream)
+        }
+    }
+
     private func makeClient(streamingResult: TransportScenario) -> JetpackAIQueryClient {
         let transport = ScriptedTransport(scenarios: [streamingResult])
         return JetpackAIQueryClient(jwtProvider: stubJWTProvider(),

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -22,11 +22,7 @@ struct JetpackAIQueryClientTests {
         let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
 
         // Then
-        let textDeltas = events.compactMap { event -> String? in
-            if case .textDelta(let text) = event { return text }
-            return nil
-        }
-        #expect(textDeltas.joined() == "Hello, world!")
+        #expect(textDeltas(in: events).joined() == "Hello, world!")
         if case .completed(let reason) = events.last {
             #expect(reason == .stop)
         } else {
@@ -54,11 +50,7 @@ struct JetpackAIQueryClientTests {
 
         // Then
         #expect(await transport.callCount == 3)
-        let textDeltas = events.compactMap { event -> String? in
-            if case .textDelta(let text) = event { return text }
-            return nil
-        }
-        #expect(textDeltas.joined() == "ok")
+        #expect(textDeltas(in: events).joined() == "ok")
         let recordedDelays = await sleepRecorder.delays
         #expect(recordedDelays == [2_000_000_000, 4_000_000_000])
     }
@@ -132,11 +124,80 @@ struct JetpackAIQueryClientTests {
         let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
 
         // Then
-        let textDeltas = events.compactMap { event -> String? in
-            if case .textDelta(let text) = event { return text }
-            return nil
+        #expect(textDeltas(in: events).joined() == "Hi \u{1F680}!")
+    }
+
+    @Test
+    func test_streamTurn_when_response_streams_one_tool_call_then_emits_assembled_toolCall() async throws {
+        // Given
+        let frames = [
+            toolCallSkeletonFrame(index: 0, id: "call_42", name: "orders_get"),
+            toolCallArgsFrame(index: 0, args: "{\"order_id\":"),
+            toolCallArgsFrame(index: 0, args: "42}"),
+            finishFrame(reason: "tool_calls"),
+            "data: [DONE]\n\n"
+        ]
+        let client = makeClient(streamingResult: .successChunks([Data(frames.joined().utf8)]))
+
+        // When
+        let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        let calls = toolCalls(in: events)
+        #expect(calls.count == 1)
+        #expect(calls.first?.id == "call_42")
+        #expect(calls.first?.function.name == "orders_get")
+        #expect(calls.first?.function.arguments == "{\"order_id\":42}")
+        if case .completed(let reason) = events.last {
+            #expect(reason == .toolCalls)
+        } else {
+            Issue.record("Expected the final event to be completed.")
         }
-        #expect(textDeltas.joined() == "Hi \u{1F680}!")
+    }
+
+    @Test
+    func test_streamTurn_when_response_streams_two_tool_calls_then_emits_them_in_index_order() async throws {
+        // Given
+        let frames = [
+            toolCallSkeletonFrame(index: 0, id: "a", name: "first"),
+            toolCallSkeletonFrame(index: 1, id: "b", name: "second"),
+            toolCallArgsFrame(index: 0, args: "{}"),
+            toolCallArgsFrame(index: 1, args: "{}"),
+            finishFrame(reason: "tool_calls"),
+            "data: [DONE]\n\n"
+        ]
+        let client = makeClient(streamingResult: .successChunks([Data(frames.joined().utf8)]))
+
+        // When
+        let events = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        let calls = toolCalls(in: events)
+        #expect(calls.map(\.id) == ["a", "b"])
+        #expect(calls.map(\.function.name) == ["first", "second"])
+        #expect(calls.map(\.function.arguments) == ["{}", "{}"])
+    }
+
+    @Test
+    func test_streamTurn_when_403_then_surfaces_without_retry_or_invalidate() async throws {
+        // Given
+        let body = Data(#"{"code":"jetpack_ai_forbidden","message":"forbidden","data":{"status":403}}"#.utf8)
+        let jwtProvider = ScriptedJWTProvider(tokens: ["t"])
+        let transport = ScriptedTransport(scenarios: [.errorBody(status: 403, body: body)])
+        let client = JetpackAIQueryClient(jwtProvider: jwtProvider,
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected 403 to surface.")
+        } catch let error as AssistantError {
+            #expect(error.code == "403")
+            #expect(error.kind == .auth)
+        }
+        #expect(await transport.callCount == 1)
+        #expect(await jwtProvider.invalidateCount == 0)
     }
 
     @Test
@@ -159,11 +220,7 @@ struct JetpackAIQueryClientTests {
         #expect(await transport.callCount == 2)
         #expect(await jwtProvider.invalidateCount == 1)
         #expect(await jwtProvider.handedOut == ["stale-token", "fresh-token"])
-        let textDeltas = events.compactMap { event -> String? in
-            if case .textDelta(let text) = event { return text }
-            return nil
-        }
-        #expect(textDeltas.joined() == "after refresh")
+        #expect(textDeltas(in: events).joined() == "after refresh")
     }
 
     @Test
@@ -305,6 +362,38 @@ struct JetpackAIQueryClientTests {
         return events
     }
 
+    private func textDeltas(in events: [ChatStreamEvent]) -> [String] {
+        events.compactMap { event in
+            if case .textDelta(let text) = event { return text }
+            return nil
+        }
+    }
+
+    private func toolCalls(in events: [ChatStreamEvent]) -> [OpenAIChat.ToolCall] {
+        events.compactMap { event in
+            if case .toolCall(let call) = event { return call }
+            return nil
+        }
+    }
+
+    private func toolCallSkeletonFrame(index: Int, id: String, name: String) -> String {
+        let payload = "{\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[" +
+            "{\"index\":\(index),\"id\":\"\(id)\",\"type\":\"function\"," +
+            "\"function\":{\"name\":\"\(name)\",\"arguments\":\"\"}}]}}]}"
+        return "data: \(payload)\n\n"
+    }
+
+    private func toolCallArgsFrame(index: Int, args: String) -> String {
+        let escaped = args.replacingOccurrences(of: "\"", with: "\\\"")
+        let payload = "{\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[" +
+            "{\"index\":\(index),\"function\":{\"arguments\":\"\(escaped)\"}}]}}]}"
+        return "data: \(payload)\n\n"
+    }
+
+    private func finishFrame(reason: String) -> String {
+        "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"\(reason)\"}]}\n\n"
+    }
+
     private func chunkifyAwkwardly(_ string: String) -> [Data] {
         let bytes = Array(string.utf8)
         var chunks: [Data] = []
@@ -401,6 +490,7 @@ private actor ScriptedTransport {
         guard !scenarios.isEmpty else {
             throw AssistantError(kind: .network, message: "scripted transport exhausted")
         }
+        let url = request.url ?? URL(string: "https://test.invalid")!
         let scenario = scenarios.removeFirst()
         switch scenario {
         case .successChunks(let chunks):
@@ -410,20 +500,14 @@ private actor ScriptedTransport {
                 }
                 continuation.finish()
             }
-            let http = HTTPURLResponse(url: request.url ?? URL(string: "https://test.invalid")!,
-                                       statusCode: 200,
-                                       httpVersion: nil,
-                                       headerFields: nil)!
+            let http = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (stream, http)
         case .errorBody(let status, let body):
             let stream = AsyncThrowingStream<Data, Error> { continuation in
                 continuation.yield(body)
                 continuation.finish()
             }
-            let http = HTTPURLResponse(url: request.url ?? URL(string: "https://test.invalid")!,
-                                       statusCode: status,
-                                       httpVersion: nil,
-                                       headerFields: nil)!
+            let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
             return (stream, http)
         }
     }

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -365,6 +365,40 @@ struct JetpackAIQueryClientTests {
         }
     }
 
+    @Test
+    func test_streamTurn_when_transport_throws_timedOut_then_surfaces_AssistantError_timeout() async throws {
+        // Given
+        let transport = ScriptedTransport(scenarios: [.throwsError(URLError(.timedOut))])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected URLError to surface as typed AssistantError.")
+        } catch let error as AssistantError {
+            #expect(error.kind == .timeout)
+        }
+    }
+
+    @Test
+    func test_streamTurn_when_transport_throws_notConnectedToInternet_then_surfaces_AssistantError_network() async throws {
+        // Given
+        let transport = ScriptedTransport(scenarios: [.throwsError(URLError(.notConnectedToInternet))])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When / Then
+        do {
+            _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+            Issue.record("Expected URLError to surface as typed AssistantError.")
+        } catch let error as AssistantError {
+            #expect(error.kind == .network)
+        }
+    }
+
     private func makeClient(streamingResult: TransportScenario) -> JetpackAIQueryClient {
         let transport = ScriptedTransport(scenarios: [streamingResult])
         return JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
@@ -489,6 +523,7 @@ private actor ScriptedJWTProvider: AssistantJWTProviding {
 private enum TransportScenario {
     case successChunks([Data])
     case errorBody(status: Int, body: Data)
+    case throwsError(Error)
 }
 
 private actor ScriptedTransport {
@@ -531,6 +566,13 @@ private actor ScriptedTransport {
             }
             let http = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
             return (stream, http)
+        case .throwsError(let error):
+            // Mirrors the production URLSession transport's URLError mapping so the scripted
+            // transport stays a faithful stand-in for the layer where URLErrors originate.
+            if let urlError = error as? URLError {
+                throw JetpackAIQueryClient.mapURLError(urlError)
+            }
+            throw error
         }
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -234,6 +234,20 @@ struct JetpackAIQueryClientTests {
     }
 
     @Test
+    func test_default_endpoint_matches_NetworkingCore_wpcom_base_url() {
+        // Given the configurable WPCOM base URL from NetworkingCore.Settings
+        let expected = URL(string: Settings.wordpressApiBaseURL + "wpcom/v2/jetpack-ai-query")!
+
+        // When constructing a client with the default endpoint
+        let mirror = Mirror(reflecting: JetpackAIQueryClient(jwtProvider: stubJWTProvider()))
+        let endpoint = mirror.descendant("endpoint") as? URL
+
+        // Then it composes against the same base, so launch-arg overrides
+        // (e.g. `mocked-wpcom-api` for WireMock) route the chat client too.
+        #expect(endpoint == expected)
+    }
+
+    @Test
     func test_streamTurn_when_request_is_built_then_carries_woo_user_agent_and_auth_headers() async throws {
         // Given
         let frame = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import NetworkingCore
 @testable import WooAIAssistant
 
 struct JetpackAIQueryClientTests {
@@ -230,6 +231,25 @@ struct JetpackAIQueryClientTests {
             #expect(error.kind == .upstreamFailure)
         }
         #expect(await transport.callCount == 1)
+    }
+
+    @Test
+    func test_streamTurn_when_request_is_built_then_carries_woo_user_agent_and_auth_headers() async throws {
+        // Given
+        let frame = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
+        let transport = ScriptedTransport(scenarios: [.successChunks([Data(frame.utf8)])])
+        let client = JetpackAIQueryClient(jwtProvider: stubJWTProvider(),
+                                          streamingTransport: transport.handler,
+                                          sleep: noOpSleep)
+
+        // When
+        _ = try await collect(client.streamTurn(messages: [userMessage()], tools: nil, toolChoice: nil))
+
+        // Then
+        let captured = try #require(await transport.lastRequest)
+        #expect(captured.value(forHTTPHeaderField: "User-Agent") == UserAgent.defaultUserAgent)
+        #expect(captured.value(forHTTPHeaderField: "Authorization") == "Bearer stub-token")
+        #expect(captured.value(forHTTPHeaderField: "Accept") == "text/event-stream")
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -4,8 +4,6 @@ import Testing
 
 struct JetpackAIQueryClientTests {
 
-    // MARK: - 1. Streaming with split chunks
-
     @Test
     func test_streamTurn_when_streaming_with_split_chunks_then_assembles_text_in_order() async throws {
         // Given
@@ -16,7 +14,6 @@ struct JetpackAIQueryClientTests {
             "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
             "data: [DONE]\n\n"
         ]
-        // Splits crafted to land mid-frame and mid-line, exercising the parser's buffering.
         let chunks = chunkifyAwkwardly(frames.joined())
         let client = makeClient(streamingResult: .successChunks(chunks))
 
@@ -35,8 +32,6 @@ struct JetpackAIQueryClientTests {
             Issue.record("Expected last event to be completed.")
         }
     }
-
-    // MARK: - 2. 429 retry with backoff
 
     @Test
     func test_streamTurn_when_429_then_retries_with_backoff() async throws {
@@ -64,11 +59,8 @@ struct JetpackAIQueryClientTests {
         }
         #expect(textDeltas.joined() == "ok")
         let recordedDelays = await sleepRecorder.delays
-        // 2s + 4s backoff = 2_000_000_000 + 4_000_000_000 nanoseconds.
         #expect(recordedDelays == [2_000_000_000, 4_000_000_000])
     }
-
-    // MARK: - 3. Wrapped-error envelope on HTTP 200
 
     @Test
     func test_streamTurn_when_wrapped_error_envelope_then_throws_typed_AssistantError() async throws {
@@ -89,8 +81,6 @@ struct JetpackAIQueryClientTests {
             #expect(error.message.contains("context_too_long"))
         }
     }
-
-    // MARK: - 4. Tool-calling assistant message encodes empty content
 
     @Test
     func test_streamTurn_when_assistant_message_carries_tool_calls_then_encodes_empty_content_string() async throws {
@@ -120,13 +110,10 @@ struct JetpackAIQueryClientTests {
         #expect(assistantOnWire["tool_calls"] != nil)
     }
 
-    // MARK: - 5. UTF-8 boundary carry
-
     @Test
     func test_streamTurn_when_utf8_boundary_split_then_recovers_full_character() async throws {
         // Given
-        // Rocket emoji U+1F680 encodes to 4 bytes: F0 9F 9A 80. Frame is split inside
-        // the emoji's byte sequence so the first chunk has only its leading bytes.
+        // Rocket emoji U+1F680 is 4 bytes (F0 9F 9A 80); the chunk break splits it 2/2.
         let prefix = "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hi "
         let suffix = "!\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"
         let emojiBytes: [UInt8] = [0xF0, 0x9F, 0x9A, 0x80]
@@ -150,8 +137,6 @@ struct JetpackAIQueryClientTests {
         }
         #expect(textDeltas.joined() == "Hi \u{1F680}!")
     }
-
-    // MARK: - 6. 401 pre-data invalidates JWT and retries once
 
     @Test
     func test_streamTurn_when_401_pre_data_then_invalidates_jwt_and_retries_once() async throws {
@@ -179,8 +164,6 @@ struct JetpackAIQueryClientTests {
         }
         #expect(textDeltas.joined() == "after refresh")
     }
-
-    // MARK: - Helpers
 
     private func makeClient(streamingResult: TransportScenario) -> JetpackAIQueryClient {
         let transport = ScriptedTransport(scenarios: [streamingResult])
@@ -229,9 +212,6 @@ struct JetpackAIQueryClientTests {
     }
 }
 
-// MARK: - Test doubles
-
-/// Records the bytes the client passes to `sleep`. Calls produce no real wait.
 private actor SleepRecorder {
     private(set) var delays: [UInt64] = []
 
@@ -246,15 +226,11 @@ private actor SleepRecorder {
     }
 }
 
-/// Returns a fixed token forever; ignores `invalidate()`. Suitable for tests
-/// that don't exercise the auth-retry path.
 private struct FixedJWTProvider: AssistantJWTProviding {
     let token: String
     func currentJWT() async throws -> String { token }
 }
 
-/// Mints from a scripted list and counts invalidations. Used by the 401-retry
-/// test to assert the client asked the provider to invalidate exactly once.
 private actor ScriptedJWTProvider: AssistantJWTProviding {
     private var tokens: [String]
     private(set) var invalidateCount = 0
@@ -278,8 +254,6 @@ private actor ScriptedJWTProvider: AssistantJWTProviding {
     }
 }
 
-/// One scenario per call to the streaming transport. The scripted transport
-/// returns scenarios in order and records every request the client built.
 private enum TransportScenario {
     case successChunks([Data])
     case errorBody(status: Int, body: Data)

--- a/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/JetpackAIQueryClientTests.swift
@@ -291,9 +291,10 @@ struct JetpackAIQueryClientTests {
     }
 
     @Test
-    func test_default_endpoint_matches_NetworkingCore_wpcom_base_url() {
+    func test_default_endpoint_matches_NetworkingCore_wpcom_base_url() throws {
         // Given the configurable WPCOM base URL from NetworkingCore.Settings
-        let expected = URL(string: Settings.wordpressApiBaseURL + "wpcom/v2/jetpack-ai-query")!
+        let base = try #require(URL(string: Settings.wordpressApiBaseURL))
+        let expected = try #require(URL(string: "wpcom/v2/jetpack-ai-query", relativeTo: base)?.absoluteURL)
 
         // When constructing a client with the default endpoint
         let mirror = Mirror(reflecting: JetpackAIQueryClient(jwtProvider: stubJWTProvider()))

--- a/Modules/Tests/WooAIAssistantTests/Networking/WpComJetpackAIJWTProviderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/WpComJetpackAIJWTProviderTests.swift
@@ -4,8 +4,6 @@ import Testing
 
 struct WpComJetpackAIJWTProviderTests {
 
-    // MARK: - 1. Cache hit returns without minting
-
     @Test
     func test_currentJWT_when_cache_warm_and_not_expired_then_returns_cached_without_minting() async throws {
         // Given
@@ -22,8 +20,6 @@ struct WpComJetpackAIJWTProviderTests {
         #expect(second == token)
         #expect(await counter.count == 1)
     }
-
-    // MARK: - 2. Expired cached token mints fresh
 
     @Test
     func test_currentJWT_when_cached_token_expired_then_mints_fresh() async throws {
@@ -44,8 +40,6 @@ struct WpComJetpackAIJWTProviderTests {
         #expect(await counter.count == 2)
     }
 
-    // MARK: - 3. Blog-id mismatch mints fresh
-
     @Test
     func test_currentJWT_when_cached_token_blog_id_mismatch_then_mints_fresh() async throws {
         // Given
@@ -64,8 +58,6 @@ struct WpComJetpackAIJWTProviderTests {
         #expect(second == correctToken)
         #expect(await counter.count == 2)
     }
-
-    // MARK: - 4. Concurrent callers single-flight the mint
 
     @Test
     func test_currentJWT_when_concurrent_callers_then_mints_exactly_once() async throws {
@@ -87,8 +79,6 @@ struct WpComJetpackAIJWTProviderTests {
         #expect(await counter.count == 1)
     }
 
-    // MARK: - 5. invalidate forces a fresh mint
-
     @Test
     func test_invalidate_when_called_then_next_currentJWT_mints_fresh() async throws {
         // Given
@@ -109,11 +99,8 @@ struct WpComJetpackAIJWTProviderTests {
         #expect(await counter.count == 2)
     }
 
-    // MARK: - JWT fixture builder
-
-    /// Builds a JWT-shaped string with `header.payload.signature`. Header is a
-    /// minimal `{"alg":"HS256","typ":"JWT"}` and signature is a constant placeholder
-    /// (the provider only inspects the payload, not the signature).
+    // header.payload.signature; signature is a constant since the provider
+    // never validates it (the proxy does).
     private func makeJWT(blogID: Int64, expiresIn seconds: Int) -> String {
         let header = #"{"alg":"HS256","typ":"JWT"}"#
         let exp = Int(Date().timeIntervalSince1970) + seconds
@@ -128,8 +115,6 @@ struct WpComJetpackAIJWTProviderTests {
             .replacingOccurrences(of: "=", with: "")
     }
 }
-
-// MARK: - Test doubles
 
 private actor MintCounter {
     private(set) var count: Int = 0

--- a/Modules/Tests/WooAIAssistantTests/Networking/WpComJetpackAIJWTProviderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/WpComJetpackAIJWTProviderTests.swift
@@ -80,6 +80,45 @@ struct WpComJetpackAIJWTProviderTests {
     }
 
     @Test
+    func test_currentJWT_when_token_within_clock_skew_margin_then_mints_fresh() async throws {
+        // Given a token whose true `exp` is within the 60s clock-skew margin
+        let blogID: Int64 = 12345
+        let nearExpiry = makeJWT(blogID: blogID, expiresIn: 30)
+        let fresh = makeJWT(blogID: blogID, expiresIn: 3600)
+        let counter = MintCounter(script: [nearExpiry, fresh])
+        let provider = WpComJetpackAIJWTProvider(blogID: blogID,
+                                                 mint: counter.makeMintScript())
+        _ = try await provider.currentJWT()
+
+        // When
+        let second = try await provider.currentJWT()
+
+        // Then a fresh mint replaces the still-valid-on-the-clock token
+        #expect(second == fresh)
+        #expect(await counter.count == 2)
+    }
+
+    @Test
+    func test_currentJWT_when_first_mint_throws_then_next_call_retries() async throws {
+        // Given
+        let blogID: Int64 = 12345
+        let token = makeJWT(blogID: blogID, expiresIn: 3600)
+        let mintBox = ThrowingMintFactory(failuresBeforeSuccess: 1, token: token)
+        let provider = WpComJetpackAIJWTProvider(blogID: blogID, mint: mintBox.makeMint())
+
+        // When / Then
+        do {
+            _ = try await provider.currentJWT()
+            Issue.record("Expected the first mint to throw.")
+        } catch {
+            // expected
+        }
+        let recovered = try await provider.currentJWT()
+        #expect(recovered == token)
+        #expect(await mintBox.callCount == 2)
+    }
+
+    @Test
     func test_invalidate_when_called_then_next_currentJWT_mints_fresh() async throws {
         // Given
         let blogID: Int64 = 12345
@@ -99,8 +138,6 @@ struct WpComJetpackAIJWTProviderTests {
         #expect(await counter.count == 2)
     }
 
-    // header.payload.signature; signature is a constant since the provider
-    // never validates it (the proxy does).
     private func makeJWT(blogID: Int64, expiresIn seconds: Int) -> String {
         let header = #"{"alg":"HS256","typ":"JWT"}"#
         let exp = Int(Date().timeIntervalSince1970) + seconds
@@ -147,5 +184,31 @@ private actor MintCounter {
             throw AssistantError(kind: .auth, message: "mint script exhausted")
         }
         return script.removeFirst()
+    }
+}
+
+private actor ThrowingMintFactory {
+    private var failuresRemaining: Int
+    private let token: String
+    private(set) var callCount = 0
+
+    init(failuresBeforeSuccess: Int, token: String) {
+        self.failuresRemaining = failuresBeforeSuccess
+        self.token = token
+    }
+
+    nonisolated func makeMint() -> WpComJetpackAIJWTProvider.Mint {
+        { @Sendable _ in
+            try await self.next()
+        }
+    }
+
+    private func next() throws -> String {
+        callCount += 1
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw AssistantError(kind: .auth, message: "scripted mint failure")
+        }
+        return token
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Networking/WpComJetpackAIJWTProviderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Networking/WpComJetpackAIJWTProviderTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct WpComJetpackAIJWTProviderTests {
+
+    // MARK: - 1. Cache hit returns without minting
+
+    @Test
+    func test_currentJWT_when_cache_warm_and_not_expired_then_returns_cached_without_minting() async throws {
+        // Given
+        let blogID: Int64 = 12345
+        let token = makeJWT(blogID: blogID, expiresIn: 3600)
+        let counter = MintCounter()
+        let provider = WpComJetpackAIJWTProvider(blogID: blogID, mint: counter.makeMint(token: token))
+        _ = try await provider.currentJWT()
+
+        // When
+        let second = try await provider.currentJWT()
+
+        // Then
+        #expect(second == token)
+        #expect(await counter.count == 1)
+    }
+
+    // MARK: - 2. Expired cached token mints fresh
+
+    @Test
+    func test_currentJWT_when_cached_token_expired_then_mints_fresh() async throws {
+        // Given
+        let blogID: Int64 = 12345
+        let staleToken = makeJWT(blogID: blogID, expiresIn: -10)
+        let freshToken = makeJWT(blogID: blogID, expiresIn: 3600)
+        let counter = MintCounter(script: [staleToken, freshToken])
+        let provider = WpComJetpackAIJWTProvider(blogID: blogID,
+                                                 mint: counter.makeMintScript())
+        _ = try await provider.currentJWT()
+
+        // When
+        let second = try await provider.currentJWT()
+
+        // Then
+        #expect(second == freshToken)
+        #expect(await counter.count == 2)
+    }
+
+    // MARK: - 3. Blog-id mismatch mints fresh
+
+    @Test
+    func test_currentJWT_when_cached_token_blog_id_mismatch_then_mints_fresh() async throws {
+        // Given
+        let expectedBlogID: Int64 = 12345
+        let mismatchToken = makeJWT(blogID: 99999, expiresIn: 3600)
+        let correctToken = makeJWT(blogID: expectedBlogID, expiresIn: 3600)
+        let counter = MintCounter(script: [mismatchToken, correctToken])
+        let provider = WpComJetpackAIJWTProvider(blogID: expectedBlogID,
+                                                 mint: counter.makeMintScript())
+        _ = try await provider.currentJWT()
+
+        // When
+        let second = try await provider.currentJWT()
+
+        // Then
+        #expect(second == correctToken)
+        #expect(await counter.count == 2)
+    }
+
+    // MARK: - 4. Concurrent callers single-flight the mint
+
+    @Test
+    func test_currentJWT_when_concurrent_callers_then_mints_exactly_once() async throws {
+        // Given
+        let blogID: Int64 = 12345
+        let token = makeJWT(blogID: blogID, expiresIn: 3600)
+        let counter = MintCounter()
+        let provider = WpComJetpackAIJWTProvider(blogID: blogID, mint: counter.makeMint(token: token))
+
+        // When
+        await withTaskGroup(of: String?.self) { group in
+            for _ in 0..<10 {
+                group.addTask { try? await provider.currentJWT() }
+            }
+            for await _ in group {}
+        }
+
+        // Then
+        #expect(await counter.count == 1)
+    }
+
+    // MARK: - 5. invalidate forces a fresh mint
+
+    @Test
+    func test_invalidate_when_called_then_next_currentJWT_mints_fresh() async throws {
+        // Given
+        let blogID: Int64 = 12345
+        let firstToken = makeJWT(blogID: blogID, expiresIn: 3600)
+        let secondToken = makeJWT(blogID: blogID, expiresIn: 3600)
+        let counter = MintCounter(script: [firstToken, secondToken])
+        let provider = WpComJetpackAIJWTProvider(blogID: blogID,
+                                                 mint: counter.makeMintScript())
+        _ = try await provider.currentJWT()
+
+        // When
+        await provider.invalidate()
+        let second = try await provider.currentJWT()
+
+        // Then
+        #expect(second == secondToken)
+        #expect(await counter.count == 2)
+    }
+
+    // MARK: - JWT fixture builder
+
+    /// Builds a JWT-shaped string with `header.payload.signature`. Header is a
+    /// minimal `{"alg":"HS256","typ":"JWT"}` and signature is a constant placeholder
+    /// (the provider only inspects the payload, not the signature).
+    private func makeJWT(blogID: Int64, expiresIn seconds: Int) -> String {
+        let header = #"{"alg":"HS256","typ":"JWT"}"#
+        let exp = Int(Date().timeIntervalSince1970) + seconds
+        let payload = "{\"blog_id\":\(blogID),\"exp\":\(exp)}"
+        return [header, payload].map { Self.base64URLEncode(Data($0.utf8)) }.joined(separator: ".") + ".signature"
+    }
+
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+// MARK: - Test doubles
+
+private actor MintCounter {
+    private(set) var count: Int = 0
+    private var script: [String] = []
+
+    init(script: [String] = []) {
+        self.script = script
+    }
+
+    nonisolated func makeMint(token: String) -> WpComJetpackAIJWTProvider.Mint {
+        { @Sendable _ in
+            await self.recordCallAndReturn(token)
+        }
+    }
+
+    nonisolated func makeMintScript() -> WpComJetpackAIJWTProvider.Mint {
+        return { @Sendable _ in
+            try await self.consumeNext()
+        }
+    }
+
+    private func recordCallAndReturn(_ token: String) -> String {
+        count += 1
+        return token
+    }
+
+    private func consumeNext() throws -> String {
+        count += 1
+        guard !script.isEmpty else {
+            throw AssistantError(kind: .auth, message: "mint script exhausted")
+        }
+        return script.removeFirst()
+    }
+}


### PR DESCRIPTION
## Why

C2 wires the production chat transport: the next PRs (UI shell, headless harness, agentic-loop end-to-end runs) all need a real `AIChatService` that talks to `wpcom/v2/jetpack-ai-query`, mints and caches a Jetpack AI JWT, and surfaces typed errors that the orchestrator already pattern-matches on. Until this lands, B6's orchestrator is wired against an internal protocol with no production conformer.

This PR ships:
- `JetpackAIQueryClient` - streams the chat over `URLSession.bytes`, retries 401-pre-data once and 429-pre-data twice, decodes the proxy's wrapped error envelope.
- `WpComJetpackAIJWTProvider` - `actor`-based JWT cache with a stored in-flight Task so concurrent callers single-flight cleanly.
- `featureName = "woo-ai-assistant"` widening on the existing pinned `AssistantConfiguration`.
- `AssistantJWTProviding.invalidate()` extension with a default no-op for non-caching stubs.

## Key non-obvious decisions

- **Two retry envelopes nest, they don't fuse.** Auth retry (401-only, once, after invalidating the JWT) wraps rate-limit retry (429, two backoffs). Folding them would either require a parameterized predicate or balloon the bridge state machine; two helpers keep each precondition obvious.
- **Wrapped envelope errors travel inside a private `WrappedEnvelopeError`** that bypasses the HTTP retry guards (which key on `error.code`). A 200 response carrying `{"code":"...","message":"...","data":{"status":401}}` is a soft-error envelope and shouldn't trigger an auth refresh. `streamTurn` unwraps it before yielding the inner `AssistantError` to the consumer. HTTP-layer 401 still goes through the auth retry as a naked AssistantError.
- **The non-2xx branch decodes the envelope for its `message` text but uses the HTTP status for `kind`/`code`.** The proxy uses the same wrapped shape for transport failures and soft failures; the HTTP status drives retry classification, the envelope text just enriches the merchant-facing message.
- **Single-flight in the JWT cache uses an `inflight: Task<String, Error>?`, not just actor isolation.** Plain isolation isn't enough: `await mint(...)` suspends and lets the next caller see an unset cache, double-minting. Validating the JWT inside the Task body means concurrent sharers all observe the same throw if the proxy ever returns a malformed token.
- **`isExpired` subtracts a 60-second clock-skew margin** so a token whose true `exp` is just past `now` doesn't ship on a request the proxy will reject. Avoids a 401-then-retry cycle at the boundary.
- **403 is terminal, only 401 retries.** A fresh JWT is unlikely to satisfy a forbidden-policy decision. Matches Android's `shouldRetryAuth` (which gates on `code == HTTP_UNAUTHORIZED` only).
- **The endpoint is composed off `NetworkingCore.Settings.wordpressApiBaseURL`** rather than hard-coded, so the WireMock launch arg (`mocked-wpcom-api`) and the `wpcom-api-base-url` env override route the chat traffic the same way they route the rest of the app's WPCOM calls.
- **`User-Agent` is set to `NetworkingCore.UserAgent.defaultUserAgent`** so the proxy attributes traffic the same as every other request out of the app.
- **Diagnostic detail goes to `DDLogError`; user-facing strings live in per-type `*+Localization.swift` extensions.** The five JWT-decode failure modes all surface the same `Localization.invalidJWT` to the merchant; the specific cause is logged for support.

## Cross-platform alignment with Android [#15756](https://github.com/woocommerce/woocommerce-android/pull/15756) / [#15757](https://github.com/woocommerce/woocommerce-android/pull/15757)

| Concern | iOS C2 | Android | Status |
|---|---|---|---|
| Chat service seam | `AIChatService.streamTurn(...) -> AsyncThrowingStream<ChatStreamEvent, Error>` (internal, from B6) | `ChatService.streamTurn(request: ChatRequest): Flow<AssistantEvent>` | ✅ Aligned at intent |
| Per-call config | None - pinned at construction via `AssistantConfiguration` | None - pinned at construction via `AssistantConfig` | ✅ Aligned |
| Pinned constants | 4 fields in `AssistantConfiguration` | 4 fields in `AssistantConfig` + `completionStack` aggregate | ✅ Aligned at field set |
| 401 retry once pre-data | `eventsEmitted == 0 + first attempt` -> `invalidate()` + retry once | `shouldRetryAuth` (same shape) | ✅ Aligned |
| 403 retry | Not retried (terminal) | Not retried | ✅ Aligned |
| Single-flighted JWT cache | Swift `actor` + in-flight `Task<String, Error>` (single-flight, blog_id check, expiry validate) | `Mutex.withLock` over `JWTToken` (same checks) | ✅ Aligned at intent |
| Empty-content for tool-call assistant message | `""` (validator rejects nil/omitted) | `JsonNull` | ⚠️ Documented seam - to verify with Android author whether `null` is accepted at the live endpoint |
| User-Agent | `UserAgent.defaultUserAgent` from `NetworkingCore` | `userAgent.apiUserAgent` from FluxC | ✅ Aligned at intent |
| 429 retry pre-data | 3 attempts, 2s + 4s backoff, only before any event delivered | Not in [#15756](https://github.com/woocommerce/woocommerce-android/pull/15756) - deferred to a higher layer | 🟦 Documented divergence (idiomatic per platform) |
| Wrapped-error envelope on 200 | Decoded into `AssistantError`; mid-stream wrapped via `WrappedEnvelopeError` to bypass HTTP retries | Not visible in Android scope yet | 🟦 iOS platform concern (jetpack-ai-query soft errors) |
| UTF-8 boundary carry | `decodeUTF8WithBoundaryCarry` (up to 3 trailing bytes) | OkHttp `EventSource` handles framing internally | 🟦 iOS-only (URLSession.bytes is byte-level) |
| Wire transport | `URLSession.bytes` + dedicated `URLSessionConfiguration` (64 conns/host, 120s req / 180s res) | OkHttp `EventSource` (read-timeout 0, call-timeout 60s) | ⚠️ Idiomatic per platform |
| `[DONE]` sentinel | Filtered at chat-client layer (parser emits it as a data event, client skips) | `transformWhile` stops the parser flow | ⚠️ Documented in C1 |

## Tests

23 unit cases covering:
- Streaming: split-chunk text reassembly, single-tool-call assembly, two-tool-call index ordering, UTF-8 boundary recovery, request headers (User-Agent + Bearer + Accept), endpoint composition off `Settings.wordpressApiBaseURL`.
- Retries: 429 retry-then-success, 429 cap-after-3-attempts, 401 pre-data retry, 401 cap-after-1-attempt, 403 no-retry, 503 no-retry, wrapped envelope on 200 (single chunk and after `:` keepalive frames), wire-format empty-content for tool-call assistant messages.
- JWT cache: cache hit, expiry refresh, blog-id mismatch refresh, 60s clock-skew margin, concurrent single-flight, mint-throws-then-recovers, invalidate forces fresh, all five malformed-JWT shapes.

Throwaway live E2E ran against the demo store before push and was reverted. Trace:

```
[e2e-loop|c2|streamTurn] textDelta="hi"
[e2e-loop|c2|streamTurn] completed=stop textTotal="hi"
✔ Test e2e_streamTurn_against_woo_ai_demo_store_returns_text_and_completes() passed after 2.694 seconds.
```

End-to-end: JWT minted via `<site>/wp-json/jetpack/v4/jetpack-ai-jwt`, presented as `Bearer` to `https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query`, SSE chunk decoded, `.textDelta("hi")` then `.completed(.stop)`. ~2.7s round trip.

Build clean, SwiftLint zero violations.

## Reviewer expectation

Sanity (10 min) - the streaming + retry path is load-bearing; the wire-format guards (empty-string content for tool-calls, UTF-8 carry, wrapped-envelope decode) are explained inline against the comments. The `WrappedEnvelopeError` source-tagging trick is the only structural surprise.