### PR TITLE
[WOOMOB-2812] Add date range parameter to Store Stats widget

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -8,9 +8,33 @@ import NetworkingCore
 
 import WooFoundationCore
 
-/// Orchestrator class that fetches today store stats data.
+/// Orchestrator class that fetches store stats for the widget and the Watch app.
 ///
 final class StoreInfoDataService {
+
+    /// Date-range parameters required to fetch a snapshot of store stats.
+    ///
+    /// Defined in primitive Networking types (no widget-specific types) so this service can be
+    /// shared across the StoreWidgets extension and the Woo Watch App targets. Range factories
+    /// for the widget's user-facing options live below; the Watch app uses `today()` directly
+    /// via `fetchTodayStats(for:)`.
+    ///
+    struct DateRange {
+        let orderStatsGranularity: StatsGranularityV4
+        let orderStatsQuantity: Int
+        let earliestDateToInclude: Date
+        let latestDateToInclude: Date
+        /// Period passed to `loadSiteSummaryStats`. The endpoint returns visitors for the
+        /// calendar-aligned period containing `latestDateToInclude` — so for `last7Days` /
+        /// `last30Days` the visitor total reflects the current calendar week / month rather
+        /// than a strict rolling window. Order stats use the rolling earliest/latest dates
+        /// above, so the two metrics can disagree on coverage early in a calendar period.
+        /// Acceptable for v1; matches Yosemite's `summaryStatsGranularity` for `thisWeek` /
+        /// `thisMonth`. Refining visitor coverage to a true rolling window is a follow-up.
+        ///
+        let summaryStatsPeriod: StatGranularity
+        let timezone: TimeZone
+    }
 
     /// Data extracted from networking types.
     ///
@@ -51,18 +75,25 @@ final class StoreInfoDataService {
         }
     }
 
-    /// Async function that fetches todays stats data.
+    /// Async function that fetches today's stats. Preserved for the Woo Watch App, which
+    /// renders a fixed today preset.
     ///
     func fetchTodayStats(for storeID: Int64) async throws -> Stats {
+        try await fetchStats(for: storeID, dateRange: .today())
+    }
+
+    /// Async function that fetches stats for the given date range.
+    ///
+    func fetchStats(for storeID: Int64, dateRange: DateRange) async throws -> Stats {
         /// If user is authenticated with site credentials only,
         /// fetch revenue and orders and skip visitor stats as its endpoint is not available.
         guard !isAuthenticatedWithoutWPCom else {
-            return try await todayStatsWithoutVisitors(for: storeID)
+            return try await statsWithoutVisitors(for: storeID, dateRange: dateRange)
         }
 
         // Prepare them to run in parallel
-        async let revenueAndOrdersRequest = fetchTodaysRevenueAndOrders(for: storeID)
-        async let siteStatsRequest = fetchTodaysVisitors(for: storeID)
+        async let revenueAndOrdersRequest = fetchRevenueAndOrders(for: storeID, dateRange: dateRange)
+        async let siteStatsRequest = fetchVisitors(for: storeID, dateRange: dateRange)
 
         // Wait for for response
         do {
@@ -83,14 +114,14 @@ final class StoreInfoDataService {
             // If there was an error fetching the stats chances are that is because jetpack is not properly configure to return stats.
             // Hence, I'm choosing to request stats without visitors again.
             // This should continue to be performant because the response should be cached.
-            return try await todayStatsWithoutVisitors(for: storeID)
+            return try await statsWithoutVisitors(for: storeID, dateRange: dateRange)
         }
     }
 
-    /// Fetches today stats without visitors data. Useful when that API is not available.
+    /// Fetches stats without visitors data. Useful when that API is not available.
     ///
-    private func todayStatsWithoutVisitors(for storeID: Int64) async throws -> Stats {
-        let revenueAndOrders = try await fetchTodaysRevenueAndOrders(for: storeID)
+    private func statsWithoutVisitors(for storeID: Int64, dateRange: DateRange) async throws -> Stats {
+        let revenueAndOrders = try await fetchRevenueAndOrders(for: storeID, dateRange: dateRange)
         return Stats(revenue: revenueAndOrders.totals.grossRevenue,
                      netRevenue: revenueAndOrders.totals.netRevenue,
                      averageOrderValue: revenueAndOrders.totals.averageOrderValue,
@@ -101,22 +132,70 @@ final class StoreInfoDataService {
     }
 }
 
+// MARK: - DateRange factories
+
+extension StoreInfoDataService.DateRange {
+    /// Today's range, used by the Watch app and by the widget's `.today` configuration.
+    ///
+    static func today(referenceDate: Date = Date(), timezone: TimeZone = .current) -> Self {
+        Self(orderStatsGranularity: .hourly,
+             orderStatsQuantity: 24,
+             earliestDateToInclude: referenceDate.startOfDay(timezone: timezone),
+             latestDateToInclude: referenceDate.endOfDay(timezone: timezone),
+             summaryStatsPeriod: .day,
+             timezone: timezone)
+    }
+
+    /// Rolling 7-day range ending at the end of `referenceDate` (inclusive).
+    ///
+    /// Order stats use a true 7-day window. Visitors use `period: .week`, which the
+    /// `SiteStatsRemote` endpoint resolves to the calendar week containing `referenceDate`
+    /// — see the `summaryStatsPeriod` doc comment on `DateRange` for the trade-off.
+    ///
+    static func last7Days(referenceDate: Date = Date(), timezone: TimeZone = .current) -> Self {
+        Self(orderStatsGranularity: .daily,
+             orderStatsQuantity: 7,
+             earliestDateToInclude: rollingStart(daysBack: 6, referenceDate: referenceDate, timezone: timezone),
+             latestDateToInclude: referenceDate.endOfDay(timezone: timezone),
+             summaryStatsPeriod: .week,
+             timezone: timezone)
+    }
+
+    /// Rolling 30-day range ending at the end of `referenceDate` (inclusive).
+    ///
+    static func last30Days(referenceDate: Date = Date(), timezone: TimeZone = .current) -> Self {
+        Self(orderStatsGranularity: .daily,
+             orderStatsQuantity: 30,
+             earliestDateToInclude: rollingStart(daysBack: 29, referenceDate: referenceDate, timezone: timezone),
+             latestDateToInclude: referenceDate.endOfDay(timezone: timezone),
+             summaryStatsPeriod: .month,
+             timezone: timezone)
+    }
+
+    private static func rollingStart(daysBack: Int, referenceDate: Date, timezone: TimeZone) -> Date {
+        var calendar = Calendar.current
+        calendar.timeZone = timezone
+        let startOfReferenceDay = referenceDate.startOfDay(timezone: timezone)
+        return calendar.date(byAdding: .day, value: -daysBack, to: startOfReferenceDay) ?? startOfReferenceDay
+    }
+}
+
 /// Async Wrappers
 ///
 private extension StoreInfoDataService {
 
-    /// Async wrapper that fetches todays revenues & orders.
+    /// Async wrapper that fetches revenue and order stats for the given range.
     ///
-    func fetchTodaysRevenueAndOrders(for storeID: Int64) async throws -> OrderStatsV4 {
+    func fetchRevenueAndOrders(for storeID: Int64, dateRange: DateRange) async throws -> OrderStatsV4 {
         try await withCheckedThrowingContinuation { continuation in
             // `WKWebView` is accessed internally, we are forced to dispatch the call in the main thread.
             Task { @MainActor in
                 orderStatsRemoteV4.loadOrderStats(for: storeID,
-                                                  unit: .hourly,
-                                                  timeZone: .current,
-                                                  earliestDateToInclude: Date().startOfDay(timezone: .current),
-                                                  latestDateToInclude: Date().endOfDay(timezone: .current),
-                                                  quantity: 24,
+                                                  unit: dateRange.orderStatsGranularity,
+                                                  timeZone: dateRange.timezone,
+                                                  earliestDateToInclude: dateRange.earliestDateToInclude,
+                                                  latestDateToInclude: dateRange.latestDateToInclude,
+                                                  quantity: dateRange.orderStatsQuantity,
                                                   forceRefresh: true) { result in
                     continuation.resume(with: result)
                 }
@@ -124,15 +203,15 @@ private extension StoreInfoDataService {
         }
     }
 
-    /// Async wrapper that fetches todays visitors.
+    /// Async wrapper that fetches visitor summary stats for the given range.
     ///
-    func fetchTodaysVisitors(for storeID: Int64) async throws -> SiteSummaryStats {
+    func fetchVisitors(for storeID: Int64, dateRange: DateRange) async throws -> SiteSummaryStats {
         try await withCheckedThrowingContinuation { continuation in
             // `WKWebView` is accessed internally, we are forced to dispatch the call in the main thread.
             Task { @MainActor in
                 siteStatsRemote.loadSiteSummaryStats(for: storeID,
-                                                     period: .day,
-                                                     includingDate: Date().endOfDay(timezone: .current)) { result in
+                                                     period: dateRange.summaryStatsPeriod,
+                                                     includingDate: dateRange.latestDateToInclude) { result in
                     continuation.resume(with: result)
                 }
             }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
@@ -2,12 +2,10 @@ import AppIntents
 import WidgetKit
 
 /// `AppIntentTimelineProvider` conformance for `StoreInfoProvider`. Kept in a separate file
-/// so the legacy `TimelineProvider` path stays a clean focal point and so this conformance
-/// can be removed in a single edit once the configurable widget rollout completes and the
-/// `StaticConfiguration` path retires.
+/// so the data-fetching logic on the main type stays a clean focal point.
 ///
-/// `placeholder(in:)` is satisfied by the conformance on the main type — both protocols
-/// use the same signature.
+/// `placeholder(in:)` is satisfied by the conformance on the main type — both the snapshot
+/// path here and the gallery placeholder share the same redacted sample entry.
 ///
 extension StoreInfoProvider: AppIntentTimelineProvider {
     typealias Intent = StoreStatsConfigurationIntent
@@ -17,6 +15,6 @@ extension StoreInfoProvider: AppIntentTimelineProvider {
     }
 
     func timeline(for configuration: StoreStatsConfigurationIntent, in context: Context) async -> Timeline<StoreInfoEntry> {
-        await loadTimeline()
+        await loadTimeline(dateRange: configuration.dateRange)
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -110,7 +110,7 @@ final class StoreInfoProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<StoreInfoEntry>) -> Void) {
         Task {
-            let timeline = await loadTimeline()
+            let timeline = await loadTimeline(dateRange: .today)
             completion(timeline)
         }
     }
@@ -118,7 +118,7 @@ final class StoreInfoProvider: TimelineProvider {
     /// Shared loader for both `TimelineProvider` and `AppIntentTimelineProvider` paths.
     /// Visible to extensions in this module so the AppIntent conformance can share logic.
     ///
-    func loadTimeline() async -> Timeline<StoreInfoEntry> {
+    func loadTimeline(dateRange: StoreStatsWidgetDateRange) async -> Timeline<StoreInfoEntry> {
         guard let dependencies = Self.fetchDependencies() else {
             return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
         }
@@ -126,12 +126,10 @@ final class StoreInfoProvider: TimelineProvider {
         let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
-            let todayStats = try await service.fetchTodayStats(for: dependencies.storeID)
-            let entry = Self.dataEntry(for: todayStats, with: dependencies)
+            let stats = try await service.fetchStats(for: dependencies.storeID, dateRange: dateRange.serviceDateRange)
+            let entry = Self.dataEntry(for: stats, dateRange: dateRange, with: dependencies)
             return Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
         } catch {
-            // WooFoundation does not expose `DDLOG` types. Should we include them?
-            print("⛔️ Error fetching today's widget stats: \(error)")
             return Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
         }
     }
@@ -200,7 +198,7 @@ private extension StoreInfoProvider {
             StoreInfoMetric(type: .conversion, value: .percentage(23.0 / 67.0))
         ]
         return .data(.init(
-            range: Localization.today,
+            range: StoreStatsWidgetDateRange.today.localizedRangeLabel,
             name: dependencies?.storeName ?? Localization.myShop,
             revenue: StoreInfoFormatter.formattedAmountString(for: revenueAmount, with: currencySettings),
             revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: revenueAmount, with: currencySettings),
@@ -214,39 +212,41 @@ private extension StoreInfoProvider {
 
     /// Real data entry.
     ///
-    static func dataEntry(for todayStats: StoreInfoDataService.Stats, with dependencies: Dependencies) -> StoreInfoEntry {
+    static func dataEntry(for stats: StoreInfoDataService.Stats,
+                          dateRange: StoreStatsWidgetDateRange,
+                          with dependencies: Dependencies) -> StoreInfoEntry {
         let currencySettings = dependencies.storeCurrencySettings
-        let visitorsValue: StoreInfoMetricValue = todayStats.totalVisitors.map { .count($0) } ?? .unavailable
-        let conversionValue: StoreInfoMetricValue = todayStats.conversion.map { .percentage($0) } ?? .unavailable
+        let visitorsValue: StoreInfoMetricValue = stats.totalVisitors.map { .count($0) } ?? .unavailable
+        let conversionValue: StoreInfoMetricValue = stats.conversion.map { .percentage($0) } ?? .unavailable
 
-        // Today's medium-widget preset. A later ticket will let users pick this list.
+        // Medium-widget preset. A later ticket will let users pick this list.
         let metrics: [StoreInfoMetric] = [
-            .init(type: .revenue, value: .currency(todayStats.revenue, currencySettings)),
+            .init(type: .revenue, value: .currency(stats.revenue, currencySettings)),
             .init(type: .visitors, value: visitorsValue),
-            .init(type: .orders, value: .count(todayStats.totalOrders)),
+            .init(type: .orders, value: .count(stats.totalOrders)),
             .init(type: .conversion, value: conversionValue)
         ]
 
         let visitorsString: String = {
-            if let visitors = todayStats.totalVisitors {
+            if let visitors = stats.totalVisitors {
                 return "\(visitors)"
             }
             return StoreInfoFormatter.Constants.valuePlaceholderText
         }()
         let conversionString: String = {
-            if let conversion = todayStats.conversion {
+            if let conversion = stats.conversion {
                 return StoreInfoFormatter.formattedConversionString(for: conversion)
             }
             return StoreInfoFormatter.Constants.valuePlaceholderText
         }()
 
         return .data(.init(
-            range: Localization.today,
+            range: dateRange.localizedRangeLabel,
             name: dependencies.storeName,
-            revenue: StoreInfoFormatter.formattedAmountString(for: todayStats.revenue, with: currencySettings),
-            revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: todayStats.revenue, with: currencySettings),
+            revenue: StoreInfoFormatter.formattedAmountString(for: stats.revenue, with: currencySettings),
+            revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: stats.revenue, with: currencySettings),
             visitors: visitorsString,
-            orders: "\(todayStats.totalOrders)",
+            orders: "\(stats.totalOrders)",
             conversion: conversionString,
             updatedTime: StoreInfoFormatter.currentFormattedTime(),
             metrics: metrics
@@ -258,11 +258,6 @@ private extension StoreInfoProvider {
             "storeWidgets.infoProvider.myShop",
             value: "My Shop",
             comment: "Generic store name for the store info widget preview"
-        )
-        static let today = AppLocalizedString(
-            "storeWidgets.infoProvider.today",
-            value: "Today",
-            comment: "Range title for the today store info widget"
         )
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -130,6 +130,8 @@ final class StoreInfoProvider: TimelineProvider {
             let entry = Self.dataEntry(for: stats, dateRange: dateRange, with: dependencies)
             return Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
         } catch {
+            // WooFoundation does not expose `DDLOG` types. Should we include them?
+            print("⛔️ Error fetching today's widget stats: \(error)")
             return Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
         }
     }

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -3,12 +3,76 @@ import WidgetKit
 
 /// Configuration intent for the Store Stats widget.
 ///
-/// Currently has no parameters — its sole purpose is to switch `StoreInfoWidget` from
-/// `StaticConfiguration` to `AppIntentConfiguration` so the widget extension is on the
-/// modern API. Subsequent tickets add `@Parameter` declarations (date range, metrics,
-/// store picker) on top of this scaffold.
+/// Surfaces the user-facing widget settings (long-press → Edit Widget). Subsequent tickets
+/// add `@Parameter` declarations (metrics, store picker) on top of the date range here.
 ///
 struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Store Stats"
     static var description = IntentDescription("Choose how the WooCommerce stats widget is displayed.")
+
+    @Parameter(title: "Date Range", default: .today)
+    var dateRange: StoreStatsWidgetDateRange
+}
+
+/// Date ranges supported by the Store Stats widget. Mirrors the Shopify reference set
+/// ("today / last 7 days / last 30 days") called out in the project's M1 scope.
+///
+enum StoreStatsWidgetDateRange: String, AppEnum {
+    case today
+    case last7Days
+    case last30Days
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Date Range")
+    }
+
+    static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .today: "Today",
+        .last7Days: "Last 7 Days",
+        .last30Days: "Last 30 Days"
+    ]
+}
+
+extension StoreStatsWidgetDateRange {
+    /// Localized label rendered inside the widget body (top-right of the medium home-screen
+    /// widget). Kept separate from `caseDisplayRepresentations` because intent UI strings live
+    /// in the widget extension's own bundle, while the in-widget body reads strings from the
+    /// host app bundle via `AppLocalizedString`.
+    ///
+    var localizedRangeLabel: String {
+        switch self {
+        case .today:
+            return AppLocalizedString(
+                "storeWidgets.dateRange.today",
+                value: "Today",
+                comment: "Range label for the Today option in the Store Stats widget"
+            )
+        case .last7Days:
+            return AppLocalizedString(
+                "storeWidgets.dateRange.last7Days",
+                value: "Last 7 Days",
+                comment: "Range label for the Last 7 Days option in the Store Stats widget"
+            )
+        case .last30Days:
+            return AppLocalizedString(
+                "storeWidgets.dateRange.last30Days",
+                value: "Last 30 Days",
+                comment: "Range label for the Last 30 Days option in the Store Stats widget"
+            )
+        }
+    }
+
+    /// Maps the user-selected widget range to the primitive parameters consumed by
+    /// `StoreInfoDataService.fetchStats(for:dateRange:)`.
+    ///
+    var serviceDateRange: StoreInfoDataService.DateRange {
+        switch self {
+        case .today:
+            return .today()
+        case .last7Days:
+            return .last7Days()
+        case .last30Days:
+            return .last30Days()
+        }
+    }
 }


### PR DESCRIPTION
WOOMOB-2812

## Description

Adds a Date Range parameter (Today / Last 7 Days / Last 30 Days) to the Store Stats widget configuration intent. Stacks on #17023 — the parameter only surfaces where the widget uses `AppIntentConfiguration` (DEBUG/ALPHA); the production `StaticConfiguration` path stays on hardcoded today data.

`StoreInfoDataService` is generalized to accept an arbitrary `DateRange` (granularity, dates, summary period, timezone). `fetchTodayStats(for:)` is kept as a thin wrapper so the Watch app keeps working unchanged.

Order stats use a true rolling 7/30-day window. Visitor totals on `last7Days` / `last30Days` follow `loadSiteSummaryStats`'s calendar-aligned `period` (week / month containing today), since the endpoint can't take an arbitrary range. Matches Yosemite's `summaryStatsGranularity` for `thisWeek` / `thisMonth`; rolling visitors is a follow-up.

## Test Steps

- Run a Debug or Alpha build and add the Store Stats widget to the home screen.
- Long-press the widget → Edit Widget. The Date Range picker shows Today / Last 7 Days / Last 30 Days.
- Pick each option. The widget re-renders for the selected window and the range label in the top-right reflects the selection.
- Add a second tile with a different range. Each tile retains its own selection across refreshes.
- Switch to a Release build. The widget continues to render today's data with no Edit Widget affordance.
- Smoke-test the Watch app's My Store screen to confirm stats still load.

## Demo

https://github.com/user-attachments/assets/01347708-fff4-48e2-9ec2-ae25abc9434b

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.