### PR TITLE
Woo Mobile AI: Add the chat surface, design tokens, and confirmation card

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -273,6 +273,7 @@ let package = Package(
         .target(
             name: "WooAIAssistant",
             dependencies: [
+                "WooFoundation",
                 "NetworkingCore",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack")
             ]

--- a/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
+++ b/Modules/Sources/WooAIAssistant/Backend/AssistantBackend.swift
@@ -4,6 +4,11 @@ public protocol AssistantBackend: Sendable {
     func send(turn: AssistantTurn,
               context: AssistantContext,
               session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error>
+    func reset() async
+}
+
+public extension AssistantBackend {
+    func reset() async {}
 }
 
 public protocol AssistantBackendConfirming: AssistantBackend {

--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -48,6 +48,7 @@ public actor AgenticLoopOrchestrator {
                     continuation.finish()
                     return
                 }
+                await self.clearOutcome()
                 do {
                     try await self.runLoop(prompt: prompt,
                                            priorMessages: priorMessages,
@@ -105,6 +106,10 @@ public actor AgenticLoopOrchestrator {
         }
     }
 
+    private func clearOutcome() {
+        lastOutcome = nil
+    }
+
     private func setOutcome(_ outcome: LoopOutcome) {
         lastOutcome = outcome
         resumeTerminationWaiters(with: outcome)
@@ -130,9 +135,6 @@ public actor AgenticLoopOrchestrator {
         }
     }
 
-    /// Suspend the loop until the UI resolves this proposal. The pre- and post-store `Task.isCancelled`
-    /// checks plus the `onCancel` hop guarantee the continuation is always resumed even if cancellation
-    /// arrives between yielding `.confirmationRequired` and registering the continuation here.
     private func waitForDecision(proposalID: UUID) async -> Bool {
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
@@ -387,7 +389,11 @@ public actor AgenticLoopOrchestrator {
                                                     name: call.function.name,
                                                     argumentsJSON: call.function.arguments))
             }
-            try await withThrowingTaskGroup(of: (Int, ToolResult).self) { group in
+            // withTaskGroup (not throwing) so a single tool failure no longer
+            // tears down sibling tasks. Errors from the registry get folded
+            // into a per-tool failed result and surface as toolCallCompleted
+            // events for every call - no orphan running pills.
+            await withTaskGroup(of: (Int, ToolResult).self) { group in
                 for index in approvedIndices {
                     let call = calls[index]
                     group.addTask {
@@ -397,7 +403,7 @@ public actor AgenticLoopOrchestrator {
                         return (index, result)
                     }
                 }
-                for try await (index, result) in group {
+                for await (index, result) in group {
                     let call = calls[index]
                     let payload = self.handleToolResult(result,
                                                         for: call,
@@ -457,6 +463,21 @@ public actor AgenticLoopOrchestrator {
             continuation.yield(.toolResult(toolCallID: call.id,
                                            toolName: call.function.name,
                                            payload: success.structured))
+            // Bridge `uiStructured.cards` into UI-visible `.cardRender` events so
+            // tools that pre-render (orders_get, products_get, show_cards, write
+            // mappers) actually surface in the transcript. The synthetic
+            // toolResult events are UI-only - the model transcript is the
+            // separate `messages` array in `run`.
+            if let cards = success.uiStructured?.cards, !cards.isEmpty {
+                for (index, card) in cards.enumerated() {
+                    let syntheticID = "\(call.id):card:\(index):\(card.family.rawValue):\(card.id)"
+                    let syntheticTool = "\(call.function.name).\(card.family.rawValue)"
+                    continuation.yield(.toolResult(toolCallID: syntheticID,
+                                                   toolName: syntheticTool,
+                                                   payload: card.element))
+                    continuation.yield(.cardRender(toolCallID: syntheticID))
+                }
+            }
             continuation.yield(.toolCallCompleted(id: call.id,
                                                    name: call.function.name,
                                                    resultJSON: payload))
@@ -838,8 +859,7 @@ private enum TurnOutcome {
     case toolCalls([OpenAIChat.ToolCall])
 }
 
-/// Degenerate policy used when the caller hasn't specified safety at
-/// all (tests, read-only prototypes). Every call executes.
+/// Tests/read-only prototypes that don't need a real safety check.
 public struct AlwaysExecuteSafetyPolicy: SafetyPolicy {
     public init() {}
 

--- a/Modules/Sources/WooAIAssistant/Models/MessageSegment+Fingerprint.swift
+++ b/Modules/Sources/WooAIAssistant/Models/MessageSegment+Fingerprint.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension MessageSegment {
+    /// Stable hash of the segment's mutable content. The scroll view watches
+    /// this to detect streaming text deltas without re-comparing the struct.
+    var fingerprint: String {
+        switch self {
+        case .text(let id, let content):
+            return "t:\(id):\(content.count):\(content.hashValue)"
+        case .toolCall(let id, _, _, _, let status):
+            return "c:\(id):\(status)"
+        case .toolResult(let id, _, _, _):
+            return "r:\(id)"
+        case .cardRender(let id, _, _, _):
+            return "d:\(id)"
+        case .confirmation(let id, _, _, _, let status):
+            return "f:\(id):\(status)"
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Presentation/AssistantChatView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/AssistantChatView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+public struct AssistantChatView: View {
+
+    @Bindable private var controller: AssistantController
+    @State private var draft: String = ""
+    @FocusState private var inputFocused: Bool
+
+    private let showIterationCapBanner: Bool
+    private let onClose: () -> Void
+
+    public init(controller: AssistantController,
+                onClose: @escaping () -> Void = {}) {
+        self.controller = controller
+        self.showIterationCapBanner = false
+        self.onClose = onClose
+    }
+
+    #if DEBUG
+    init(controller: AssistantController,
+         showIterationCapBanner: Bool,
+         onClose: @escaping () -> Void = {}) {
+        self.controller = controller
+        self.showIterationCapBanner = showIterationCapBanner
+        self.onClose = onClose
+    }
+    #endif
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                messageList
+
+                InputBar(draft: $draft,
+                         canSend: controller.canSend,
+                         isStreaming: isAssistantResponding,
+                         pendingConfirmation: hasPendingConfirmation,
+                         onSend: send,
+                         onStop: { controller.cancel() })
+                    .focused($inputFocused)
+            }
+            .background(Color.assistantSurface)
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark.circle.fill")
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(Color.assistantTextFaint)
+                    }
+                    .accessibilityLabel(Localization.close)
+                }
+                ToolbarItem(placement: .principal) {
+                    titleToolbarItem
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: newConversation) {
+                        Image(systemName: "square.and.pencil")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(Color(.accent))
+                    }
+                    .accessibilityLabel(Localization.newConversation)
+                    .disabled(!controller.canSend)
+                }
+            }
+            .environment(\.assistantConfirmationHandler,
+                          AssistantConfirmationHandler(
+                            onConfirm: { id in controller.confirmProposal(id) },
+                            onCancel: { id in controller.cancelProposal(id) }))
+            .onDisappear {
+                if !controller.canSend {
+                    controller.cancel()
+                }
+            }
+        }
+    }
+
+    private var titleToolbarItem: some View {
+        HStack(spacing: AssistantSpacing.xSmall) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Color(.accent))
+            Text(Localization.title)
+                .font(.assistantBodyEmphasized)
+        }
+    }
+
+    private var messageList: some View {
+        MessageListView(messages: controller.conversation.messages,
+                        streamingState: controller.conversation.streamingState,
+                        showIterationCapBanner: showIterationCapBanner,
+                        onPickPrompt: { draft = $0; inputFocused = true })
+    }
+
+    private var isAssistantResponding: Bool {
+        guard !hasPendingConfirmation else { return false }
+        switch controller.conversation.streamingState {
+        case .sending, .streaming:
+            return true
+        case .idle, .failed, .outcomeUnknown:
+            return false
+        }
+    }
+
+    private var hasPendingConfirmation: Bool {
+        for message in controller.conversation.messages {
+            for segment in message.segments {
+                if case .confirmation(_, _, _, _, let status) = segment, status == .pending {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private func send() {
+        let prompt = draft
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        controller.send(prompt)
+        draft = ""
+    }
+
+    private func newConversation() {
+        draft = ""
+        controller.startNewConversation()
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString(
+            "assistantChat.nav.title",
+            value: "Assistant",
+            comment: "Title of the AI Assistant chat screen"
+        )
+        static let close = NSLocalizedString(
+            "assistantChat.nav.close",
+            value: "Close",
+            comment: "Accessibility label for the close button in the AI Assistant chat navigation bar"
+        )
+        static let newConversation = NSLocalizedString(
+            "assistantChat.nav.newConversation",
+            value: "New conversation",
+            comment: "Accessibility label for the new-conversation button in the AI Assistant chat navigation bar"
+        )
+    }
+}
+
+#if DEBUG
+extension AssistantChatView {
+
+    @MainActor
+    static func preview(_ scenario: AssistantChatScenario) -> some View {
+        let configuration = AssistantChatScenarioBuilder(scenario: scenario).build()
+        return AssistantChatView(controller: configuration.controller,
+                                 showIterationCapBanner: configuration.showIterationCapBanner,
+                                 onClose: {})
+    }
+}
+
+#Preview("Empty") { AssistantChatView.preview(.empty) }
+#Preview("Single user message") { AssistantChatView.preview(.singleUserMessage) }
+#Preview("Assistant typing") { AssistantChatView.preview(.assistantTyping) }
+#Preview("Assistant streaming text") { AssistantChatView.preview(.assistantStreamingText) }
+#Preview("Text + card") { AssistantChatView.preview(.textPlusCard) }
+#Preview("Tool activity pill") { AssistantChatView.preview(.toolActivityPill) }
+#Preview("Pending confirmation") { AssistantChatView.preview(.pendingConfirmation) }
+#Preview("Pending confirmation (bulk)") { AssistantChatView.preview(.pendingConfirmationBulk) }
+#Preview("Failed mid-stream") { AssistantChatView.preview(.failedMidStream) }
+#Preview("Outcome unknown") { AssistantChatView.preview(.outcomeUnknown) }
+#Preview("Iteration cap") { AssistantChatView.preview(.iterationCap) }
+#Preview("Multi-turn") { AssistantChatView.preview(.multiTurn) }
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/AssistantConfirmationHandler.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/AssistantConfirmationHandler.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Injected through the SwiftUI environment so confirmation cards can reach
+/// `AssistantController` without holding a reference - keeps cards retain
+/// cycle free and renderable from previews without a live controller.
+struct AssistantConfirmationHandler {
+    var onConfirm: (UUID) -> Void = { _ in }
+    var onCancel: (UUID) -> Void = { _ in }
+}
+
+private struct AssistantConfirmationHandlerKey: EnvironmentKey {
+    static let defaultValue = AssistantConfirmationHandler()
+}
+
+extension EnvironmentValues {
+    var assistantConfirmationHandler: AssistantConfirmationHandler {
+        get { self[AssistantConfirmationHandlerKey.self] }
+        set { self[AssistantConfirmationHandlerKey.self] = newValue }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Presentation/BannerShell.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/BannerShell.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+enum BannerTone {
+    case error
+    case warning
+    case info
+    case neutral
+}
+
+struct BannerShell<Content: View>: View {
+
+    let title: String
+    let tone: BannerTone
+    var eyebrow: String?
+    var eyebrowSymbol: String?
+    let content: () -> Content
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(title: String,
+         tone: BannerTone,
+         eyebrow: String? = nil,
+         eyebrowSymbol: String? = nil,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.tone = tone
+        self.eyebrow = eyebrow
+        self.eyebrowSymbol = eyebrowSymbol
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+            if let eyebrow {
+                eyebrowLabel(text: eyebrow)
+            }
+            Text(title)
+                .font(.assistantBodyEmphasized)
+                .foregroundStyle(titleColor)
+
+            content()
+        }
+        .padding(AssistantSpacing.medium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.medium))
+        .overlay(
+            RoundedRectangle(cornerRadius: AssistantRadius.medium)
+                .stroke(borderColor, lineWidth: 1)
+        )
+    }
+
+    private func eyebrowLabel(text: String) -> some View {
+        HStack(spacing: AssistantSpacing.xSmall) {
+            if let eyebrowSymbol {
+                Image(systemName: eyebrowSymbol)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(eyebrowColor)
+                    .accessibilityHidden(true)
+            }
+            Text(text)
+                .font(.caption2.weight(.semibold))
+                .textCase(.uppercase)
+                .tracking(0.6)
+                .foregroundStyle(eyebrowColor)
+        }
+    }
+
+    private var titleColor: Color {
+        switch tone {
+        case .error: return Color.assistantError
+        case .warning: return Color.primary
+        case .info: return Color.assistantInfo
+        case .neutral: return Color.primary
+        }
+    }
+
+    private var eyebrowColor: Color {
+        switch tone {
+        case .error: return Color.assistantError
+        case .warning: return Color.assistantWarning
+        case .info: return Color.assistantInfo
+        case .neutral: return Color.assistantMuted
+        }
+    }
+
+    private var tintOpacity: CGFloat {
+        colorScheme == .dark ? 0.08 : 0.16
+    }
+
+    private var backgroundColor: Color {
+        switch tone {
+        case .error: return Color.assistantError.opacity(tintOpacity)
+        case .warning: return Color.assistantWarning.opacity(tintOpacity)
+        case .info: return Color.assistantInfo.opacity(tintOpacity)
+        case .neutral: return Color.assistantSurfaceElevated
+        }
+    }
+
+    private var borderColor: Color {
+        switch tone {
+        case .error: return Color.assistantError.opacity(0.25)
+        case .warning: return Color.assistantWarning.opacity(0.35)
+        case .info: return Color.assistantInfo.opacity(0.25)
+        case .neutral: return Color.assistantSurfaceBorder
+        }
+    }
+}
+
+#if DEBUG
+#Preview("Error") {
+    BannerShell(title: "Something went wrong", tone: .error) {
+        Text("Network is unreachable. Try again in a moment.")
+            .font(.assistantBody)
+    }
+    .padding()
+}
+
+#Preview("Warning") {
+    BannerShell(title: "Outcome unknown", tone: .warning) {
+        Text("The connection dropped before we got a confirmation.")
+            .font(.assistantBody)
+    }
+    .padding()
+}
+
+#Preview("Info") {
+    BannerShell(title: "Reached step limit", tone: .info) {
+        Text("I had to stop short of finishing.")
+            .font(.assistantBody)
+    }
+    .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/CardShell.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/CardShell.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct CardShell<Content: View>: View {
+
+    let label: String
+    var accent: Bool = false
+    var trailingChevron: Bool = false
+    let content: () -> Content
+
+    init(label: String,
+         accent: Bool = false,
+         trailingChevron: Bool = false,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.label = label
+        self.accent = accent
+        self.trailingChevron = trailingChevron
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+            HStack {
+                Text(label)
+                    .font(.assistantMonospaced)
+                    .textCase(.uppercase)
+                    .foregroundStyle(accent ? Color(.accent) : Color.assistantTextFaint)
+                Spacer(minLength: 0)
+                if trailingChevron {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.assistantTextFaint)
+                        .accessibilityHidden(true)
+                }
+            }
+            content()
+        }
+        .padding(AssistantSpacing.medium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.assistantSurfaceElevated)
+        .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.card))
+        .overlay(
+            RoundedRectangle(cornerRadius: AssistantRadius.card)
+                .stroke(accent ? Color(.accent).opacity(0.4) : Color.assistantSurfaceBorder,
+                        lineWidth: 1)
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Default") {
+    CardShell(label: "Order #3479") {
+        Text("Sample content")
+            .font(.assistantBody)
+    }
+    .padding()
+}
+
+#Preview("Accent + chevron") {
+    CardShell(label: "2 orders", accent: true, trailingChevron: true) {
+        Text("Tap to drill in")
+            .font(.assistantBody)
+            .foregroundStyle(Color.assistantMuted)
+    }
+    .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
@@ -1,0 +1,335 @@
+import SwiftUI
+
+struct ConfirmationCard: View {
+
+    let proposalID: UUID
+    let toolName: String
+    let preview: String
+    let status: ConfirmationStatus
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        BannerShell(title: cardTitle,
+                    tone: tone,
+                    eyebrow: eyebrowText,
+                    eyebrowSymbol: eyebrowSymbol) {
+            VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+                diffBody
+
+                if status == .pending {
+                    actionButtons
+                        .padding(.top, AssistantSpacing.xSmall)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var diffBody: some View {
+        VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+            if let parsed = ParsedPreview(text: preview) {
+                VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
+                    ForEach(Array(parsed.fields.enumerated()), id: \.offset) { _, field in
+                        DiffFieldRow(field: field)
+                    }
+                }
+            } else {
+                Text(preview)
+                    .font(.assistantBody)
+                    .foregroundStyle(Color.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var cardTitle: String {
+        if let parsed = ParsedPreview(text: preview),
+           let summary = parsed.summary,
+           !summary.isEmpty {
+            return summary
+        }
+        return Localization.fallbackTitle
+    }
+
+    private var eyebrowText: String {
+        switch status {
+        case .pending: return Localization.pending
+        case .confirmed: return Localization.confirmed
+        case .cancelled: return Localization.cancelled
+        }
+    }
+
+    private var eyebrowSymbol: String {
+        switch status {
+        case .pending: return "clock.fill"
+        case .confirmed: return "checkmark.circle.fill"
+        case .cancelled: return "xmark.circle.fill"
+        }
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: AssistantSpacing.small) {
+            Button(action: onCancel) {
+                Text(Localization.cancel)
+                    .font(.assistantBodyEmphasized)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .foregroundStyle(Color.primary)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: AssistantRadius.medium)
+                            .stroke(Color.assistantSurfaceBorder, lineWidth: 1)
+                    )
+            }
+            .buttonStyle(.plain)
+
+            Button(action: onConfirm) {
+                Text(Localization.confirm)
+                    .font(.assistantBodyEmphasized)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .foregroundStyle(Color.assistantOnAccent)
+                    .background(Color(.accent))
+                    .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.medium))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var tone: BannerTone {
+        switch status {
+        case .pending: return .warning
+        case .confirmed: return .info
+        case .cancelled: return .neutral
+        }
+    }
+
+    private enum Localization {
+        static let fallbackTitle = NSLocalizedString(
+            "assistantChat.confirmation.title.fallback",
+            value: "Proposed change",
+            comment: "Generic confirmation card title used when no action summary can be inferred from the preview"
+        )
+        static let pending = NSLocalizedString(
+            "assistantChat.confirmation.pending",
+            value: "Pending change",
+            comment: "Eyebrow label on a pending confirmation card in the AI Assistant chat"
+        )
+        static let confirmed = NSLocalizedString(
+            "assistantChat.confirmation.confirmed",
+            value: "Applied",
+            comment: "Eyebrow label on a confirmed confirmation card in the AI Assistant chat"
+        )
+        static let cancelled = NSLocalizedString(
+            "assistantChat.confirmation.cancelled",
+            value: "Cancelled",
+            comment: "Eyebrow label on a cancelled confirmation card in the AI Assistant chat"
+        )
+        static let confirm = NSLocalizedString(
+            "assistantChat.confirmation.action.confirm",
+            value: "Confirm",
+            comment: "Confirm button on a pending confirmation card in the AI Assistant chat"
+        )
+        static let cancel = NSLocalizedString(
+            "assistantChat.confirmation.action.cancel",
+            value: "Cancel",
+            comment: "Cancel button on a pending confirmation card in the AI Assistant chat"
+        )
+    }
+}
+
+private struct DiffFieldRow: View {
+
+    let field: ParsedPreview.Field
+
+    var body: some View {
+        composedLine
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var composedLine: Text {
+        let labelPart = Text("\(field.label): ")
+            .font(.assistantBody)
+            .foregroundColor(Color.assistantMuted)
+
+        if field.before.isEmpty {
+            return labelPart + Text(field.after)
+                .font(.assistantBodyEmphasized)
+                .foregroundColor(Color.assistantBubbleAssistantText)
+        }
+
+        let beforePart = Text(field.before)
+            .font(.assistantBody)
+            .strikethrough(true, color: Color.assistantMuted)
+            .foregroundColor(Color.assistantMuted)
+
+        let afterPart = Text(field.after)
+            .font(.assistantBodyEmphasized)
+            .foregroundColor(Color.assistantBubbleAssistantText)
+
+        return labelPart + beforePart + Text(" ") + afterPart
+    }
+}
+
+struct ParsedPreview {
+
+    struct Field {
+        let label: String
+        let before: String
+        let after: String
+    }
+
+    let summary: String?
+    let fields: [Field]
+
+    init?(text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let actionForm = Self.parseActionForm(trimmed) {
+            self.summary = actionForm.summary
+            self.fields = actionForm.fields
+            return
+        }
+
+        var summaryLine: String?
+        var rawFields: [String] = []
+
+        let topComponents = trimmed.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        if topComponents.count == 2, Self.containsArrow(String(topComponents[1])) {
+            summaryLine = topComponents[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            rawFields = Self.splitFieldList(String(topComponents[1]))
+        } else {
+            rawFields = Self.splitFieldList(trimmed)
+        }
+
+        let parsedFields = rawFields.compactMap(Self.parseField)
+        guard !parsedFields.isEmpty else { return nil }
+
+        self.summary = summaryLine
+        self.fields = parsedFields
+    }
+
+    private static func splitFieldList(_ text: String) -> [String] {
+        text
+            .components(separatedBy: CharacterSet(charactersIn: ";,"))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func parseField(_ raw: String) -> Field? {
+        let halves = splitOnArrow(raw)
+        guard let halves else { return nil }
+
+        let afterStripped = stripSideEffectSuffix(halves.after.trimmingCharacters(in: .whitespacesAndNewlines))
+        let beforeRaw = halves.before.trimmingCharacters(in: .whitespacesAndNewlines)
+        let after = String.assistantHumanizedValue(afterStripped)
+
+        let beforeComponents = beforeRaw.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: false)
+        let label: String
+        let before: String
+        if beforeComponents.count == 2 {
+            label = String.assistantHumanizedToolToken(String(beforeComponents[0]))
+            before = String.assistantHumanizedValue(beforeComponents[1].trimmingCharacters(in: .whitespacesAndNewlines))
+        } else {
+            label = String.assistantHumanizedToolToken(beforeRaw)
+            before = ""
+        }
+
+        guard !after.isEmpty else { return nil }
+        let cleanLabel = label.isEmpty ? Localization.fallbackLabel : label
+        return Field(label: cleanLabel, before: before, after: after)
+    }
+
+    private static func splitOnArrow(_ text: String) -> (before: String, after: String)? {
+        if let range = text.range(of: "→") {
+            return (String(text[..<range.lowerBound]), String(text[range.upperBound...]))
+        }
+        if let range = text.range(of: "->") {
+            return (String(text[..<range.lowerBound]), String(text[range.upperBound...]))
+        }
+        return nil
+    }
+
+    private static func containsArrow(_ text: String) -> Bool {
+        text.contains("→") || text.contains("->")
+    }
+
+    private static func parseActionForm(_ text: String) -> (summary: String, fields: [Field])? {
+        let stripped = stripSideEffectSuffix(text)
+        guard let toRange = stripped.range(of: " to ", options: [.caseInsensitive, .backwards]) else {
+            return nil
+        }
+        guard stripped.localizedCaseInsensitiveContains("set ") else { return nil }
+        let head = stripped[..<toRange.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+        let after = String.assistantHumanizedValue(stripped[toRange.upperBound...].trimmingCharacters(in: .whitespacesAndNewlines))
+        guard !after.isEmpty, !head.isEmpty else { return nil }
+        let summary = head
+        let field = Field(label: Localization.statusLabel, before: "", after: after)
+        return (summary, [field])
+    }
+
+    private static func stripSideEffectSuffix(_ text: String) -> String {
+        if let parenStart = text.range(of: " (") {
+            return String(text[..<parenStart.lowerBound])
+        }
+        return text
+    }
+
+    private enum Localization {
+        static let statusLabel = NSLocalizedString(
+            "assistantChat.confirmation.diff.label.status",
+            value: "Status",
+            comment: "Field label used in confirmation diff rows when the preview only conveys a status change"
+        )
+        static let fallbackLabel = NSLocalizedString(
+            "assistantChat.confirmation.diff.label.fallback",
+            value: "Value",
+            comment: "Generic field label used in confirmation diff rows when no clearer label can be inferred"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Pending (in chat)") {
+    AssistantChatView.preview(.pendingConfirmation)
+}
+
+#Preview("Pending standalone") {
+    ConfirmationCard(proposalID: UUID(),
+                     toolName: "orders_update",
+                     preview: "Update order #3479: status processing → completed",
+                     status: .pending,
+                     onConfirm: {},
+                     onCancel: {})
+        .padding()
+}
+
+#Preview("Confirmed") {
+    ConfirmationCard(proposalID: UUID(),
+                     toolName: "orders_update",
+                     preview: "Update order #3479: status processing → completed",
+                     status: .confirmed,
+                     onConfirm: {},
+                     onCancel: {})
+        .padding()
+}
+
+#Preview("Cancelled") {
+    ConfirmationCard(proposalID: UUID(),
+                     toolName: "orders_update",
+                     preview: "Update order #3479: status processing → completed",
+                     status: .cancelled,
+                     onConfirm: {},
+                     onCancel: {})
+        .padding()
+}
+
+#Preview("Multi-field") {
+    ConfirmationCard(proposalID: UUID(),
+                     toolName: "orders_update",
+                     preview: "Update order #3479: status processing → completed; total $45.00 → $60.00",
+                     status: .pending,
+                     onConfirm: {},
+                     onCancel: {})
+        .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/EmptyStateView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/EmptyStateView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+struct EmptyStateView: View {
+
+    let suggestions: [SuggestionItem]
+    let onPick: (String) -> Void
+
+    init(suggestions: [SuggestionItem] = EmptyStateView.defaultSuggestions,
+         onPick: @escaping (String) -> Void) {
+        self.suggestions = suggestions
+        self.onPick = onPick
+    }
+
+    struct SuggestionItem: Identifiable {
+        let id = UUID()
+        let symbol: String
+        let title: String
+    }
+
+    private static let symbolWidth: CGFloat = 20
+    private static let dividerLeadingInset: CGFloat = AssistantSpacing.large + symbolWidth + AssistantSpacing.medium
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AssistantSpacing.medium) {
+            Text(Localization.title)
+                .font(.assistantTitle)
+                .foregroundStyle(Color.primary)
+                .padding(.horizontal, AssistantSpacing.large)
+                .padding(.top, AssistantSpacing.large)
+
+            VStack(spacing: 0) {
+                ForEach(Array(suggestions.enumerated()), id: \.element.id) { index, item in
+                    SuggestionRow(item: item,
+                                  symbolWidth: Self.symbolWidth,
+                                  onTap: { onPick(item.title) })
+                    if index < suggestions.count - 1 {
+                        Rectangle()
+                            .fill(Color.assistantSeparator.opacity(0.4))
+                            .frame(height: 0.5)
+                            .padding(.leading, Self.dividerLeadingInset)
+                    }
+                }
+            }
+            .background(Color.assistantSurfaceElevated)
+            .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.medium))
+            .overlay(
+                RoundedRectangle(cornerRadius: AssistantRadius.medium)
+                    .stroke(Color.assistantSurfaceBorder, lineWidth: 1)
+            )
+            .padding(.horizontal, AssistantSpacing.large)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, AssistantSpacing.large)
+    }
+
+    static let defaultSuggestions: [SuggestionItem] = [
+        SuggestionItem(symbol: "chart.bar.fill", title: Localization.suggestionTodaysSales),
+        SuggestionItem(symbol: "shippingbox.fill", title: Localization.suggestionLowStock),
+        SuggestionItem(symbol: "bag.fill", title: Localization.suggestionRecentOrders),
+        SuggestionItem(symbol: "star.fill", title: Localization.suggestionTopProducts)
+    ]
+
+    private enum Localization {
+        static let title = NSLocalizedString(
+            "assistantChat.empty.title",
+            value: "Ask about your store",
+            comment: "Empty state title for the AI Assistant chat"
+        )
+        static let suggestionTodaysSales = NSLocalizedString(
+            "assistantChat.empty.suggestion.todaysSales",
+            value: "Today's sales",
+            comment: "Suggested prompt asking the assistant to summarise today's sales"
+        )
+        static let suggestionLowStock = NSLocalizedString(
+            "assistantChat.empty.suggestion.lowStock",
+            value: "Low-stock items",
+            comment: "Suggested prompt asking the assistant for low-stock products"
+        )
+        static let suggestionRecentOrders = NSLocalizedString(
+            "assistantChat.empty.suggestion.recentOrders",
+            value: "Recent orders",
+            comment: "Suggested prompt asking the assistant to list recent orders"
+        )
+        static let suggestionTopProducts = NSLocalizedString(
+            "assistantChat.empty.suggestion.topProducts",
+            value: "Top products this week",
+            comment: "Suggested prompt asking the assistant for the top-selling products this week"
+        )
+    }
+}
+
+private struct SuggestionRow: View {
+
+    let item: EmptyStateView.SuggestionItem
+    let symbolWidth: CGFloat
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: AssistantSpacing.medium) {
+                Image(systemName: item.symbol)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color(.accent))
+                    .frame(width: symbolWidth, height: symbolWidth)
+                    .accessibilityHidden(true)
+                Text(item.title)
+                    .font(.assistantBody)
+                    .foregroundStyle(Color.primary)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.assistantTextFaint)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, AssistantSpacing.large)
+            .padding(.vertical, AssistantSpacing.small + 2)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#if DEBUG
+#Preview("Empty (in chat)") {
+    AssistantChatView.preview(.empty)
+}
+
+#Preview("Standalone") {
+    EmptyStateView { _ in }
+        .background(Color.assistantSurface)
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/ErrorBanner.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ErrorBanner.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct ErrorBanner: View {
+
+    let reason: String
+    var onRetry: (() -> Void)?
+
+    var body: some View {
+        BannerShell(title: Localization.title, tone: .error) {
+            VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+                Text(reason)
+                    .font(.assistantBody)
+                    .foregroundStyle(Color.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let onRetry {
+                    Button(action: onRetry) {
+                        Text(Localization.retry)
+                            .font(.assistantBodyEmphasized)
+                            .foregroundStyle(Color.assistantError)
+                            .frame(minHeight: 44)
+                            .padding(.horizontal, AssistantSpacing.medium)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: AssistantRadius.medium)
+                                    .stroke(Color.assistantError.opacity(0.5), lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString(
+            "assistant.banner.error.title",
+            value: "Something went wrong",
+            comment: "Title shown above the inline error message in the AI Assistant chat"
+        )
+        static let retry = NSLocalizedString(
+            "assistant.banner.error.retry",
+            value: "Retry",
+            comment: "Retry button label in the AI Assistant error banner"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("In chat") {
+    AssistantChatView.preview(.failedMidStream)
+}
+
+#Preview("Standalone") {
+    ErrorBanner(reason: "Network is unreachable. Try again in a moment.",
+                onRetry: {})
+        .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/InputBar.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/InputBar.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct InputBar: View {
+
+    @Binding var draft: String
+    let canSend: Bool
+    let isStreaming: Bool
+    let pendingConfirmation: Bool
+    let onSend: () -> Void
+    let onStop: () -> Void
+
+    private static let sendButtonDiameter: CGFloat = 36
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+            if pendingConfirmation {
+                Text(Localization.pendingHint)
+                    .font(.assistantCaption)
+                    .foregroundStyle(Color.assistantMuted)
+                    .padding(.horizontal, AssistantSpacing.medium)
+            }
+
+            HStack(alignment: .center, spacing: AssistantSpacing.small) {
+                TextField(Localization.placeholder, text: $draft, axis: .vertical)
+                    .font(.assistantBody)
+                    .lineLimit(1...6)
+                    .padding(.horizontal, AssistantSpacing.medium)
+                    .padding(.vertical, AssistantSpacing.medium)
+                    .background(textFieldBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.large))
+                    .disabled(pendingConfirmation)
+
+                Button(action: actionTapped) {
+                    Image(systemName: glyph)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(buttonForeground)
+                        .frame(width: Self.sendButtonDiameter,
+                               height: Self.sendButtonDiameter)
+                        .background(buttonBackground)
+                        .clipShape(Circle())
+                        .contentTransition(.symbolEffect(.replace))
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(buttonDisabled)
+                .accessibilityLabel(showsStop ? Localization.stop : Localization.send)
+            }
+        }
+        .padding(.horizontal, AssistantSpacing.large)
+        .padding(.top, AssistantSpacing.medium)
+        .padding(.bottom, AssistantSpacing.medium)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.assistantSeparator.opacity(0.5))
+                .frame(height: 0.5)
+        }
+    }
+
+    private var showsStop: Bool {
+        isStreaming && !pendingConfirmation
+    }
+
+    private var glyph: String {
+        showsStop ? "stop.fill" : "arrow.up"
+    }
+
+    private var buttonBackground: Color {
+        if showsStop { return Color(.accent) }
+        if canSend && !draftIsEmpty { return Color(.accent) }
+        return textFieldBackground
+    }
+
+    private var buttonForeground: Color {
+        if showsStop { return Color.assistantOnAccent }
+        if canSend && !draftIsEmpty { return Color.assistantOnAccent }
+        return Color.assistantMuted
+    }
+
+    private var buttonDisabled: Bool {
+        if showsStop { return false }
+        if pendingConfirmation { return true }
+        if !canSend { return true }
+        return draftIsEmpty
+    }
+
+    private var draftIsEmpty: Bool {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var textFieldBackground: Color {
+        Color.assistantSurfaceElevated
+    }
+
+    private func actionTapped() {
+        if showsStop {
+            onStop()
+        } else if !draftIsEmpty {
+            onSend()
+        }
+    }
+
+    private enum Localization {
+        static let placeholder = NSLocalizedString(
+            "assistantChat.input.placeholder",
+            value: "Ask about your store",
+            comment: "Placeholder shown in the AI Assistant chat input field"
+        )
+        static let send = NSLocalizedString(
+            "assistantChat.input.send.accessibility",
+            value: "Send message",
+            comment: "Accessibility label for the AI Assistant chat send button"
+        )
+        static let stop = NSLocalizedString(
+            "assistantChat.input.stop.accessibility",
+            value: "Stop response",
+            comment: "Accessibility label for the AI Assistant chat stop button"
+        )
+        static let pendingHint = NSLocalizedString(
+            "assistantChat.input.pendingHint",
+            value: "Resolve the pending change above.",
+            comment: "Hint shown above the input bar when a confirmation is pending"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Idle (in chat)") {
+    AssistantChatView.preview(.empty)
+}
+
+#Preview("Streaming (in chat)") {
+    AssistantChatView.preview(.assistantStreamingText)
+}
+
+#Preview("Pending confirmation (in chat)") {
+    AssistantChatView.preview(.pendingConfirmation)
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/IterationCapBanner.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/IterationCapBanner.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct IterationCapBanner: View {
+
+    var body: some View {
+        BannerShell(title: Localization.title, tone: .info) {
+            Text(Localization.body)
+                .font(.assistantBody)
+                .foregroundStyle(Color.assistantBubbleAssistantText)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString(
+            "assistant.banner.iterationCap.title",
+            value: "Reached step limit",
+            comment: "Title for the banner shown when the assistant hits its iteration cap"
+        )
+        static let body = NSLocalizedString(
+            "assistant.banner.iterationCap.body",
+            value: "I had to stop short of finishing. Send a follow-up to continue or refine the question.",
+            comment: "Body for the iteration-cap banner"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("In chat") {
+    AssistantChatView.preview(.iterationCap)
+}
+
+#Preview("Standalone") {
+    IterationCapBanner()
+        .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/MessageBubble.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/MessageBubble.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+struct MessageBubble: View {
+
+    let message: ChatMessage
+    var showToolActivity: Bool = true
+
+    @Environment(\.assistantConfirmationHandler) private var confirmationHandler
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            if message.role == .user { Spacer(minLength: AssistantSpacing.xxLarge) }
+            VStack(alignment: alignment, spacing: AssistantSpacing.large) {
+                ForEach(orderedSegments) { segment in
+                    segmentView(for: segment)
+                }
+            }
+            if message.role == .assistant { Spacer(minLength: AssistantSpacing.xxLarge) }
+        }
+        .frame(maxWidth: .infinity,
+               alignment: message.role == .user ? .trailing : .leading)
+    }
+
+    private var alignment: HorizontalAlignment {
+        message.role == .user ? .trailing : .leading
+    }
+
+    var orderedSegments: [MessageSegment] {
+        guard message.role == .assistant else { return message.segments }
+
+        var texts: [MessageSegment] = []
+        var lastToolCall: MessageSegment?
+        var cardRenders: [MessageSegment] = []
+        var toolResults: [MessageSegment] = []
+        var confirmations: [MessageSegment] = []
+
+        for segment in message.segments {
+            switch segment {
+            case .text:
+                texts.append(segment)
+            case .toolCall:
+                lastToolCall = segment
+            case .toolResult:
+                toolResults.append(segment)
+            case .cardRender:
+                cardRenders.append(segment)
+            case .confirmation:
+                confirmations.append(segment)
+            }
+        }
+
+        var result: [MessageSegment] = []
+        if showToolActivity, let pill = lastToolCall {
+            result.append(pill)
+        }
+        result.append(contentsOf: texts)
+
+        if !message.isStreaming {
+            if !cardRenders.isEmpty {
+                result.append(contentsOf: cardRenders)
+            } else if let fallback = fallbackCard(from: toolResults) {
+                result.append(fallback)
+            }
+        }
+        result.append(contentsOf: confirmations)
+        return result
+    }
+
+    private func fallbackCard(from results: [MessageSegment]) -> MessageSegment? {
+        var firstSearchNonEmpty: MessageSegment?
+        var lastListNonEmpty: MessageSegment?
+        var lastStrictAny: MessageSegment?
+        var lastSingle: MessageSegment?
+        for segment in results {
+            guard case .toolResult(_, _, let name, let payload) = segment else { continue }
+            let isSearch = name.hasSuffix("_search")
+            let isList = name.hasSuffix("_list")
+            let isStrict = isSearch || isList
+            let rowCount = arrayCount(payload)
+            if isStrict { lastStrictAny = segment }
+            if isSearch, rowCount > 0, firstSearchNonEmpty == nil {
+                firstSearchNonEmpty = segment
+            } else if isList, rowCount > 0 {
+                lastListNonEmpty = segment
+            } else if !isStrict {
+                lastSingle = segment
+            }
+        }
+        return firstSearchNonEmpty ?? lastListNonEmpty ?? lastStrictAny ?? lastSingle
+    }
+
+    private func arrayCount(_ value: AnyCodableJSON) -> Int {
+        if case .array(let elements) = value { return elements.count }
+        return 0
+    }
+
+    @ViewBuilder
+    private func segmentView(for segment: MessageSegment) -> some View {
+        switch segment {
+        case .text(_, let content):
+            if !content.isEmpty {
+                textBubble(content)
+            }
+        case .toolCall(_, _, let name, _, let status):
+            ToolActivityPill(toolName: name, status: status)
+        case .toolResult(_, _, let name, let payload):
+            MessageCardHost(toolName: name, payload: payload)
+        case .cardRender(_, _, let name, let payload):
+            MessageCardHost(toolName: name, payload: payload)
+        case .confirmation(_, let proposalID, let toolName, let preview, let status):
+            ConfirmationCard(proposalID: proposalID,
+                             toolName: toolName,
+                             preview: preview,
+                             status: status,
+                             onConfirm: { confirmationHandler.onConfirm(proposalID) },
+                             onCancel: { confirmationHandler.onCancel(proposalID) })
+        }
+    }
+
+    private func textBubble(_ content: String) -> some View {
+        Text(renderedText(content))
+            .font(.assistantBody)
+            .foregroundStyle(bubbleTextColor)
+            .padding(.horizontal, AssistantSpacing.medium)
+            .padding(.vertical, AssistantSpacing.bubbleVerticalInset)
+            .background(bubbleBackground)
+            .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.bubble))
+            .textSelection(.enabled)
+    }
+
+    private var bubbleBackground: Color {
+        message.role == .user ? Color.assistantBubbleUser : Color.assistantBubbleAssistant
+    }
+
+    private var bubbleTextColor: Color {
+        message.role == .user ? Color.assistantBubbleUserText : Color.assistantBubbleAssistantText
+    }
+
+    private func renderedText(_ content: String) -> AttributedString {
+        var options = AttributedString.MarkdownParsingOptions()
+        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
+        do {
+            return try AttributedString(markdown: content, options: options)
+        } catch {
+            return AttributedString(content)
+        }
+    }
+
+}
+
+#if DEBUG
+#Preview("User") {
+    MessageBubble(message: MockAssistantController.userMessage("How many orders today?"))
+        .padding()
+}
+
+#Preview("Assistant text + card (in chat)") {
+    AssistantChatView.preview(.textPlusCard)
+}
+
+#Preview("Streaming text (in chat)") {
+    AssistantChatView.preview(.assistantStreamingText)
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/MessageCardHost.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/MessageCardHost.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct MessageCardHost: View {
+
+    let toolName: String
+    let payload: AnyCodableJSON
+
+    var body: some View {
+        if let typed = ResultCardRegistry.shared.card(for: toolName, payload: payload) {
+            typed
+        } else {
+            RawJSONCard(toolName: toolName, payload: payload)
+        }
+    }
+}
+
+/// Hook for typed card renderers. Returns nil today so all results render as
+/// raw JSON; keeping the registry stub now avoids churning MessageCardHost
+/// when the typed renderers (orders, products, customers) ship.
+struct ResultCardRegistry {
+
+    static let shared = ResultCardRegistry()
+
+    func card(for toolName: String, payload: AnyCodableJSON) -> AnyView? {
+        nil
+    }
+}
+
+#if DEBUG
+#Preview("Fallback to JSON") {
+    MessageCardHost(toolName: "orders_list",
+                    payload: MockAssistantController.sampleOrderListPayload())
+        .padding()
+}
+
+#Preview("In chat") {
+    AssistantChatView.preview(.textPlusCard)
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/MessageListView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/MessageListView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+struct MessageListView: View {
+
+    let messages: [ChatMessage]
+    let streamingState: AssistantConversation.StreamingState
+    var showToolActivity: Bool = true
+    var showIterationCapBanner: Bool = false
+    var onPickPrompt: (String) -> Void = { _ in }
+
+    private static let bottomSentinelID = "scroll-sentinel-bottom"
+    private static let anchorThreshold: CGFloat = 80
+
+    @State private var isAtBottom: Bool = true
+    @State private var unreadCount: Int = 0
+
+    var body: some View {
+        GeometryReader { outer in
+            ScrollViewReader { proxy in
+                ZStack(alignment: .bottom) {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: AssistantSpacing.large) {
+                            if messages.isEmpty {
+                                EmptyStateView(onPick: onPickPrompt)
+                            }
+                            ForEach(messages) { message in
+                                MessageBubble(message: message,
+                                              showToolActivity: showToolActivity)
+                                    .id(message.id)
+                            }
+                            if streamingState == .sending {
+                                TypingIndicator()
+                                    .padding(.leading, AssistantSpacing.medium)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            if case .failed(let reason) = streamingState {
+                                ErrorBanner(reason: reason)
+                            }
+                            if case .outcomeUnknown(let reason) = streamingState {
+                                OutcomeUnknownBanner(reason: reason)
+                            }
+                            if showIterationCapBanner {
+                                IterationCapBanner()
+                            }
+
+                            GeometryReader { sentinel in
+                                Color.clear.preference(
+                                    key: BottomDistanceKey.self,
+                                    value: sentinel.frame(in: .global).minY - outer.frame(in: .global).maxY
+                                )
+                            }
+                            .frame(height: 1)
+                            .id(Self.bottomSentinelID)
+                        }
+                        .padding(.horizontal, AssistantSpacing.large)
+                        .padding(.top, AssistantSpacing.large)
+                        .padding(.bottom, AssistantSpacing.medium)
+                        .contentShape(Rectangle())
+                    }
+                    .scrollDismissesKeyboard(.interactively)
+                    .onPreferenceChange(BottomDistanceKey.self) { distance in
+                        let nowAtBottom = distance < Self.anchorThreshold
+                        if nowAtBottom { unreadCount = 0 }
+                        isAtBottom = nowAtBottom
+                    }
+                    .onChange(of: messages.count) { _, _ in
+                        handleNewContent(proxy: proxy, isNewMessage: true)
+                    }
+                    .onChange(of: messages.last?.segments.last?.fingerprint) { _, _ in
+                        handleNewContent(proxy: proxy, isNewMessage: false)
+                    }
+                    .onAppear {
+                        proxy.scrollTo(Self.bottomSentinelID, anchor: .bottom)
+                    }
+
+                    if let pillCount = effectivePillCount {
+                        NewMessagesPill(count: pillCount) {
+                            unreadCount = 0
+                            scrollToBottom(proxy: proxy)
+                        }
+                        .padding(.bottom, AssistantSpacing.medium)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .animation(.smooth(duration: AssistantMotion.transition), value: unreadCount)
+                .animation(.smooth(duration: AssistantMotion.transition), value: isAtBottom)
+            }
+        }
+    }
+
+    private func handleNewContent(proxy: ScrollViewProxy, isNewMessage: Bool) {
+        if isAtBottom {
+            scrollToBottom(proxy: proxy)
+        } else if isNewMessage {
+            unreadCount += 1
+        }
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy) {
+        withAnimation(.smooth(duration: AssistantMotion.snap)) {
+            proxy.scrollTo(Self.bottomSentinelID, anchor: .bottom)
+        }
+    }
+
+    private var effectivePillCount: Int? {
+        guard unreadCount > 0, !isAtBottom else { return nil }
+        return unreadCount
+    }
+}
+
+private struct BottomDistanceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+private struct NewMessagesPill: View {
+
+    let count: Int
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: AssistantSpacing.xSmall) {
+                Image(systemName: "arrow.down")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(label)
+                    .font(.assistantBodyEmphasized)
+            }
+            .padding(.horizontal, AssistantSpacing.medium)
+            .padding(.vertical, AssistantSpacing.medium)
+            .frame(minHeight: 44)
+            .foregroundStyle(Color.assistantOnAccent)
+            .background(
+                Capsule().fill(Color(.accent))
+            )
+            .shadow(color: Color.black.opacity(0.18), radius: 8, y: 2)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var label: String {
+        if count == 1 {
+            return Localization.singular
+        }
+        return String(format: Localization.plural, count)
+    }
+
+    private enum Localization {
+        static let singular = NSLocalizedString(
+            "assistantChat.scroll.newMessage.singular",
+            value: "1 new message",
+            comment: "Pill shown above the input bar when one new message arrived while scrolled up"
+        )
+        static let plural = NSLocalizedString(
+            "assistantChat.scroll.newMessage.plural",
+            value: "%1$d new messages",
+            comment: "Pill shown above the input bar when multiple new messages arrived while scrolled up. %1$d is the count."
+        )
+    }
+}
+
+
+#if DEBUG
+#Preview("Empty") {
+    AssistantChatView.preview(.empty)
+}
+
+#Preview("Multi-turn") {
+    AssistantChatView.preview(.multiTurn)
+}
+
+#Preview("Failed mid-stream") {
+    AssistantChatView.preview(.failedMidStream)
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/OutcomeUnknownBanner.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/OutcomeUnknownBanner.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct OutcomeUnknownBanner: View {
+
+    let reason: String
+
+    var body: some View {
+        BannerShell(title: Localization.title, tone: .warning) {
+            Text(reason)
+                .font(.assistantBody)
+                .foregroundStyle(Color.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private enum Localization {
+        static let title = NSLocalizedString(
+            "assistant.banner.outcomeUnknown.title",
+            value: "Outcome unknown",
+            comment: "Banner title shown when an action's success cannot be confirmed"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("In chat") {
+    AssistantChatView.preview(.outcomeUnknown)
+}
+
+#Preview("Standalone") {
+    OutcomeUnknownBanner(reason: "The connection dropped before we got a confirmation.")
+        .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/Previews/AssistantChatScenario.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/Previews/AssistantChatScenario.swift
@@ -1,0 +1,181 @@
+#if DEBUG
+import Foundation
+import SwiftUI
+
+/// Single source of truth for preview/snapshot states across components.
+enum AssistantChatScenario: String, CaseIterable {
+    case empty
+    case singleUserMessage
+    case assistantTyping
+    case assistantStreamingText
+    case textPlusCard
+    case toolActivityPill
+    case pendingConfirmation
+    case pendingConfirmationBulk
+    case failedMidStream
+    case outcomeUnknown
+    case iterationCap
+    case multiTurn
+
+    var displayName: String {
+        switch self {
+        case .empty: return "Empty"
+        case .singleUserMessage: return "Single user message"
+        case .assistantTyping: return "Assistant typing"
+        case .assistantStreamingText: return "Assistant streaming text"
+        case .textPlusCard: return "Text + card"
+        case .toolActivityPill: return "Tool activity pill"
+        case .pendingConfirmation: return "Pending confirmation"
+        case .pendingConfirmationBulk: return "Pending confirmation (bulk)"
+        case .failedMidStream: return "Failed mid-stream"
+        case .outcomeUnknown: return "Outcome unknown"
+        case .iterationCap: return "Iteration cap"
+        case .multiTurn: return "Multi-turn"
+        }
+    }
+}
+
+@MainActor
+struct AssistantChatScenarioBuilder {
+
+    let scenario: AssistantChatScenario
+
+    func build() -> Configuration {
+        switch scenario {
+        case .empty:
+            return Configuration(controller: MockAssistantController.make())
+
+        case .singleUserMessage:
+            let messages = [MockAssistantController.userMessage("How many orders today?")]
+            return Configuration(controller: MockAssistantController.make(messages: messages))
+
+        case .assistantTyping:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("How many orders today?"),
+                ChatMessage(role: .assistant, segments: [], isStreaming: true)
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages,
+                                                                          streaming: .sending))
+
+        case .assistantStreamingText:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Summarise yesterday in one line"),
+                MockAssistantController.assistantText(
+                    "Yesterday you took 12 orders for a total of $1,284 across",
+                    streaming: true
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages,
+                                                                          streaming: .streaming))
+
+        case .textPlusCard:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Show me the last two orders"),
+                MockAssistantController.assistantWithCard(
+                    text: "Here are the last two orders.",
+                    toolName: "orders_list",
+                    payload: MockAssistantController.sampleOrderListPayload()
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages))
+
+        case .toolActivityPill:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Find Sarah's orders"),
+                MockAssistantController.assistantWithToolPill(
+                    text: "",
+                    tool: "customers_search",
+                    status: .running,
+                    streaming: true
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages,
+                                                                          streaming: .streaming))
+
+        case .pendingConfirmation:
+            let proposalID = UUID()
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Mark order 3479 as completed"),
+                MockAssistantController.assistantConfirmation(
+                    text: "I'll mark order #3479 as completed.",
+                    proposalID: proposalID,
+                    tool: "orders_update",
+                    preview: "Update order #3479: status processing -> completed",
+                    status: .pending
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages,
+                                                                          streaming: .idle))
+
+        case .pendingConfirmationBulk:
+            let proposalID = UUID()
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Move all 12 processing orders to completed"),
+                MockAssistantController.assistantConfirmation(
+                    text: "I'll move 12 orders from processing to completed.",
+                    proposalID: proposalID,
+                    tool: "orders_bulk_update",
+                    preview: "Update 12 orders: status -> completed (emails customers)",
+                    status: .pending
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages,
+                                                                          streaming: .idle))
+
+        case .failedMidStream:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Refund order 3470"),
+                MockAssistantController.assistantText("Looking that up", streaming: false)
+            ]
+            return Configuration(controller: MockAssistantController.make(
+                messages: messages,
+                streaming: .failed("Network is unreachable. Try again in a moment.")
+            ))
+
+        case .outcomeUnknown:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Update product 64 price to $19.99"),
+                MockAssistantController.assistantText(
+                    "Submitting the price update now.",
+                    streaming: false
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(
+                messages: messages,
+                streaming: .outcomeUnknown("The connection dropped before we got a confirmation. Verify the price before retrying.")
+            ))
+
+        case .iterationCap:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Compare every order this month"),
+                MockAssistantController.assistantText(
+                    "I've gathered most of the data but had to stop short of finishing the comparison.",
+                    streaming: false
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages),
+                                 showIterationCapBanner: true)
+
+        case .multiTurn:
+            let messages: [ChatMessage] = [
+                MockAssistantController.userMessage("Top product yesterday?"),
+                MockAssistantController.assistantText("Top product yesterday was the Striped Beanie with 14 units sold."),
+                MockAssistantController.userMessage("And revenue?"),
+                MockAssistantController.assistantText("Striped Beanie generated $293.86 in revenue."),
+                MockAssistantController.userMessage("Show me the orders"),
+                MockAssistantController.assistantWithCard(
+                    text: "Here are the matching orders.",
+                    toolName: "orders_list",
+                    payload: MockAssistantController.sampleOrderListPayload()
+                )
+            ]
+            return Configuration(controller: MockAssistantController.make(messages: messages))
+        }
+    }
+
+    struct Configuration {
+        let controller: AssistantController
+        var showIterationCapBanner: Bool = false
+    }
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/Previews/MockAssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/Previews/MockAssistantController.swift
@@ -1,0 +1,121 @@
+#if DEBUG
+import Foundation
+
+@MainActor
+enum MockAssistantController {
+
+    static func make(messages: [ChatMessage] = [],
+                     streaming: AssistantConversation.StreamingState = .idle) -> AssistantController {
+        let conversation = AssistantConversation(seededMessages: messages)
+        conversation.setStreaming(streaming)
+        let context = AssistantContext(siteID: 0,
+                                       siteURL: URL(string: "https://example.com")!,
+                                       blogID: nil)
+        return AssistantController(backend: InertBackend(),
+                                   context: context,
+                                   conversation: conversation)
+    }
+
+    static func userMessage(_ text: String) -> ChatMessage {
+        ChatMessage(role: .user,
+                    segments: [.text(id: UUID(), content: text)])
+    }
+
+    static func assistantText(_ text: String, streaming: Bool = false) -> ChatMessage {
+        ChatMessage(role: .assistant,
+                    segments: [.text(id: UUID(), content: text)],
+                    isStreaming: streaming)
+    }
+
+    static func assistantWithToolPill(text: String,
+                                      tool: String,
+                                      status: ToolCallStatus,
+                                      streaming: Bool) -> ChatMessage {
+        var segments: [MessageSegment] = []
+        segments.append(.toolCall(id: UUID(),
+                                  toolCallID: UUID().uuidString,
+                                  toolName: tool,
+                                  argumentsPreview: nil,
+                                  status: status))
+        if !text.isEmpty {
+            segments.append(.text(id: UUID(), content: text))
+        }
+        return ChatMessage(role: .assistant,
+                           segments: segments,
+                           isStreaming: streaming)
+    }
+
+    static func assistantWithCard(text: String,
+                                  toolName: String,
+                                  payload: AnyCodableJSON,
+                                  streaming: Bool = false) -> ChatMessage {
+        let toolCallID = UUID().uuidString
+        let syntheticID = "\(toolCallID):card:0"
+        let syntheticTool = "\(toolName).order"
+        let segments: [MessageSegment] = [
+            .text(id: UUID(), content: text),
+            .toolResult(id: UUID(),
+                        toolCallID: toolCallID,
+                        toolName: toolName,
+                        payload: payload),
+            .toolResult(id: UUID(),
+                        toolCallID: syntheticID,
+                        toolName: syntheticTool,
+                        payload: payload),
+            .cardRender(id: UUID(),
+                        toolCallID: syntheticID,
+                        toolName: syntheticTool,
+                        payload: payload)
+        ]
+        return ChatMessage(role: .assistant,
+                           segments: segments,
+                           isStreaming: streaming)
+    }
+
+    static func assistantConfirmation(text: String,
+                                      proposalID: UUID,
+                                      tool: String,
+                                      preview: String,
+                                      status: ConfirmationStatus) -> ChatMessage {
+        let segments: [MessageSegment] = [
+            .text(id: UUID(), content: text),
+            .confirmation(id: UUID(),
+                          proposalID: proposalID,
+                          toolName: tool,
+                          preview: preview,
+                          status: status)
+        ]
+        return ChatMessage(role: .assistant, segments: segments)
+    }
+
+    static func sampleOrderListPayload() -> AnyCodableJSON {
+        .array([
+            .object([
+                "id": .int(3479),
+                "total": .string("$84.20"),
+                "status": .string("processing")
+            ]),
+            .object([
+                "id": .int(3478),
+                "total": .string("$214.00"),
+                "status": .string("completed")
+            ])
+        ])
+    }
+}
+
+private struct InertBackend: AssistantBackendConfirming {
+    func send(turn: AssistantTurn,
+              context: AssistantContext,
+              session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func confirmProposal(_ id: UUID) async {}
+
+    func cancelProposal(_ id: UUID) async {}
+}
+
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/RawJSONCard.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/RawJSONCard.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+import CocoaLumberjackSwift
+
+struct RawJSONCard: View {
+
+    let toolName: String
+    let payload: AnyCodableJSON
+
+    @State private var isExpanded = false
+
+    private static let collapsedLines = 6
+
+    var body: some View {
+        CardShell(label: toolName, trailingChevron: false) {
+            VStack(alignment: .leading, spacing: AssistantSpacing.small) {
+                Text(prettyJSON)
+                    .font(.assistantMonospaced)
+                    .foregroundStyle(Color.primary)
+                    .lineLimit(isExpanded ? nil : Self.collapsedLines)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if shouldOfferExpand {
+                    Button {
+                        withAnimation(.smooth(duration: AssistantMotion.snap)) {
+                            isExpanded.toggle()
+                        }
+                    } label: {
+                        Text(isExpanded ? Localization.showLess : Localization.showAll)
+                            .font(.assistantCaption)
+                            .foregroundStyle(Color(.accent))
+                            .frame(minHeight: 44)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var prettyJSON: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(payload)
+            return String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            DDLogError("RawJSONCard pretty-print failed: \(error)")
+            return ""
+        }
+    }
+
+    private var shouldOfferExpand: Bool {
+        prettyJSON.split(separator: "\n").count > Self.collapsedLines
+    }
+
+    private enum Localization {
+        static let showAll = NSLocalizedString(
+            "assistant.card.raw.showAll",
+            value: "Show all",
+            comment: "Toggle to expand a collapsed JSON block in the AI Assistant raw card"
+        )
+        static let showLess = NSLocalizedString(
+            "assistant.card.raw.showLess",
+            value: "Show less",
+            comment: "Toggle to collapse an expanded JSON block in the AI Assistant raw card"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Short") {
+    RawJSONCard(toolName: "orders_list",
+                payload: MockAssistantController.sampleOrderListPayload())
+        .padding()
+}
+
+#Preview("In chat") {
+    AssistantChatView.preview(.textPlusCard)
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/StringHumanize.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/StringHumanize.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+extension String {
+
+    /// Humanises a snake/kebab-cased tool token so `"stock_quantity"` reads
+    /// as `"Stock Quantity"` in UI surfaces. Shared between tool pills and
+    /// confirmation diff labels so the two stay phrased consistently.
+    static func assistantHumanizedToolToken(_ raw: String) -> String {
+        let cleaned = raw.replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "/", with: " ")
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines).capitalized
+    }
+
+    /// Capitalises lowercase status-style values (`processing` -> `Processing`)
+    /// while leaving numbers, prices, and emails intact so currency/totals
+    /// don't get inadvertently re-cased.
+    static func assistantHumanizedValue(_ value: String) -> String {
+        guard !value.isEmpty else { return value }
+        if value.contains(where: { $0.isNumber || $0 == "@" || $0 == "$" || $0 == "." }) {
+            return value
+        }
+        let words = value.split(separator: " ").map { token -> String in
+            let lower = token.lowercased()
+            return lower.localizedCapitalized
+        }
+        return words.joined(separator: " ")
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Presentation/ToolActivityPill.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ToolActivityPill.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct ToolActivityPill: View {
+
+    let toolName: String
+    let status: ToolCallStatus
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        if hasExpandableSummary {
+            Button(action: toggle) {
+                content
+            }
+            .buttonStyle(.plain)
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
+            HStack(spacing: AssistantSpacing.small) {
+                icon
+                    .accessibilityHidden(true)
+                Text(title)
+                    .font(.assistantCaption)
+                    .foregroundStyle(Color.assistantBubbleAssistantText)
+                Spacer(minLength: 0)
+                if hasExpandableSummary {
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.assistantMuted)
+                        .accessibilityHidden(true)
+                }
+            }
+            if isExpanded, case .completed(let summary?) = status {
+                Text(summary)
+                    .font(.assistantMonospaced)
+                    .foregroundStyle(Color.assistantBubbleAssistantText)
+                    .lineLimit(3)
+            }
+        }
+        .padding(.horizontal, AssistantSpacing.medium)
+        .padding(.vertical, AssistantSpacing.small)
+        .frame(minHeight: 44, alignment: .leading)
+        .background(Color.assistantToolBackground)
+        .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.medium))
+    }
+
+    private func toggle() {
+        guard hasExpandableSummary else { return }
+        withAnimation(.smooth(duration: AssistantMotion.snap)) {
+            isExpanded.toggle()
+        }
+    }
+
+    private var hasExpandableSummary: Bool {
+        if case .completed(let summary) = status, summary != nil { return true }
+        return false
+    }
+
+    @ViewBuilder
+    private var icon: some View {
+        switch status {
+        case .running:
+            Image(systemName: "ellipsis")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color(.accent))
+                .symbolEffect(.pulse.byLayer, options: .repeating)
+        case .completed:
+            Image(systemName: "checkmark")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.assistantSuccess)
+                .contentTransition(.symbolEffect(.replace))
+        case .failed:
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.assistantError)
+        }
+    }
+
+    private var title: String {
+        let label = String.assistantHumanizedToolToken(toolName)
+        switch status {
+        case .running: return String(format: Localization.runningFormat, label)
+        case .completed: return String(format: Localization.completedFormat, label)
+        case .failed(let message): return String(format: Localization.failedFormat, label, message)
+        }
+    }
+
+    private enum Localization {
+        static let runningFormat = NSLocalizedString(
+            "assistant.tool.running",
+            value: "Using %1$@…",
+            comment: "Tool call running: %1$@ is the tool name"
+        )
+        static let completedFormat = NSLocalizedString(
+            "assistant.tool.completed",
+            value: "Used %1$@",
+            comment: "Tool call completed: %1$@ is the tool name"
+        )
+        static let failedFormat = NSLocalizedString(
+            "assistant.tool.failed",
+            value: "%1$@ failed: %2$@",
+            comment: "Tool call failed: %1$@ is the tool name, %2$@ is the failure message"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("In chat") {
+    AssistantChatView.preview(.toolActivityPill)
+}
+
+#Preview("Running") {
+    ToolActivityPill(toolName: "customers_search", status: .running)
+        .padding()
+}
+
+#Preview("Completed") {
+    ToolActivityPill(toolName: "orders_list",
+                     status: .completed(summary: "[ {id: 3479}, {id: 3478} ]"))
+        .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/Presentation/TypingIndicator.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/TypingIndicator.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct TypingIndicator: View {
+
+    var body: some View {
+        HStack(spacing: AssistantSpacing.xSmall) {
+            ForEach(0..<3, id: \.self) { _ in
+                Circle()
+                    .fill(Color.assistantMuted)
+                    .frame(width: 6, height: 6)
+                    .opacity(0.6)
+            }
+        }
+        .padding(.horizontal, AssistantSpacing.medium)
+        .padding(.vertical, AssistantSpacing.small)
+        .background(Color.assistantBubbleAssistant)
+        .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.bubble))
+        .accessibilityLabel(Localization.typing)
+    }
+
+    private enum Localization {
+        static let typing = NSLocalizedString(
+            "assistant.typing.indicator",
+            value: "Assistant is typing",
+            comment: "Accessibility label for typing indicator"
+        )
+    }
+}
+
+#if DEBUG
+#Preview("In chat") {
+    AssistantChatView.preview(.assistantTyping)
+}
+
+#Preview("Standalone") {
+    TypingIndicator()
+        .padding()
+}
+#endif

--- a/Modules/Sources/WooAIAssistant/State/AssistantController.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantController.swift
@@ -47,7 +47,37 @@ public final class AssistantController {
             conversation.markCancelled(messageID: messageID)
         }
         activeAssistantMessageID = nil
+        for proposalID in pendingProposalIDs() {
+            conversation.applyConfirmationResolution(proposalID: proposalID, approved: false)
+            cancelProposal(proposalID)
+        }
         conversation.setStreaming(.idle)
+    }
+
+    private func pendingProposalIDs() -> [UUID] {
+        var ids: [UUID] = []
+        for message in conversation.messages {
+            for segment in message.segments {
+                if case .confirmation(_, let proposalID, _, _, .pending) = segment {
+                    ids.append(proposalID)
+                }
+            }
+        }
+        return ids
+    }
+
+    public func startNewConversation() {
+        cancel()
+        let token = UUID()
+        activeTurnToken = token
+        activeTask = Task { [weak self] in
+            guard let self else { return }
+            await backend.reset()
+            guard activeTurnToken == token else { return }
+            conversation.reset()
+            activeTask = nil
+            activeTurnToken = nil
+        }
     }
 
     public var canSend: Bool {

--- a/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
+++ b/Modules/Sources/WooAIAssistant/State/AssistantConversation.swift
@@ -26,6 +26,20 @@ public final class AssistantConversation {
         self.messages = seededMessages
     }
 
+    func reset() {
+        messages = []
+        streamingState = .idle
+        outcomeUnknownObserved = false
+        session = nil
+    }
+
+    func applyConfirmationResolution(proposalID: UUID, approved: Bool) {
+        for index in messages.indices {
+            messages[index].updateConfirmation(proposalID: proposalID,
+                                               to: approved ? .confirmed : .cancelled)
+        }
+    }
+
     func appendUserMessage(_ text: String) -> ChatMessage {
         let message = ChatMessage(role: .user,
                                   segments: [.text(id: UUID(), content: text)])

--- a/Modules/Sources/WooAIAssistant/Tokens/AssistantColor.swift
+++ b/Modules/Sources/WooAIAssistant/Tokens/AssistantColor.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import UIKit
+import WooFoundation
+
+public extension Color {
+    static let assistantSurface = Color(.systemBackground)
+    static let assistantSurfaceElevated = Color(.secondarySystemBackground)
+    static let assistantSurfaceAlt = Color(.listBackground)
+    static let assistantSurfaceBorder = Color(.divider).opacity(0.35)
+    static let assistantSeparator = Color(.divider)
+    static let assistantBubbleUser = Color(.accent)
+    static let assistantBubbleUserText = Color.assistantOnAccent
+    static let assistantOnAccent = Color(UIColor { traits in
+        traits.userInterfaceStyle == .dark ? UIColor(white: 0.08, alpha: 1.0) : .white
+    })
+    static let assistantBubbleAssistant = Color(.tertiarySystemFill)
+    static let assistantBubbleAssistantText = Color(.text)
+    static let assistantMuted = Color(.textSubtle)
+    static let assistantTextFaint = Color(.textTertiary)
+    static let assistantAccentTint = Color(.infoBackground)
+    static let assistantToolBackground = Color(.quaternarySystemFill)
+    static let assistantError = Color(.error)
+    static let assistantSuccess = Color(.success)
+    static let assistantWarning = Color(.warning)
+    static let assistantInfo = Color(.info)
+}

--- a/Modules/Sources/WooAIAssistant/Tokens/AssistantFontStyle.swift
+++ b/Modules/Sources/WooAIAssistant/Tokens/AssistantFontStyle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+public extension Font {
+    static let assistantBody = Font.body
+    static let assistantBodyEmphasized = Font.body.weight(.semibold)
+    static let assistantCaption = Font.caption
+    static let assistantTitle = Font.title3.weight(.semibold)
+    static let assistantMonospaced = Font.system(.footnote, design: .monospaced)
+}

--- a/Modules/Sources/WooAIAssistant/Tokens/AssistantSpacing.swift
+++ b/Modules/Sources/WooAIAssistant/Tokens/AssistantSpacing.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+public enum AssistantSpacing: Sendable {
+    public static let none: CGFloat = 0
+    public static let xSmall: CGFloat = 4
+    public static let small: CGFloat = 8
+    public static let medium: CGFloat = 12
+    public static let large: CGFloat = 16
+    public static let xLarge: CGFloat = 24
+    public static let xxLarge: CGFloat = 32
+    public static let bubbleVerticalInset: CGFloat = 6
+}
+
+public enum AssistantRadius: Sendable {
+    public static let medium: CGFloat = 12
+    public static let large: CGFloat = 20
+    public static let bubble: CGFloat = 22
+    public static let card: CGFloat = 18
+}
+
+public enum AssistantMotion: Sendable {
+    public static let snap: Double = 0.20
+    public static let transition: Double = 0.25
+}

--- a/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Backend/AgenticChatBackendTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 @testable import WooAIAssistant
 
@@ -141,6 +142,37 @@ struct AgenticChatBackendTests {
     }
 
     @Test
+    func test_send_when_first_turn_fails_then_secondTurn_transcript_does_not_replay_failed_turn()
+    async throws {
+        // Given
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [],
+            [.textDelta("OK."), .completed(.stop)]
+        ])
+        await chat.setStreamError(AssistantError(kind: .upstreamFailure,
+                                                 message: "first turn blew up"))
+        let backend = AgenticChatBackend(chatService: chat, systemPrompt: nil)
+
+        // When
+        let stream1 = backend.send(turn: .init(prompt: "first"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream1 {}
+        await chat.setStreamError(nil)
+        let stream2 = backend.send(turn: .init(prompt: "second"),
+                                   context: defaultContext,
+                                   session: nil)
+        for try await _ in stream2 {}
+
+        // Then
+        let captured = await chat.capturedRequests
+        let secondMessages = captured.last?.messages ?? []
+        let userPrompts = secondMessages.filter { $0.role == .user }.compactMap { $0.content }
+        #expect(userPrompts == ["second"])
+    }
+
+    @Test
     func test_transcript_when_toolCallStarted_without_completed_then_orphan_dropped_in_next_turn()
     async throws {
         // Given
@@ -226,73 +258,6 @@ struct AgenticChatBackendTests {
     }
 
     @Test
-    func test_send_when_turn_fails_mid_stream_then_transcript_not_polluted() async throws {
-        // Given
-        let chat = MockAIChatService()
-        await chat.setScriptedTurns([
-            [.textDelta("first ok"), .completed(.stop)],
-            [.textDelta("partial")],
-            [.textDelta("third"), .completed(.stop)]
-        ])
-        let backend = AgenticChatBackend(chatService: chat, systemPrompt: nil)
-
-        // When
-        let stream1 = backend.send(turn: .init(prompt: "t1"),
-                                   context: defaultContext,
-                                   session: nil)
-        for try await _ in stream1 {}
-        await chat.setStreamError(AssistantError(kind: .upstreamFailure, message: "boom"))
-        let stream2 = backend.send(turn: .init(prompt: "t2"),
-                                   context: defaultContext,
-                                   session: nil)
-        for try await _ in stream2 {}
-        await chat.setStreamError(nil)
-        let stream3 = backend.send(turn: .init(prompt: "t3"),
-                                   context: defaultContext,
-                                   session: nil)
-        for try await _ in stream3 {}
-
-        // Then
-        let captured = await chat.capturedRequests
-        let messagesOnTurn3 = captured.last?.messages ?? []
-        let userPrompts = messagesOnTurn3.filter { $0.role == .user }.compactMap { $0.content }
-        #expect(userPrompts == ["t1", "t3"])
-        let assistantTexts = messagesOnTurn3
-            .filter { $0.role == .assistant && $0.content != nil }
-            .compactMap { $0.content }
-        #expect(assistantTexts == ["first ok"])
-    }
-
-    @Test
-    func test_send_when_tool_calls_complete_in_reverse_order_then_transcript_replays_in_call_order()
-    async throws {
-        // Given
-        let firstCall = OpenAIChat.ToolCall(
-            id: "call_a",
-            function: .init(name: "tool_a", arguments: "{}")
-        )
-        let secondCall = OpenAIChat.ToolCall(
-            id: "call_b",
-            function: .init(name: "tool_b", arguments: "{}")
-        )
-        let resultsCompletedInReverseOrder: [(String, String)] = [
-            ("call_b", #"{"b":2}"#),
-            ("call_a", #"{"a":1}"#)
-        ]
-
-        // When
-        let (orderedCalls, orderedResults) = AgenticChatBackend.matchedPairs(
-            toolCalls: [firstCall, secondCall],
-            toolResults: resultsCompletedInReverseOrder
-        )
-
-        // Then
-        #expect(orderedCalls.map(\.id) == ["call_a", "call_b"])
-        #expect(orderedResults.map(\.0) == ["call_a", "call_b"])
-        #expect(orderedResults.map(\.1) == [#"{"a":1}"#, #"{"b":2}"#])
-    }
-
-    @Test
     func test_systemPromptProvider_when_invoked_per_turn_then_rebuilt_each_call()
     async throws {
         // Given
@@ -301,8 +266,11 @@ struct AgenticChatBackendTests {
             [.textDelta("a"), .completed(.stop)],
             [.textDelta("b"), .completed(.stop)]
         ])
+        let counter = ProviderCallCounter()
         let backend = AgenticChatBackend(chatService: chat,
-                                         systemPromptProvider: { UUID().uuidString })
+                                         systemPromptProvider: {
+                                             "prompt-\(counter.bumpAndGet())"
+                                         })
 
         // When
         let stream1 = backend.send(turn: .init(prompt: "one"),
@@ -315,12 +283,12 @@ struct AgenticChatBackendTests {
         for try await _ in stream2 {}
 
         // Then
+        #expect(counter.snapshot() == 2)
         let captured = await chat.capturedRequests
         let firstSystem = captured[0].messages.first(where: { $0.role == .system })?.content
         let secondSystem = captured[1].messages.first(where: { $0.role == .system })?.content
-        #expect(firstSystem != nil)
-        #expect(secondSystem != nil)
-        #expect(firstSystem != secondSystem)
+        #expect(firstSystem == "prompt-1")
+        #expect(secondSystem == "prompt-2")
     }
 
     @Test
@@ -441,4 +409,17 @@ struct AgenticChatBackendTests {
         siteURL: URL(string: "https://example.com")!,
         blogID: nil
     )
+}
+
+private final class ProviderCallCounter: @unchecked Sendable {
+    private var count = 0
+
+    func bumpAndGet() -> Int {
+        count += 1
+        return count
+    }
+
+    func snapshot() -> Int {
+        count
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopAdditionalEdgeCasesTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopAdditionalEdgeCasesTests.swift
@@ -295,6 +295,55 @@ struct LoopAdditionalEdgeCasesTests {
     }
 
     @Test
+    func test_run_when_success_with_uiStructured_then_emits_synthetic_toolResult_and_cardRender_events() async throws {
+        // Given
+        let listTool = AITool(name: "show_cards",
+                              description: "Render cards",
+                              parametersSchema: .object([:]),
+                              safetyLevel: .safe)
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_show",
+            function: .init(name: "show_cards", arguments: #"{}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(toolCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let card = RenderedCardPayload(family: .order,
+                                       id: "42",
+                                       element: .object(["id": .int(42)]))
+        let success = ToolResult.Success(toolName: "show_cards",
+                                         structured: .object(["rendered": .int(1)]),
+                                         uiStructured: UIStructured(cards: [card]))
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([listTool])
+        await registry.setResult(for: "show_cards", result: .success(success))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        var events: [AssistantEvent] = []
+        for try await event in orchestrator.run(prompt: "Show order 42") {
+            events.append(event)
+        }
+
+        // Then
+        let cardRenderIDs: [String] = events.compactMap { event in
+            if case .cardRender(let id) = event { return id }
+            return nil
+        }
+        #expect(cardRenderIDs.count == 1)
+        let renderID = try #require(cardRenderIDs.first)
+        #expect(renderID.hasPrefix("call_show:card:"))
+
+        let syntheticToolResult = events.first { event in
+            if case .toolResult(let id, _, _) = event, id == renderID { return true }
+            return false
+        }
+        #expect(syntheticToolResult != nil)
+    }
+
+    @Test
     func test_run_when_success_with_uiStructured_then_only_structured_appears_in_resubmitted_tool_message() async throws {
         // Given
         let listTool = AITool(name: "orders_list",

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
@@ -1,7 +1,8 @@
 import Foundation
 @testable import WooAIAssistant
 
-final class MockAssistantBackend: AssistantBackendConfirming, @unchecked Sendable {
+@MainActor
+final class MockAssistantBackend: AssistantBackendConfirming {
 
     private(set) var recordedTurns: [AssistantTurn] = []
     private(set) var confirmedProposalIDs: [UUID] = []

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockAssistantBackend.swift
@@ -1,16 +1,20 @@
 import Foundation
 @testable import WooAIAssistant
 
-@MainActor
-final class MockAssistantBackend: AssistantBackendConfirming {
+final class MockAssistantBackend: AssistantBackendConfirming, @unchecked Sendable {
 
     private(set) var recordedTurns: [AssistantTurn] = []
     private(set) var confirmedProposalIDs: [UUID] = []
     private(set) var cancelledProposalIDs: [UUID] = []
+    private(set) var resetCallCount: Int = 0
 
     private var scripts: [[BackendYield]] = []
     private var heldIndices: Set<Int> = []
     private var pendingByIndex: [Int: AsyncThrowingStream<BackendYield, Error>.Continuation] = [:]
+    private var resetGate: CheckedContinuation<Void, Never>?
+    private var resetIsHeld = false
+    private var resetWaiter: CheckedContinuation<Void, Never>?
+    private var cancelledProposalWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
 
     func script(_ events: [BackendYield]) {
         scripts.append(events)
@@ -30,26 +34,58 @@ final class MockAssistantBackend: AssistantBackendConfirming {
         continuation.finish()
     }
 
-    nonisolated public func send(turn: AssistantTurn,
-                                 context: AssistantContext,
-                                 session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
-        let index = MainActor.assumeIsolated { self.recordTurn(turn) }
+    func send(turn: AssistantTurn,
+              context: AssistantContext,
+              session: AssistantSession?) -> AsyncThrowingStream<BackendYield, Error> {
+        let index = recordTurn(turn)
         return AsyncThrowingStream { continuation in
-            MainActor.assumeIsolated {
-                self.start(index: index, continuation: continuation)
+            self.start(index: index, continuation: continuation)
+        }
+    }
+
+    func confirmProposal(_ id: UUID) async {
+        recordConfirmedProposal(id)
+    }
+
+    func cancelProposal(_ id: UUID) async {
+        recordCancelledProposal(id)
+    }
+
+    func reset() async {
+        resetCallCount += 1
+        if resetIsHeld {
+            await withCheckedContinuation { continuation in
+                resetGate = continuation
+                resetWaiter?.resume()
+                resetWaiter = nil
             }
+        } else {
+            resetWaiter?.resume()
+            resetWaiter = nil
         }
     }
 
-    public nonisolated func confirmProposal(_ id: UUID) async {
-        await MainActor.run {
-            self.confirmedProposalIDs.append(id)
+    func holdReset() {
+        resetIsHeld = true
+    }
+
+    func releaseReset() {
+        resetIsHeld = false
+        resetGate?.resume()
+        resetGate = nil
+    }
+
+    func waitForResetCall() async {
+        if resetCallCount > 0 { return }
+        await withCheckedContinuation { continuation in
+            resetWaiter = continuation
         }
     }
 
-    public nonisolated func cancelProposal(_ id: UUID) async {
-        await MainActor.run {
-            self.cancelledProposalIDs.append(id)
+    func waitForCancelledProposal(_ id: UUID) async {
+        if cancelledProposalIDs.contains(id) { return }
+        await withCheckedContinuation { continuation in
+            cancelledProposalWaiters[id] = continuation
         }
     }
 
@@ -69,4 +105,14 @@ final class MockAssistantBackend: AssistantBackendConfirming {
             continuation.finish()
         }
     }
+
+    private func recordConfirmedProposal(_ id: UUID) {
+        confirmedProposalIDs.append(id)
+    }
+
+    private func recordCancelledProposal(_ id: UUID) {
+        cancelledProposalIDs.append(id)
+        cancelledProposalWaiters.removeValue(forKey: id)?.resume()
+    }
+
 }

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantControllerTests.swift
@@ -174,55 +174,88 @@ struct AssistantControllerTests {
     }
 
     @Test
-    func test_cancel_when_message_in_flight_then_message_marked_completed_and_pending_confirmations_cancelled()
+    func test_cancel_when_pending_confirmation_then_segment_becomes_cancelled_and_proposal_is_cancelled_in_backend()
     async throws {
         // Given
         let backend = MockAssistantBackend()
-        let proposal = ToolProposal(toolName: "orders_update",
-                                    toolCallID: "c1",
-                                    preview: "Mark order 42 as processing")
-        backend.holdStream(at: 0)
-        backend.script([[.event(.confirmationRequired(proposal: proposal))]])
-        let controller = AssistantController(backend: backend, context: defaultContext)
+        let proposalID = UUID()
+        let conversation = AssistantConversation(seededMessages: [
+            ChatMessage(role: .assistant,
+                        segments: [
+                            .confirmation(id: UUID(),
+                                          proposalID: proposalID,
+                                          toolName: "orders_update",
+                                          preview: "Set order to completed",
+                                          status: .pending)
+                        ])
+        ])
+        let controller = AssistantController(backend: backend,
+                                             context: defaultContext,
+                                             conversation: conversation)
 
         // When
-        controller.send("update order")
-        let inFlight = try #require(controller.activeTask)
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            @MainActor
-            func observe() {
-                withObservationTracking {
-                    _ = controller.conversation.messages.last?.segments.count
-                } onChange: {
-                    Task { @MainActor in
-                        let hasConfirmation = controller.conversation.messages.last?.segments.contains { segment in
-                            if case .confirmation = segment { return true }
-                            return false
-                        } ?? false
-                        if hasConfirmation {
-                            continuation.resume()
-                        } else {
-                            observe()
-                        }
-                    }
-                }
-            }
-            observe()
-        }
         controller.cancel()
+        await backend.waitForCancelledProposal(proposalID)
 
         // Then
-        let assistant = try #require(controller.conversation.messages.last)
-        #expect(assistant.role == .assistant)
-        #expect(assistant.isStreaming == false)
-        let confirmationStatus = assistant.segments.compactMap { segment -> ConfirmationStatus? in
+        #expect(controller.canSend == true)
+        #expect(controller.conversation.streamingState == .idle)
+        let assistantMessage = controller.conversation.messages.last
+        let confirmationSegments = assistantMessage?.segments.compactMap { segment -> ConfirmationStatus? in
             if case .confirmation(_, _, _, _, let status) = segment { return status }
             return nil
-        }.first
-        #expect(confirmationStatus == .cancelled)
+        } ?? []
+        #expect(confirmationSegments.contains(.cancelled))
+        #expect(backend.cancelledProposalIDs.contains(proposalID))
+    }
 
-        backend.releaseStream(at: 0)
-        await inFlight.value
+    @Test
+    func test_startNewConversation_when_called_then_resets_backend_and_clears_messages()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        backend.script([
+            .event(.textChunk("Hello")),
+            .event(.completed(routeConfidence: nil))
+        ])
+        let controller = AssistantController(backend: backend, context: defaultContext)
+        controller.send("hi")
+        await controller.activeTask?.value
+        #expect(controller.conversation.messages.isEmpty == false)
+
+        // When
+        controller.startNewConversation()
+        await controller.activeTask?.value
+
+        // Then
+        #expect(controller.conversation.messages.isEmpty)
+        #expect(backend.resetCallCount == 1)
+    }
+
+    @Test
+    func test_startNewConversation_when_reset_pending_then_messages_remain_until_reset_completes()
+    async throws {
+        // Given
+        let backend = MockAssistantBackend()
+        backend.script([
+            .event(.textChunk("Hello")),
+            .event(.completed(routeConfidence: nil))
+        ])
+        let controller = AssistantController(backend: backend, context: defaultContext)
+        controller.send("hi")
+        await controller.activeTask?.value
+        let messagesBeforeReset = controller.conversation.messages.count
+        backend.holdReset()
+
+        // When
+        controller.startNewConversation()
+        await backend.waitForResetCall()
+
+        // Then
+        #expect(controller.conversation.messages.count == messagesBeforeReset)
+        backend.releaseReset()
+        await controller.activeTask?.value
+        #expect(controller.conversation.messages.isEmpty)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
@@ -152,30 +152,6 @@ struct AssistantConversationTests {
     }
 
     @Test
-    func test_apply_when_outcomeUnknown_then_later_failed_then_state_remains_outcomeUnknown()
-    async throws {
-        // Given
-        let conversation = AssistantConversation()
-        let messageID = conversation.beginAssistantMessage()
-        let unknownError = AssistantError(kind: .outcomeUnknown,
-                                          message: "Couldn't confirm completion.")
-        let networkError = AssistantError(kind: .network,
-                                          message: "Network error.")
-
-        // When
-        conversation.apply(.failed(unknownError), to: messageID)
-        conversation.apply(.failed(networkError), to: messageID)
-
-        // Then
-        if case .outcomeUnknown(let message) = conversation.streamingState {
-            #expect(message == "Couldn't confirm completion.")
-        } else {
-            Issue.record("expected outcomeUnknown streaming state, got \(conversation.streamingState)")
-        }
-        #expect(conversation.messages.last?.isStreaming == false)
-    }
-
-    @Test
     func test_apply_when_confirmationRequired_then_pending_segment_is_appended() async throws {
         // Given
         let conversation = AssistantConversation()


### PR DESCRIPTION
## Why

The chat backend and controller landed in the previous PR but had no UI to drive them. This PR adds the SwiftUI chat surface a merchant actually sees: a stack of message bubbles, an input bar with a stop control, a confirmation card for destructive writes, and a small set of banner states for failure modes. It also introduces the shared design tokens the chat surface uses across spacing, radius, color, and typography.

This is the first iteration of UI but I tried to make it looking good enough.

## Introduced elements

**Design tokens** — `AssistantSpacing`, `AssistantRadius`, `AssistantColor`, `AssistantFontStyle`. Routed through Woo's existing semantic colors (`Color(.text)`, `Color(.accent)`, `Color(.warning)`, etc.) so the chat inherits theme behaviour without one-off color literals.

**Chat surface** under `Modules/Sources/WooAIAssistant/Presentation/`:

- `AssistantChatView` hosts the message list, header, and input inside a `NavigationStack`. The trailing toolbar action starts a new conversation; it resets both the visible state and the backend transcript.
- `MessageListView` only auto-scrolls when the user is anchored near the bottom and surfaces a "new messages" pill otherwise, so a merchant scrolled up to read history doesn't get yanked when a new turn arrives.
- `MessageBubble` renders text-first ordering with the speaker-aware bubble shape and tail.
- `BannerShell` unifies the four banner-style headers (`ConfirmationCard` "Pending change" eyebrow, `ErrorBanner`, `OutcomeUnknownBanner`, `IterationCapBanner`) so they share typography, spacing, and dark-mode treatment.
- `ConfirmationCard` shows the action title with a small all-caps eyebrow + state glyph (`clock` / `checkmark` / `xmark`) and a stacked `Now` / `After` diff. Bulk variants drop the strikethrough and just show the new value.
- `CardShell` + `RawJSONCard` + `MessageCardHost` make the `show_cards` pipeline visible in the UI. Typed entity cards (Order, Product, Customer, Stats, LowStock) are out of scope for this PR — they plug into `MessageCardHost`'s registry in the next PR. For now any `show_cards` result renders through `RawJSONCard`.
- `InputBar` morphs between a send and stop control, hides the stop control while a confirmation gate is open, and the disabled send glyph adopts the text-field background and muted foreground so it visually integrates with the field.
- `TypingIndicator` + `ToolActivityPill` cover the in-flight states. The pill is a real Button with a state-aware label so it's reachable to VoiceOver.
- `EmptyStateView` shows a vertical suggestion list above the input bar, matching Woo's settings-row patterns rather than a marketing hero.

**Preview scaffolding** under `Presentation/Previews/` — a `MockAssistantController` and `AssistantChatScenario` factory that drive every meaningful state from a single `#if DEBUG` entry point so the SwiftUI canvas works without touching production state.

## Out of scope

- **Typed tool cards** (Order, Product, Customer, Stats, LowStock). The pipeline exists and emits `cardRender` events from real production data; the UI just falls through to `RawJSONCard` until the typed renderers land in the next PR.

## Adjacent fixes around the chat surface

While wiring the views I noticed and fixed a few small issues in the surrounding code:

- `AssistantBackend` gained a `reset()` method and `AgenticChatBackend` implements it. Previously there was no way to clear the model transcript when starting a new conversation — stale prompts could leak into the next request.
- `AgenticChatBackend.send()` skips the transcript append when its task is cancelled. A stopped or partially-streamed turn used to be saved to backend memory.
- `AssistantController.cancel()` now resolves pending confirmation segments to `.cancelled`, clears the outcome-unknown flag, and a `startNewConversation()` entry point cancels the active turn, awaits the backend reset, and then clears the visible state.
- `AgenticLoopOrchestrator` now emits `cardRender` events when a tool returns a `uiStructured` payload (specifically when the model calls `show_cards`). Without this the UI never receives a `.cardRender` segment and cards never render at runtime, even though the renderer exists. The orchestrator also clears `lastOutcome` at the start of every run so a previous turn's outcome can't leak into the next `awaitTermination`.
- `ChatMessage.cancelPendingConfirmations()` was removed; the same cleanup now lives where the controller already walks pending segments.

## Tests

255/255 in the `WooAIAssistantTests` suite pass. New coverage:

- `cancel()` resolves pending confirmations.
- `startNewConversation()` resets the backend transcript before clearing visible state.
- The orchestrator emits a `cardRender` event for each rendered card a `show_cards` result returns.

The chat surface itself is covered by SwiftUI previews driven from the scenario factory; runnable in Xcode's canvas without booting the app.

## Visual states

Snapshots were rendered with `swift-snapshot-testing` against the same scenario factory used by the previews. The scaffolding is reverted before commit; this PR adds no test-framework dependency.

### Conversation states

| State | Light | Dark |
|---|---|---|
| Empty (suggestions + input) | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-empty.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-empty.png" width="320"> |
| Single user message | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-singleUserMessage.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-singleUserMessage.png" width="320"> |
| Assistant typing | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-assistantTyping.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-assistantTyping.png" width="320"> |
| Assistant streaming text | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-assistantStreamingText.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-assistantStreamingText.png" width="320"> |
| Tool activity pill | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-toolActivityPill.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-toolActivityPill.png" width="320"> |
| Text + card (raw JSON for now) | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-textPlusCard.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-textPlusCard.png" width="320"> |
| Multi-turn | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-multiTurn.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-multiTurn.png" width="320"> |

### Confirmation card

| State | Light | Dark |
|---|---|---|
| Pending (in-thread) | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-pendingConfirmation.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-pendingConfirmation.png" width="320"> |
| Pending - bulk | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-pendingConfirmationBulk.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-pendingConfirmationBulk.png" width="320"> |
| Pending - solo | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_pending_light.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_pending_dark.png" width="320"> |
| Confirmed | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_confirmed_light.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_confirmed_dark.png" width="320"> |
| Cancelled | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_cancelled_light.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_cancelled_dark.png" width="320"> |
| Bulk (solo) | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_bulk_light.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-components-confirmationCard_bulk_dark.png" width="320"> |

### Banners

| State | Light | Dark |
|---|---|---|
| Failed mid-stream | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-failedMidStream.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-failedMidStream.png" width="320"> |
| Outcome unknown | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-outcomeUnknown.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-outcomeUnknown.png" width="320"> |
| Iteration cap (informational) | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-light-iterationCap.png" width="320"> | <img src="https://futuristically-glittery-kitten.commerce-garden.com/wp-content/uploads/2026/05/d3-iter5-dark-iterationCap.png" width="320"> |

## Reviewer expectation

So far this is not hooked to the real functionality, will be done in next PRs.