### PR TITLE
WOOMOB-2813: Add metrics picker to Store Stats widget configuration

### DIFF
--- a/WooCommerce/StoreWidgets/AvailableMetricsQuery.swift
+++ b/WooCommerce/StoreWidgets/AvailableMetricsQuery.swift
@@ -1,0 +1,23 @@
+import AppIntents
+
+/// Drives the Edit Widget UI for the `metrics` parameter on `StoreStatsConfigurationIntent`.
+///
+/// Backs the entity-array `IntentParameter` initializer, which renders a section (titled by the
+/// parameter `title`) of N inline rows per widget family — N is enforced by the parameter's
+/// `size:` map. Tapping a row opens the picker populated by `suggestedEntities()`.
+///
+/// The picker shows the full catalog regardless of auth mode. Metrics whose data sources
+/// require WPCom/Jetpack (`visitors`, `conversion`) come back as `.unavailable` for self-hosted
+/// users and render as the standard "-" placeholder in the cell — see
+/// `StoreInfoFormatter.Constants.valuePlaceholderText`. Filtering the picker by auth mode is
+/// tracked as a follow-up.
+///
+struct AvailableMetricsQuery: EntityQuery {
+    func entities(for identifiers: [StoreInfoMetricType.ID]) async throws -> [StoreInfoMetricType] {
+        StoreInfoMetricType.allCases.filter { identifiers.contains($0.id) }
+    }
+
+    func suggestedEntities() async throws -> [StoreInfoMetricType] {
+        StoreInfoMetricType.allCases
+    }
+}

--- a/WooCommerce/StoreWidgets/AvailableMetricsQuery.swift
+++ b/WooCommerce/StoreWidgets/AvailableMetricsQuery.swift
@@ -6,13 +6,23 @@ import AppIntents
 /// parameter `title`) of N inline rows per widget family — N is enforced by the parameter's
 /// `size:` map. Tapping a row opens the picker populated by `suggestedEntities()`.
 ///
+/// Conforms to `EnumerableEntityQuery` because the catalog is finite and static. iOS uses
+/// `allEntities()` to materialize the full set upfront so the parameter's `default:` IDs are
+/// validated synchronously when the Edit Widget sheet opens — without this, the Metrics
+/// section can render empty (or be hidden entirely) on first widget configuration while iOS
+/// lazily resolves the defaults through `entities(for:)`.
+///
 /// The picker shows the full catalog regardless of auth mode. Metrics whose data sources
 /// require WPCom/Jetpack (`visitors`, `conversion`) come back as `.unavailable` for self-hosted
 /// users and render as the standard "-" placeholder in the cell — see
 /// `StoreInfoFormatter.Constants.valuePlaceholderText`. Filtering the picker by auth mode is
 /// tracked as a follow-up.
 ///
-struct AvailableMetricsQuery: EntityQuery {
+struct AvailableMetricsQuery: EnumerableEntityQuery {
+    func allEntities() async throws -> [StoreInfoMetricType] {
+        StoreInfoMetricType.allCases
+    }
+
     func entities(for identifiers: [StoreInfoMetricType.ID]) async throws -> [StoreInfoMetricType] {
         StoreInfoMetricType.allCases.filter { identifiers.contains($0.id) }
     }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMediumMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMediumMetricsView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Renders the metrics layout used by medium and larger home-screen widget families.
+struct StoreInfoMediumMetricsView: View {
+    let data: StoreInfoData
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+                HStack {
+                    Text(data.name)
+                        .storeNameStyle()
+                    Spacer()
+                    Text(data.range)
+                        .statRangeStyle()
+                }
+                Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
+                    .statRangeStyle()
+            }
+
+            if dynamicTypeSize > Layout.accessibilityDynamicTypeSize {
+                MetricsAccessibilityCard(entryData: data)
+            } else {
+                StoreInfoMetricsCard(metrics: data.metrics)
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    private enum Layout {
+        static let sectionSpacing = 8.0
+        static let cardSpacing = 2.0
+        static let accessibilityDynamicTypeSize: DynamicTypeSize = .xLarge
+    }
+}
+
+/// Renders an ordered list of metrics in a 2-column grid for the medium-style metrics layout.
+/// Operates on the presentation protocol so the layout is decoupled from
+/// the concrete `StoreInfoMetric` type.
+///
+private struct StoreInfoMetricsCard: View {
+    let metrics: [any MetricPresentable]
+
+    /// Chunks metrics into rows of two for the medium-style widget layout.
+    ///
+    private var rows: [[any MetricPresentable]] {
+        stride(from: 0, to: metrics.count, by: Layout.metricsPerRow).map { start in
+            Array(metrics[start..<min(start + Layout.metricsPerRow, metrics.count)])
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack {
+                    ForEach(Array(row.enumerated()), id: \.offset) { _, metric in
+                        MetricCellView(metric: metric)
+                    }
+                    // Pad the last row so a trailing cell keeps the grid alignment
+                    // when the row has fewer metrics than the slot count.
+                    if row.count < Layout.metricsPerRow {
+                        ForEach(0..<(Layout.metricsPerRow - row.count), id: \.self) { _ in
+                            Color.clear.frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private enum Layout {
+        static let sectionSpacing = 8.0
+        static let metricsPerRow = 2
+    }
+}
+
+/// Accessibility card for metric widget layouts. Shows only revenue and a `View More` indicator.
+///
+private struct MetricsAccessibilityCard: View {
+    let entryData: StoreInfoData
+
+    var body: some View {
+        let revenue = entryData.metric(of: .revenue)
+        Group {
+            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+                Text(revenue.title)
+                    .statTitleStyle()
+
+                Text(revenue.formattedValue)
+                    .statValueStyle()
+            }
+
+            Text(StoreInfoMetricsView.Localization.viewMore)
+                .statButtonStyle()
+        }
+    }
+
+    private enum Layout {
+        static let cardSpacing = 2.0
+    }
+}
+
+// MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
+import WidgetKit
+
+struct StoreInfoMediumMetricsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreInfoMediumMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .previewDisplayName("Medium")
+
+        StoreInfoMediumMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.dynamicTypeSize, .xxLarge)
+            .previewDisplayName("Medium - XXL font")
+    }
+}
+#endif

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -21,11 +21,11 @@ struct StoreInfoMetricsView: View {
         Group {
             switch family {
             case .systemSmall:
-                SmallView(data: entryData)
+                StoreInfoSmallMetricsView(data: entryData)
             case .systemMedium, .systemLarge, .systemExtraLarge:
                 mediumView()
             default:
-                let _ = assert(true, "This view only supports system families")
+                let _ = assertionFailure("This view only supports system families")
                 EmptyView()
             }
         }
@@ -141,7 +141,7 @@ extension StoreInfoMetricsView {
 }
 
 /// View that renders widget for .systemSmall family
-struct SmallView: View {
+private struct StoreInfoSmallMetricsView: View {
     let data: StoreInfoData
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -179,7 +179,6 @@ struct SmallView: View {
                 }
             }
         }
-        .padding(Layout.noSpacing)
     }
 
     private enum Layout {
@@ -188,8 +187,6 @@ struct SmallView: View {
         static let metricSpacing = 6.0
         static let logoSpacing = 4.0
         static let logoSize = 30.0
-        static let bigLogoSize = 50.0
-        static let messageSpacing = 8.0
         static let defaultMetricLimit = 2
         static let accessibilityMetricLimit = 1
     }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -1,21 +1,16 @@
 import SwiftUI
 import WidgetKit
 
-/// Medium home-screen widget view driven by the metric catalog.
+/// Home-screen widget dispatcher driven by the metric catalog.
 ///
-/// Companion to the legacy `StoreInfoView`; both render the same widget family but consume
+/// Companion to the legacy `StoreInfoView`; both render the same widget families but consume
 /// different shapes off `StoreInfoData`. Selection happens in `StoreInfoHomescreenWidget`
 /// based on `useMetricsHomescreenWidget`.
 ///
 struct StoreInfoMetricsView: View {
     let entryData: StoreInfoData
 
-    @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.widgetFamily) private var family
-
-    var accessibilityDynamicTypeSize: DynamicTypeSize {
-        return .xLarge
-    }
 
     var body: some View {
         Group {
@@ -23,102 +18,13 @@ struct StoreInfoMetricsView: View {
             case .systemSmall:
                 StoreInfoSmallMetricsView(data: entryData)
             case .systemMedium, .systemLarge, .systemExtraLarge:
-                mediumView()
+                StoreInfoMediumMetricsView(data: entryData)
             default:
                 let _ = assertionFailure("This view only supports system families")
                 EmptyView()
             }
         }
         .widgetBackground(backgroundView: Color(.brand))
-    }
-
-    private func mediumView() -> some View {
-        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                HStack {
-                    Text(entryData.name)
-                        .storeNameStyle()
-                    Spacer()
-                    Text(entryData.range)
-                        .statRangeStyle()
-                }
-                Text(Localization.updatedAt(entryData.updatedTime))
-                    .statRangeStyle()
-            }
-
-            if dynamicTypeSize > accessibilityDynamicTypeSize {
-                MetricsAccessibilityCard(entryData: entryData)
-            } else {
-                StoreInfoMetricsCard(metrics: entryData.metrics)
-            }
-        }
-        .padding(.horizontal)
-    }
-
-    fileprivate enum Layout {
-        static let sectionSpacing = 8.0
-        static let cardSpacing = 2.0
-    }
-}
-
-/// Renders an ordered list of metrics in a 2-column grid for the medium widget.
-/// Operates on the presentation protocol so the layout is decoupled from
-/// the concrete `StoreInfoMetric` type.
-///
-struct StoreInfoMetricsCard: View {
-    let metrics: [any MetricPresentable]
-
-    /// Chunks metrics into rows of two for the medium widget layout.
-    ///
-    private var rows: [[any MetricPresentable]] {
-        stride(from: 0, to: metrics.count, by: Layout.metricsPerRow).map { start in
-            Array(metrics[start..<min(start + Layout.metricsPerRow, metrics.count)])
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: StoreInfoMetricsView.Layout.sectionSpacing) {
-            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                HStack {
-                    ForEach(Array(row.enumerated()), id: \.offset) { _, metric in
-                        MetricCellView(metric: metric)
-                    }
-                    // Pad the last row so a trailing cell keeps the grid alignment
-                    // when the row has fewer metrics than the slot count.
-                    if row.count < Layout.metricsPerRow {
-                        ForEach(0..<(Layout.metricsPerRow - row.count), id: \.self) { _ in
-                            Color.clear.frame(maxWidth: .infinity)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private enum Layout {
-        static let metricsPerRow = 2
-    }
-}
-
-/// Accessibility card for `StoreInfoMetricsView`. Shows only revenue and a `View More` button.
-///
-private struct MetricsAccessibilityCard: View {
-    let entryData: StoreInfoData
-
-    var body: some View {
-        let revenue = entryData.metric(of: .revenue)
-        Group {
-            VStack(alignment: .leading, spacing: StoreInfoMetricsView.Layout.cardSpacing) {
-                Text(revenue.title)
-                    .statTitleStyle()
-
-                Text(revenue.formattedValue)
-                    .statValueStyle()
-            }
-
-            Text(StoreInfoMetricsView.Localization.viewMore)
-                .statButtonStyle()
-        }
     }
 }
 
@@ -137,58 +43,6 @@ extension StoreInfoMetricsView {
                                             comment: "Displays the time when the widget was last updated. %1$@ is the time to render.")
             return LocalizedString.localizedStringWithFormat(format, updatedTime)
         }
-    }
-}
-
-/// View that renders widget for .systemSmall family
-private struct StoreInfoSmallMetricsView: View {
-    let data: StoreInfoData
-
-    @Environment(\.dynamicTypeSize) var dynamicTypeSize
-
-    private var visibleMetrics: [any MetricPresentable] {
-        let limit = dynamicTypeSize > .xLarge ? Layout.accessibilityMetricLimit : Layout.defaultMetricLimit
-        return Array(data.metrics.prefix(limit))
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
-            HStack(alignment: .top, spacing: Layout.noSpacing) {
-                Image("woo-mini-logo", bundle: nil)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Layout.logoSize, height: Layout.logoSize)
-                    .accessibilityHidden(true)
-
-                Spacer(minLength: Layout.logoSpacing)
-
-                VStack(alignment: .leading, spacing: Layout.noSpacing) {
-                    Text(data.name)
-                        .storeNameStyle()
-
-                    Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
-                        .statRangeStyle()
-                }
-            }
-
-            Spacer(minLength: Layout.metricSpacing)
-
-            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
-                ForEach(Array(visibleMetrics.enumerated()), id: \.offset) { _, metric in
-                    MetricCellView(metric: metric)
-                }
-            }
-        }
-    }
-
-    private enum Layout {
-        static let noSpacing = 0.0
-        static let headerSpacing = 6.0
-        static let metricSpacing = 6.0
-        static let logoSpacing = 4.0
-        static let logoSize = 30.0
-        static let defaultMetricLimit = 2
-        static let accessibilityMetricLimit = 1
     }
 }
 

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -11,12 +11,28 @@ struct StoreInfoMetricsView: View {
     let entryData: StoreInfoData
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.widgetFamily) private var family
 
     var accessibilityDynamicTypeSize: DynamicTypeSize {
         return .xLarge
     }
 
     var body: some View {
+        Group {
+            switch family {
+            case .systemSmall:
+                SmallView(data: entryData)
+            case .systemMedium, .systemLarge, .systemExtraLarge:
+                mediumView()
+            default:
+                let _ = assert(true, "This view only supports system families")
+                EmptyView()
+            }
+        }
+        .widgetBackground(backgroundView: Color(.brand))
+    }
+
+    private func mediumView() -> some View {
         VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
             VStack(alignment: .leading, spacing: Layout.cardSpacing) {
                 HStack {
@@ -37,7 +53,11 @@ struct StoreInfoMetricsView: View {
             }
         }
         .padding(.horizontal)
-        .widgetBackground(backgroundView: Color(.brand))
+    }
+
+    fileprivate enum Layout {
+        static let sectionSpacing = 8.0
+        static let cardSpacing = 2.0
     }
 }
 
@@ -118,10 +138,60 @@ extension StoreInfoMetricsView {
             return LocalizedString.localizedStringWithFormat(format, updatedTime)
         }
     }
+}
 
-    enum Layout {
-        static let sectionSpacing = 8.0
-        static let cardSpacing = 2.0
+/// View that renders widget for .systemSmall family
+struct SmallView: View {
+    let data: StoreInfoData
+
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    private var visibleMetrics: [any MetricPresentable] {
+        let limit = dynamicTypeSize > .xLarge ? Layout.accessibilityMetricLimit : Layout.defaultMetricLimit
+        return Array(data.metrics.prefix(limit))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
+            HStack(alignment: .top, spacing: Layout.noSpacing) {
+                Image("woo-mini-logo", bundle: nil)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Layout.logoSize, height: Layout.logoSize)
+                    .accessibilityHidden(true)
+
+                Spacer(minLength: Layout.logoSpacing)
+
+                VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                    Text(data.name)
+                        .storeNameStyle()
+
+                    Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
+                        .statRangeStyle()
+                }
+            }
+
+            Spacer(minLength: Layout.metricSpacing)
+
+            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
+                ForEach(Array(visibleMetrics.enumerated()), id: \.offset) { _, metric in
+                    MetricCellView(metric: metric)
+                }
+            }
+        }
+        .padding(Layout.noSpacing)
+    }
+
+    private enum Layout {
+        static let noSpacing = 0.0
+        static let headerSpacing = 6.0
+        static let metricSpacing = 6.0
+        static let logoSpacing = 4.0
+        static let logoSize = 30.0
+        static let bigLogoSize = 50.0
+        static let messageSpacing = 8.0
+        static let defaultMetricLimit = 2
+        static let accessibilityMetricLimit = 1
     }
 }
 
@@ -150,11 +220,21 @@ struct StoreInfoMetricsView_Previews: PreviewProvider {
     static var previews: some View {
         StoreInfoMetricsView(entryData: exampleData)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .previewDisplayName("Medium")
 
         StoreInfoMetricsView(entryData: exampleData)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
             .environment(\.dynamicTypeSize, .xxLarge)
-            .previewDisplayName("XXL font")
+            .previewDisplayName("Medium - XXL font")
+
+        StoreInfoMetricsView(entryData: exampleData)
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .previewDisplayName("Small")
+
+        StoreInfoMetricsView(entryData: exampleData)
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environment(\.dynamicTypeSize, .xxLarge)
+            .previewDisplayName("Small - XXL font")
     }
 }
 #endif

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoSmallMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoSmallMetricsView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Renders the metrics layout used by the small home-screen widget family.
+struct StoreInfoSmallMetricsView: View {
+    let data: StoreInfoData
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var visibleMetrics: [any MetricPresentable] {
+        let limit = dynamicTypeSize > .xLarge ? Layout.accessibilityMetricLimit : Layout.defaultMetricLimit
+        return Array(data.metrics.prefix(limit))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
+            HStack(alignment: .top, spacing: Layout.noSpacing) {
+                Image("woo-mini-logo", bundle: nil)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Layout.logoSize, height: Layout.logoSize)
+                    .accessibilityHidden(true)
+
+                Spacer(minLength: Layout.logoSpacing)
+
+                VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                    Text(data.name)
+                        .storeNameStyle()
+
+                    Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
+                        .statRangeStyle()
+                }
+            }
+
+            Spacer(minLength: Layout.metricSpacing)
+
+            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
+                ForEach(Array(visibleMetrics.enumerated()), id: \.offset) { _, metric in
+                    MetricCellView(metric: metric)
+                }
+            }
+        }
+    }
+
+    private enum Layout {
+        static let noSpacing = 0.0
+        static let headerSpacing = 6.0
+        static let metricSpacing = 6.0
+        static let logoSpacing = 4.0
+        static let logoSize = 30.0
+        static let defaultMetricLimit = 2
+        static let accessibilityMetricLimit = 1
+    }
+}
+
+// MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
+import WidgetKit
+
+struct StoreInfoSmallMetricsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreInfoSmallMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .previewDisplayName("Small")
+
+        StoreInfoSmallMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environment(\.dynamicTypeSize, .xxLarge)
+            .previewDisplayName("Small - XXL font")
+    }
+}
+#endif

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -132,6 +132,24 @@ final class StoreInfoDataService {
     }
 }
 
+// MARK: - Placeholder sample
+
+extension StoreInfoDataService.Stats {
+    /// Sample values used by the widget's redacted/placeholder entry. Picked to render
+    /// non-zero, plausible numbers across all catalog metrics so the placeholder reads as
+    /// real data rather than a blank slate.
+    ///
+    static let placeholderSample = Self(
+        revenue: 132.234,
+        netRevenue: 120.000,
+        averageOrderValue: 5.75,
+        totalOrders: 23,
+        totalItemsSold: 41,
+        totalVisitors: 67,
+        conversion: 23.0 / 67.0
+    )
+}
+
 // MARK: - DateRange factories
 
 extension StoreInfoDataService.DateRange {

--- a/WooCommerce/StoreWidgets/StoreInfoMetricType.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoMetricType.swift
@@ -1,9 +1,11 @@
+import AppIntents
 import Foundation
 
 /// Catalog of metrics that store widgets can surface.
 ///
-/// The raw value is a stable, persistence-safe identifier — it is written into App Group storage
-/// and (later) into `AppIntentConfiguration` options. Do not rename cases without a migration.
+/// The raw value is the stable, persistence-safe identifier — written into App Group storage
+/// and into `AppIntentConfiguration` options (the intent system uses it as the entity `id`).
+/// Do not rename cases without a migration.
 ///
 enum StoreInfoMetricType: String, CaseIterable, Hashable {
     // ⚠️ Don't rename these raw values without a migration —
@@ -45,16 +47,40 @@ enum StoreInfoMetricType: String, CaseIterable, Hashable {
         case .conversion: return .percentage
         }
     }
+}
 
-    /// Whether the metric's data source requires WPCOM/Jetpack endpoints.
-    /// Used by the metric picker to filter options for self-hosted users.
-    ///
-    var requiresWPCom: Bool {
+// MARK: - AppEntity
+
+/// Surfaces the catalog as the element type for the `metrics` parameter on
+/// `StoreStatsConfigurationIntent`. Modeled as `AppEntity` because only the entity-array
+/// `IntentParameter` initializer accepts the family-keyed `size:` map.
+///
+/// Intent-UI strings here are English literals; the AppIntents metadata processor extracts
+/// them at build time and rejects runtime-evaluated expressions, and the project policy of
+/// "no `.strings` files in extensions" rules out the obvious workaround. Localization is
+/// tracked as a follow-up; in-widget cells continue to use `displayName` (host-bundle,
+/// fully localized).
+///
+extension StoreInfoMetricType: AppEntity {
+    var id: String { rawValue }
+
+    var displayRepresentation: DisplayRepresentation {
         switch self {
-        case .visitors, .conversion: return true
-        case .revenue, .netSales, .orders, .itemsSold, .averageOrderValue: return false
+        case .revenue: return "Total sales"
+        case .netSales: return "Net sales"
+        case .orders: return "Orders"
+        case .itemsSold: return "Items sold"
+        case .visitors: return "Visitors"
+        case .conversion: return "Conversion"
+        case .averageOrderValue: return "Average order value"
         }
     }
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Metric")
+    }
+
+    static var defaultQuery: AvailableMetricsQuery { AvailableMetricsQuery() }
 }
 
 // MARK: - Localization

--- a/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
@@ -15,6 +15,10 @@ extension StoreInfoProvider: AppIntentTimelineProvider {
     }
 
     func timeline(for configuration: StoreStatsConfigurationIntent, in context: Context) async -> Timeline<StoreInfoEntry> {
-        await loadTimeline(dateRange: configuration.dateRange)
+        let metrics = StoreInfoProvider.resolveMetricSelection(
+            requested: configuration.metrics,
+            family: context.family
+        )
+        return await loadTimeline(dateRange: configuration.dateRange, metrics: metrics)
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -110,7 +110,10 @@ final class StoreInfoProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<StoreInfoEntry>) -> Void) {
         Task {
-            let timeline = await loadTimeline(dateRange: .today)
+            // Legacy `StaticConfiguration` path. Hardcoded today range + 4-cell preset, bypassing
+            // the AppIntent metric resolver on purpose — the configurable behavior belongs to
+            // the `AppIntentConfiguration` branch only.
+            let timeline = await loadTimeline(dateRange: .today, metrics: Self.legacyMetricsPreset)
             completion(timeline)
         }
     }
@@ -118,7 +121,13 @@ final class StoreInfoProvider: TimelineProvider {
     /// Shared loader for both `TimelineProvider` and `AppIntentTimelineProvider` paths.
     /// Visible to extensions in this module so the AppIntent conformance can share logic.
     ///
-    func loadTimeline(dateRange: StoreStatsWidgetDateRange) async -> Timeline<StoreInfoEntry> {
+    /// The legacy path passes `legacyMetricsPreset`; the AppIntent path passes the resolved
+    /// user selection from `resolveMetricSelection`.
+    ///
+    func loadTimeline(
+        dateRange: StoreStatsWidgetDateRange,
+        metrics: [StoreInfoMetricType]
+    ) async -> Timeline<StoreInfoEntry> {
         guard let dependencies = Self.fetchDependencies() else {
             return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
         }
@@ -127,10 +136,115 @@ final class StoreInfoProvider: TimelineProvider {
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
             let stats = try await service.fetchStats(for: dependencies.storeID, dateRange: dateRange.serviceDateRange)
-            let entry = Self.dataEntry(for: stats, dateRange: dateRange, with: dependencies)
+            let entry = Self.dataEntry(
+                for: stats,
+                dateRange: dateRange,
+                with: dependencies,
+                metrics: metrics
+            )
             return Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
         } catch {
             return Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
+        }
+    }
+}
+
+// MARK: - Metric presets & resolution
+
+extension StoreInfoProvider {
+    /// Hardcoded preset used by the legacy `StaticConfiguration` path (`getTimeline`) and by
+    /// `placeholderEntry`. Matches the original 4-cell shape — non-WPCom users see `visitors` /
+    /// `conversion` as `.unavailable`. Not consumed by the AppIntent path; the configurable
+    /// branch derives its own selection from the user's stored configuration.
+    ///
+    static let legacyMetricsPreset: [StoreInfoMetricType] = [
+        .revenue, .visitors, .orders, .conversion
+    ]
+}
+
+extension StoreInfoProvider {
+    /// Catalog priority order. Mirrors the parameter `default:` in `StoreStatsConfigurationIntent`
+    /// so the render-time top-up draws from the same list iOS hands out at first install — a
+    /// resize-up tile renders identically to a fresh install at the new family.
+    ///
+    private static let catalogPriorityOrder: [StoreInfoMetricType] = [
+        .revenue, .orders, .itemsSold, .averageOrderValue,
+        .netSales, .visitors, .conversion
+    ]
+
+    /// Family slot counts that the home-screen view caps at when rendering. Mirrors the `size:`
+    /// map on the intent's `metrics` parameter. Lock-screen families return `nil` — they ignore
+    /// `StoreInfoData.metrics` and read fixed fields off `StoreInfoData` directly.
+    ///
+    private static func homescreenSlotCount(_ family: WidgetFamily) -> Int? {
+        switch family {
+        case .systemSmall: return 2
+        case .systemMedium: return 4
+        case .systemLarge: return 7
+        default: return nil
+        }
+    }
+
+    /// Maps the user's requested metric set onto what the configurable widget can render.
+    /// **AppIntent path only** — the legacy `StaticConfiguration` path bypasses this entirely
+    /// and uses `legacyMetricsPreset`.
+    ///
+    /// iOS persists the user's selection per tile and does not auto-extend the array when a
+    /// tile resizes to a larger family — `EntityQuery` has no default-fill hook to participate
+    /// in that. To keep the widget body looking complete after a resize-up, this resolver:
+    ///
+    /// 1. Slices oversized arrays (resize-down) to the family's slot count.
+    /// 2. Tops up undersized arrays from `catalogPriorityOrder` until full, deduping. The
+    ///    auto-fill order matches the parameter `default:` so resize-up content is predictable
+    ///    and identical to a fresh install at the new family.
+    ///
+    /// Trade-off: the Edit Widget UI is iOS-controlled and shows "Choose" placeholders for
+    /// slots that don't have an explicit user pick — even though the widget body has rendered
+    /// content there. Apple owns the Edit Widget UI; we can't surface our top-up there.
+    ///
+    static func resolveMetricSelection(
+        requested: [StoreInfoMetricType],
+        family: WidgetFamily
+    ) -> [StoreInfoMetricType] {
+        guard let target = homescreenSlotCount(family) else {
+            return requested
+        }
+
+        if requested.count > target {
+            return Array(requested.prefix(target))
+        }
+
+        var resolved = requested
+        for fallback in catalogPriorityOrder where resolved.count < target {
+            guard !resolved.contains(fallback) else { continue }
+            resolved.append(fallback)
+        }
+        return resolved
+    }
+}
+
+private extension StoreInfoDataService.Stats {
+    /// Maps a catalog metric type to the corresponding resolved value off this stats snapshot.
+    /// Currency-typed metrics carry the store's `CurrencySettings`; metrics whose data the
+    /// service couldn't fetch (`visitors` / `conversion` for self-hosted, network-degraded WPCom
+    /// fall-back) fall through to `.unavailable`.
+    ///
+    func value(for metric: StoreInfoMetricType, currencySettings: CurrencySettings) -> StoreInfoMetricValue {
+        switch metric {
+        case .revenue:
+            return .currency(revenue, currencySettings)
+        case .netSales:
+            return .currency(netRevenue, currencySettings)
+        case .averageOrderValue:
+            return .currency(averageOrderValue, currencySettings)
+        case .orders:
+            return .count(totalOrders)
+        case .itemsSold:
+            return .count(totalItemsSold)
+        case .visitors:
+            return totalVisitors.map { .count($0) } ?? .unavailable
+        case .conversion:
+            return conversion.map { .percentage($0) } ?? .unavailable
         }
     }
 }
@@ -186,46 +300,44 @@ private extension StoreInfoProvider {
 ///
 private extension StoreInfoProvider {
 
-    /// Redacted entry with sample data. If dependencies are available - store name and currency settings will be used.
+    /// Redacted entry with sample data. If dependencies are available — store name and currency
+    /// settings will be used. Both the legacy String fields and the metric-driven `metrics`
+    /// array derive from `Stats.placeholderSample` + `legacyMetricsPreset` so the two views of
+    /// the same data stay in sync.
     ///
     static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
         let currencySettings = dependencies?.storeCurrencySettings ?? CurrencySettings()
-        let revenueAmount: Decimal = 132.234
-        let metrics: [StoreInfoMetric] = [
-            StoreInfoMetric(type: .revenue, value: .currency(revenueAmount, currencySettings)),
-            StoreInfoMetric(type: .visitors, value: .count(67)),
-            StoreInfoMetric(type: .orders, value: .count(23)),
-            StoreInfoMetric(type: .conversion, value: .percentage(23.0 / 67.0))
-        ]
+        let sample = StoreInfoDataService.Stats.placeholderSample
+        let metrics: [StoreInfoMetric] = legacyMetricsPreset.map { type in
+            StoreInfoMetric(type: type, value: sample.value(for: type, currencySettings: currencySettings))
+        }
+        let visitorsString = sample.totalVisitors.map(String.init) ?? StoreInfoFormatter.Constants.valuePlaceholderText
+        let conversionString = sample.conversion.map(StoreInfoFormatter.formattedConversionString) ?? StoreInfoFormatter.Constants.valuePlaceholderText
         return .data(.init(
             range: StoreStatsWidgetDateRange.today.localizedRangeLabel,
             name: dependencies?.storeName ?? Localization.myShop,
-            revenue: StoreInfoFormatter.formattedAmountString(for: revenueAmount, with: currencySettings),
-            revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: revenueAmount, with: currencySettings),
-            visitors: "67",
-            orders: "23",
-            conversion: StoreInfoFormatter.formattedConversionString(for: 23.0 / 67.0),
+            revenue: StoreInfoFormatter.formattedAmountString(for: sample.revenue, with: currencySettings),
+            revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: sample.revenue, with: currencySettings),
+            visitors: visitorsString,
+            orders: "\(sample.totalOrders)",
+            conversion: conversionString,
             updatedTime: StoreInfoFormatter.currentFormattedTime(),
             metrics: metrics
         ))
     }
 
-    /// Real data entry.
+    /// Real data entry. `metrics` is the resolved selection — already family-sliced and topped
+    /// up by `resolveMetricSelection` for the AppIntent path, or the legacy hardcoded preset for
+    /// the `StaticConfiguration` path. Ordering here is what the home-screen view renders.
     ///
     static func dataEntry(for stats: StoreInfoDataService.Stats,
                           dateRange: StoreStatsWidgetDateRange,
-                          with dependencies: Dependencies) -> StoreInfoEntry {
+                          with dependencies: Dependencies,
+                          metrics: [StoreInfoMetricType]) -> StoreInfoEntry {
         let currencySettings = dependencies.storeCurrencySettings
-        let visitorsValue: StoreInfoMetricValue = stats.totalVisitors.map { .count($0) } ?? .unavailable
-        let conversionValue: StoreInfoMetricValue = stats.conversion.map { .percentage($0) } ?? .unavailable
-
-        // Medium-widget preset. A later ticket will let users pick this list.
-        let metrics: [StoreInfoMetric] = [
-            .init(type: .revenue, value: .currency(stats.revenue, currencySettings)),
-            .init(type: .visitors, value: visitorsValue),
-            .init(type: .orders, value: .count(stats.totalOrders)),
-            .init(type: .conversion, value: conversionValue)
-        ]
+        let resolvedMetrics: [StoreInfoMetric] = metrics.map { type in
+            StoreInfoMetric(type: type, value: stats.value(for: type, currencySettings: currencySettings))
+        }
 
         let visitorsString: String = {
             if let visitors = stats.totalVisitors {
@@ -249,7 +361,7 @@ private extension StoreInfoProvider {
             orders: "\(stats.totalOrders)",
             conversion: conversionString,
             updatedTime: StoreInfoFormatter.currentFormattedTime(),
-            metrics: metrics
+            metrics: resolvedMetrics
         ))
     }
 

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -90,7 +90,8 @@ private struct StoreInfoWidgetEntryView: View {
         case .systemMedium, .systemSmall, .systemLarge:
             // `.systemSmall` and `.systemLarge` only enter `supportedFamilies` when the
             // configurable-widgets FF is on, so reaching them implies the metric-driven path.
-            // Layouts dedicated to these sizes will land in Tickets #7 / #8.
+            // Family-specific layouts are still pending; for now all three render via
+            // `StoreInfoHomescreenWidget`'s shared body.
             StoreInfoHomescreenWidget(entry: entry)
         default:
             EmptyView()

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -3,8 +3,8 @@ import WidgetKit
 
 /// Configuration intent for the Store Stats widget.
 ///
-/// Surfaces the user-facing widget settings (long-press → Edit Widget). Subsequent tickets
-/// add `@Parameter` declarations (metrics, store picker) on top of the date range here.
+/// Surfaces the user-facing widget settings (long-press → Edit Widget). The `store` picker is
+/// added by a later ticket on top of `dateRange` and `metrics`.
 ///
 struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Store Stats"
@@ -12,9 +12,37 @@ struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
 
     @Parameter(title: "Date Range", default: .today)
     var dateRange: StoreStatsWidgetDateRange
+
+    /// User-selected metric set, in display order.
+    ///
+    /// The `size:` map drives iOS's family-aware fixed-slot rendering — small shows 2 inline
+    /// rows, medium 4, large 7. The picker shows the full catalog; metrics whose data isn't
+    /// available for the user's auth mode (`visitors`, `conversion` on self-hosted) render
+    /// with the standard "-" placeholder in the cell.
+    ///
+    /// The default lists all 7 catalog metrics in priority order so iOS persists enough state
+    /// to cover the largest family on first install. After a resize-up,
+    /// `StoreInfoProvider.resolveMetricSelection` tops up undersized arrays from the same
+    /// priority order so the widget body renders identically to a fresh install at the new
+    /// family.
+    ///
+    @Parameter(
+        title: "Metrics",
+        default: [
+            .revenue, .orders, .itemsSold, .averageOrderValue,
+            .netSales, .visitors, .conversion
+        ],
+        size: [
+            .systemSmall: .init(exactly: 2),
+            .systemMedium: .init(exactly: 4),
+            .systemLarge: .init(exactly: 7)
+        ],
+        query: AvailableMetricsQuery()
+    )
+    var metrics: [StoreInfoMetricType]
 }
 
-/// Date ranges supported by the Store Stats widget. Mirrors the Shopify reference set
+/// Date ranges supported by the Store Stats widget.
 /// ("today / last 7 days / last 30 days") called out in the project's M1 scope.
 ///
 enum StoreStatsWidgetDateRange: String, AppEnum {


### PR DESCRIPTION
WOOMOB-2813

## Description

Adds a Metrics picker to the Store Stats widget configuration intent. Stacks on #17024 — like the date range, the parameter only surfaces where the widget uses `AppIntentConfiguration` (DEBUG/ALPHA); the production `StaticConfiguration` path stays on the pre-#5 hardcoded preset.

`StoreInfoMetricType` becomes an `AppEntity` so the parameter can use the entity-array `IntentParameter` initializer with iOS 17's family-keyed `size:` map (small=2, medium=4, large=7). iOS renders this as a "Metrics" section with N inline reorderable rows; tapping a row opens the entity picker driven by `AvailableMetricsQuery`. Default lists all 7 catalog metrics so iOS persists enough state to cover the largest family on first install — a resize-up tile gets the same content as a fresh install at the new family.

The new behavior is fully gated:
- Compile-time `#if DEBUG || ALPHA` swap of `StaticConfiguration` ↔ `AppIntentConfiguration` (existing, from #17023).
- `resolveMetricSelection` and `AvailableMetricsQuery` are only invoked from `timeline(for:in:)` on the AppIntent path. The legacy `getTimeline` passes `legacyMetricsPreset = [revenue, visitors, orders, conversion]` and bypasses the resolver entirely. Production output is bit-for-bit unchanged.

## Test Steps

- Run a Debug or Alpha build and add the Store Stats widget to the home screen at small / medium / large.
- Long-press the widget → Edit Widget. Below Date Range, a "Metrics" section shows N inline rows (2 / 4 / 7) with drag handles, each tap-opening an entity picker with all 7 catalog metrics.
- Reorder rows by dragging. The widget body re-renders with the new order.
- Resize a tile from small → medium → large. New slots fill with the next entries in priority order; widget body and Edit Widget UI both reflect the change.
- For a self-hosted (non-WPCom) auth, `Visitors` and `Conversion` cells render with the standard "-" placeholder; cells for the other metrics render real values.
- Switch to a Release build. The widget continues to render the legacy 4-cell preset with no Edit Widget affordance.

## Demo

Demo video to follow.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.