### PR TITLE
WOOMOB-2809: Migrate StoreInfoWidget to AppIntentConfiguration

### DIFF
--- a/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
@@ -6,11 +6,7 @@ import SwiftUI
 struct AppLinkWidget: Widget {
     private var supportedFamilies: [WidgetFamily] {
 #if !os(watchOS)
-        if #available(iOSApplicationExtension 16.0, *) {
-            return [.accessoryCircular]
-        } else {
-            return []
-        }
+        return [.accessoryCircular]
 #else
         return [.accessoryCorner, .accessoryCircular]
 #endif
@@ -100,7 +96,6 @@ private extension AppLinkWidget {
 
 // MARK: Previews
 
-@available(iOSApplicationExtension 16.0, *)
 struct AppLinkWidget_Previews: PreviewProvider {
     static var previews: some View {
         AppButtonView()

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoCircularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoCircularWidget.swift
@@ -49,7 +49,6 @@ private struct UnableToFetchView: View {
 #if DEBUG
 import class WooFoundation.CurrencySettings
 
-@available(iOSApplicationExtension 16.0, *)
 struct StoreInfoCircularWidget_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoInlineWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoInlineWidget.swift
@@ -63,7 +63,6 @@ private extension UnableToFetchView {
 #if DEBUG
 import class WooFoundation.CurrencySettings
 
-@available(iOSApplicationExtension 16.0, *)
 struct StoreInfoInlineWidget_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
@@ -76,7 +76,6 @@ private extension UnableToFetchView {
 #if DEBUG
 import class WooFoundation.CurrencySettings
 
-@available(iOSApplicationExtension 16.0, *)
 struct StoreInfoRectangularWidget_Previews: PreviewProvider {
     static var exampleData = StoreInfoData(range: "Today",
                                            name: "Ernest Shop",

--- a/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
@@ -1,0 +1,22 @@
+import AppIntents
+import WidgetKit
+
+/// `AppIntentTimelineProvider` conformance for `StoreInfoProvider`. Kept in a separate file
+/// so the legacy `TimelineProvider` path stays a clean focal point and so this conformance
+/// can be removed in a single edit once the configurable widget rollout completes and the
+/// `StaticConfiguration` path retires.
+///
+/// `placeholder(in:)` is satisfied by the conformance on the main type — both protocols
+/// use the same signature.
+///
+extension StoreInfoProvider: AppIntentTimelineProvider {
+    typealias Intent = StoreStatsConfigurationIntent
+
+    func snapshot(for configuration: StoreStatsConfigurationIntent, in context: Context) async -> StoreInfoEntry {
+        placeholder(in: context)
+    }
+
+    func timeline(for configuration: StoreStatsConfigurationIntent, in context: Context) async -> Timeline<StoreInfoEntry> {
+        await loadTimeline()
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -85,11 +85,13 @@ extension StoreInfoData {
 
 /// Type that provides data entries to the widget system.
 ///
+/// Backs both the legacy `StaticConfiguration` path (via `TimelineProvider` here) and the
+/// `AppIntentConfiguration` path (via `AppIntentTimelineProvider` conformance in
+/// `StoreInfoProvider+AppIntentTimelineProvider.swift`). Sharing one provider keeps the
+/// data-fetching logic in a single place while the configurable widget rolls out behind
+/// `FeatureFlag.configurableStoreStatsWidgets`.
+///
 final class StoreInfoProvider: TimelineProvider {
-
-    /// Holds a reference to the service while a network request is being performed.
-    ///
-    private var networkService: StoreInfoDataService?
 
     /// Desired data reload interval provided to system = 30 minutes.
     ///
@@ -102,36 +104,35 @@ final class StoreInfoProvider: TimelineProvider {
         return Self.placeholderEntry(for: dependencies)
     }
 
-    /// Quick Snapshot. Required when previewing the widget.
-    ///
     func getSnapshot(in context: Context, completion: @escaping (StoreInfoEntry) -> Void) {
         completion(placeholder(in: context))
     }
 
-    /// Real data widget.
-    ///
     func getTimeline(in context: Context, completion: @escaping (Timeline<StoreInfoEntry>) -> Void) {
+        Task {
+            let timeline = await loadTimeline()
+            completion(timeline)
+        }
+    }
+
+    /// Shared loader for both `TimelineProvider` and `AppIntentTimelineProvider` paths.
+    /// Visible to extensions in this module so the AppIntent conformance can share logic.
+    ///
+    func loadTimeline() async -> Timeline<StoreInfoEntry> {
         guard let dependencies = Self.fetchDependencies() else {
-            return completion(Timeline<StoreInfoEntry>(entries: [StoreInfoEntry.notConnected], policy: .never))
+            return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
         }
 
-        let strongService = StoreInfoDataService(credentials: dependencies.credentials)
-        networkService = strongService
-        Task {
-            do {
-                let todayStats = try await strongService.fetchTodayStats(for: dependencies.storeID)
-                let entry = Self.dataEntry(for: todayStats, with: dependencies)
-                let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
-                let timeline = Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
-                completion(timeline)
-            } catch {
-                // WooFoundation does not expose `DDLOG` types. Should we include them?
-                print("⛔️ Error fetching today's widget stats: \(error)")
-
-                let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
-                let timeline = Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
-                completion(timeline)
-            }
+        let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
+        let service = StoreInfoDataService(credentials: dependencies.credentials)
+        do {
+            let todayStats = try await service.fetchTodayStats(for: dependencies.storeID)
+            let entry = Self.dataEntry(for: todayStats, with: dependencies)
+            return Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
+        } catch {
+            // WooFoundation does not expose `DDLOG` types. Should we include them?
+            print("⛔️ Error fetching today's widget stats: \(error)")
+            return Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -15,10 +15,6 @@ struct StoreInfoWidget: Widget {
     /// relaunch).
     ///
     private var supportedFamilies: [WidgetFamily] {
-        guard #available(iOSApplicationExtension 16.0, *) else {
-            return .wooFallbackFamilies
-        }
-
         /// Temporary developer flag
         /// Will be removed before feature rollout
         let isConfigurableEnabled = UserDefaults.group?.configurableStoreStatsWidgetsEnabled ?? false
@@ -42,7 +38,6 @@ struct StoreInfoWidget: Widget {
 
 /// Widget family constants
 private extension Array where Element == WidgetFamily {
-    static let wooFallbackFamilies: [WidgetFamily] = [.systemMedium]
     static let wooConfigurableFamilies: [WidgetFamily] = [
         .systemSmall,
         .systemLarge
@@ -62,24 +57,20 @@ private struct StoreInfoWidgetEntryView: View {
     let entry: StoreInfoEntry
 
     var body: some View {
-        if #available(iOSApplicationExtension 16.0, *) {
-            switch widgetFamily {
-            case .accessoryInline:
-                StoreInfoInlineWidget(entry: entry)
-            case .accessoryRectangular:
-                StoreInfoRectangularWidget(entry: entry)
-            case .accessoryCircular:
-                StoreInfoCircularWidget(entry: entry)
-            case .systemMedium, .systemSmall, .systemLarge:
-                // `.systemSmall` and `.systemLarge` only enter `supportedFamilies` when the
-                // configurable-widgets FF is on, so reaching them implies the metric-driven path.
-                // Layouts dedicated to these sizes will land in Tickets #7 / #8.
-                StoreInfoHomescreenWidget(entry: entry)
-            default:
-                EmptyView()
-            }
-        } else {
+        switch widgetFamily {
+        case .accessoryInline:
+            StoreInfoInlineWidget(entry: entry)
+        case .accessoryRectangular:
+            StoreInfoRectangularWidget(entry: entry)
+        case .accessoryCircular:
+            StoreInfoCircularWidget(entry: entry)
+        case .systemMedium, .systemSmall, .systemLarge:
+            // `.systemSmall` and `.systemLarge` only enter `supportedFamilies` when the
+            // configurable-widgets FF is on, so reaching them implies the metric-driven path.
+            // Layouts dedicated to these sizes will land in Tickets #7 / #8.
             StoreInfoHomescreenWidget(entry: entry)
+        default:
+            EmptyView()
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -27,12 +27,35 @@ struct StoreInfoWidget: Widget {
     }
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: WooConstants.storeInfoWidgetKind, provider: StoreInfoProvider()) { entry in
+        // Compile-time gate on the configuration type — matches the runtime
+        // `configurableStoreStatsWidgets` FF policy (localDeveloper || alpha) at the build
+        // level. A runtime gate is not expressible: `Widget.body` is `some WidgetConfiguration`
+        // (opaque return — branches must agree on a single concrete type) and
+        // `WidgetBundleBuilder` explicitly disables `buildOptional` for runtime `if`. The
+        // configuration `kind` is identical across both branches, so existing tiles survive
+        // the compile-time switch when alpha builds upgrade to App Store builds and back.
+#if DEBUG || ALPHA
+        AppIntentConfiguration(
+            kind: WooConstants.storeInfoWidgetKind,
+            intent: StoreStatsConfigurationIntent.self,
+            provider: StoreInfoProvider()
+        ) { entry in
             StoreInfoWidgetEntryView(entry: entry)
         }
         .configurationDisplayName(Localization.title)
         .description(Localization.description)
         .supportedFamilies(supportedFamilies)
+#else
+        StaticConfiguration(
+            kind: WooConstants.storeInfoWidgetKind,
+            provider: StoreInfoProvider()
+        ) { entry in
+            StoreInfoWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName(Localization.title)
+        .description(Localization.description)
+        .supportedFamilies(supportedFamilies)
+#endif
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -1,0 +1,14 @@
+import AppIntents
+import WidgetKit
+
+/// Configuration intent for the Store Stats widget.
+///
+/// Currently has no parameters — its sole purpose is to switch `StoreInfoWidget` from
+/// `StaticConfiguration` to `AppIntentConfiguration` so the widget extension is on the
+/// modern API. Subsequent tickets add `@Parameter` declarations (date range, metrics,
+/// store picker) on top of this scaffold.
+///
+struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Store Stats"
+    static var description = IntentDescription("Choose how the WooCommerce stats widget is displayed.")
+}


### PR DESCRIPTION
WOOMOB-2809

## Description

Migrates `StoreInfoWidget` from `StaticConfiguration` to `AppIntentConfiguration` so subsequent tickets can attach `@Parameter` declarations to `StoreStatsConfigurationIntent`. Widget `kind` is preserved, so existing installs survive the migration in either direction.

The configuration-type swap is gated by `#if DEBUG || ALPHA` — production builds keep `StaticConfiguration` (no Edit Widget affordance) until at least one parameter exists. A runtime gate is not expressible: `Widget.body` is `some WidgetConfiguration`, and `WidgetBundleBuilder` explicitly disables `buildOptional` for runtime `if`. Once the first user-visible parameter ships, the `#if`/`#else` goes away.

Three commits: dead iOS-16 availability cleanup, AppIntent scaffolding (`StoreStatsConfigurationIntent` + `AppIntentTimelineProvider` extension on `StoreInfoProvider`), build-config gate.

## Test Steps

Build a Release configuration. Add the Today widget at medium size. Verify it renders revenue / visitors / orders / conversion identically to trunk.

Long-press the widget — the "Edit Widget" affordance is hidden.

Build a Debug or Release-Alpha configuration on top of the existing Release install. The tile keeps its placement and renders unchanged.

Long-press — "Edit Widget" appears. Tapping it shows an empty configuration sheet. Expected: no `@Parameter`s yet, the next ticket fills it in.

Confirm Debug, Release, and Release-Alpha all build cleanly.

## Screenshots

N/A.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.