### PR TITLE
[RSM] Add Other payment methods sheet scaffold to POS totals view

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleOtherPaymentMethodsSheet.swift
@@ -1,0 +1,163 @@
+import SwiftUI
+
+/// Bottom sheet listing the long-tail POS payment methods that don't deserve a top-level button.
+///
+/// Each row dismisses the sheet first, then triggers the corresponding action so the parent view
+/// can present its own UI (QR code, confirmation alert, etc.) without fighting the sheet.
+///
+/// Each row is gated by its own feature flag — when both flags are off, the entire sheet is
+/// dead code and the parent view's "Other payment methods" button is hidden.
+struct PointOfSaleOtherPaymentMethodsSheet: View {
+    let isScanToPayAvailable: Bool
+    let isMarkOrderAsPaidAvailable: Bool
+    let onScanToPay: () -> Void
+    let onMarkOrderAsPaid: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.medium) {
+            Text(Localization.title)
+                .font(.posHeadingBold)
+                .foregroundColor(.posOnSurface)
+                .accessibilityAddTraits(.isHeader)
+
+            Text(Localization.subtitle)
+                .font(.posBodyMediumRegular())
+                .foregroundColor(.posOnSurfaceVariantHighest)
+
+            VStack(spacing: POSSpacing.small) {
+                if isScanToPayAvailable {
+                    methodRow(systemImage: "qrcode",
+                              title: Localization.scanToPayTitle,
+                              subtitle: Localization.scanToPaySubtitle,
+                              accessibilityIdentifier: "pos-other-payments-scan-to-pay") {
+                        dismiss()
+                        onScanToPay()
+                    }
+                }
+
+                if isMarkOrderAsPaidAvailable {
+                    methodRow(systemImage: "checkmark.circle",
+                              title: Localization.markOrderAsPaidTitle,
+                              subtitle: Localization.markOrderAsPaidSubtitle,
+                              accessibilityIdentifier: "pos-other-payments-mark-order-as-paid") {
+                        dismiss()
+                        onMarkOrderAsPaid()
+                    }
+                }
+            }
+        }
+        .padding(POSPadding.large)
+        // iPad's default sheet is taller than this content; without explicit alignment SwiftUI
+        // centers the VStack vertically, leaving a tall blank gutter above the title.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    @ViewBuilder
+    private func methodRow(systemImage: String,
+                           title: String,
+                           subtitle: String,
+                           accessibilityIdentifier: String,
+                           action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: POSSpacing.medium) {
+                Image(systemName: systemImage)
+                    .font(.posBodyLargeBold)
+                    .foregroundColor(.posPrimary)
+                    .frame(width: 32, alignment: .center)
+
+                VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                    Text(title)
+                        .font(.posBodyLargeBold)
+                        .foregroundColor(.posOnSurface)
+                    Text(subtitle)
+                        .font(.posBodySmallRegular())
+                        .foregroundColor(.posOnSurfaceVariantHighest)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: POSSpacing.medium)
+
+                Image(systemName: "chevron.right")
+                    .font(.posBodyMediumRegular())
+                    .foregroundColor(.posOnSurfaceVariantHighest)
+            }
+            .padding(.vertical, POSPadding.medium)
+            .padding(.horizontal, POSPadding.medium)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(subtitle)
+    }
+}
+
+private extension PointOfSaleOtherPaymentMethodsSheet {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.otherPaymentMethods.title",
+            value: "Other payment methods",
+            comment: "Title of the bottom sheet listing additional Point of Sale payment options."
+        )
+        static let subtitle = NSLocalizedString(
+            "pointOfSale.otherPaymentMethods.subtitle",
+            value: "Choose how the customer is paying for this order.",
+            comment: "Subtitle on the Point of Sale Other Payment Methods sheet."
+        )
+        static let scanToPayTitle = NSLocalizedString(
+            "pointOfSale.otherPaymentMethods.scanToPay.title",
+            value: "Scan to Pay",
+            comment: "Row title in the Other Payment Methods sheet for the QR-based scan-to-pay flow."
+        )
+        static let scanToPaySubtitle = NSLocalizedString(
+            "pointOfSale.otherPaymentMethods.scanToPay.subtitle",
+            value: "Show a QR code for the customer to pay from their phone.",
+            comment: "Row subtitle in the Other Payment Methods sheet for the QR-based scan-to-pay flow."
+        )
+        static let markOrderAsPaidTitle = NSLocalizedString(
+            "pointOfSale.otherPaymentMethods.markOrderAsPaid.title",
+            value: "Mark order as paid",
+            comment: "Row title in the Other Payment Methods sheet for manually marking an order as paid."
+        )
+        static let markOrderAsPaidSubtitle = NSLocalizedString(
+            "pointOfSale.otherPaymentMethods.markOrderAsPaid.subtitle",
+            value: "Use when payment was already collected another way.",
+            comment: "Row subtitle in the Other Payment Methods sheet for manually marking an order as paid."
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Both rows") {
+    PointOfSaleOtherPaymentMethodsSheet(
+        isScanToPayAvailable: true,
+        isMarkOrderAsPaidAvailable: true,
+        onScanToPay: {},
+        onMarkOrderAsPaid: {}
+    )
+    .background(Color.posSurface)
+}
+
+#Preview("Only Scan to Pay") {
+    PointOfSaleOtherPaymentMethodsSheet(
+        isScanToPayAvailable: true,
+        isMarkOrderAsPaidAvailable: false,
+        onScanToPay: {},
+        onMarkOrderAsPaid: {}
+    )
+    .background(Color.posSurface)
+}
+
+#Preview("Only Mark order as paid") {
+    PointOfSaleOtherPaymentMethodsSheet(
+        isScanToPayAvailable: false,
+        isMarkOrderAsPaidAvailable: true,
+        onScanToPay: {},
+        onMarkOrderAsPaid: {}
+    )
+    .background(Color.posSurface)
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -1,11 +1,16 @@
 import SwiftUI
 import WooFoundation
+import Experiments
 
 struct TotalsView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(POSPaymentModel.self) private var paymentModel
+    @Environment(\.posFeatureFlags) private var featureFlags
+    @Environment(\.posAnalytics) private var analytics
     private let viewHelper = POSPaymentViewHelper()
     private let totalsViewHelper = TotalsViewHelper()
+
+    @State private var isShowingOtherPaymentMethodsSheet: Bool = false
 
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
     /// This makes SwiftUI treat these views as a single entity in the context of animation.
@@ -67,11 +72,17 @@ struct TotalsView: View {
 
                     Spacer()
 
-                    CashPaymentButton(
+                    SecondaryPaymentButtons(
                         orderState: posModel.orderState,
                         paymentState: displayPaymentState,
                         cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
-                        startCashPaymentAction: { paymentModel.startCashPayment() }
+                        isScanToPayEnabled: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
+                        isMarkOrderAsPaidEnabled: featureFlags.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid),
+                        startCashPaymentAction: { paymentModel.startCashPayment() },
+                        startOtherPaymentMethodsAction: {
+                            analytics.track(.pointOfSaleOtherPaymentMethodsTapped)
+                            isShowingOtherPaymentMethodsSheet = true
+                        }
                     )
                 }
                 .scrollVerticallyIfNeeded()
@@ -95,6 +106,18 @@ struct TotalsView: View {
         }
         .onChange(of: shouldShowTotalsFields) {
             hideTotalsFieldsWithDelay(shouldShowTotalsFields)
+        }
+        .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
+            PointOfSaleOtherPaymentMethodsSheet(
+                isScanToPayAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
+                isMarkOrderAsPaidAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid),
+                onScanToPay: {
+                    // TODO: Wired in the Scan to Pay feature PR (rsm/pos-scan-to-pay-feature).
+                },
+                onMarkOrderAsPaid: {
+                    // TODO: Wired in the Mark order as paid feature PR (rsm/pos-mark-order-as-paid-feature).
+                }
+            )
         }
     }
 
@@ -276,6 +299,12 @@ private extension TotalsView {
             "pos.totalsView.cash.button.title",
             value: "Cash payment",
             comment: "Title for the cash payment button title")
+        static let otherPaymentMethodsButtonTitle = NSLocalizedString(
+            "pos.totalsView.otherPaymentMethods.button.title",
+            value: "Other payment methods",
+            comment: "Title for the Other payment methods button in the Point of Sale checkout. " +
+            "Tapping this button opens a sheet listing alternative payment methods like Scan to Pay " +
+            "or Mark order as paid.")
     }
 }
 
@@ -474,32 +503,64 @@ private struct PaymentViewContent: View {
     }
 }
 
-private struct CashPaymentButton: View {
+/// Bottom-of-totals action row with the always-on Cash payment button plus a feature-flagged
+/// "Other payment methods" button rendered side-by-side. When neither secondary payment-method
+/// flag is enabled, the layout collapses to the original single Cash button — the feature flags
+/// gate the second button entirely so App Store builds see no regression vs trunk.
+private struct SecondaryPaymentButtons: View {
     let orderState: PointOfSaleOrderState
     let paymentState: PointOfSalePaymentState
     let cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus
+    let isScanToPayEnabled: Bool
+    let isMarkOrderAsPaidEnabled: Bool
     let startCashPaymentAction: () -> Void
+    let startOtherPaymentMethodsAction: () -> Void
 
     private let viewHelper = TotalsViewHelper()
 
+    private var isAnySecondaryPaymentMethodEnabled: Bool {
+        isScanToPayEnabled || isMarkOrderAsPaidEnabled
+    }
+
     var body: some View {
-        Button(action: {
-            startCashPaymentAction()
-        }, label: {
-            Text(TotalsView.Localization.cashPaymentButtonTitle)
-                .font(POSFontStyle.posBodyLargeBold)
-        })
-        .layoutPriority(1)
-        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-        .accessibilityIdentifier("pos-cash-payment-button")
+        HStack(spacing: POSSpacing.small) {
+            Button(action: {
+                startCashPaymentAction()
+            }, label: {
+                Text(TotalsView.Localization.cashPaymentButtonTitle)
+                    .font(POSFontStyle.posBodyLargeBold)
+                    .frame(maxWidth: .infinity)
+            })
+            .layoutPriority(1)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .accessibilityIdentifier("pos-cash-payment-button")
+            .renderedIf(viewHelper.shouldShowCollectCashPaymentButton(
+                orderState: orderState,
+                paymentState: paymentState,
+                cardReaderConnectionStatus: cardReaderConnectionStatus
+            ))
+
+            Button(action: {
+                startOtherPaymentMethodsAction()
+            }, label: {
+                Text(TotalsView.Localization.otherPaymentMethodsButtonTitle)
+                    .font(POSFontStyle.posBodyLargeBold)
+                    .frame(maxWidth: .infinity)
+            })
+            .layoutPriority(1)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .accessibilityIdentifier("pos-other-payment-methods-button")
+            .renderedIf(viewHelper.shouldShowOtherPaymentMethodsButton(
+                orderState: orderState,
+                paymentState: paymentState,
+                cardReaderConnectionStatus: cardReaderConnectionStatus,
+                isAnySecondaryPaymentMethodEnabled: isAnySecondaryPaymentMethodEnabled
+            ))
+        }
         .padding(.horizontal, TotalsView.Constants.buttonHorizontalPadding)
         .safeAreaPadding(.bottom, TotalsView.Constants.cashButtonBottomPadding)
-        .renderedIf(viewHelper.shouldShowCollectCashPaymentButton(
-            orderState: orderState,
-            paymentState: paymentState,
-            cardReaderConnectionStatus: cardReaderConnectionStatus
-        ))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -535,11 +535,6 @@ private struct SecondaryPaymentButtons: View {
             .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             .buttonStyle(POSOutlinedButtonStyle(size: .normal))
             .accessibilityIdentifier("pos-cash-payment-button")
-            .renderedIf(viewHelper.shouldShowCollectCashPaymentButton(
-                orderState: orderState,
-                paymentState: paymentState,
-                cardReaderConnectionStatus: cardReaderConnectionStatus
-            ))
 
             Button(action: {
                 startOtherPaymentMethodsAction()
@@ -552,15 +547,20 @@ private struct SecondaryPaymentButtons: View {
             .dynamicTypeSize(...DynamicTypeSize.accessibility1)
             .buttonStyle(POSOutlinedButtonStyle(size: .normal))
             .accessibilityIdentifier("pos-other-payment-methods-button")
-            .renderedIf(viewHelper.shouldShowOtherPaymentMethodsButton(
-                orderState: orderState,
-                paymentState: paymentState,
-                cardReaderConnectionStatus: cardReaderConnectionStatus,
-                isAnySecondaryPaymentMethodEnabled: isAnySecondaryPaymentMethodEnabled
-            ))
+            .renderedIf(isAnySecondaryPaymentMethodEnabled)
         }
         .padding(.horizontal, TotalsView.Constants.buttonHorizontalPadding)
         .safeAreaPadding(.bottom, TotalsView.Constants.cashButtonBottomPadding)
+        // Gate the whole row on the cash visibility envelope. Without this, when the cash
+        // button is hidden (e.g. during card processing) the HStack still applies its
+        // safeAreaPadding(.bottom), reserving space at the bottom of the totals view that
+        // didn't exist before this row was introduced. Other-payment visibility shares the
+        // same envelope, so this single check is enough.
+        .renderedIf(viewHelper.shouldShowCollectCashPaymentButton(
+            orderState: orderState,
+            paymentState: paymentState,
+            cardReaderConnectionStatus: cardReaderConnectionStatus
+        ))
     }
 }
 

--- a/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
@@ -54,6 +54,24 @@ struct TotalsViewHelper {
                                                              isZeroTotal: isZeroTotal)
     }
 
+    /// "Other payment methods" button visibility for the cart flow.
+    /// Shown only when at least one of the secondary payment-method feature flags is enabled —
+    /// otherwise the sheet would have no rows to render. Otherwise mirrors the cash button rules.
+    func shouldShowOtherPaymentMethodsButton(orderState: PointOfSaleOrderState,
+                                             paymentState: PointOfSalePaymentState,
+                                             cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus,
+                                             isAnySecondaryPaymentMethodEnabled: Bool) -> Bool {
+        guard isAnySecondaryPaymentMethodEnabled else {
+            return false
+        }
+
+        // Reuse the cash button's order-state and connection guards — the visibility envelope is
+        // identical for both buttons (we want them to appear/disappear together).
+        return shouldShowCollectCashPaymentButton(orderState: orderState,
+                                                   paymentState: paymentState,
+                                                   cardReaderConnectionStatus: cardReaderConnectionStatus)
+    }
+
     func shouldShowTotalDiscountField(cart: Cart, orderTotals: PointOfSaleOrderTotals?) -> Bool {
         let hasCoupons = cart.coupons.isNotEmpty
         let orderIsLoading = orderTotals == nil

--- a/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/TotalsViewHelper.swift
@@ -54,24 +54,6 @@ struct TotalsViewHelper {
                                                              isZeroTotal: isZeroTotal)
     }
 
-    /// "Other payment methods" button visibility for the cart flow.
-    /// Shown only when at least one of the secondary payment-method feature flags is enabled —
-    /// otherwise the sheet would have no rows to render. Otherwise mirrors the cash button rules.
-    func shouldShowOtherPaymentMethodsButton(orderState: PointOfSaleOrderState,
-                                             paymentState: PointOfSalePaymentState,
-                                             cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus,
-                                             isAnySecondaryPaymentMethodEnabled: Bool) -> Bool {
-        guard isAnySecondaryPaymentMethodEnabled else {
-            return false
-        }
-
-        // Reuse the cash button's order-state and connection guards — the visibility envelope is
-        // identical for both buttons (we want them to appear/disappear together).
-        return shouldShowCollectCashPaymentButton(orderState: orderState,
-                                                   paymentState: paymentState,
-                                                   cardReaderConnectionStatus: cardReaderConnectionStatus)
-    }
-
     func shouldShowTotalDiscountField(cart: Cart, orderTotals: PointOfSaleOrderTotals?) -> Bool {
         let hasCoupons = cart.coupons.isNotEmpty
         let orderIsLoading = orderTotals == nil

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1297,6 +1297,7 @@ public enum WooAnalyticsStat: String {
     case pointOfSaleCashPaymentTapped = "cash_payment_tapped"
     case pointOfSaleCashPaymentFailed = "cash_payment_failed"
     case pointOfSaleBackToCheckoutFromCashTapped = "back_to_checkout_from_cash"
+    case pointOfSaleOtherPaymentMethodsTapped = "other_payment_methods_tapped"
     case pointOfSaleClearCartTapped = "clear_cart_tapped"
     case pointOfSaleExitMenuItemTapped = "exit_menu_item_tapped"
     case pointOfSaleExitConfirmed = "exit_confirmed"


### PR DESCRIPTION
## Description

Stacks on top of [#17030](https://github.com/woocommerce/woocommerce-ios/pull/17030) and lays down the entry-point UI for the upcoming Scan to Pay and Mark order as paid features. The two underlying flows are intentionally **not** wired in this PR — the sheet's row callbacks are TODO no-ops that the feature PRs will replace.

This PR auto-rebases onto trunk once #17030 lands.

### TotalsView

The single Cash payment button is replaced by a side-by-side `HStack` of two buttons sharing the same horizontal space: **Cash payment** on the left, **Other payment methods** on the right. Each `.frame(maxWidth: .infinity)` so they split the available width 50/50, or — if either is hidden — the surviving button stretches to fill on its own.

Existing visibility rules for Cash are unchanged; the Other payment methods button only appears when at least one of the two new feature flags from #17030 is enabled, otherwise the layout collapses back to the original single-Cash layout. **App Store builds therefore see zero behavior change vs trunk.**

### PointOfSaleOtherPaymentMethodsSheet

New bottom sheet with two rows — Scan to Pay and Mark order as paid — gated individually by their respective feature flags so each can be rolled out independently. Each row dismisses the sheet first, then fires its action closure so the parent view owns destination presentation.

### View helper

`TotalsViewHelper.shouldShowOtherPaymentMethodsButton(...)` reuses the cash button's order-state and connection guards plus the feature-flag gate, so the two buttons appear and disappear together as the merchant moves through the cart / checkout / finalizing stages.

### Analytics

New `pointOfSaleOtherPaymentMethodsTapped` stat fired when the merchant opens the sheet.

### Out of scope

- Bookings flow (`POSPaymentContentView`) is not updated yet — same pattern will be added when the feature PRs land.
- The sheet's row callbacks are TODO no-ops; tapping a row dismisses the sheet without doing anything else. Behavior fills in when the Scan to Pay and Mark as paid feature PRs land.
- No state-machine changes (no new `PointOfSalePaymentMethod` cases, no new substates). Those land with the feature PRs that introduce the corresponding flows.

## Test Steps

On a `localDeveloper` or `alpha` build (both feature flags default on):

1. Open POS, add an item to the cart, tap **Check out**.
2. Confirm the totals view shows two side-by-side buttons: **Cash payment** (left) and **Other payment methods** (right).
3. Tap **Other payment methods**. A bottom sheet opens listing two rows: **Scan to Pay** and **Mark order as paid**.
4. Tap any row. The sheet dismisses; nothing else happens (TODO no-op as expected).
5. Confirm `pointOfSaleOtherPaymentMethodsTapped` is logged when the sheet opens.

Toggle each feature flag off via the override panel (Help → Override remote feature flags) and verify:

6. With only `pointOfSaleScanToPay` on: sheet shows only the Scan to Pay row.
7. With only `pointOfSaleMarkOrderAsPaid` on: sheet shows only the Mark order as paid row.
8. With both flags off: the **Other payment methods** button is hidden entirely; layout collapses to a single full-width Cash payment button (matches trunk).

Connect a card reader and start a card payment; while the card flow is in progress, both Cash and Other payment methods should hide together (existing rule, unchanged).

## Screenshots

N/A — UI scaffold only, the sheet rows have no destinations yet. Screenshots will accompany the feature PRs that wire them up.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.