### PR TITLE
Enable IPP and POS in new countries

### DIFF
--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -33,6 +33,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case posLocalCatalogM1
     case wooPosTabletPromoBanner
     case selfDrivenPushNotificationsM1
+    case inPersonPaymentsCountryExpansion
+    case inPersonPaymentsCountryExpansionEUExtended
 
     init?(rawValue: String) {
         switch rawValue {
@@ -48,6 +50,10 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .wooPosTabletPromoBanner
         case "woo_self_driven_push_notifications_m1":
             self = .selfDrivenPushNotificationsM1
+        case "woo_ipp_country_expansion":
+            self = .inPersonPaymentsCountryExpansion
+        case "woo_ipp_country_expansion_eu_extended":
+            self = .inPersonPaymentsCountryExpansionEUExtended
         default:
             return nil
         }

--- a/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -132,7 +132,8 @@ extension Storage.GeneralStoreSettings {
         lastPOSOpenedDate: NullableCopiableProp<Date> = .copy,
         firstPOSCatalogSyncDate: NullableCopiableProp<Date> = .copy,
         syncPOSCatalogOverCellular: CopiableProp<Bool> = .copy,
-        lastSunsetWarningDismissedDate: NullableCopiableProp<Date> = .copy
+        lastSunsetWarningDismissedDate: NullableCopiableProp<Date> = .copy,
+        isCardPresentPaymentsCountryExpansionEligible: NullableCopiableProp<Bool> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -158,6 +159,7 @@ extension Storage.GeneralStoreSettings {
         let firstPOSCatalogSyncDate = firstPOSCatalogSyncDate ?? self.firstPOSCatalogSyncDate
         let syncPOSCatalogOverCellular = syncPOSCatalogOverCellular ?? self.syncPOSCatalogOverCellular
         let lastSunsetWarningDismissedDate = lastSunsetWarningDismissedDate ?? self.lastSunsetWarningDismissedDate
+        let isCardPresentPaymentsCountryExpansionEligible = isCardPresentPaymentsCountryExpansionEligible ?? self.isCardPresentPaymentsCountryExpansionEligible
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -183,7 +185,8 @@ extension Storage.GeneralStoreSettings {
             lastPOSOpenedDate: lastPOSOpenedDate,
             firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
             syncPOSCatalogOverCellular: syncPOSCatalogOverCellular,
-            lastSunsetWarningDismissedDate: lastSunsetWarningDismissedDate
+            lastSunsetWarningDismissedDate: lastSunsetWarningDismissedDate,
+            isCardPresentPaymentsCountryExpansionEligible: isCardPresentPaymentsCountryExpansionEligible
         )
     }
 }

--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -103,6 +103,13 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var lastSunsetWarningDismissedDate: Date?
 
+    /// Whether this site is eligible for the In-Person Payments country expansion (RSM-637).
+    /// `nil` until the eligibility refresher has run for the first time. Cached based on
+    /// the relevant remote feature flag (`inPersonPaymentsCountryExpansion` or
+    /// `inPersonPaymentsCountryExpansionEUExtended`) for the site's country, with US/PR/CA/GB
+    /// short-circuited to `true`.
+    public var isCardPresentPaymentsCountryExpansionEligible: Bool?
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -126,7 +133,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastPOSOpenedDate: Date? = nil,
                 firstPOSCatalogSyncDate: Date? = nil,
                 syncPOSCatalogOverCellular: Bool = true,
-                lastSunsetWarningDismissedDate: Date? = nil) {
+                lastSunsetWarningDismissedDate: Date? = nil,
+                isCardPresentPaymentsCountryExpansionEligible: Bool? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -151,6 +159,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.firstPOSCatalogSyncDate = firstPOSCatalogSyncDate
         self.syncPOSCatalogOverCellular = syncPOSCatalogOverCellular
         self.lastSunsetWarningDismissedDate = lastSunsetWarningDismissedDate
+        self.isCardPresentPaymentsCountryExpansionEligible = isCardPresentPaymentsCountryExpansionEligible
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -175,7 +184,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              isPOSTabVisible: isPOSTabVisible,
                              lastPOSOpenedDate: lastPOSOpenedDate,
                              firstPOSCatalogSyncDate: firstPOSCatalogSyncDate,
-                             lastSunsetWarningDismissedDate: lastSunsetWarningDismissedDate)
+                             lastSunsetWarningDismissedDate: lastSunsetWarningDismissedDate,
+                             isCardPresentPaymentsCountryExpansionEligible: isCardPresentPaymentsCountryExpansionEligible)
     }
 }
 
@@ -214,6 +224,10 @@ extension GeneralStoreSettings {
         self.firstPOSCatalogSyncDate = try container.decodeIfPresent(Date.self, forKey: .firstPOSCatalogSyncDate)
         self.syncPOSCatalogOverCellular = try container.decodeIfPresent(Bool.self, forKey: .syncPOSCatalogOverCellular) ?? true
         self.lastSunsetWarningDismissedDate = try container.decodeIfPresent(Date.self, forKey: .lastSunsetWarningDismissedDate)
+        self.isCardPresentPaymentsCountryExpansionEligible = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .isCardPresentPaymentsCountryExpansionEligible
+        )
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -45,6 +45,12 @@ public struct CardPresentPaymentsConfiguration: Equatable {
 
     public init(country: CountryCode) {
         /// Changing `minimumVersion` values here? You'll need to also update `CardPresentPaymentsOnboardingUseCaseTests`
+        ///
+        /// This initializer describes Stripe Terminal capabilities for the given country.
+        /// The decision of whether IPP/POS should be *exposed* to the merchant is gated
+        /// upstream by `CardPresentConfigurationLoader` and the IPP entry points, which
+        /// consult the country expansion eligibility cache (RSM-637) before consuming
+        /// this configuration.
         switch country {
         case .US:
             self.init(
@@ -104,6 +110,62 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.3"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 contactlessLimitAmount: 10000,
+                minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
+            )
+        case .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES:
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.EUR],
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [
+                    .init(plugin: .wcPay, minimumVersion: "4.4.0"),
+                    .init(plugin: .stripe, minimumVersion: "6.2.0")
+                ],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                // €50 — Stripe Terminal contactless CVM limit, shared by all
+                // EEA-Euro countries we support (see https://docs.stripe.com/terminal/features/contactless).
+                contactlessLimitAmount: 5000,
+                minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
+            )
+        case .SG:
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.SGD],
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [
+                    .init(plugin: .wcPay, minimumVersion: "4.4.0"),
+                    .init(plugin: .stripe, minimumVersion: "6.2.0")
+                ],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                // Stripe Terminal's published contactless limits don't include SG
+                // (see https://docs.stripe.com/terminal/features/contactless), so
+                // we leave this `nil` to match the US/PR shape and let the reader
+                // apply its own scheme limits.
+                contactlessLimitAmount: nil,
+                minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
+            )
+        case .NZ:
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.NZD],
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [
+                    .init(plugin: .wcPay, minimumVersion: "4.4.0"),
+                    .init(plugin: .stripe, minimumVersion: "6.2.0")
+                ],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                // NZD 200 — Stripe Terminal contactless CVM limit
+                // (see https://docs.stripe.com/terminal/features/contactless).
+                contactlessLimitAmount: 20000,
                 minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
             )
         default:

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
@@ -2,36 +2,82 @@ import Foundation
 import enum WooFoundation.CountryCode
 import enum WooFoundation.CurrencyCode
 
-/// Validator for POS country and currency support
-/// Single source of truth for supported countries and currencies
+/// Validator for POS country and currency support.
+///
+/// Single source of truth for the supported country/currency pairings. The 13 expansion
+/// countries (RSM-637) are accepted only when the supplied
+/// ``CardPresentPaymentsCountryExpansionEligibilityServiceProtocol`` reports the site as
+/// eligible. US/GB are always supported.
 public enum POSCountryCurrencyValidator {
-    /// Supported countries for POS feature
-    public static let supportedCountries: [CountryCode] = [.US, .GB]
+    /// Supported countries for POS feature.
+    /// Always includes US and GB. The 13 expansion countries are added when the supplied
+    /// eligibility service reports the site as eligible.
+    public static func supportedCountries(
+        siteID: Int64,
+        eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+    ) -> [CountryCode] {
+        var countries: [CountryCode] = [.US, .GB]
+        if eligibilityService.isEligible(siteID: siteID) {
+            countries.append(contentsOf: expansionCountries)
+        }
+        return countries
+    }
 
-    /// Supported currencies per country for POS feature
-    public static let supportedCurrencies: [CountryCode: [CurrencyCode]] = [
-        .US: [.USD],
-        .GB: [.GBP]
-    ]
+    /// Supported currencies per country for POS feature.
+    /// Always includes US/USD and GB/GBP. Expansion entries are added when the supplied
+    /// eligibility service reports the site as eligible.
+    public static func supportedCurrencies(
+        siteID: Int64,
+        eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+    ) -> [CountryCode: [CurrencyCode]] {
+        var map: [CountryCode: [CurrencyCode]] = [
+            .US: [.USD],
+            .GB: [.GBP]
+        ]
+        if eligibilityService.isEligible(siteID: siteID) {
+            for country in eeaEuroCountries {
+                map[country] = [.EUR]
+            }
+            map[.SG] = [.SGD]
+            map[.NZ] = [.NZD]
+        }
+        return map
+    }
 
-    /// Validates if a country and currency combination is eligible for POS
+    /// Validates if a country and currency combination is eligible for POS.
     /// - Parameters:
-    ///   - countryCode: The store's country code
-    ///   - currencyCode: The store's currency code
-    /// - Returns: Eligibility state with reason if ineligible
-    public static func validate(countryCode: CountryCode, currencyCode: CurrencyCode) -> ValidationResult {
+    ///   - countryCode: The store's country code.
+    ///   - currencyCode: The store's currency code.
+    ///   - siteID: The site ID, used to look up per-site expansion eligibility.
+    ///   - eligibilityService: The cached expansion eligibility for this site.
+    /// - Returns: Eligibility state with reason if ineligible.
+    public static func validate(
+        countryCode: CountryCode,
+        currencyCode: CurrencyCode,
+        siteID: Int64,
+        eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+    ) -> ValidationResult {
+        let supportedCountries = self.supportedCountries(siteID: siteID, eligibilityService: eligibilityService)
         // Check country first
         guard supportedCountries.contains(countryCode) else {
             return .ineligible(reason: .unsupportedCountry(supportedCountries: supportedCountries))
         }
 
         // Check currency for the country
-        let supportedCurrenciesForCountry = supportedCurrencies[countryCode] ?? []
+        let supportedCurrenciesForCountry = supportedCurrencies(siteID: siteID, eligibilityService: eligibilityService)[countryCode] ?? []
         guard supportedCurrenciesForCountry.contains(currencyCode) else {
             return .ineligible(reason: .unsupportedCurrency(countryCode: countryCode, supportedCurrencies: supportedCurrenciesForCountry))
         }
 
         return .eligible
+    }
+
+    private static let eeaEuroCountries: [CountryCode] = [
+        .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES
+    ]
+
+    private static var expansionCountries: [CountryCode] {
+        eeaEuroCountries + [.SG, .NZ]
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
@@ -7,16 +7,16 @@ import enum WooFoundation.CurrencyCode
 /// Single source of truth for the supported country/currency pairings. The 13 expansion
 /// countries (RSM-637) are accepted only when the supplied
 /// ``CardPresentPaymentsCountryExpansionEligibilityServiceProtocol`` reports the site as
-/// eligible. US/GB are always supported.
+/// eligible. US/PR/GB are always supported.
 public enum POSCountryCurrencyValidator {
     /// Supported countries for POS feature.
-    /// Always includes US and GB. The 13 expansion countries are added when the supplied
+    /// Always includes US, PR, and GB. The 13 expansion countries are added when the supplied
     /// eligibility service reports the site as eligible.
     public static func supportedCountries(
         siteID: Int64,
         eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
     ) -> [CountryCode] {
-        var countries: [CountryCode] = [.US, .GB]
+        var countries: [CountryCode] = [.US, .PR, .GB]
         if eligibilityService.isEligible(siteID: siteID) {
             countries.append(contentsOf: expansionCountries)
         }
@@ -24,7 +24,7 @@ public enum POSCountryCurrencyValidator {
     }
 
     /// Supported currencies per country for POS feature.
-    /// Always includes US/USD and GB/GBP. Expansion entries are added when the supplied
+    /// Always includes US/USD, PR/USD, and GB/GBP. Expansion entries are added when the supplied
     /// eligibility service reports the site as eligible.
     public static func supportedCurrencies(
         siteID: Int64,
@@ -32,6 +32,7 @@ public enum POSCountryCurrencyValidator {
     ) -> [CountryCode: [CurrencyCode]] {
         var map: [CountryCode: [CurrencyCode]] = [
             .US: [.USD],
+            .PR: [.USD],
             .GB: [.GBP]
         ]
         if eligibilityService.isEligible(siteID: siteID) {

--- a/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SiteSpecificAppSettingsStoreMethods.swift
@@ -25,6 +25,10 @@ public protocol SiteSpecificAppSettingsStoreMethodsProtocol {
     // POS sunset warning
     func getSunsetWarningLastDismissedDate(siteID: Int64) -> Date?
     func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date)
+
+    // Card-present payments country expansion eligibility (RSM-637)
+    func loadCardPresentPaymentsCountryExpansionEligibility(siteID: Int64) -> Bool?
+    func saveCardPresentPaymentsCountryExpansionEligibility(siteID: Int64, isEligible: Bool)
 }
 
 /// Methods for managing site-specific app settings
@@ -156,6 +160,19 @@ extension SiteSpecificAppSettingsStoreMethods {
     public func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {
         let storeSettings = getStoreSettings(for: siteID)
         let updatedSettings = storeSettings.copy(lastSunsetWarningDismissedDate: date)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+}
+
+// MARK: - Card-present payments country expansion eligibility (RSM-637)
+extension SiteSpecificAppSettingsStoreMethods {
+    public func loadCardPresentPaymentsCountryExpansionEligibility(siteID: Int64) -> Bool? {
+        getStoreSettings(for: siteID).isCardPresentPaymentsCountryExpansionEligible
+    }
+
+    public func saveCardPresentPaymentsCountryExpansionEligibility(siteID: Int64, isEligible: Bool) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(isCardPresentPaymentsCountryExpansionEligible: isEligible)
         setStoreSettings(settings: updatedSettings, for: siteID)
     }
 }

--- a/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresher.swift
+++ b/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresher.swift
@@ -1,0 +1,72 @@
+import Foundation
+import enum WooFoundation.CountryCode
+
+/// Refreshes the cached In-Person Payments country expansion eligibility for a site
+/// (RSM-637). Maps the site's country to the relevant remote feature flag, fetches
+/// the latest value via the supplied provider, and writes it back through
+/// ``CardPresentPaymentsCountryExpansionEligibilityServiceProtocol``.
+///
+/// US/PR/CA/GB short-circuit to `true` without any flag dispatch.
+public final class CardPresentPaymentsCountryExpansionEligibilityRefresher: @unchecked Sendable {
+    private let eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+    private let remoteFeatureFlagProvider: @Sendable (RemoteFeatureFlag) async -> Bool
+
+    public init(
+        eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService(),
+        remoteFeatureFlagProvider: @escaping @Sendable (RemoteFeatureFlag) async -> Bool
+    ) {
+        self.eligibilityService = eligibilityService
+        self.remoteFeatureFlagProvider = remoteFeatureFlagProvider
+    }
+
+    /// Refreshes the cached eligibility for `siteID` based on `countryCode`.
+    /// Existing IPP countries (US/PR/CA/GB) short-circuit to `true`.
+    /// Expansion countries dispatch the relevant remote feature flag and persist the result.
+    public func refresh(siteID: Int64, countryCode: CountryCode) async {
+        guard let flag = Self.flag(for: countryCode) else {
+            // Either an existing supported country or one we don't know about — short-circuit.
+            // For existing supported countries we want eligibility = true so they keep working.
+            // For unknown countries the eligibility flag is irrelevant (the country lookup will
+            // fail at the configuration level), so returning `true` is harmless.
+            eligibilityService.cacheEligibility(siteID: siteID, isEligible: true)
+            return
+        }
+        let isEnabled = await remoteFeatureFlagProvider(flag)
+        eligibilityService.cacheEligibility(siteID: siteID, isEligible: isEnabled)
+    }
+
+    /// Returns the remote feature flag that gates IPP for the given country, if any.
+    /// Returns `nil` for the existing supported countries (US/PR/CA/GB), which need no flag.
+    public static func flag(for country: CountryCode) -> RemoteFeatureFlag? {
+        switch country {
+        case .US, .PR, .CA, .GB:
+            return nil
+        case .FR, .DE, .IE, .NL, .SG, .NZ:
+            return .inPersonPaymentsCountryExpansion
+        case .AT, .BE, .FI, .IT, .LU, .PT, .ES:
+            return .inPersonPaymentsCountryExpansionEUExtended
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - Factory
+
+public extension CardPresentPaymentsCountryExpansionEligibilityRefresher {
+    /// Builds a `(RemoteFeatureFlag) async -> Bool` provider that dispatches a
+    /// `FeatureFlagAction` against the supplied stores. Defaults to `false` when the
+    /// network or remote flag is unavailable.
+    static func makeRemoteFeatureFlagProvider(stores: StoresManager) -> @Sendable (RemoteFeatureFlag) async -> Bool {
+        return { flag in
+            await withCheckedContinuation { continuation in
+                Task { @MainActor in
+                    let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(flag, defaultValue: false) { isEnabled in
+                        continuation.resume(returning: isEnabled)
+                    }
+                    stores.dispatch(action)
+                }
+            }
+        }
+    }
+}

--- a/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityService.swift
+++ b/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityService.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Storage
+
+/// Protocol defining the interface for the In-Person Payments country expansion
+/// eligibility service (RSM-637).
+///
+/// Provides synchronous reads of a per-site cached boolean answering "is this site
+/// allowed to expose IPP based on its country and the relevant remote feature flag".
+public protocol CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    /// Returns the cached eligibility for a given site. Defaults to `false` until the
+    /// refresher has run for the first time.
+    func isEligible(siteID: Int64) -> Bool
+
+    /// Persists the latest eligibility for a given site. Reads from
+    /// ``isEligible(siteID:)`` will reflect the new value on subsequent launches.
+    func cacheEligibility(siteID: Int64, isEligible: Bool)
+}
+
+public final class CardPresentPaymentsCountryExpansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    private let siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol
+
+    public convenience init() {
+        self.init(siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethods(fileStorage: PListFileStorage()))
+    }
+
+    init(siteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStoreMethodsProtocol) {
+        self.siteSpecificAppSettingsStoreMethods = siteSpecificAppSettingsStoreMethods
+    }
+
+    public func isEligible(siteID: Int64) -> Bool {
+        siteSpecificAppSettingsStoreMethods.loadCardPresentPaymentsCountryExpansionEligibility(siteID: siteID) ?? false
+    }
+
+    public func cacheEligibility(siteID: Int64, isEligible: Bool) {
+        siteSpecificAppSettingsStoreMethods.saveCardPresentPaymentsCountryExpansionEligibility(siteID: siteID, isEligible: isEligible)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -63,4 +63,10 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     }
 
     func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {}
+
+    func loadCardPresentPaymentsCountryExpansionEligibility(siteID: Int64) -> Bool? {
+        nil
+    }
+
+    func saveCardPresentPaymentsCountryExpansionEligibility(siteID: Int64, isEligible: Bool) {}
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSpecificAppSettingsStoreMethods.swift
@@ -44,6 +44,13 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     var setSunsetWarningLastDismissedDateCalled = false
     var mockSunsetWarningLastDismissedDate: Date?
 
+    // Card-present payments country expansion eligibility (RSM-637)
+    var loadCardPresentPaymentsCountryExpansionEligibilityCalled = false
+    var saveCardPresentPaymentsCountryExpansionEligibilityCalled = false
+    var mockCardPresentPaymentsCountryExpansionEligibility: Bool?
+    var spySavedCardPresentPaymentsCountryExpansionEligibility: Bool?
+    var spySavedCardPresentPaymentsCountryExpansionEligibilitySiteID: Int64?
+
     func getStoreSettings(for siteID: Int64) -> GeneralStoreSettings {
         getStoreSettingsCalled = true
         return storeSettings
@@ -140,5 +147,18 @@ final class MockSiteSpecificAppSettingsStoreMethods: SiteSpecificAppSettingsStor
     func setSunsetWarningLastDismissedDate(siteID: Int64, date: Date) {
         setSunsetWarningLastDismissedDateCalled = true
         mockSunsetWarningLastDismissedDate = date
+    }
+
+    // Card-present payments country expansion eligibility methods
+    func loadCardPresentPaymentsCountryExpansionEligibility(siteID: Int64) -> Bool? {
+        loadCardPresentPaymentsCountryExpansionEligibilityCalled = true
+        return mockCardPresentPaymentsCountryExpansionEligibility
+    }
+
+    func saveCardPresentPaymentsCountryExpansionEligibility(siteID: Int64, isEligible: Bool) {
+        saveCardPresentPaymentsCountryExpansionEligibilityCalled = true
+        spySavedCardPresentPaymentsCountryExpansionEligibility = isEligible
+        spySavedCardPresentPaymentsCountryExpansionEligibilitySiteID = siteID
+        mockCardPresentPaymentsCountryExpansionEligibility = isEligible
     }
 }

--- a/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -51,6 +51,62 @@ class CardPresentConfigurationTests: XCTestCase {
         assertEqual(10000, configuration.contactlessLimitAmount)
     }
 
+    // MARK: - Country Expansion (RSM-637)
+    //
+    // The model knows about all 13 expansion countries unconditionally; per-site exposure
+    // is gated upstream by `CardPresentConfigurationLoader` + the eligibility cache.
+
+    func test_configuration_for_each_EEA_Euro_expansion_country() {
+        let eeaCountries: [CountryCode] = [.AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES]
+        for country in eeaCountries {
+            let configuration = CardPresentPaymentsConfiguration(country: country)
+            XCTAssertTrue(configuration.isSupportedCountry, "Expected \(country) to be supported by the model")
+            XCTAssertEqual(configuration.currencies, [.EUR])
+            XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+            XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
+            XCTAssertEqual(configuration.supportedReaders, [.wisepad3])
+            XCTAssertEqual(configuration.supportedPluginVersions, [
+                .init(plugin: .wcPay, minimumVersion: "4.4.0"),
+                .init(plugin: .stripe, minimumVersion: "6.2.0")
+            ])
+            XCTAssertEqual(configuration.minimumAllowedChargeAmount, NSDecimalNumber(string: "0.5"))
+            // €50 — Stripe Terminal contactless CVM limit for EEA-Euro countries.
+            XCTAssertEqual(configuration.contactlessLimitAmount, 5000)
+            XCTAssertEqual(configuration.stripeSmallestCurrencyUnitMultiplier, 100)
+        }
+    }
+
+    func test_configuration_for_Singapore() {
+        let configuration = CardPresentPaymentsConfiguration(country: .SG)
+        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertEqual(configuration.currencies, [.SGD])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
+        XCTAssertEqual(configuration.supportedReaders, [.wisepad3])
+        XCTAssertEqual(configuration.minimumAllowedChargeAmount, NSDecimalNumber(string: "0.5"))
+        // SG isn't in Stripe Terminal's published contactless limit table, so we leave it nil.
+        XCTAssertNil(configuration.contactlessLimitAmount)
+    }
+
+    func test_configuration_for_New_Zealand() {
+        let configuration = CardPresentPaymentsConfiguration(country: .NZ)
+        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertEqual(configuration.currencies, [.NZD])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
+        XCTAssertEqual(configuration.supportedReaders, [.wisepad3])
+        XCTAssertEqual(configuration.minimumAllowedChargeAmount, NSDecimalNumber(string: "0.5"))
+        // NZD 200 — Stripe Terminal contactless CVM limit.
+        XCTAssertEqual(configuration.contactlessLimitAmount, 20000)
+    }
+
+    // Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643).
+    func test_configuration_for_Australia_is_unsupported() {
+        let configuration = CardPresentPaymentsConfiguration(country: .AU)
+        XCTAssertFalse(configuration.isSupportedCountry)
+        XCTAssertEqual(configuration.paymentMethods, [])
+        XCTAssertEqual(configuration.currencies, [])
+    }
 
     private enum Constants {
 

--- a/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
@@ -30,6 +30,15 @@ struct POSCountryCurrencyValidatorTests {
         #expect(result == .eligible)
     }
 
+    @Test("PR with USD is eligible without expansion eligibility")
+    func test_PR_with_USD_is_eligible_without_expansion_eligibility() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .PR,
+                                                          currencyCode: .USD,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
+        #expect(result == .eligible)
+    }
+
     // MARK: - Unsupported Countries (eligibility off)
 
     @Test("CA with USD is ineligible due to unsupported country when expansion eligibility off")
@@ -149,19 +158,21 @@ struct POSCountryCurrencyValidatorTests {
 
     // MARK: - Supported Countries List
 
-    @Test("Supported countries list contains only US and GB when expansion eligibility off")
+    @Test("Supported countries list contains only US, PR, and GB when expansion eligibility off")
     func testSupportedCountriesList() {
         let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: ineligibleService)
-        #expect(supportedCountries.count == 2)
+        #expect(supportedCountries.count == 3)
         #expect(supportedCountries.contains(.US))
+        #expect(supportedCountries.contains(.PR))
         #expect(supportedCountries.contains(.GB))
     }
 
-    @Test("Supported countries list contains all 15 countries when expansion eligibility on")
+    @Test("Supported countries list contains all 16 countries when expansion eligibility on")
     func testSupportedCountriesIncludeExpansionCountriesWhenEligibilityOn() {
         let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: eligibleService)
 
         #expect(supportedCountries.contains(.US))
+        #expect(supportedCountries.contains(.PR))
         #expect(supportedCountries.contains(.GB))
         for country in expansionCountries {
             #expect(supportedCountries.contains(country), "Expected \(country) to be supported when eligibility is on")
@@ -172,11 +183,12 @@ struct POSCountryCurrencyValidatorTests {
 
     // MARK: - Supported Currencies Map
 
-    @Test("Supported currencies map only contains US and GB entries when expansion eligibility off")
+    @Test("Supported currencies map only contains US, PR, and GB entries when expansion eligibility off")
     func testSupportedCurrenciesMap() {
         let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies(siteID: siteID, eligibilityService: ineligibleService)
 
         #expect(supportedCurrencies[.US] == [.USD])
+        #expect(supportedCurrencies[.PR] == [.USD])
         #expect(supportedCurrencies[.GB] == [.GBP])
         #expect(supportedCurrencies[.CA] == nil)
         #expect(supportedCurrencies[.AT] == nil)

--- a/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
@@ -6,37 +6,47 @@ import enum WooFoundation.CurrencyCode
 
 @Suite("POSCountryCurrencyValidator Tests")
 struct POSCountryCurrencyValidatorTests {
+    private let siteID: Int64 = 42
+    private let ineligibleService = StubExpansionEligibilityService(isEligible: false)
+    private let eligibleService = StubExpansionEligibilityService(isEligible: true)
 
-    // MARK: - Eligible Combinations
+    // MARK: - Eligible Combinations (always-on)
 
     @Test("US with USD is eligible")
     func testUSWithUSDIsEligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .US, currencyCode: .USD)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .US,
+                                                          currencyCode: .USD,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
         #expect(result == .eligible)
     }
 
     @Test("GB with GBP is eligible")
     func testGBWithGBPIsEligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .GB, currencyCode: .GBP)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .GB,
+                                                          currencyCode: .GBP,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
         #expect(result == .eligible)
     }
 
-    // MARK: - Unsupported Countries
+    // MARK: - Unsupported Countries (eligibility off)
 
-    @Test("CA with USD is ineligible due to unsupported country")
+    @Test("CA with USD is ineligible due to unsupported country when expansion eligibility off")
     func testCAWithUSDIsIneligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .CA, currencyCode: .USD)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .CA,
+                                                          currencyCode: .USD,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
             return
         }
-
         guard case .unsupportedCountry(let supportedCountries) = reason else {
             Issue.record("Expected unsupportedCountry reason")
             return
         }
-
         #expect(supportedCountries.contains(.US))
         #expect(supportedCountries.contains(.GB))
         #expect(!supportedCountries.contains(.CA))
@@ -44,13 +54,15 @@ struct POSCountryCurrencyValidatorTests {
 
     @Test("AU with AUD is ineligible due to unsupported country")
     func testAUWithAUDIsIneligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .AU, currencyCode: .AUD)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .AU,
+                                                          currencyCode: .AUD,
+                                                          siteID: siteID,
+                                                          eligibilityService: eligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
             return
         }
-
         guard case .unsupportedCountry = reason else {
             Issue.record("Expected unsupportedCountry reason")
             return
@@ -61,94 +73,194 @@ struct POSCountryCurrencyValidatorTests {
 
     @Test("US with EUR is ineligible due to unsupported currency")
     func testUSWithEURIsIneligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .US, currencyCode: .EUR)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .US,
+                                                          currencyCode: .EUR,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
             return
         }
-
         guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
             Issue.record("Expected unsupportedCurrency reason")
             return
         }
-
         #expect(countryCode == .US)
         #expect(supportedCurrencies == [.USD])
     }
 
     @Test("US with GBP is ineligible due to unsupported currency")
     func testUSWithGBPIsIneligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .US, currencyCode: .GBP)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .US,
+                                                          currencyCode: .GBP,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
             return
         }
-
         guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
             Issue.record("Expected unsupportedCurrency reason")
             return
         }
-
         #expect(countryCode == .US)
         #expect(supportedCurrencies == [.USD])
     }
 
     @Test("GB with USD is ineligible due to unsupported currency")
     func testGBWithUSDIsIneligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .GB, currencyCode: .USD)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .GB,
+                                                          currencyCode: .USD,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
             return
         }
-
         guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
             Issue.record("Expected unsupportedCurrency reason")
             return
         }
-
         #expect(countryCode == .GB)
         #expect(supportedCurrencies == [.GBP])
     }
 
     @Test("GB with EUR is ineligible due to unsupported currency")
     func testGBWithEURIsIneligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .GB, currencyCode: .EUR)
+        let result = POSCountryCurrencyValidator.validate(countryCode: .GB,
+                                                          currencyCode: .EUR,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
             return
         }
-
         guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
             Issue.record("Expected unsupportedCurrency reason")
             return
         }
-
         #expect(countryCode == .GB)
         #expect(supportedCurrencies == [.GBP])
     }
 
     // MARK: - Supported Countries List
 
-    @Test("Supported countries list contains US and GB")
+    @Test("Supported countries list contains only US and GB when expansion eligibility off")
     func testSupportedCountriesList() {
-        let supportedCountries = POSCountryCurrencyValidator.supportedCountries
+        let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: ineligibleService)
         #expect(supportedCountries.count == 2)
         #expect(supportedCountries.contains(.US))
         #expect(supportedCountries.contains(.GB))
     }
 
+    @Test("Supported countries list contains all 15 countries when expansion eligibility on")
+    func testSupportedCountriesIncludeExpansionCountriesWhenEligibilityOn() {
+        let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: eligibleService)
+
+        #expect(supportedCountries.contains(.US))
+        #expect(supportedCountries.contains(.GB))
+        for country in expansionCountries {
+            #expect(supportedCountries.contains(country), "Expected \(country) to be supported when eligibility is on")
+        }
+        // Australia is intentionally excluded pending EFTPOS support (RSM-642/643)
+        #expect(!supportedCountries.contains(.AU))
+    }
+
     // MARK: - Supported Currencies Map
 
-    @Test("Supported currencies map has correct structure")
+    @Test("Supported currencies map only contains US and GB entries when expansion eligibility off")
     func testSupportedCurrenciesMap() {
-        let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies
+        let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies(siteID: siteID, eligibilityService: ineligibleService)
 
         #expect(supportedCurrencies[.US] == [.USD])
         #expect(supportedCurrencies[.GB] == [.GBP])
         #expect(supportedCurrencies[.CA] == nil)
+        #expect(supportedCurrencies[.AT] == nil)
+        #expect(supportedCurrencies[.SG] == nil)
+        #expect(supportedCurrencies[.NZ] == nil)
+    }
+
+    @Test("Supported currencies map includes EUR/SGD/NZD entries when expansion eligibility on")
+    func testSupportedCurrenciesMapIncludesExpansionEntriesWhenEligibilityOn() {
+        let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies(siteID: siteID, eligibilityService: eligibleService)
+
+        for country in eeaEuroCountries {
+            #expect(supportedCurrencies[country] == [.EUR], "Expected \(country) to map to EUR when eligibility is on")
+        }
+        #expect(supportedCurrencies[.SG] == [.SGD])
+        #expect(supportedCurrencies[.NZ] == [.NZD])
+        #expect(supportedCurrencies[.AU] == nil)
+    }
+
+    // MARK: - Country Expansion (eligibility on)
+
+    @Test(arguments: [
+        (country: CountryCode.AT, currency: CurrencyCode.EUR),
+        (country: CountryCode.BE, currency: CurrencyCode.EUR),
+        (country: CountryCode.FI, currency: CurrencyCode.EUR),
+        (country: CountryCode.FR, currency: CurrencyCode.EUR),
+        (country: CountryCode.DE, currency: CurrencyCode.EUR),
+        (country: CountryCode.IE, currency: CurrencyCode.EUR),
+        (country: CountryCode.IT, currency: CurrencyCode.EUR),
+        (country: CountryCode.LU, currency: CurrencyCode.EUR),
+        (country: CountryCode.NL, currency: CurrencyCode.EUR),
+        (country: CountryCode.PT, currency: CurrencyCode.EUR),
+        (country: CountryCode.ES, currency: CurrencyCode.EUR),
+        (country: CountryCode.SG, currency: CurrencyCode.SGD),
+        (country: CountryCode.NZ, currency: CurrencyCode.NZD)
+    ])
+    func expansion_country_with_local_currency_is_eligible_when_eligibility_on(country: CountryCode, currency: CurrencyCode) {
+        let result = POSCountryCurrencyValidator.validate(countryCode: country,
+                                                          currencyCode: currency,
+                                                          siteID: siteID,
+                                                          eligibilityService: eligibleService)
+        #expect(result == .eligible)
+    }
+
+    @Test("Expansion country with mismatched currency is ineligible when eligibility on")
+    func test_expansion_country_with_mismatched_currency_is_ineligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .DE,
+                                                          currencyCode: .USD,
+                                                          siteID: siteID,
+                                                          eligibilityService: eligibleService)
+        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .DE, supportedCurrencies: [.EUR])))
+    }
+
+    @Test("Expansion country is unsupported when eligibility off")
+    func test_expansion_country_is_unsupported_when_eligibility_off() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .DE,
+                                                          currencyCode: .EUR,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
+        guard case .ineligible(let reason) = result, case .unsupportedCountry = reason else {
+            Issue.record("Expected unsupportedCountry result, got \(result)")
+            return
+        }
+    }
+
+    private let eeaEuroCountries: [CountryCode] = [
+        .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES
+    ]
+
+    private var expansionCountries: [CountryCode] {
+        eeaEuroCountries + [.SG, .NZ]
+    }
+}
+
+// MARK: - Test Helpers
+
+private struct StubExpansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    let isEligible: Bool
+
+    func isEligible(siteID: Int64) -> Bool {
+        isEligible
+    }
+
+    func cacheEligibility(siteID: Int64, isEligible: Bool) {
+        // No-op; tests don't exercise caching here.
     }
 }

--- a/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresherTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresherTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import Testing
+import enum WooFoundation.CountryCode
+@testable import Yosemite
+
+@Suite("CardPresentPaymentsCountryExpansionEligibilityRefresher Tests")
+struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
+    private let siteID: Int64 = 99
+
+    // MARK: - Country → flag mapping
+
+    @Test("flag(for:) returns nil for existing supported countries")
+    func test_flag_for_existing_supported_countries() {
+        for country in [CountryCode.US, .PR, .CA, .GB] {
+            #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: country) == nil,
+                    "Expected \(country) to require no expansion flag")
+        }
+    }
+
+    @Test("flag(for:) returns inPersonPaymentsCountryExpansion for the primary group")
+    func test_flag_for_primary_expansion_group() {
+        for country in [CountryCode.FR, .DE, .IE, .NL, .SG, .NZ] {
+            #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: country)
+                    == .inPersonPaymentsCountryExpansion,
+                    "Expected \(country) to map to inPersonPaymentsCountryExpansion")
+        }
+    }
+
+    @Test("flag(for:) returns inPersonPaymentsCountryExpansionEUExtended for the EU extended group")
+    func test_flag_for_eu_extended_expansion_group() {
+        for country in [CountryCode.AT, .BE, .FI, .IT, .LU, .PT, .ES] {
+            #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: country)
+                    == .inPersonPaymentsCountryExpansionEUExtended,
+                    "Expected \(country) to map to inPersonPaymentsCountryExpansionEUExtended")
+        }
+    }
+
+    @Test("flag(for:) returns nil for AU (intentionally excluded — RSM-642/643)")
+    func test_flag_for_excluded_australia() {
+        #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: .AU) == nil)
+    }
+
+    // MARK: - Refresh behaviour
+
+    @Test("refresh short-circuits to true for existing supported countries without dispatching a flag")
+    func test_refresh_short_circuits_for_existing_country() async {
+        // Given
+        let service = SpyEligibilityService()
+        var providerInvocations: [RemoteFeatureFlag] = []
+        let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: service,
+            remoteFeatureFlagProvider: { flag in
+                providerInvocations.append(flag)
+                return false
+            }
+        )
+
+        // When
+        await refresher.refresh(siteID: siteID, countryCode: .US)
+
+        // Then
+        #expect(providerInvocations.isEmpty, "Existing supported country must not dispatch a flag check")
+        #expect(service.cachedValues == [siteID: true])
+    }
+
+    @Test("refresh persists the provider's true value for primary-group countries")
+    func test_refresh_persists_true_for_primary_group_when_flag_on() async {
+        // Given
+        let service = SpyEligibilityService()
+        let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: service,
+            remoteFeatureFlagProvider: { flag in
+                #expect(flag == .inPersonPaymentsCountryExpansion)
+                return true
+            }
+        )
+
+        // When
+        await refresher.refresh(siteID: siteID, countryCode: .FR)
+
+        // Then
+        #expect(service.cachedValues == [siteID: true])
+    }
+
+    @Test("refresh persists the provider's false value for primary-group countries")
+    func test_refresh_persists_false_for_primary_group_when_flag_off() async {
+        // Given
+        let service = SpyEligibilityService()
+        let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: service,
+            remoteFeatureFlagProvider: { _ in false }
+        )
+
+        // When
+        await refresher.refresh(siteID: siteID, countryCode: .NZ)
+
+        // Then
+        #expect(service.cachedValues == [siteID: false])
+    }
+
+    @Test("refresh dispatches inPersonPaymentsCountryExpansionEUExtended for EU extended countries")
+    func test_refresh_dispatches_eu_extended_flag() async {
+        // Given
+        let service = SpyEligibilityService()
+        var dispatchedFlag: RemoteFeatureFlag?
+        let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: service,
+            remoteFeatureFlagProvider: { flag in
+                dispatchedFlag = flag
+                return true
+            }
+        )
+
+        // When
+        await refresher.refresh(siteID: siteID, countryCode: .ES)
+
+        // Then
+        #expect(dispatchedFlag == .inPersonPaymentsCountryExpansionEUExtended)
+        #expect(service.cachedValues == [siteID: true])
+    }
+
+    @Test("refresh persists per site")
+    func test_refresh_persists_per_site() async {
+        // Given
+        let service = SpyEligibilityService()
+        let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: service,
+            remoteFeatureFlagProvider: { _ in true }
+        )
+
+        // When
+        await refresher.refresh(siteID: 1, countryCode: .DE)
+        await refresher.refresh(siteID: 2, countryCode: .ES)
+        await refresher.refresh(siteID: 3, countryCode: .US)
+
+        // Then
+        #expect(service.cachedValues == [1: true, 2: true, 3: true])
+    }
+}
+
+// MARK: - Test Helpers
+
+private final class SpyEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    private(set) var cachedValues: [Int64: Bool] = [:]
+
+    func isEligible(siteID: Int64) -> Bool {
+        cachedValues[siteID] ?? false
+    }
+
+    func cacheEligibility(siteID: Int64, isEligible: Bool) {
+        cachedValues[siteID] = isEligible
+    }
+}

--- a/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityServiceTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+import Storage
+@testable import Yosemite
+
+@Suite("CardPresentPaymentsCountryExpansionEligibilityService Tests")
+struct CardPresentPaymentsCountryExpansionEligibilityServiceTests {
+    private let siteID: Int64 = 1234
+
+    @Test("isEligible returns false when no value has been cached")
+    func test_isEligible_returns_false_when_uncached() {
+        // Given
+        let mockStore = MockSiteSpecificAppSettingsStoreMethods()
+        mockStore.currentSiteID = siteID
+        let service = CardPresentPaymentsCountryExpansionEligibilityService(siteSpecificAppSettingsStoreMethods: mockStore)
+
+        // When / Then
+        #expect(service.isEligible(siteID: siteID) == false)
+    }
+
+    @Test("isEligible returns true after cacheEligibility(true)")
+    func test_isEligible_returns_true_after_caching_true() {
+        // Given
+        let mockStore = MockSiteSpecificAppSettingsStoreMethods()
+        mockStore.currentSiteID = siteID
+        let service = CardPresentPaymentsCountryExpansionEligibilityService(siteSpecificAppSettingsStoreMethods: mockStore)
+
+        // When
+        service.cacheEligibility(siteID: siteID, isEligible: true)
+
+        // Then
+        #expect(service.isEligible(siteID: siteID) == true)
+    }
+
+    @Test("isEligible returns false after cacheEligibility(false)")
+    func test_isEligible_returns_false_after_caching_false() {
+        // Given
+        let mockStore = MockSiteSpecificAppSettingsStoreMethods()
+        mockStore.currentSiteID = siteID
+        mockStore.mockCardPresentPaymentsCountryExpansionEligibility = true
+        let service = CardPresentPaymentsCountryExpansionEligibilityService(siteSpecificAppSettingsStoreMethods: mockStore)
+
+        // When
+        service.cacheEligibility(siteID: siteID, isEligible: false)
+
+        // Then
+        #expect(service.isEligible(siteID: siteID) == false)
+        #expect(mockStore.spySavedCardPresentPaymentsCountryExpansionEligibility == false)
+        #expect(mockStore.spySavedCardPresentPaymentsCountryExpansionEligibilitySiteID == siteID)
+    }
+
+    @Test("cacheEligibility persists per site via the storage methods")
+    func test_cacheEligibility_persists_per_site() {
+        // Given
+        let mockStore = MockSiteSpecificAppSettingsStoreMethods()
+        mockStore.currentSiteID = siteID
+        let service = CardPresentPaymentsCountryExpansionEligibilityService(siteSpecificAppSettingsStoreMethods: mockStore)
+
+        // When
+        service.cacheEligibility(siteID: siteID, isEligible: true)
+
+        // Then
+        #expect(mockStore.saveCardPresentPaymentsCountryExpansionEligibilityCalled == true)
+        #expect(mockStore.spySavedCardPresentPaymentsCountryExpansionEligibility == true)
+        #expect(mockStore.spySavedCardPresentPaymentsCountryExpansionEligibilitySiteID == siteID)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Performance card: pick which order date type drives the totals (paid, placed, or completed) from a bottom sheet. [https://github.com/woocommerce/woocommerce-ios/pull/16988]
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
 - [*] POS: Update empty orders state copy and replace "Learn more" with "Refresh" [https://github.com/woocommerce/woocommerce-ios/pull/16961]
+- [Internal] Add `inPersonPaymentsCountryExpansion` and `inPersonPaymentsCountryExpansionEUExtended` remote feature flags gating IPP and POS support for 13 new countries — `inPersonPaymentsCountryExpansion` covers FR/DE/IE/NL/SG/NZ; `inPersonPaymentsCountryExpansionEUExtended` covers AT/BE/FI/IT/LU/PT/ES. Eligibility is cached per site in `GeneralStoreSettings`. Existing supported countries (US, PR, CA, GB) are unaffected; AU is intentionally excluded pending EFTPOS support.
 
 
 24.6

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Performance card: pick which order date type drives the totals (paid, placed, or completed) from a bottom sheet. [https://github.com/woocommerce/woocommerce-ios/pull/16988]
 - [*] Add FedEx Terms of Service handling for shipping label purchases [https://github.com/woocommerce/woocommerce-ios/pull/16925]
 - [*] POS: Update empty orders state copy and replace "Learn more" with "Refresh" [https://github.com/woocommerce/woocommerce-ios/pull/16961]
+- [*] Point of Sale is now available for stores based in Puerto Rico. [https://github.com/woocommerce/woocommerce-ios/pull/17026]
 - [Internal] Add `inPersonPaymentsCountryExpansion` and `inPersonPaymentsCountryExpansionEUExtended` remote feature flags gating IPP and POS support for 13 new countries — `inPersonPaymentsCountryExpansion` covers FR/DE/IE/NL/SG/NZ; `inPersonPaymentsCountryExpansionEUExtended` covers AT/BE/FI/IT/LU/PT/ES. Eligibility is cached per site in `GeneralStoreSettings`. Existing supported countries (US, PR, CA, GB) are unaffected; AU is intentionally excluded pending EFTPOS support.
 
 

--- a/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
+++ b/WooCommerce/Classes/Tools/In-Person Payments/CardPresentConfigurationLoader.swift
@@ -3,10 +3,16 @@ import Yosemite
 import WooFoundation
 
 final class CardPresentConfigurationLoader {
-    init(stores: StoresManager = ServiceLocator.stores) {
-        // This initializer is kept since this is where we'd check for
+    private let stores: StoresManager
+    private let eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService()) {
+        // The `stores` parameter is kept since this is where we'd check for
         // feature flags while developing support for a new country
         // See https://github.com/woocommerce/woocommerce-ios/pull/6954
+        self.stores = stores
+        self.eligibilityService = eligibilityService
     }
 
     var configuration: CardPresentPaymentsConfiguration {
@@ -14,8 +20,18 @@ final class CardPresentConfigurationLoader {
         // The configuration it results in will not support any card payments.
         let countryCode = SiteAddress().countryCode
 
-        return .init(
-            country: countryCode
-        )
+        // RSM-637: gate the country expansion behind a per-site eligibility cache.
+        // When the country requires the expansion flag and the site isn't yet eligible,
+        // surface as an unsupported country so the existing IPP entry points (which all
+        // gate on `isSupportedCountry`) hide downstream.
+        // When the flag is removed, delete this guard and the `flag(for:)` lookup; the
+        // configuration will return the country's normal config unconditionally.
+        if let _ = CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: countryCode),
+           let siteID = stores.sessionManager.defaultStoreID,
+           !eligibilityService.isEligible(siteID: siteID) {
+            return CardPresentPaymentsConfiguration(country: .unknown)
+        }
+
+        return .init(country: countryCode)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -20,6 +20,8 @@ import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
 import enum PointOfSale.POSEligibilityState
 import enum PointOfSale.POSIneligibleReason
 import enum Yosemite.POSCountryCurrencyValidator
+import protocol Yosemite.CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+import class Yosemite.CardPresentPaymentsCountryExpansionEligibilityService
 
 final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let siteID: Int64
@@ -28,15 +30,18 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let systemStatusService: POSSystemStatusServiceProtocol
     private let siteSettingService: POSSiteSettingServiceProtocol
     private let appPasswordSupportState: ApplicationPasswordsExperimentState
+    private let expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
 
     init(siteID: Int64,
          siteSettings: SelectedSiteSettingsProtocol = ServiceLocator.selectedSiteSettings,
          stores: StoresManager = ServiceLocator.stores,
          systemStatusService: POSSystemStatusServiceProtocol? = nil,
-         siteSettingService: POSSiteSettingServiceProtocol? = nil) {
+         siteSettingService: POSSiteSettingServiceProtocol? = nil,
+         expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService()) {
         self.siteID = siteID
         self.siteSettings = siteSettings
         self.stores = stores
+        self.expansionEligibilityService = expansionEligibilityService
         self.appPasswordSupportState = ApplicationPasswordsExperimentState()
 
         let credentials = stores.sessionManager.defaultCredentials
@@ -214,7 +219,12 @@ private extension POSTabEligibilityChecker {
     }
 
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> SiteSettingsEligibilityState {
-        let validationResult = POSCountryCurrencyValidator.validate(countryCode: countryCode, currencyCode: currencyCode)
+        let validationResult = POSCountryCurrencyValidator.validate(
+            countryCode: countryCode,
+            currencyCode: currencyCode,
+            siteID: siteID,
+            eligibilityService: expansionEligibilityService
+        )
 
         switch validationResult {
         case .eligible:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -14,6 +14,7 @@ import class Yosemite.SiteAddress
 import enum Yosemite.POSCountryCurrencyValidator
 import protocol Yosemite.CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
 import class Yosemite.CardPresentPaymentsCountryExpansionEligibilityService
+import class Yosemite.CardPresentPaymentsCountryExpansionEligibilityRefresher
 
 final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     private let site: Site
@@ -23,6 +24,7 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
     private let expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+    private let expansionEligibilityRefresher: CardPresentPaymentsCountryExpansionEligibilityRefresher
 
     init(site: Site,
          userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
@@ -30,7 +32,8 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
          eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService()) {
+         expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService(),
+         expansionEligibilityRefresher: CardPresentPaymentsCountryExpansionEligibilityRefresher? = nil) {
         self.site = site
         self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
@@ -38,6 +41,10 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         self.stores = stores
         self.featureFlagService = featureFlagService
         self.expansionEligibilityService = expansionEligibilityService
+        self.expansionEligibilityRefresher = expansionEligibilityRefresher ?? CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: expansionEligibilityService,
+            remoteFeatureFlagProvider: CardPresentPaymentsCountryExpansionEligibilityRefresher.makeRemoteFeatureFlagProvider(stores: stores)
+        )
     }
 
     /// Checks the initial visibility of the POS tab without dependance on network requests.
@@ -98,6 +105,11 @@ private extension POSTabVisibilityChecker {
         // Conditions that can change if site settings are synced during the lifetime.
         let countryCode = SiteAddress(siteSettings: siteSettings).countryCode
         let currencyCode = CurrencySettings(siteSettings: siteSettings).currencyCode
+
+        // Refresh the per-site IPP country expansion eligibility cache (RSM-637) before
+        // validating, so the country/currency check reflects the latest remote feature
+        // flag rather than a stale or empty cache on first launch.
+        await expansionEligibilityRefresher.refresh(siteID: site.siteID, countryCode: countryCode)
 
         return isEligibleFromCountryAndCurrencyCode(countryCode: countryCode, currencyCode: currencyCode)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -12,6 +12,8 @@ import class Yosemite.POSEligibilityService
 import enum Yosemite.FeatureFlagAction
 import class Yosemite.SiteAddress
 import enum Yosemite.POSCountryCurrencyValidator
+import protocol Yosemite.CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+import class Yosemite.CardPresentPaymentsCountryExpansionEligibilityService
 
 final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     private let site: Site
@@ -20,19 +22,22 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     private let eligibilityService: POSEligibilityServiceProtocol
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
+    private let expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
 
     init(site: Site,
          userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
          siteSettings: SelectedSiteSettingsProtocol = ServiceLocator.selectedSiteSettings,
          eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
          stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService()) {
         self.site = site
         self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
         self.eligibilityService = eligibilityService
         self.stores = stores
         self.featureFlagService = featureFlagService
+        self.expansionEligibilityService = expansionEligibilityService
     }
 
     /// Checks the initial visibility of the POS tab without dependance on network requests.
@@ -109,7 +114,12 @@ private extension POSTabVisibilityChecker {
     }
 
     func isEligibleFromCountryAndCurrencyCode(countryCode: CountryCode, currencyCode: CurrencyCode) -> SiteSettingsEligibilityState {
-        let validationResult = POSCountryCurrencyValidator.validate(countryCode: countryCode, currencyCode: currencyCode)
+        let validationResult = POSCountryCurrencyValidator.validate(
+            countryCode: countryCode,
+            currencyCode: currencyCode,
+            siteID: site.siteID,
+            eligibilityService: expansionEligibilityService
+        )
 
         switch validationResult {
         case .eligible:

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -160,7 +160,10 @@ final class MainTabBarController: UITabBarController {
     private var bookingsEligibilityChecker: BookingsTabEligibilityCheckerProtocol?
     private var bookingsEligibilityCheckTask: Task<Void, Never>?
 
-    /// Refreshes the per-site IPP country expansion eligibility cache (RSM-637) when the site changes.
+    /// Refreshes the per-site IPP country expansion eligibility cache (RSM-637) on phones
+    /// where the POS visibility check is short-circuited and would otherwise not run the
+    /// refresher. iPad goes through `POSTabVisibilityChecker` which refreshes inline before
+    /// reading the cache.
     private lazy var cardPresentExpansionRefresher: CardPresentPaymentsCountryExpansionEligibilityRefresher = {
         CardPresentPaymentsCountryExpansionEligibilityRefresher(
             remoteFeatureFlagProvider: CardPresentPaymentsCountryExpansionEligibilityRefresher.makeRemoteFeatureFlagProvider(stores: stores)
@@ -224,10 +227,10 @@ final class MainTabBarController: UITabBarController {
     }
 
     deinit {
-        cardPresentExpansionRefreshTask?.cancel()
         cancellableSiteID?.cancel()
         posEligibilityCheckTask?.cancel()
         bookingsEligibilityCheckTask?.cancel()
+        cardPresentExpansionRefreshTask?.cancel()
     }
 
     // MARK: - Overridden Methods
@@ -836,14 +839,15 @@ private extension MainTabBarController {
 
                 observePOSEligibilityForPOSTabVisibility(site: site)
                 observeBookingsEligibilityForBookingsTabVisibility(site: site)
-                refreshCardPresentPaymentsCountryExpansionEligibility(for: site)
+                refreshCardPresentExpansionEligibilityIfNeeded(for: site)
             }
     }
 
-    /// Refreshes the per-site IPP country expansion eligibility cache (RSM-637) when the site changes.
-    /// Waits for the first non-empty site settings event for the site so we have a country code,
-    /// then dispatches the relevant remote feature flag check via the refresher and persists the result.
-    func refreshCardPresentPaymentsCountryExpansionEligibility(for site: Site) {
+    /// Refreshes the IPP country expansion eligibility cache for phones, where the
+    /// POS visibility check is skipped. On iPad the visibility checker handles this
+    /// inline before reading the cache, so we no-op to avoid a duplicate dispatch.
+    func refreshCardPresentExpansionEligibilityIfNeeded(for site: Site) {
+        guard !isPad else { return }
         cardPresentExpansionRefreshTask?.cancel()
         cardPresentExpansionRefreshTask = Task { @MainActor [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -160,6 +160,14 @@ final class MainTabBarController: UITabBarController {
     private var bookingsEligibilityChecker: BookingsTabEligibilityCheckerProtocol?
     private var bookingsEligibilityCheckTask: Task<Void, Never>?
 
+    /// Refreshes the per-site IPP country expansion eligibility cache (RSM-637) when the site changes.
+    private lazy var cardPresentExpansionRefresher: CardPresentPaymentsCountryExpansionEligibilityRefresher = {
+        CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            remoteFeatureFlagProvider: CardPresentPaymentsCountryExpansionEligibilityRefresher.makeRemoteFeatureFlagProvider(stores: stores)
+        )
+    }()
+    private var cardPresentExpansionRefreshTask: Task<Void, Never>?
+
     private var isPOSTabVisible: Bool = false
     private var isBookingsTabVisible: Bool = false
     private var isBookingsFeatureAvailable: Bool = false
@@ -216,6 +224,7 @@ final class MainTabBarController: UITabBarController {
     }
 
     deinit {
+        cardPresentExpansionRefreshTask?.cancel()
         cancellableSiteID?.cancel()
         posEligibilityCheckTask?.cancel()
         bookingsEligibilityCheckTask?.cancel()
@@ -827,7 +836,36 @@ private extension MainTabBarController {
 
                 observePOSEligibilityForPOSTabVisibility(site: site)
                 observeBookingsEligibilityForBookingsTabVisibility(site: site)
+                refreshCardPresentPaymentsCountryExpansionEligibility(for: site)
             }
+    }
+
+    /// Refreshes the per-site IPP country expansion eligibility cache (RSM-637) when the site changes.
+    /// Waits for the first non-empty site settings event for the site so we have a country code,
+    /// then dispatches the relevant remote feature flag check via the refresher and persists the result.
+    func refreshCardPresentPaymentsCountryExpansionEligibility(for site: Site) {
+        cardPresentExpansionRefreshTask?.cancel()
+        cardPresentExpansionRefreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let siteSettings = await waitForSiteSettings(siteID: site.siteID)
+            guard !Task.isCancelled else { return }
+            let countryCode = SiteAddress(siteSettings: siteSettings).countryCode
+            await cardPresentExpansionRefresher.refresh(siteID: site.siteID, countryCode: countryCode)
+        }
+    }
+
+    /// Waits for the first non-empty site settings event matching the given site ID.
+    /// Mirrors `POSTabVisibilityChecker.waitForSiteSettingsRefresh()`.
+    private func waitForSiteSettings(siteID: Int64) async -> [SiteSetting] {
+        for await event in ServiceLocator.selectedSiteSettings.settingsStream.values {
+            guard event.siteID == siteID,
+                  event.settings.isNotEmpty,
+                  event.source != .initialLoad else {
+                continue
+            }
+            return event.settings
+        }
+        return []
     }
 
     func observeSiteIDForViewControllers() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsCountryExpansionEligibilityService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsCountryExpansionEligibilityService.swift
@@ -1,0 +1,18 @@
+import Foundation
+import protocol Yosemite.CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+
+final class MockCardPresentPaymentsCountryExpansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    private var eligibilityBySite: [Int64: Bool] = [:]
+
+    init(initialEligibilityBySite: [Int64: Bool] = [:]) {
+        self.eligibilityBySite = initialEligibilityBySite
+    }
+
+    func isEligible(siteID: Int64) -> Bool {
+        eligibilityBySite[siteID] ?? false
+    }
+
+    func cacheEligibility(siteID: Int64, isEligible: Bool) {
+        eligibilityBySite[siteID] = isEligible
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/POSSunsetWarningCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSSunsetWarningCheckerTests.swift
@@ -233,4 +233,6 @@ private final class MockSunsetSiteSettings: SiteSpecificAppSettingsStoreMethodsP
     func setFirstPOSCatalogSyncDate(siteID: Int64, date: Date) {}
     func setPOSLocalCatalogCellularDataAllowed(siteID: Int64, allowed: Bool) {}
     func getPOSLocalCatalogCellularDataAllowed(siteID: Int64) -> Bool { false }
+    func loadCardPresentPaymentsCountryExpansionEligibility(siteID: Int64) -> Bool? { nil }
+    func saveCardPresentPaymentsCountryExpansionEligibility(siteID: Int64, isEligible: Bool) {}
 }

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -16,12 +16,17 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 1234
 
+    private var ineligibleService: StubCardPresentExpansionEligibilityService!
+    private var eligibleService: StubCardPresentExpansionEligibilityService!
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         storageManager = MockStorageManager()
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.sessionManager.setStoreId(sampleSiteID)
         ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
+        ineligibleService = StubCardPresentExpansionEligibilityService(isEligible: false)
+        eligibleService = StubCardPresentExpansionEligibilityService(isEligible: true)
     }
 
     override func tearDownWithError() throws {
@@ -29,55 +34,100 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         storageManager.reset()
         storageManager = nil
         stores = nil
+        ineligibleService = nil
+        eligibleService = nil
         try super.tearDownWithError()
     }
 
-    func test_configuration_for_US() {
+    func test_configuration_for_US_is_supported() {
         // Given
         setupCountry(country: .us)
 
         // When
-        let loader = CardPresentConfigurationLoader(stores: stores)
-        let configuration = loader.configuration
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: ineligibleService)
 
         // Then
-        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_Canada() {
+    func test_configuration_for_Canada_is_supported() {
         // Given
         setupCountry(country: .ca)
 
         // When
-        let loader = CardPresentConfigurationLoader(stores: stores)
-        let configuration = loader.configuration
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: ineligibleService)
 
         // Then
-        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_Spain() {
-        // Given
-        setupCountry(country: .es)
-
-        // When
-        let loader = CardPresentConfigurationLoader(stores: stores)
-        let configuration = loader.configuration
-
-        // Then
-        XCTAssertFalse(configuration.isSupportedCountry)
-    }
-
-    func test_configuration_for_UK() {
+    func test_configuration_for_UK_is_supported() {
         // Given
         setupCountry(country: .gb)
 
         // When
-        let loader = CardPresentConfigurationLoader(stores: stores)
-        let configuration = loader.configuration
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: ineligibleService)
 
         // Then
-        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
+    }
+
+    func test_configuration_for_Spain_is_unsupported_when_expansion_ineligible() {
+        // Given
+        setupCountry(country: .es)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: ineligibleService)
+
+        // Then
+        XCTAssertFalse(loader.configuration.isSupportedCountry)
+    }
+
+    func test_configuration_for_Spain_is_supported_when_expansion_eligible() {
+        // Given
+        setupCountry(country: .es)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
+
+        // Then
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
+        XCTAssertEqual(loader.configuration.currencies, [.EUR])
+    }
+
+    func test_configuration_for_Singapore_is_supported_when_expansion_eligible() {
+        // Given
+        setupCountry(country: .sg)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
+
+        // Then
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
+        XCTAssertEqual(loader.configuration.currencies, [.SGD])
+    }
+
+    func test_configuration_for_New_Zealand_is_supported_when_expansion_eligible() {
+        // Given
+        setupCountry(country: .nz)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
+
+        // Then
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
+        XCTAssertEqual(loader.configuration.currencies, [.NZD])
+    }
+
+    func test_configuration_for_Australia_remains_unsupported_when_expansion_eligible() {
+        // Given - Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643)
+        setupCountry(country: .au)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
+
+        // Then
+        XCTAssertFalse(loader.configuration.isSupportedCountry)
     }
 }
 
@@ -99,5 +149,26 @@ private extension CardPresentConfigurationLoaderTests {
         case ca = "CA:NS"
         case es = "ES"
         case gb = "GB"
+        case sg = "SG"
+        case nz = "NZ"
+        case au = "AU"
+    }
+}
+
+// MARK: - Test Helper
+
+private final class StubCardPresentExpansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    private var isEligibleValue: Bool
+
+    init(isEligible: Bool) {
+        self.isEligibleValue = isEligible
+    }
+
+    func isEligible(siteID: Int64) -> Bool {
+        isEligibleValue
+    }
+
+    func cacheEligibility(siteID: Int64, isEligible: Bool) {
+        isEligibleValue = isEligible
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -17,6 +17,8 @@ struct POSTabEligibilityCheckerTests {
     private var mockSiteSettingService: MockPOSSiteSettingService!
     private let site = Site.fake().copy(siteID: 2)
     private var siteID: Int64 { site.siteID }
+    private let ineligibleExpansionService = StubCardPresentExpansionEligibilityService(isEligible: false)
+    private let eligibleExpansionService = StubCardPresentExpansionEligibilityService(isEligible: true)
 
     init() async throws {
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -455,6 +457,104 @@ struct POSTabEligibilityCheckerTests {
         // Then
         #expect(result == .ineligible(reason: .wooCommercePluginNotFound))
     }
+
+    // MARK: - IPP Country Expansion Gate Tests
+
+    @Test(arguments: [
+        (country: Country.de, currency: CurrencyCode.EUR),
+        (country: Country.es, currency: CurrencyCode.EUR),
+        (country: Country.fr, currency: CurrencyCode.EUR),
+        (country: Country.sg, currency: CurrencyCode.SGD),
+        (country: Country.nz, currency: CurrencyCode.NZD)
+    ])
+    fileprivate func is_eligible_when_expansion_eligibility_is_enabled(country: Country, currency: CurrencyCode) async throws {
+        // Given
+        setupCountry(country: country, currency: currency)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService,
+                                               expansionEligibilityService: eligibleExpansionService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .eligible)
+    }
+
+    @Test(arguments: [
+        Country.de,
+        Country.es,
+        Country.sg,
+        Country.nz
+    ])
+    fileprivate func is_ineligible_when_expansion_eligibility_is_disabled(country: Country) async throws {
+        // Given - currencies that would be valid if eligibility were enabled
+        let currency: CurrencyCode = country == .sg ? .SGD : (country == .nz ? .NZD : .EUR)
+        setupCountry(country: country, currency: currency)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService,
+                                               expansionEligibilityService: ineligibleExpansionService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then - falls through with `siteSettingsNotAvailable` (the unsupportedCountry path is mapped here)
+        #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
+    }
+
+    @Test func expansion_country_with_mismatched_currency_is_ineligible_when_expansion_eligibility_is_enabled() async throws {
+        // Given - DE store with USD currency (mismatch)
+        setupCountry(country: .de, currency: .USD)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService,
+                                               expansionEligibilityService: eligibleExpansionService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .DE, supportedCurrencies: [.EUR])))
+    }
+
+    @Test func australia_is_ineligible_even_when_expansion_eligibility_is_enabled() async throws {
+        // Given - Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643)
+        setupCountry(country: .au, currency: .AUD)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService,
+                                               expansionEligibilityService: eligibleExpansionService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
+    }
+}
+
+// MARK: - Test Helper
+
+private final class StubCardPresentExpansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+    private var isEligibleValue: Bool
+
+    init(isEligible: Bool) {
+        self.isEligibleValue = isEligible
+    }
+
+    func isEligible(siteID: Int64) -> Bool {
+        isEligibleValue
+    }
+
+    func cacheEligibility(siteID: Int64, isEligible: Bool) {
+        isEligibleValue = isEligible
+    }
 }
 
 private extension POSTabEligibilityCheckerTests {
@@ -488,6 +588,11 @@ private extension POSTabEligibilityCheckerTests {
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
+        case de = "DE"
+        case fr = "FR"
+        case sg = "SG"
+        case nz = "NZ"
+        case au = "AU"
 
         var countryCode: CountryCode {
             switch self {
@@ -499,6 +604,16 @@ private extension POSTabEligibilityCheckerTests {
                 return .GB
             case .es:
                 return .ES
+            case .de:
+                return .DE
+            case .fr:
+                return .FR
+            case .sg:
+                return .SG
+            case .nz:
+                return .NZ
+            case .au:
+                return .AU
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -101,6 +101,7 @@ struct POSTabEligibilityCheckerTests {
 
     @Test(arguments: [
         (country: Country.us, currency: CurrencyCode.USD),
+        (country: Country.pr, currency: CurrencyCode.USD),
         (country: Country.gb, currency: CurrencyCode.GBP)
     ])
     fileprivate func is_eligible_when_all_conditions_satisfied(country: Country, currency: CurrencyCode) async throws {
@@ -585,6 +586,7 @@ private extension POSTabEligibilityCheckerTests {
 
     enum Country: String {
         case us = "US:CA"
+        case pr = "PR"
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
@@ -598,6 +600,8 @@ private extension POSTabEligibilityCheckerTests {
             switch self {
             case .us:
                 return .US
+            case .pr:
+                return .PR
             case .ca:
                 return .CA
             case .gb:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -29,6 +29,7 @@ struct POSTabVisibilityCheckerTests {
 
     @Test(arguments: [
         (country: Country.us, currency: CurrencyCode.USD),
+        (country: Country.pr, currency: CurrencyCode.USD),
         (country: Country.gb, currency: CurrencyCode.GBP)
     ])
     fileprivate func is_visible_when_all_conditions_satisfied(country: Country, currency: CurrencyCode) async throws {
@@ -284,6 +285,7 @@ private extension POSTabVisibilityCheckerTests {
 
     enum Country: String {
         case us = "US:CA"
+        case pr = "PR"
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
@@ -292,6 +294,8 @@ private extension POSTabVisibilityCheckerTests {
             switch self {
             case .us:
                 return .US
+            case .pr:
+                return .PR
             case .ca:
                 return .CA
             case .gb:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -116,6 +116,47 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == true)
     }
 
+    @Test func is_visible_for_expansion_country_when_expansion_flag_enabled_even_with_empty_cache() async throws {
+        // Given - ES (an expansion country) with an empty expansion-eligibility cache,
+        // and the country-expansion remote feature flag enabled.
+        let featureFlagService = MockFeatureFlagService()
+        setupCountry(country: .es, currency: .EUR)
+        accountWhitelistedInBackend(true, expansionFlagsEnabled: true)
+        let expansionEligibilityService = MockCardPresentPaymentsCountryExpansionEligibilityService()
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              expansionEligibilityService: expansionEligibilityService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then - checkVisibility refreshes the expansion eligibility cache before validating,
+        // so ES is reported as visible without requiring a prior pre-warm.
+        #expect(result == true)
+        #expect(expansionEligibilityService.isEligible(siteID: siteID) == true)
+    }
+
+    @Test func is_invisible_for_expansion_country_when_expansion_flag_disabled() async throws {
+        // Given - ES (an expansion country) with the country-expansion remote feature flag disabled.
+        let featureFlagService = MockFeatureFlagService()
+        setupCountry(country: .es, currency: .EUR)
+        accountWhitelistedInBackend(true, expansionFlagsEnabled: false)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
     @Test func is_invisible_when_remote_feature_flag_disabled() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
@@ -270,11 +311,22 @@ private extension POSTabVisibilityCheckerTests {
         ].publisher.eraseToAnyPublisher()
     }
 
-    func accountWhitelistedInBackend(_ isAllowed: Bool = false) {
+    /// Configures the mock stores to respond to `FeatureFlagAction.isRemoteFeatureFlagEnabled`.
+    /// `isAllowed` controls the `.pointOfSale` flag (whitelisting).
+    /// `expansionFlagsEnabled` controls the IPP country-expansion flags consulted by the
+    /// `CardPresentPaymentsCountryExpansionEligibilityRefresher` injected into the checker.
+    func accountWhitelistedInBackend(_ isAllowed: Bool = false, expansionFlagsEnabled: Bool = false) {
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
-            case .isRemoteFeatureFlagEnabled(_, _, _, completion: let completion):
-                completion(isAllowed)
+            case let .isRemoteFeatureFlagEnabled(flag, _, _, completion):
+                switch flag {
+                case .pointOfSale:
+                    completion(isAllowed)
+                case .inPersonPaymentsCountryExpansion, .inPersonPaymentsCountryExpansionEUExtended:
+                    completion(expansionFlagsEnabled)
+                default:
+                    completion(false)
+                }
             }
         }
     }


### PR DESCRIPTION
Closes [RSM-637](https://linear.app/a8c/issue/RSM-637).

## Description

Rolls out In-Person Payments and POS to 13 new countries behind two new remote feature flags. With both flags off, the app behaves exactly as before — only US, PR, CA, GB are supported for IPP, and US, PR, GB for POS. With either flag on, the relevant countries become eligible.

Also adds **Puerto Rico to the always-supported POS countries**. PR was already an always-supported IPP country (it shares the US Stripe Terminal config), but `POSCountryCurrencyValidator` was previously hard-coded to US/GB only, so the POS tab was hidden for PR sites. PR now joins US/GB on the always-on list and does not need the country-expansion remote feature flag.

The 13 new countries split across two flags:

- **`inPersonPaymentsCountryExpansion`** (`woo_ipp_country_expansion`) — FR, DE, IE, NL, SG, NZ
- **`inPersonPaymentsCountryExpansionEUExtended`** (`woo_ipp_country_expansion_eu_extended`) — AT, BE, FI, IT, LU, PT, ES

It took quite a lot of code to do this without (new) negative UI implications, because the flag is needed for showing the POS tab and it's another asynchronous call in that decision. Sorry for the size of the PR, but the biggest culprit is tests. Most of this will be removed once we actually go live, and we'll be back to a simple configuration-based list of countries. There's a flicker on the POS tab for unsupported countries, but that's pre-existing. Since we're planning to show the tab for everyone, I didn't think it was worth spending time to improve this right now.

**Australia is intentionally excluded** pending EFTPOS support per [RSM-642](https://linear.app/a8c/issue/RSM-642) / [RSM-643](https://linear.app/a8c/issue/RSM-643). A unit test asserts that AU remains unsupported even when both flags are enabled.

Both flags default to `false` until WPCom registers them, and the existing `RemoteFeatureFlagOverrideStore` plumbing lets us toggle each independently in non-AppStore builds via Settings → Debug Panel → Override Feature Flags.

### Per-country configuration

Each new country gets:
- `paymentMethods: [.cardPresent]`
- `paymentGateways: [WCPay, Stripe]`
- `supportedReaders: [.wisepad3]` (no Tap to Pay)
- `supportedPluginVersions: WCPay >= 4.4.0`, `Stripe >= 6.2.0`
- `stripeSmallestCurrencyUnitMultiplier: 100`
- `minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion`
- `minimumAllowedChargeAmount: 0.5` (in local currency — EUR/SGD/NZD)

### Contactless limits (verified against Stripe Terminal)

`contactlessLimitAmount` set per Stripe Terminal's published contactless CVM table:

| Country group | Currency | `contactlessLimitAmount` | Notes |
|---|---|---|---|
| AT, BE, FI, FR, DE, IE, IT, LU, NL, PT, ES | EUR | **5000** (€50) | Stripe Terminal published EUR limit |
| NZ | NZD | **20000** (NZD 200) | Stripe Terminal published NZD limit |
| SG | SGD | **`nil`** | Not on Stripe's published table; matches the US/PR shape and lets the reader apply scheme defaults |

Source: https://docs.stripe.com/terminal/features/contactless. Per-country Stripe values were confirmed against the published "PIN verification limits" table; SG isn't listed there, so we leave it `nil`. These values are only used for TTP messaging, so have no practical implication right now.

`minimumAllowedChargeAmount: 0.5` matches the existing US/PR/CA values and Stripe's per-currency minimum charge for EUR/SGD/NZD.

## Architecture

The gate is per-site, persisted in `GeneralStoreSettings`, and read synchronously by every existing IPP entry point — no in-memory `.shared` singleton, no first-launch race after the first successful refresh.

- **`CardPresentPaymentsCountryExpansionEligibilityService`** (Yosemite) — sync `isEligible(siteID:)` / `cacheEligibility(siteID:isEligible:)` backed by `SiteSpecificAppSettingsStoreMethods`. Mirrors `POSEligibilityService` 1:1.
- **`CardPresentPaymentsCountryExpansionEligibilityRefresher`** — maps `(CountryCode) -> RemoteFeatureFlag?`, dispatches `FeatureFlagAction.isRemoteFeatureFlagEnabled`, persists the result. US/PR/CA/GB short-circuit to `true` without dispatching.
- **`MainTabBarController.observeSiteForConditionalTabs`** — triggers the refresher whenever the default site changes, after waiting for the first non-empty site settings event so we have a country code. Same lifecycle as the POS visibility check.
- **`CardPresentConfigurationLoader.configuration`** — consults the eligibility cache before constructing the country's config; expansion countries with an ineligible site fall back to the unsupported `.unknown` config, so all five existing IPP entry points (`InPersonPaymentsMenuViewModel`, `OrderListViewModel`, `PaymentMethodsViewModel`, `CardPresentPaymentsOnboardingUseCase`, …) gate transitively via `isSupportedCountry`.
- **`POSCountryCurrencyValidator.validate(...)`** + `POSTabVisibilityChecker` + `POSTabEligibilityChecker` — thread the eligibility service through the same way. `POSCountryCurrencyValidator`'s always-on list is `US`, `PR`, `GB`; expansion countries are added when the eligibility service reports the site as eligible.
- **`CardPresentPaymentsConfiguration.init(country:)`** — unconditional. Describes Stripe Terminal capabilities for any of the 15 countries; the loader and validator make the per-site exposure decision.

`GeneralStoreSettings` gains a `Bool?` field (`isCardPresentPaymentsCountryExpansionEligible`) that the refresher writes after each flag check. `nil` until first refresh; `true`/`false` thereafter. 

### Cold-start behaviour

- **Subsequent launches** (cache populated): sync read returns the persisted value, IPP/POS eligibility evaluated correctly from the first frame.
- **First launch in a flag-on country** (cache `nil` ⇒ default `false`): IPP/POS hidden until the async refresh completes. On the next launch the persisted value renders.
- **Logged out at launch**: refresher only runs after `observeSiteForConditionalTabs` fires (i.e. post-auth), so the dispatch never hits an unregistered `FeatureFlagStore`. No hung continuations.

## Test Steps

1. Sign in to a test store **outside** the new countries (e.g. a US/USD store). IPP and POS behave exactly as on `trunk`.
2. Sign in to a test store in one of the new countries — for example a German EUR store, a Singapore SGD store, an Italian EUR store (covers both flag groups), and a New Zealand NZD store.
3. Without any flag override, the IPP/POS entry points remain hidden / surface "country not supported" exactly as before this change.
4. Open Settings → Debug Panel → **Override Feature Flags**, enable `inPersonPaymentsCountryExpansion`, then relaunch the app.
5. The DE/NL/FR/SG/NZ test stores now render the IPP onboarding flows; reader pairing offers **WisePad 3 only** (no Tap to Pay, no Chipper).
6. Disable that flag, enable `inPersonPaymentsCountryExpansionEUExtended`, relaunch. The AT/BE/FI/IT/LU/PT/ES test stores now render IPP; the FR/DE/IE/NL/SG/NZ stores fall back to "unsupported" again.
7. Verify the existing US/PR/CA/GB stores remain unchanged with both overrides on (US should still expose Chipper / Stripe M2 / Tap to Pay; CA should still expose interac+contactless 25000; GB should still expose WisePad 3 + Tap to Pay). **PR USD stores should now also see the POS tab**, even with both expansion flags off.
8. Toggle both overrides off and confirm the new countries fall back to "unsupported".
9. **Australia check**: sign in to an AU/AUD test store with both overrides enabled — IPP/POS must remain unsupported (RSM-642/RSM-643 EFTPOS work pending).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.