### PR TITLE
Enable SwiftLint rule: unused_closure_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -112,6 +112,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # Unused parameters in a closure should be replaced with `_`.
+  - unused_closure_parameter
+
   - untyped_error_in_catch
 
   - vertical_whitespace

--- a/Modules/Sources/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
+++ b/Modules/Sources/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
@@ -22,7 +22,7 @@ public final class AirPrintReceiptPrinterService: NSObject, PrinterService {
         renderer.configureFormatterForPrinting()
         printController.printPageRenderer = renderer
 
-        printController.present(animated: true) { (controller, completed, error) in
+        printController.present(animated: true) { (_, completed, error) in
             switch (completed, error) {
             case (_, .some(let error)):
                 // Printing failed

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -57,7 +57,7 @@ extension ShippingLabelPackagesResponse: Decodable {
         rawPredefinedFormSchema.forEach { (key, value) in
 
             let provider: [String: Any]? = try? value.toDictionary()
-            provider?.forEach({ (providerKey, providerValue) in
+            provider?.forEach({ (_, providerValue) in
 
                 let providerValueDict = providerValue as? [String: Any]
                 let packages = ShippingLabelPackagesResponse.getAllPredefinedPackages(packageDefinitions: providerValueDict)

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -53,7 +53,7 @@ extension WooShippingPackagesResponse: Decodable {
             // key is a carrier id, for example "usps"
             if let provider: [String: Any]? = try? value.toDictionary() {
                 var providerOptions: [WooShippingPredefinedOption] = []
-                provider?.forEach({ (providerKey, providerValue) in
+                provider?.forEach({ (_, providerValue) in
                     // providerKey is package group id, for example "pri_flat_boxes"
                     let providerValueDict = providerValue as? [String: Any]
                     let title: String = providerValueDict?["title"] as? String ?? ""

--- a/Modules/Sources/Networking/Remote/JetpackConnectionRemote.swift
+++ b/Modules/Sources/Networking/Remote/JetpackConnectionRemote.swift
@@ -70,7 +70,7 @@ public final class JetpackConnectionRemote: Remote {
         let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
         do {
             let request = try URLRequest(url: url, method: .get)
-            let task = session.dataTask(with: request) { [weak self] data, response, error in
+            let task = session.dataTask(with: request) { [weak self] _, _, error in
                 if let result = self?.accountConnectionURL {
                     DispatchQueue.main.async {
                         completion(.success(result))

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleItemsController.swift
@@ -162,7 +162,7 @@ protocol PointOfSaleSearchingItemsControllerProtocol: PointOfSaleItemsController
     private func loadChildItems(for parent: POSItem) async {
         let paginationTracker = paginationTracker(for: parent)
         do {
-            try await paginationTracker.resync { [weak self] pageNumber in
+            try await paginationTracker.resync { [weak self] _ in
                 guard let self else { return true }
                 return try await fetchChildItems(for: parent, pageNumber: Store.Default.firstPageNumber, appendToExistingItems: false)
             }

--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -58,7 +58,7 @@ struct POSSearchField: View {
             .autocorrectionDisabled()
             .textInputAutocapitalization(.never)
             .focused($isSearchFieldFocused)
-            .onChange(of: searchTerm) { oldValue, newValue in
+            .onChange(of: searchTerm) { _, newValue in
                 handleSearchTermChange(newValue)
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -54,7 +54,7 @@ struct POSOrdersView: View {
                     orderListModel.ordersController.selectOrder(firstOrder)
                 }
             }
-            .onChange(of: orderListModel.ordersController.ordersViewState.orders) { oldOrders, newOrders in
+            .onChange(of: orderListModel.ordersController.ordersViewState.orders) { _, newOrders in
                 guard horizontalSizeClass == .regular else { return }
 
                 guard let firstOrder = newOrders.first else {

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSendReceiptView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSendReceiptView.swift
@@ -96,7 +96,7 @@ private extension POSSendReceiptView {
 
 #if DEBUG
 #Preview {
-    POSSendReceiptView(isShowingSendReceiptView: .constant(true)) { email in
+    POSSendReceiptView(isShowingSendReceiptView: .constant(true)) { _ in
         try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
     }
 }

--- a/Modules/Sources/Storage/CoreData/CoreDataManager.swift
+++ b/Modules/Sources/Storage/CoreData/CoreDataManager.swift
@@ -195,7 +195,7 @@ public final class CoreDataManager: StorageManagerType {
 
             /// Retry!
             ///
-            container.loadPersistentStores { (storeDescription, underlyingError) in
+            container.loadPersistentStores { (_, underlyingError) in
                 guard let underlyingError = underlyingError as NSError? else {
                     return
                 }

--- a/Modules/Sources/UITestsFoundation/BaseScreen.swift
+++ b/Modules/Sources/UITestsFoundation/BaseScreen.swift
@@ -19,7 +19,7 @@ open class BaseScreen {
 
     @discardableResult
     func waitForPage() throws -> BaseScreen {
-        XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (activity) in
+        XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (_) in
             let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
             XCTAssert(result, "Page \(self) is not loaded.")
         }

--- a/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
+++ b/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
@@ -37,7 +37,7 @@ extension XCTestCase {
 
     public func takeScreenshotOfFailedTest() {
         if let failureCount = testRun?.failureCount, failureCount > 0 {
-            XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { (activity) in
+            XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { (_) in
                 add(XCTAttachment(screenshot: XCUIApplication().windows.firstMatch.screenshot()))
             }
         }

--- a/Modules/Sources/WooFoundation/ViewModifiers/View+Measurements.swift
+++ b/Modules/Sources/WooFoundation/ViewModifiers/View+Measurements.swift
@@ -48,10 +48,10 @@ public extension View {
                     .onAppear {
                         callback(proxy.frame(in: .global))
                     }
-                    .onChange(of: proxy.size.height) { _, newHeight in
+                    .onChange(of: proxy.size.height) { _, _ in
                         callback(proxy.frame(in: .global))
                     }
-                    .onChange(of: proxy.frame(in: .global)) { _, newHeight in
+                    .onChange(of: proxy.frame(in: .global)) { _, _ in
                         callback(proxy.frame(in: .global))
                     }
             }

--- a/Modules/Sources/WordPressShared/Utility/Debouncer.swift
+++ b/Modules/Sources/WordPressShared/Utility/Debouncer.swift
@@ -52,7 +52,7 @@ public final class Debouncer {
     }
 
     private func scheduleCallback() {
-        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [callback] timer in
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [callback] _ in
             callback?()
         }
     }

--- a/Modules/Sources/Yosemite/Stores/AccountStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AccountStore.swift
@@ -110,7 +110,7 @@ private extension AccountStore {
         if let site = storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly(), !forcedUpdate {
             onCompletion(.success(site))
         } else {
-            synchronizeSites(selectedSiteID: siteID) { [weak self] result in
+            synchronizeSites(selectedSiteID: siteID) { [weak self] _ in
                 guard let self else { return }
                 guard let site = self.storageManager.viewStorage.loadSite(siteID: siteID)?.toReadOnly() else {
                     return onCompletion(.failure(SynchronizeSiteError.unknownSite))

--- a/Modules/Sources/Yosemite/Tools/Payments/PaymentCaptureCelebration.swift
+++ b/Modules/Sources/Yosemite/Tools/Payments/PaymentCaptureCelebration.swift
@@ -29,7 +29,7 @@ private extension PaymentCaptureCelebration {
 
         let url = URL(fileURLWithPath: path)
         AudioServicesCreateSystemSoundID(url as CFURL, &soundID)
-        AudioServicesAddSystemSoundCompletion(soundID, nil, nil, { (soundId, clientData) -> Void in
+        AudioServicesAddSystemSoundCompletion(soundID, nil, nil, { (soundId, _) -> Void in
             AudioServicesDisposeSystemSoundID(soundId)
           }, nil)
 

--- a/Modules/Sources/Yosemite/Tools/ShippingSettings/StorageShippingSettingsService.swift
+++ b/Modules/Sources/Yosemite/Tools/ShippingSettings/StorageShippingSettingsService.swift
@@ -31,7 +31,7 @@ public final class StorageShippingSettingsService: ShippingSettingsService {
 
 private extension StorageShippingSettingsService {
     func configureResultsController() {
-        resultsController.onDidChangeObject = { [weak self] (object, indexPath, type, newIndexPath) in
+        resultsController.onDidChangeObject = { [weak self] (object, _, _, _) in
             self?.updateShippingSettings(with: object)
         }
         refreshResultsPredicate(siteID: siteID)

--- a/Modules/Sources/YosemiteTestHelpers/MockStorageManager.swift
+++ b/Modules/Sources/YosemiteTestHelpers/MockStorageManager.swift
@@ -34,7 +34,7 @@ open class MockStorageManager: StorageManagerType {
         let container = NSPersistentContainer(name: name, managedObjectModel: managedModel)
         container.persistentStoreDescriptions = [storeDescription]
 
-        container.loadPersistentStores { (storeDescription, error) in
+        container.loadPersistentStores { (_, error) in
             if let error = error as NSError? {
                 fatalError("CoreData Fatal Error: \(error) [\(error.userInfo)]")
             }

--- a/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
+++ b/Modules/Tests/NetworkingTests/ApplicationPassword/RequestProcessorTests.swift
@@ -205,7 +205,7 @@ final class RequestProcessorTests: XCTestCase {
         // When
         let error = RequestAuthenticatorError.applicationPasswordNotAvailable
         waitFor { promise in
-            self.sut.retry(request, for: session, dueTo: error) { shouldRetry in
+            self.sut.retry(request, for: session, dueTo: error) { _ in
                 promise(())
             }
         }
@@ -223,7 +223,7 @@ final class RequestProcessorTests: XCTestCase {
         mockRequestAuthenticator.mockedShouldRetryValue = false
         waitFor { promise in
             let error = RequestAuthenticatorError.applicationPasswordNotAvailable
-            self.sut.retry(request, for: session, dueTo: error) { shouldRetry in
+            self.sut.retry(request, for: session, dueTo: error) { _ in
                 promise(())
             }
         }
@@ -242,7 +242,7 @@ final class RequestProcessorTests: XCTestCase {
         // When
         let error = RequestAuthenticatorError.applicationPasswordNotAvailable
         waitFor { promise in
-            self.sut.retry(request, for: session, dueTo: error) { shouldRetry in
+            self.sut.retry(request, for: session, dueTo: error) { _ in
                 promise(())
             }
         }
@@ -262,7 +262,7 @@ final class RequestProcessorTests: XCTestCase {
         // When
         let error = RequestAuthenticatorError.applicationPasswordNotAvailable
         waitFor { promise in
-            self.sut.retry(request, for: session, dueTo: error) { shouldRetry in
+            self.sut.retry(request, for: session, dueTo: error) { _ in
                 promise(())
             }
         }
@@ -283,7 +283,7 @@ final class RequestProcessorTests: XCTestCase {
         // When
         let error = RequestAuthenticatorError.applicationPasswordNotAvailable
         waitFor { promise in
-            self.sut.retry(request, for: session, dueTo: error) { shouldRetry in
+            self.sut.retry(request, for: session, dueTo: error) { _ in
                 promise(())
             }
         }

--- a/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Modules/Tests/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -30,7 +30,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // When
         let network = AlamofireNetwork(credentials: nil, selectedSite: nil, appPasswordSupportState: nil, sessionManager: createSessionWithMockURLProtocol())
         let error = waitFor { promise in
-            network.responseData(for: request) { data, error in
+            network.responseData(for: request) { _, error in
                 promise(error)
             }
         }
@@ -52,7 +52,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // When
         let network = AlamofireNetwork(credentials: nil, selectedSite: nil, appPasswordSupportState: nil, sessionManager: createSessionWithMockURLProtocol())
         let error = waitFor { promise in
-            network.responseData(for: request) { data, error in
+            network.responseData(for: request) { _, error in
                 promise(error)
             }
         }
@@ -74,7 +74,7 @@ final class AlamofireNetworkTests: XCTestCase {
         // When
         let network = AlamofireNetwork(credentials: nil, selectedSite: nil, appPasswordSupportState: nil, sessionManager: createSessionWithMockURLProtocol())
         let error = waitFor { promise in
-            network.responseData(for: request) { data, error in
+            network.responseData(for: request) { _, error in
                 promise(error)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -221,7 +221,7 @@ final class OrdersRemoteTests: XCTestCase {
 
         // When
         let order: Order = waitFor { promise in
-            remote.loadOrder(for: self.sampleSiteID, orderID: self.sampleOrderID) { order, error in
+            remote.loadOrder(for: self.sampleSiteID, orderID: self.sampleOrderID) { order, _ in
                 if let order {
                     promise(order)
                 }
@@ -338,7 +338,7 @@ final class OrdersRemoteTests: XCTestCase {
         let remote = OrdersRemote(network: network)
 
         // When
-        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { (order, error) in }
+        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { (_, _) in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -353,7 +353,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(shippingLines: [shipping])
 
         // When
-        remote.updateOrder(from: 123, order: order, giftCard: nil, fields: [.shippingLines]) { result in }
+        remote.updateOrder(from: 123, order: order, giftCard: nil, fields: [.shippingLines]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -374,7 +374,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(fees: [fee])
 
         // When
-        remote.updateOrder(from: 123, order: order, giftCard: nil, fields: [.fees]) { result in }
+        remote.updateOrder(from: 123, order: order, giftCard: nil, fields: [.fees]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -397,7 +397,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(orderID: sampleOrderID, status: status)
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.status]) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.status]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -413,7 +413,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(items: [orderItem])
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.items]) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.items]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -445,7 +445,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(items: [orderItem])
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.items]) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.items]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -482,7 +482,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(coupons: [coupon])
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.couponLines]) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.couponLines]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -499,7 +499,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: "ABAE-DCCA", fields: []) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: "ABAE-DCCA", fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -514,7 +514,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(paymentMethodID: "cod", paymentMethodTitle: "Pay in Person")
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.paymentMethodID, .paymentMethodTitle]) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.paymentMethodID, .paymentMethodTitle]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -530,7 +530,7 @@ final class OrdersRemoteTests: XCTestCase {
         let cashPaymentChangeDueAmount = "$6.00"
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, cashPaymentChangeDueAmount: cashPaymentChangeDueAmount, fields: []) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, cashPaymentChangeDueAmount: cashPaymentChangeDueAmount, fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -547,7 +547,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: []) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -560,7 +560,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.customerNote]) { result in }
+        remote.updateOrder(from: sampleSiteID, order: order, giftCard: nil, fields: [.customerNote]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -629,7 +629,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(coupons: [coupon])
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.couponLines]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.couponLines]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -647,7 +647,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(fees: [fee])
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.feeLines]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.feeLines]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -669,7 +669,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(fees: [fee])
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.feeLines]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.feeLines]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -692,7 +692,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(status: status)
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.status]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.status]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -708,7 +708,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(status: status)
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.status]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.status]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -724,7 +724,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(items: [orderItem])
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.items]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.items]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -745,7 +745,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(billingAddress: address1, shippingAddress: address2)
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.billingAddress, .shippingAddress]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.billingAddress, .shippingAddress]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -784,7 +784,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake().copy(shippingLines: [shipping])
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.shippingLines]) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: [.shippingLines]) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -804,7 +804,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: "ABAE-DCCA", fields: []) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: "ABAE-DCCA", fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -819,7 +819,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -850,7 +850,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -863,7 +863,7 @@ final class OrdersRemoteTests: XCTestCase {
         let order = Order.fake()
 
         // When
-        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { result in }
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -911,7 +911,7 @@ final class OrdersRemoteTests: XCTestCase {
         let remote = OrdersRemote(network: network)
 
         // When
-        remote.deleteOrder(for: sampleSiteID, orderID: sampleOrderID, force: true) { result in }
+        remote.deleteOrder(for: sampleSiteID, orderID: sampleOrderID, force: true) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -771,7 +771,7 @@ final class ProductsRemoteTests: XCTestCase {
 
         // When
         waitForExpectation { expectation in
-            remote.loadProductIDs(for: sampleSiteID) { result in
+            remote.loadProductIDs(for: sampleSiteID) { _ in
                 expectation.fulfill()
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
@@ -32,7 +32,7 @@ final class RemoteTests: XCTestCase {
         let remote = Remote(network: network)
         let expectation = self.expectation(description: "Enqueue with Mapper")
 
-        remote.enqueue(request, mapper: mapper) { (payload, error) in
+        remote.enqueue(request, mapper: mapper) { (payload, _) in
             guard let receivedRequest = network.requestsForResponseData.first as? JetpackRequest else {
                 XCTFail()
                 return
@@ -114,7 +114,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "something", filename: "order")
 
-        remote.enqueue(request, mapper: mapper) { (payload, error) in
+        remote.enqueue(request, mapper: mapper) { (_, _) in
             XCTAssertEqual(mapper.input, Loader.contentsOf("order"))
             XCTAssertNotNil(mapper.input)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/TelemetryRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/TelemetryRemoteTests.swift
@@ -103,7 +103,7 @@ final class TelemetryRemoteTests: XCTestCase {
 
         // When
         waitFor { promise in
-            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: installationDate) { result in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: installationDate) { _ in
                 promise(())
             }
         }
@@ -119,7 +119,7 @@ final class TelemetryRemoteTests: XCTestCase {
 
         // When
         waitFor { promise in
-            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { result in
+            remote.sendTelemetry(for: self.sampleSiteID, versionString: "1.2", installationDate: nil) { _ in
                 promise(())
             }
         }

--- a/Modules/Tests/StorageTests/CoreData/CoreDataManagerTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/CoreDataManagerTests.swift
@@ -118,7 +118,7 @@ final class CoreDataManagerTests: XCTestCase {
 
         // Action
         let result: Result<Int64, Error> = waitFor { promise in
-            manager.performAndSave({ storage -> Int64 in
+            manager.performAndSave({ _ -> Int64 in
                 XCTAssertFalse(Thread.current.isMainThread, "Write operations should be performed in the background.")
                 throw CoreDataManagerTestsError.unexpectedFailure
             }, completion: { result in

--- a/Modules/Tests/YosemiteTests/Stores/AccountStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AccountStoreTests.swift
@@ -806,7 +806,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let _: Void = waitFor { promise in
-            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true) { result in
+            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true) { _ in
                 promise(())
             }
             accountStore.onAction(action)
@@ -830,7 +830,7 @@ final class AccountStoreTests: XCTestCase {
 
         // When
         let _: Void = waitFor { promise in
-            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true) { result in
+            let action = AccountAction.loadAndSynchronizeSite(siteID: 123, forcedUpdate: true) { _ in
                 promise(())
             }
             accountStore.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -173,7 +173,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     }
 
     func test_cancel_discovery_action_hits_cancel_in_service() {
-        let action = CardPresentPaymentAction.cancelCardReaderDiscovery { result in
+        let action = CardPresentPaymentAction.cancelCardReaderDiscovery { _ in
             //
         }
 
@@ -242,7 +242,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     }
 
     func test_disconnect_action_hits_disconnect_in_service() {
-        let action = CardPresentPaymentAction.disconnect(onCompletion: { result in
+        let action = CardPresentPaymentAction.disconnect(onCompletion: { _ in
             //
         })
 
@@ -606,7 +606,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher())
-        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { _ in
             // Card is not removed.
         })
 
@@ -617,10 +617,10 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .US,
-                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
+                                terminalPaymentPreparationEnabled: false) { _ in
                 } onProcessingCompletion: { intent in
                     promise(intent)
-                } onCompletion: { result in
+                } onCompletion: { _ in
                     XCTFail("Payment collection is not complete until the card removal step completes.")
                 }
             cardPresentStore.onAction(action)
@@ -653,8 +653,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .US,
-                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: false) { _ in
+                } onProcessingCompletion: { _ in
                 } onCompletion: { result in
                     promise(result)
                 }
@@ -693,8 +693,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .AU,
-                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: true) { _ in
+                } onProcessingCompletion: { _ in
                 } onCompletion: { result in
                     promise(result)
                 }
@@ -734,8 +734,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .AU,
-                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: true) { _ in
+                } onProcessingCompletion: { _ in
                 } onCompletion: { result in
                     promise(result)
                 }
@@ -773,8 +773,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .AU,
-                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: true) { _ in
+                } onProcessingCompletion: { _ in
                 } onCompletion: { result in
                     promise(result)
                 }
@@ -810,8 +810,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "CAD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .CA,
-                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: false) { _ in
+                } onProcessingCompletion: { _ in
                 } onCompletion: { result in
                     promise(result)
                 }
@@ -852,8 +852,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .US,
-                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: false) { _ in
+                } onProcessingCompletion: { _ in
                 } onCompletion: { result in
                     promise(result)
                 }
@@ -886,8 +886,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .CA,
-                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: true) { _ in
+                } onProcessingCompletion: { _ in
                     XCTFail("`onProcessingCompletion` should only be called after the payment intent is prepared and confirmed.")
                 } onCompletion: { result in
                     promise(result)
@@ -932,8 +932,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                     if cardReaderEvent == .cardRemovedAfterClientSidePaymentCapture {
                         promise(())
                     }
-                } onProcessingCompletion: { intent in
-                } onCompletion: { result in
+                } onProcessingCompletion: { _ in
+                } onCompletion: { _ in
                 }
             self.cardPresentStore.onAction(action)
         }
@@ -952,7 +952,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         let error = UnderlyingError.readerBusy
         mockCardReaderService.whenCapturingPayment(thenReturn: Fail<PaymentIntent, Error>(error: error)
             .eraseToAnyPublisher())
-        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { _ in
             // Card is not removed.
         })
 
@@ -963,8 +963,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
                                 orderID: sampleOrderID,
                                 parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
                                 countryCode: .US,
-                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
-                } onProcessingCompletion: { intent in
+                                terminalPaymentPreparationEnabled: false) { _ in
+                } onProcessingCompletion: { _ in
                     XCTFail("`onProcessingCompletion` should only be called when payment capture succeeds.")
                 } onCompletion: { result in
                     promise(result)

--- a/Modules/Tests/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -240,7 +240,7 @@ final class CustomerStoreTests: XCTestCase {
                                                         order: .asc,
                                                         keyword: self.dummyKeyword,
                                                         retrieveFullCustomersData: true,
-                                                        filter: .name) { result in
+                                                        filter: .name) { _ in
                 promise(())
             }
             self.dispatcher.dispatch(action)

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -102,14 +102,14 @@ final class NotificationStoreTests: XCTestCase {
         /// This call is expected to just request the Hashes, and not to perform a 4th network call (because everything
         /// will be up to date. Supposedly.)
         ///
-        let nestedSyncAction = NotificationAction.synchronizeNotifications() { (error) in
+        let nestedSyncAction = NotificationAction.synchronizeNotifications() { (_) in
             XCTAssertEqual(self.network.requestsForResponseData.count, 3)
             expectation.fulfill()
         }
 
         /// Initial Sync
         ///
-        let initialSyncAction = NotificationAction.synchronizeNotifications() { (error) in
+        let initialSyncAction = NotificationAction.synchronizeNotifications() { (_) in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Note.self), MockNetwork.notificationLoadAllJSONCount)
             notificationStore.onAction(nestedSyncAction)
         }

--- a/Modules/Tests/YosemiteTests/Stores/OrderFulfillmentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderFulfillmentStoreTests.swift
@@ -147,7 +147,7 @@ final class OrderFulfillmentStoreTests: XCTestCase {
 
         // When
         await withCheckedContinuation { continuation in
-            let action = OrderFulfillmentAction.synchronizeOrderFulfillments(siteID: sampleSiteID, orderID: sampleOrderID) { error in
+            let action = OrderFulfillmentAction.synchronizeOrderFulfillments(siteID: sampleSiteID, orderID: sampleOrderID) { _ in
                 continuation.resume(returning: ())
             }
             store.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
@@ -343,7 +343,7 @@ final class OrderStoreTests: XCTestCase {
         let firstAction = OrderAction.searchOrders(siteID: sampleSiteID,
                                                    keyword: defaultSearchKeyword,
                                                    pageNumber: defaultPageNumber,
-                                                   pageSize: defaultPageSize) { error in
+                                                   pageSize: defaultPageSize) { _ in
             orderStore.onAction(nestedAction)
         }
 
@@ -416,7 +416,7 @@ final class OrderStoreTests: XCTestCase {
         let storedOrder = self.viewStorage.firstObject(ofType: Storage.Order.self, matching: predicate)?.toReadOnly()
 
         let fetchedOrder: Yosemite.Order? = waitFor { promise in
-            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (order, error) in
+            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (order, _) in
                 promise(order)
             }
 
@@ -438,7 +438,7 @@ final class OrderStoreTests: XCTestCase {
 
         // When
         let fetchedOrder: Yosemite.Order? = waitFor { promise in
-            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (order, error) in
+            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (order, _) in
                 promise(order)
             }
 
@@ -978,7 +978,7 @@ final class OrderStoreTests: XCTestCase {
 
         // Track Events: Upsert == 1 / Delete == 0
         var numberOfUpsertEvents = 0
-        entityListener.onUpsert = { upserted in
+        entityListener.onUpsert = { _ in
             numberOfUpsertEvents += 1
         }
 

--- a/Modules/Tests/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -319,7 +319,7 @@ final class ProductCategoryStoreTests: XCTestCase {
                 return
             }
 
-            let action = ProductCategoryAction.synchronizeProductCategory(siteID: self.sampleSiteID, categoryID: categoryID) { result in
+            let action = ProductCategoryAction.synchronizeProductCategory(siteID: self.sampleSiteID, categoryID: categoryID) { _ in
                 promise(self.viewStorage.loadProductCategory(siteID: self.sampleSiteID, categoryID: 104))
             }
 

--- a/Modules/Tests/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -342,7 +342,7 @@ final class ProductReviewStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve single product review error response")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews/173", filename: "generic_error")
-        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (product, error) in
+        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (_, error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }

--- a/Modules/Tests/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
@@ -342,7 +342,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
-            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (shippingClass, error) in
+            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (_, error) in
                 XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 1)
                 XCTAssertNil(error)
 
@@ -376,14 +376,14 @@ final class ProductShippingClassStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
-            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (shippingClass, error) in
+            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (_, error) in
                 XCTAssertNil(error)
 
                 let storedProductShippingClasses = self.viewStorage.loadProductShippingClasses(siteID: self.sampleSiteID)
                 XCTAssertEqual(storedProductShippingClasses?.count, 1)
 
                 let action = ProductShippingClassAction
-                    .retrieveProductShippingClass(siteID: self.sampleSiteID, remoteID: self.sampleShippingClassID) { (model, error) in
+                    .retrieveProductShippingClass(siteID: self.sampleSiteID, remoteID: self.sampleShippingClassID) { (_, error) in
                         XCTAssertNil(error)
 
                         let storedProductShippingClasses = self.viewStorage

--- a/Modules/Tests/YosemiteTests/Stores/ProductStore+ProductsSortOrderTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStore+ProductsSortOrderTests.swift
@@ -55,7 +55,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productStatus: nil,
                                                        productType: nil,
                                                        productCategory: nil,
-                                                       sortOrder: .nameAscending) { [weak self] error in
+                                                       sortOrder: .nameAscending) { [weak self] _ in
                                                         guard let self else {
                                                             XCTFail()
                                                             return
@@ -80,7 +80,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productStatus: nil,
                                                        productType: nil,
                                                        productCategory: nil,
-                                                       sortOrder: .nameDescending) { [weak self] error in
+                                                       sortOrder: .nameDescending) { [weak self] _ in
                                                         guard let self else {
                                                             XCTFail()
                                                             return
@@ -105,7 +105,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productStatus: nil,
                                                        productType: nil,
                                                        productCategory: nil,
-                                                       sortOrder: .dateAscending) { [weak self] error in
+                                                       sortOrder: .dateAscending) { [weak self] _ in
                                                         guard let self else {
                                                             XCTFail()
                                                             return
@@ -130,7 +130,7 @@ final class ProductStore_ProductsSortOrderTests: XCTestCase {
                                                        productStatus: nil,
                                                        productType: nil,
                                                        productCategory: nil,
-                                                       sortOrder: .dateDescending) { [weak self] error in
+                                                       sortOrder: .dateDescending) { [weak self] _ in
                                                         guard let self else {
                                                             XCTFail()
                                                             return

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -333,7 +333,7 @@ final class ProductStoreTests: XCTestCase {
                                                        productStatus: nil,
                                                        productType: nil,
                                                        productCategory: nil,
-                                                       sortOrder: .nameAscending) { error in
+                                                       sortOrder: .nameAscending) { _ in
             expectation.fulfill()
         }
         productStore.onAction(action)
@@ -946,7 +946,7 @@ final class ProductStoreTests: XCTestCase {
 
         // Track Events: Upsert == 2 / Delete == 0
         var numberOfUpsertEvents = 0
-        entityListener.onUpsert = { upserted in
+        entityListener.onUpsert = { _ in
             numberOfUpsertEvents += 1
         }
 
@@ -1185,7 +1185,7 @@ final class ProductStoreTests: XCTestCase {
                                                            keyword: keyword,
                                                            pageNumber: self.defaultPageNumber,
                                                            pageSize: self.defaultPageSize,
-                                                           onCompletion: { result in
+                                                           onCompletion: { _ in
                                                             store.onAction(nestedAction)
                                                            })
             store.onAction(firstAction)
@@ -2161,7 +2161,7 @@ final class ProductStoreTests: XCTestCase {
                 name: expectedName,
                 description: expectedDescription,
                 language: expectedLangugae
-            ) { result in
+            ) { _ in
                 promise(())
             })
         }
@@ -2192,7 +2192,7 @@ final class ProductStoreTests: XCTestCase {
                 name: "Sample product",
                 description: "Sample description",
                 language: "en"
-            ) { result in
+            ) { _ in
                 promise(())
             })
         }
@@ -2220,7 +2220,7 @@ final class ProductStoreTests: XCTestCase {
                 name: "Sample product",
                 description: "Sample description",
                 language: "en"
-            ) { result in
+            ) { _ in
                 promise(())
             })
         }
@@ -2559,7 +2559,7 @@ final class ProductStoreTests: XCTestCase {
         let onFailure = waitFor { promise in
             let action = ProductAction.retrieveFirstPurchasableItemMatchFromIdentifier(siteID: self.sampleSiteID,
                                                                         identifier: nonExistingProductIdentifier,
-                                                                        onCompletion: { product in
+                                                                        onCompletion: { _ in
                 promise(false)
             })
             store.onAction(action)
@@ -2583,7 +2583,7 @@ final class ProductStoreTests: XCTestCase {
          let onSuccess: Bool = waitFor { promise in
              let action = ProductAction.retrieveFirstPurchasableItemMatchFromIdentifier(siteID: self.sampleSiteID,
                                                                                         identifier: expectedProductSKU,
-                                                                                        onCompletion: { product in
+                                                                                        onCompletion: { _ in
                  promise(true)
              })
              store.onAction(action)
@@ -2610,7 +2610,7 @@ final class ProductStoreTests: XCTestCase {
          let onSuccess: Bool = waitFor { promise in
              let action = ProductAction.retrieveFirstPurchasableItemMatchFromIdentifier(siteID: self.sampleSiteID,
                                                                                         identifier: expectedProductGlobalUniqueId,
-                                                                                        onCompletion: { product in
+                                                                                        onCompletion: { _ in
                  promise(true)
              })
              store.onAction(action)
@@ -2637,7 +2637,7 @@ final class ProductStoreTests: XCTestCase {
          let onSuccess: Bool = waitFor { promise in
              let action = ProductAction.retrieveFirstPurchasableItemMatchFromIdentifier(siteID: self.sampleSiteID,
                                                                                         identifier: expectedProductSKU,
-                                                                                        onCompletion: { product in
+                                                                                        onCompletion: { _ in
                  promise(true)
              })
              store.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/RefundStoreTests.swift
@@ -233,7 +233,7 @@ class RefundStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/refunds/\(refundID)", filename: "generic_error")
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: refundID) { (refund, error) in
+                                                 refundID: refundID) { (_, error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -250,7 +250,7 @@ class RefundStoreTests: XCTestCase {
 
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: refundID) { (refund, error) in
+                                                 refundID: refundID) { (_, error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -386,7 +386,7 @@ class RefundStoreTests: XCTestCase {
 
         // Track Events: Upsert == 1 / Delete == 0
         var numberOfUpsertEvents = 0
-        entityListener.onUpsert = { upserted in
+        entityListener.onUpsert = { _ in
             numberOfUpsertEvents += 1
         }
 

--- a/Modules/Tests/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -307,7 +307,7 @@ final class StatsStoreV4Tests: XCTestCase {
                                                               latestDateToInclude: DateFormatter.dateFromString(with: "2020-07-22T12:00:00"),
                                                               quantity: quantity,
                                                               forceRefresh: false,
-                                                              saveInStorage: true) { result in
+                                                              saveInStorage: true) { _ in
                 promise(())
             }
             store.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/TaxStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/TaxStoreTests.swift
@@ -68,7 +68,7 @@ final class TaxStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxClass.self), 0)
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (taxClasses, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.TaxClass.self), 3)
             XCTAssertNil(error)
 
@@ -90,7 +90,7 @@ final class TaxStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxClass.self), 0)
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (taxClasses, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
             XCTAssertNil(error)
 
             let storedTaxClass = self.viewStorage.loadTaxClass(slug: remoteTaxClass.slug)
@@ -113,7 +113,7 @@ final class TaxStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "generic_error")
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (taxClasses, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -127,7 +127,7 @@ final class TaxStoreTests: XCTestCase {
     func testRetrieveTaxClassesReturnsErrorUponEmptyResponse() {
         let expectation = self.expectation(description: "Retrieve tax class empty response")
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (taxClasses, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -164,7 +164,7 @@ final class TaxStoreTests: XCTestCase {
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 2020, taxClass: "standard")
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
-        let action = TaxAction.requestMissingTaxClasses(for: product) { (taxClass, error) in
+        let action = TaxAction.requestMissingTaxClasses(for: product) { (taxClass, _) in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.TaxClass.self), 3)
 
             XCTAssertEqual(taxClass?.slug, product.taxClass)

--- a/Modules/Tests/YosemiteTests/Tools/EntityListenerTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/EntityListenerTests.swift
@@ -71,7 +71,7 @@ class EntityListenerTests: XCTestCase {
         let listener = EntityListener(viewContext: viewContext, readOnlyEntity: storageAccount.toReadOnly())
         let expectation = self.expectation(description: "onDelete")
 
-        listener.onUpsert = { updated in
+        listener.onUpsert = { _ in
             XCTFail()
         }
 
@@ -100,7 +100,7 @@ class EntityListenerTests: XCTestCase {
         let listener = EntityListener(viewContext: viewContext, readOnlyEntity: storageAccount.toReadOnly())
         let expectation = self.expectation(description: "onUpsert")
 
-        listener.onUpsert = { updated in
+        listener.onUpsert = { _ in
             expectation.fulfill()
         }
 
@@ -130,7 +130,7 @@ class EntityListenerTests: XCTestCase {
         let listener = EntityListener(viewContext: viewContext, readOnlyEntity: storageAccount.toReadOnly())
         let expectation = self.expectation(description: "onUpsert")
 
-        listener.onUpsert = { updated in
+        listener.onUpsert = { _ in
             expectation.fulfill()
         }
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/BatchedRequestLoaderTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/BatchedRequestLoaderTests.swift
@@ -87,7 +87,7 @@ struct BatchedRequestLoaderTests {
         )
 
         let attemptCount = Counter()
-        let makeRequest: (Int) async throws -> PagedItems<String> = { pageNumber in
+        let makeRequest: (Int) async throws -> PagedItems<String> = { _ in
             await attemptCount.increment()
             throw NetworkError.unacceptableStatusCode(statusCode: 401, response: nil)
         }
@@ -111,7 +111,7 @@ struct BatchedRequestLoaderTests {
 
         let attemptCount = Counter()
         let expectedError = URLError(.networkConnectionLost)
-        let makeRequest: (Int) async throws -> PagedItems<String> = { pageNumber in
+        let makeRequest: (Int) async throws -> PagedItems<String> = { _ in
             await attemptCount.increment()
             throw expectedError
         }

--- a/Modules/Tests/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -173,7 +173,7 @@ final class ResultsControllerTests: XCTestCase {
         try? resultsController.performFetch()
 
         let expectation = self.expectation(description: "OnDidChange")
-        resultsController.onDidChangeObject = { (object, indexPath, type, newIndexPath) in
+        resultsController.onDidChangeObject = { (_, _, type, newIndexPath) in
             let expectedIndexPath = IndexPath(row: 0, section: 0)
 
             XCTAssertEqual(type, .insert)
@@ -197,7 +197,7 @@ final class ResultsControllerTests: XCTestCase {
         try? resultsController.performFetch()
 
         let expectation = self.expectation(description: "OnDidChange")
-        resultsController.onDidChangeSection = { (sectionInfo, index, type) in
+        resultsController.onDidChangeSection = { (_, _, type) in
             XCTAssertEqual(type, .insert)
             expectation.fulfill()
         }

--- a/WooCommerce/Classes/Bookings/BookingsTabView.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabView.swift
@@ -64,7 +64,7 @@ struct BookingsTabView: View {
                     .frame(height: OfflineBannerView.height)
             }
         }
-        .onChange(of: selectedBooking) { _, newValue in
+        .onChange(of: selectedBooking) { _, _ in
             bookingListContainerViewModel.selectedBookingChanged()
         }
     }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1205,7 +1205,7 @@ extension UIImage {
         let rect = CGRect(origin: .zero, size: size)
         let vectorImage = UIImage(named: "woo-logo")!
         let renderer = UIGraphicsImageRenderer(size: size)
-        let im2 = renderer.image { ctx in
+        let im2 = renderer.image { _ in
             vectorImage.draw(in: rect)
         }
 

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
@@ -10,7 +10,7 @@ extension MarkOrderAsReadUseCase {
     @MainActor
     static func markOrderNoteAsReadIfNeeded(stores: StoresManager, noteID: Int64, orderID: Int) async -> Result<Note, Error> {
         let syncronizedNoteResult: Result<Note, Error> = await withCheckedContinuation { continuation in
-            let action = NotificationAction.synchronizeNotification(noteID: noteID) { syncronizedNote, error in
+            let action = NotificationAction.synchronizeNotification(noteID: noteID) { syncronizedNote, _ in
                 guard let syncronizedNote else {
                     continuation.resume(returning: .failure(MarkOrderAsReadUseCase.Error.unavailableNote))
                     return

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -110,7 +110,7 @@ final class AggregateDataHelper {
             return item.itemID
         }
 
-        let unsortedResult: [AggregateOrderItem] = grouped.compactMap { (key, items) in
+        let unsortedResult: [AggregateOrderItem] = grouped.compactMap { (_, items) in
             // Here we iterate over each group's items
 
             // All items should be equal except for quantity and price, so we pick the first

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -98,7 +98,7 @@ private struct CurrentOrderListSyncUseCase {
                                            pageSize: SyncingCoordinator.Defaults.pageSize,
                                            reason: .backgroundFetch,
                                            lastFullSyncTimestamp: OrderListSyncBackgroundTask.latestSyncDate,
-                                           completionHandler: { timeInterval, error in
+                                           completionHandler: { _, error in
                 if let error {
                     continuation.resume(throwing: error)
                 } else {

--- a/WooCommerce/Classes/Tools/BoldableTextParser.swift
+++ b/WooCommerce/Classes/Tools/BoldableTextParser.swift
@@ -29,7 +29,7 @@ struct BoldableTextParser {
         var elements: [BoldableElement] = []
 
         var startingIndex = string.startIndex
-        matches.enumerated().forEach { index, match in
+        matches.enumerated().forEach { _, match in
             // Each `NSTextCheckingResult` has two ranges: the first one (index 0) is the range that includes the bold marks (**..**).
             // The second one (index 1) is the range that excludes the bold marks, which corresponds to the bolded substring.
             guard match.numberOfRanges == 2 else {

--- a/WooCommerce/Classes/Tools/MapsHelper.swift
+++ b/WooCommerce/Classes/Tools/MapsHelper.swift
@@ -9,7 +9,7 @@ final class MapsHelper {
             completion(.failure(.locationNotFound))
             return
         }
-        CLGeocoder().geocodeAddressString(address) { (placemarksOptional, error) -> Void in
+        CLGeocoder().geocodeAddressString(address) { (placemarksOptional, _) -> Void in
             guard let placemarks = placemarksOptional else {
                 completion(.failure(.locationNotFound))
                 return

--- a/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/DefaultNoticePresenter.swift
@@ -88,7 +88,7 @@ private extension DefaultNoticePresenter {
         let content = UNMutableNotificationContent(notice: notice)
         let request = UNNotificationRequest(identifier: notificationInfo.identifier, content: content, trigger: nil)
 
-        UNUserNotificationCenter.current().add(request) { error in
+        UNUserNotificationCenter.current().add(request) { _ in
             DispatchQueue.main.async {
                 self.dismiss()
             }

--- a/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
+++ b/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
@@ -74,7 +74,7 @@ private extension ResultsController {
     /// Sets up all of the Object Events from the inner FRC over to the specified TableView.
     ///
     func startForwardingObjectEvents(to tableView: UITableView, with animations: ResultsTableAnimations) {
-        onDidChangeObject = { [weak tableView] (object, indexPath, type, newIndexPath) in
+        onDidChangeObject = { [weak tableView] (_, indexPath, type, newIndexPath) in
             guard let `tableView` = tableView else {
                 return
             }
@@ -120,7 +120,7 @@ private extension ResultsController {
     /// Sets up all of the Section Events from the inner FRC over to the specified TableView.
     ///
     func startForwardingSectionEvents(to tableView: UITableView, with animations: ResultsTableAnimations) {
-        onDidChangeSection = { [weak tableView] (sectionInfo, sectionIndex, type) in
+        onDidChangeSection = { [weak tableView] (_, sectionIndex, type) in
             guard let `tableView` = tableView else {
                 return
             }

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -69,7 +69,7 @@ extension SelectedSiteSettings {
     /// Setup: ResultsController
     ///
     private func configureResultsController() {
-        resultsController.onDidChangeObject = { [weak self] (object, indexPath, type, newIndexPath) in
+        resultsController.onDidChangeObject = { [weak self] (object, _, _, _) in
             guard let self else { return }
             ServiceLocator.currencySettings.updateCurrencyOptions(with: object)
             self.siteSettings = self.resultsController.fetchedObjects

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -250,14 +250,14 @@ struct BlazePaymentMethodsView_Previews: PreviewProvider {
 
         let viewModel = BlazePaymentMethodsViewModel(siteID: 123,
                                                      selectedPaymentMethodID: nil,
-                                                     completion: { newPaymentID in
+                                                     completion: { _ in
         })
 
         BlazePaymentMethodsView(viewModel: viewModel)
 
         let emptyPaymentsViewModel = BlazePaymentMethodsViewModel(siteID: 123,
                                                      selectedPaymentMethodID: nil,
-                                                     completion: { newPaymentID in
+                                                     completion: { _ in
         })
 
         BlazePaymentMethodsView(viewModel: emptyPaymentsViewModel)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -564,7 +564,7 @@ private extension CardReaderConnectionController {
     }
 
     func observePermissionChanges() {
-        locationService.observePermissionChanges { [weak self] permission in
+        locationService.observePermissionChanges { [weak self] _ in
             guard let self else { return }
             locationService.stopObservingPermissionChanges()
             if case .requestLocationPermission = state {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
@@ -388,7 +388,7 @@ private extension TapToPayCardReaderConnectionController {
     }
 
     func observePermissionChanges() {
-        locationService.observePermissionChanges { [weak self] permission in
+        locationService.observePermissionChanges { [weak self] _ in
             guard let self else { return }
             locationService.stopObservingPermissionChanges()
             if case .requestLocationPermission = state {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -84,7 +84,7 @@ struct AddEditCoupon: View {
 
     var body: some View {
         NavigationView {
-            GeometryReader { geometry in
+            GeometryReader { _ in
                 ScrollView {
                     VStack (alignment: .leading, spacing: 0) {
                         Group {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/CouponExpiryDateView.swift
@@ -11,7 +11,7 @@ struct CouponExpiryDateView: View {
     let onCompletion: (Date?) -> Void
 
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             ScrollView {
                 VStack {
                     DatePicker("Date picker", selection: $date, displayedComponents: .date)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
@@ -16,7 +16,7 @@ struct DashboardCustomizationView: View {
                                           contentKeyPath: \.type.name,
                                           selectedItems: $viewModel.selectedCards,
                                           inactiveItems: viewModel.inactiveCards,
-                                          inactiveAccessoryView: { card in
+                                          inactiveAccessoryView: { _ in
                 BadgeView(text: Localization.unavailable,
                           customizations: BadgeView.Customizations(textColor: .white,
                                                                    backgroundColor: .gray)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -216,7 +216,7 @@ private extension DashboardView {
     @ViewBuilder
     func dashboardCardList(with items: [DashboardCard]) -> some View {
         VStack(spacing: Layout.padding) {
-            ForEach(Array(items.enumerated()), id: \.element.hashValue) { index, card in
+            ForEach(Array(items.enumerated()), id: \.element.hashValue) { _, card in
                 VStack(spacing: Layout.padding) {
                     switch card.type {
                     case .onboarding:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsResultsControllers.swift
@@ -35,7 +35,7 @@ final class CardReaderSettingsResultsControllers {
             onReload()
         }
 
-        paymentGatewayAccountResultsController.onDidChangeObject = { (object, indexPath, type, newIndexPath) in
+        paymentGatewayAccountResultsController.onDidChangeObject = { (_, _, _, _) in
             onReload()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -413,7 +413,7 @@ private extension HelpAndSupportViewController {
             return
         }
 
-        ZendeskProvider.shared.showSupportEmailPrompt(from: navController) { [weak self] (success, email) in
+        ZendeskProvider.shared.showSupportEmailPrompt(from: navController) { [weak self] (success, _) in
             guard success else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecTextViewAttachmentHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecTextViewAttachmentHandler.swift
@@ -25,7 +25,7 @@ final class AztecTextViewAttachmentHandler: TextViewAttachmentDelegate {
                 }
             }
 
-            let task = imageService.downloadImage(with: url, shouldCacheImage: true) { image, error in
+            let task = imageService.downloadImage(with: url, shouldCacheImage: true) { image, _ in
                 guard let image else {
                     failure()
                     return

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -114,7 +114,7 @@ final class TooltipPresenter {
             self.tooltip.alpha = 0
             tooltipTopConstraint.constant += Constants.tooltipTopConstraintAnimationOffset
             self.containerView.layoutIfNeeded()
-        } completion: { isSuccess in
+        } completion: { _ in
             self.primaryTooltipAction?()
             self.removeTooltip()
         }
@@ -217,7 +217,7 @@ final class TooltipPresenter {
             self.tooltip.alpha = 0
             tooltipTopConstraint.constant += Constants.tooltipTopConstraintAnimationOffset
             self.containerView.layoutIfNeeded()
-        } completion: { isSuccess in
+        } completion: { _ in
             self.tooltip.removeFromSuperview()
             self.tooltip = self.tooltip.copy(containerWidth: self.containerView.bounds.width)
             self.showTooltip()

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -614,7 +614,7 @@ private extension FilterListViewController {
             configuration.buttonSize = .mini
             configuration.title = NSLocalizedString("Explore", comment: "Button title to explore an extension that isn't installed")
 
-            let action = UIAction { [weak self] action in
+            let action = UIAction { [weak self] _ in
                 self?.launchPromoteWebview(for: promotableType)
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
@@ -184,7 +184,7 @@ private extension EditableOrderShippingLineViewModel {
                     return ShippingLineRowViewModel(shippingLine: shippingLine,
                                                     shippingMethods: self.allShippingMethods,
                                                     editable: !isNonEditable,
-                                                    onEditShippingLine: { [weak self] shippingID in
+                                                    onEditShippingLine: { [weak self] _ in
                         guard let self else {
                             return
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -680,10 +680,10 @@ private extension OrderDetailsViewController {
                                                 message: Localization.Alert.orderTrashConfirmationMessage,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.orderTrashConfirmationCancelButton,
-                                   style: .cancel) { (action) in
+                                   style: .cancel) { (_) in
         }
         let confirm = UIAlertAction(title: Localization.Alert.orderTrashConfirmationConfirmButton,
-                                    style: .default) { [weak self] (action) in
+                                    style: .default) { [weak self] (_) in
             self?.trashOrderAction()
         }
         alertController.addAction(cancel)
@@ -782,7 +782,7 @@ extension OrderDetailsViewController: UITableViewDelegate {
         }
 
         let copyActionTitle = NSLocalizedString("Copy", comment: "Copy address text button title — should be one word and as short as possible.")
-        let copyAction = UIContextualAction(style: .normal, title: copyActionTitle) { [weak self] (action, view, success) in
+        let copyAction = UIContextualAction(style: .normal, title: copyActionTitle) { [weak self] (_, _, success) in
             self?.viewModel.dataSource.copyText(at: indexPath)
             success(true)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -273,7 +273,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
     private func configureTrackingNumberScanAction(on cell: TitleAndEditableValueTableViewCell) {
         let actionButton = UIButton(type: .detailDisclosure)
         actionButton.applyIconButtonStyle(icon: .scanImage)
-        actionButton.on(.touchUpInside) { [weak self, weak cell] sender in
+        actionButton.on(.touchUpInside) { [weak self, weak cell] _ in
             self?.present(ScannerContainerViewController(navigationTitle: Localization.title,
                                                          instructionText: Localization.instructionText,
                                                          onBarcodeScanned: { barcode in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -38,7 +38,7 @@ struct ShippingLabelCarriers: View {
                                                               edgeInsets: edgeInsets,
                                                               shippingMethod: viewModel.shippingMethod,
                                                               shippingCost: viewModel.shippingCost).renderedIf(viewModel.shouldDisplayTopBanner)
-                        ForEach(Array(viewModel.sections.enumerated()), id: \.offset) { index, sectionVM in
+                        ForEach(Array(viewModel.sections.enumerated()), id: \.offset) { _, sectionVM in
                             ShippingLabelCarriersSection(section: sectionVM, safeAreaInsets: geometry.safeAreaInsets)
                                 .background(Color(.listForeground(modal: false)))
                             Spacer().frame(height: Constants.spaceBetweenSections)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -210,26 +210,26 @@ struct ShippingLabelPaymentMethods_Previews: PreviewProvider {
         let accountSettingsWithoutEditPermissions = ShippingLabelPaymentMethodsViewModel.sampleAccountSettings(withPermissions: false)
         let disabledViewModel = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettingsWithoutEditPermissions)
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (newAccountSettings) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
         })
         .colorScheme(.light)
         .previewDisplayName("Light mode")
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (newAccountSettings) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
         })
         .colorScheme(.dark)
         .previewDisplayName("Dark Mode")
 
-        ShippingLabelPaymentMethods(viewModel: disabledViewModel, completion: { (newAccountSettings) in
+        ShippingLabelPaymentMethods(viewModel: disabledViewModel, completion: { (_) in
         })
         .previewDisplayName("Disabled state")
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (newAccountSettings) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
         })
         .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
         .previewDisplayName("Accessibility: Large Font Size")
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (newAccountSettings) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
         })
         .environment(\.layoutDirection, .rightToLeft)
         .previewDisplayName("Localization: Right-to-Left Layout")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethodsViewModel.swift
@@ -25,7 +25,7 @@ final class ShippingLabelPaymentMethodsViewModel: ObservableObject {
     ///
     var paymentMethods: [ShippingLabelPaymentMethod] {
         /// sort methods to display the selected one on the top
-        accountSettings.paymentMethods.sorted { lhs, rhs in
+        accountSettings.paymentMethods.sorted { lhs, _ in
             if lhs.paymentMethodID == accountSettings.selectedPaymentMethodID {
                 return true
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -846,7 +846,7 @@ extension ShippingLabelFormViewModel {
             return
         }
 
-        let packages = selectedPackages.enumerated().compactMap { (index, package) -> ShippingLabelPackagePurchase? in
+        let packages = selectedPackages.enumerated().compactMap { (_, package) -> ShippingLabelPackagePurchase? in
             guard let selectedRate = selectedRates.first(where: { $0.packageID == package.id }),
                   let details = selectedPackagesDetails.first(where: { $0.id == package.id }) else {
                 return nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsForm.swift
@@ -68,9 +68,9 @@ struct WooShippingCustomsForm: View {
 
     var body: some View {
         NavigationView {
-            GeometryReader { geometry in
+            GeometryReader { _ in
                 VStack {
-                    ScrollViewReader { proxy in
+                    ScrollViewReader { _ in
                         ScrollView {
                             VStack(alignment: .leading, spacing: Constants.defaultVerticalSpacing) {
                                 Text(Localization.contentType)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/CollapsibleShipmentItemCardViewModel.swift
@@ -73,7 +73,7 @@ private extension CollapsibleShipmentItemCardViewModel {
         }
 
         childItemRows.forEach({
-            $0.onSelectedChange = { [weak self] row in
+            $0.onSelectedChange = { [weak self] _ in
                 guard let self else { return }
 
                 // Check if all child items are selected

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -270,7 +270,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
             }
             return newState.isEmpty ? Localization.Validation.state : nil
         }
-        self.phone.validate = { [weak self] newPhone in
+        self.phone.validate = { [weak self] _ in
             guard let self else {
                 return nil
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -793,7 +793,7 @@ private extension OrderListViewController {
             image: .magnifyingGlassNotFound,
             details: "",
             buttonTitle: Localization.clearButton,
-            onTap: { [weak self] button in
+            onTap: { [weak self] _ in
                 self?.delegate?.clearFilters()
             },
             onPullToRefresh: { [weak self] refreshControl in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -388,7 +388,7 @@ private extension OrdersRootViewController {
     /// This is useful for stay up to date with the remote statuses, resetting the filters if one of the local status filters was deleted remotely.
     ///
     func configureStatusResultsController() {
-        statusResultsController.onDidChangeObject = { [weak self] (updatedOrdersStatus, _, _, _) in
+        statusResultsController.onDidChangeObject = { [weak self] (_, _, _, _) in
             guard let self else { return }
             self.resetFiltersIfAnyStatusFilterIsNoMoreExisting(orderStatuses: self.statusResultsController.fetchedObjects)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -624,7 +624,7 @@ private extension ProductDetailPreviewViewModel {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(ProductCategoryAction.synchronizeProductCategories(siteID: siteID,
                                                                                fromPageNumber: Default.firstPageNumber,
-                                                                               onCompletion: { result in
+                                                                               onCompletion: { _ in
                 continuation.resume()
             }))
         }
@@ -653,7 +653,7 @@ private extension ProductDetailPreviewViewModel {
     func synchronizeAllTags() async throws {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(ProductTagAction.synchronizeAllProductTags(siteID: siteID,
-                                                                       onCompletion: { result in
+                                                                       onCompletion: { _ in
                 continuation.resume()
             }))
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
@@ -72,7 +72,7 @@ extension ProductDownloadFileViewController {
         menuAlert.view.tintColor = .text
 
         let deleteTitle = Localization.actionSheetDeleteTitle
-        let deleteAction = UIAlertAction(title: deleteTitle, style: .destructive) { [weak self] (action) in
+        let deleteAction = UIAlertAction(title: deleteTitle, style: .destructive) { [weak self] (_) in
             ServiceLocator.analytics.track(.productsDownloadableFile, withProperties: ["action": "deleted"])
             self?.onDeletion()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController+Droppable.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController+Droppable.swift
@@ -45,7 +45,7 @@ extension ProductDownloadListViewController: UITableViewDropDelegate {
 
         for item in coordinator.items {
             guard let sourceIndexPathRow = item.sourceIndexPath?.row else { continue }
-            item.dragItem.itemProvider.loadObject(ofClass: ProductDownloadDragAndDrop.self) { [weak self] (object, error) in
+            item.dragItem.itemProvider.loadObject(ofClass: ProductDownloadDragAndDrop.self) { [weak self] (object, _) in
                 DispatchQueue.main.async {
                     if let item = object as? ProductDownloadDragAndDrop {
                         self?.viewModel.remove(at: sourceIndexPathRow)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -85,7 +85,7 @@ final class ProductDownloadListViewController: UIViewController {
         onWPLibraryPickerCompletion = { [weak self] mediaItems in
             self?.onWPMediaPickerCompletion(mediaItems: mediaItems)
         }
-        cancellable = productImageActionHandler?.addAssetUploadObserver(self) { [weak self] asset, result in
+        cancellable = productImageActionHandler?.addAssetUploadObserver(self) { [weak self] _, result in
             switch result {
             case let .success(productImage):
                 ServiceLocator.analytics.track(.productDownloadableFileUploadingSuccess)
@@ -287,7 +287,7 @@ private extension ProductDownloadListViewController {
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         menuAlert.view.tintColor = .text
 
-        let downloadSettingsAction = UIAlertAction(title: Localization.downloadSettingsAction, style: .default) { [weak self] (action) in
+        let downloadSettingsAction = UIAlertAction(title: Localization.downloadSettingsAction, style: .default) { [weak self] (_) in
             self?.showDownloadableFilesSettings()
         }
         menuAlert.addAction(downloadSettingsAction)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -186,7 +186,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     // MARK: - Initialization
 
     func retrieveProductTaxClass(completion: @escaping () -> Void) {
-        let action = TaxAction.requestMissingTaxClasses(for: product) { [weak self] (taxClass, error) in
+        let action = TaxAction.requestMissingTaxClasses(for: product) { [weak self] (taxClass, _) in
             self?.taxClass = taxClass ?? self?.standardTaxClass
             completion()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductsListSelectorViewController.swift
@@ -170,7 +170,7 @@ private extension LinkedProductsListSelectorViewController {
     }
 
     func observeLinkedProductIDs() {
-        productIDsSubscription = dataSource.productIDs.sink { [weak self] productIDs in
+        productIDsSubscription = dataSource.productIDs.sink { [weak self] _ in
             self?.paginatedListSelector.updateResultsController()
             self?.updateNavigationRightBarButtonItem()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductTaxClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductTaxClassListSelectorDataSource.swift
@@ -43,7 +43,7 @@ struct ProductTaxClassListSelectorDataSource: PaginatedListSelectorDataSource {
     }
 
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Result<Bool, Error>) -> Void)?) {
-        let action = TaxAction.retrieveTaxClasses(siteID: siteID) { (taxClasses, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: siteID) { (_, error) in
             if let error {
                 DDLogError("⛔️ Error synchronizing tax classes: \(error)")
                 onCompletion?(.failure(error))

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -384,7 +384,7 @@ private extension ProductFormRemoteActionUseCase {
             let createAction = ProductVariationAction.createProductVariation(
                 siteID: parent.siteID,
                 productID: parent.productID,
-                newVariation: newVariation) { result in
+                newVariation: newVariation) { _ in
                 continuation.resume(returning: ())
             }
             DispatchQueue.main.async { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -175,7 +175,7 @@ private extension ProductFormTableViewDataSource {
         else {
             cell.configure(with: productImageStatuses, config: .extendedAddImages(isVariation: isVariation), productUIImageLoader: productUIImageLoader)
         }
-        cell.onImageSelected = { [weak self] (productImage, indexPath) in
+        cell.onImageSelected = { [weak self] (_, _) in
             self?.onAddImage?()
         }
         cell.onAddImage = { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -22,11 +22,11 @@ extension ProductFormViewController {
                                                 message: body,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.productTypeChangeCancelButton,
-                                   style: .cancel) { (action) in
+                                   style: .cancel) { (_) in
                                        completion(false)
                                    }
         let confirm = UIAlertAction(title: Localization.Alert.productTypeChangeConfirmButton,
-                                    style: .default) { (action) in
+                                    style: .default) { (_) in
                                         completion(true)
                                     }
         alertController.addAction(cancel)
@@ -72,11 +72,11 @@ extension ProductFormViewController {
                                                 message: Localization.Alert.productDeleteConfirmationMessage,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.productDeleteConfirmationCancelButton,
-                                   style: .cancel) { (action) in
+                                   style: .cancel) { (_) in
                                        completion(false)
                                    }
         let confirm = UIAlertAction(title: Localization.Alert.productDeleteConfirmationConfirmButton,
-                                    style: .default) { (action) in
+                                    style: .default) { (_) in
                                         completion(true)
                                     }
         alertController.addAction(cancel)
@@ -91,11 +91,11 @@ extension ProductFormViewController {
                                                 message: Localization.Alert.variationDeleteConfirmationMessage,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.variationDeleteConfirmationCancelButton,
-                                   style: .cancel) { (action) in
+                                   style: .cancel) { (_) in
             completion(false)
         }
         let confirm = UIAlertAction(title: Localization.Alert.variationDeleteConfirmationConfirmButton,
-                                    style: .default) { (action) in
+                                    style: .default) { (_) in
             completion(true)
         }
         alertController.addAction(cancel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -251,7 +251,7 @@ final class ProductFormViewModel: ProductFormViewModelProtocol {
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.favoriteProductsUseCase = favoriteProductsUseCase ?? DefaultFavoriteProductsUseCase(siteID: product.siteID)
 
-        self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
+        self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] _ in
             guard let self else { return }
             self.isUpdateEnabledSubject.send(self.hasUnsavedChanges())
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormViewModel.swift
@@ -131,7 +131,7 @@ final class ProductVariationFormViewModel: ProductFormViewModelProtocol {
         self.actionsFactory = ProductVariationFormActionsFactory(productVariation: productVariation, editable: editable)
         self.isUpdateEnabledSubject = PassthroughSubject<Bool, Never>()
         self.productImagesUploader = productImagesUploader
-        self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] allStatuses in
+        self.cancellable = productImageActionHandler.addUpdateObserver(self) { [weak self] _ in
             guard let self else { return }
             self.isUpdateEnabledSubject.send(self.hasUnsavedChanges())
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRules.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRules.swift
@@ -90,8 +90,8 @@ private extension QuantityRules {
 
 struct QuantityRules_Previews: PreviewProvider {
 
-    static let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2", onCompletion: { rules, hasUnsavedChanges in })
-    static let noQuantityRules = QuantityRulesViewModel(minQuantity: "", maxQuantity: "", groupOf: "", onCompletion: { rules, hasUnsavedChanges in })
+    static let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2", onCompletion: { _, _ in })
+    static let noQuantityRules = QuantityRulesViewModel(minQuantity: "", maxQuantity: "", groupOf: "", onCompletion: { _, _ in })
 
     static var previews: some View {
         QuantityRules(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -100,7 +100,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
         }
 
         if let downloadedImage = await withCheckedContinuation({ continuation in
-            _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, error) in
+            _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, _) in
                 if let image {
                     continuation.resume(returning: image)
                 } else {
@@ -147,7 +147,7 @@ private extension DefaultProductUIImageLoader {
             phAssetImageLoader.requestImage(for: asset,
                                             targetSize: PHImageManagerMaximumSize,
                                             contentMode: .aspectFit,
-                                            options: nil) { [weak self] (image, info) in
+                                            options: nil) { [weak self] (image, _) in
                 guard let image, let self else {
                     return
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
@@ -118,7 +118,7 @@ private extension MediaPickingCoordinator {
     func cameraAction(origin: UIViewController) -> UIAlertAction {
         let title = NSLocalizedString("Take a photo",
                                       comment: "Menu option for taking an image or video with the device's camera.")
-        return UIAlertAction(title: title, style: .default) { [weak self] action in
+        return UIAlertAction(title: title, style: .default) { [weak self] _ in
             self?.showMediaPicker(source: .camera, from: origin)
         }
     }
@@ -127,7 +127,7 @@ private extension MediaPickingCoordinator {
     func photoLibraryAction(origin: UIViewController) -> UIAlertAction {
         let title = NSLocalizedString("Choose from device",
                                       comment: "Menu option for selecting media from the device's photo library.")
-        return UIAlertAction(title: title, style: .default) { [weak self] action in
+        return UIAlertAction(title: title, style: .default) { [weak self] _ in
             self?.showMediaPicker(source: .photoLibrary, from: origin)
         }
     }
@@ -136,7 +136,7 @@ private extension MediaPickingCoordinator {
     func siteMediaLibraryAction(origin: UIViewController) -> UIAlertAction {
         let title = NSLocalizedString("WordPress Media Library",
                                       comment: "Menu option for selecting media from the site's media library.")
-        return UIAlertAction(title: title, style: .default) { [weak self] action in
+        return UIAlertAction(title: title, style: .default) { [weak self] _ in
             self?.showMediaPicker(source: .siteMediaLibrary, from: origin)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImageActionHandler.swift
@@ -97,7 +97,7 @@ final class ProductImageActionHandler: ProductImageActionHandlerProtocol {
                 return
             }
 
-            self.observations.allStatusesUpdated[id] = { [weak self, weak observer] allStatuses in
+            self.observations.allStatusesUpdated[id] = { [weak self, weak observer] _ in
                 guard let self else {
                     return
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -233,7 +233,7 @@ private extension ProductsSplitViewCoordinator {
 
     func autoSelectProductOnInitialDataLoad() {
         Publishers.CombineLatest(selectedProduct, productsViewController.onDataReloaded)
-            .first(where: { [weak self] selectedProduct, onDataReloaded in
+            .first(where: { [weak self] selectedProduct, _ in
                 guard let self else {
                     return false
                 }
@@ -241,7 +241,7 @@ private extension ProductsSplitViewCoordinator {
                     !splitViewController.isCollapsed &&
                     splitViewController.traitCollection.horizontalSizeClass == .regular
             })
-            .sink { [weak self] selectedProduct, onDataReloaded in
+            .sink { [weak self] _, _ in
                 self?.productsViewController.selectFirstProductIfAvailable()
             }
             .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1030,7 +1030,7 @@ private extension ProductsViewController {
 
     func listenToSelectedProductToAutoScrollWhenProductChanges(product: Product) {
         selectedProductListener = .init(storageManager: ServiceLocator.storageManager, readOnlyEntity: product)
-        selectedProductListener?.onUpsert = { [weak self] product in
+        selectedProductListener?.onUpsert = { [weak self] _ in
             guard let self,
                   let selectedIndexPath = tableView.indexPathForSelectedRow,
                   !isIndexPathVisible(selectedIndexPath) else {
@@ -1475,7 +1475,7 @@ extension ProductsViewController: PaginationTrackerDelegate {
                                                               productStatusFilter: filters.productStatus,
                                                               productTypeFilter: filters.promotableProductType?.productType,
                                                               productCategoryFilter: filters.productCategory,
-                                                              favoriteProduct: filters.favoriteProduct != nil) { (error) in
+                                                              favoriteProduct: filters.favoriteProduct != nil) { (_) in
         }
         ServiceLocator.stores.dispatch(action)
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -105,7 +105,7 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                         panelHeight = calculateHeight()
                     }
                 })
-                .onChange(of: geometryProxy.size.height) { _, newValue in
+                .onChange(of: geometryProxy.size.height) { _, _ in
                     if !isDragging {
                         DispatchQueue.main.async {
                             withAnimation {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -246,7 +246,7 @@ struct TopTabView<Content: View>: View {
                     // The gesture could be simultaneous with an external scroll view
                     .simultaneousGesture(
                         DragGesture()
-                            .updating($dragState) { drag, state, transaction in
+                            .updating($dragState) { drag, state, _ in
                                 let isHorizontalDrag = abs(drag.translation.width) > abs(drag.translation.height)
                                 if isHorizontalDrag {
                                     state = .dragging(translation: drag.translation)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwitchTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwitchTableViewCell.swift
@@ -93,7 +93,7 @@ private extension SwitchTableViewCell {
 
     func setupGestureRecognizers() {
         let gestureRecognizer = UITapGestureRecognizer()
-        gestureRecognizer.on { [weak self] gesture in
+        gestureRecognizer.on { [weak self] _ in
             self?.contentViewWasPressed()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -152,7 +152,7 @@ private extension ReviewDetailsViewController {
     /// Synchronizes the Notifications associated to the active WordPress.com account.
     ///
     func synchronizeReview(reviewID: Int64, onCompletion: @escaping () -> Void) {
-        let action = ProductReviewAction.retrieveProductReview(siteID: siteID, reviewID: reviewID) { (productReview, error) in
+        let action = ProductReviewAction.retrieveProductReview(siteID: siteID, reviewID: reviewID) { (_, error) in
             if let error {
                 DDLogError("⛔️ Error synchronizing product review [\(reviewID)]: \(error)")
                 ServiceLocator.analytics.track(.reviewLoadFailed,

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -216,7 +216,7 @@ class DefaultStoresManager: StoresManager {
     func listenToWPCOMInvalidWPCOMTokenNotification() {
         invalidWPCOMTokenNotificationObserver = notificationCenter.addObserver(forName: .RemoteDidReceiveInvalidTokenError,
                                                                                object: nil,
-                                                                               queue: .main) { [weak self] note in
+                                                                               queue: .main) { [weak self] _ in
             _ = self?.deauthenticate()
         }
     }

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -203,7 +203,7 @@ open class Snapshot: NSObject {
                 let format = UIGraphicsImageRendererFormat()
                 format.scale = image.scale
                 let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-                return renderer.image { context in
+                return renderer.image { _ in
                     image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
                 }
             } else {

--- a/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
+++ b/WooCommerce/WooCommerceTests/Stripe Integration Tests/StripeCardReaderIntegrationTests.swift
@@ -22,7 +22,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
         let readerService = ServiceLocator.cardReaderService
 
-        readerService.discoveredReaders.sink { completion in
+        readerService.discoveredReaders.sink { _ in
             readerService.cancelDiscovery()
                 .fulfillOnCompletion(expectation: receivedReaders)
         } receiveValue: { readers in
@@ -45,7 +45,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
         let readerService = ServiceLocator.cardReaderService
 
-        readerService.discoveredReaders.sink { completion in
+        readerService.discoveredReaders.sink { _ in
             readerService.cancelDiscovery()
                 .fulfillOnCompletion(expectation: discoveredReaders)
         } receiveValue: { readers in
@@ -79,7 +79,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
 
         let readerService = ServiceLocator.cardReaderService
 
-        readerService.discoveredReaders.dropFirst(1).sink { completion in
+        readerService.discoveredReaders.dropFirst(1).sink { _ in
             readerService.cancelDiscovery()
                 .fulfillOnCompletion(expectation: discoveredReaders)
         } receiveValue: { readers in
@@ -89,7 +89,7 @@ final class StripeCardReaderIntegrationTests: XCTestCase {
             }
             discoveredReaders.fulfill()
             readerService.cancelDiscovery().discard()
-            readerService.connect(firstReader, options: nil).sink { completion in
+            readerService.connect(firstReader, options: nil).sink { _ in
                 readerService.cancelDiscovery().discard()
             } receiveValue: { _ in
                 readerService.cancelDiscovery()

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -30,7 +30,7 @@ final class DefaultImageServiceTests: XCTestCase {
         // Downloads the image and retrieves it again.
         let waitForDownloadingAndCachingAnImage = expectation(description: "Wait for downloading and caching an image")
         let waitForRetrievingImageAfterDownload = expectation(description: "Wait for retrieving image after the previous download")
-        _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, error) in
+        _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, _) in
             XCTAssertNotNil(image)
             waitForDownloadingAndCachingAnImage.fulfill()
 
@@ -47,7 +47,7 @@ final class DefaultImageServiceTests: XCTestCase {
         // Downloads the image without caching and retrieves it again.
         let waitForDownloadingAndCachingAnImage = expectation(description: "Wait for downloading an image")
         let waitForRetrievingImageAfterDownload = expectation(description: "Wait for retrieving image after the previous download")
-        _ = imageService.downloadImage(with: url, shouldCacheImage: false) { (image, error) in
+        _ = imageService.downloadImage(with: url, shouldCacheImage: false) { (image, _) in
             XCTAssertNotNil(image)
             waitForDownloadingAndCachingAnImage.fulfill()
 
@@ -63,7 +63,7 @@ final class DefaultImageServiceTests: XCTestCase {
     func testCancellingDownloadingAnImage() {
         // Arrange
         let waitForDownloadingAnImage = expectation(description: "Wait for downloading an image")
-        let task = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, error) in
+        let task = imageService.downloadImage(with: url, shouldCacheImage: true) { (_, _) in
             waitForDownloadingAnImage.fulfill()
         }
 
@@ -98,7 +98,7 @@ final class DefaultImageServiceTests: XCTestCase {
             .downloadAndCacheImageForImageView(mockImageView,
                                                with: url.absoluteString,
                                                placeholder: mockPlaceholder,
-                                               progressBlock: nil) { (image, error) in
+                                               progressBlock: nil) { (image, _) in
                                                 XCTAssertNotNil(image)
                                                 waitForDownloadingAndCachingAnImage.fulfill()
 
@@ -134,7 +134,7 @@ final class DefaultImageServiceTests: XCTestCase {
             .downloadAndCacheImageForImageView(mockImageView,
                                                with: urlStringWithSpecialChars,
                                                placeholder: mockPlaceholder,
-                                               progressBlock: nil) { (image, error) in
+                                               progressBlock: nil) { (image, _) in
                 XCTAssertNotNil(image)
                 waitForDownloadingAndCachingAnImage.fulfill()
 

--- a/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ResultsControllerUIKitTests.swift
@@ -169,11 +169,11 @@ final class ResultsControllerUIKitTests: XCTestCase {
         let _ = storageManager.insertSampleAccount()
         storageManager.viewStorage.saveIfNeeded()
 
-        tableView.onInsertedSections = { indexSet in
+        tableView.onInsertedSections = { _ in
             expectation.fulfill()
         }
 
-        tableView.onDeletedSections = { indexSet in
+        tableView.onDeletedSections = { _ in
             XCTFail()
         }
 
@@ -190,11 +190,11 @@ final class ResultsControllerUIKitTests: XCTestCase {
         let first = storageManager.insertSampleAccount()
         storageManager.viewStorage.saveIfNeeded()
 
-        tableView.onInsertedSections = { indexSet in
+        tableView.onInsertedSections = { _ in
             XCTFail()
         }
 
-        tableView.onDeletedSections = { indexSet in
+        tableView.onDeletedSections = { _ in
             expectation.fulfill()
         }
 

--- a/WooCommerce/WooCommerceTests/Tools/SyncCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/SyncCoordinatorTests.swift
@@ -89,7 +89,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedMarksCacheAsValidOnSuccess() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (page, callback) in
+        delegate.onSync = { (_, callback) in
             callback?(true)
 
             XCTAssertFalse(self.coordinator.isCacheInvalid(pageNumber: self.secondPageNumber))
@@ -106,7 +106,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedMarksCacheAsValidOnError() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (page, callback) in
+        delegate.onSync = { (_, callback) in
             callback?(false)
 
             XCTAssertTrue(self.coordinator.isCacheInvalid(pageNumber: self.secondPageNumber))
@@ -122,7 +122,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedEffectivelyTracksPagesBeingSynced() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (page, callback) in
+        delegate.onSync = { (_, callback) in
 
             XCTAssertTrue(self.coordinator.isPageBeingSynced(pageNumber: self.secondPageNumber))
             callback?(false)

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -113,7 +113,7 @@ final class UniversalLinkRouterTests: XCTestCase {
         // Given
         let subPath = "/test/path"
 
-        let route = MockRoute(handledSubpaths: [subPath], performAction: { _, parameters in
+        let route = MockRoute(handledSubpaths: [subPath], performAction: { _, _ in
             return true
         })
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -716,11 +716,11 @@ private extension CollectOrderPaymentUseCaseTests {
     }
 
     func mockSuccessfulCardPresentPaymentActions(intent: PaymentIntent, capturedPaymentData: CardPresentCapturedPaymentData) {
-        mockPaymentOrchestrator.mockCollectPaymentHandler = { onPreparingReader,
-                                                              onWaitingForInput,
-                                                              onProcessingMessage,
-                                                              onCardInserted,
-                                                              onDisplayMessage,
+        mockPaymentOrchestrator.mockCollectPaymentHandler = { _,
+                                                              _,
+                                                              _,
+                                                              _,
+                                                              _,
                                                               onProcessingCompletion,
                                                               onCompletion in
             onProcessingCompletion(intent)
@@ -729,11 +729,11 @@ private extension CollectOrderPaymentUseCaseTests {
     }
 
     func mockFailedCardPresentPaymentActions(intent: PaymentIntent, error: any Error) {
-        mockPaymentOrchestrator.mockCollectPaymentHandler = { onPreparingReader,
-                                                              onWaitingForInput,
-                                                              onProcessingMessage,
-                                                              onCardInserted,
-                                                              onDisplayMessage,
+        mockPaymentOrchestrator.mockCollectPaymentHandler = { _,
+                                                              _,
+                                                              _,
+                                                              _,
+                                                              _,
                                                               onProcessingCompletion,
                                                               onCompletion in
             onProcessingCompletion(intent)

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -61,7 +61,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
                 promise(())
             }
         }
@@ -106,7 +106,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // When
         waitFor { promise in
-            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { _ in
                 promise(())
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingListViewModelTests.swift
@@ -638,7 +638,7 @@ class BookingListViewModelTests {
         let booking = createBooking(id: 1, startDate: testDate, status: .confirmed)
         insertBookings([booking])
 
-        stores.whenReceivingAction(ofType: BookingAction.self) { action in
+        stores.whenReceivingAction(ofType: BookingAction.self) { _ in
             // Don't complete the sync — keep it in progress
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -23,7 +23,7 @@ final class CardReaderConnectionControllerTests: XCTestCase {
         storageManager = MockStorageManager()
         locationService = MockLocationService(status: .authorized)
 
-        storageManager.performAndSave({ [weak self] storage in
+        storageManager.performAndSave({ [weak self] _ in
             guard let self else { return }
             let paymentGateway = storageManager.viewStorage.insertNewObject(ofType: StoragePaymentGatewayAccount.self)
             paymentGateway.update(with: .fake().copy(siteID: sampleSiteID, gatewayID: "woocommerce-payments", isCardPresentEligible: true))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Keyboard/KeyboardFrameObserverTests.swift
@@ -70,7 +70,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
-        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (_: CGRect) in
             expectationForKeyboardFrame.fulfill()
         }
         keyboardFrameObserver.startObservingKeyboardFrame()
@@ -88,7 +88,7 @@ final class KeyboardFrameObserverTests: XCTestCase {
 
         let expectationForKeyboardFrame = expectation(description: "Wait for keyboard frame updates")
 
-        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (keyboardFrame: CGRect) in
+        let keyboardFrameObserver = KeyboardFrameObserver(notificationCenter: notificationCenter) { (_: CGRect) in
             expectationForKeyboardFrame.fulfill()
         }
         keyboardFrameObserver.startObservingKeyboardFrame()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/RefundConfirmationViewModelTests.swift
@@ -540,7 +540,7 @@ final class RefundConfirmationViewModelTests: XCTestCase {
         let viewModel = RefundConfirmationViewModel(details: details, actionProcessor: dispatcher, analytics: analytics)
         waitForExpectation { exp in
             viewModel.submit(rootViewController: .init(),
-                             showInProgressUI: {}) { result in
+                             showInProgressUI: {}) { _ in
                 exp.fulfill()
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomAmounts/AddCustomAmountViewModelTests.swift
@@ -30,7 +30,7 @@ final class AddCustomAmountViewModelTests: XCTestCase {
     func test_doneButtonPressed_when_there_is_no_name_then_passes_placeholder() {
         // Given
         var passedName: String?
-        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: { amount, name, _, _ in
+        let viewModel = AddCustomAmountViewModel(inputType: .fixedAmount, onCustomAmountEntered: { _, name, _, _ in
             passedName = name
         })
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleProductViewModelTests.swift
@@ -277,7 +277,7 @@ final class ConfigurableBundleProductViewModelTests: XCTestCase {
                                                            // The bundle is not new when there are non-empty child items.
                                                            childItems: [.fake()],
                                                            stores: stores,
-                                                           onConfigure: { configurations in
+                                                           onConfigure: { _ in
             // Then
             XCTFail("The configure closure should not be invoked")
         })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
@@ -19,7 +19,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
     func test_selected_value_after_change() {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (_) in
             // noop
         }
         // Assert
@@ -28,7 +28,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
 
     func test_isSelected_returns_true_if_given_the_initial_value() {
         // Arrange
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (selected) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (_) in
             // noop
         }
         // Action
@@ -38,7 +38,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
     }
     func test_isSelected_returns_false_if_given_a_different_value() {
         // Arrange
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (selected) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (_) in
             // noop
         }
         // Action

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -553,7 +553,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
             // Assert
             XCTAssertEqual(finalRegularPrice, regularPrice)
             XCTAssertEqual(finalSalePrice, salePrice)
-        }, onError: { error in
+        }, onError: { _ in
             XCTFail("Completion block should not be called")
         })
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+ObservablesTests.swift
@@ -131,7 +131,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        productSubscription = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 
@@ -172,7 +172,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              formType: .edit,
                                              productImageActionHandler: productImageActionHandler)
         var isProductUpdated: Bool?
-        productSubscription = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 
@@ -212,7 +212,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
         viewModel.resetPassword("134")
 
         var isProductUpdated: Bool?
-        productSubscription = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 
@@ -256,7 +256,7 @@ final class ProductFormViewModel_ObservablesTests: XCTestCase {
                                              productImageActionHandler: productImageActionHandler,
                                              productImagesUploader: mockProductImageUploader)
         var isProductUpdated: Bool?
-        productSubscription = viewModel.observableProduct.sink { product in
+        productSubscription = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -79,7 +79,7 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
 
         // When
         waitForExpectation { expectation in
-            viewModel.saveProductRemotely(status: .pending) { result in
+            viewModel.saveProductRemotely(status: .pending) { _ in
                 expectation.fulfill()
             }
         }
@@ -100,7 +100,7 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
 
         // When
         waitForExpectation { expectation in
-            viewModel.saveProductRemotely(status: .pending) { result in
+            viewModel.saveProductRemotely(status: .pending) { _ in
                 expectation.fulfill()
             }
         }
@@ -227,7 +227,7 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
 
         // When
         waitForExpectation { expectation in
-            viewModel.saveProductRemotely(status: .published) { result in
+            viewModel.saveProductRemotely(status: .published) { _ in
                 expectation.fulfill()
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ImageUploaderTests.swift
@@ -45,7 +45,7 @@ final class ProductVariationFormViewModel_ImageUploaderTests: XCTestCase {
 
         // When
         waitFor { promise in
-            viewModel.saveProductRemotely(status: .published) { result in
+            viewModel.saveProductRemotely(status: .published) { _ in
                 promise(())
             }
         }
@@ -91,7 +91,7 @@ final class ProductVariationFormViewModel_ImageUploaderTests: XCTestCase {
 
         let _: Void = waitFor { promise in
             productImageUploader.whenHasUnsavedChangesOnImagesIsCalled(thenReturn: false)
-            viewModel.saveProductRemotely(status: .published) { result in
+            viewModel.saveProductRemotely(status: .published) { _ in
                 promise(())
             }
             XCTAssertEqual(isUpdateEnabledValues, [true, false])
@@ -143,7 +143,7 @@ final class ProductVariationFormViewModel_ImageUploaderTests: XCTestCase {
         XCTAssertEqual(isUpdateEnabledValues, [false])
 
         let _: Void = waitFor { promise in
-            viewModel.saveProductRemotely(status: .published) { result in
+            viewModel.saveProductRemotely(status: .published) { _ in
                 promise(())
             }
             XCTAssertEqual(isUpdateEnabledValues, [false])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductVariationFormViewModel+ObservablesTests.swift
@@ -90,7 +90,7 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
             productImagesUploader: mockProductImageUploader)
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        cancellableProduct = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 
@@ -123,7 +123,7 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
                                                       storesManager: mockStoresManager)
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        cancellableProduct = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 
@@ -160,7 +160,7 @@ final class ProductVariationFormViewModel_ObservablesTests: XCTestCase {
                                                       storesManager: mockStoresManager)
 
         var isProductUpdated: Bool?
-        cancellableProduct = viewModel.observableProduct.sink { product in
+        cancellableProduct = viewModel.observableProduct.sink { _ in
             isProductUpdated = true
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModelTests.swift
@@ -41,7 +41,7 @@ final class QuantityRulesViewModelTests: XCTestCase {
         var passedMaxQuantity: String?
         var passedGroupOfValue: String?
 
-        let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2") { rules, hasUnchangedValues in
+        let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2") { rules, _ in
             passedMinQuantity = rules.minQuantity
             passedMaxQuantity = rules.maxQuantity
             passedGroupOfValue = rules.groupOf

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageUploaderTests.swift
@@ -204,14 +204,14 @@ final class ProductImageUploaderTests: XCTestCase {
         imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key:
                 .init(siteID: self.siteID,
                       productOrVariationID: self.productID,
-                      isLocalID: false)) { result in
+                      isLocalID: false)) { _ in
             XCTFail("The product save callback should not be triggered after another save request.")
         }
 
         // Adds a remote image.
         actionHandler.addSiteMediaLibraryImagesToProduct(mediaItems: [.fake().copy(mediaID: 606)])
         waitFor { promise in
-            actionHandler.addUpdateObserver(self) { statuses in
+            actionHandler.addUpdateObserver(self) { _ in
                 promise(())
             }
         }
@@ -333,7 +333,7 @@ final class ProductImageUploaderTests: XCTestCase {
 
         imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: siteID,
                                                                                  productOrVariationID: productID,
-                                                                                 isLocalID: false)) { result in }
+                                                                                 isLocalID: false)) { _ in }
 
         // Then
         waitUntil {
@@ -400,13 +400,13 @@ final class ProductImageUploaderTests: XCTestCase {
         let asset = PHAsset()
         actionHandler.uploadMediaAssetToSiteMediaLibrary(asset: .phAsset(asset: asset))
         waitFor { promise in
-            actionHandler.addUpdateObserver(self) { statuses in
+            actionHandler.addUpdateObserver(self) { _ in
                 promise(())
             }
         }
         imageUploader.saveProductImagesWhenNoneIsPendingUploadAnymore(key: .init(siteID: siteID,
                                                                                  productOrVariationID: productID,
-                                                                                 isLocalID: false)) { result in }
+                                                                                 isLocalID: false)) { _ in }
         var errors: [ProductImageUploadErrorInfo] = []
         let _: Void = waitFor { promise in
             self.errorsSubscription = imageUploader.errors.sink { error in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImagesSaverTests.swift
@@ -264,7 +264,7 @@ final class ProductImagesSaverTests: XCTestCase {
         // When
         waitFor { promise in
             // Saves product images.
-            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { result in
+            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { _ in
                 promise(())
             }
         }
@@ -293,7 +293,7 @@ final class ProductImagesSaverTests: XCTestCase {
         // When
         waitFor { promise in
             // Saves product images.
-            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { result in
+            imagesSaver.saveProductImagesWhenNoneIsPendingUploadAnymore(imageActionHandler: actionHandler) { _ in
                 promise(())
             }
         }
@@ -308,7 +308,7 @@ final class ProductImagesSaverTests: XCTestCase {
 private extension ProductImagesSaverTests {
     func waitForImageStatusesUpdate(actionHandler: ProductImageActionHandler) {
         waitFor { promise in
-            actionHandler.addUpdateObserver(self) { statuses in
+            actionHandler.addUpdateObserver(self) { _ in
                 promise(())
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -90,7 +90,7 @@ final class OrderSearchUICommandTests: XCTestCase {
 
         // When
         waitFor { promise in
-            systemUnderTestWithMockedAnalytics.synchronizeModels(siteID: self.siteID, keyword: keyword, pageNumber: 1, pageSize: 20) { success in
+            systemUnderTestWithMockedAnalytics.synchronizeModels(siteID: self.siteID, keyword: keyword, pageNumber: 1, pageSize: 20) { _ in
                 promise(())
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Product/ProductSearchUICommandTests.swift
@@ -105,7 +105,7 @@ final class ProductSearchUICommandTests: XCTestCase {
         // When
         // Syncing models for the first time for the first page.
         waitFor { promise in
-            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "Melon", pageNumber: 1, pageSize: 10) { success in
+            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "Melon", pageNumber: 1, pageSize: 10) { _ in
                 promise(())
             }
         }
@@ -113,7 +113,7 @@ final class ProductSearchUICommandTests: XCTestCase {
 
         // Syncing models for the same keyword for the second time for the first page.
         waitFor { promise in
-            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "Melon", pageNumber: 1, pageSize: 10) { success in
+            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "Melon", pageNumber: 1, pageSize: 10) { _ in
                 promise(())
             }
         }
@@ -121,7 +121,7 @@ final class ProductSearchUICommandTests: XCTestCase {
 
         // Syncing models for the same keyword for the third time, but for the second page.
         waitFor { promise in
-            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "Melon", pageNumber: 2, pageSize: 10) { success in
+            command.synchronizeModels(siteID: self.sampleSiteID, keyword: "Melon", pageNumber: 2, pageSize: 10) { _ in
                 promise(())
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -436,7 +436,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (result) in
+        viewModel.validateAddress(onlyLocally: false) { (_) in
         }
 
         // Then
@@ -475,7 +475,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (result) in
+        viewModel.validateAddress(onlyLocally: false) { (_) in
         }
 
         // Then
@@ -514,7 +514,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (result) in
+        viewModel.validateAddress(onlyLocally: false) { (_) in
         }
 
         // Then
@@ -557,7 +557,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (result) in
+        viewModel.validateAddress(onlyLocally: false) { (_) in
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
@@ -63,7 +63,7 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { (rate, signatureRate, _) in
+                                                         currencySettings: CurrencySettings()) { (_, signatureRate, _) in
             promise(signatureRate)
         }
             // When
@@ -86,7 +86,7 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { (rate,
+                                                         currencySettings: CurrencySettings()) { (_,
                                                                                                                                     _,
                                                                                                                                     adultSignatureRate) in
             promise(adultSignatureRate)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -551,7 +551,7 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
                                                                     userDefaults: userDefaults)
 
         // When
-        shippingLabelFormViewModel.validateAddress(type: .origin) { validationState, validationSuccess in
+        shippingLabelFormViewModel.validateAddress(type: .origin) { validationState, _ in
             guard case let .validationError(error) = validationState else {
                 XCTFail("Validation error was not returned")
                 return

--- a/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/TopBanner/TopBannerViewTests.swift
@@ -34,7 +34,7 @@ final class TopBannerViewTests: XCTestCase {
     func test_it_forwards_actionButtons_actions_correctly() throws {
         // Given
         var actionInvoked = false
-        let actionButton = TopBannerViewModel.ActionButton(title: "Button", action: { sourceView in
+        let actionButton = TopBannerViewModel.ActionButton(title: "Button", action: { _ in
             actionInvoked = true
         })
         let viewModel = createViewModel(with: [actionButton])

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComOAuthClientTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComOAuthClientTests.swift
@@ -297,7 +297,7 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             },
-            failure: { (error) in
+            failure: { (_) in
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             }

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
@@ -514,7 +514,7 @@ class WordPressComRestApiTests: XCTestCase {
                 complete.fulfill()
                 XCTFail("The API call should complete with a failure")
             },
-            failure: { error, _ in
+            failure: { _, _ in
                 complete.fulfill()
             }
         )

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressOrgXMLRPCApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressOrgXMLRPCApiTests.swift
@@ -53,7 +53,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -78,7 +78,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -105,7 +105,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -132,7 +132,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -158,7 +158,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -186,7 +186,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -217,7 +217,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
@@ -243,7 +243,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },


### PR DESCRIPTION
## Summary

Enables the `unused_closure_parameter` SwiftLint rule.
The rule prefers `_` over named parameters that are never referenced inside a closure body, making intent clearer and preventing accidental shadowing.

Part of the Orchard SwiftLint rollout campaign — Phase 1.

## Numbers

- Auto-fixed violations: **131 files** (285 insertions / 282 deletions)
- Manual (agentic) fixes: 0
- Violations left for human review: 0
- Disable directives added: 0

## How to test

- CI runs lint, build, and tests across all targets.
- The rule is purely cosmetic at the call-site (renames an unused parameter to `_`); behaviour is unchanged.
