### PR TITLE
Add AI support chat entry point from pre-login troubleshooting

### DIFF
--- a/Modules/Sources/Networking/Remote/SupportChatRemote.swift
+++ b/Modules/Sources/Networking/Remote/SupportChatRemote.swift
@@ -15,6 +15,7 @@ public protocol SupportChatRemoteProtocol {
     func sendMessage(botSlug: String,
                      message: String,
                      chatID: Int64?,
+                     sessionID: String?,
                      context: [String: Any]?) async throws -> SupportChatResponse
 
     /// Fetches an existing chat thread by id, returning every turn (user + bot).
@@ -34,6 +35,7 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
     public func sendMessage(botSlug: String,
                             message: String,
                             chatID: Int64?,
+                            sessionID: String?,
                             context: [String: Any]?) async throws -> SupportChatResponse {
         let path: String = {
             if let chatID {
@@ -45,6 +47,9 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
         var parameters: [String: Any] = [ParameterKey.message: message]
         if let context {
             parameters[ParameterKey.context] = context
+        }
+        if let sessionID {
+            parameters[ParameterKey.sessionID] = sessionID
         }
 
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
@@ -77,5 +82,6 @@ private extension SupportChatRemote {
     enum ParameterKey {
         static let message = "message"
         static let context = "context"
+        static let sessionID = "session_id"
     }
 }

--- a/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
@@ -9,11 +9,13 @@ public enum SupportChatAction: Action {
     ///   - botSlug: The bot/assistant slug (e.g., "woo-chat-allusers").
     ///   - message: The user's message text.
     ///   - chatID: If provided, continues an existing chat; otherwise starts a new one.
+    ///   - sessionID: Current session if continuing an existing chat
     ///   - context: Optional context forwarded to the assistant (site info, troubleshooting data).
     ///   - completion: Called with the full chat thread including the bot's response.
     case sendMessage(botSlug: String,
                      message: String,
                      chatID: Int64?,
+                     sessionID: String?,
                      context: [String: Any]?,
                      completion: (Result<SupportChatResponse, Error>) -> Void)
 

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
@@ -10,7 +10,7 @@ struct MockSupportChatActionHandler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-        case let .sendMessage(_, _, _, _, completion):
+        case let .sendMessage(_, _, _, _, _, completion):
             completion(.success(Self.emptyResponse))
         case let .fetchChat(_, _, completion):
             completion(.success(Self.emptyResponse))

--- a/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
@@ -33,8 +33,8 @@ public final class SupportChatStore: Store {
         }
 
         switch action {
-        case let .sendMessage(botSlug, message, chatID, context, completion):
-            sendMessage(botSlug: botSlug, message: message, chatID: chatID, context: context, completion: completion)
+        case let .sendMessage(botSlug, message, chatID, sessionID, context, completion):
+            sendMessage(botSlug: botSlug, message: message, chatID: chatID, sessionID: sessionID, context: context, completion: completion)
         case let .fetchChat(botSlug, chatID, completion):
             fetchChat(botSlug: botSlug, chatID: chatID, completion: completion)
         case let .registerChat(chatID, siteID, wpcomUserID, botSlug, firstUserMessage, onCompletion):
@@ -60,6 +60,7 @@ private extension SupportChatStore {
     func sendMessage(botSlug: String,
                      message: String,
                      chatID: Int64?,
+                     sessionID: String?,
                      context: [String: Any]?,
                      completion: @escaping (Result<SupportChatResponse, Error>) -> Void) {
         Task {
@@ -67,6 +68,7 @@ private extension SupportChatStore {
                 try await remote.sendMessage(botSlug: botSlug,
                                              message: message,
                                              chatID: chatID,
+                                             sessionID: sessionID,
                                              context: context)
             }
 

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -17,6 +17,7 @@ struct SupportChatRemoteTests {
         _ = try? await remote.sendMessage(botSlug: botSlug,
                                           message: "hi",
                                           chatID: nil,
+                                          sessionID: nil,
                                           context: nil)
 
         // Then
@@ -33,6 +34,7 @@ struct SupportChatRemoteTests {
         _ = try? await remote.sendMessage(botSlug: botSlug,
                                           message: "hi",
                                           chatID: chatID,
+                                          sessionID: nil,
                                           context: nil)
 
         // Then
@@ -49,6 +51,7 @@ struct SupportChatRemoteTests {
         _ = try? await remote.sendMessage(botSlug: botSlug,
                                           message: message,
                                           chatID: nil,
+                                          sessionID: nil,
                                           context: nil)
 
         // Then
@@ -68,6 +71,7 @@ struct SupportChatRemoteTests {
         _ = try? await remote.sendMessage(botSlug: botSlug,
                                           message: "hi",
                                           chatID: nil,
+                                          sessionID: nil,
                                           context: context)
 
         // Then
@@ -85,6 +89,7 @@ struct SupportChatRemoteTests {
         _ = try? await remote.sendMessage(botSlug: botSlug,
                                           message: "hi",
                                           chatID: nil,
+                                          sessionID: nil,
                                           context: nil)
 
         // Then
@@ -104,6 +109,7 @@ struct SupportChatRemoteTests {
         let response = try await remote.sendMessage(botSlug: botSlug,
                                                     message: "hi",
                                                     chatID: nil,
+                                                    sessionID: nil,
                                                     context: nil)
 
         // Then
@@ -129,6 +135,7 @@ struct SupportChatRemoteTests {
         let response = try await remote.sendMessage(botSlug: botSlug,
                                                     message: "hi",
                                                     chatID: nil,
+                                                    sessionID: nil,
                                                     context: nil)
 
         // Then
@@ -151,6 +158,7 @@ struct SupportChatRemoteTests {
         let response = try await remote.sendMessage(botSlug: botSlug,
                                                     message: "hi",
                                                     chatID: nil,
+                                                    sessionID: nil,
                                                     context: nil)
 
         // Then
@@ -171,6 +179,7 @@ struct SupportChatRemoteTests {
         let response = try await remote.sendMessage(botSlug: botSlug,
                                                     message: "hi",
                                                     chatID: nil,
+                                                    sessionID: nil,
                                                     context: nil)
 
         // Then — unrecognized roles must not crash decoding; they fall back to .unknown.
@@ -188,6 +197,7 @@ struct SupportChatRemoteTests {
         let response = try await remote.sendMessage(botSlug: botSlug,
                                                     message: "I need a human",
                                                     chatID: nil,
+                                                    sessionID: nil,
                                                     context: nil)
 
         // Then
@@ -207,6 +217,7 @@ struct SupportChatRemoteTests {
             try await remote.sendMessage(botSlug: botSlug,
                                          message: "hi",
                                          chatID: nil,
+                                         sessionID: nil,
                                          context: nil)
         }
     }
@@ -222,6 +233,7 @@ struct SupportChatRemoteTests {
             try await remote.sendMessage(botSlug: botSlug,
                                          message: "hi",
                                          chatID: nil,
+                                         sessionID: nil,
                                          context: nil)
         }
     }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
@@ -21,6 +21,7 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
     func sendMessage(botSlug: String,
                      message: String,
                      chatID: Int64?,
+                     sessionID: String?,
                      context: [String: Any]?) async throws -> SupportChatResponse {
         sendMessageInvocations.append((botSlug, message, chatID))
         guard let result = sendMessageResult else {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -51,7 +51,7 @@ final class ConnectivityToolViewModel {
     /// (not application password), since the chatbot requires WPCom authentication.
     ///
     var isBotChatSupported: Bool {
-        featureFlagService.isFeatureFlagEnabled(.aiSupportChat) && stores.isAuthenticatedWithoutWPCom == false
+        featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
     }
 
     /// Remote used to check the connection to WPCom servers.

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
@@ -21,26 +21,50 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
         rootView.onContactSupportTapped = { [weak self] in
             self?.showContactSupportForm()
         }
+
+        rootView.onChatWithSupportTapped = { [weak self] in
+            self?.showSupportChat()
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func showContactSupportForm() {
-        let attachments: [ZendeskAttachment] = {
-            guard let description = viewModel.troubleshootingDescription(),
-                  let data = description.data(using: .utf8) else { return [] }
-            return [
-                ZendeskAttachment(
-                    data: data,
-                    filename: "prelogin_connectivitytest_log.md",
-                    contentType: "text/markdown"
-                )
-            ]
-        }()
+    private func showContactSupportForm(chatTranscript: String? = nil) {
+        var attachments: [ZendeskAttachment] = []
+
+        if let description = viewModel.troubleshootingDescription(),
+           let data = description.data(using: .utf8) {
+            attachments.append(ZendeskAttachment(
+                data: data,
+                filename: "prelogin_connectivitytest_log.md",
+                contentType: "text/markdown"
+            ))
+        }
+
+        if let transcript = chatTranscript,
+           !transcript.isEmpty,
+           let data = transcript.data(using: .utf8) {
+            attachments.append(ZendeskAttachment(
+                data: data,
+                filename: "support_chat_transcript.txt",
+                contentType: "text/plain"
+            ))
+        }
+
         let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(attachments: attachments))
         supportController.show(from: self)
+    }
+
+    private func showSupportChat() {
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] transcript in
+            self?.navigationController?.popViewController(animated: true)
+            self?.showContactSupportForm(chatTranscript: transcript)
+        }
+
+        let chatController = SupportChatHostingController(viewModel: chatViewModel)
+        chatController.show(from: self)
     }
 }
 
@@ -52,6 +76,9 @@ struct PreLoginConnectivityToolView: View {
 
     /// Closure invoked when the "Contact Support" button is tapped.
     var onContactSupportTapped: (() -> Void)?
+
+    /// Closure invoked when the "Chat with AI Support" button is tapped.
+    var onChatWithSupportTapped: (() -> Void)?
 
     var body: some View {
         VStack(spacing: .zero) {
@@ -71,11 +98,19 @@ struct PreLoginConnectivityToolView: View {
                 }
             }
 
-            Button(Localization.contactSupport) {
-                onContactSupportTapped?()
+            if viewModel.showChatButton {
+                Button(Localization.chatWithSupport) {
+                    onChatWithSupportTapped?()
+                }
+                .buttonStyle(SecondaryButtonStyle())
+                .padding()
+            } else if viewModel.showContactSupportButton {
+                Button(Localization.contactSupport) {
+                    onContactSupportTapped?()
+                }
+                .buttonStyle(SecondaryButtonStyle())
+                .padding()
             }
-            .buttonStyle(SecondaryButtonStyle())
-            .padding()
         }
         .background(Color(uiColor: .listForeground(modal: false)))
         .navigationTitle(Localization.title)
@@ -188,6 +223,11 @@ private extension PreLoginConnectivityToolView {
             "preLoginConnectivityToolView.contactSupport",
             value: "Contact Support",
             comment: "Contact support button in the pre-login connectivity tool"
+        )
+        static let chatWithSupport = NSLocalizedString(
+            "preLoginConnectivityToolView.chatWithSupport",
+            value: "Chat with Support",
+            comment: "Chat with AI support button in the pre-login connectivity tool"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
@@ -1,9 +1,11 @@
 import Foundation
+import UIKit
 import class Networking.UserAgent
 import struct NetworkingCore.WordPressAPIDiscovery
 import protocol NetworkingCore.URLSessionProtocol
 import class WordPressAuthenticator.WordPressComSiteInfo
 import protocol WooFoundation.Analytics
+import protocol Experiments.FeatureFlagService
 
 /// Represents the state of a pre-login connectivity check.
 ///
@@ -73,6 +75,22 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
     ///
     @Published var cards: [PreLoginCheckCard] = []
 
+    /// Whether the chat button should be shown.
+    /// True when bot chat is supported and all tests have completed.
+    ///
+    @Published private(set) var showChatButton = false
+
+    /// Whether the contact support button should be shown.
+    /// True when bot chat is NOT supported and all tests have completed.
+    ///
+    @Published private(set) var showContactSupportButton = false
+
+    /// Whether the AI support chat is supported.
+    ///
+    var isBotChatSupported: Bool {
+        featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
+    }
+
     /// The site URL being tested.
     ///
     let siteURL: URL
@@ -98,17 +116,23 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
     ///
     private let analytics: Analytics
 
+    /// Feature flag service for checking AI support chat availability.
+    ///
+    private let featureFlagService: FeatureFlagService
+
     private static let requestTimeout: TimeInterval = 15
 
     init(siteURL: URL,
          session: URLSessionProtocol = URLSession.shared,
          analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          discoverAPIRoot: @escaping (String) async -> String? = {
              await WordPressAPIDiscovery().discoverRESTAPIRootURL(for: $0)
          }) {
         self.siteURL = siteURL
         self.session = session
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
         self.discoverAPIRoot = discoverAPIRoot
     }
 
@@ -124,6 +148,8 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
         cards = []
         restAPIRootURL = nil
         restAPIRootJSON = nil
+        showChatButton = false
+        showContactSupportButton = false
 
         for testCase in ConnectivityTest.allCases {
             let cardIndex = cards.count
@@ -137,6 +163,10 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
 
             trackResponseEvent(for: testCase, success: state.isSuccess, timeTaken: timeTaken)
         }
+
+        // Show appropriate support button after all tests complete
+        showChatButton = isBotChatSupported
+        showContactSupportButton = !isBotChatSupported
     }
 
     /// Generates a text description of test results for support attachment.
@@ -150,6 +180,26 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
         guard !logs.isEmpty else { return nil }
         let header = "# Connectivity Diagnosis Report\n**Site:** \(siteURL.absoluteString)"
         return header + "\n\n" + logs.joined(separator: "\n\n")
+    }
+
+    /// Creates a SupportChatViewModel with the current troubleshooting context.
+    ///
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping (_ transcript: String) -> Void) -> SupportChatViewModel {
+        var context: [String: Any] = [:]
+
+        if let troubleshootingDescription = troubleshootingDescription() {
+            context["troubleshooting_results"] = troubleshootingDescription
+        }
+
+        context["site_url"] = siteURL.absoluteString
+        context["app_version"] = Bundle.main.marketingVersion
+        context["ios_version"] = UIDevice.current.systemVersion
+
+        return SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            initialContext: context,
+            onContactHumanSupport: onContactHumanSupport
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -80,6 +80,9 @@ struct SupportChatView: View {
                     scrollToBottom(proxy: proxy)
                 }
             }
+            .onChange(of: viewModel.shouldPromptHumanSupport) {
+                scrollToBottom(proxy: proxy)
+            }
         }
     }
 
@@ -250,7 +253,7 @@ struct SupportChatView: View {
             .buttonStyle(SecondaryButtonStyle())
         }
         .padding()
-        .background(Color(.secondarySystemBackground))
+        .background(Color(.listBackground))
     }
 
     // MARK: - Input Area

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -136,6 +136,7 @@ final class SupportChatViewModel {
     // MARK: - Private Properties
 
     private var chatID: Int64?
+    private var sessionID: String?
     private let entryPoint: EntryPoint
     private let botSlug: String
     private let stores: StoresManager
@@ -528,6 +529,7 @@ final class SupportChatViewModel {
             botSlug: botSlug,
             message: trimmedText,
             chatID: chatID,
+            sessionID: sessionID,
             context: context
         ) { [weak self] result in
             self?.handleSendMessageResult(result,
@@ -587,6 +589,7 @@ final class SupportChatViewModel {
         switch result {
         case .success(let response):
             chatID = response.chatID
+            sessionID = response.sessionID
             persistChatBookmark(wasNewChat: wasNewChat,
                                 response: response,
                                 firstUserMessage: firstUserMessage)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -620,6 +620,7 @@ final class SupportChatViewModel {
     private func handleFetchChatResult(_ result: Result<SupportChatResponse, Error>) {
         switch result {
         case .success(let response):
+            sessionID = response.sessionID
             let rehydrated: [ChatMessage] = response.messages.compactMap { message in
                 switch message.role {
                 case .user:

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -595,14 +595,15 @@ final class SupportChatViewModel {
                                 firstUserMessage: firstUserMessage)
 
             if let lastBotMessage = response.messages.last(where: { $0.role == .bot }) {
-                let assistantMessage = ChatMessage(
-                    role: .bot,
-                    text: lastBotMessage.content
-                )
-                messages.append(assistantMessage)
-
+                /// Skips displaying last bot message when human support is required. User is suggested to contact support manually.
                 if let flags = lastBotMessage.context?.flags, flags.forwardToHumanSupport {
                     shouldPromptHumanSupport = true
+                } else {
+                    let assistantMessage = ChatMessage(
+                        role: .bot,
+                        text: lastBotMessage.content
+                    )
+                    messages.append(assistantMessage)
                 }
             }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ConnectivityToolViewModelTests.swift
@@ -445,7 +445,7 @@ struct ConnectivityToolViewModelTests {
         #expect(sut.isBotChatSupported == false)
     }
 
-    @Test func test_isBotChatSupported_when_authenticated_without_wpcom_then_returns_false() {
+    @Test func test_isBotChatSupported_when_authenticated_without_wpcom_then_returns_true() {
         // Given
         let featureFlagService = MockFeatureFlagService()
         featureFlagService.isFeatureFlagEnabledReturnValue[.aiSupportChat] = true
@@ -460,7 +460,7 @@ struct ConnectivityToolViewModelTests {
         )
 
         // Then
-        #expect(sut.isBotChatSupported == false)
+        #expect(sut.isBotChatSupported)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/PreLoginConnectivityToolViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/PreLoginConnectivityToolViewModelTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Experiments
 import WooFoundation
 @testable import WooCommerce
 
@@ -343,6 +344,45 @@ struct PreLoginConnectivityToolViewModelTests {
         #expect(firstProperties?["success"] as? Bool == false)
         #expect(firstProperties?["time_taken"] as? Double != nil)
     }
+
+    // MARK: - AI Support Chat Button Visibility
+
+    @Test func test_startConnectivityTests_when_AI_chat_enabled_then_showChatButton_is_true() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.aiSupportChat] = true
+        let sut = makeSUTForButtonVisibilityTests(featureFlagService: featureFlagService)
+
+        // When
+        await sut.startConnectivityTests()
+
+        // Then
+        #expect(sut.showChatButton == true)
+        #expect(sut.showContactSupportButton == false)
+    }
+
+    @Test func test_startConnectivityTests_when_AI_chat_disabled_then_showContactSupportButton_is_true() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.aiSupportChat] = false
+        let sut = makeSUTForButtonVisibilityTests(featureFlagService: featureFlagService)
+
+        // When
+        await sut.startConnectivityTests()
+
+        // Then
+        #expect(sut.showChatButton == false)
+        #expect(sut.showContactSupportButton == true)
+    }
+
+    @Test func test_buttons_are_hidden_before_tests_complete() {
+        // Given
+        let sut = makeSUT()
+
+        // Then
+        #expect(sut.showChatButton == false)
+        #expect(sut.showContactSupportButton == false)
+    }
 }
 
 // MARK: - Helpers
@@ -354,13 +394,44 @@ private extension PreLoginConnectivityToolViewModelTests {
     func makeSUT(siteURL: URL = URL(string: "https://example.com")!,
                  session: MockURLSession = MockURLSession(),
                  analytics: Analytics = ServiceLocator.analytics,
+                 featureFlagService: FeatureFlagService = MockFeatureFlagService(),
                  discoverAPIRoot: @escaping (String) async -> String? = { _ in nil }
     ) -> PreLoginConnectivityToolViewModel {
         PreLoginConnectivityToolViewModel(
             siteURL: siteURL,
             session: session,
             analytics: analytics,
+            featureFlagService: featureFlagService,
             discoverAPIRoot: discoverAPIRoot
+        )
+    }
+
+    /// Creates a SUT with minimal mocking for button visibility tests (all tests pass quickly).
+    func makeSUTForButtonVisibilityTests(featureFlagService: FeatureFlagService) -> PreLoginConnectivityToolViewModel {
+        let mockSession = MockURLSession()
+
+        // Site info succeeds
+        let siteInfoJSON = """
+        {"name":"Store","urlAfterRedirects":"https://example.com",\
+        "hasJetpack":false,"isJetpackActive":false,"isJetpackConnected":false,\
+        "isWordPressDotCom":false,"isCommerceGarden":false,"isWordPress":true,"exists":true}
+        """
+        mockSession.simulateResponse(
+            for: "https://public-api.wordpress.com/rest/v1.1/connect/site-info/?url=https://example.com",
+            data: siteInfoJSON.data(using: .utf8)!
+        )
+
+        // REST API root returns valid JSON with app passwords
+        let restJSON = """
+        {"name":"Site","namespaces":["wp/v2","wc/v3"],\
+        "authentication":{"application-passwords":{"endpoints":{"authorization":"https://example.com/wp-login.php"}}}}
+        """
+        mockSession.simulateResponse(for: "https://example.com/wp-json/", data: restJSON.data(using: .utf8)!)
+
+        return makeSUT(
+            session: mockSession,
+            featureFlagService: featureFlagService,
+            discoverAPIRoot: { _ in Self.discoveredAPIRoot }
         )
     }
 


### PR DESCRIPTION
## Description
Adds an AI support chat option to the pre-login site compatibility (troubleshooting) screen. When users encounter site issues before logging in, they can now chat with the AI support bot for help.

Key changes:
- Show "Chat with Support" button (when AI chat feature flag is enabled) or "Contact Support" button after all connectivity tests complete
- Create `SupportChatViewModel` with troubleshooting context including site URL, test results, app version, and iOS version
- Support escalation to human support with chat transcript attachment
- Send session ID when sending followup messages to maintain conversation continuity. Without this, sending followup messages would fail if user is not authenticated (session ID cannot be inferred).
- Skip displaying last bot message when human support is required (avoids misleading escalation message that we cannot update through the bot)

## Test Steps

### Pre-login entry point
1. Launch app without logging in
2. On the login screen, enter a store address 
3. Tap Help > Site Compatibility
4. Wait for connectivity tests to complete
5. Verify the "Chat with Support" button appears (if AI chat flag is enabled)
6. Tap the button and verify the AI chat opens with site context
7. Test escalation to human support by entering negative sentiment - verify bot message "This has been forwarded to human..." is not displayed.

### Connectivity tool entry point
- Log in with site credentials
- Navigate to Settings > Troubleshoot connection.
- When all check completes, confirm that CTA to open AI chat is enabled.
- Confirm that you can send more than 1 message to the bot.

### Regression check
- Log in with WPCom
- Test the entry points from Troubleshoot connection & Chat with support
- Confirm that chatting works as before.

## Screenshots
<!-- Add before/after screenshots if applicable -->


https://github.com/user-attachments/assets/99c2fbec-4557-44f3-be18-5abf7f1108d0



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.