### PR TITLE
[RSM] Add feature flags for POS Scan to Pay and Mark order as paid

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -97,6 +97,10 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .pointOfSaleCustomAmounts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleScanToPay:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleMarkOrderAsPaid:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .selfDrivenPushToken:
             return false
         case .clientSideDashboardBanner:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -203,6 +203,18 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case pointOfSaleCustomAmounts
 
+    /// Enables Scan to Pay as a secondary payment method in Point of Sale.
+    /// When enabled, the merchant can have the customer pay by scanning a QR code that
+    /// opens the order's gateway-hosted payment page on their phone.
+    ///
+    case pointOfSaleScanToPay
+
+    /// Enables "Mark order as paid" as a secondary payment method in Point of Sale.
+    /// Used when the merchant has collected payment out-of-band (external reader, gift card,
+    /// account credit, etc.) and just needs the order marked as completed.
+    ///
+    case pointOfSaleMarkOrderAsPaid
+
     /// Enables self driven push token registration
     ///
     case selfDrivenPushToken

--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -35,6 +35,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case selfDrivenPushNotificationsM1
     case inPersonPaymentsCountryExpansion
     case inPersonPaymentsCountryExpansionEUExtended
+    case pointOfSaleScanToPay
+    case pointOfSaleMarkOrderAsPaid
 
     init?(rawValue: String) {
         switch rawValue {
@@ -54,6 +56,10 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .inPersonPaymentsCountryExpansion
         case "woo_ipp_country_expansion_eu_extended":
             self = .inPersonPaymentsCountryExpansionEUExtended
+        case "woo_pos_scan_to_pay":
+            self = .pointOfSaleScanToPay
+        case "woo_pos_mark_order_as_paid":
+            self = .pointOfSaleMarkOrderAsPaid
         default:
             return nil
         }


### PR DESCRIPTION
## Description

Foundation for the upcoming Point of Sale "Other payment methods" work. Adds two paired feature flags — one local (Experiments) and one remote (Networking) for each capability — so subsequent PRs can gate the UI and business logic without exposing the work-in-progress to App Store builds.

This is the first in a series of stacked PRs that progressively land the feature behind the flags. The split mirrors how the [POS custom amounts feature](https://github.com/woocommerce/woocommerce-ios/pull/16998) was rolled out: foundation → wiring → UI iterations.

### Flags introduced

- **`pointOfSaleScanToPay`** / `"woo_pos_scan_to_pay"` — gates the QR-based scan-to-pay flow. The merchant promotes the order to `.pending` so the WC backend populates `payment_url`, then displays a QR code; the customer pays via the gateway-hosted page on their phone.
- **`pointOfSaleMarkOrderAsPaid`** / `"woo_pos_mark_order_as_paid"` — gates the manual mark-as-paid flow used when payment was already collected out-of-band (external reader, gift card, account credit, etc.). Marks the order as completed with `paymentMethodID = "other"`.

### Defaults

Local defaults are scoped to `localDeveloper` and `alpha` builds, matching the convention already used by other in-progress POS features (`pointOfSaleCustomAmounts`, `posLocalCatalogM1`). App Store builds default to **off** locally; they'll only flip on when the corresponding remote flag is enabled per-merchant by the server.

Remote flags follow the existing `RemoteFeatureFlag` pattern with `woo_pos_*` slugs so the backend feature-flags endpoint can selectively enable them.

### Out of scope

No call sites yet — both flags are dead code in this PR. They become live in the feature PRs that follow:

1. Other payment methods sheet (entry point UI, gated by `pointOfSaleScanToPay || pointOfSaleMarkOrderAsPaid`)
2. Mark order as paid (full feature)
3. Scan to Pay (full feature, includes polling + autoDraft → pending promotion + analytics)

Reference experiment: [hack-week PR #15384](https://github.com/woocommerce/woocommerce-ios/pull/15384) used a similar `pointOfSaleScanToPay` remote flag for the same scan-to-pay flow.

## Test Steps

This PR is pure feature-flag scaffolding with no user-visible behavior change. Verification is limited to confirming the flags compile, register correctly, and default to the right values.

1. On a `localDeveloper` build, confirm `ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleScanToPay)` returns `true`.
2. On a `localDeveloper` build, confirm `ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid)` returns `true`.
3. Build for App Store configuration. Both flags should resolve to `false` locally (only remote can enable them in production).
4. Trigger the `mobile/feature-flags` lookup (relaunch the app on a JP-connected store). The two new keys (`woo_pos_scan_to_pay`, `woo_pos_mark_order_as_paid`) should be parsed without warnings if the server returns them.

## Screenshots

N/A — pure infrastructure change, no UI.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.