### PR TITLE
[WOOMOB-2816] Add small home-screen layout to Store Stats widget

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMediumMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMediumMetricsView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Renders the metrics layout used by medium and larger home-screen widget families.
+struct StoreInfoMediumMetricsView: View {
+    let data: StoreInfoData
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+                HStack {
+                    Text(data.name)
+                        .storeNameStyle()
+                    Spacer()
+                    Text(data.range)
+                        .statRangeStyle()
+                }
+                Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
+                    .statRangeStyle()
+            }
+
+            if dynamicTypeSize > Layout.accessibilityDynamicTypeSize {
+                MetricsAccessibilityCard(entryData: data)
+            } else {
+                StoreInfoMetricsCard(metrics: data.metrics)
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    private enum Layout {
+        static let sectionSpacing = 8.0
+        static let cardSpacing = 2.0
+        static let accessibilityDynamicTypeSize: DynamicTypeSize = .xLarge
+    }
+}
+
+/// Renders an ordered list of metrics in a 2-column grid for the medium-style metrics layout.
+/// Operates on the presentation protocol so the layout is decoupled from
+/// the concrete `StoreInfoMetric` type.
+///
+private struct StoreInfoMetricsCard: View {
+    let metrics: [any MetricPresentable]
+
+    /// Chunks metrics into rows of two for the medium-style widget layout.
+    ///
+    private var rows: [[any MetricPresentable]] {
+        stride(from: 0, to: metrics.count, by: Layout.metricsPerRow).map { start in
+            Array(metrics[start..<min(start + Layout.metricsPerRow, metrics.count)])
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                HStack {
+                    ForEach(Array(row.enumerated()), id: \.offset) { _, metric in
+                        MetricCellView(metric: metric)
+                    }
+                    // Pad the last row so a trailing cell keeps the grid alignment
+                    // when the row has fewer metrics than the slot count.
+                    if row.count < Layout.metricsPerRow {
+                        ForEach(0..<(Layout.metricsPerRow - row.count), id: \.self) { _ in
+                            Color.clear.frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private enum Layout {
+        static let sectionSpacing = 8.0
+        static let metricsPerRow = 2
+    }
+}
+
+/// Accessibility card for metric widget layouts. Shows only revenue and a `View More` indicator.
+///
+private struct MetricsAccessibilityCard: View {
+    let entryData: StoreInfoData
+
+    var body: some View {
+        let revenue = entryData.metric(of: .revenue)
+        Group {
+            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
+                Text(revenue.title)
+                    .statTitleStyle()
+
+                Text(revenue.formattedValue)
+                    .statValueStyle()
+            }
+
+            Text(StoreInfoMetricsView.Localization.viewMore)
+                .statButtonStyle()
+        }
+    }
+
+    private enum Layout {
+        static let cardSpacing = 2.0
+    }
+}
+
+// MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
+import WidgetKit
+
+struct StoreInfoMediumMetricsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreInfoMediumMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .previewDisplayName("Medium")
+
+        StoreInfoMediumMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .environment(\.dynamicTypeSize, .xxLarge)
+            .previewDisplayName("Medium - XXL font")
+    }
+}
+#endif

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -21,11 +21,11 @@ struct StoreInfoMetricsView: View {
         Group {
             switch family {
             case .systemSmall:
-                SmallView(data: entryData)
+                StoreInfoSmallMetricsView(data: entryData)
             case .systemMedium, .systemLarge, .systemExtraLarge:
                 mediumView()
             default:
-                let _ = assert(true, "This view only supports system families")
+                let _ = assertionFailure("This view only supports system families")
                 EmptyView()
             }
         }
@@ -141,7 +141,7 @@ extension StoreInfoMetricsView {
 }
 
 /// View that renders widget for .systemSmall family
-struct SmallView: View {
+private struct StoreInfoSmallMetricsView: View {
     let data: StoreInfoData
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -179,7 +179,6 @@ struct SmallView: View {
                 }
             }
         }
-        .padding(Layout.noSpacing)
     }
 
     private enum Layout {
@@ -188,8 +187,6 @@ struct SmallView: View {
         static let metricSpacing = 6.0
         static let logoSpacing = 4.0
         static let logoSize = 30.0
-        static let bigLogoSize = 50.0
-        static let messageSpacing = 8.0
         static let defaultMetricLimit = 2
         static let accessibilityMetricLimit = 1
     }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -1,21 +1,16 @@
 import SwiftUI
 import WidgetKit
 
-/// Medium home-screen widget view driven by the metric catalog.
+/// Home-screen widget dispatcher driven by the metric catalog.
 ///
-/// Companion to the legacy `StoreInfoView`; both render the same widget family but consume
+/// Companion to the legacy `StoreInfoView`; both render the same widget families but consume
 /// different shapes off `StoreInfoData`. Selection happens in `StoreInfoHomescreenWidget`
 /// based on `useMetricsHomescreenWidget`.
 ///
 struct StoreInfoMetricsView: View {
     let entryData: StoreInfoData
 
-    @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.widgetFamily) private var family
-
-    var accessibilityDynamicTypeSize: DynamicTypeSize {
-        return .xLarge
-    }
 
     var body: some View {
         Group {
@@ -23,102 +18,13 @@ struct StoreInfoMetricsView: View {
             case .systemSmall:
                 StoreInfoSmallMetricsView(data: entryData)
             case .systemMedium, .systemLarge, .systemExtraLarge:
-                mediumView()
+                StoreInfoMediumMetricsView(data: entryData)
             default:
                 let _ = assertionFailure("This view only supports system families")
                 EmptyView()
             }
         }
         .widgetBackground(backgroundView: Color(.brand))
-    }
-
-    private func mediumView() -> some View {
-        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-            VStack(alignment: .leading, spacing: Layout.cardSpacing) {
-                HStack {
-                    Text(entryData.name)
-                        .storeNameStyle()
-                    Spacer()
-                    Text(entryData.range)
-                        .statRangeStyle()
-                }
-                Text(Localization.updatedAt(entryData.updatedTime))
-                    .statRangeStyle()
-            }
-
-            if dynamicTypeSize > accessibilityDynamicTypeSize {
-                MetricsAccessibilityCard(entryData: entryData)
-            } else {
-                StoreInfoMetricsCard(metrics: entryData.metrics)
-            }
-        }
-        .padding(.horizontal)
-    }
-
-    fileprivate enum Layout {
-        static let sectionSpacing = 8.0
-        static let cardSpacing = 2.0
-    }
-}
-
-/// Renders an ordered list of metrics in a 2-column grid for the medium widget.
-/// Operates on the presentation protocol so the layout is decoupled from
-/// the concrete `StoreInfoMetric` type.
-///
-struct StoreInfoMetricsCard: View {
-    let metrics: [any MetricPresentable]
-
-    /// Chunks metrics into rows of two for the medium widget layout.
-    ///
-    private var rows: [[any MetricPresentable]] {
-        stride(from: 0, to: metrics.count, by: Layout.metricsPerRow).map { start in
-            Array(metrics[start..<min(start + Layout.metricsPerRow, metrics.count)])
-        }
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: StoreInfoMetricsView.Layout.sectionSpacing) {
-            ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
-                HStack {
-                    ForEach(Array(row.enumerated()), id: \.offset) { _, metric in
-                        MetricCellView(metric: metric)
-                    }
-                    // Pad the last row so a trailing cell keeps the grid alignment
-                    // when the row has fewer metrics than the slot count.
-                    if row.count < Layout.metricsPerRow {
-                        ForEach(0..<(Layout.metricsPerRow - row.count), id: \.self) { _ in
-                            Color.clear.frame(maxWidth: .infinity)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private enum Layout {
-        static let metricsPerRow = 2
-    }
-}
-
-/// Accessibility card for `StoreInfoMetricsView`. Shows only revenue and a `View More` button.
-///
-private struct MetricsAccessibilityCard: View {
-    let entryData: StoreInfoData
-
-    var body: some View {
-        let revenue = entryData.metric(of: .revenue)
-        Group {
-            VStack(alignment: .leading, spacing: StoreInfoMetricsView.Layout.cardSpacing) {
-                Text(revenue.title)
-                    .statTitleStyle()
-
-                Text(revenue.formattedValue)
-                    .statValueStyle()
-            }
-
-            Text(StoreInfoMetricsView.Localization.viewMore)
-                .statButtonStyle()
-        }
     }
 }
 
@@ -137,58 +43,6 @@ extension StoreInfoMetricsView {
                                             comment: "Displays the time when the widget was last updated. %1$@ is the time to render.")
             return LocalizedString.localizedStringWithFormat(format, updatedTime)
         }
-    }
-}
-
-/// View that renders widget for .systemSmall family
-private struct StoreInfoSmallMetricsView: View {
-    let data: StoreInfoData
-
-    @Environment(\.dynamicTypeSize) var dynamicTypeSize
-
-    private var visibleMetrics: [any MetricPresentable] {
-        let limit = dynamicTypeSize > .xLarge ? Layout.accessibilityMetricLimit : Layout.defaultMetricLimit
-        return Array(data.metrics.prefix(limit))
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
-            HStack(alignment: .top, spacing: Layout.noSpacing) {
-                Image("woo-mini-logo", bundle: nil)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: Layout.logoSize, height: Layout.logoSize)
-                    .accessibilityHidden(true)
-
-                Spacer(minLength: Layout.logoSpacing)
-
-                VStack(alignment: .leading, spacing: Layout.noSpacing) {
-                    Text(data.name)
-                        .storeNameStyle()
-
-                    Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
-                        .statRangeStyle()
-                }
-            }
-
-            Spacer(minLength: Layout.metricSpacing)
-
-            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
-                ForEach(Array(visibleMetrics.enumerated()), id: \.offset) { _, metric in
-                    MetricCellView(metric: metric)
-                }
-            }
-        }
-    }
-
-    private enum Layout {
-        static let noSpacing = 0.0
-        static let headerSpacing = 6.0
-        static let metricSpacing = 6.0
-        static let logoSpacing = 4.0
-        static let logoSize = 30.0
-        static let defaultMetricLimit = 2
-        static let accessibilityMetricLimit = 1
     }
 }
 

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -11,12 +11,28 @@ struct StoreInfoMetricsView: View {
     let entryData: StoreInfoData
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.widgetFamily) private var family
 
     var accessibilityDynamicTypeSize: DynamicTypeSize {
         return .xLarge
     }
 
     var body: some View {
+        Group {
+            switch family {
+            case .systemSmall:
+                SmallView(data: entryData)
+            case .systemMedium, .systemLarge, .systemExtraLarge:
+                mediumView()
+            default:
+                let _ = assert(true, "This view only supports system families")
+                EmptyView()
+            }
+        }
+        .widgetBackground(backgroundView: Color(.brand))
+    }
+
+    private func mediumView() -> some View {
         VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
             VStack(alignment: .leading, spacing: Layout.cardSpacing) {
                 HStack {
@@ -37,7 +53,11 @@ struct StoreInfoMetricsView: View {
             }
         }
         .padding(.horizontal)
-        .widgetBackground(backgroundView: Color(.brand))
+    }
+
+    fileprivate enum Layout {
+        static let sectionSpacing = 8.0
+        static let cardSpacing = 2.0
     }
 }
 
@@ -118,10 +138,60 @@ extension StoreInfoMetricsView {
             return LocalizedString.localizedStringWithFormat(format, updatedTime)
         }
     }
+}
 
-    enum Layout {
-        static let sectionSpacing = 8.0
-        static let cardSpacing = 2.0
+/// View that renders widget for .systemSmall family
+struct SmallView: View {
+    let data: StoreInfoData
+
+    @Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+    private var visibleMetrics: [any MetricPresentable] {
+        let limit = dynamicTypeSize > .xLarge ? Layout.accessibilityMetricLimit : Layout.defaultMetricLimit
+        return Array(data.metrics.prefix(limit))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
+            HStack(alignment: .top, spacing: Layout.noSpacing) {
+                Image("woo-mini-logo", bundle: nil)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Layout.logoSize, height: Layout.logoSize)
+                    .accessibilityHidden(true)
+
+                Spacer(minLength: Layout.logoSpacing)
+
+                VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                    Text(data.name)
+                        .storeNameStyle()
+
+                    Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
+                        .statRangeStyle()
+                }
+            }
+
+            Spacer(minLength: Layout.metricSpacing)
+
+            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
+                ForEach(Array(visibleMetrics.enumerated()), id: \.offset) { _, metric in
+                    MetricCellView(metric: metric)
+                }
+            }
+        }
+        .padding(Layout.noSpacing)
+    }
+
+    private enum Layout {
+        static let noSpacing = 0.0
+        static let headerSpacing = 6.0
+        static let metricSpacing = 6.0
+        static let logoSpacing = 4.0
+        static let logoSize = 30.0
+        static let bigLogoSize = 50.0
+        static let messageSpacing = 8.0
+        static let defaultMetricLimit = 2
+        static let accessibilityMetricLimit = 1
     }
 }
 
@@ -150,11 +220,21 @@ struct StoreInfoMetricsView_Previews: PreviewProvider {
     static var previews: some View {
         StoreInfoMetricsView(entryData: exampleData)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
+            .previewDisplayName("Medium")
 
         StoreInfoMetricsView(entryData: exampleData)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
             .environment(\.dynamicTypeSize, .xxLarge)
-            .previewDisplayName("XXL font")
+            .previewDisplayName("Medium - XXL font")
+
+        StoreInfoMetricsView(entryData: exampleData)
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .previewDisplayName("Small")
+
+        StoreInfoMetricsView(entryData: exampleData)
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environment(\.dynamicTypeSize, .xxLarge)
+            .previewDisplayName("Small - XXL font")
     }
 }
 #endif

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoSmallMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoSmallMetricsView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Renders the metrics layout used by the small home-screen widget family.
+struct StoreInfoSmallMetricsView: View {
+    let data: StoreInfoData
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var visibleMetrics: [any MetricPresentable] {
+        let limit = dynamicTypeSize > .xLarge ? Layout.accessibilityMetricLimit : Layout.defaultMetricLimit
+        return Array(data.metrics.prefix(limit))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.headerSpacing) {
+            HStack(alignment: .top, spacing: Layout.noSpacing) {
+                Image("woo-mini-logo", bundle: nil)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: Layout.logoSize, height: Layout.logoSize)
+                    .accessibilityHidden(true)
+
+                Spacer(minLength: Layout.logoSpacing)
+
+                VStack(alignment: .leading, spacing: Layout.noSpacing) {
+                    Text(data.name)
+                        .storeNameStyle()
+
+                    Text(StoreInfoMetricsView.Localization.updatedAt(data.updatedTime))
+                        .statRangeStyle()
+                }
+            }
+
+            Spacer(minLength: Layout.metricSpacing)
+
+            VStack(alignment: .leading, spacing: Layout.metricSpacing) {
+                ForEach(Array(visibleMetrics.enumerated()), id: \.offset) { _, metric in
+                    MetricCellView(metric: metric)
+                }
+            }
+        }
+    }
+
+    private enum Layout {
+        static let noSpacing = 0.0
+        static let headerSpacing = 6.0
+        static let metricSpacing = 6.0
+        static let logoSpacing = 4.0
+        static let logoSize = 30.0
+        static let defaultMetricLimit = 2
+        static let accessibilityMetricLimit = 1
+    }
+}
+
+// MARK: - Previews
+#if DEBUG
+import class WooFoundation.CurrencySettings
+import WidgetKit
+
+struct StoreInfoSmallMetricsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreInfoSmallMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .previewDisplayName("Small")
+
+        StoreInfoSmallMetricsView(data: StoreInfoMetricsView_Previews.exampleData)
+            .widgetBackground(backgroundView: Color(.brand))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+            .environment(\.dynamicTypeSize, .xxLarge)
+            .previewDisplayName("Small - XXL font")
+    }
+}
+#endif


### PR DESCRIPTION
## Description

Adds the `.systemSmall` layout to the metric-driven home-screen Store Stats widget. The systemSmall family was already wired into `supportedFamilies` and `StoreInfoWidgetEntryView` upstream in this stack; this PR supplies the actual view.

### What's added

- `StoreInfoSmallMetricsView` (private to the same file as `StoreInfoMetricsView`) — renders a compact layout for the systemSmall family: the Woo mini-logo + store name + "As of …" header on top, and the configured metrics stacked below. Operates on `[any MetricPresentable]` and reuses the existing `MetricCellView`, so deep-linking metrics keep their `tapURL` behaviour.
- Visible-metric trimming for the small canvas: 2 metrics by default, 1 when `dynamicTypeSize > .xLarge` so accessibility text fits.
- `StoreInfoMetricsView.body` is now a `Group` that switches on `@Environment(\.widgetFamily)` and routes systemSmall to the new view; the previously-inlined medium body has been extracted into a `mediumView()` helper. Other system families fall through to the medium layout (matching the existing routing in `StoreInfoWidgetEntryView`). The unreachable default branch trips `assertionFailure`.
- SwiftUI previews for systemSmall (default + XXL accessibility font) alongside the existing systemMedium previews.

### What's not touched

- `StoreInfoData`, the provider, the data service, and the AppIntent configuration are unchanged in this PR — `StoreInfoSmallMetricsView` consumes the same `StoreInfoData.metrics` array the medium view already reads.
- The legacy `StoreInfoView` / `StatsCard` rendering path is untouched.
- Lock-screen widgets (`StoreInfoCircularWidget`, `StoreInfoInlineWidget`, `StoreInfoRectangularWidget`) are unchanged.
- No new strings: the small layout reuses `StoreInfoMetricsView.Localization.updatedAt`.

### Notes for reviewers

- **Feature-flagged.** The systemSmall family is only listed in `supportedFamilies` when `configurableStoreStatsWidgets` is enabled (alpha / dev only), so this change is invisible on App Store builds.
- **Stacked PR.** Targets `woomob-2813-5-appintent-parameter-metric-picker-multi-select` (#17025), not `trunk`. Will rebase to `trunk` once the upstream stack lands.

Tracking: WOOMOB-2816.

## Test Steps

This PR is only exercisable when the `configurableStoreStatsWidgets` flag is on (default for local / alpha builds).

1. Run the app on a debug or alpha build with `configurableStoreStatsWidgets` enabled.
2. Long-press the home screen and add the **Today** widget at **small** size for an account that has data.
3. Verify the layout: Woo mini-logo top-left, store name and "As of …" timestamp to the right, and 2 metric cells stacked below.
4. Verify the metric values match the medium widget on the same account.
5. Tap the Orders metric (if configured) — it should still deep-link to the orders list via `MetricPresentable.tapURL`.
6. Switch the device to an XXL accessibility font size and confirm the small widget renders only 1 metric and remains readable without truncation.
7. Add the medium and large variants of the same widget — they should keep rendering the existing medium layout (regression check on the family switch).

## Screenshots

<img width="311" height="287" alt="Screenshot 2026-05-01 at 13 45 52" src="https://github.com/user-attachments/assets/cc8f788c-9f31-4b64-8be2-0920192228fe" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.