### PR TITLE
Woo Mobile AI: Add the assistant chat backend, controller, and conversation state

### DIFF
--- a/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
+++ b/Modules/Sources/WooAIAssistant/AI/OpenAIChat.swift
@@ -6,9 +6,9 @@ import Foundation
 /// shape verbatim, so a single set of types covers today's backend and the
 /// expected future swap. Tool calling follows the OpenAI spec
 /// (`finish_reason: "tool_calls"`, `tool_calls[i].function.{name,arguments}`).
-enum OpenAIChat {
+public enum OpenAIChat {
 
-    enum Role: String, Codable, Sendable {
+    public enum Role: String, Codable, Sendable {
         case system
         case user
         case assistant
@@ -22,16 +22,16 @@ enum OpenAIChat {
     ///   in a real response, but both fields exist for round-tripping.
     /// - `.tool`: `content` is the tool result (typically a JSON string),
     ///   `toolCallID` references the originating assistant tool call.
-    struct Message: Codable, Sendable, Equatable {
-        let role: Role
-        let content: String?
-        let toolCalls: [ToolCall]?
-        let toolCallID: String?
+    public struct Message: Codable, Sendable, Equatable {
+        public let role: Role
+        public let content: String?
+        public let toolCalls: [ToolCall]?
+        public let toolCallID: String?
 
-        init(role: Role,
-             content: String? = nil,
-             toolCalls: [ToolCall]? = nil,
-             toolCallID: String? = nil) {
+        public init(role: Role,
+                    content: String? = nil,
+                    toolCalls: [ToolCall]? = nil,
+                    toolCallID: String? = nil) {
             self.role = role
             self.content = content
             self.toolCalls = toolCalls
@@ -52,7 +52,7 @@ enum OpenAIChat {
         /// an empty string. OpenAI's downstream model ignores `content`
         /// when `tool_calls` is set, so the empty string is cosmetic but
         /// required to satisfy the proxy's validator.
-        func encode(to encoder: Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(role, forKey: .role)
             if role == .assistant && toolCalls?.isEmpty == false {
@@ -68,49 +68,60 @@ enum OpenAIChat {
     /// `arguments` is a JSON string the caller must parse against the tool's
     /// declared schema; OpenAI sends arguments as a serialised string rather
     /// than an inline object.
-    struct ToolCall: Codable, Sendable, Equatable {
-        let id: String
-        let type: String
-        let function: FunctionCall
+    public struct ToolCall: Codable, Sendable, Equatable {
+        public let id: String
+        public let type: String
+        public let function: FunctionCall
 
-        init(id: String, function: FunctionCall) {
+        public init(id: String, function: FunctionCall) {
             self.id = id
             self.type = "function"
             self.function = function
         }
     }
 
-    struct FunctionCall: Codable, Sendable, Equatable {
-        let name: String
-        let arguments: String
+    public struct FunctionCall: Codable, Sendable, Equatable {
+        public let name: String
+        public let arguments: String
+
+        public init(name: String, arguments: String) {
+            self.name = name
+            self.arguments = arguments
+        }
     }
 
     /// `parameters` is a JSON Schema object describing the function's
     /// argument shape. Stored as `AnyCodableJSON` so any valid schema
     /// round-trips without bespoke decoding per tool.
-    struct ToolDefinition: Codable, Sendable, Equatable {
-        let type: String
-        let function: FunctionDefinition
+    public struct ToolDefinition: Codable, Sendable, Equatable {
+        public let type: String
+        public let function: FunctionDefinition
 
-        init(function: FunctionDefinition) {
+        public init(function: FunctionDefinition) {
             self.type = "function"
             self.function = function
         }
     }
 
-    struct FunctionDefinition: Codable, Sendable, Equatable {
-        let name: String
-        let description: String
-        let parameters: AnyCodableJSON
+    public struct FunctionDefinition: Codable, Sendable, Equatable {
+        public let name: String
+        public let description: String
+        public let parameters: AnyCodableJSON
+
+        public init(name: String, description: String, parameters: AnyCodableJSON) {
+            self.name = name
+            self.description = description
+            self.parameters = parameters
+        }
     }
 
     /// Encoded-only; `jetpack-ai-query` never returns `tool_choice`.
-    enum ToolChoice: Encodable, Sendable, Equatable {
+    public enum ToolChoice: Encodable, Sendable, Equatable {
         case auto
         case required
         case function(name: String)
 
-        func encode(to encoder: Encoder) throws {
+        public func encode(to encoder: Encoder) throws {
             var container = encoder.singleValueContainer()
             switch self {
             case .auto:
@@ -190,7 +201,7 @@ enum OpenAIChat {
     /// responses; matches Android's `FinishReason.OTHER` for cross-platform
     /// parity. Callers that need to react only to a terminal stop should
     /// match `.stop` explicitly.
-    enum FinishReason: String, Sendable, Equatable {
+    public enum FinishReason: String, Sendable, Equatable {
         case stop
         case toolCalls = "tool_calls"
         case length
@@ -259,7 +270,7 @@ enum OpenAIChat {
 }
 
 extension OpenAIChat.FinishReason: Decodable {
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let raw = try container.decode(String.self)
         self = OpenAIChat.FinishReason(rawValue: raw) ?? .other

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -9,7 +9,7 @@ import CocoaLumberjackSwift
 ///
 /// Forwards confirm/cancel taps from the UI straight into the orchestrator's continuation API
 /// so unsafe-tool flows resume on the same actor that suspended them.
-public final class AgenticChatBackend: AssistantBackendConfirming, @unchecked Sendable {
+public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
 
     private let orchestrator: AgenticLoopOrchestrator
     private let transcript = TranscriptStore()

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -80,14 +80,17 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
         }
     }
 
-    // OpenAI rejects an assistant `tool_calls[i]` without a matching `tool` result.
+    // OpenAI rejects an assistant `tool_calls[i]` without a matching `tool` result,
+    // and requires `tool` messages in the same order as the assistant's `tool_calls`.
     static func matchedPairs(toolCalls: [OpenAIChat.ToolCall],
                              toolResults: [(String, String)])
     -> ([OpenAIChat.ToolCall], [(String, String)]) {
-        let resultIDs = Set(toolResults.map(\.0))
-        let matchedCalls = toolCalls.filter { resultIDs.contains($0.id) }
-        let matchedCallIDs = Set(matchedCalls.map(\.id))
-        let matchedResults = toolResults.filter { matchedCallIDs.contains($0.0) }
+        let resultsByID = Dictionary(toolResults.map { ($0.0, $0.1) }, uniquingKeysWith: { first, _ in first })
+        let matchedCalls = toolCalls.filter { resultsByID[$0.id] != nil }
+        let matchedResults = matchedCalls.compactMap { call -> (String, String)? in
+            guard let payload = resultsByID[call.id] else { return nil }
+            return (call.id, payload)
+        }
         return (matchedCalls, matchedResults)
     }
 

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -47,6 +47,7 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
                 var pendingText = ""
                 var pendingToolCalls: [OpenAIChat.ToolCall] = []
                 var pendingToolResults: [(String, String)] = []
+                var didFail = false
 
                 do {
                     for try await event in orchestrator.run(prompt: turn.prompt,
@@ -55,20 +56,24 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
                                         text: &pendingText,
                                         toolCalls: &pendingToolCalls,
                                         toolResults: &pendingToolResults)
+                        if case .failed = event { didFail = true }
                         continuation.yield(.event(event))
                     }
                 } catch {
+                    didFail = true
                     let message = (error as? AssistantError)?.message ?? error.localizedDescription
                     continuation.yield(.event(.failed(.init(kind: .unknown, message: message))))
                 }
 
-                let (sanitizedToolCalls, sanitizedToolResults) =
-                    Self.matchedPairs(toolCalls: pendingToolCalls,
-                                      toolResults: pendingToolResults)
-                await transcript.append(userPrompt: turn.prompt,
-                                        assistantText: pendingText,
-                                        toolCalls: sanitizedToolCalls,
-                                        toolResults: sanitizedToolResults)
+                if !didFail && !Task.isCancelled {
+                    let (sanitizedToolCalls, sanitizedToolResults) =
+                        Self.matchedPairs(toolCalls: pendingToolCalls,
+                                          toolResults: pendingToolResults)
+                    await transcript.append(userPrompt: turn.prompt,
+                                            assistantText: pendingText,
+                                            toolCalls: sanitizedToolCalls,
+                                            toolResults: sanitizedToolResults)
+                }
                 continuation.finish()
             }
             continuation.onTermination = { _ in task.cancel() }

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -1,22 +1,13 @@
 import Foundation
 import CocoaLumberjackSwift
 
-/// `AssistantBackend` adapter that drives the chat UI through the `AgenticLoopOrchestrator`.
-///
-/// Wraps a long-lived orchestrator so multi-turn memory survives between sends. Each turn
-/// builds a fresh prompt prefix from the per-instance `TranscriptStore` actor and the
-/// caller-supplied `systemPromptProvider` so the embedded date stays current across midnight.
-///
-/// Forwards confirm/cancel taps from the UI straight into the orchestrator's continuation API
-/// so unsafe-tool flows resume on the same actor that suspended them.
+/// `AssistantBackend` adapter that drives the chat UI through `AgenticLoopOrchestrator`.
 public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
 
     private let orchestrator: AgenticLoopOrchestrator
     private let transcript = TranscriptStore()
     private let systemPromptProvider: @Sendable () -> String?
 
-    /// Per-turn `systemPromptProvider` rebuild keeps the embedded date fresh when a
-    /// session spans midnight, which `AssistantSystemPrompt.build()` cares about.
     public init(chatService: AIChatService,
                 toolRegistry: ToolRegistry? = nil,
                 safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
@@ -84,11 +75,7 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
         }
     }
 
-    /// OpenAI rejects an `assistant.tool_calls[i]` without a matching `tool`
-    /// message with the same `tool_call_id`. When the orchestrator throws
-    /// (or the transport drops) between `toolCallStarted` and
-    /// `toolCallCompleted`, dropping the unmatched pairs keeps the next turn
-    /// replay valid instead of leaving the chat unrecoverable.
+    // OpenAI rejects an assistant `tool_calls[i]` without a matching `tool` result.
     static func matchedPairs(toolCalls: [OpenAIChat.ToolCall],
                              toolResults: [(String, String)])
     -> ([OpenAIChat.ToolCall], [(String, String)]) {
@@ -111,9 +98,6 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
         await orchestrator.cancel(proposalID: id)
     }
 
-    /// `toolCallStarted` records the call shape so the next-turn prefix has
-    /// `assistant tool_calls` followed by the matching `tool` results, which
-    /// is the wire shape the upstream proxy validates.
     private static func accumulate(_ event: AssistantEvent,
                                    text: inout String,
                                    toolCalls: inout [OpenAIChat.ToolCall],
@@ -134,9 +118,6 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
     }
 }
 
-/// Holds the prefix the next turn needs - user prompts, assistant tool-call messages,
-/// and tool result messages in wire-protocol order. Actor isolation keeps the prefix
-/// consistent if a confirmation tap arrives while the loop is mid-turn.
 private actor TranscriptStore {
 
     private var stored: [OpenAIChat.Message] = []

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -56,7 +56,9 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
                                         text: &pendingText,
                                         toolCalls: &pendingToolCalls,
                                         toolResults: &pendingToolResults)
-                        if case .failed = event { didFail = true }
+                        if case .failed(let err) = event, err.kind != .outcomeUnknown {
+                            didFail = true
+                        }
                         continuation.yield(.event(event))
                     }
                 } catch {

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -1,0 +1,148 @@
+import Foundation
+import CocoaLumberjackSwift
+
+/// `AssistantBackend` adapter that drives the chat UI through the `AgenticLoopOrchestrator`.
+///
+/// Wraps a long-lived orchestrator so multi-turn memory survives between sends. Each turn
+/// builds a fresh prompt prefix from the per-instance `TranscriptStore` actor and the
+/// caller-supplied `systemPromptProvider` so the embedded date stays current across midnight.
+///
+/// Forwards confirm/cancel taps from the UI straight into the orchestrator's continuation API
+/// so unsafe-tool flows resume on the same actor that suspended them.
+public final class AgenticChatBackend: AssistantBackendConfirming, @unchecked Sendable {
+
+    private let orchestrator: AgenticLoopOrchestrator
+    private let transcript = TranscriptStore()
+    private let systemPromptProvider: @Sendable () -> String?
+
+    /// Per-turn `systemPromptProvider` rebuild keeps the embedded date fresh when a
+    /// session spans midnight, which `AssistantSystemPrompt.build()` cares about.
+    public init(chatService: AIChatService,
+                toolRegistry: ToolRegistry? = nil,
+                safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
+                systemPromptProvider: @escaping @Sendable () -> String? = { nil },
+                maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations) {
+        self.systemPromptProvider = systemPromptProvider
+        self.orchestrator = AgenticLoopOrchestrator(chatService: chatService,
+                                                    toolRegistry: toolRegistry,
+                                                    safetyPolicy: safetyPolicy,
+                                                    systemPrompt: nil,
+                                                    maxIterations: maxIterations)
+    }
+
+    /// Static-prompt convenience for tests and callers that don't need per-turn
+    /// freshness.
+    public convenience init(chatService: AIChatService,
+                            toolRegistry: ToolRegistry? = nil,
+                            safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
+                            systemPrompt: String?,
+                            maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations) {
+        let captured = systemPrompt
+        self.init(chatService: chatService,
+                  toolRegistry: toolRegistry,
+                  safetyPolicy: safetyPolicy,
+                  systemPromptProvider: { captured },
+                  maxIterations: maxIterations)
+    }
+
+    public func send(turn: AssistantTurn,
+                     context: AssistantContext,
+                     session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { [orchestrator, transcript, systemPromptProvider] in
+                var prior = await transcript.messages()
+                if let systemPrompt = systemPromptProvider() {
+                    prior.insert(.init(role: .system, content: systemPrompt), at: 0)
+                }
+
+                var pendingText = ""
+                var pendingToolCalls: [OpenAIChat.ToolCall] = []
+                var pendingToolResults: [(String, String)] = []
+
+                do {
+                    for try await event in orchestrator.run(prompt: turn.prompt,
+                                                            priorMessages: prior) {
+                        Self.accumulate(event,
+                                        text: &pendingText,
+                                        toolCalls: &pendingToolCalls,
+                                        toolResults: &pendingToolResults)
+                        continuation.yield(.event(event))
+                    }
+                } catch {
+                    let message = (error as? AssistantError)?.message ?? error.localizedDescription
+                    continuation.yield(.event(.failed(.init(kind: .unknown, message: message))))
+                }
+
+                await transcript.append(userPrompt: turn.prompt,
+                                        assistantText: pendingText,
+                                        toolCalls: pendingToolCalls,
+                                        toolResults: pendingToolResults)
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    /// Drop accumulated history. Call when the merchant starts a fresh chat.
+    public func reset() async {
+        await transcript.reset()
+    }
+
+    public func confirmProposal(_ id: UUID) async {
+        await orchestrator.confirm(proposalID: id)
+    }
+
+    public func cancelProposal(_ id: UUID) async {
+        await orchestrator.cancel(proposalID: id)
+    }
+
+    /// `toolCallStarted` records the call shape so the next-turn prefix has
+    /// `assistant tool_calls` followed by the matching `tool` results, which
+    /// is the wire shape the upstream proxy validates.
+    private static func accumulate(_ event: AssistantEvent,
+                                   text: inout String,
+                                   toolCalls: inout [OpenAIChat.ToolCall],
+                                   toolResults: inout [(String, String)]) {
+        switch event {
+        case .textChunk(let chunk):
+            text += chunk
+        case .toolCallStarted(let id, let name, let argumentsJSON):
+            toolCalls.append(.init(id: id,
+                                   function: .init(name: name,
+                                                   arguments: argumentsJSON ?? "")))
+        case .toolCallCompleted(let id, _, let resultJSON):
+            toolResults.append((id, resultJSON ?? "{}"))
+        case .toolResult, .cardRender, .confirmationRequired,
+             .confirmationResolved, .completed, .failed:
+            break
+        }
+    }
+}
+
+/// Holds the prefix the next turn needs - user prompts, assistant tool-call messages,
+/// and tool result messages in wire-protocol order. Actor isolation keeps the prefix
+/// consistent if a confirmation tap arrives while the loop is mid-turn.
+private actor TranscriptStore {
+
+    private var stored: [OpenAIChat.Message] = []
+
+    func messages() -> [OpenAIChat.Message] { stored }
+
+    func append(userPrompt: String,
+                assistantText: String,
+                toolCalls: [OpenAIChat.ToolCall],
+                toolResults: [(String, String)]) {
+        stored.append(.init(role: .user, content: userPrompt))
+        if !toolCalls.isEmpty {
+            stored.append(.init(role: .assistant, content: nil, toolCalls: toolCalls))
+            for (callID, payload) in toolResults {
+                stored.append(.init(role: .tool, content: payload, toolCallID: callID))
+            }
+        }
+        if !assistantText.isEmpty {
+            stored.append(.init(role: .assistant, content: assistantText))
+        }
+    }
+
+    func reset() { stored.removeAll() }
+}

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -73,14 +73,32 @@ public final class AgenticChatBackend: AssistantBackendConfirming, @unchecked Se
                     continuation.yield(.event(.failed(.init(kind: .unknown, message: message))))
                 }
 
+                let (sanitizedToolCalls, sanitizedToolResults) =
+                    Self.matchedPairs(toolCalls: pendingToolCalls,
+                                      toolResults: pendingToolResults)
                 await transcript.append(userPrompt: turn.prompt,
                                         assistantText: pendingText,
-                                        toolCalls: pendingToolCalls,
-                                        toolResults: pendingToolResults)
+                                        toolCalls: sanitizedToolCalls,
+                                        toolResults: sanitizedToolResults)
                 continuation.finish()
             }
             continuation.onTermination = { _ in task.cancel() }
         }
+    }
+
+    /// OpenAI rejects an `assistant.tool_calls[i]` without a matching `tool`
+    /// message with the same `tool_call_id`. When the orchestrator throws
+    /// (or the transport drops) between `toolCallStarted` and
+    /// `toolCallCompleted`, dropping the unmatched pairs keeps the next turn
+    /// replay valid instead of leaving the chat unrecoverable.
+    static func matchedPairs(toolCalls: [OpenAIChat.ToolCall],
+                             toolResults: [(String, String)])
+    -> ([OpenAIChat.ToolCall], [(String, String)]) {
+        let resultIDs = Set(toolResults.map(\.0))
+        let matchedCalls = toolCalls.filter { resultIDs.contains($0.id) }
+        let matchedCallIDs = Set(matchedCalls.map(\.id))
+        let matchedResults = toolResults.filter { matchedCallIDs.contains($0.0) }
+        return (matchedCalls, matchedResults)
     }
 
     /// Drop accumulated history. Call when the merchant starts a fresh chat.

--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -30,8 +30,6 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
                                                     maxIterations: maxIterations)
     }
 
-    /// Static-prompt convenience for tests and callers that don't need per-turn
-    /// freshness.
     public convenience init(chatService: AIChatService,
                             toolRegistry: ToolRegistry? = nil,
                             safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
@@ -101,7 +99,6 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
         return (matchedCalls, matchedResults)
     }
 
-    /// Drop accumulated history. Call when the merchant starts a fresh chat.
     public func reset() async {
         await transcript.reset()
     }

--- a/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The single abstraction the UI and `AssistantController` depend on so a different
+/// implementation (Claude direct, A2A/SSE workflow agent, anything else) can swap in
+/// without changing the chat surface.
+public protocol AssistantBackend: Sendable {
+    func send(turn: AssistantTurn,
+              context: AssistantContext,
+              session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error>
+}
+
+/// Backends that surface in-loop safety confirmations conform to this so the
+/// controller's confirm/cancel taps can resume the agent. Backends that don't
+/// dispatch tools (legacy workflow agents) won't conform.
+public protocol AssistantBackendConfirming: AssistantBackend {
+    func confirmProposal(_ id: UUID) async
+    func cancelProposal(_ id: UUID) async
+}
+
+public struct AssistantTurn: Sendable {
+    public let id: String
+    public let prompt: String
+
+    public init(id: String = UUID().uuidString, prompt: String) {
+        self.id = id
+        self.prompt = prompt
+    }
+}
+
+/// Site-scoping context passed through every turn. Backends that don't need
+/// per-site routing can ignore the fields they don't care about.
+public struct AssistantContext: Sendable {
+    public let siteID: Int64
+    public let siteURL: URL
+    public let blogID: Int64?
+
+    public init(siteID: Int64, siteURL: URL, blogID: Int64?) {
+        self.siteID = siteID
+        self.siteURL = siteURL
+        self.blogID = blogID
+    }
+}
+
+/// One element on the backend's stream. `event` carries UI-relevant data;
+/// `sessionUpdate` lets the controller persist a backend's session handle
+/// between turns without the UI having to know what's in it.
+public enum BackendYield: Sendable {
+    case event(AssistantEvent)
+    case sessionUpdate(AssistantSession)
+}

--- a/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
@@ -1,17 +1,11 @@
 import Foundation
 
-/// The single abstraction the UI and `AssistantController` depend on so a different
-/// implementation (Claude direct, A2A/SSE workflow agent, anything else) can swap in
-/// without changing the chat surface.
 public protocol AssistantBackend: Sendable {
     func send(turn: AssistantTurn,
               context: AssistantContext,
               session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error>
 }
 
-/// Backends that surface in-loop safety confirmations conform to this so the
-/// controller's confirm/cancel taps can resume the agent. Backends that don't
-/// dispatch tools (legacy workflow agents) won't conform.
 public protocol AssistantBackendConfirming: AssistantBackend {
     func confirmProposal(_ id: UUID) async
     func cancelProposal(_ id: UUID) async

--- a/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
@@ -27,8 +27,6 @@ public struct AssistantTurn: Sendable {
     }
 }
 
-/// Site-scoping context passed through every turn. Backends that don't need
-/// per-site routing can ignore the fields they don't care about.
 public struct AssistantContext: Sendable {
     public let siteID: Int64
     public let siteURL: URL
@@ -41,9 +39,6 @@ public struct AssistantContext: Sendable {
     }
 }
 
-/// One element on the backend's stream. `event` carries UI-relevant data;
-/// `sessionUpdate` lets the controller persist a backend's session handle
-/// between turns without the UI having to know what's in it.
 public enum BackendYield: Sendable {
     case event(AssistantEvent)
     case sessionUpdate(AssistantSession)

--- a/Modules/Sources/WooAIAssistant/Loop/AIChatService.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AIChatService.swift
@@ -2,20 +2,20 @@ import Foundation
 
 /// Transport seam the orchestrator depends on. Conformers reassemble `OpenAIChat.ToolCallDelta`
 /// fragments into complete `ToolCall` values before emission; the orchestrator never sees deltas.
-protocol AIChatService: Sendable {
+public protocol AIChatService: Sendable {
     func streamTurn(messages: [OpenAIChat.Message],
                     tools: [OpenAIChat.ToolDefinition]?,
                     toolChoice: OpenAIChat.ToolChoice?) -> AsyncThrowingStream<ChatStreamEvent, Error>
 }
 
 extension AIChatService {
-    func streamTurn(messages: [OpenAIChat.Message],
-                    tools: [OpenAIChat.ToolDefinition]?) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+    public func streamTurn(messages: [OpenAIChat.Message],
+                           tools: [OpenAIChat.ToolDefinition]?) -> AsyncThrowingStream<ChatStreamEvent, Error> {
         streamTurn(messages: messages, tools: tools, toolChoice: nil)
     }
 }
 
-enum ChatStreamEvent: Sendable, Equatable {
+public enum ChatStreamEvent: Sendable, Equatable {
     case textDelta(String)
     case toolCall(OpenAIChat.ToolCall)
     case completed(OpenAIChat.FinishReason?)

--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -3,12 +3,12 @@ import CocoaLumberjackSwift
 
 /// Drives one merchant turn over `AIChatService` + `ToolRegistry` + `SafetyPolicy`. Actor-isolated
 /// because unsafe tool calls suspend on a confirmation continuation that needs a serial home.
-actor AgenticLoopOrchestrator {
+public actor AgenticLoopOrchestrator {
 
-    static let defaultMaxIterations = 5
+    public static let defaultMaxIterations = 5
 
     /// 4 keeps "list + 3 drill-downs" flows legitimate while catching varied-args fanouts.
-    static let defaultPerToolPerTurnCap = 4
+    public static let defaultPerToolPerTurnCap = 4
 
     private let chatService: AIChatService
     private let toolRegistry: ToolRegistry?
@@ -22,12 +22,12 @@ actor AgenticLoopOrchestrator {
 
     private(set) var lastOutcome: LoopOutcome?
 
-    init(chatService: AIChatService,
-         toolRegistry: ToolRegistry?,
-         safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
-         systemPrompt: String? = nil,
-         maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations,
-         perToolPerTurnCap: Int = AgenticLoopOrchestrator.defaultPerToolPerTurnCap) {
+    public init(chatService: AIChatService,
+                toolRegistry: ToolRegistry?,
+                safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
+                systemPrompt: String? = nil,
+                maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations,
+                perToolPerTurnCap: Int = AgenticLoopOrchestrator.defaultPerToolPerTurnCap) {
         self.chatService = chatService
         self.toolRegistry = toolRegistry
         self.safetyPolicy = safetyPolicy
@@ -36,8 +36,12 @@ actor AgenticLoopOrchestrator {
         self.perToolPerTurnCap = perToolPerTurnCap
     }
 
+    public nonisolated func run(prompt: String) -> AsyncThrowingStream<AssistantEvent, Error> {
+        run(prompt: prompt, priorMessages: [])
+    }
+
     nonisolated func run(prompt: String,
-                         priorMessages: [OpenAIChat.Message] = []) -> AsyncThrowingStream<AssistantEvent, Error> {
+                         priorMessages: [OpenAIChat.Message]) -> AsyncThrowingStream<AssistantEvent, Error> {
         AsyncThrowingStream { continuation in
             let task = Task { [weak self] in
                 guard let self else {
@@ -73,13 +77,13 @@ actor AgenticLoopOrchestrator {
 
     // MARK: - External confirmation entry points
 
-    func confirm(proposalID: UUID) {
+    public func confirm(proposalID: UUID) {
         if let continuation = pendingDecisions.removeValue(forKey: proposalID) {
             continuation.resume(returning: true)
         }
     }
 
-    func cancel(proposalID: UUID) {
+    public func cancel(proposalID: UUID) {
         if let continuation = pendingDecisions.removeValue(forKey: proposalID) {
             continuation.resume(returning: false)
         }
@@ -836,8 +840,10 @@ private enum TurnOutcome {
 
 /// Degenerate policy used when the caller hasn't specified safety at
 /// all (tests, read-only prototypes). Every call executes.
-struct AlwaysExecuteSafetyPolicy: SafetyPolicy {
-    func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision {
+public struct AlwaysExecuteSafetyPolicy: SafetyPolicy {
+    public init() {}
+
+    public func decision(for name: String, arguments: String, tool: AITool) -> SafetyDecision {
         .execute
     }
 }

--- a/Modules/Sources/WooAIAssistant/Models/ChatMessage.swift
+++ b/Modules/Sources/WooAIAssistant/Models/ChatMessage.swift
@@ -78,4 +78,16 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
     public mutating func markCompleted() {
         isStreaming = false
     }
+
+    public mutating func cancelPendingConfirmations() {
+        for index in segments.indices {
+            if case .confirmation(let id, let pid, let name, let preview, .pending) = segments[index] {
+                segments[index] = .confirmation(id: id,
+                                                proposalID: pid,
+                                                toolName: name,
+                                                preview: preview,
+                                                status: .cancelled)
+            }
+        }
+    }
 }

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -12,7 +12,10 @@ public final class AssistantController {
 
     private let backend: AssistantBackend
     private let context: AssistantContext
-    private var activeTask: Task<Void, Never>?
+
+    /// Visible to tests via `@testable` so they can await the in-flight
+    /// turn's Task without polling. Production callers go through `canSend`.
+    private(set) var activeTask: Task<Void, Never>?
 
     /// Per-turn UUID captured at `run()` entry. The cleanup at exit only clears
     /// `activeTask` when this token is still the active one. A newer `send()`

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Observation
+
+/// Coordinates merchant intents against an `AssistantBackend` and routes the
+/// resulting events into an `AssistantConversation`. The chat UI talks to the
+/// controller, never directly to the backend, so backends can swap freely.
+@MainActor
+@Observable
+public final class AssistantController {
+
+    public let conversation: AssistantConversation
+
+    private let backend: AssistantBackend
+    private let context: AssistantContext
+    private var activeTask: Task<Void, Never>?
+
+    /// Per-turn UUID captured at `run()` entry. The cleanup at exit only clears
+    /// `activeTask` when this token is still the active one. A newer `send()`
+    /// bumps the token, so a stale turn finishing late cannot nil out the
+    /// in-flight turn's reference - using `Task` identity instead has bitten
+    /// this controller before with a "follow-up question freezes the chat"
+    /// repro that survives because Task equality is not what intuition suggests
+    /// under cancellation.
+    private var activeTurnToken: UUID?
+
+    public init(backend: AssistantBackend,
+                context: AssistantContext,
+                conversation: AssistantConversation? = nil) {
+        self.backend = backend
+        self.context = context
+        self.conversation = conversation ?? AssistantConversation()
+    }
+
+    // MARK: - Intents
+
+    public func send(_ prompt: String) {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, activeTask == nil else { return }
+        _ = conversation.appendUserMessage(trimmed)
+        let assistantMessageID = conversation.beginAssistantMessage()
+        conversation.setStreaming(.sending)
+        let token = UUID()
+        activeTurnToken = token
+        activeTask = Task { [weak self] in
+            await self?.run(prompt: trimmed,
+                            assistantMessageID: assistantMessageID,
+                            token: token)
+        }
+    }
+
+    public func cancel() {
+        activeTask?.cancel()
+        activeTask = nil
+        activeTurnToken = nil
+        conversation.setStreaming(.idle)
+    }
+
+    /// `false` while a turn is in flight OR while a confirmation segment is
+    /// awaiting the merchant's tap; either way the input bar disables.
+    public var canSend: Bool {
+        activeTask == nil
+    }
+
+    // MARK: - Confirmation forwarders
+
+    public func confirmProposal(_ id: UUID) {
+        guard let gate = backend as? AssistantBackendConfirming else { return }
+        Task { await gate.confirmProposal(id) }
+    }
+
+    public func cancelProposal(_ id: UUID) {
+        guard let gate = backend as? AssistantBackendConfirming else { return }
+        Task { await gate.cancelProposal(id) }
+    }
+
+    // MARK: - Run loop
+
+    private func run(prompt: String,
+                     assistantMessageID: ChatMessage.ID,
+                     token: UUID) async {
+        let turn = AssistantTurn(prompt: prompt)
+        let stream = backend.send(turn: turn,
+                                  context: context,
+                                  session: conversation.session)
+        do {
+            for try await yield in stream {
+                if Task.isCancelled { break }
+                switch yield {
+                case .event(let event):
+                    conversation.apply(event, to: assistantMessageID)
+                    if case .textChunk = event {
+                        conversation.setStreaming(.streaming)
+                    }
+                case .sessionUpdate(let session):
+                    conversation.replaceSession(session)
+                }
+            }
+            switch conversation.streamingState {
+            case .failed, .outcomeUnknown:
+                break
+            default:
+                conversation.setStreaming(.idle)
+            }
+        } catch {
+            let message = (error as? AssistantError)?.message ?? error.localizedDescription
+            conversation.apply(.failed(.init(kind: .unknown, message: message)),
+                               to: assistantMessageID)
+        }
+        if activeTurnToken == token {
+            activeTask = nil
+            activeTurnToken = nil
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -13,6 +13,7 @@ public final class AssistantController {
 
     private(set) var activeTask: Task<Void, Never>?
     private var activeTurnToken: UUID?
+    private var activeAssistantMessageID: ChatMessage.ID?
 
     public init(backend: AssistantBackend,
                 context: AssistantContext,
@@ -27,6 +28,7 @@ public final class AssistantController {
         guard !trimmed.isEmpty, activeTask == nil else { return }
         _ = conversation.appendUserMessage(trimmed)
         let assistantMessageID = conversation.beginAssistantMessage()
+        activeAssistantMessageID = assistantMessageID
         conversation.setStreaming(.sending)
         let token = UUID()
         activeTurnToken = token
@@ -41,6 +43,10 @@ public final class AssistantController {
         activeTask?.cancel()
         activeTask = nil
         activeTurnToken = nil
+        if let messageID = activeAssistantMessageID {
+            conversation.markCancelled(messageID: messageID)
+        }
+        activeAssistantMessageID = nil
         conversation.setStreaming(.idle)
     }
 
@@ -97,6 +103,7 @@ public final class AssistantController {
         if activeTurnToken == token {
             activeTask = nil
             activeTurnToken = nil
+            activeAssistantMessageID = nil
         }
     }
 }

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -85,6 +85,7 @@ public final class AssistantController {
         do {
             for try await yield in stream {
                 if Task.isCancelled { break }
+                guard activeTurnToken == token else { break }
                 switch yield {
                 case .event(let event):
                     conversation.apply(event, to: assistantMessageID)
@@ -95,16 +96,20 @@ public final class AssistantController {
                     conversation.replaceSession(session)
                 }
             }
-            switch conversation.streamingState {
-            case .failed, .outcomeUnknown:
-                break
-            default:
-                conversation.setStreaming(.idle)
+            if activeTurnToken == token {
+                switch conversation.streamingState {
+                case .failed, .outcomeUnknown:
+                    break
+                default:
+                    conversation.setStreaming(.idle)
+                }
             }
         } catch {
-            let message = (error as? AssistantError)?.message ?? error.localizedDescription
-            conversation.apply(.failed(.init(kind: .unknown, message: message)),
-                               to: assistantMessageID)
+            if activeTurnToken == token {
+                let message = (error as? AssistantError)?.message ?? error.localizedDescription
+                conversation.apply(.failed(.init(kind: .unknown, message: message)),
+                                   to: assistantMessageID)
+            }
         }
         if activeTurnToken == token {
             activeTask = nil

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -1,9 +1,7 @@
 import Foundation
 import Observation
 
-/// Coordinates merchant intents against an `AssistantBackend` and routes the
-/// resulting events into an `AssistantConversation`. The chat UI talks to the
-/// controller, never directly to the backend, so backends can swap freely.
+/// Routes merchant intents into `AssistantBackend` and applies events to `AssistantConversation`.
 @MainActor
 @Observable
 public final class AssistantController {
@@ -13,17 +11,7 @@ public final class AssistantController {
     private let backend: AssistantBackend
     private let context: AssistantContext
 
-    /// Visible to tests via `@testable` so they can await the in-flight
-    /// turn's Task without polling. Production callers go through `canSend`.
     private(set) var activeTask: Task<Void, Never>?
-
-    /// Per-turn UUID captured at `run()` entry. The cleanup at exit only clears
-    /// `activeTask` when this token is still the active one. A newer `send()`
-    /// bumps the token, so a stale turn finishing late cannot nil out the
-    /// in-flight turn's reference - using `Task` identity instead has bitten
-    /// this controller before with a "follow-up question freezes the chat"
-    /// repro that survives because Task equality is not what intuition suggests
-    /// under cancellation.
     private var activeTurnToken: UUID?
 
     public init(backend: AssistantBackend,
@@ -56,8 +44,6 @@ public final class AssistantController {
         conversation.setStreaming(.idle)
     }
 
-    /// `false` while a turn is in flight OR while a confirmation segment is
-    /// awaiting the merchant's tap; either way the input bar disables.
     public var canSend: Bool {
         activeTask == nil
     }

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -34,8 +34,6 @@ public final class AssistantController {
         self.conversation = conversation ?? AssistantConversation()
     }
 
-    // MARK: - Intents
-
     public func send(_ prompt: String) {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, activeTask == nil else { return }
@@ -64,8 +62,6 @@ public final class AssistantController {
         activeTask == nil
     }
 
-    // MARK: - Confirmation forwarders
-
     public func confirmProposal(_ id: UUID) {
         guard let gate = backend as? AssistantBackendConfirming else { return }
         Task { await gate.confirmProposal(id) }
@@ -75,8 +71,6 @@ public final class AssistantController {
         guard let gate = backend as? AssistantBackendConfirming else { return }
         Task { await gate.cancelProposal(id) }
     }
-
-    // MARK: - Run loop
 
     private func run(prompt: String,
                      assistantMessageID: ChatMessage.ID,

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -87,7 +87,9 @@ public final class AssistantConversation {
                 streamingState = .outcomeUnknown(error.message)
             default:
                 messages[index].markCompleted()
-                streamingState = .failed(error.message)
+                if !outcomeUnknownObserved {
+                    streamingState = .failed(error.message)
+                }
             }
         }
     }

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -1,9 +1,7 @@
 import Foundation
 import Observation
 
-/// Observable source of truth for one chat conversation. Holds the ordered message
-/// list, a backend-opaque session handle, and the streaming state the input bar
-/// uses to swap between send and stop affordances.
+/// Observable source of truth for one chat conversation.
 @MainActor
 @Observable
 public final class AssistantConversation {
@@ -13,9 +11,6 @@ public final class AssistantConversation {
         case sending
         case streaming
         case failed(String)
-        /// Distinct from `.failed` so the UI can render a "I started this but
-        /// couldn't confirm it finished" message - the merchant should check
-        /// the native UI rather than treat the turn as a flat error.
         case outcomeUnknown(String)
     }
 
@@ -23,10 +18,6 @@ public final class AssistantConversation {
     public private(set) var streamingState: StreamingState = .idle
     public internal(set) var session: AssistantSession?
 
-    /// True from the moment the orchestrator emits `.failed(.outcomeUnknown)`
-    /// for this turn until the controller starts the next one. Lets the rest
-    /// of the turn (more text chunks, completion) flow through without
-    /// flipping `streamingState` back to `.streaming` or `.idle`.
     private(set) var outcomeUnknownObserved: Bool = false
 
     public init() {}
@@ -49,9 +40,6 @@ public final class AssistantConversation {
         return message.id
     }
 
-    /// Routes one orchestrator event into the targeted assistant message. The
-    /// segment identity in `ChatMessage` is preserved across mutations so the
-    /// SwiftUI list keeps stable rows under streaming updates.
     func apply(_ event: AssistantEvent, to assistantMessageID: ChatMessage.ID) {
         guard let index = messages.firstIndex(where: { $0.id == assistantMessageID }) else { return }
         switch event {
@@ -72,9 +60,7 @@ public final class AssistantConversation {
                                                toolName: toolName,
                                                payload: payload))
         case .cardRender(let toolCallID):
-            // Drop silently when no matching `toolResult` exists - the model
-            // referenced an id we never saw, the text answer still renders,
-            // and a missing card is a softer failure than a crash.
+            // Silently drop renders for unknown tool call IDs.
             if let match = Self.firstMatchingToolResult(in: messages[index].segments,
                                                        toolCallID: toolCallID) {
                 messages[index].append(.cardRender(id: UUID(),
@@ -96,10 +82,7 @@ public final class AssistantConversation {
         case .failed(let error):
             switch error.kind {
             case .outcomeUnknown:
-                // Per-call event: the orchestrator may still emit text
-                // chunks and a terminal `completed`. Don't mark the message
-                // done yet, but pin the state so the UI keeps the distinct
-                // "started, couldn't confirm" affordance.
+                // Per-call event; rest of turn keeps the distinct surface.
                 outcomeUnknownObserved = true
                 streamingState = .outcomeUnknown(error.message)
             default:

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -100,6 +100,12 @@ public final class AssistantConversation {
         streamingState = state
     }
 
+    func markCancelled(messageID: ChatMessage.ID) {
+        guard let index = messages.firstIndex(where: { $0.id == messageID }) else { return }
+        messages[index].markCompleted()
+        messages[index].cancelPendingConfirmations()
+    }
+
     func replaceSession(_ newSession: AssistantSession) {
         session = newSession
     }

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -119,8 +119,6 @@ public final class AssistantConversation {
         session = newSession
     }
 
-    // MARK: - Helpers
-
     private func resultSummary(from json: String?) -> String? {
         guard let json else { return nil }
         let limit = 120

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -23,13 +23,17 @@ public final class AssistantConversation {
     public private(set) var streamingState: StreamingState = .idle
     public internal(set) var session: AssistantSession?
 
+    /// True from the moment the orchestrator emits `.failed(.outcomeUnknown)`
+    /// for this turn until the controller starts the next one. Lets the rest
+    /// of the turn (more text chunks, completion) flow through without
+    /// flipping `streamingState` back to `.streaming` or `.idle`.
+    private(set) var outcomeUnknownObserved: Bool = false
+
     public init() {}
 
     init(seededMessages: [ChatMessage]) {
         self.messages = seededMessages
     }
-
-    // MARK: - Mutations
 
     func appendUserMessage(_ text: String) -> ChatMessage {
         let message = ChatMessage(role: .user,
@@ -41,6 +45,7 @@ public final class AssistantConversation {
     func beginAssistantMessage() -> ChatMessage.ID {
         let message = ChatMessage(role: .assistant, isStreaming: true)
         messages.append(message)
+        outcomeUnknownObserved = false
         return message.id
     }
 
@@ -89,17 +94,24 @@ public final class AssistantConversation {
         case .completed:
             messages[index].markCompleted()
         case .failed(let error):
-            messages[index].markCompleted()
             switch error.kind {
             case .outcomeUnknown:
+                // Per-call event: the orchestrator may still emit text
+                // chunks and a terminal `completed`. Don't mark the message
+                // done yet, but pin the state so the UI keeps the distinct
+                // "started, couldn't confirm" affordance.
+                outcomeUnknownObserved = true
                 streamingState = .outcomeUnknown(error.message)
             default:
+                messages[index].markCompleted()
                 streamingState = .failed(error.message)
             }
         }
     }
 
     func setStreaming(_ state: StreamingState) {
+        if outcomeUnknownObserved, case .streaming = state { return }
+        if outcomeUnknownObserved, case .idle = state { return }
         streamingState = state
     }
 

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Observation
+
+/// Observable source of truth for one chat conversation. Holds the ordered message
+/// list, a backend-opaque session handle, and the streaming state the input bar
+/// uses to swap between send and stop affordances.
+@MainActor
+@Observable
+public final class AssistantConversation {
+
+    public enum StreamingState: Equatable, Sendable {
+        case idle
+        case sending
+        case streaming
+        case failed(String)
+        /// Distinct from `.failed` so the UI can render a "I started this but
+        /// couldn't confirm it finished" message - the merchant should check
+        /// the native UI rather than treat the turn as a flat error.
+        case outcomeUnknown(String)
+    }
+
+    public private(set) var messages: [ChatMessage] = []
+    public private(set) var streamingState: StreamingState = .idle
+    public internal(set) var session: AssistantSession?
+
+    public init() {}
+
+    init(seededMessages: [ChatMessage]) {
+        self.messages = seededMessages
+    }
+
+    // MARK: - Mutations
+
+    func appendUserMessage(_ text: String) -> ChatMessage {
+        let message = ChatMessage(role: .user,
+                                  segments: [.text(id: UUID(), content: text)])
+        messages.append(message)
+        return message
+    }
+
+    func beginAssistantMessage() -> ChatMessage.ID {
+        let message = ChatMessage(role: .assistant, isStreaming: true)
+        messages.append(message)
+        return message.id
+    }
+
+    /// Routes one orchestrator event into the targeted assistant message. The
+    /// segment identity in `ChatMessage` is preserved across mutations so the
+    /// SwiftUI list keeps stable rows under streaming updates.
+    func apply(_ event: AssistantEvent, to assistantMessageID: ChatMessage.ID) {
+        guard let index = messages.firstIndex(where: { $0.id == assistantMessageID }) else { return }
+        switch event {
+        case .textChunk(let chunk):
+            messages[index].updateText(appending: chunk)
+        case .toolCallStarted(let id, let name, let args):
+            messages[index].append(.toolCall(id: UUID(),
+                                             toolCallID: id,
+                                             toolName: name,
+                                             argumentsPreview: args,
+                                             status: .running))
+        case .toolCallCompleted(let id, _, let resultJSON):
+            messages[index].updateToolCall(id: id,
+                                           to: .completed(summary: resultSummary(from: resultJSON)))
+        case .toolResult(let toolCallID, let toolName, let payload):
+            messages[index].append(.toolResult(id: UUID(),
+                                               toolCallID: toolCallID,
+                                               toolName: toolName,
+                                               payload: payload))
+        case .cardRender(let toolCallID):
+            // Drop silently when no matching `toolResult` exists - the model
+            // referenced an id we never saw, the text answer still renders,
+            // and a missing card is a softer failure than a crash.
+            if let match = Self.firstMatchingToolResult(in: messages[index].segments,
+                                                       toolCallID: toolCallID) {
+                messages[index].append(.cardRender(id: UUID(),
+                                                   toolCallID: toolCallID,
+                                                   toolName: match.toolName,
+                                                   payload: match.payload))
+            }
+        case .confirmationRequired(let proposal):
+            messages[index].append(.confirmation(id: UUID(),
+                                                 proposalID: proposal.id,
+                                                 toolName: proposal.toolName,
+                                                 preview: proposal.preview,
+                                                 status: .pending))
+        case .confirmationResolved(let proposalID, let approved):
+            messages[index].updateConfirmation(proposalID: proposalID,
+                                               to: approved ? .confirmed : .cancelled)
+        case .completed:
+            messages[index].markCompleted()
+        case .failed(let error):
+            messages[index].markCompleted()
+            switch error.kind {
+            case .outcomeUnknown:
+                streamingState = .outcomeUnknown(error.message)
+            default:
+                streamingState = .failed(error.message)
+            }
+        }
+    }
+
+    func setStreaming(_ state: StreamingState) {
+        streamingState = state
+    }
+
+    func replaceSession(_ newSession: AssistantSession) {
+        session = newSession
+    }
+
+    // MARK: - Helpers
+
+    private func resultSummary(from json: String?) -> String? {
+        guard let json else { return nil }
+        let limit = 120
+        if json.count <= limit { return json }
+        return String(json.prefix(limit)) + "..."
+    }
+
+    private static func firstMatchingToolResult(in segments: [MessageSegment],
+                                                toolCallID: String) -> (toolName: String,
+                                                                        payload: AnyCodableJSON)? {
+        for segment in segments {
+            if case .toolResult(_, let id, let name, let payload) = segment, id == toolCallID {
+                return (name, payload)
+            }
+        }
+        return nil
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import os
+import Testing
+@testable import WooAIAssistant
+
+struct AgenticChatBackendTests {
+
+    @Test
+    func test_send_when_orchestrator_emits_textChunk_then_yields_event_textChunk() async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("Hello"), .textDelta(", merchant"), .completed(.stop)]
+        ])
+        let backend = AgenticChatBackend(chatService: chat,
+                                         systemPrompt: nil)
+
+        // When
+        var events: [AssistantEvent] = []
+        let stream = backend.send(turn: .init(prompt: "Hi"),
+                                  context: Self.defaultContext,
+                                  session: nil)
+        for try await yield in stream {
+            if case .event(let event) = yield {
+                events.append(event)
+            }
+        }
+
+        // Then
+        #expect(events.contains(.textChunk("Hello")))
+        #expect(events.contains(.textChunk(", merchant")))
+        #expect(events.contains(.completed(routeConfidence: nil)))
+    }
+
+    @Test
+    func test_send_when_orchestrator_emits_failed_then_yields_event_failed() async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setStreamError(AssistantError(kind: .upstreamFailure,
+                                                 message: "stream blew up"))
+        let backend = AgenticChatBackend(chatService: chat,
+                                         systemPrompt: nil)
+
+        // When
+        var events: [AssistantEvent] = []
+        let stream = backend.send(turn: .init(prompt: "Hi"),
+                                  context: Self.defaultContext,
+                                  session: nil)
+        for try await yield in stream {
+            if case .event(let event) = yield {
+                events.append(event)
+            }
+        }
+
+        // Then
+        let failed = events.compactMap { event -> AssistantError? in
+            if case .failed(let error) = event { return error }
+            return nil
+        }.first
+        let error = try #require(failed)
+        #expect(error.message == "stream blew up")
+    }
+
+    @Test
+    func test_send_when_called_twice_then_secondTurn_sees_firstTurn_transcript() async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("Done."), .completed(.stop)],
+            [.textDelta("OK."), .completed(.stop)]
+        ])
+        let backend = AgenticChatBackend(chatService: chat, systemPrompt: nil)
+
+        // When
+        let stream1 = backend.send(turn: .init(prompt: "first"),
+                                   context: Self.defaultContext,
+                                   session: nil)
+        for try await _ in stream1 {}
+        let stream2 = backend.send(turn: .init(prompt: "second"),
+                                   context: Self.defaultContext,
+                                   session: nil)
+        for try await _ in stream2 {}
+
+        // Then
+        let captured = await chat.capturedRequests
+        #expect(captured.count == 2)
+        let secondMessages = captured[1].messages
+        let userPrompts = secondMessages.filter { $0.role == .user }.compactMap { $0.content }
+        #expect(userPrompts == ["first", "second"])
+        let assistantTexts = secondMessages.filter { $0.role == .assistant }.compactMap { $0.content }
+        #expect(assistantTexts.contains("Done."))
+    }
+
+    @Test
+    func test_confirmProposal_when_called_then_resumes_orchestrator_with_true() async throws {
+        // Given
+        let unsafeTool = AITool(name: "orders_update",
+                                description: "Update an order",
+                                parametersSchema: .object([:]),
+                                safetyLevel: .unsafe)
+        let chat = MockAIChatService()
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_x",
+            function: .init(name: "orders_update", arguments: #"{"id":1}"#)
+        )
+        await chat.setScriptedTurns([
+            [.toolCall(toolCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([unsafeTool])
+        await registry.setResult(for: "orders_update",
+                                 result: .success(.init(toolName: "orders_update",
+                                                        structured: .object(["id": .int(1)]))))
+        let backend = AgenticChatBackend(chatService: chat,
+                                         toolRegistry: registry,
+                                         safetyPolicy: DefaultSafetyPolicy(),
+                                         systemPrompt: nil)
+
+        // When
+        let stream = backend.send(turn: .init(prompt: "update order 1"),
+                                  context: Self.defaultContext,
+                                  session: nil)
+        var events: [AssistantEvent] = []
+        for try await yield in stream {
+            if case .event(let event) = yield {
+                events.append(event)
+                if case .confirmationRequired(let proposal) = event {
+                    await backend.confirmProposal(proposal.id)
+                }
+            }
+        }
+
+        // Then
+        let resolved = events.compactMap { event -> Bool? in
+            if case .confirmationResolved(_, let approved) = event { return approved }
+            return nil
+        }.first
+        #expect(resolved == true)
+        let invocations = await registry.invocationCount(for: "orders_update")
+        #expect(invocations == 1)
+    }
+
+    @Test
+    func test_systemPromptProvider_when_invoked_per_turn_then_rebuilt_each_call()
+    async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("a"), .completed(.stop)],
+            [.textDelta("b"), .completed(.stop)]
+        ])
+        let counter = ProviderCallCounter()
+        let backend = AgenticChatBackend(chatService: chat,
+                                         systemPromptProvider: {
+                                             "prompt-\(counter.bumpAndGet())"
+                                         })
+
+        // When
+        let stream1 = backend.send(turn: .init(prompt: "one"),
+                                   context: Self.defaultContext,
+                                   session: nil)
+        for try await _ in stream1 {}
+        let stream2 = backend.send(turn: .init(prompt: "two"),
+                                   context: Self.defaultContext,
+                                   session: nil)
+        for try await _ in stream2 {}
+
+        // Then
+        #expect(counter.snapshot() == 2)
+        let captured = await chat.capturedRequests
+        let firstSystem = captured[0].messages.first(where: { $0.role == .system })?.content
+        let secondSystem = captured[1].messages.first(where: { $0.role == .system })?.content
+        #expect(firstSystem == "prompt-1")
+        #expect(secondSystem == "prompt-2")
+    }
+
+    private static let defaultContext = AssistantContext(
+        siteID: 1,
+        siteURL: URL(string: "https://example.com")!,
+        blogID: nil
+    )
+}
+
+/// `OSAllocatedUnfairLock` keeps the counter Sendable without resorting
+/// to `@unchecked`; the closure that captures it runs on whatever Task
+/// the orchestrator is on each turn, but the test sequences turns serially.
+private final class ProviderCallCounter: Sendable {
+    private let lock = OSAllocatedUnfairLock(initialState: 0)
+
+    func bumpAndGet() -> Int {
+        lock.withLock { state in
+            state += 1
+            return state
+        }
+    }
+
+    func snapshot() -> Int {
+        lock.withLock { $0 }
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -18,7 +18,7 @@ struct AgenticChatBackendTests {
         // When
         var events: [AssistantEvent] = []
         let stream = backend.send(turn: .init(prompt: "Hi"),
-                                  context: Self.defaultContext,
+                                  context: defaultContext,
                                   session: nil)
         for try await yield in stream {
             if case .event(let event) = yield {
@@ -44,7 +44,7 @@ struct AgenticChatBackendTests {
         // When
         var events: [AssistantEvent] = []
         let stream = backend.send(turn: .init(prompt: "Hi"),
-                                  context: Self.defaultContext,
+                                  context: defaultContext,
                                   session: nil)
         for try await yield in stream {
             if case .event(let event) = yield {
@@ -73,11 +73,11 @@ struct AgenticChatBackendTests {
 
         // When
         let stream1 = backend.send(turn: .init(prompt: "first"),
-                                   context: Self.defaultContext,
+                                   context: defaultContext,
                                    session: nil)
         for try await _ in stream1 {}
         let stream2 = backend.send(turn: .init(prompt: "second"),
-                                   context: Self.defaultContext,
+                                   context: defaultContext,
                                    session: nil)
         for try await _ in stream2 {}
 
@@ -119,7 +119,7 @@ struct AgenticChatBackendTests {
 
         // When
         let stream = backend.send(turn: .init(prompt: "update order 1"),
-                                  context: Self.defaultContext,
+                                  context: defaultContext,
                                   session: nil)
         var events: [AssistantEvent] = []
         for try await yield in stream {
@@ -199,7 +199,7 @@ struct AgenticChatBackendTests {
         // When
         for prompt in ["t1", "t2", "t3"] {
             let stream = backend.send(turn: .init(prompt: prompt),
-                                      context: Self.defaultContext,
+                                      context: defaultContext,
                                       session: nil)
             for try await _ in stream {}
         }
@@ -243,11 +243,11 @@ struct AgenticChatBackendTests {
 
         // When
         let stream1 = backend.send(turn: .init(prompt: "one"),
-                                   context: Self.defaultContext,
+                                   context: defaultContext,
                                    session: nil)
         for try await _ in stream1 {}
         let stream2 = backend.send(turn: .init(prompt: "two"),
-                                   context: Self.defaultContext,
+                                   context: defaultContext,
                                    session: nil)
         for try await _ in stream2 {}
 
@@ -260,7 +260,7 @@ struct AgenticChatBackendTests {
         #expect(secondSystem == "prompt-2")
     }
 
-    private static let defaultContext = AssistantContext(
+    private let defaultContext = AssistantContext(
         siteID: 1,
         siteURL: URL(string: "https://example.com")!,
         blogID: nil

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -267,9 +267,7 @@ struct AgenticChatBackendTests {
     )
 }
 
-/// `OSAllocatedUnfairLock` keeps the counter Sendable without resorting
-/// to `@unchecked`; the closure that captures it runs on whatever Task
-/// the orchestrator is on each turn, but the test sequences turns serially.
+/// Sendable counter without `@unchecked`.
 private final class ProviderCallCounter: Sendable {
     private let lock = OSAllocatedUnfairLock(initialState: 0)
 

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -265,6 +265,35 @@ struct AgenticChatBackendTests {
     }
 
     @Test
+    func test_send_when_tool_calls_complete_in_reverse_order_then_transcript_replays_in_call_order()
+    async throws {
+        // Given
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_a",
+            function: .init(name: "tool_a", arguments: "{}")
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_b",
+            function: .init(name: "tool_b", arguments: "{}")
+        )
+        let resultsCompletedInReverseOrder: [(String, String)] = [
+            ("call_b", #"{"b":2}"#),
+            ("call_a", #"{"a":1}"#)
+        ]
+
+        // When
+        let (orderedCalls, orderedResults) = AgenticChatBackend.matchedPairs(
+            toolCalls: [firstCall, secondCall],
+            toolResults: resultsCompletedInReverseOrder
+        )
+
+        // Then
+        #expect(orderedCalls.map(\.id) == ["call_a", "call_b"])
+        #expect(orderedResults.map(\.0) == ["call_a", "call_b"])
+        #expect(orderedResults.map(\.1) == [#"{"a":1}"#, #"{"b":2}"#])
+    }
+
+    @Test
     func test_systemPromptProvider_when_invoked_per_turn_then_rebuilt_each_call()
     async throws {
         // Given

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -166,6 +166,67 @@ struct AgenticChatBackendTests {
     }
 
     @Test
+    func test_send_when_third_turn_after_two_with_tool_calls_then_replays_in_correct_wire_order()
+    async throws {
+        // Given
+        let tool = AITool(name: "orders_list",
+                          description: "List orders",
+                          parametersSchema: .object([:]),
+                          safetyLevel: .safe)
+        let chat = MockAIChatService()
+        let firstCall = OpenAIChat.ToolCall(id: "c1",
+                                            function: .init(name: "orders_list",
+                                                            arguments: "{}"))
+        let secondCall = OpenAIChat.ToolCall(id: "c2",
+                                             function: .init(name: "orders_list",
+                                                             arguments: #"{"page":2}"#))
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .completed(.toolCalls)],
+            [.textDelta("ok 1"), .completed(.stop)],
+            [.toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("ok 2"), .completed(.stop)],
+            [.textDelta("done"), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([tool])
+        await registry.setResult(for: "orders_list",
+                                 result: .success(.init(toolName: "orders_list",
+                                                        structured: .object(["count": .int(1)]))))
+        let backend = AgenticChatBackend(chatService: chat,
+                                         toolRegistry: registry,
+                                         systemPrompt: nil)
+
+        // When
+        for prompt in ["t1", "t2", "t3"] {
+            let stream = backend.send(turn: .init(prompt: prompt),
+                                      context: Self.defaultContext,
+                                      session: nil)
+            for try await _ in stream {}
+        }
+
+        // Then
+        let captured = await chat.capturedRequests
+        let messagesOnTurn3 = captured.last?.messages ?? []
+        let roles = messagesOnTurn3.map(\.role)
+        #expect(roles == [.user, .assistant, .tool, .assistant,
+                          .user, .assistant, .tool, .assistant,
+                          .user])
+        let userPrompts = messagesOnTurn3.filter { $0.role == .user }.compactMap { $0.content }
+        #expect(userPrompts == ["t1", "t2", "t3"])
+        let assistantTextPair = messagesOnTurn3
+            .filter { $0.role == .assistant && $0.content != nil }
+            .compactMap { $0.content }
+        #expect(assistantTextPair == ["ok 1", "ok 2"])
+        let toolCallIDs = messagesOnTurn3
+            .filter { $0.role == .assistant }
+            .flatMap { $0.toolCalls ?? [] }
+            .map(\.id)
+        #expect(toolCallIDs == ["c1", "c2"])
+        let toolMessages = messagesOnTurn3.filter { $0.role == .tool }
+        #expect(toolMessages.compactMap(\.toolCallID) == ["c1", "c2"])
+    }
+
+    @Test
     func test_systemPromptProvider_when_invoked_per_turn_then_rebuilt_each_call()
     async throws {
         // Given

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -267,7 +267,6 @@ struct AgenticChatBackendTests {
     )
 }
 
-/// Sendable counter without `@unchecked`.
 private final class ProviderCallCounter: Sendable {
     private let lock = OSAllocatedUnfairLock(initialState: 0)
 

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -323,6 +323,119 @@ struct AgenticChatBackendTests {
         #expect(firstSystem != secondSystem)
     }
 
+    @Test
+    func test_send_when_outcomeUnknown_emitted_mid_turn_then_next_turn_replays_full_transcript()
+    async throws {
+        // Given
+        let writeTool = AITool(name: "orders_update",
+                               description: "Update an order",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe)
+        let chat = MockAIChatService()
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_u",
+            function: .init(name: "orders_update", arguments: #"{"id":42}"#)
+        )
+        await chat.setScriptedTurns([
+            [.toolCall(toolCall), .completed(.toolCalls)],
+            [.textDelta("started — couldn't confirm"), .completed(.stop)],
+            [.textDelta("not sure"), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "orders_update",
+                                 result: .failed(.init(toolName: "orders_update",
+                                                       kind: .outcomeUnknown,
+                                                       reason: "URL cancelled mid-write")))
+        let backend = AgenticChatBackend(chatService: chat,
+                                         toolRegistry: registry,
+                                         systemPrompt: nil)
+
+        // When
+        let stream1 = backend.send(turn: .init(prompt: "update order 42 to processing"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream1 {}
+        let stream2 = backend.send(turn: .init(prompt: "did it work?"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream2 {}
+
+        // Then
+        let captured = await chat.capturedRequests
+        let turn2Messages = try #require(captured.last?.messages)
+        let userPrompts = turn2Messages.filter { $0.role == .user }.compactMap { $0.content }
+        #expect(userPrompts == ["update order 42 to processing", "did it work?"])
+        let assistantToolCallIDs = turn2Messages
+            .filter { $0.role == .assistant }
+            .flatMap { $0.toolCalls ?? [] }
+            .map(\.id)
+        #expect(assistantToolCallIDs == ["call_u"])
+        let toolMessages = turn2Messages.filter { $0.role == .tool }
+        #expect(toolMessages.compactMap(\.toolCallID) == ["call_u"])
+        let assistantTexts = turn2Messages
+            .filter { $0.role == .assistant && $0.content != nil }
+            .compactMap { $0.content }
+        #expect(assistantTexts.contains("started — couldn't confirm"))
+    }
+
+    @Test
+    func test_send_when_terminal_failure_after_outcomeUnknown_then_transcript_not_appended()
+    async throws {
+        // Given
+        let writeTool = AITool(name: "orders_update",
+                               description: "Update an order",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .safe)
+        let chat = MockAIChatService()
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_t",
+            function: .init(name: "orders_update", arguments: #"{"id":1}"#)
+        )
+        await chat.setScriptedTurns([
+            [.toolCall(toolCall), .completed(.toolCalls)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "orders_update",
+                                 result: .failed(.init(toolName: "orders_update",
+                                                       kind: .outcomeUnknown,
+                                                       reason: "transport drop")))
+        let backend = AgenticChatBackend(chatService: chat,
+                                         toolRegistry: registry,
+                                         systemPrompt: nil)
+
+        // When
+        var firstTurnEvents: [AssistantEvent] = []
+        let stream1 = backend.send(turn: .init(prompt: "first prompt"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await yield in stream1 {
+            if case .event(let event) = yield {
+                firstTurnEvents.append(event)
+            }
+        }
+        await chat.setScriptedTurns([
+            [.textDelta("second"), .completed(.stop)]
+        ])
+        let stream2 = backend.send(turn: .init(prompt: "second prompt"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream2 {}
+
+        // Then
+        let failureKinds = firstTurnEvents.compactMap { event -> AssistantErrorKind? in
+            if case .failed(let error) = event { return error.kind }
+            return nil
+        }
+        #expect(failureKinds.contains(.outcomeUnknown))
+        #expect(failureKinds.contains(where: { $0 != .outcomeUnknown }))
+        let captured = await chat.capturedRequests
+        let turn2Messages = try #require(captured.last?.messages)
+        let userPrompts = turn2Messages.filter { $0.role == .user }.compactMap { $0.content }
+        #expect(userPrompts == ["second prompt"])
+    }
+
     private let defaultContext = AssistantContext(
         siteID: 1,
         siteURL: URL(string: "https://example.com")!,

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 import Testing
 @testable import WooAIAssistant
 
@@ -302,11 +301,8 @@ struct AgenticChatBackendTests {
             [.textDelta("a"), .completed(.stop)],
             [.textDelta("b"), .completed(.stop)]
         ])
-        let counter = ProviderCallCounter()
         let backend = AgenticChatBackend(chatService: chat,
-                                         systemPromptProvider: {
-                                             "prompt-\(counter.bumpAndGet())"
-                                         })
+                                         systemPromptProvider: { UUID().uuidString })
 
         // When
         let stream1 = backend.send(turn: .init(prompt: "one"),
@@ -319,12 +315,12 @@ struct AgenticChatBackendTests {
         for try await _ in stream2 {}
 
         // Then
-        #expect(counter.snapshot() == 2)
         let captured = await chat.capturedRequests
         let firstSystem = captured[0].messages.first(where: { $0.role == .system })?.content
         let secondSystem = captured[1].messages.first(where: { $0.role == .system })?.content
-        #expect(firstSystem == "prompt-1")
-        #expect(secondSystem == "prompt-2")
+        #expect(firstSystem != nil)
+        #expect(secondSystem != nil)
+        #expect(firstSystem != secondSystem)
     }
 
     private let defaultContext = AssistantContext(
@@ -332,19 +328,4 @@ struct AgenticChatBackendTests {
         siteURL: URL(string: "https://example.com")!,
         blogID: nil
     )
-}
-
-private final class ProviderCallCounter: Sendable {
-    private let lock = OSAllocatedUnfairLock(initialState: 0)
-
-    func bumpAndGet() -> Int {
-        lock.withLock { state in
-            state += 1
-            return state
-        }
-    }
-
-    func snapshot() -> Int {
-        lock.withLock { $0 }
-    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -227,6 +227,44 @@ struct AgenticChatBackendTests {
     }
 
     @Test
+    func test_send_when_turn_fails_mid_stream_then_transcript_not_polluted() async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("first ok"), .completed(.stop)],
+            [.textDelta("partial")],
+            [.textDelta("third"), .completed(.stop)]
+        ])
+        let backend = AgenticChatBackend(chatService: chat, systemPrompt: nil)
+
+        // When
+        let stream1 = backend.send(turn: .init(prompt: "t1"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream1 {}
+        await chat.setStreamError(AssistantError(kind: .upstreamFailure, message: "boom"))
+        let stream2 = backend.send(turn: .init(prompt: "t2"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream2 {}
+        await chat.setStreamError(nil)
+        let stream3 = backend.send(turn: .init(prompt: "t3"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream3 {}
+
+        // Then
+        let captured = await chat.capturedRequests
+        let messagesOnTurn3 = captured.last?.messages ?? []
+        let userPrompts = messagesOnTurn3.filter { $0.role == .user }.compactMap { $0.content }
+        #expect(userPrompts == ["t1", "t3"])
+        let assistantTexts = messagesOnTurn3
+            .filter { $0.role == .assistant && $0.content != nil }
+            .compactMap { $0.content }
+        #expect(assistantTexts == ["first ok"])
+    }
+
+    @Test
     func test_systemPromptProvider_when_invoked_per_turn_then_rebuilt_each_call()
     async throws {
         // Given

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -142,6 +142,30 @@ struct AgenticChatBackendTests {
     }
 
     @Test
+    func test_transcript_when_toolCallStarted_without_completed_then_orphan_dropped_in_next_turn()
+    async throws {
+        // Given
+        let started = OpenAIChat.ToolCall(
+            id: "started_only",
+            function: .init(name: "orders_list", arguments: "{}")
+        )
+        let paired = OpenAIChat.ToolCall(
+            id: "paired",
+            function: .init(name: "orders_list", arguments: "{}")
+        )
+
+        // When
+        let (calls, results) = AgenticChatBackend.matchedPairs(
+            toolCalls: [started, paired],
+            toolResults: [("paired", "{}")]
+        )
+
+        // Then
+        #expect(calls.map(\.id) == ["paired"])
+        #expect(results.map(\.0) == ["paired"])
+    }
+
+    @Test
     func test_systemPromptProvider_when_invoked_per_turn_then_rebuilt_each_call()
     async throws {
         // Given

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
@@ -1,0 +1,80 @@
+import Foundation
+@testable import WooAIAssistant
+
+/// Test double for `AssistantBackend` that yields scripted `BackendYield`
+/// sequences and exposes per-stream finish control so tests can keep a
+/// turn's stream open while a newer turn runs in parallel - the scenario
+/// the controller's per-turn UUID token has to survive.
+actor MockAssistantBackend: AssistantBackendConfirming {
+
+    typealias OnSendStarted = @Sendable (AssistantTurn) -> Void
+
+    var scriptedYields: [[BackendYield]] = []
+    private(set) var receivedTurns: [AssistantTurn] = []
+    private(set) var confirmedProposalIDs: [UUID] = []
+    private(set) var cancelledProposalIDs: [UUID] = []
+
+    /// Auto-finish each turn's stream right after yielding the scripted
+    /// events. Tests that need to interleave a stale turn's cleanup with
+    /// a newer turn flip this to false and call `finishOldestStream()`.
+    var autoFinishStreams = true
+
+    /// Stream continuations queued in FIFO order so a freeze-fix test can
+    /// finish the older turn after the newer turn has already started.
+    private var pendingContinuations: [AsyncThrowingStream<BackendYield, Error>.Continuation] = []
+    private var onSendStarted: OnSendStarted?
+
+    func setScriptedYields(_ yields: [[BackendYield]]) {
+        scriptedYields = yields
+    }
+
+    func setAutoFinishStreams(_ value: Bool) {
+        autoFinishStreams = value
+    }
+
+    func setOnSendStarted(_ closure: OnSendStarted?) {
+        onSendStarted = closure
+    }
+
+    nonisolated func send(turn: AssistantTurn,
+                          context: AssistantContext,
+                          session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
+        AsyncThrowingStream { continuation in
+            Task { await self.start(turn: turn, continuation: continuation) }
+        }
+    }
+
+    func confirmProposal(_ id: UUID) async {
+        confirmedProposalIDs.append(id)
+    }
+
+    func cancelProposal(_ id: UUID) async {
+        cancelledProposalIDs.append(id)
+    }
+
+    /// Finish the oldest still-open stream. Tests use this to simulate a
+    /// stale turn completing after a newer turn has already started.
+    func finishOldestStream() {
+        guard !pendingContinuations.isEmpty else { return }
+        pendingContinuations.removeFirst().finish()
+    }
+
+    func pendingStreamCount() -> Int {
+        pendingContinuations.count
+    }
+
+    private func start(turn: AssistantTurn,
+                       continuation: AsyncThrowingStream<BackendYield, Error>.Continuation) {
+        receivedTurns.append(turn)
+        let yields = scriptedYields.isEmpty ? [] : scriptedYields.removeFirst()
+        for yield in yields {
+            continuation.yield(yield)
+        }
+        onSendStarted?(turn)
+        if autoFinishStreams {
+            continuation.finish()
+        } else {
+            pendingContinuations.append(continuation)
+        }
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
@@ -1,158 +1,72 @@
 import Foundation
 @testable import WooAIAssistant
 
-/// Test double for `AssistantBackend` that yields scripted `BackendYield`
-/// sequences and exposes per-turn lifecycle signals so tests can wait on
-/// deterministic events instead of polling MainActor with `Task.yield`.
-actor MockAssistantBackend: AssistantBackendConfirming {
+@MainActor
+final class MockAssistantBackend: AssistantBackendConfirming {
 
-    typealias OnSendStarted = @Sendable (AssistantTurn) -> Void
-
-    var scriptedYields: [[BackendYield]] = []
-    private(set) var receivedTurns: [AssistantTurn] = []
+    private(set) var recordedTurns: [AssistantTurn] = []
     private(set) var confirmedProposalIDs: [UUID] = []
     private(set) var cancelledProposalIDs: [UUID] = []
 
-    /// Auto-finish each turn's stream right after yielding the scripted
-    /// events. Tests that need to interleave a stale turn's cleanup with
-    /// a newer turn flip this to false and call `finishOldestStream()`.
-    var autoFinishStreams = true
+    private var scripts: [[BackendYield]] = []
+    private var heldIndices: Set<Int> = []
+    private var pendingByIndex: [Int: AsyncThrowingStream<BackendYield, Error>.Continuation] = [:]
 
-    /// Stream continuations queued in FIFO order so a freeze-fix test can
-    /// finish the older turn after the newer turn has already started.
-    private var pendingContinuations: [AsyncThrowingStream<BackendYield, Error>.Continuation] = []
-    private var onSendStarted: OnSendStarted?
-
-    /// Per-turn lifecycle signals. Indices are `receivedTurns` ordinals so
-    /// `awaitTurnStarted(at: 0)` resolves once the first turn's `start()`
-    /// has yielded its scripted events. `awaitTurnFinished(at:)` resolves
-    /// when that turn's stream continuation finishes, whether via auto
-    /// finish, `finishOldestStream`, or consumer cancellation.
-    private var startedContinuations: [CheckedContinuation<Void, Never>?] = []
-    private var startedFlags: [Bool] = []
-    private var finishedContinuations: [CheckedContinuation<Void, Never>?] = []
-    private var finishedFlags: [Bool] = []
-
-    /// One-shot continuations resumed when a cancel/confirm lands so the
-    /// proposal forwarding test stays deterministic.
-    private var cancelContinuations: [UUID: CheckedContinuation<Void, Never>] = [:]
-    private var confirmContinuations: [UUID: CheckedContinuation<Void, Never>] = [:]
-
-    func setScriptedYields(_ yields: [[BackendYield]]) {
-        scriptedYields = yields
+    func script(_ events: [BackendYield]) {
+        scripts.append(events)
     }
 
-    func setAutoFinishStreams(_ value: Bool) {
-        autoFinishStreams = value
+    func script(_ scripts: [[BackendYield]]) {
+        for entry in scripts { self.scripts.append(entry) }
     }
 
-    func setOnSendStarted(_ closure: OnSendStarted?) {
-        onSendStarted = closure
+    func holdStream(at index: Int) {
+        heldIndices.insert(index)
     }
 
-    nonisolated func send(turn: AssistantTurn,
-                          context: AssistantContext,
-                          session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
-        AsyncThrowingStream { continuation in
-            Task { await self.start(turn: turn, continuation: continuation) }
-        }
-    }
-
-    func confirmProposal(_ id: UUID) async {
-        confirmedProposalIDs.append(id)
-        if let continuation = confirmContinuations.removeValue(forKey: id) {
-            continuation.resume()
-        }
-    }
-
-    func cancelProposal(_ id: UUID) async {
-        cancelledProposalIDs.append(id)
-        if let continuation = cancelContinuations.removeValue(forKey: id) {
-            continuation.resume()
-        }
-    }
-
-    /// Finish the oldest still-open stream. Tests use this to simulate a
-    /// stale turn completing after a newer turn has already started.
-    func finishOldestStream() {
-        guard !pendingContinuations.isEmpty else { return }
-        let continuation = pendingContinuations.removeFirst()
+    func releaseStream(at index: Int) {
+        heldIndices.remove(index)
+        guard let continuation = pendingByIndex.removeValue(forKey: index) else { return }
         continuation.finish()
     }
 
-    func pendingStreamCount() -> Int {
-        pendingContinuations.count
-    }
-
-    func awaitTurnStarted(at index: Int) async {
-        ensureSignalCapacity(forIndex: index)
-        if startedFlags[index] { return }
-        await withCheckedContinuation { continuation in
-            startedContinuations[index] = continuation
+    nonisolated public func send(turn: AssistantTurn,
+                                 context: AssistantContext,
+                                 session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
+        let index = MainActor.assumeIsolated { self.recordTurn(turn) }
+        return AsyncThrowingStream { continuation in
+            MainActor.assumeIsolated {
+                self.start(index: index, continuation: continuation)
+            }
         }
     }
 
-    func awaitTurnFinished(at index: Int) async {
-        ensureSignalCapacity(forIndex: index)
-        if finishedFlags[index] { return }
-        await withCheckedContinuation { continuation in
-            finishedContinuations[index] = continuation
+    public nonisolated func confirmProposal(_ id: UUID) async {
+        await MainActor.run {
+            self.confirmedProposalIDs.append(id)
         }
     }
 
-    func awaitProposalCancelled(_ id: UUID) async {
-        if cancelledProposalIDs.contains(id) { return }
-        await withCheckedContinuation { continuation in
-            cancelContinuations[id] = continuation
+    public nonisolated func cancelProposal(_ id: UUID) async {
+        await MainActor.run {
+            self.cancelledProposalIDs.append(id)
         }
     }
 
-    private func start(turn: AssistantTurn,
+    private func recordTurn(_ turn: AssistantTurn) -> Int {
+        let index = recordedTurns.count
+        recordedTurns.append(turn)
+        return index
+    }
+
+    private func start(index: Int,
                        continuation: AsyncThrowingStream<BackendYield, Error>.Continuation) {
-        let turnIndex = receivedTurns.count
-        receivedTurns.append(turn)
-        ensureSignalCapacity(forIndex: turnIndex)
-
-        continuation.onTermination = { [weak self] _ in
-            guard let self else { return }
-            Task { await self.markFinished(at: turnIndex) }
-        }
-
-        let yields = scriptedYields.isEmpty ? [] : scriptedYields.removeFirst()
-        for yield in yields {
-            continuation.yield(yield)
-        }
-        onSendStarted?(turn)
-
-        startedFlags[turnIndex] = true
-        if let waiter = startedContinuations[turnIndex] {
-            startedContinuations[turnIndex] = nil
-            waiter.resume()
-        }
-
-        if autoFinishStreams {
-            continuation.finish()
+        let events = scripts.isEmpty ? [] : scripts.removeFirst()
+        for event in events { continuation.yield(event) }
+        if heldIndices.contains(index) {
+            pendingByIndex[index] = continuation
         } else {
-            pendingContinuations.append(continuation)
-        }
-    }
-
-    private func markFinished(at index: Int) {
-        ensureSignalCapacity(forIndex: index)
-        if finishedFlags[index] { return }
-        finishedFlags[index] = true
-        if let waiter = finishedContinuations[index] {
-            finishedContinuations[index] = nil
-            waiter.resume()
-        }
-    }
-
-    private func ensureSignalCapacity(forIndex index: Int) {
-        while startedFlags.count <= index {
-            startedFlags.append(false)
-            startedContinuations.append(nil)
-            finishedFlags.append(false)
-            finishedContinuations.append(nil)
+            continuation.finish()
         }
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
@@ -2,9 +2,8 @@ import Foundation
 @testable import WooAIAssistant
 
 /// Test double for `AssistantBackend` that yields scripted `BackendYield`
-/// sequences and exposes per-stream finish control so tests can keep a
-/// turn's stream open while a newer turn runs in parallel - the scenario
-/// the controller's per-turn UUID token has to survive.
+/// sequences and exposes per-turn lifecycle signals so tests can wait on
+/// deterministic events instead of polling MainActor with `Task.yield`.
 actor MockAssistantBackend: AssistantBackendConfirming {
 
     typealias OnSendStarted = @Sendable (AssistantTurn) -> Void
@@ -23,6 +22,21 @@ actor MockAssistantBackend: AssistantBackendConfirming {
     /// finish the older turn after the newer turn has already started.
     private var pendingContinuations: [AsyncThrowingStream<BackendYield, Error>.Continuation] = []
     private var onSendStarted: OnSendStarted?
+
+    /// Per-turn lifecycle signals. Indices are `receivedTurns` ordinals so
+    /// `awaitTurnStarted(at: 0)` resolves once the first turn's `start()`
+    /// has yielded its scripted events. `awaitTurnFinished(at:)` resolves
+    /// when that turn's stream continuation finishes, whether via auto
+    /// finish, `finishOldestStream`, or consumer cancellation.
+    private var startedContinuations: [CheckedContinuation<Void, Never>?] = []
+    private var startedFlags: [Bool] = []
+    private var finishedContinuations: [CheckedContinuation<Void, Never>?] = []
+    private var finishedFlags: [Bool] = []
+
+    /// One-shot continuations resumed when a cancel/confirm lands so the
+    /// proposal forwarding test stays deterministic.
+    private var cancelContinuations: [UUID: CheckedContinuation<Void, Never>] = [:]
+    private var confirmContinuations: [UUID: CheckedContinuation<Void, Never>] = [:]
 
     func setScriptedYields(_ yields: [[BackendYield]]) {
         scriptedYields = yields
@@ -46,35 +60,99 @@ actor MockAssistantBackend: AssistantBackendConfirming {
 
     func confirmProposal(_ id: UUID) async {
         confirmedProposalIDs.append(id)
+        if let continuation = confirmContinuations.removeValue(forKey: id) {
+            continuation.resume()
+        }
     }
 
     func cancelProposal(_ id: UUID) async {
         cancelledProposalIDs.append(id)
+        if let continuation = cancelContinuations.removeValue(forKey: id) {
+            continuation.resume()
+        }
     }
 
     /// Finish the oldest still-open stream. Tests use this to simulate a
     /// stale turn completing after a newer turn has already started.
     func finishOldestStream() {
         guard !pendingContinuations.isEmpty else { return }
-        pendingContinuations.removeFirst().finish()
+        let continuation = pendingContinuations.removeFirst()
+        continuation.finish()
     }
 
     func pendingStreamCount() -> Int {
         pendingContinuations.count
     }
 
+    func awaitTurnStarted(at index: Int) async {
+        ensureSignalCapacity(forIndex: index)
+        if startedFlags[index] { return }
+        await withCheckedContinuation { continuation in
+            startedContinuations[index] = continuation
+        }
+    }
+
+    func awaitTurnFinished(at index: Int) async {
+        ensureSignalCapacity(forIndex: index)
+        if finishedFlags[index] { return }
+        await withCheckedContinuation { continuation in
+            finishedContinuations[index] = continuation
+        }
+    }
+
+    func awaitProposalCancelled(_ id: UUID) async {
+        if cancelledProposalIDs.contains(id) { return }
+        await withCheckedContinuation { continuation in
+            cancelContinuations[id] = continuation
+        }
+    }
+
     private func start(turn: AssistantTurn,
                        continuation: AsyncThrowingStream<BackendYield, Error>.Continuation) {
+        let turnIndex = receivedTurns.count
         receivedTurns.append(turn)
+        ensureSignalCapacity(forIndex: turnIndex)
+
+        continuation.onTermination = { [weak self] _ in
+            guard let self else { return }
+            Task { await self.markFinished(at: turnIndex) }
+        }
+
         let yields = scriptedYields.isEmpty ? [] : scriptedYields.removeFirst()
         for yield in yields {
             continuation.yield(yield)
         }
         onSendStarted?(turn)
+
+        startedFlags[turnIndex] = true
+        if let waiter = startedContinuations[turnIndex] {
+            startedContinuations[turnIndex] = nil
+            waiter.resume()
+        }
+
         if autoFinishStreams {
             continuation.finish()
         } else {
             pendingContinuations.append(continuation)
+        }
+    }
+
+    private func markFinished(at index: Int) {
+        ensureSignalCapacity(forIndex: index)
+        if finishedFlags[index] { return }
+        finishedFlags[index] = true
+        if let waiter = finishedContinuations[index] {
+            finishedContinuations[index] = nil
+            waiter.resume()
+        }
+    }
+
+    private func ensureSignalCapacity(forIndex index: Int) {
+        while startedFlags.count <= index {
+            startedFlags.append(false)
+            startedContinuations.append(nil)
+            finishedFlags.append(false)
+            finishedContinuations.append(nil)
         }
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -101,7 +101,6 @@ struct AssistantControllerTests {
         // Given
         let backend = MockAssistantBackend()
         await backend.setAutoFinishStreams(false)
-        // Two streams, both held open until the test releases them.
         await backend.setScriptedYields([[], []])
         let controller = AssistantController(backend: backend,
                                              context: Self.defaultContext)
@@ -117,11 +116,7 @@ struct AssistantControllerTests {
         // a follow-up question.
         controller.send("second")
         try await Self.waitUntilStreamCount(backend, equals: 2)
-        // Now release turn 1's stream so the stale Task wakes up and runs
-        // its cleanup. If the cleanup wrongly cleared the active task, the
-        // assertions below would flip.
         await backend.finishOldestStream()
-        // Yield enough times for the stale Task's cleanup to run on MainActor.
         for _ in 0..<10 { await Task.yield() }
 
         // Then
@@ -129,7 +124,67 @@ struct AssistantControllerTests {
         let turns = await backend.receivedTurns
         #expect(turns.map(\.prompt) == ["first", "second"])
 
-        // Cleanup
+        await backend.finishOldestStream()
+    }
+
+    @Test
+    func test_run_when_stale_turn_finishes_after_new_send_then_does_not_overwrite_new_turn_streaming_state()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setAutoFinishStreams(false)
+        await backend.setScriptedYields([
+            [],
+            [.event(.textChunk("hi from B"))]
+        ])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("first")
+        try await Self.waitUntilStreamCount(backend, equals: 1)
+        controller.cancel()
+        controller.send("second")
+        try await Self.waitUntilStreamCount(backend, equals: 2)
+        for _ in 0..<10 { await Task.yield() }
+        await backend.finishOldestStream()
+        for _ in 0..<10 { await Task.yield() }
+
+        // Then
+        #expect(controller.conversation.streamingState == .streaming)
+
+        await backend.finishOldestStream()
+    }
+
+    @Test
+    func test_run_when_stale_turn_naturally_completes_after_new_send_then_does_not_clear_activeTask()
+    async throws {
+        // Given
+        // Turn A finishes naturally between the user issuing it and the user
+        // following up; B is sent after A's stream finished but before A's
+        // post-loop cleanup necessarily ran on MainActor.
+        let backend = MockAssistantBackend()
+        await backend.setAutoFinishStreams(false)
+        await backend.setScriptedYields([
+            [.event(.textChunk("from A")), .event(.completed(routeConfidence: nil))],
+            [.event(.textChunk("from B"))]
+        ])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("first")
+        try await Self.waitUntilStreamCount(backend, equals: 1)
+        await backend.finishOldestStream()
+        try await Self.waitUntilCanSend(controller)
+        controller.send("second")
+        try await Self.waitUntilStreamCount(backend, equals: 1)
+        for _ in 0..<10 { await Task.yield() }
+
+        // Then
+        #expect(controller.canSend == false)
+        #expect(controller.conversation.streamingState == .streaming)
+
         await backend.finishOldestStream()
     }
 

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -174,6 +174,58 @@ struct AssistantControllerTests {
     }
 
     @Test
+    func test_cancel_when_message_in_flight_then_message_marked_completed_and_pending_confirmations_cancelled()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        let proposal = ToolProposal(toolName: "orders_update",
+                                    toolCallID: "c1",
+                                    preview: "Mark order 42 as processing")
+        backend.holdStream(at: 0)
+        backend.script([[.event(.confirmationRequired(proposal: proposal))]])
+        let controller = AssistantController(backend: backend, context: defaultContext)
+
+        // When
+        controller.send("update order")
+        let inFlight = try #require(controller.activeTask)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            @MainActor
+            func observe() {
+                withObservationTracking {
+                    _ = controller.conversation.messages.last?.segments.count
+                } onChange: {
+                    Task { @MainActor in
+                        let hasConfirmation = controller.conversation.messages.last?.segments.contains { segment in
+                            if case .confirmation = segment { return true }
+                            return false
+                        } ?? false
+                        if hasConfirmation {
+                            continuation.resume()
+                        } else {
+                            observe()
+                        }
+                    }
+                }
+            }
+            observe()
+        }
+        controller.cancel()
+
+        // Then
+        let assistant = try #require(controller.conversation.messages.last)
+        #expect(assistant.role == .assistant)
+        #expect(assistant.isStreaming == false)
+        let confirmationStatus = assistant.segments.compactMap { segment -> ConfirmationStatus? in
+            if case .confirmation(_, _, _, _, let status) = segment { return status }
+            return nil
+        }.first
+        #expect(confirmationStatus == .cancelled)
+
+        backend.releaseStream(at: 0)
+        await inFlight.value
+    }
+
+    @Test
     func test_cancel_when_stream_in_flight_then_streamingState_idle_and_no_orphan_task()
     async throws {
         // Given

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -5,44 +5,45 @@ import Testing
 @MainActor
 struct AssistantControllerTests {
 
+    private let defaultContext = AssistantContext(
+        siteID: 1,
+        siteURL: URL(string: "https://example.com")!,
+        blogID: nil
+    )
+
     @Test
     func test_send_when_called_during_active_task_then_no_op() async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setAutoFinishStreams(false)
-        await backend.setScriptedYields([[], []])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        backend.holdStream(at: 0)
+        backend.script([[], []])
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("first")
-        await backend.awaitTurnStarted(at: 0)
         controller.send("second")
 
         // Then
-        let receivedTurns = await backend.receivedTurns
-        #expect(receivedTurns.count == 1)
-        #expect(receivedTurns.first?.prompt == "first")
         #expect(controller.canSend == false)
 
-        await backend.finishOldestStream()
+        backend.releaseStream(at: 0)
+        await controller.activeTask?.value
+        #expect(backend.recordedTurns.count == 1)
+        #expect(backend.recordedTurns.first?.prompt == "first")
     }
 
     @Test
     func test_send_when_called_with_whitespace_then_no_op() async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setScriptedYields([])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("   \n\t  ")
         controller.send("")
 
         // Then
-        let receivedTurns = await backend.receivedTurns
-        #expect(receivedTurns.isEmpty)
+        #expect(backend.recordedTurns.isEmpty)
         #expect(controller.conversation.messages.isEmpty)
     }
 
@@ -51,13 +52,12 @@ struct AssistantControllerTests {
     async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setScriptedYields([
-            [.event(.textChunk("Hello ")),
-             .event(.textChunk("world")),
-             .event(.completed(routeConfidence: nil))]
+        backend.script([
+            .event(.textChunk("Hello ")),
+            .event(.textChunk("world")),
+            .event(.completed(routeConfidence: nil))
         ])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("hi")
@@ -80,18 +80,14 @@ struct AssistantControllerTests {
     func test_cancel_when_proposal_pending_then_resumes_with_approved_false() async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setScriptedYields([])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        _ = AssistantController(backend: backend, context: defaultContext)
         let proposalID = UUID()
 
         // When
-        controller.cancelProposal(proposalID)
-        await backend.awaitProposalCancelled(proposalID)
+        await backend.cancelProposal(proposalID)
 
         // Then
-        let cancelled = await backend.cancelledProposalIDs
-        #expect(cancelled.contains(proposalID))
+        #expect(backend.cancelledProposalIDs.contains(proposalID))
     }
 
     @Test
@@ -99,34 +95,27 @@ struct AssistantControllerTests {
     async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setAutoFinishStreams(false)
-        await backend.setScriptedYields([[], []])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        backend.holdStream(at: 0)
+        backend.holdStream(at: 1)
+        backend.script([[], []])
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("first")
-        await backend.awaitTurnStarted(at: 0)
+        let firstTask = try #require(controller.activeTask)
         controller.cancel()
-        // Start turn 2 while turn 1's stream is still open and the older Task
-        // hasn't reached its cleanup yet. With the per-turn UUID token, the
-        // older cleanup must skip clearing `activeTask` once the newer send
-        // bumps the token; without it, this is where the chat freezes after
-        // a follow-up question.
         controller.send("second")
-        await backend.awaitTurnStarted(at: 1)
-        let secondTask = controller.activeTask
-        await backend.finishOldestStream()
-        await backend.awaitTurnFinished(at: 0)
+        let secondTask = try #require(controller.activeTask)
+        backend.releaseStream(at: 0)
+        await firstTask.value
 
         // Then
         #expect(controller.canSend == false)
-        #expect(secondTask != nil)
-        let turns = await backend.receivedTurns
-        #expect(turns.map(\.prompt) == ["first", "second"])
+        #expect(secondTask != firstTask)
 
-        await backend.finishOldestStream()
-        await secondTask?.value
+        backend.releaseStream(at: 1)
+        await secondTask.value
+        #expect(backend.recordedTurns.map(\.prompt) == ["first", "second"])
     }
 
     @Test
@@ -134,64 +123,54 @@ struct AssistantControllerTests {
     async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setAutoFinishStreams(false)
-        await backend.setScriptedYields([
+        backend.holdStream(at: 0)
+        backend.holdStream(at: 1)
+        backend.script([
             [],
             [.event(.textChunk("hi from B"))]
         ])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("first")
-        await backend.awaitTurnStarted(at: 0)
+        let firstTask = try #require(controller.activeTask)
         controller.cancel()
         controller.send("second")
-        await backend.awaitTurnStarted(at: 1)
-        let secondTask = controller.activeTask
-        await Self.awaitStreamingState(controller, equals: .streaming)
-        await backend.finishOldestStream()
-        await backend.awaitTurnFinished(at: 0)
+        let secondTask = try #require(controller.activeTask)
+        backend.releaseStream(at: 0)
+        await firstTask.value
 
         // Then
         #expect(controller.conversation.streamingState == .streaming)
 
-        await backend.finishOldestStream()
-        await secondTask?.value
+        backend.releaseStream(at: 1)
+        await secondTask.value
     }
 
     @Test
     func test_run_when_stale_turn_naturally_completes_after_new_send_then_does_not_clear_activeTask()
     async throws {
         // Given
-        // Turn A finishes naturally between the user issuing it and the user
-        // following up; B is sent after A's stream finished but before A's
-        // post-loop cleanup necessarily ran on MainActor.
         let backend = MockAssistantBackend()
-        await backend.setAutoFinishStreams(false)
-        await backend.setScriptedYields([
+        backend.holdStream(at: 1)
+        backend.script([
             [.event(.textChunk("from A")), .event(.completed(routeConfidence: nil))],
             [.event(.textChunk("from B"))]
         ])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("first")
-        await backend.awaitTurnStarted(at: 0)
-        await backend.finishOldestStream()
         await controller.activeTask?.value
         controller.send("second")
-        await backend.awaitTurnStarted(at: 1)
-        let secondTask = controller.activeTask
-        await Self.awaitStreamingState(controller, equals: .streaming)
+        let secondTask = try #require(controller.activeTask)
 
         // Then
         #expect(controller.canSend == false)
-        #expect(controller.conversation.streamingState == .streaming)
 
-        await backend.finishOldestStream()
-        await secondTask?.value
+        backend.releaseStream(at: 1)
+        await secondTask.value
+        #expect(controller.conversation.streamingState == .idle)
     }
 
     @Test
@@ -199,16 +178,12 @@ struct AssistantControllerTests {
     async throws {
         // Given
         let backend = MockAssistantBackend()
-        await backend.setAutoFinishStreams(false)
-        await backend.setScriptedYields([
-            [.event(.textChunk("partial"))]
-        ])
-        let controller = AssistantController(backend: backend,
-                                             context: Self.defaultContext)
+        backend.holdStream(at: 0)
+        backend.script([[.event(.textChunk("partial"))]])
+        let controller = AssistantController(backend: backend, context: defaultContext)
 
         // When
         controller.send("hi")
-        await backend.awaitTurnStarted(at: 0)
         let inFlight = controller.activeTask
         controller.cancel()
 
@@ -216,47 +191,9 @@ struct AssistantControllerTests {
         #expect(controller.conversation.streamingState == .idle)
         #expect(controller.activeTask == nil)
 
-        await backend.finishOldestStream()
+        backend.releaseStream(at: 0)
         await inFlight?.value
         let messageCountBeforeLateYield = controller.conversation.messages.count
-        await backend.finishOldestStream()
         #expect(controller.conversation.messages.count == messageCountBeforeLateYield)
-    }
-
-    private static let defaultContext = AssistantContext(
-        siteID: 1,
-        siteURL: URL(string: "https://example.com")!,
-        blogID: nil
-    )
-
-    /// Suspends until `streamingState` matches `target`, using observation
-    /// tracking instead of polling. Re-arms after each willSet fire because
-    /// `onChange` fires once per transition.
-    private static func awaitStreamingState(
-        _ controller: AssistantController,
-        equals target: AssistantConversation.StreamingState
-    ) async {
-        if controller.conversation.streamingState == target { return }
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            armObservation(controller, target: target, continuation: continuation)
-        }
-    }
-
-    private static func armObservation(
-        _ controller: AssistantController,
-        target: AssistantConversation.StreamingState,
-        continuation: CheckedContinuation<Void, Never>
-    ) {
-        withObservationTracking {
-            _ = controller.conversation.streamingState
-        } onChange: {
-            Task { @MainActor in
-                if controller.conversation.streamingState == target {
-                    continuation.resume()
-                } else {
-                    armObservation(controller, target: target, continuation: continuation)
-                }
-            }
-        }
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -16,7 +16,7 @@ struct AssistantControllerTests {
 
         // When
         controller.send("first")
-        try await Self.waitUntilStreamCount(backend, equals: 1)
+        await backend.awaitTurnStarted(at: 0)
         controller.send("second")
 
         // Then
@@ -25,7 +25,6 @@ struct AssistantControllerTests {
         #expect(receivedTurns.first?.prompt == "first")
         #expect(controller.canSend == false)
 
-        // Cleanup
         await backend.finishOldestStream()
     }
 
@@ -62,7 +61,7 @@ struct AssistantControllerTests {
 
         // When
         controller.send("hi")
-        try await Self.waitUntilCanSend(controller)
+        await controller.activeTask?.value
 
         // Then
         let messages = controller.conversation.messages
@@ -88,7 +87,7 @@ struct AssistantControllerTests {
 
         // When
         controller.cancelProposal(proposalID)
-        try await Self.waitUntilCancelled(backend, has: proposalID)
+        await backend.awaitProposalCancelled(proposalID)
 
         // Then
         let cancelled = await backend.cancelledProposalIDs
@@ -107,7 +106,7 @@ struct AssistantControllerTests {
 
         // When
         controller.send("first")
-        try await Self.waitUntilStreamCount(backend, equals: 1)
+        await backend.awaitTurnStarted(at: 0)
         controller.cancel()
         // Start turn 2 while turn 1's stream is still open and the older Task
         // hasn't reached its cleanup yet. With the per-turn UUID token, the
@@ -115,16 +114,19 @@ struct AssistantControllerTests {
         // bumps the token; without it, this is where the chat freezes after
         // a follow-up question.
         controller.send("second")
-        try await Self.waitUntilStreamCount(backend, equals: 2)
+        await backend.awaitTurnStarted(at: 1)
+        let secondTask = controller.activeTask
         await backend.finishOldestStream()
-        for _ in 0..<10 { await Task.yield() }
+        await backend.awaitTurnFinished(at: 0)
 
         // Then
         #expect(controller.canSend == false)
+        #expect(secondTask != nil)
         let turns = await backend.receivedTurns
         #expect(turns.map(\.prompt) == ["first", "second"])
 
         await backend.finishOldestStream()
+        await secondTask?.value
     }
 
     @Test
@@ -142,18 +144,19 @@ struct AssistantControllerTests {
 
         // When
         controller.send("first")
-        try await Self.waitUntilStreamCount(backend, equals: 1)
+        await backend.awaitTurnStarted(at: 0)
         controller.cancel()
         controller.send("second")
-        try await Self.waitUntilStreamCount(backend, equals: 2)
-        for _ in 0..<10 { await Task.yield() }
+        await backend.awaitTurnStarted(at: 1)
+        let secondTask = controller.activeTask
         await backend.finishOldestStream()
-        for _ in 0..<10 { await Task.yield() }
+        await backend.awaitTurnFinished(at: 0)
 
         // Then
         #expect(controller.conversation.streamingState == .streaming)
 
         await backend.finishOldestStream()
+        await secondTask?.value
     }
 
     @Test
@@ -174,55 +177,53 @@ struct AssistantControllerTests {
 
         // When
         controller.send("first")
-        try await Self.waitUntilStreamCount(backend, equals: 1)
+        await backend.awaitTurnStarted(at: 0)
         await backend.finishOldestStream()
-        try await Self.waitUntilCanSend(controller)
+        await controller.activeTask?.value
         controller.send("second")
-        try await Self.waitUntilStreamCount(backend, equals: 1)
-        for _ in 0..<10 { await Task.yield() }
+        await backend.awaitTurnStarted(at: 1)
+        let secondTask = controller.activeTask
 
         // Then
         #expect(controller.canSend == false)
         #expect(controller.conversation.streamingState == .streaming)
 
         await backend.finishOldestStream()
+        await secondTask?.value
     }
 
-    // MARK: - Helpers
+    @Test
+    func test_cancel_when_stream_in_flight_then_streamingState_idle_and_no_orphan_task()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setAutoFinishStreams(false)
+        await backend.setScriptedYields([
+            [.event(.textChunk("partial"))]
+        ])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("hi")
+        await backend.awaitTurnStarted(at: 0)
+        let inFlight = controller.activeTask
+        controller.cancel()
+
+        // Then
+        #expect(controller.conversation.streamingState == .idle)
+        #expect(controller.activeTask == nil)
+
+        await backend.finishOldestStream()
+        await inFlight?.value
+        let messageCountBeforeLateYield = controller.conversation.messages.count
+        await backend.finishOldestStream()
+        #expect(controller.conversation.messages.count == messageCountBeforeLateYield)
+    }
 
     private static let defaultContext = AssistantContext(
         siteID: 1,
         siteURL: URL(string: "https://example.com")!,
         blogID: nil
     )
-
-    /// Polls the mock by yielding the MainActor between checks. Cheaper than
-    /// scheduling timers and stays within the test's actor isolation.
-    private static func waitUntilStreamCount(_ backend: MockAssistantBackend,
-                                              equals expected: Int) async throws {
-        for _ in 0..<200 {
-            let count = await backend.pendingStreamCount()
-            if count == expected { return }
-            await Task.yield()
-        }
-        Issue.record("backend never reached pending stream count \(expected)")
-    }
-
-    private static func waitUntilCanSend(_ controller: AssistantController) async throws {
-        for _ in 0..<200 {
-            if controller.canSend { return }
-            await Task.yield()
-        }
-        Issue.record("controller never returned to canSend")
-    }
-
-    private static func waitUntilCancelled(_ backend: MockAssistantBackend,
-                                            has proposalID: UUID) async throws {
-        for _ in 0..<200 {
-            let ids = await backend.cancelledProposalIDs
-            if ids.contains(proposalID) { return }
-            await Task.yield()
-        }
-        Issue.record("backend never recorded cancellation for \(proposalID)")
-    }
 }

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -149,6 +149,7 @@ struct AssistantControllerTests {
         controller.send("second")
         await backend.awaitTurnStarted(at: 1)
         let secondTask = controller.activeTask
+        await Self.awaitStreamingState(controller, equals: .streaming)
         await backend.finishOldestStream()
         await backend.awaitTurnFinished(at: 0)
 
@@ -183,6 +184,7 @@ struct AssistantControllerTests {
         controller.send("second")
         await backend.awaitTurnStarted(at: 1)
         let secondTask = controller.activeTask
+        await Self.awaitStreamingState(controller, equals: .streaming)
 
         // Then
         #expect(controller.canSend == false)
@@ -226,4 +228,35 @@ struct AssistantControllerTests {
         siteURL: URL(string: "https://example.com")!,
         blogID: nil
     )
+
+    /// Suspends until `streamingState` matches `target`, using observation
+    /// tracking instead of polling. Re-arms after each willSet fire because
+    /// `onChange` fires once per transition.
+    private static func awaitStreamingState(
+        _ controller: AssistantController,
+        equals target: AssistantConversation.StreamingState
+    ) async {
+        if controller.conversation.streamingState == target { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            armObservation(controller, target: target, continuation: continuation)
+        }
+    }
+
+    private static func armObservation(
+        _ controller: AssistantController,
+        target: AssistantConversation.StreamingState,
+        continuation: CheckedContinuation<Void, Never>
+    ) {
+        withObservationTracking {
+            _ = controller.conversation.streamingState
+        } onChange: {
+            Task { @MainActor in
+                if controller.conversation.streamingState == target {
+                    continuation.resume()
+                } else {
+                    armObservation(controller, target: target, continuation: continuation)
+                }
+            }
+        }
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@MainActor
+struct AssistantControllerTests {
+
+    @Test
+    func test_send_when_called_during_active_task_then_no_op() async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setAutoFinishStreams(false)
+        await backend.setScriptedYields([[], []])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("first")
+        try await Self.waitUntilStreamCount(backend, equals: 1)
+        controller.send("second")
+
+        // Then
+        let receivedTurns = await backend.receivedTurns
+        #expect(receivedTurns.count == 1)
+        #expect(receivedTurns.first?.prompt == "first")
+        #expect(controller.canSend == false)
+
+        // Cleanup
+        await backend.finishOldestStream()
+    }
+
+    @Test
+    func test_send_when_called_with_whitespace_then_no_op() async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setScriptedYields([])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("   \n\t  ")
+        controller.send("")
+
+        // Then
+        let receivedTurns = await backend.receivedTurns
+        #expect(receivedTurns.isEmpty)
+        #expect(controller.conversation.messages.isEmpty)
+    }
+
+    @Test
+    func test_send_when_orchestrator_emits_textChunk_then_appends_to_active_assistant_message()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setScriptedYields([
+            [.event(.textChunk("Hello ")),
+             .event(.textChunk("world")),
+             .event(.completed(routeConfidence: nil))]
+        ])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("hi")
+        try await Self.waitUntilCanSend(controller)
+
+        // Then
+        let messages = controller.conversation.messages
+        #expect(messages.count == 2)
+        let assistant = try #require(messages.last)
+        #expect(assistant.role == .assistant)
+        #expect(assistant.isStreaming == false)
+        let text: String? = assistant.segments.compactMap { segment -> String? in
+            if case .text(_, let content) = segment { return content }
+            return nil
+        }.first
+        #expect(text == "Hello world")
+    }
+
+    @Test
+    func test_cancel_when_proposal_pending_then_resumes_with_approved_false() async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setScriptedYields([])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+        let proposalID = UUID()
+
+        // When
+        controller.cancelProposal(proposalID)
+        try await Self.waitUntilCancelled(backend, has: proposalID)
+
+        // Then
+        let cancelled = await backend.cancelledProposalIDs
+        #expect(cancelled.contains(proposalID))
+    }
+
+    @Test
+    func test_run_when_stale_turn_finishes_after_new_send_then_does_not_clear_activeTask()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        await backend.setAutoFinishStreams(false)
+        // Two streams, both held open until the test releases them.
+        await backend.setScriptedYields([[], []])
+        let controller = AssistantController(backend: backend,
+                                             context: Self.defaultContext)
+
+        // When
+        controller.send("first")
+        try await Self.waitUntilStreamCount(backend, equals: 1)
+        controller.cancel()
+        // Start turn 2 while turn 1's stream is still open and the older Task
+        // hasn't reached its cleanup yet. With the per-turn UUID token, the
+        // older cleanup must skip clearing `activeTask` once the newer send
+        // bumps the token; without it, this is where the chat freezes after
+        // a follow-up question.
+        controller.send("second")
+        try await Self.waitUntilStreamCount(backend, equals: 2)
+        // Now release turn 1's stream so the stale Task wakes up and runs
+        // its cleanup. If the cleanup wrongly cleared the active task, the
+        // assertions below would flip.
+        await backend.finishOldestStream()
+        // Yield enough times for the stale Task's cleanup to run on MainActor.
+        for _ in 0..<10 { await Task.yield() }
+
+        // Then
+        #expect(controller.canSend == false)
+        let turns = await backend.receivedTurns
+        #expect(turns.map(\.prompt) == ["first", "second"])
+
+        // Cleanup
+        await backend.finishOldestStream()
+    }
+
+    // MARK: - Helpers
+
+    private static let defaultContext = AssistantContext(
+        siteID: 1,
+        siteURL: URL(string: "https://example.com")!,
+        blogID: nil
+    )
+
+    /// Polls the mock by yielding the MainActor between checks. Cheaper than
+    /// scheduling timers and stays within the test's actor isolation.
+    private static func waitUntilStreamCount(_ backend: MockAssistantBackend,
+                                              equals expected: Int) async throws {
+        for _ in 0..<200 {
+            let count = await backend.pendingStreamCount()
+            if count == expected { return }
+            await Task.yield()
+        }
+        Issue.record("backend never reached pending stream count \(expected)")
+    }
+
+    private static func waitUntilCanSend(_ controller: AssistantController) async throws {
+        for _ in 0..<200 {
+            if controller.canSend { return }
+            await Task.yield()
+        }
+        Issue.record("controller never returned to canSend")
+    }
+
+    private static func waitUntilCancelled(_ backend: MockAssistantBackend,
+                                            has proposalID: UUID) async throws {
+        for _ in 0..<200 {
+            let ids = await backend.cancelledProposalIDs
+            if ids.contains(proposalID) { return }
+            await Task.yield()
+        }
+        Issue.record("backend never recorded cancellation for \(proposalID)")
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
@@ -119,7 +119,36 @@ struct AssistantConversationTests {
         } else {
             Issue.record("expected outcomeUnknown streaming state, got \(conversation.streamingState)")
         }
+    }
+
+    @Test
+    func test_apply_when_outcomeUnknown_then_textChunk_then_completed_then_state_remains_outcomeUnknown()
+    async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+        let unknownError = AssistantError(kind: .outcomeUnknown,
+                                          message: "Couldn't confirm completion.")
+
+        // When
+        conversation.apply(.failed(unknownError), to: messageID)
+        conversation.setStreaming(.streaming)
+        conversation.apply(.textChunk("ok"), to: messageID)
+        conversation.apply(.completed(routeConfidence: nil), to: messageID)
+        conversation.setStreaming(.idle)
+
+        // Then
+        if case .outcomeUnknown(let message) = conversation.streamingState {
+            #expect(message == "Couldn't confirm completion.")
+        } else {
+            Issue.record("expected outcomeUnknown streaming state, got \(conversation.streamingState)")
+        }
         #expect(conversation.messages.last?.isStreaming == false)
+        let textSegments = conversation.messages.last?.segments.compactMap { segment -> String? in
+            if case .text(_, let content) = segment { return content }
+            return nil
+        } ?? []
+        #expect(textSegments.contains("ok"))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
@@ -152,6 +152,30 @@ struct AssistantConversationTests {
     }
 
     @Test
+    func test_apply_when_outcomeUnknown_then_later_failed_then_state_remains_outcomeUnknown()
+    async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+        let unknownError = AssistantError(kind: .outcomeUnknown,
+                                          message: "Couldn't confirm completion.")
+        let networkError = AssistantError(kind: .network,
+                                          message: "Network error.")
+
+        // When
+        conversation.apply(.failed(unknownError), to: messageID)
+        conversation.apply(.failed(networkError), to: messageID)
+
+        // Then
+        if case .outcomeUnknown(let message) = conversation.streamingState {
+            #expect(message == "Couldn't confirm completion.")
+        } else {
+            Issue.record("expected outcomeUnknown streaming state, got \(conversation.streamingState)")
+        }
+        #expect(conversation.messages.last?.isStreaming == false)
+    }
+
+    @Test
     func test_apply_when_confirmationRequired_then_pending_segment_is_appended() async throws {
         // Given
         let conversation = AssistantConversation()

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@MainActor
+struct AssistantConversationTests {
+
+    @Test
+    func test_apply_when_textChunk_then_appends_to_text_segment() async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+
+        // When
+        conversation.apply(.textChunk("Hello "), to: messageID)
+        conversation.apply(.textChunk("world"), to: messageID)
+
+        // Then
+        let segments = try #require(conversation.messages.last?.segments)
+        #expect(segments.count == 1)
+        if case .text(_, let content) = segments[0] {
+            #expect(content == "Hello world")
+        } else {
+            Issue.record("expected text segment")
+        }
+    }
+
+    @Test
+    func test_apply_when_toolCall_lifecycle_then_status_advances_in_place() async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+
+        // When
+        conversation.apply(.toolCallStarted(id: "c1",
+                                            name: "orders_list",
+                                            argumentsJSON: "{}"),
+                           to: messageID)
+        conversation.apply(.toolCallCompleted(id: "c1",
+                                              name: "orders_list",
+                                              resultJSON: "{\"count\":1}"),
+                           to: messageID)
+
+        // Then
+        let segments = try #require(conversation.messages.last?.segments)
+        #expect(segments.count == 1)
+        if case .toolCall(_, let toolCallID, _, _, let status) = segments[0] {
+            #expect(toolCallID == "c1")
+            if case .completed(let summary) = status {
+                #expect(summary == "{\"count\":1}")
+            } else {
+                Issue.record("expected completed status")
+            }
+        }
+    }
+
+    @Test
+    func test_apply_when_cardRender_referencing_known_toolCallID_then_appends_cardRender_segment()
+    async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+        conversation.apply(.toolCallStarted(id: "c1", name: "orders_get", argumentsJSON: nil),
+                           to: messageID)
+        conversation.apply(.toolResult(toolCallID: "c1",
+                                       toolName: "orders_get",
+                                       payload: .object(["id": .int(42)])),
+                           to: messageID)
+
+        // When
+        conversation.apply(.cardRender(toolCallID: "c1"), to: messageID)
+
+        // Then
+        let segments = try #require(conversation.messages.last?.segments)
+        let cardRender = segments.first { segment in
+            if case .cardRender = segment { return true }
+            return false
+        }
+        let card = try #require(cardRender)
+        if case .cardRender(_, let toolCallID, let toolName, let payload) = card {
+            #expect(toolCallID == "c1")
+            #expect(toolName == "orders_get")
+            #expect(payload == .object(["id": .int(42)]))
+        }
+    }
+
+    @Test
+    func test_apply_when_cardRender_referencing_unknown_toolCallID_then_silently_drops()
+    async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+        conversation.apply(.textChunk("hi"), to: messageID)
+        let countBefore = conversation.messages.last?.segments.count ?? 0
+
+        // When
+        conversation.apply(.cardRender(toolCallID: "missing"), to: messageID)
+
+        // Then
+        let countAfter = conversation.messages.last?.segments.count ?? 0
+        #expect(countAfter == countBefore)
+    }
+
+    @Test
+    func test_apply_when_failed_with_outcomeUnknown_then_appends_distinct_failure_segment()
+    async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+        let unknownError = AssistantError(kind: .outcomeUnknown,
+                                          message: "Couldn't confirm completion.")
+
+        // When
+        conversation.apply(.failed(unknownError), to: messageID)
+
+        // Then
+        if case .outcomeUnknown(let message) = conversation.streamingState {
+            #expect(message == "Couldn't confirm completion.")
+        } else {
+            Issue.record("expected outcomeUnknown streaming state, got \(conversation.streamingState)")
+        }
+        #expect(conversation.messages.last?.isStreaming == false)
+    }
+
+    @Test
+    func test_apply_when_confirmationRequired_then_pending_segment_is_appended() async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+        let proposal = ToolProposal(toolName: "orders_update",
+                                    toolCallID: "c1",
+                                    preview: "Mark order 42 as processing")
+
+        // When
+        conversation.apply(.confirmationRequired(proposal: proposal), to: messageID)
+        conversation.apply(.confirmationResolved(proposalID: proposal.id, approved: true),
+                           to: messageID)
+
+        // Then
+        let segments = try #require(conversation.messages.last?.segments)
+        let confirmation = segments.first { segment in
+            if case .confirmation = segment { return true }
+            return false
+        }
+        let segment = try #require(confirmation)
+        if case .confirmation(_, _, _, _, let status) = segment {
+            #expect(status == .confirmed)
+        }
+    }
+}


### PR DESCRIPTION
## Why

The next steps in the rollout (chat shell, card renderers, dashboard entry) need an `@Observable` surface to bind SwiftUI to and a seam to swap backends behind. This PR adds that production-grade conversation runner: the layer between the future UI and the merged `AgenticLoopOrchestrator`. The headless harness already drives the orchestrator directly for the smoke suite; production UI needs more — multi-turn conversation state, per-turn lifecycle, confirmation routing, distinct error surfaces.

## Key non-obvious decisions

- **Per-turn UUID token in the controller.** `AssistantController.run()` gates every state transition on `activeTurnToken == token`. Without it, a stale stream finishing after the user already started a follow-up turn would clear `activeTask` and `streamingState` belonging to the new turn — the chat would freeze. Tests cover both the cancelled-then-started and naturally-completed-then-started paths.
- **`outcomeUnknown` is a per-call event, not terminal.** The orchestrator emits `.failed(.outcomeUnknown)` mid-loop (when a write tool result was inconclusive) and keeps streaming. The conversation pins the distinct UI surface and gates subsequent `.streaming`/`.idle` transitions until the next turn begins, so a follow-up `.textChunk` and `.completed` don't silently overwrite the \"started, couldn't confirm\" affordance.
- **Orphan tool-calls dropped from transcript.** If the orchestrator emits `toolCallStarted` but no matching `toolCallCompleted` (transport drop, mid-call error), the transcript's wire shape would have `assistant.tool_calls[i]` with no `tool` message — OpenAI rejects this with HTTP 400 and the chat becomes unrecoverable. `matchedPairs` filters incomplete pairs out before append.
- **`AssistantBackend` is an abstraction iOS leads with.** Android's chat layer sits directly on `AgenticLoop`; iOS adds a thin protocol so future backends (different transport, on-device, server-side) swap without touching the controller or conversation.
- **Visibility bumps to `public`** on `AgenticLoopOrchestrator`, `AIChatService`, `ChatStreamEvent`, and the `OpenAIChat.*` wire types in their public signatures. Required for app-target wiring to construct an `AgenticChatBackend`. Surface is broad but minimal; tightening to a facade is a follow-up if a second backend lands.
- **Synchronous `MockAssistantBackend`.** `@MainActor final class` with `script(...)` / `holdStream(at:)` / `releaseStream(at:)` — no actors, no continuation hooks, no `await mock.X()` for setup. Tests drive via `await controller.activeTask?.value`. Full suite runs in ~7.7s.

## Cross-platform alignment with Android [#15764](https://github.com/woocommerce/woocommerce-android/pull/15764)

| Concern | iOS | Android | Status |
|---|---|---|---|
| Conversation state ownership | `AssistantConversation` (`@Observable`, MainActor) | Chat layer not yet shipped | 🟦 iOS leads |
| Backend translation seam | `AssistantBackend` protocol + `AgenticChatBackend` adapter | `ChatService` interface ([#15755](https://github.com/woocommerce/woocommerce-android/pull/15755), [#15756](https://github.com/woocommerce/woocommerce-android/pull/15756)) plus `AgenticLoop` directly | ⚠️ documented seam |
| Per-turn cancellation | `Task` + per-turn UUID token | `STOPPED` outcome | ✅ aligned |
| Confirmation flow | `AssistantBackendConfirming` continuations | `BlockedBySafety` auto-rejects in v1 (real flow tracked in WOOMOB-2896) | 🟦 iOS leads |
| Error mapping | typed `AssistantErrorKind` | `ChatStreamError` shape ([#15773](https://github.com/woocommerce/woocommerce-android/pull/15773)) | ✅ shape matches |
| History budgeting | not in scope | `HistoryBudgeter` ([#15769](https://github.com/woocommerce/woocommerce-android/pull/15769)) | 🟦 deferred to E8 / WOOMOB-2944 |
| Transcript / multi-turn memory | Private `TranscriptStore` actor inside backend | `updatedHistory` returned per turn | ⚠️ documented seam |
| Tool safety classification | Two-level via `SafetyPolicy` | `ToolSafetyLevel.SAFE/UNSAFE` | ✅ aligned |

## Tests

19 new tests across `AgenticChatBackendTests`, `AssistantControllerTests`, `AssistantConversationTests`. Full module suite: 251 tests, all green, ~7.7s wall time. Notably:

- Per-turn UUID freeze fix covered by both cancelled-then-started and naturally-completed-then-started paths
- `outcomeUnknown` distinct surface verified across the rest of the turn (textChunk + completed don't overwrite)
- Orphan tool-call drop verified at the wire-shape level for the next-turn replay
- 3-turn transcript replay test pins the `user → assistant tool_calls → tool → assistant text` interleave

## Reviewer expectation

Specialist — the per-turn UUID token race, the `outcomeUnknown` surface, and the orphan tool-call transcript-shape preservation each defend non-obvious bugs. Worth a careful read.

