### PR TITLE
Woo Mobile AI: Add a sliding-window history budgeter for the chat backend

### DIFF
--- a/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AgenticChatBackend.swift
@@ -7,13 +7,16 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
     private let orchestrator: AgenticLoopOrchestrator
     private let transcript = TranscriptStore()
     private let systemPromptProvider: @Sendable () -> String?
+    private let historyBudgeter: HistoryBudgeter
 
     public init(chatService: AIChatService,
                 toolRegistry: ToolRegistry? = nil,
                 safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
                 systemPromptProvider: @escaping @Sendable () -> String? = { nil },
+                historyBudgeter: HistoryBudgeter = SlidingWindowHistoryBudgeter(),
                 maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations) {
         self.systemPromptProvider = systemPromptProvider
+        self.historyBudgeter = historyBudgeter
         self.orchestrator = AgenticLoopOrchestrator(chatService: chatService,
                                                     toolRegistry: toolRegistry,
                                                     safetyPolicy: safetyPolicy,
@@ -25,12 +28,14 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
                             toolRegistry: ToolRegistry? = nil,
                             safetyPolicy: SafetyPolicy = AlwaysExecuteSafetyPolicy(),
                             systemPrompt: String?,
+                            historyBudgeter: HistoryBudgeter = SlidingWindowHistoryBudgeter(),
                             maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations) {
         let captured = systemPrompt
         self.init(chatService: chatService,
                   toolRegistry: toolRegistry,
                   safetyPolicy: safetyPolicy,
                   systemPromptProvider: { captured },
+                  historyBudgeter: historyBudgeter,
                   maxIterations: maxIterations)
     }
 
@@ -38,11 +43,14 @@ public final class AgenticChatBackend: AssistantBackendConfirming, Sendable {
                      context: AssistantContext,
                      session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
         AsyncThrowingStream { continuation in
-            let task = Task { [orchestrator, transcript, systemPromptProvider] in
-                var prior = await transcript.messages()
-                if let systemPrompt = systemPromptProvider() {
-                    prior.insert(.init(role: .system, content: systemPrompt), at: 0)
+            let task = Task { [orchestrator, transcript, systemPromptProvider, historyBudgeter] in
+                let rawTranscript = await transcript.messages()
+                let systemMessage: OpenAIChat.Message? = systemPromptProvider().map {
+                    .init(role: .system, content: $0)
                 }
+                let prior = historyBudgeter.budget(systemPrompt: systemMessage,
+                                                   priorMessages: rawTranscript,
+                                                   currentUserPrompt: turn.prompt)
 
                 var pendingText = ""
                 var pendingToolCalls: [OpenAIChat.ToolCall] = []

--- a/Modules/Sources/WooAIAssistant/Backend/HistoryBudgeter.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/HistoryBudgeter.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public protocol HistoryBudgeter: Sendable {
+    func budget(systemPrompt: OpenAIChat.Message?,
+                priorMessages: [OpenAIChat.Message],
+                currentUserPrompt: String) -> [OpenAIChat.Message]
+}
+
+public struct SlidingWindowHistoryBudgeter: HistoryBudgeter {
+
+    private let windowSize: Int
+
+    public init(windowSize: Int = AssistantConfiguration.historyWindowSize) {
+        self.windowSize = max(0, windowSize)
+    }
+
+    public func budget(systemPrompt: OpenAIChat.Message?,
+                       priorMessages: [OpenAIChat.Message],
+                       currentUserPrompt: String) -> [OpenAIChat.Message] {
+        var output: [OpenAIChat.Message] = []
+        if let systemPrompt {
+            output.append(systemPrompt)
+        }
+        guard windowSize > 0 else {
+            return output
+        }
+        var window = Array(priorMessages.suffix(windowSize))
+        // Drop leading orphan tool messages: OpenAI rejects a `.tool` message
+        // without a preceding `.assistant` message carrying matching tool_calls.
+        while let first = window.first, first.role == .tool {
+            window.removeFirst()
+        }
+        // Second pass: an assistant with tool_calls whose IDs are not all
+        // matched by later .tool messages in the window is itself an orphan.
+        if let first = window.first,
+           first.role == .assistant,
+           let calls = first.toolCalls, calls.isEmpty == false {
+            let laterToolIDs = Set(window.dropFirst()
+                .filter { $0.role == .tool }
+                .compactMap { $0.toolCallID })
+            let allMatched = calls.allSatisfy { laterToolIDs.contains($0.id) }
+            if allMatched == false {
+                window.removeFirst()
+            }
+        }
+        output.append(contentsOf: window)
+        return output
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Backend/HistoryBudgeter.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/HistoryBudgeter.swift
@@ -25,13 +25,10 @@ public struct SlidingWindowHistoryBudgeter: HistoryBudgeter {
             return output
         }
         var window = Array(priorMessages.suffix(windowSize))
-        // Drop leading orphan tool messages: OpenAI rejects a `.tool` message
-        // without a preceding `.assistant` message carrying matching tool_calls.
+        // OpenAI rejects orphan .tool messages without a preceding assistant tool_calls.
         while let first = window.first, first.role == .tool {
             window.removeFirst()
         }
-        // Second pass: an assistant with tool_calls whose IDs are not all
-        // matched by later .tool messages in the window is itself an orphan.
         if let first = window.first,
            first.role == .assistant,
            let calls = first.toolCalls, calls.isEmpty == false {

--- a/Modules/Sources/WooAIAssistant/Backend/HistoryBudgeter.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/HistoryBudgeter.swift
@@ -25,22 +25,32 @@ public struct SlidingWindowHistoryBudgeter: HistoryBudgeter {
             return output
         }
         var window = Array(priorMessages.suffix(windowSize))
-        // OpenAI rejects orphan .tool messages without a preceding assistant tool_calls.
-        while let first = window.first, first.role == .tool {
-            window.removeFirst()
-        }
-        if let first = window.first,
-           first.role == .assistant,
-           let calls = first.toolCalls, calls.isEmpty == false {
-            let laterToolIDs = Set(window.dropFirst()
-                .filter { $0.role == .tool }
-                .compactMap { $0.toolCallID })
-            let allMatched = calls.allSatisfy { laterToolIDs.contains($0.id) }
-            if allMatched == false {
+        while let first = window.first {
+            if first.role == .tool {
                 window.removeFirst()
+                continue
             }
+            if first.hasUnmatchedToolCalls(in: window.dropFirst()) {
+                window.removeFirst()
+                continue
+            }
+            break
         }
         output.append(contentsOf: window)
         return output
+    }
+}
+
+private extension OpenAIChat.Message {
+    func hasUnmatchedToolCalls(in laterMessages: ArraySlice<OpenAIChat.Message>) -> Bool {
+        guard role == .assistant,
+              let calls = toolCalls,
+              calls.isEmpty == false else {
+            return false
+        }
+        let laterToolIDs = Set(laterMessages
+            .filter { $0.role == .tool }
+            .compactMap { $0.toolCallID })
+        return calls.contains { laterToolIDs.contains($0.id) == false }
     }
 }

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantConfiguration.swift
@@ -5,4 +5,5 @@ public enum AssistantConfiguration {
     public static let promptVersion = "v1"
     public static let toolCatalogVersion = "v1"
     public static let featureName = "woo-ai-assistant"
+    public static let historyWindowSize = 20
 }

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackend+HistoryBudgeterTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackend+HistoryBudgeterTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 import Testing
 @testable import WooAIAssistant
 
@@ -57,10 +56,9 @@ struct AgenticChatBackendHistoryBudgeterTests {
             [.textDelta("a4"), .completed(.stop)],
             [.textDelta("a5"), .completed(.stop)]
         ])
-        let spy = SpyHistoryBudgeter(inner: SlidingWindowHistoryBudgeter(windowSize: 2))
         let backend = AgenticChatBackend(chatService: chat,
                                          systemPrompt: nil,
-                                         historyBudgeter: spy)
+                                         historyBudgeter: PassthroughHistoryBudgeter())
 
         // When
         for prompt in ["t1", "t2", "t3", "t4", "t5"] {
@@ -71,11 +69,14 @@ struct AgenticChatBackendHistoryBudgeterTests {
         }
 
         // Then
-        let lastRaw = spy.lastPriorMessages()
-        let userContents = lastRaw.filter { $0.role == .user }.compactMap(\.content)
-        let assistantContents = lastRaw.filter { $0.role == .assistant }.compactMap(\.content)
+        let captured = await chat.capturedRequests
+        let lastMessages = try #require(captured.last?.messages)
+        let lastPriorMessages = lastMessages.dropLast()
+        let userContents = lastPriorMessages.filter { $0.role == .user }.compactMap(\.content)
+        let assistantContents = lastPriorMessages.filter { $0.role == .assistant }.compactMap(\.content)
         #expect(userContents == ["t1", "t2", "t3", "t4"])
         #expect(assistantContents == ["a1", "a2", "a3", "a4"])
+        #expect(lastMessages.last?.content == "t5")
     }
 
     @Test
@@ -111,25 +112,11 @@ struct AgenticChatBackendHistoryBudgeterTests {
     }
 }
 
-private struct SpyHistoryBudgeter: HistoryBudgeter {
-
-    private let inner: any HistoryBudgeter
-    private let lock = OSAllocatedUnfairLock<[[OpenAIChat.Message]]>(initialState: [])
-
-    init(inner: any HistoryBudgeter) {
-        self.inner = inner
-    }
+private struct PassthroughHistoryBudgeter: HistoryBudgeter {
 
     func budget(systemPrompt: OpenAIChat.Message?,
                 priorMessages: [OpenAIChat.Message],
                 currentUserPrompt: String) -> [OpenAIChat.Message] {
-        lock.withLock { $0.append(priorMessages) }
-        return inner.budget(systemPrompt: systemPrompt,
-                            priorMessages: priorMessages,
-                            currentUserPrompt: currentUserPrompt)
-    }
-
-    func lastPriorMessages() -> [OpenAIChat.Message] {
-        lock.withLock { $0.last ?? [] }
+        [systemPrompt].compactMap { $0 } + priorMessages
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackend+HistoryBudgeterTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackend+HistoryBudgeterTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import os
+import Testing
+@testable import WooAIAssistant
+
+struct AgenticChatBackendHistoryBudgeterTests {
+
+    private let defaultContext = AssistantContext(
+        siteID: 1,
+        siteURL: URL(string: "https://example.com")!,
+        blogID: nil
+    )
+
+    @Test
+    func test_send_when_transcript_exceeds_window_then_orchestrator_receives_only_budgeted_messages()
+    async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("a1"), .completed(.stop)],
+            [.textDelta("a2"), .completed(.stop)],
+            [.textDelta("a3"), .completed(.stop)],
+            [.textDelta("a4"), .completed(.stop)]
+        ])
+        let backend = AgenticChatBackend(chatService: chat,
+                                         systemPrompt: nil,
+                                         historyBudgeter: SlidingWindowHistoryBudgeter(windowSize: 2))
+
+        // When
+        for prompt in ["t1", "t2", "t3", "t4"] {
+            let stream = backend.send(turn: .init(prompt: prompt),
+                                      context: defaultContext,
+                                      session: nil)
+            for try await _ in stream {}
+        }
+
+        // Then
+        let captured = await chat.capturedRequests
+        let lastMessages = try #require(captured.last?.messages)
+        let priorOnly = lastMessages.dropLast()
+        #expect(priorOnly.count == 2)
+        let priorContents = priorOnly.compactMap(\.content)
+        #expect(priorContents == ["t3", "a3"])
+        #expect(lastMessages.last?.role == .user)
+        #expect(lastMessages.last?.content == "t4")
+    }
+
+    @Test
+    func test_send_when_transcript_exceeds_window_then_TranscriptStore_retains_full_history()
+    async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("a1"), .completed(.stop)],
+            [.textDelta("a2"), .completed(.stop)],
+            [.textDelta("a3"), .completed(.stop)],
+            [.textDelta("a4"), .completed(.stop)],
+            [.textDelta("a5"), .completed(.stop)]
+        ])
+        let spy = SpyHistoryBudgeter(inner: SlidingWindowHistoryBudgeter(windowSize: 2))
+        let backend = AgenticChatBackend(chatService: chat,
+                                         systemPrompt: nil,
+                                         historyBudgeter: spy)
+
+        // When
+        for prompt in ["t1", "t2", "t3", "t4", "t5"] {
+            let stream = backend.send(turn: .init(prompt: prompt),
+                                      context: defaultContext,
+                                      session: nil)
+            for try await _ in stream {}
+        }
+
+        // Then
+        let lastRaw = spy.lastPriorMessages()
+        let userContents = lastRaw.filter { $0.role == .user }.compactMap(\.content)
+        let assistantContents = lastRaw.filter { $0.role == .assistant }.compactMap(\.content)
+        #expect(userContents == ["t1", "t2", "t3", "t4"])
+        #expect(assistantContents == ["a1", "a2", "a3", "a4"])
+    }
+
+    @Test
+    func test_send_when_systemPromptProvider_returns_value_then_budgeted_output_starts_with_system()
+    async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.textDelta("a1"), .completed(.stop)],
+            [.textDelta("a2"), .completed(.stop)]
+        ])
+        let backend = AgenticChatBackend(chatService: chat,
+                                         systemPrompt: "you are helpful",
+                                         historyBudgeter: SlidingWindowHistoryBudgeter(windowSize: 1))
+
+        // When
+        for prompt in ["t1", "t2"] {
+            let stream = backend.send(turn: .init(prompt: prompt),
+                                      context: defaultContext,
+                                      session: nil)
+            for try await _ in stream {}
+        }
+
+        // Then
+        let captured = await chat.capturedRequests
+        let lastMessages = try #require(captured.last?.messages)
+        #expect(lastMessages.first?.role == .system)
+        #expect(lastMessages.first?.content == "you are helpful")
+        let beforeUser = lastMessages.dropFirst().dropLast()
+        #expect(beforeUser.count == 1)
+        #expect(beforeUser.first?.content == "a1")
+        #expect(lastMessages.last?.content == "t2")
+    }
+}
+
+private struct SpyHistoryBudgeter: HistoryBudgeter {
+
+    private let inner: any HistoryBudgeter
+    private let lock = OSAllocatedUnfairLock<[[OpenAIChat.Message]]>(initialState: [])
+
+    init(inner: any HistoryBudgeter) {
+        self.inner = inner
+    }
+
+    func budget(systemPrompt: OpenAIChat.Message?,
+                priorMessages: [OpenAIChat.Message],
+                currentUserPrompt: String) -> [OpenAIChat.Message] {
+        lock.withLock { $0.append(priorMessages) }
+        return inner.budget(systemPrompt: systemPrompt,
+                            priorMessages: priorMessages,
+                            currentUserPrompt: currentUserPrompt)
+    }
+
+    func lastPriorMessages() -> [OpenAIChat.Message] {
+        lock.withLock { $0.last ?? [] }
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Backend/HistoryBudgeterTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/HistoryBudgeterTests.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct HistoryBudgeterTests {
+
+    @Test
+    func test_budget_when_transcript_empty_then_returns_only_system_prompt() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 20)
+        let system = OpenAIChat.Message(role: .system, content: "you are helpful")
+
+        // When
+        let result = budgeter.budget(systemPrompt: system,
+                                     priorMessages: [],
+                                     currentUserPrompt: "hi")
+
+        // Then
+        #expect(result.count == 1)
+        #expect(result.first?.role == .system)
+        #expect(result.first?.content == "you are helpful")
+    }
+
+    @Test
+    func test_budget_when_transcript_shorter_than_window_then_returns_full_transcript_with_system_prepended() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 20)
+        let system = OpenAIChat.Message(role: .system, content: "sys")
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: "a1"),
+            .init(role: .user, content: "u2"),
+            .init(role: .assistant, content: "a2")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: system,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "u3")
+
+        // Then
+        #expect(result.map(\.role) == [.system, .user, .assistant, .user, .assistant])
+        #expect(result.dropFirst().compactMap(\.content) == ["u1", "a1", "u2", "a2"])
+    }
+
+    @Test
+    func test_budget_when_transcript_longer_than_window_then_returns_last_N_messages_with_system_prepended() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 3)
+        let system = OpenAIChat.Message(role: .system, content: "sys")
+        let transcript: [OpenAIChat.Message] = (1...5).map {
+            .init(role: .user, content: "msg\($0)")
+        }
+
+        // When
+        let result = budgeter.budget(systemPrompt: system,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.count == 4)
+        #expect(result.first?.role == .system)
+        let trailingContents = result.dropFirst().compactMap(\.content)
+        #expect(trailingContents == ["msg3", "msg4", "msg5"])
+    }
+
+    @Test
+    func test_budget_when_no_system_prompt_then_omits_system_message() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 5)
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: "a1")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: nil,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "u2")
+
+        // Then
+        #expect(result.contains(where: { $0.role == .system }) == false)
+        #expect(result.map(\.role) == [.user, .assistant])
+    }
+
+    @Test
+    func test_budget_when_window_cuts_orphan_tool_message_then_drops_leading_tool() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 2)
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: nil, toolCalls: [
+                .init(id: "c1", function: .init(name: "tool", arguments: "{}"))
+            ]),
+            .init(role: .tool, content: "{}", toolCallID: "c1"),
+            .init(role: .assistant, content: "a1")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: nil,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.map(\.role) == [.assistant])
+        #expect(result.first?.content == "a1")
+    }
+
+    @Test
+    func test_budget_when_window_cuts_assistant_with_unmatched_toolCalls_then_drops_that_assistant() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 2)
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: nil, toolCalls: [
+                .init(id: "c1", function: .init(name: "tool", arguments: "{}"))
+            ]),
+            .init(role: .tool, content: "{}", toolCallID: "c1"),
+            .init(role: .assistant, content: nil, toolCalls: [
+                .init(id: "c2", function: .init(name: "tool", arguments: "{}"))
+            ]),
+            .init(role: .user, content: "u2")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: nil,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.map(\.role) == [.user])
+        #expect(result.first?.content == "u2")
+    }
+
+    @Test
+    func test_budget_when_window_keeps_complete_tool_pair_then_pair_preserved() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 3)
+        let toolCall = OpenAIChat.ToolCall(id: "c1",
+                                           function: .init(name: "tool", arguments: "{}"))
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: nil, toolCalls: [toolCall]),
+            .init(role: .tool, content: "{}", toolCallID: "c1")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: nil,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.map(\.role) == [.user, .assistant, .tool])
+        #expect(result[1].toolCalls?.map(\.id) == ["c1"])
+        #expect(result[2].toolCallID == "c1")
+    }
+
+    @Test
+    func test_budget_when_windowSize_zero_then_returns_only_system_prompt() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 0)
+        let system = OpenAIChat.Message(role: .system, content: "sys")
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: "a1")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: system,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.map(\.role) == [.system])
+    }
+
+    @Test
+    func test_init_when_windowSize_negative_then_clamps_to_zero() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: -5)
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: "a1")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: nil,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.isEmpty)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Backend/HistoryBudgeterTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/HistoryBudgeterTests.swift
@@ -133,6 +133,32 @@ struct HistoryBudgeterTests {
     }
 
     @Test
+    func test_budget_when_window_keeps_partial_multi_tool_match_then_drops_invalid_pair() {
+        // Given
+        let budgeter = SlidingWindowHistoryBudgeter(windowSize: 4)
+        let transcript: [OpenAIChat.Message] = [
+            .init(role: .user, content: "u1"),
+            .init(role: .assistant, content: nil, toolCalls: [
+                .init(id: "c1", function: .init(name: "tool_one", arguments: "{}")),
+                .init(id: "c2", function: .init(name: "tool_two", arguments: "{}"))
+            ]),
+            .init(role: .tool, content: "{}", toolCallID: "c1"),
+            .init(role: .user, content: "u2"),
+            .init(role: .assistant, content: "a2")
+        ]
+
+        // When
+        let result = budgeter.budget(systemPrompt: nil,
+                                     priorMessages: transcript,
+                                     currentUserPrompt: "next")
+
+        // Then
+        #expect(result.map(\.role) == [.user, .assistant])
+        #expect(result.first?.role != .tool)
+        #expect(result.compactMap(\.content) == ["u2", "a2"])
+    }
+
+    @Test
     func test_budget_when_window_keeps_complete_tool_pair_then_pair_preserved() {
         // Given
         let budgeter = SlidingWindowHistoryBudgeter(windowSize: 3)


### PR DESCRIPTION
## Why

Conversation history grows unboundedly. Every turn replays the full transcript to the model, which gets expensive on long sessions and eventually approaches the model's context window. The chat backend needs a transform that narrows what the model sees per turn while keeping the UI's transcript intact for display and product analytics.

This adds the smallest credible thing that solves it: a stateless message-count sliding window matching Android's [#15769](https://github.com/woocommerce/woocommerce-android/pull/15769). 20-message default. Pluggable behind a `HistoryBudgeter` protocol so a token-aware variant can drop in later without changing the call site.

## Key non-obvious decisions

- **Message-count, not token-count.** Token-aware would need either a vendored BPE tokenizer or a heuristic on top of a heuristic (Woo card payloads are JSON-heavy, `count/4` is off by 30%+). gpt-4o-mini's 128k window plus 20 messages of typical Woo payloads (~5-15k tokens) is well under cap. When budget pressure becomes the real constraint, a `TokenAwareHistoryBudgeter` slots into the same protocol.
- **Stricter orphan handling than Android.** Android does `dropWhile { it is Tool }`. iOS adds a second pass: an orphan `.assistant` whose `tool_calls` IDs aren't all matched by later `.tool` messages within the window also gets dropped. Without this, a window cut at the wrong boundary produces a wire shape OpenAI rejects with HTTP 400 (`assistant.tool_calls[i]` requires a matching `tool` message). Defensive — the backend's `matchedPairs` invariant should already prevent the upstream condition, but the cost is a one-line check.
- **Negative `windowSize` clamps to 0** rather than throwing. Tests can drive a fully-trimmed scenario without try/catch noise; production pins the value to `AssistantConfiguration.historyWindowSize = 20` anyway.
- **`TranscriptStore` is untouched.** The full-history record stays as it was. The budgeter sits between `transcript.messages()` and `orchestrator.run(priorMessages:)`. Single-direction read, no mutation. The UI transcript and the budgeted model view are now decoupled.
- **`currentUserPrompt` is on the protocol but unused by the sliding window.** The orchestrator already injects the current prompt; future budgeters might use it as a signal (recency-biased, intent-aware variants), so it stays in the protocol surface.

## Cross-platform alignment with Android [#15769](https://github.com/woocommerce/woocommerce-android/pull/15769)

| Concern | iOS | Android | Status |
|---|---|---|---|
| Trim signal | message count | message count | ✅ aligned |
| Default window | 20 | 20 | ✅ aligned |
| Scope | per-turn | per-turn | ✅ aligned |
| Stateless transform | \`struct\`, no state | \`class\`, no mutable state | ✅ aligned |
| Full transcript preserved | \`TranscriptStore\` (untouched) | \`history + newTurnMessages\` | ✅ aligned (different mechanism) |
| Orphan \`.tool\` drop | yes | yes (\`dropWhile { it is Tool }\`) | ✅ aligned |
| Orphan \`.assistant\` w/ unmatched tool_calls | yes (extra pass) | no | ⚠️ iOS-stricter (intentional) |
| Negative windowSize | clamps to 0 | \`require()\` throws | ⚠️ iOS more lenient (intentional) |
| Return shape | \`[OpenAIChat.Message]\` | \`BudgetedHistory(messages, retainedEntityRefs)\` | 🟦 iOS minimal; \`retainedEntityRefs\` deferred until a consumer ships |

## Tests

12 new tests, full WooAIAssistant suite stays green at 263 / 263. ~11s wall time.

- \`HistoryBudgeterTests\` (9): pure transform — empty, under-window, over-window, no-system, orphan \`.tool\` drop, orphan \`.assistant\`-with-unmatched drop, complete-pair preservation, \`windowSize=0\`, negative-clamps-to-zero
- \`AgenticChatBackend+HistoryBudgeterTests\` (3): backend wiring — orchestrator receives the budgeted slice, \`TranscriptStore\` retains the full history, system prompt prepends correctly

No live API calls; everything in-process via the existing scripted chat-service / REST-client mocks.

## Reviewer expectation

Specialist — the orphan-pair handling and the message-count vs token-aware decision both warrant a careful read. The Android impl is the reference; divergences are documented above.

## Stacking note

Stacked on top of [#17018](https://github.com/woocommerce/woocommerce-ios/pull/17018) (chat backend, controller, conversation state). The diff against that base is E8-only; trunk's view will be cleaner once the stack lands.