### PR TITLE
Revert "Add 2.7% percentage and split Canada/Interac flat application fees"

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -317,9 +317,7 @@ private extension PaymentCaptureOrchestrator {
             return nil
         }
 
-        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee)
-            .adding(Constants.canadaFlatFee)
-            .adding(Constants.interacFlatFee)
+        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee).adding(Constants.canadaFlatFee)
 
         let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
                                                    scale: 2,
@@ -356,12 +354,8 @@ private extension PaymentCaptureOrchestrator {
 
 private extension PaymentCaptureOrchestrator {
     enum Constants {
-        // The base Canada fee and percentage are overwritten by Transact Server at the
-        // capture step for non-Interac payments. Interac payments have no capture step,
-        // so the full combined fee (base + Interac + percentage) is what Stripe charges.
-        static let canadaFlatFee = NSDecimalNumber(string: "0.05")
-        static let interacFlatFee = NSDecimalNumber(string: "0.15")
-        static let canadaPercentageFee = NSDecimalNumber(string: "0.027")
+        static let canadaFlatFee = NSDecimalNumber(string: "0.15")
+        static let canadaPercentageFee = NSDecimalNumber(0)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -188,7 +188,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertNil(parameters.applicationFee)
     }
 
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_canada_applicationFee_in_the_payment_intent() throws {
+    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_15cents_applicationFee_in_the_payment_intent() throws {
         // Given
         let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
                                                         defaultCurrency: "CAD",
@@ -223,8 +223,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         }
 
         // Then
-        // 150 * 0.027 + 0.05 (Canada base) + 0.15 (Interac) = 4.25
-        let expectedFee = NSDecimalNumber(string: "4.25").decimalValue
+        let expectedFee = NSDecimalNumber(string: "0.15").decimalValue
         assertEqual(expectedFee, parameters.applicationFee)
     }
 }


### PR DESCRIPTION
Reverts woocommerce/woocommerce-ios#16972

As per discussion on TRAPLAT-3863, we've actually been correct in charging C$0.15 flat rate all along. 😌 

Reverting this before release is cut prevents any overcharging.