### PR TITLE
[RSM] Allow lump-sum lines through the POS refund calculator

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundCalculator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSRefundCalculator.swift
@@ -33,12 +33,21 @@ public struct POSRefundableItem {
     public let lineItemTotal: Decimal
     public let totalTax: Decimal
     public let originalQuantity: Decimal
+    /// `true` for lines that don't have a unit/quantity concept and refund as a single lump sum
+    /// (e.g. order fee lines / custom amounts). When true, the calculator emits the line as a
+    /// single request item with `quantity = 0` and uses `lineItemTotal`/`totalTax` directly.
+    public let isLumpSum: Bool
 
-    public init(itemID: Int64, lineItemTotal: Decimal, totalTax: Decimal, originalQuantity: Decimal) {
+    public init(itemID: Int64,
+                lineItemTotal: Decimal,
+                totalTax: Decimal,
+                originalQuantity: Decimal,
+                isLumpSum: Bool = false) {
         self.itemID = itemID
         self.lineItemTotal = lineItemTotal
         self.totalTax = totalTax
         self.originalQuantity = originalQuantity
+        self.isLumpSum = isLumpSum
     }
 }
 
@@ -80,9 +89,11 @@ private extension POSRefundCalculator {
 
     func buildRefundRequestItems(from groupedItems: [Int64: [POSRefundableItem]], numberOfDecimals: Int) -> [POSRefundRequestItem] {
         groupedItems.compactMap { itemID, items -> POSRefundRequestItem? in
-            guard items.first != nil else { return nil }
+            guard let firstItem = items.first else { return nil }
 
-            let quantityToRefund = items.count
+            // Lump-sum lines (e.g. fee/custom amount) refund as a single line with quantity 0,
+            // matching the WooCommerce REST refund API expectation for non-unit items.
+            let quantityToRefund = firstItem.isLumpSum ? 0 : items.count
             let refundTotal = calculateRefundTotal(for: items, numberOfDecimals: numberOfDecimals)
             let refundTax = calculateRefundTax(for: items, numberOfDecimals: numberOfDecimals)
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSRefundCalculatorTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSRefundCalculatorTests.swift
@@ -206,4 +206,75 @@ struct POSRefundCalculatorTests {
         // Then
         #expect(request.amount == Decimal(string: "11.666"))
     }
+
+    // MARK: - Lump-sum lines (custom amounts / fees)
+
+    @Test func buildRefundRequest_when_lump_sum_then_emits_quantity_zero() {
+        // Given
+        let items = [
+            POSRefundableItem(itemID: 99, lineItemTotal: Decimal(15), totalTax: Decimal.zero, originalQuantity: 1, isLumpSum: true)
+        ]
+
+        // When
+        let request = sut.buildRefundRequest(orderID: 123, selectedItems: items, reason: nil, numberOfDecimals: defaultDecimals)
+
+        // Then
+        #expect(request.items.count == 1)
+        #expect(request.items[0].itemID == 99)
+        #expect(request.items[0].quantity == 0)
+        #expect(request.items[0].refundTotal == Decimal(15))
+    }
+
+    @Test func buildRefundRequest_when_lump_sum_with_tax_then_uses_full_tax() {
+        // Given
+        let items = [
+            POSRefundableItem(itemID: 99, lineItemTotal: Decimal(20), totalTax: Decimal(2), originalQuantity: 1, isLumpSum: true)
+        ]
+
+        // When
+        let request = sut.buildRefundRequest(orderID: 123, selectedItems: items, reason: nil, numberOfDecimals: defaultDecimals)
+
+        // Then
+        #expect(request.amount == Decimal(22))
+        #expect(request.items[0].refundTax == Decimal(2))
+    }
+
+    @Test func buildRefundRequest_when_mixing_products_and_lump_sum_then_each_is_emitted_with_correct_quantity() throws {
+        // Given
+        let items = [
+            // Two units of a product
+            POSRefundableItem(itemID: 1, lineItemTotal: Decimal(50), totalTax: Decimal(5), originalQuantity: 2),
+            POSRefundableItem(itemID: 1, lineItemTotal: Decimal(50), totalTax: Decimal(5), originalQuantity: 2),
+            // One lump-sum fee
+            POSRefundableItem(itemID: 99, lineItemTotal: Decimal(15), totalTax: Decimal.zero, originalQuantity: 1, isLumpSum: true)
+        ]
+
+        // When
+        let request = sut.buildRefundRequest(orderID: 123, selectedItems: items, reason: nil, numberOfDecimals: defaultDecimals)
+
+        // Then
+        #expect(request.items.count == 2)
+        let product = try #require(request.items.first(where: { $0.itemID == 1 }))
+        let fee = try #require(request.items.first(where: { $0.itemID == 99 }))
+        #expect(product.quantity == 2)
+        #expect(product.refundTotal == Decimal(50))
+        #expect(fee.quantity == 0)
+        #expect(fee.refundTotal == Decimal(15))
+        #expect(request.amount == Decimal(70))
+    }
+
+    @Test func calculateRefundAmounts_when_lump_sum_then_uses_full_subtotal_and_tax() {
+        // Given
+        let items = [
+            POSRefundableItem(itemID: 99, lineItemTotal: Decimal(15), totalTax: Decimal(1), originalQuantity: 1, isLumpSum: true)
+        ]
+
+        // When
+        let amounts = sut.calculateRefundAmounts(for: items, numberOfDecimals: defaultDecimals)
+
+        // Then
+        #expect(amounts.subtotal == Decimal(15))
+        #expect(amounts.tax == Decimal(1))
+        #expect(amounts.total == Decimal(16))
+    }
 }


### PR DESCRIPTION
## Description
Stacks on top of [#16999](https://github.com/woocommerce/woocommerce-ios/pull/16999). First in a small chain to add custom-amount support to the POS refund flow. **This PR is data-layer plumbing only** — no user-visible behavior changes yet.

- Adds an `isLumpSum: Bool = false` flag to `POSRefundableItem`. Default keeps every existing call site unchanged.
- When `true`, `POSRefundCalculator.buildRefundRequestItems` emits the line as a single request item with `quantity = 0`, matching the WooCommerce REST refund API expectation for non-unit items and mirroring the precedent in `RefundCreationUseCase` (the app-target refund flow that already supports fees and shipping).
- The math path is reused: a lump-sum line is modelled as `originalQuantity = 1`, so the existing full-refund branch returns `lineItemTotal` and `totalTax` directly with no rounding drift.

The selection layer (`POSOrderListController.startRefundFlow`) still iterates products only. Wiring custom amounts into the refund flow lands on the follow-up PR alongside the UI changes (selection screen, review screen, refunded-fees rendering in order details).

I considered the protocol-based abstraction (separate `POSRefundableLineItem` protocol with `POSRefundableItem` and `POSRefundableFee` conformers). The hybrid flag keeps the diff small and surgical for now; if shipping/discount refunds land later we can refactor to the protocol with a clean follow-up.

## Test Steps
1. Run `YosemiteTests/POSRefundCalculatorTests`. Four new lump-sum cases pass alongside the existing 15.
2. No UI changes. Issue a product-only refund in POS to confirm no regression in the existing path.

## Screenshots
N/A — no UI changes.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.