### PR TITLE
Enable SwiftLint rule: unneeded_parentheses_in_closure_argument

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -124,6 +124,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # Closure parameters should not be wrapped in parentheses.
+  - unneeded_parentheses_in_closure_argument
+
   # Unused parameters in a closure should be replaced with `_`.
   - unused_closure_parameter
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -88,7 +88,7 @@ private extension Hardware.PaymentIntentParameters {
             "platform": "\(meta.platformMetadataKey)"
         ]
 
-        let updatedMetadata = metadata?.merging(cardReaderMetadata) { (_, new) in new }
+        let updatedMetadata = metadata?.merging(cardReaderMetadata) { _, new in new }
 
         return updatedMetadata
     }

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -438,7 +438,7 @@ extension StripeCardReaderService: CardReaderService {
             self.cancellationStartedInApp = true
 
             let cancelPaymentIntent = { [weak self] in
-                Terminal.shared.cancelPaymentIntent(activePaymentIntent) { (intent, error) in
+                Terminal.shared.cancelPaymentIntent(activePaymentIntent) { intent, error in
                     if let error {
                         let underlyingError = Self.logAndDecodeError(error)
                         promise(.failure(CardReaderServiceError.paymentCancellation(underlyingError: underlyingError)))
@@ -568,7 +568,7 @@ extension StripeCardReaderService: CardReaderService {
                 return
             }
 
-            Terminal.shared.connectReader(reader, connectionConfig: configuration) { [weak self] (reader, error) in
+            Terminal.shared.connectReader(reader, connectionConfig: configuration) { [weak self] reader, error in
                 guard let self else {
                     promise(.failure(CardReaderServiceError.connection()))
                     return
@@ -609,7 +609,7 @@ extension StripeCardReaderService: CardReaderService {
                 return
             }
 
-            Terminal.shared.connectReader(reader, connectionConfig: configuration) { [weak self] (reader, error) in
+            Terminal.shared.connectReader(reader, connectionConfig: configuration) { [weak self] reader, error in
                 guard let self else {
                     promise(.failure(CardReaderServiceError.connection()))
                     return
@@ -719,7 +719,7 @@ private extension StripeCardReaderService {
                 return
             }
 
-            Terminal.shared.createPaymentIntent(parameters) { (intent, error) in
+            Terminal.shared.createPaymentIntent(parameters) { intent, error in
                 if let error {
                     let underlyingError = Self.logAndDecodeError(error)
                     promise(.failure(CardReaderServiceError.intentCreation(underlyingError: underlyingError)))
@@ -743,7 +743,7 @@ private extension StripeCardReaderService {
             /// Collect Payment method returns a cancellable
             /// Because we are chaining promises, we need to retain a reference
             /// to this cancellable if we want to cancel
-            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent, collectConfig: collectConfiguration) { (intent, error) in
+            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent, collectConfig: collectConfiguration) { intent, error in
                 if let error {
                     var underlyingError = Self.logAndDecodeError(error)
                     /// the completion block for collectPaymentMethod will be called
@@ -813,7 +813,7 @@ private extension StripeCardReaderService {
 
     func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {
         return Future() { [weak self] promise in
-            Terminal.shared.confirmPaymentIntent(intent) { (intent, error) in
+            Terminal.shared.confirmPaymentIntent(intent) { intent, error in
                 guard let self else { return }
                 if let error {
                     let underlyingError = Self.logAndDecodeError(error)

--- a/Modules/Sources/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
+++ b/Modules/Sources/Hardware/Printer/AirPrintReceipt/AirPrintReceiptPrinterService.swift
@@ -22,7 +22,7 @@ public final class AirPrintReceiptPrinterService: NSObject, PrinterService {
         renderer.configureFormatterForPrinting()
         printController.printPageRenderer = renderer
 
-        printController.present(animated: true) { (_, completed, error) in
+        printController.present(animated: true) { _, completed, error in
             switch (completed, error) {
             case (_, .some(let error)):
                 // Printing failed

--- a/Modules/Sources/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
+++ b/Modules/Sources/Hardware/Printer/AirPrintReceipt/ReceiptRenderer.swift
@@ -194,7 +194,7 @@ private extension ReceiptRenderer {
     }
 
     private func cardIconCSS() -> String {
-        CardBrand.allCases.map { (cardBrand) in
+        CardBrand.allCases.map { cardBrand in
             ".\(cardBrand.iconName)-icon { background-image: url(\"data:image/svg+xml;base64,\(cardBrand.iconData.base64EncodedString())\") }"
         }.joined(separator: "\n\n")
     }

--- a/Modules/Sources/Networking/Mapper/ProductCategoryListMapper.swift
+++ b/Modules/Sources/Networking/Mapper/ProductCategoryListMapper.swift
@@ -38,7 +38,7 @@ struct ProductCategoryListMapper: Mapper {
             }()
             return categories
                 .filter { $0.error == nil }
-                .compactMap { (categoryCreated) -> ProductCategory? in
+                .compactMap { categoryCreated -> ProductCategory? in
                     if let name = categoryCreated.name, let slug = categoryCreated.slug {
                         return ProductCategory(categoryID: categoryCreated.categoryID,
                                                siteID: categoryCreated.siteID,

--- a/Modules/Sources/Networking/Mapper/ProductTagListMapper.swift
+++ b/Modules/Sources/Networking/Mapper/ProductTagListMapper.swift
@@ -37,7 +37,7 @@ struct ProductTagListMapper: Mapper {
             }()
             return tags
                 .filter { $0.error == nil }
-                .compactMap { (tagCreated) -> ProductTag? in
+                .compactMap { tagCreated -> ProductTag? in
                     if let name = tagCreated.name, let slug = tagCreated.slug {
                         return ProductTag(siteID: tagCreated.siteID, tagID: tagCreated.tagID, name: name, slug: slug)
                     }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/ShippingLabelPackagesResponse.swift
@@ -54,10 +54,10 @@ extension ShippingLabelPackagesResponse: Decodable {
 
         // Iterate around keys of `formSchema` and `formData` for creating the predefined options available for this website.
         //
-        rawPredefinedFormSchema.forEach { (key, value) in
+        rawPredefinedFormSchema.forEach { key, value in
 
             let provider: [String: Any]? = try? value.toDictionary()
-            provider?.forEach({ (_, providerValue) in
+            provider?.forEach({ _, providerValue in
 
                 let providerValueDict = providerValue as? [String: Any]
                 let packages = ShippingLabelPackagesResponse.getAllPredefinedPackages(packageDefinitions: providerValueDict)
@@ -109,8 +109,8 @@ private extension ShippingLabelPackagesResponse {
     static func getPredefinedPackages(withIDs packageIDs: [Any?], in packages: [ShippingLabelPredefinedPackage]) -> [ShippingLabelPredefinedPackage] {
         var predefinedPackages: [ShippingLabelPredefinedPackage] = []
 
-        packageIDs.compactMap { $0 }.forEach { (packageID) in
-            packages.forEach { (package) in
+        packageIDs.compactMap { $0 }.forEach { packageID in
+            packages.forEach { package in
                 if packageID as? String == package.id {
                     predefinedPackages.append(package)
                 }

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingCreatePackageResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingCreatePackageResponse.swift
@@ -29,7 +29,7 @@ extension WooShippingCreatePackageResponse: Decodable {
         //
         let rawPredefinedOptions: [String: [String]] = container.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
 
-        let predefinedOptions = rawPredefinedOptions.map { (carrier, packageIDs) in
+        let predefinedOptions = rawPredefinedOptions.map { carrier, packageIDs in
             WooShippingPredefinedSavedOption(id: carrier, predefinedPackageIDs: packageIDs)
         }
 

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/WooShippingPackagesResponse.swift
@@ -41,7 +41,7 @@ extension WooShippingPackagesResponse: Decodable {
         let savedPackagesData = try packagesData.nestedContainer(keyedBy: SavedPackagesKeys.self, forKey: .saved)
         let customPackages = try savedPackagesData.decodeIfPresent([WooShippingCustomPackage].self, forKey: .custom) ?? []
         let rawSavedPredefinedOptions: [String: [String]] = savedPackagesData.failsafeDecodeIfPresent([String: [String]].self, forKey: .predefined) ?? [:]
-        let savedPredefinedOptions = rawSavedPredefinedOptions.map { (carrier, packageIDs) in
+        let savedPredefinedOptions = rawSavedPredefinedOptions.map { carrier, packageIDs in
             WooShippingPredefinedSavedOption(id: carrier, predefinedPackageIDs: packageIDs)
         }
 
@@ -49,11 +49,11 @@ extension WooShippingPackagesResponse: Decodable {
         var allPredefinedOptions: [WooShippingCarrierPredefinedOptions] = []
         var allSavedPredefinedPackages: [WooShippingSavedPredefinedPackage] = []
 
-        allPredefinedPackagesData.forEach { (key, value) in
+        allPredefinedPackagesData.forEach { key, value in
             // key is a carrier id, for example "usps"
             if let provider: [String: Any]? = try? value.toDictionary() {
                 var providerOptions: [WooShippingPredefinedOption] = []
-                provider?.forEach({ (_, providerValue) in
+                provider?.forEach({ _, providerValue in
                     // providerKey is package group id, for example "pri_flat_boxes"
                     let providerValueDict = providerValue as? [String: Any]
                     let title: String = providerValueDict?["title"] as? String ?? ""

--- a/Modules/Sources/Networking/Remote/DevicesRemote.swift
+++ b/Modules/Sources/Networking/Remote/DevicesRemote.swift
@@ -34,7 +34,7 @@ public class DevicesRemote: Remote {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: Paths.register, parameters: parameters)
         let mapper = DotcomDeviceMapper()
 
-        enqueue(request, mapper: mapper) { (device, error) in
+        enqueue(request, mapper: mapper) { device, error in
             completion(device, error)
         }
     }
@@ -51,7 +51,7 @@ public class DevicesRemote: Remote {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
         let mapper = SuccessResultMapper()
 
-        enqueue(request, mapper: mapper) { (success, error) in
+        enqueue(request, mapper: mapper) { success, error in
             guard success == true else {
                 completion(error ?? DotcomError.empty())
                 return

--- a/Modules/Sources/Networking/Remote/MediaRemote.swift
+++ b/Modules/Sources/Networking/Remote/MediaRemote.swift
@@ -120,7 +120,7 @@ public class MediaRemote: Remote, MediaRemoteProtocol {
             let mapper = WordPressMediaMapper()
 
             enqueueMultipartFormDataUpload(request, mapper: mapper, multipartFormData: { multipartFormData in
-                formParameters.forEach { (key, value) in
+                formParameters.forEach { key, value in
                     multipartFormData.append(Data(value.utf8), withName: key)
                 }
 

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -203,7 +203,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.contextKey: context ?? Default.context,
             ParameterKey.orderBy: orderBy.value,
             ParameterKey.order: order.value
-        ].merging(filterParameters, uniquingKeysWith: { (first, _) in first })
+        ].merging(filterParameters, uniquingKeysWith: { first, _ in first })
 
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
@@ -468,7 +468,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.searchFields: searchFields.map { $0.rawValue },
             ParameterKey.exclude: stringOfExcludedProductIDs,
             ParameterKey.contextKey: Default.context
-        ].merging(filterParameters, uniquingKeysWith: { (first, _) in first })
+        ].merging(filterParameters, uniquingKeysWith: { first, _ in first })
 
         let path = Path.products
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)

--- a/Modules/Sources/Networking/Remote/SitePostsRemote.swift
+++ b/Modules/Sources/Networking/Remote/SitePostsRemote.swift
@@ -36,7 +36,7 @@ public class SitePostsRemote: Remote {
         do {
             var parameters = try post.toDictionary()
             let parametersFields = ["fields": "site_ID,password"]
-            parameters.merge(parametersFields) { (current, _) in current }
+            parameters.merge(parametersFields) { current, _ in current }
             let path = String(format: "sites/%d/posts/%d", siteID, postID)
             let request = DotcomRequest(wordpressApiVersion: .mark1_2, method: .post, path: path, parameters: parameters)
             let mapper = PostMapper()

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -47,7 +47,7 @@ public final class WordPressOrgNetwork: Network {
 
             self.alamofireSession.request(request)
                 .validate()
-                .responseData(completionHandler: { (response) in
+                .responseData(completionHandler: { response in
                 switch response.result {
                 case .success(let responseObject):
                     continuation.resume(returning: responseObject)

--- a/Modules/Sources/NetworkingCore/Remote/NotificationsRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/NotificationsRemote.swift
@@ -72,7 +72,7 @@ public final class NotificationsRemote: Remote, NotificationsRemoteProtocol {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: Paths.read, parameters: parameters)
         let mapper = SuccessResultMapper()
 
-        enqueue(request, mapper: mapper) { (success, error) in
+        enqueue(request, mapper: mapper) { success, error in
             guard success == true else {
                 completion(error ?? DotcomError.empty())
                 return
@@ -97,7 +97,7 @@ public final class NotificationsRemote: Remote, NotificationsRemoteProtocol {
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: Paths.seen, parameters: parameters)
         let mapper = SuccessResultMapper()
 
-        enqueue(request, mapper: mapper) { (success, error) in
+        enqueue(request, mapper: mapper) { success, error in
             guard success == true else {
                 completion(error ?? DotcomError.empty())
                 return

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -86,7 +86,7 @@ open class Remote: NSObject {
     ///     - completion: Closure to be executed upon completion.
     ///
     public func enqueue<M: Mapper>(_ request: Request, mapper: M, completion: @escaping (M.Output?, Error?) -> Void) {
-        network.responseData(for: request) { [weak self] (data, networkError) in
+        network.responseData(for: request) { [weak self] data, networkError in
             guard let self else {
                 return
             }
@@ -202,7 +202,7 @@ open class Remote: NSObject {
                                                    multipartFormData: @escaping (MultipartFormData) -> Void,
                                                    completion: @escaping (Result<M.Output, Error>) -> Void) {
         network.uploadMultipartFormData(multipartFormData: multipartFormData,
-                                        to: request) { [weak self] (data, networkError) in
+                                        to: request) { [weak self] data, networkError in
                                             guard let self else {
                                                 return
                                             }

--- a/Modules/Sources/NetworkingCore/Tools/AnyEncodable.swift
+++ b/Modules/Sources/NetworkingCore/Tools/AnyEncodable.swift
@@ -204,6 +204,6 @@ extension _AnyEncodable {
     }
 
     public init(dictionaryLiteral elements: (AnyHashable, Any)...) {
-        self.init(Dictionary<AnyHashable, Any>(elements, uniquingKeysWith: { (first, _) in first }))
+        self.init(Dictionary<AnyHashable, Any>(elements, uniquingKeysWith: { first, _ in first }))
     }
 }

--- a/Modules/Sources/Storage/CoreData/CoreDataManager.swift
+++ b/Modules/Sources/Storage/CoreData/CoreDataManager.swift
@@ -174,7 +174,7 @@ public final class CoreDataManager: StorageManagerType {
                                                                  storeURL: storeURL,
                                                                  modelsInventory: modelsInventory)
 
-        container.loadPersistentStores { (storeDescription, error) in
+        container.loadPersistentStores { storeDescription, error in
             guard let persistentStoreLoadingError = error else {
                 return
             }
@@ -195,7 +195,7 @@ public final class CoreDataManager: StorageManagerType {
 
             /// Retry!
             ///
-            container.loadPersistentStores { (_, underlyingError) in
+            container.loadPersistentStores { _, underlyingError in
                 guard let underlyingError = underlyingError as NSError? else {
                     return
                 }

--- a/Modules/Sources/UITestsFoundation/BaseScreen.swift
+++ b/Modules/Sources/UITestsFoundation/BaseScreen.swift
@@ -19,7 +19,7 @@ open class BaseScreen {
 
     @discardableResult
     func waitForPage() throws -> BaseScreen {
-        XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (_) in
+        XCTContext.runActivity(named: "Confirm page \(self) is loaded") { _ in
             let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
             XCTAssert(result, "Page \(self) is not loaded.")
         }
@@ -114,7 +114,7 @@ private extension XCUIElementAttributes {
 
 private extension XCUIElementQuery {
     var networkLoadingIndicators: XCUIElementQuery {
-        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+        let isNetworkLoadingIndicator = NSPredicate { evaluatedObject, _ in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
 
             return element.isNetworkLoadingIndicator

--- a/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
+++ b/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
@@ -37,14 +37,14 @@ extension XCTestCase {
 
     public func takeScreenshotOfFailedTest() {
         if let failureCount = testRun?.failureCount, failureCount > 0 {
-            XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { (_) in
+            XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { _ in
                 add(XCTAttachment(screenshot: XCUIApplication().windows.firstMatch.screenshot()))
             }
         }
     }
 
     public func systemAlertHandler(alertTitle: String, alertButton: String) {
-        addUIInterruptionMonitor(withDescription: alertTitle) { (alert) -> Bool in
+        addUIInterruptionMonitor(withDescription: alertTitle) { alert -> Bool in
             let alertButtonElement = alert.buttons[alertButton]
             XCTAssert(alertButtonElement.waitForExistence(timeout: 5))
             alertButtonElement.tap()

--- a/Modules/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImageView+Gravatar.swift
@@ -41,7 +41,7 @@ extension UIImageView {
             gravatarWrapper = nil
         }
 
-        let observer = NotificationCenter.default.addObserver(forName: .GravatarImageUpdateNotification, object: nil, queue: nil) { [weak self] (notification) in
+        let observer = NotificationCenter.default.addObserver(forName: .GravatarImageUpdateNotification, object: nil, queue: nil) { [weak self] notification in
             guard let userInfo = notification.userInfo,
                 let email = userInfo[Defaults.emailKey] as? String,
                 email == trackedEmail,

--- a/Modules/Sources/WordPressUI/Ghosts/Internal/GhostLayer.swift
+++ b/Modules/Sources/WordPressUI/Ghosts/Internal/GhostLayer.swift
@@ -51,7 +51,7 @@ private extension GhostLayer {
     /// Starts listening for Bounds Changes on the specified UIView instance.
     ///
     func startObservingBoundEvents(on container: UIView) {
-        observerToken = container.observe(\.bounds, options: .initial) { [weak self] (view, _) in
+        observerToken = container.observe(\.bounds, options: .initial) { [weak self] view, _ in
             self?.bounds = view.bounds
         }
     }

--- a/Modules/Sources/Yosemite/Stores/AccountStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AccountStore.swift
@@ -160,8 +160,7 @@ private extension AccountStore {
                             let wcAvailabilityPublisher = self.remote.checkIfWooCommerceIsActive(for: site.siteID)
                             let wpSiteSettingsPublisher = self.remote.fetchWordPressSiteSettings(for: site.siteID)
                             return Publishers.Zip3(sitePublisher, wcAvailabilityPublisher, wpSiteSettingsPublisher)
-                                .map {
-                                    (site, isWooCommerceActiveResult, wpSiteSettingsResult) -> Site in
+                                .map {site, isWooCommerceActiveResult, wpSiteSettingsResult -> Site in
                                     var site = site
                                     guard case let .success(isWooCommerceActive) = isWooCommerceActiveResult,
                                           case let .success(wpSiteSettings) = wpSiteSettingsResult else {

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -578,7 +578,7 @@ private extension AppSettingsStore {
     func storeInPersonPaymentsTransactionIfFirst(siteID: Int64, using cardReaderType: CardReaderType) {
         let storeSettings = getStoreSettings(for: siteID)
         let updatedDictionary = storeSettings.firstInPersonPaymentsTransactionsByReaderType
-            .merging([StorageCardReaderType(from: cardReaderType): Date()]) { (current, _) in
+            .merging([StorageCardReaderType(from: cardReaderType): Date()]) { current, _ in
                 // We never want to update stored value, because we keep the first transaction date for each site/reader pair.
                 return current
             }

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -230,7 +230,7 @@ private extension CardPresentPaymentStore {
     func cancelCardReaderDiscovery(completion: @escaping (Result<Void, Error>) -> Void) {
         cardReaderService.cancelDiscovery()
             .subscribe(Subscribers.Sink(
-                receiveCompletion: { (result) in
+                receiveCompletion: { result in
                     switch result {
                     case .failure(let error):
                         completion(.failure(error))
@@ -249,13 +249,13 @@ private extension CardPresentPaymentStore {
         // https://github.com/woocommerce/woocommerce-ios/issues/3734
         // https://github.com/woocommerce/woocommerce-ios/issues/3741
         cardReaderService.connect(reader, options: options)
-            .subscribe(Subscribers.Sink(receiveCompletion: { (completion) in
+            .subscribe(Subscribers.Sink(receiveCompletion: { completion in
                 if case let .failure(underlyingError) = completion {
                     onCompletion(.failure(underlyingError))
                 }
                 // We don't want to propagate successful completion since we already did that by
                 // calling onCompletion when a value was received.
-            }, receiveValue: { (reader) in
+            }, receiveValue: { reader in
                 onCompletion(.success(reader))
             }))
     }

--- a/Modules/Sources/Yosemite/Stores/CommentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CommentStore.swift
@@ -66,7 +66,7 @@ private extension CommentStore {
     }
 
     func moderateComment(siteID: Int64, commentID: Int64, status: CommentStatus, onCompletion: @escaping (CommentStatus?, Error?) -> Void) {
-        remote.moderateComment(siteID: siteID, commentID: commentID, status: status) { (updatedStatus, error) in
+        remote.moderateComment(siteID: siteID, commentID: commentID, status: status) { updatedStatus, error in
             onCompletion(updatedStatus, error)
         }
     }

--- a/Modules/Sources/Yosemite/Stores/DataStore.swift
+++ b/Modules/Sources/Yosemite/Stores/DataStore.swift
@@ -43,7 +43,7 @@ private extension DataStore {
 
     func synchronizeCountries(siteID: Int64,
                               completion: @escaping (Result<[Country], Error>) -> Void) {
-        remote.loadCountries(siteID: siteID) { [weak self] (result) in
+        remote.loadCountries(siteID: siteID) { [weak self] result in
             guard let self else { return }
 
             switch result {

--- a/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -37,7 +37,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     /// Synchronizes the general site settings associated with the provided Site ID (if any!).
     ///
     func synchronizeGeneralSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        siteSettingsRemote.loadGeneralSettings(for: siteID) { [weak self] (settings, error) in
+        siteSettingsRemote.loadGeneralSettings(for: siteID) { [weak self] settings, error in
             guard let settings else {
                 onCompletion(error)
                 return
@@ -52,7 +52,7 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
     /// Synchronizes the product site settings associated with the provided Site ID (if any!).
     ///
     func synchronizeProductSiteSettings(siteID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        siteSettingsRemote.loadProductSettings(for: siteID) { [weak self] (settings, error) in
+        siteSettingsRemote.loadProductSettings(for: siteID) { [weak self] settings, error in
             guard let settings else {
                 onCompletion(error)
                 return

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -185,7 +185,7 @@ private extension NotificationStore {
     /// Retrieves the latest notifications (if any!).
     ///
     func synchronizeNotifications(onCompletion: @escaping (Error?) -> Void) {
-        remote.loadHashes(pageSize: Constants.maximumPageSize) { [weak self] (hashes, error) in
+        remote.loadHashes(pageSize: Constants.maximumPageSize) { [weak self] hashes, error in
             guard let hashes else {
                 onCompletion(error)
                 return
@@ -242,7 +242,7 @@ private extension NotificationStore {
     /// Updates the last seen notification
     ///
     func updateLastSeen(timestamp: String, onCompletion: @escaping (Error?) -> Void) {
-        remote.updateLastSeen(timestamp) { (error) in
+        remote.updateLastSeen(timestamp) { error in
             onCompletion(error)
         }
     }

--- a/Modules/Sources/Yosemite/Stores/Order/Order+CurrencyFormattedValues.swift
+++ b/Modules/Sources/Yosemite/Stores/Order/Order+CurrencyFormattedValues.swift
@@ -15,7 +15,7 @@ public extension Order {
     }
 
     var subtotal: Decimal {
-        let subtotal = items.reduce(.zero) { (output, item) in
+        let subtotal = items.reduce(.zero) { output, item in
             let itemSubtotal = Decimal(string: item.subtotal) ?? .zero
             return output + itemSubtotal
         }

--- a/Modules/Sources/Yosemite/Stores/OrderFulfillmentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderFulfillmentStore.swift
@@ -40,7 +40,7 @@ public class OrderFulfillmentStore: Store {
 private extension OrderFulfillmentStore {
 
     func synchronizeOrderFulfillments(siteID: Int64, orderID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        remote.loadOrderFulfillments(for: siteID, orderID: orderID) { [weak self] (fulfillments, error) in
+        remote.loadOrderFulfillments(for: siteID, orderID: orderID) { [weak self] fulfillments, error in
             guard let readOnlyFulfillments = fulfillments else {
                 onCompletion(error)
                 return

--- a/Modules/Sources/Yosemite/Stores/OrderNoteStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderNoteStore.swift
@@ -43,7 +43,7 @@ private extension OrderNoteStore {
     /// Retrieves the order notes associated with the provided Site ID & Order ID (if any!).
     ///
     func retrieveOrderNotes(siteID: Int64, orderID: Int64, onCompletion: @escaping ([OrderNote]?, Error?) -> Void) {
-        remote.loadOrderNotes(for: siteID, orderID: orderID) { [weak self] (orderNotes, error) in
+        remote.loadOrderNotes(for: siteID, orderID: orderID) { [weak self] orderNotes, error in
             guard let orderNotes else {
                 onCompletion(nil, error)
                 return
@@ -58,7 +58,7 @@ private extension OrderNoteStore {
     /// Adds a single order note and associates it with the provided siteID and orderID.
     ///
     func addOrderNote(siteID: Int64, orderID: Int64, isCustomerNote: Bool, note: String, onCompletion: @escaping (OrderNote?, Error?) -> Void) {
-        remote.addOrderNote(for: siteID, orderID: orderID, isCustomerNote: isCustomerNote, with: note) { [weak self] (orderNote, error) in
+        remote.addOrderNote(for: siteID, orderID: orderID, isCustomerNote: isCustomerNote, with: note) { [weak self] orderNote, error in
             guard let note = orderNote else {
                 onCompletion(nil, error)
                 return

--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -279,7 +279,7 @@ private extension OrderStore {
     /// Loads a specific order associated with a given Site ID from remote.
     ///
     private func loadOrderFromRemote(siteID: Int64, orderID: Int64, onCompletion: @escaping (Order?, Error?) -> Void) {
-        remote.loadOrder(for: siteID, orderID: orderID) { [weak self] (order, error) in
+        remote.loadOrder(for: siteID, orderID: orderID) { [weak self] order, error in
             guard let order else {
                 if case NetworkError.notFound? = error {
                     self?.deleteStoredOrder(siteID: siteID, orderID: orderID) {
@@ -388,7 +388,7 @@ private extension OrderStore {
             guard let self else {
                 return onCompletion(UpdateOrderStatusError.undefinedState)
             }
-            remote.updateOrder(from: siteID, orderID: orderID, statusKey: status) { [weak self] (order, error) in
+            remote.updateOrder(from: siteID, orderID: orderID, statusKey: status) { [weak self] order, error in
                 guard let error else {
                     if let order {
                         self?.upsertStoredOrder(readOnlyOrder: order)

--- a/Modules/Sources/Yosemite/Stores/ProductAttributeStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductAttributeStore.swift
@@ -46,7 +46,7 @@ private extension ProductAttributeStore {
     /// Synchronizes global product attributes associated with a given Site ID.
     ///
     func synchronizeProductAttributes(siteID: Int64, onCompletion: @escaping (Result<[ProductAttribute], Error>) -> Void) {
-        remote.loadAllProductAttributes(for: siteID) { [weak self] (result) in
+        remote.loadAllProductAttributes(for: siteID) { [weak self] result in
             switch result {
             case .success(let productAttributes):
                 self?.upsertStoredProductAttributesInBackground(productAttributes,
@@ -63,7 +63,7 @@ private extension ProductAttributeStore {
     /// Create a new global product attribute associated with a given Site ID.
     ///
     func addProductAttribute(siteID: Int64, name: String, onCompletion: @escaping (Result<ProductAttribute, Error>) -> Void) {
-        remote.createProductAttribute(for: siteID, name: name) { [weak self] (result) in
+        remote.createProductAttribute(for: siteID, name: name) { [weak self] result in
             switch result {
             case .success(let productAttribute):
                 self?.upsertStoredProductAttributesInBackground([productAttribute], siteID: siteID, onCompletion: {
@@ -78,7 +78,7 @@ private extension ProductAttributeStore {
     /// Update a global product attribute associated with a given Site ID.
     ///
     func updateProductAttribute(siteID: Int64, attributeID: Int64, name: String, onCompletion: @escaping (Result<ProductAttribute, Error>) -> Void) {
-        remote.updateProductAttribute(for: siteID, productAttributeID: attributeID, name: name) { [weak self] (result) in
+        remote.updateProductAttribute(for: siteID, productAttributeID: attributeID, name: name) { [weak self] result in
             switch result {
             case .success(let productAttribute):
                 self?.upsertStoredProductAttributesInBackground([productAttribute], siteID: siteID, onCompletion: {
@@ -93,7 +93,7 @@ private extension ProductAttributeStore {
     /// Delete a global product attribute associated with a given Site ID.
     ///
     func deleteProductAttribute(siteID: Int64, attributeID: Int64, onCompletion: @escaping (Result<ProductAttribute, Error>) -> Void) {
-        remote.deleteProductAttribute(for: siteID, productAttributeID: attributeID) { [weak self] (result) in
+        remote.deleteProductAttribute(for: siteID, productAttributeID: attributeID) { [weak self] result in
             switch result {
             case .success(let productAttribute):
                 self?.deleteStoredProductAttribute(siteID: siteID, attributeID: attributeID) {

--- a/Modules/Sources/Yosemite/Stores/ProductCategoryStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductCategoryStore.swift
@@ -91,7 +91,7 @@ private extension ProductCategoryStore {
     /// Synchronizes product categories associated with a given Site ID.
     ///
     func synchronizeProductCategories(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping ([ProductCategory]?, Error?) -> Void) {
-        remote.loadAllProductCategories(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (productCategories, error) in
+        remote.loadAllProductCategories(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] productCategories, error in
             guard let productCategories else {
                 onCompletion(nil, error)
                 return

--- a/Modules/Sources/Yosemite/Stores/ProductReviewStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductReviewStore.swift
@@ -192,7 +192,7 @@ private extension ProductReviewStore {
     }
 
     func moderateReview(siteID: Int64, reviewID: Int64, status: ProductReviewStatus, onCompletion: @escaping (ProductReviewStatus?, Error?) -> Void) {
-        remote.updateProductReviewStatus(for: siteID, reviewID: reviewID, statusKey: status.rawValue) { [weak self] (productReview, error) in
+        remote.updateProductReviewStatus(for: siteID, reviewID: reviewID, statusKey: status.rawValue) { [weak self] productReview, error in
             guard let self, let productReview else {
                 onCompletion(nil, error)
                 return

--- a/Modules/Sources/Yosemite/Stores/ProductShippingClassStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductShippingClassStore.swift
@@ -66,7 +66,7 @@ private extension ProductShippingClassStore {
     /// Retrieves the `ProductShippingClass` associated with a given `Product`.
     ///
     func retrieveProductShippingClass(siteID: Int64, remoteID: Int64, onCompletion: @escaping (ProductShippingClass?, Error?) -> Void) {
-        remote.loadOne(for: siteID, remoteID: remoteID) { [weak self] (model, error) in
+        remote.loadOne(for: siteID, remoteID: remoteID) { [weak self] model, error in
             guard let model else {
                 onCompletion(nil, error)
                 return

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -475,7 +475,7 @@ private extension ProductStore {
     /// Delete an existing product.
     ///
     func deleteProduct(siteID: Int64, productID: Int64, onCompletion: @escaping (Result<Product, ProductUpdateError>) -> Void) {
-        remote.deleteProduct(for: siteID, productID: productID) { (result) in
+        remote.deleteProduct(for: siteID, productID: productID) { result in
             switch result {
             case .failure(let error):
                 onCompletion(.failure(ProductUpdateError(error: error)))

--- a/Modules/Sources/Yosemite/Stores/ProductTagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductTagStore.swift
@@ -46,7 +46,7 @@ private extension ProductTagStore {
     func synchronizeAllProductTags(siteID: Int64, fromPageNumber: Int = 1, onCompletion: @escaping (ProductTagActionError?) -> Void) {
 
         // Start fetching the provided initial page
-        synchronizeProductTags(siteID: siteID, pageNumber: fromPageNumber, pageSize: Constants.defaultMaxPageSize) { [weak self] (result) in
+        synchronizeProductTags(siteID: siteID, pageNumber: fromPageNumber, pageSize: Constants.defaultMaxPageSize) { [weak self] result in
             guard let self  else {
                 return
             }
@@ -72,7 +72,7 @@ private extension ProductTagStore {
     /// Synchronizes product tags associated with a given Site ID.
     ///
     func synchronizeProductTags(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Result<[ProductTag], Error>) -> Void) {
-        remote.loadAllProductTags(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] (result) in
+        remote.loadAllProductTags(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
 
             switch result {
             case .success(let productTags):
@@ -91,7 +91,7 @@ private extension ProductTagStore {
         guard tags.isEmpty == false else {
             return onCompletion(.success([]))
         }
-        remote.createProductTags(for: siteID, names: tags) { [weak self] (result) in
+        remote.createProductTags(for: siteID, names: tags) { [weak self] result in
             switch result {
             case .success(let productTags):
                 self?.upsertStoredProductTagsInBackground(productTags, siteID: siteID) {
@@ -106,7 +106,7 @@ private extension ProductTagStore {
     /// Delete product tags associated with a given Site ID.
     ///
     func deleteProductTags(siteID: Int64, ids: [Int64], onCompletion: @escaping (Result<[ProductTag], Error>) -> Void) {
-        remote.deleteProductTags(for: siteID, ids: ids) { [weak self] (result) in
+        remote.deleteProductTags(for: siteID, ids: ids) { [weak self] result in
             switch result {
             case .success(let productTags):
                 self?.deleteStoredProductTags(siteID: siteID, ids: ids) {

--- a/Modules/Sources/Yosemite/Stores/ProductVariationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductVariationStore.swift
@@ -104,7 +104,7 @@ private extension ProductVariationStore {
                                         variationIDs: variationIDs,
                                         context: nil,
                                         pageNumber: pageNumber,
-                                        pageSize: pageSize) { [weak self] (productVariations, error) in
+                                        pageSize: pageSize) { [weak self] productVariations, error in
             guard let productVariations else {
                 onCompletion(.failure(error ?? ProductVariationLoadError.unexpected))
                 return

--- a/Modules/Sources/Yosemite/Stores/RefundStore.swift
+++ b/Modules/Sources/Yosemite/Stores/RefundStore.swift
@@ -50,7 +50,7 @@ private extension RefundStore {
     /// Creates a new Refund.
     ///
     func createRefund(siteID: Int64, orderID: Int64, refund: Refund, onCompletion: @escaping (Refund?, Error?) -> Void) {
-        remote.createRefund(for: siteID, by: orderID, refund: refund) { [weak self] (refund, error) in
+        remote.createRefund(for: siteID, by: orderID, refund: refund) { [weak self] refund, error in
             guard let refund else {
                 onCompletion(nil, error)
                 return
@@ -65,7 +65,7 @@ private extension RefundStore {
     /// Retrieves a single Refund by ID.
     ///
     func retrieveRefund(siteID: Int64, orderID: Int64, refundID: Int64, onCompletion: @escaping (Networking.Refund?, Error?) -> Void) {
-        remote.loadRefund(siteID: siteID, orderID: orderID, refundID: refundID) { [weak self] (refund, error) in
+        remote.loadRefund(siteID: siteID, orderID: orderID, refundID: refundID) { [weak self] refund, error in
             guard let refund else {
                 if case NetworkError.notFound? = error {
                     self?.deleteStoredRefund(siteID: siteID, orderID: orderID, refundID: refundID) {
@@ -120,7 +120,7 @@ private extension RefundStore {
         }
 
         // Request any refunds that don't exist in storage.
-        remote.loadRefunds(for: siteID, by: orderID, with: missingRefundIDs) { [weak self] (refunds, error) in
+        remote.loadRefunds(for: siteID, by: orderID, with: missingRefundIDs) { [weak self] refunds, error in
             guard let refunds else {
                 return onCompletion(error)
             }
@@ -137,7 +137,7 @@ private extension RefundStore {
     /// Synchronizes the refunds associated with a given orderID
     ///
     func synchronizeRefunds(siteID: Int64, orderID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Error?) -> Void) {
-        remote.loadAllRefunds(for: siteID, by: orderID) { [weak self] (refunds, error) in
+        remote.loadAllRefunds(for: siteID, by: orderID) { [weak self] refunds, error in
             guard let refunds else {
                 onCompletion(error)
                 return

--- a/Modules/Sources/Yosemite/Stores/ShipmentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ShipmentStore.swift
@@ -76,7 +76,7 @@ public class ShipmentStore: Store {
 private extension ShipmentStore {
 
     func synchronizeShipmentTrackingData(siteID: Int64, orderID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        remote.loadShipmentTrackings(for: siteID, orderID: orderID) { [weak self] (shipmentTrackingData, error) in
+        remote.loadShipmentTrackings(for: siteID, orderID: orderID) { [weak self] shipmentTrackingData, error in
             guard let readOnlyShipmentTrackingData = shipmentTrackingData else {
                 onCompletion(error)
                 return
@@ -89,7 +89,7 @@ private extension ShipmentStore {
     }
 
     func syncronizeShipmentTrackingProviderGroupsData(siteID: Int64, orderID: Int64, onCompletion: @escaping (Error?) -> Void) {
-        remote.loadShipmentTrackingProviderGroups(for: siteID, orderID: orderID) { [weak self] (groups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: siteID, orderID: orderID) { [weak self] groups, error in
             guard let readOnlyShipmentTrackingProviderGroups = groups else {
                 onCompletion(error)
                 return
@@ -177,7 +177,7 @@ extension ShipmentStore {
                                       orderID: orderID,
                                       trackingProvider: providerName,
                                       dateShipped: dateShipped,
-                                      trackingNumber: trackingNumber) { [weak self] (tracking, error) in
+                                      trackingNumber: trackingNumber) { [weak self] tracking, error in
                                         guard let newTracking = tracking else {
                                             onCompletion(error)
                                             return
@@ -203,7 +203,7 @@ extension ShipmentStore {
                                                         trackingProvider: trackingProvider,
                                                         trackingNumber: trackingNumber,
                                                         trackingURL: trackingURL,
-                                                        dateShipped: dateShipped) { [weak self] (tracking, error) in
+                                                        dateShipped: dateShipped) { [weak self] tracking, error in
             guard let newTracking = tracking else {
                 onCompletion(error)
                 return
@@ -223,7 +223,7 @@ extension ShipmentStore {
                         orderID: Int64,
                         trackingID: String,
                         onCompletion: @escaping (Error?) -> Void) {
-        remote.deleteShipmentTracking(for: siteID, orderID: orderID, trackingID: trackingID) { [weak self] (tracking, error) in
+        remote.deleteShipmentTracking(for: siteID, orderID: orderID, trackingID: trackingID) { [weak self] tracking, error in
             guard let _ = tracking else {
                 onCompletion(error)
                 return

--- a/Modules/Sources/Yosemite/Stores/SitePostStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SitePostStore.swift
@@ -41,7 +41,7 @@ private extension SitePostStore {
     /// Retrieve the password for a specific site post from WP.com
     ///
     func retrieveSitePostPassword(siteID: Int64, postID: Int64, onCompletion: @escaping (_ password: String?, _ error: Error?) -> Void) {
-        remote.loadSitePost(for: siteID, postID: postID) { (sitePost, error) in
+        remote.loadSitePost(for: siteID, postID: postID) { sitePost, error in
             guard error == nil else {
                 onCompletion(nil, error)
                 return

--- a/Modules/Sources/Yosemite/Stores/TaxStore.swift
+++ b/Modules/Sources/Yosemite/Stores/TaxStore.swift
@@ -57,7 +57,7 @@ private extension TaxStore {
     /// Retrieve and synchronizes the Tax Classes associated with a given Site ID (if any!).
     ///
     func retrieveTaxClasses(siteID: Int64, onCompletion: @escaping ([TaxClass]?, Error?) -> Void) {
-        remote.loadAllTaxClasses(for: siteID) { [weak self] (taxClasses, error) in
+        remote.loadAllTaxClasses(for: siteID) { [weak self] taxClasses, error in
             guard let taxClasses else {
                 onCompletion(nil, error)
                 return
@@ -84,7 +84,7 @@ private extension TaxStore {
             return
         }
         else {
-            remote.loadAllTaxClasses(for: taxClassRequestable.siteID) { [weak self] (taxClasses, error) in
+            remote.loadAllTaxClasses(for: taxClassRequestable.siteID) { [weak self] taxClasses, error in
                 guard let taxClasses else {
                     onCompletion(nil, error)
                     return

--- a/Modules/Sources/Yosemite/Stores/WooShippingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/WooShippingStore.swift
@@ -446,7 +446,7 @@ private extension WooShippingStore {
             guard let self, let contents = try? result.get() else {
                 return completion(result)
             }
-            let shipments = contents.map { (index, items) in
+            let shipments = contents.map { index, items in
                 WooShippingShipment(siteID: siteID,
                                     orderID: orderID,
                                     index: index,

--- a/Modules/Sources/Yosemite/Tools/Media/MediaAssetExporter.swift
+++ b/Modules/Sources/Yosemite/Tools/Media/MediaAssetExporter.swift
@@ -139,7 +139,7 @@ private extension MediaAssetExporter {
     func requestImage(asset: PHAsset, options: PHImageRequestOptions?) async -> (Data?, String?, CGImagePropertyOrientation, [AnyHashable: Any]?) {
         await withCheckedContinuation { continuation in
             imageManager.requestImageDataAndOrientation(for: asset,
-                                                        options: options) { (data, uti, orientation, info) in
+                                                        options: options) { data, uti, orientation, info in
                 continuation.resume(returning: (data, uti, orientation, info))
             }
         }

--- a/Modules/Sources/Yosemite/Tools/Payments/PaymentCaptureCelebration.swift
+++ b/Modules/Sources/Yosemite/Tools/Payments/PaymentCaptureCelebration.swift
@@ -29,7 +29,7 @@ private extension PaymentCaptureCelebration {
 
         let url = URL(fileURLWithPath: path)
         AudioServicesCreateSystemSoundID(url as CFURL, &soundID)
-        AudioServicesAddSystemSoundCompletion(soundID, nil, nil, { (soundId, _) -> Void in
+        AudioServicesAddSystemSoundCompletion(soundID, nil, nil, { soundId, _ -> Void in
             AudioServicesDisposeSystemSoundID(soundId)
           }, nil)
 

--- a/Modules/Sources/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
+++ b/Modules/Sources/Yosemite/Tools/ProductVariations/ProductVariationFormatter.swift
@@ -46,7 +46,7 @@ public struct ProductVariationFormatter {
     ///
     public func generateAttributes(for variation: ProductVariationFormattable, from allAttributes: [ProductAttribute]) -> [VariationAttributeViewModel] {
         return allAttributes
-            .sorted(by: { (lhs, rhs) -> Bool in
+            .sorted(by: { lhs, rhs -> Bool in
                 lhs.position < rhs.position
             })
             .map { attribute -> VariationAttributeViewModel in

--- a/Modules/Sources/Yosemite/Tools/ResultsController.swift
+++ b/Modules/Sources/Yosemite/Tools/ResultsController.swift
@@ -260,7 +260,7 @@ public class GenericResultsController<T: ResultsControllerMutableType, Output> {
             self?.onDidChangeContent?()
         }
 
-        internalDelegate.onDidChangeObject = { [weak self] (object, indexPath, type, newIndexPath) in
+        internalDelegate.onDidChangeObject = { [weak self] object, indexPath, type, newIndexPath in
             guard let `self` = self, let object = object as? T else {
                 return
             }
@@ -269,7 +269,7 @@ public class GenericResultsController<T: ResultsControllerMutableType, Output> {
             self.onDidChangeObject?(transformedObject, indexPath, type, newIndexPath)
         }
 
-        internalDelegate.onDidChangeSection = { [weak self] (mutableSection, sectionIndex, type) in
+        internalDelegate.onDidChangeSection = { [weak self] mutableSection, sectionIndex, type in
             guard let `self` = self else {
                 return
             }

--- a/Modules/Sources/Yosemite/Tools/Settings/SiteAddress.swift
+++ b/Modules/Sources/Yosemite/Tools/Settings/SiteAddress.swift
@@ -60,7 +60,7 @@ public class SiteAddress {
     }
 
     private func getValueFromSiteSettings(_ settingID: String) -> String? {
-        return siteSettings.first { (setting) -> Bool in
+        return siteSettings.first { setting -> Bool in
             return setting.settingID == settingID
         }?.value
     }

--- a/Modules/Sources/Yosemite/Tools/ShippingSettings/StorageShippingSettingsService.swift
+++ b/Modules/Sources/Yosemite/Tools/ShippingSettings/StorageShippingSettingsService.swift
@@ -31,7 +31,7 @@ public final class StorageShippingSettingsService: ShippingSettingsService {
 
 private extension StorageShippingSettingsService {
     func configureResultsController() {
-        resultsController.onDidChangeObject = { [weak self] (object, _, _, _) in
+        resultsController.onDidChangeObject = { [weak self] object, _, _, _ in
             self?.updateShippingSettings(with: object)
         }
         refreshResultsPredicate(siteID: siteID)

--- a/Modules/Sources/YosemiteTestHelpers/MockStorageManager.swift
+++ b/Modules/Sources/YosemiteTestHelpers/MockStorageManager.swift
@@ -34,7 +34,7 @@ open class MockStorageManager: StorageManagerType {
         let container = NSPersistentContainer(name: name, managedObjectModel: managedModel)
         container.persistentStoreDescriptions = [storeDescription]
 
-        container.loadPersistentStores { (_, error) in
+        container.loadPersistentStores { _, error in
             if let error = error as NSError? {
                 fatalError("CoreData Fatal Error: \(error) [\(error.userInfo)]")
             }
@@ -73,7 +73,7 @@ open class MockStorageManager: StorageManagerType {
                 fatalError("☠️ [CoreDataManager] Cannot Destroy persistentStore! \(error)")
             }
 
-            storeCoordinator.addPersistentStore(with: storeDescriptor) { (_, error) in
+            storeCoordinator.addPersistentStore(with: storeDescriptor) { _, error in
                 guard let error else {
                     onCompletion?()
                     return

--- a/Modules/Tests/NetworkingTests/Mapper/ReportOrderMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/ReportOrderMapperTests.swift
@@ -27,7 +27,7 @@ class ReportOrderMapperTests: XCTestCase {
         }
 
         var reportTotals = [OrderStatusEnum: Int]()
-        results.forEach({ (orderStatus) in
+        results.forEach({ orderStatus in
             let status = OrderStatusEnum(rawValue: orderStatus.slug)
             reportTotals[status] = orderStatus.total
         })

--- a/Modules/Tests/NetworkingTests/Remote/CommentRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/CommentRemoteTests.swift
@@ -33,7 +33,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as spam")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-spam")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .spam) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .spam) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertNotNil(updatedStatus)
             XCTAssertEqual(updatedStatus, .spam)
@@ -51,7 +51,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as unspam")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-approved")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .unspam) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .unspam) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertNotNil(updatedStatus)
             XCTAssertEqual(updatedStatus, .approved)
@@ -69,7 +69,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as approved")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-approved")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .approved) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .approved) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertNotNil(updatedStatus)
             XCTAssertEqual(updatedStatus, .approved)
@@ -87,7 +87,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as unapproved")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-unapproved")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .unapproved) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .unapproved) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertNotNil(updatedStatus)
             XCTAssertEqual(updatedStatus, .unapproved)
@@ -105,7 +105,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as trash")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-trash")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .trash) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .trash) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertNotNil(updatedStatus)
             XCTAssertEqual(updatedStatus, .trash)
@@ -123,7 +123,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as untrash")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-approved")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .untrash) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .untrash) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertNotNil(updatedStatus)
             XCTAssertEqual(updatedStatus, .approved)
@@ -141,7 +141,7 @@ class CommentRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Error Handling")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "generic_error")
-        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .untrash) { (updatedStatus, error) in
+        remote.moderateComment(siteID: sampleSiteID, commentID: sampleCommentID, status: .untrash) { updatedStatus, error in
             guard let error = error as? DotcomError else {
                 XCTFail()
                 return

--- a/Modules/Tests/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -141,7 +141,7 @@ final class CouponsRemoteTests: XCTestCase {
         let result = waitFor { promise in
             remote.deleteCoupon(for: self.sampleSiteID,
                                 couponID: sampleCouponID,
-                                completion: { (result) in
+                                completion: { result in
                 promise(result)
             })
         }
@@ -187,7 +187,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.updateCoupon(coupon) { (result) in
+            remote.updateCoupon(coupon) { result in
                 promise(result)
             }
         }
@@ -233,7 +233,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.createCoupon(coupon) { (result) in
+            remote.createCoupon(coupon) { result in
                 promise(result)
             }
         }
@@ -255,7 +255,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { (result) in
+            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { result in
                 promise(result)
             }
         }
@@ -278,7 +278,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { (result) in
+            remote.loadCouponReport(for: self.sampleSiteID, couponID: 571, from: Date()) { result in
                 promise(result)
             }
         }
@@ -304,7 +304,7 @@ final class CouponsRemoteTests: XCTestCase {
                                          numberOfCouponsToLoad: 3,
                                          from: Date(),
                                          to: Date()
-            ) { (result) in
+            ) { result in
                 promise(result)
             }
         }
@@ -331,7 +331,7 @@ final class CouponsRemoteTests: XCTestCase {
                                          numberOfCouponsToLoad: 3,
                                          from: Date(),
                                          to: Date()
-            ) { (result) in
+            ) { result in
                 promise(result)
             }
         }
@@ -434,7 +434,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { (result) in
+            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { result in
                 promise(result)
             }
         }
@@ -457,7 +457,7 @@ final class CouponsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { (result) in
+            remote.retrieveCoupon(for: self.sampleSiteID, couponID: sampleCouponID) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/DataRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/DataRemoteTests.swift
@@ -28,7 +28,7 @@ class DataRemoteTests: XCTestCase {
 
         // When
         let result: Result<[Country], Error> = waitFor { promise in
-            remote.loadCountries(siteID: self.sampleSiteID) { (result) in
+            remote.loadCountries(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
         }
@@ -49,7 +49,7 @@ class DataRemoteTests: XCTestCase {
 
         // When
         let result: Result<[Country], Error> = waitFor { promise in
-            remote.loadCountries(siteID: self.sampleSiteID) { (result) in
+            remote.loadCountries(siteID: self.sampleSiteID) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/DevicesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/DevicesRemoteTests.swift
@@ -29,7 +29,7 @@ final class DevicesRemoteTests: XCTestCase {
 
         remote.registerDevice(device: Parameters.appleDevice,
                               applicationId: Parameters.applicationId,
-                              applicationVersion: Parameters.applicationVersion) { (settings, error) in
+                              applicationVersion: Parameters.applicationVersion) { settings, error in
 
             XCTAssertNil(error)
             XCTAssertNotNil(settings)
@@ -50,7 +50,7 @@ final class DevicesRemoteTests: XCTestCase {
 
         remote.registerDevice(device: Parameters.appleDevice,
                               applicationId: Parameters.applicationId,
-                              applicationVersion: Parameters.applicationVersion) { (settings, error) in
+                              applicationVersion: Parameters.applicationVersion) { settings, error in
 
             XCTAssertNotNil(error)
             XCTAssertNil(settings)

--- a/Modules/Tests/NetworkingTests/Remote/InboxNotesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/InboxNotesRemoteTests.swift
@@ -91,7 +91,7 @@ final class InboxNotesRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.loadAllInboxNotes(for: self.sampleSiteID,
-                                  completion: { (result) in
+                                  completion: { result in
                                     promise(result)
                                 })
         }

--- a/Modules/Tests/NetworkingTests/Remote/NotificationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/NotificationsRemoteTests.swift
@@ -52,7 +52,7 @@ final class NotificationsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "notifications", filename: "notifications-load-hashes")
 
-        remote.loadHashes { (notes, error) in
+        remote.loadHashes { notes, error in
             XCTAssertNotNil(notes)
             XCTAssertNil(error)
             XCTAssertEqual(notes?.count, 40)
@@ -71,7 +71,7 @@ final class NotificationsRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "notifications", filename: "generic_error")
 
-        remote.loadHashes { (notes, error) in
+        remote.loadHashes { notes, error in
             XCTAssertNotNil(error)
             XCTAssertNil(notes)
 

--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -309,7 +309,7 @@ final class OrdersRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)", filename: "order")
 
-        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { (order, error) in
+        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { order, error in
             XCTAssertNil(error)
             XCTAssertNotNil(order)
             expectation.fulfill()
@@ -324,7 +324,7 @@ final class OrdersRemoteTests: XCTestCase {
         let remote = OrdersRemote(network: network)
         let expectation = self.expectation(description: "Update Order")
 
-        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { (order, error) in
+        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { order, error in
             XCTAssertNil(order)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -338,7 +338,7 @@ final class OrdersRemoteTests: XCTestCase {
         let remote = OrdersRemote(network: network)
 
         // When
-        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { (_, _) in }
+        remote.updateOrder(from: sampleSiteID, orderID: sampleOrderID, statusKey: .pending) { _, _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -612,7 +612,7 @@ final class OrdersRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/notes", filename: "new-order-note")
 
-        remote.addOrderNote(for: sampleSiteID, orderID: sampleOrderID, isCustomerNote: true, with: noteData) { (orderNote, error) in
+        remote.addOrderNote(for: sampleSiteID, orderID: sampleOrderID, isCustomerNote: true, with: noteData) { orderNote, error in
             XCTAssertNil(error)
             XCTAssertNotNil(orderNote)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/PaymentsGatewayRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/PaymentsGatewayRemoteTests.swift
@@ -75,7 +75,7 @@ final class PaymentsGatewayRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.updatePaymentGateway(paymentGateway) { (result) in
+            remote.updatePaymentGateway(paymentGateway) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/ProductShippingClassRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductShippingClassRemoteTests.swift
@@ -97,7 +97,7 @@ final class ProductShippingClassRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load One Product Shipping Class returns error")
 
         let remoteID = Int64(96987515)
-        remote.loadOne(for: sampleSiteID, remoteID: remoteID) { (productShippingClass, error) in
+        remote.loadOne(for: sampleSiteID, remoteID: remoteID) { productShippingClass, error in
             XCTAssertNil(productShippingClass)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/ProductTagsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductTagsRemoteTests.swift
@@ -83,7 +83,7 @@ final class ProductTagsRemoteTests: XCTestCase {
         // When
         var result: Result<[ProductTag], Error>?
         waitForExpectation { exp in
-            remote.createProductTags(for: sampleSiteID, names: ["Round toe", "Flat"]) { (aResult) in
+            remote.createProductTags(for: sampleSiteID, names: ["Round toe", "Flat"]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -105,7 +105,7 @@ final class ProductTagsRemoteTests: XCTestCase {
         // When
         var result: Result<[ProductTag], Error>?
         waitForExpectation { exp in
-            remote.createProductTags(for: sampleSiteID, names: ["Leather Shoes"]) { (aResult) in
+            remote.createProductTags(for: sampleSiteID, names: ["Leather Shoes"]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -128,7 +128,7 @@ final class ProductTagsRemoteTests: XCTestCase {
         // When
         var result: Result<[ProductTag], Error>?
         waitForExpectation { exp in
-            remote.deleteProductTags(for: sampleSiteID, ids: [35]) { (aResult) in
+            remote.deleteProductTags(for: sampleSiteID, ids: [35]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -150,7 +150,7 @@ final class ProductTagsRemoteTests: XCTestCase {
         // When
         var result: Result<[ProductTag], Error>?
         waitForExpectation { exp in
-            remote.deleteProductTags(for: sampleSiteID, ids: [35]) { (aResult) in
+            remote.deleteProductTags(for: sampleSiteID, ids: [35]) { aResult in
                 result = aResult
                 exp.fulfill()
             }

--- a/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -114,7 +114,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
 
         remote.loadAllProductVariations(for: sampleSiteID,
                                         productID: sampleProductID,
-                                        variationIDs: []) { (productVariations, error) in
+                                        variationIDs: []) { productVariations, error in
             XCTAssertNil(productVariations)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -361,7 +361,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
             remote.createProductVariation(for: self.sampleSiteID,
                                           productID: self.sampleProductID,
                                           newVariation:
-                                            self.sampleCreateProductVariation(siteID: self.sampleSiteID, productID: self.sampleProductID)) { (result) in
+                                            self.sampleCreateProductVariation(siteID: self.sampleSiteID, productID: self.sampleProductID)) { result in
                 promise(result)
             }
         }
@@ -385,7 +385,7 @@ final class ProductVariationsRemoteTests: XCTestCase {
             remote.createProductVariation(for: self.sampleSiteID,
                                           productID: self.sampleProductID,
                                           newVariation:
-                                            self.sampleCreateProductVariation(siteID: self.sampleSiteID, productID: self.sampleProductID)) { (result) in
+                                            self.sampleCreateProductVariation(siteID: self.sampleSiteID, productID: self.sampleProductID)) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -152,7 +152,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         var deletedProduct: Product?
         waitForExpectation { expectation in
-            remote.deleteProduct(for: sampleSiteID, productID: sampleProductID) { (result) in
+            remote.deleteProduct(for: sampleSiteID, productID: sampleProductID) { result in
                 deletedProduct = try? result.get()
                 expectation.fulfill()
             }
@@ -243,7 +243,7 @@ final class ProductsRemoteTests: XCTestCase {
         // When
         var result: Result<Product, Error>?
         waitForExpectation { expectation in
-            remote.deleteProduct(for: sampleSiteID, productID: sampleProductID) { (aResult) in
+            remote.deleteProduct(for: sampleSiteID, productID: sampleProductID) { aResult in
                 result = aResult
                 expectation.fulfill()
             }

--- a/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
@@ -32,7 +32,7 @@ final class RemoteTests: XCTestCase {
         let remote = Remote(network: network)
         let expectation = self.expectation(description: "Enqueue with Mapper")
 
-        remote.enqueue(request, mapper: mapper) { (payload, _) in
+        remote.enqueue(request, mapper: mapper) { payload, _ in
             guard let receivedRequest = network.requestsForResponseData.first as? JetpackRequest else {
                 XCTFail()
                 return
@@ -114,7 +114,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "something", filename: "order")
 
-        remote.enqueue(request, mapper: mapper) { (_, _) in
+        remote.enqueue(request, mapper: mapper) { _, _ in
             XCTAssertEqual(mapper.input, Loader.contentsOf("order"))
             XCTAssertNotNil(mapper.input)
             expectation.fulfill()
@@ -200,7 +200,7 @@ final class RemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "something", filename: "timeout_error")
 
-        remote.enqueue(request, mapper: mapper) { (payload, error) in
+        remote.enqueue(request, mapper: mapper) { payload, error in
             XCTAssertNil(payload)
             XCTAssert(error is DotcomError)
             expectationForRequest.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/ShipmentsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ShipmentsRemoteTests.swift
@@ -35,7 +35,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking information")
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/", filename: "shipment_tracking_multiple")
-        remote.loadShipmentTrackings(for: sampleSiteID, orderID: sampleOrderID, completion: { (shipmentTrackings, error) in
+        remote.loadShipmentTrackings(for: sampleSiteID, orderID: sampleOrderID, completion: { shipmentTrackings, error in
             XCTAssertNil(error)
             XCTAssertNotNil(shipmentTrackings)
             XCTAssertEqual(shipmentTrackings?.count, 4)
@@ -53,7 +53,7 @@ final class ShipmentsRemoteTests: XCTestCase {
 
         remote.loadShipmentTrackings(for: sampleSiteID,
                                      orderID: sampleOrderID,
-                                     completion: { (shipmentTrackings, error) in
+                                     completion: { shipmentTrackings, error in
             XCTAssertNil(shipmentTrackings)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -69,7 +69,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking information contains errors")
 
         network.simulateError(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/", error: NetworkError.notFound())
-        remote.loadShipmentTrackings(for: sampleSiteID, orderID: sampleOrderID, completion: { (shipmentTrackings, error) in
+        remote.loadShipmentTrackings(for: sampleSiteID, orderID: sampleOrderID, completion: { shipmentTrackings, error in
             XCTAssertNil(shipmentTrackings)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -86,7 +86,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking information")
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/", filename: "shipment_tracking_plugin_not_active")
-        remote.loadShipmentTrackings(for: sampleSiteID, orderID: sampleOrderID, completion: { (shipmentTrackings, error) in
+        remote.loadShipmentTrackings(for: sampleSiteID, orderID: sampleOrderID, completion: { shipmentTrackings, error in
             XCTAssertNil(shipmentTrackings)
             XCTAssertNotNil(error)
 
@@ -118,7 +118,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                       orderID: orderID,
                                       trackingProvider: "Some provider",
                                       dateShipped: "2019-04-01",
-                                      trackingNumber: "1111") { (shipmentTracking, error) in
+                                      trackingNumber: "1111") { shipmentTracking, error in
             XCTAssertNil(error)
             XCTAssertNotNil(shipmentTracking)
             XCTAssertEqual(shipmentTracking?.orderID, orderID)
@@ -138,7 +138,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                       orderID: sampleOrderID,
                                       trackingProvider: "Some provider",
                                       dateShipped: "2019-04-01",
-                                      trackingNumber: "11111") { (shipmentTracking, error) in
+                                      trackingNumber: "11111") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -159,7 +159,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                       orderID: sampleOrderID,
                                       trackingProvider: "Some provider",
                                       dateShipped: "2019-04-01",
-                                      trackingNumber: "1111") { (shipmentTracking, error) in
+                                      trackingNumber: "1111") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -180,7 +180,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                       orderID: sampleOrderID,
                                       trackingProvider: "some tracking provider",
                                       dateShipped: "2019-04-01",
-                                      trackingNumber: "1111") { (shipmentTracking, error) in
+                                      trackingNumber: "1111") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
 
@@ -213,7 +213,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                                         trackingProvider: "Some provider",
                                                         trackingNumber: "1111",
                                                         trackingURL: "https://somewhere.online.net.com?q=%1$s",
-                                                        dateShipped: "12345") { (shipmentTracking, error) in
+                                                        dateShipped: "12345") { shipmentTracking, error in
             XCTAssertNil(error)
             XCTAssertNotNil(shipmentTracking)
             XCTAssertEqual(shipmentTracking?.orderID, orderID)
@@ -234,7 +234,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                                         trackingProvider: "Some provider",
                                                         trackingNumber: "11111",
                                                         trackingURL: "https://somewhere.online.net.com?q=%1$s",
-                                                        dateShipped: "12345") { (shipmentTracking, error) in
+                                                        dateShipped: "12345") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -256,7 +256,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                                         trackingProvider: "Some provider",
                                                         trackingNumber: "1111",
                                                         trackingURL: "https://somewhere.online.net.com?q=%1$s",
-                                                        dateShipped: "1234") { (shipmentTracking, error) in
+                                                        dateShipped: "1234") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -278,7 +278,7 @@ final class ShipmentsRemoteTests: XCTestCase {
                                                         trackingProvider: "some tracking provider",
                                                         trackingNumber: "1111",
                                                         trackingURL: "https://somewhere.online.net.com?q=%1$s",
-                                                        dateShipped: "1234") { (shipmentTracking, error) in
+                                                        dateShipped: "1234") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
 
@@ -322,7 +322,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let remote = ShipmentsRemote(network: network)
         let expectation = self.expectation(description: "Delete shipment tracking information contains errors")
 
-        remote.deleteShipmentTracking(for: sampleSiteID, orderID: sampleOrderID, trackingID: "trackingID") { (shipmentTracking, error) in
+        remote.deleteShipmentTracking(for: sampleSiteID, orderID: sampleOrderID, trackingID: "trackingID") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -339,7 +339,7 @@ final class ShipmentsRemoteTests: XCTestCase {
 
         network.simulateError(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/", error: NetworkError.notFound())
 
-        remote.deleteShipmentTracking(for: sampleSiteID, orderID: sampleOrderID, trackingID: "1111") { (shipmentTracking, error) in
+        remote.deleteShipmentTracking(for: sampleSiteID, orderID: sampleOrderID, trackingID: "1111") { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -358,7 +358,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let trackingID = "trackingID"
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/\(trackingID)", filename: "shipment_tracking_plugin_not_active")
-        remote.deleteShipmentTracking(for: sampleSiteID, orderID: sampleOrderID, trackingID: trackingID) { (shipmentTracking, error) in
+        remote.deleteShipmentTracking(for: sampleSiteID, orderID: sampleOrderID, trackingID: trackingID) { shipmentTracking, error in
             XCTAssertNil(shipmentTracking)
             XCTAssertNotNil(error)
 
@@ -383,7 +383,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking providers information")
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/providers", filename: "shipment_tracking_providers")
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (groups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { groups, error in
             XCTAssertNil(error)
             XCTAssertNotNil(groups)
             XCTAssertEqual(groups?.count, 19)
@@ -399,7 +399,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let remote = ShipmentsRemote(network: network)
         let expectation = self.expectation(description: "Load shipment tracking providers information contains errors")
 
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (shipmentTrackingGroups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { shipmentTrackingGroups, error in
             XCTAssertNil(shipmentTrackingGroups)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -416,7 +416,7 @@ final class ShipmentsRemoteTests: XCTestCase {
 
         network.simulateError(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/providers", error: NetworkError.notFound())
 
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (shipmentTrackingGroups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { shipmentTrackingGroups, error in
             XCTAssertNil(shipmentTrackingGroups)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -433,7 +433,7 @@ final class ShipmentsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load shipment tracking information")
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/shipment-trackings/providers", filename: "shipment_tracking_plugin_not_active")
-        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { (shipmentTrackingGroups, error) in
+        remote.loadShipmentTrackingProviderGroups(for: sampleSiteID, orderID: sampleOrderID) { shipmentTrackingGroups, error in
             XCTAssertNil(shipmentTrackingGroups)
             XCTAssertNotNil(error)
 

--- a/Modules/Tests/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ShippingLabelRemoteTests.swift
@@ -313,7 +313,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
             remote.loadCarriersAndRates(siteID: self.sampleSiteID,
                                         orderID: self.sampleOrderID,
                                         originAddress: ShippingLabelAddress.fake(), destinationAddress: ShippingLabelAddress.fake(),
-                                        packages: [ShippingLabelPackageSelected.fake()]) { (result) in
+                                        packages: [ShippingLabelPackageSelected.fake()]) { result in
                 promise(result)
             }
         }
@@ -458,7 +458,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
                                          originAddress: ShippingLabelAddress.fake(),
                                          destinationAddress: ShippingLabelAddress.fake(),
                                          packages: [ShippingLabelPackagePurchase.fake()],
-                                         emailCustomerReceipt: true) { (result) in
+                                         emailCustomerReceipt: true) { result in
                 promise(result)
             }
         }
@@ -516,7 +516,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelStatusPollingResponse], Error> = waitFor { promise in
             remote.checkLabelStatus(siteID: self.sampleSiteID,
                                     orderID: self.sampleOrderID,
-                                    labelIDs: [sampleLabelID]) { (result) in
+                                    labelIDs: [sampleLabelID]) { result in
                 promise(result)
             }
         }
@@ -537,7 +537,7 @@ final class ShippingLabelRemoteTests: XCTestCase {
         let result: Result<[ShippingLabelStatusPollingResponse], Error> = waitFor { promise in
             remote.checkLabelStatus(siteID: self.sampleSiteID,
                                     orderID: self.sampleOrderID,
-                                    labelIDs: [sampleLabelID]) { (result) in
+                                    labelIDs: [sampleLabelID]) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/SitePostsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SitePostsRemoteTests.swift
@@ -37,7 +37,7 @@ class SitePostsRemoteTests: XCTestCase {
         let postID: Int64 = 7
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/posts/\(postID)", filename: "site-post")
-        remote.loadSitePost(for: sampleSiteID, postID: postID) {[weak self] (sitePost, error) in
+        remote.loadSitePost(for: sampleSiteID, postID: postID) {[weak self] sitePost, error in
             XCTAssertNil(error)
             XCTAssertNotNil(sitePost)
             XCTAssertEqual(sitePost?.siteID, self?.sampleSiteID)
@@ -54,7 +54,7 @@ class SitePostsRemoteTests: XCTestCase {
         let remote = SitePostsRemote(network: network)
         let expectation = self.expectation(description: "Wait for a site post result")
 
-        remote.loadSitePost(for: sampleSiteID, postID: 7) { (sitePost, error) in
+        remote.loadSitePost(for: sampleSiteID, postID: 7) { sitePost, error in
             XCTAssertNil(sitePost)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -29,7 +29,7 @@ final class SiteSettingsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load site settings")
 
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "settings-general")
-        remote.loadGeneralSettings(for: sampleSiteID) { (siteSettings, error) in
+        remote.loadGeneralSettings(for: sampleSiteID) { siteSettings, error in
             XCTAssertNil(error)
             XCTAssertNotNil(siteSettings)
             XCTAssertEqual(siteSettings?.count, 20)
@@ -45,7 +45,7 @@ final class SiteSettingsRemoteTests: XCTestCase {
         let remote = SiteSettingsRemote(network: network)
         let expectation = self.expectation(description: "Load site settings contains errors")
 
-        remote.loadGeneralSettings(for: sampleSiteID) { (siteSettings, error) in
+        remote.loadGeneralSettings(for: sampleSiteID) { siteSettings, error in
             XCTAssertNil(siteSettings)
             XCTAssertNotNil(error)
             expectation.fulfill()
@@ -63,7 +63,7 @@ final class SiteSettingsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load product settings")
 
         network.simulateResponse(requestUrlSuffix: "settings/products", filename: "settings-product")
-        remote.loadProductSettings(for: sampleSiteID) { (siteSettings, error) in
+        remote.loadProductSettings(for: sampleSiteID) { siteSettings, error in
             XCTAssertNil(error)
             XCTAssertNotNil(siteSettings)
             XCTAssertEqual(siteSettings?.count, 23)
@@ -79,7 +79,7 @@ final class SiteSettingsRemoteTests: XCTestCase {
         let remote = SiteSettingsRemote(network: network)
         let expectation = self.expectation(description: "Load product settings contains errors")
 
-        remote.loadProductSettings(for: sampleSiteID) { (siteSettings, error) in
+        remote.loadProductSettings(for: sampleSiteID) { siteSettings, error in
             XCTAssertNil(siteSettings)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/SubscriptionsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SubscriptionsRemoteTests.swift
@@ -70,7 +70,7 @@ final class SubscriptionsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadSubscription(siteID: self.sampleSiteID, subscriptionID: self.sampleSubscriptionID) { (result) in
+            remote.loadSubscription(siteID: self.sampleSiteID, subscriptionID: self.sampleSubscriptionID) { result in
                 promise(result)
             }
         }
@@ -114,7 +114,7 @@ final class SubscriptionsRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            remote.loadSubscriptions(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (result) in
+            remote.loadSubscriptions(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/TaxRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/TaxRemoteTests.swift
@@ -30,7 +30,7 @@ final class TaxRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
 
-        remote.loadAllTaxClasses(for: sampleSiteID) { [weak self] (taxClasses, error) in
+        remote.loadAllTaxClasses(for: sampleSiteID) { [weak self] taxClasses, error in
             guard let self else {
                 expectation.fulfill()
                 return
@@ -59,7 +59,7 @@ final class TaxRemoteTests: XCTestCase {
         let remote = TaxRemote(network: network)
         let expectation = self.expectation(description: "Load All Tax Classes returns error")
 
-        remote.loadAllTaxClasses(for: sampleSiteID) { (taxClasses, error) in
+        remote.loadAllTaxClasses(for: sampleSiteID) { taxClasses, error in
             XCTAssertNil(taxClasses)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/TopEarnerStatsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/TopEarnerStatsRemoteTests.swift
@@ -29,7 +29,7 @@ class TopEarnerStatsRemoteTests: XCTestCase {
         let expectation = self.expectation(description: "Load top earner stats")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/stats/top-earners/", filename: "top-performers-year")
-        remote.loadTopEarnersStats(for: sampleSiteID, unit: .year, latestDateToInclude: "2018", limit: 5) { (topEarnerStats, error) in
+        remote.loadTopEarnersStats(for: sampleSiteID, unit: .year, latestDateToInclude: "2018", limit: 5) { topEarnerStats, error in
             XCTAssertNil(error)
             XCTAssertNotNil(topEarnerStats)
             XCTAssertEqual(topEarnerStats?.items?.count, 4)
@@ -45,7 +45,7 @@ class TopEarnerStatsRemoteTests: XCTestCase {
         let remote = TopEarnersStatsRemote(network: network)
         let expectation = self.expectation(description: "Load top earner stats contains errors")
 
-        remote.loadTopEarnersStats(for: sampleSiteID, unit: .year, latestDateToInclude: "2018", limit: 5) { (topEarnerStats, error) in
+        remote.loadTopEarnersStats(for: sampleSiteID, unit: .year, latestDateToInclude: "2018", limit: 5) { topEarnerStats, error in
             XCTAssertNil(topEarnerStats)
             XCTAssertNotNil(error)
             expectation.fulfill()

--- a/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WooShippingRemoteTests.swift
@@ -181,7 +181,7 @@ final class WooShippingRemoteTests: XCTestCase {
                                   orderID: self.sampleOrderID,
                                   originAddress: WooShippingAddress.fake(),
                                   destinationAddress: WooShippingAddress.fake(),
-                                  packages: [expectedPackage]) { (result) in
+                                  packages: [expectedPackage]) { result in
                 promise(result)
             }
         }

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests+ProductsSettings.swift
@@ -56,7 +56,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
 
         // When
         let result: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
-            let initialReadAction = AppSettingsAction.loadProductsSettings(siteID: siteID) { (result) in
+            let initialReadAction = AppSettingsAction.loadProductsSettings(siteID: siteID) { result in
                 promise(result)
             }
             self.subject.onAction(initialReadAction)
@@ -70,7 +70,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                                    productStatusFilter: productSettings.productStatusFilter,
                                                                    productTypeFilter: productSettings.productTypeFilter,
                                                                    productCategoryFilter: productSettings.productCategoryFilter,
-                                                                   favoriteProduct: productSettings.favoriteProduct) { (error) in
+                                                                   favoriteProduct: productSettings.favoriteProduct) { error in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction)
@@ -78,7 +78,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
 
         // Then
         let result2: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
-            let readAction = AppSettingsAction.loadProductsSettings(siteID: siteID) { (result) in
+            let readAction = AppSettingsAction.loadProductsSettings(siteID: siteID) { result in
                 promise(result)
             }
             self.subject.onAction(readAction)
@@ -118,7 +118,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                                     productStatusFilter: productSettings1.productStatusFilter,
                                                                     productTypeFilter: productSettings1.productTypeFilter,
                                                                     productCategoryFilter: productSettings1.productCategoryFilter,
-                                                                    favoriteProduct: productSettings1.favoriteProduct) { (error) in
+                                                                    favoriteProduct: productSettings1.favoriteProduct) { error in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction1)
@@ -129,14 +129,14 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
                                                                     productStatusFilter: productSettings2.productStatusFilter,
                                                                     productTypeFilter: productSettings2.productTypeFilter,
                                                                     productCategoryFilter: productSettings2.productCategoryFilter,
-                                                                    favoriteProduct: productSettings2.favoriteProduct) { (error) in
+                                                                    favoriteProduct: productSettings2.favoriteProduct) { error in
             XCTAssertNil(error)
         }
         subject.onAction(writeAction2)
 
         // Then
         let result1: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
-            let initialReadAction = AppSettingsAction.loadProductsSettings(siteID: siteID1) { (result) in
+            let initialReadAction = AppSettingsAction.loadProductsSettings(siteID: siteID1) { result in
                 promise(result)
             }
             self.subject.onAction(initialReadAction)
@@ -145,7 +145,7 @@ final class AppSettingsStoreTests_ProductsSettings: XCTestCase {
         XCTAssertEqual(try result1.get(), productSettings1)
 
         let result2: Result<StoredProductSettings.Setting, Error> = waitFor { promise in
-            let readAction = AppSettingsAction.loadProductsSettings(siteID: siteID2) { (result) in
+            let readAction = AppSettingsAction.loadProductsSettings(siteID: siteID2) { result in
                 promise(result)
             }
             self.subject.onAction(readAction)

--- a/Modules/Tests/YosemiteTests/Stores/CommentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CommentStoreTests.swift
@@ -53,7 +53,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Approve comment")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-approved")
-        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: true) { (updatedStatus, error) in
+        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: true) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertEqual(updatedStatus, .approved)
             expectation.fulfill()
@@ -70,7 +70,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Unpprove comment")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-unapproved")
-        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: false) { (updatedStatus, error) in
+        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: false) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertEqual(updatedStatus, .unapproved)
             expectation.fulfill()
@@ -87,7 +87,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Approve comment error response")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "generic_error")
-        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: true) { (updatedStatus, error) in
+        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: true) { updatedStatus, error in
             XCTAssertNotNil(error)
             XCTAssertNil(updatedStatus)
             expectation.fulfill()
@@ -103,7 +103,7 @@ class CommentStoreTests: XCTestCase {
         let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let expectation = self.expectation(description: "Approve comment empty response error")
 
-        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: true) { (updatedStatus, error) in
+        let action = CommentAction.updateApprovalStatus(siteID: sampleSiteID, commentID: sampleCommentID, isApproved: true) { updatedStatus, error in
             XCTAssertNotNil(error)
             XCTAssertNil(updatedStatus)
             expectation.fulfill()
@@ -123,7 +123,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as spam")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-spam")
-        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: true) { (updatedStatus, error) in
+        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: true) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertEqual(updatedStatus, .spam)
             expectation.fulfill()
@@ -140,7 +140,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as not spam")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-approved")
-        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: false) { (updatedStatus, error) in
+        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: false) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertEqual(updatedStatus, .approved)
             expectation.fulfill()
@@ -157,7 +157,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as spam error response")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "generic_error")
-        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: true) { (updatedStatus, error) in
+        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: true) { updatedStatus, error in
             XCTAssertNotNil(error)
             XCTAssertNil(updatedStatus)
             expectation.fulfill()
@@ -173,7 +173,7 @@ class CommentStoreTests: XCTestCase {
         let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let expectation = self.expectation(description: "Mark comment as spam empty response")
 
-        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: true) { (updatedStatus, error) in
+        let action = CommentAction.updateSpamStatus(siteID: sampleSiteID, commentID: sampleCommentID, isSpam: true) { updatedStatus, error in
             XCTAssertNotNil(error)
             XCTAssertNil(updatedStatus)
             expectation.fulfill()
@@ -193,7 +193,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as trash")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-trash")
-        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: true) { (updatedStatus, error) in
+        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: true) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertEqual(updatedStatus, .trash)
             expectation.fulfill()
@@ -210,7 +210,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as not trash")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "comment-moderate-approved")
-        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: false) { (updatedStatus, error) in
+        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: false) { updatedStatus, error in
             XCTAssertNil(error)
             XCTAssertEqual(updatedStatus, .approved)
             expectation.fulfill()
@@ -227,7 +227,7 @@ class CommentStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Mark comment as trash error response")
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/comments/\(sampleCommentID)", filename: "generic_error")
-        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: true) { (updatedStatus, error) in
+        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: true) { updatedStatus, error in
             XCTAssertNotNil(error)
             XCTAssertNil(updatedStatus)
             expectation.fulfill()
@@ -243,7 +243,7 @@ class CommentStoreTests: XCTestCase {
         let store = CommentStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         let expectation = self.expectation(description: "Mark comment as trash empty response")
 
-        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: true) { (updatedStatus, error) in
+        let action = CommentAction.updateTrashStatus(siteID: sampleSiteID, commentID: sampleCommentID, isTrash: true) { updatedStatus, error in
             XCTAssertNotNil(error)
             XCTAssertNil(updatedStatus)
             expectation.fulfill()

--- a/Modules/Tests/YosemiteTests/Stores/DataStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/DataStoreTests.swift
@@ -67,7 +67,7 @@ final class DataStoreTests: XCTestCase {
         XCTAssertEqual(persistedCountries[2].code, "US")
         XCTAssertEqual(persistedCountries[2].name, "United States (US)")
 
-        let states = persistedCountries[2].states.sorted { (lhs, rhs) -> Bool in
+        let states = persistedCountries[2].states.sorted { lhs, rhs -> Bool in
             lhs.name < rhs.name
         }
         XCTAssertEqual(states.count, 54)

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -46,7 +46,7 @@ final class NotificationStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "notifications", filename: "notifications-load-all")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Note.self), 0)
-        let action = NotificationAction.synchronizeNotifications() { (error) in
+        let action = NotificationAction.synchronizeNotifications() { error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Note.self), MockNetwork.notificationLoadAllJSONCount)
 
@@ -102,14 +102,14 @@ final class NotificationStoreTests: XCTestCase {
         /// This call is expected to just request the Hashes, and not to perform a 4th network call (because everything
         /// will be up to date. Supposedly.)
         ///
-        let nestedSyncAction = NotificationAction.synchronizeNotifications() { (_) in
+        let nestedSyncAction = NotificationAction.synchronizeNotifications() { _ in
             XCTAssertEqual(self.network.requestsForResponseData.count, 3)
             expectation.fulfill()
         }
 
         /// Initial Sync
         ///
-        let initialSyncAction = NotificationAction.synchronizeNotifications() { (_) in
+        let initialSyncAction = NotificationAction.synchronizeNotifications() { _ in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Note.self), MockNetwork.notificationLoadAllJSONCount)
             notificationStore.onAction(nestedSyncAction)
         }
@@ -154,7 +154,7 @@ final class NotificationStoreTests: XCTestCase {
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "notifications/seen", filename: "generic_success")
-        let action = NotificationAction.updateLastSeen(timestamp: "2018-11-05T16:03:15+00:00") { (error) in
+        let action = NotificationAction.updateLastSeen(timestamp: "2018-11-05T16:03:15+00:00") { error in
             XCTAssertNil(error)
             expectation.fulfill()
         }
@@ -170,7 +170,7 @@ final class NotificationStoreTests: XCTestCase {
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "notifications/seen", filename: "generic_error")
-        let action = NotificationAction.updateLastSeen(timestamp: "2018-11-05T16:03:15+00:00") { (error) in
+        let action = NotificationAction.updateLastSeen(timestamp: "2018-11-05T16:03:15+00:00") { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -185,7 +185,7 @@ final class NotificationStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Update last seen empty response")
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = NotificationAction.updateLastSeen(timestamp: "2018-11-05T16:03:15+00:00") { (error) in
+        let action = NotificationAction.updateLastSeen(timestamp: "2018-11-05T16:03:15+00:00") { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -206,7 +206,7 @@ final class NotificationStoreTests: XCTestCase {
         let expectedNote = sampleNotificationMutated()
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_success")
-        let action = NotificationAction.updateReadStatus(noteID: originalNote.noteID, read: true) { [weak self] (error) in
+        let action = NotificationAction.updateReadStatus(noteID: originalNote.noteID, read: true) { [weak self] error in
             XCTAssertNil(error)
             let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteID)
             XCTAssertEqual(storageNote?.toReadOnly().read, expectedNote.read)
@@ -229,7 +229,7 @@ final class NotificationStoreTests: XCTestCase {
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_error")
-        let action = NotificationAction.updateReadStatus(noteID: 9999, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: 9999, read: true) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -244,7 +244,7 @@ final class NotificationStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Update notification read status empty response")
         let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = NotificationAction.updateReadStatus(noteID: 9999, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: 9999, read: true) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -300,7 +300,7 @@ final class NotificationStoreTests: XCTestCase {
         let originalNote = sampleNotification()
 
         network.simulateResponse(requestUrlSuffix: "notifications/read", filename: "generic_error")
-        let action = NotificationAction.updateReadStatus(noteID: originalNote.noteID, read: true) { [weak self] (error) in
+        let action = NotificationAction.updateReadStatus(noteID: originalNote.noteID, read: true) { [weak self] error in
             XCTAssertNotNil(error)
 
             let storageNote = self?.viewStorage.loadNotification(noteID: originalNote.noteID)
@@ -365,7 +365,7 @@ final class NotificationStoreTests: XCTestCase {
         let (device, error): (DotcomDevice?, Error?) = waitFor { promise in
             let action = NotificationAction.registerDevice(device: self.sampleAPNSDevice(),
                                                            applicationId: self.sampleApplicationID,
-                                                           applicationVersion: self.sampleApplicationVersion) { (device, error) in
+                                                           applicationVersion: self.sampleApplicationVersion) { device, error in
                 promise((device, error))
             }
             noteStore.onAction(action)
@@ -389,7 +389,7 @@ final class NotificationStoreTests: XCTestCase {
         let (device, error): (DotcomDevice?, Error?) = waitFor { promise in
             let action = NotificationAction.registerDevice(device: self.sampleAPNSDevice(),
                                                            applicationId: self.sampleApplicationID,
-                                                           applicationVersion: self.sampleApplicationVersion) { (device, error) in
+                                                           applicationVersion: self.sampleApplicationVersion) { device, error in
                 promise((device, error))
             }
             noteStore.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/OrderNoteStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderNoteStoreTests.swift
@@ -62,7 +62,7 @@ class OrderNoteStoreTests: XCTestCase {
         let orderNoteStore = OrderNoteStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/notes/", filename: "order-notes")
-        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { (orderNotes, error) in
+        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { orderNotes, error in
             XCTAssertNil(error)
             guard let orderNotes else {
                 XCTFail()
@@ -89,7 +89,7 @@ class OrderNoteStoreTests: XCTestCase {
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrder(), in: viewStorage)
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/notes/", filename: "order-notes")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderNote.self), 0)
-        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { (orderNotes, error) in
+        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { orderNotes, error in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.OrderNote.self), 19)
             XCTAssertNotNil(orderNotes)
             XCTAssertNil(error)
@@ -112,7 +112,7 @@ class OrderNoteStoreTests: XCTestCase {
         orderStore.upsertStoredOrder(readOnlyOrder: sampleOrder(), in: viewStorage)
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/notes/", filename: "order-notes")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.OrderNote.self), 0)
-        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { (orderNotes, error) in
+        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { orderNotes, error in
             XCTAssertNotNil(orderNotes)
             XCTAssertNil(error)
 
@@ -200,7 +200,7 @@ class OrderNoteStoreTests: XCTestCase {
         let orderNoteStore = OrderNoteStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/notes/", filename: "generic_error")
-        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { (orderNotes, error) in
+        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { orderNotes, error in
             XCTAssertNil(orderNotes)
             XCTAssertNotNil(error)
             guard let _ = error else {
@@ -220,7 +220,7 @@ class OrderNoteStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve order notes empty response")
         let orderNoteStore = OrderNoteStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { (orderNotes, error) in
+        let action = OrderNoteAction.retrieveOrderNotes(siteID: sampleSiteID, orderID: sampleOrderID) { orderNotes, error in
             XCTAssertNotNil(error)
             XCTAssertNil(orderNotes)
             guard let _ = error else {
@@ -246,7 +246,7 @@ class OrderNoteStoreTests: XCTestCase {
             let action = OrderNoteAction.addOrderNote(siteID: self.sampleSiteID,
                                                       orderID: self.sampleOrderID,
                                                       isCustomerNote: true,
-                                                      note: "This order would be so much better with ketchup.") { (orderNote, error) in
+                                                      note: "This order would be so much better with ketchup.") { orderNote, error in
                 promise((orderNote, error))
             }
             orderNoteStore.onAction(action)
@@ -273,7 +273,7 @@ class OrderNoteStoreTests: XCTestCase {
             let action = OrderNoteAction.addOrderNote(siteID: self.sampleSiteID,
                                                       orderID: self.sampleOrderID,
                                                       isCustomerNote: true,
-                                                      note: "") { (orderNote, error) in
+                                                      note: "") { orderNote, error in
                 promise((orderNote, error))
             }
             orderNoteStore.onAction(action)
@@ -297,7 +297,7 @@ class OrderNoteStoreTests: XCTestCase {
             let action = OrderNoteAction.addOrderNote(siteID: self.sampleSiteID,
                                                       orderID: self.sampleOrderID,
                                                       isCustomerNote: true,
-                                                      note: "") { (orderNote, error) in
+                                                      note: "") { orderNote, error in
                 promise((orderNote, error))
             }
             orderNoteStore.onAction(action)
@@ -319,7 +319,7 @@ class OrderNoteStoreTests: XCTestCase {
             let action = OrderNoteAction.addOrderNote(siteID: self.sampleSiteID,
                                                       orderID: self.sampleOrderID,
                                                       isCustomerNote: true,
-                                                      note: "") { (orderNote, error) in
+                                                      note: "") { orderNote, error in
                 promise((orderNote, error))
             }
             orderNoteStore.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
@@ -362,7 +362,7 @@ final class OrderStoreTests: XCTestCase {
         let remoteOrder = sampleOrder()
 
         network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
-        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { order, error in
             XCTAssertNil(error)
             XCTAssertEqual(order, remoteOrder)
 
@@ -384,7 +384,7 @@ final class OrderStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
 
-        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { order, error in
             XCTAssertNotNil(order)
             XCTAssertNil(error)
 
@@ -416,7 +416,7 @@ final class OrderStoreTests: XCTestCase {
         let storedOrder = self.viewStorage.firstObject(ofType: Storage.Order.self, matching: predicate)?.toReadOnly()
 
         let fetchedOrder: Yosemite.Order? = waitFor { promise in
-            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (order, _) in
+            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { order, _ in
                 promise(order)
             }
 
@@ -438,7 +438,7 @@ final class OrderStoreTests: XCTestCase {
 
         // When
         let fetchedOrder: Yosemite.Order? = waitFor { promise in
-            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { (order, _) in
+            let action = OrderAction.retrieveOrder(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { order, _ in
                 promise(order)
             }
 
@@ -670,7 +670,7 @@ final class OrderStoreTests: XCTestCase {
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "orders/963", filename: "generic_error")
-        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { order, error in
             XCTAssertNil(order)
             XCTAssertNotNil(error)
 
@@ -687,7 +687,7 @@ final class OrderStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve single order empty response")
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { order, error in
             XCTAssertNotNil(error)
             XCTAssertNil(order)
 
@@ -709,7 +709,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
 
         network.simulateError(requestUrlSuffix: "orders/963", error: NetworkError.notFound())
-        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: sampleSiteID, orderID: sampleOrderID) { order, error in
             XCTAssertNotNil(error)
             XCTAssertNil(order)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Order.self), 0)

--- a/Modules/Tests/YosemiteTests/Stores/ProductCategoryStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductCategoryStoreTests.swift
@@ -225,7 +225,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `addProductCategory` action
         var result: Result<Networking.ProductCategory, Error>?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { aResult in
                 result = aResult
                 exp.fulfill()
@@ -248,7 +248,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `addProductCategory` action
         var result: Result<Networking.ProductCategory, Error>?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { aResult in
                 result = aResult
                 exp.fulfill()
@@ -268,7 +268,7 @@ final class ProductCategoryStoreTests: XCTestCase {
 
         // When dispatching a `addProductCategory` action
         var result: Result<Networking.ProductCategory, Error>?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductCategoryAction.addProductCategory(siteID: sampleSiteID, name: "Dress", parentID: 0) { aResult in
                 result = aResult
                 exp.fulfill()

--- a/Modules/Tests/YosemiteTests/Stores/ProductReviewStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductReviewStoreTests.swift
@@ -324,7 +324,7 @@ final class ProductReviewStoreTests: XCTestCase {
         let remoteProductReview = sampleProductReview()
 
         network.simulateResponse(requestUrlSuffix: "products/reviews/173", filename: "reviews-single")
-        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (productReview, error) in
+        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { productReview, error in
             XCTAssertNil(error)
             XCTAssertNotNil(productReview)
             XCTAssertEqual(productReview, remoteProductReview)
@@ -342,7 +342,7 @@ final class ProductReviewStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve single product review error response")
 
         network.simulateResponse(requestUrlSuffix: "products/reviews/173", filename: "generic_error")
-        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (_, error) in
+        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { _, error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -356,7 +356,7 @@ final class ProductReviewStoreTests: XCTestCase {
     func test_retrieve_single_product_review_returns_error_upon_empty_response() {
         let expectation = self.expectation(description: "Retrieve single product review empty response")
 
-        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (product, error) in
+        let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { product, error in
             XCTAssertNotNil(error)
             XCTAssertNil(product)
             expectation.fulfill()
@@ -377,7 +377,7 @@ final class ProductReviewStoreTests: XCTestCase {
         // When
         var resultMaybe: (review: Yosemite.ProductReview?, error: Error?)?
         waitForExpectation { expectation in
-            let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { (review, error) in
+            let action = ProductReviewAction.retrieveProductReview(siteID: sampleSiteID, reviewID: sampleReviewID) { review, error in
                 resultMaybe = (review: review, error: error)
                 expectation.fulfill()
             }

--- a/Modules/Tests/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductShippingClassStoreTests.swift
@@ -342,7 +342,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
-            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (_, error) in
+            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { _, error in
                 XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ProductShippingClass.self), 1)
                 XCTAssertNil(error)
 
@@ -376,14 +376,14 @@ final class ProductShippingClassStoreTests: XCTestCase {
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
         let action = ProductShippingClassAction
-            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (_, error) in
+            .retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { _, error in
                 XCTAssertNil(error)
 
                 let storedProductShippingClasses = self.viewStorage.loadProductShippingClasses(siteID: self.sampleSiteID)
                 XCTAssertEqual(storedProductShippingClasses?.count, 1)
 
                 let action = ProductShippingClassAction
-                    .retrieveProductShippingClass(siteID: self.sampleSiteID, remoteID: self.sampleShippingClassID) { (_, error) in
+                    .retrieveProductShippingClass(siteID: self.sampleSiteID, remoteID: self.sampleShippingClassID) { _, error in
                         XCTAssertNil(error)
 
                         let storedProductShippingClasses = self.viewStorage
@@ -410,7 +410,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         let product = Product.fake().copy(siteID: sampleSiteID, shippingClassID: sampleShippingClassID)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
-        let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (model, error) in
+        let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { model, error in
             XCTAssertNil(model)
             XCTAssertNotNil(error)
 
@@ -430,7 +430,7 @@ final class ProductShippingClassStoreTests: XCTestCase {
         let product = Product.fake().copy(siteID: sampleSiteID, shippingClassID: sampleShippingClassID)
         storageManager.insertSampleProduct(readOnlyProduct: product)
 
-        let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { (model, error) in
+        let action = ProductShippingClassAction.retrieveProductShippingClass(siteID: sampleSiteID, remoteID: sampleShippingClassID) { model, error in
             XCTAssertNil(model)
             XCTAssertNotNil(error)
 

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -208,7 +208,7 @@ final class ProductStoreTests: XCTestCase {
 
         var result: Result<Yosemite.Product, ProductUpdateError>?
         waitForExpectation { expectation in
-            let action = ProductAction.deleteProduct(siteID: sampleSiteID, productID: sampleProductID) { (aResult) in
+            let action = ProductAction.deleteProduct(siteID: sampleSiteID, productID: sampleProductID) { aResult in
                 result = aResult
                 expectation.fulfill()
             }
@@ -243,7 +243,7 @@ final class ProductStoreTests: XCTestCase {
         // Action
         var result: Result<Yosemite.Product, ProductUpdateError>?
         waitForExpectation { expectation in
-            let action = ProductAction.deleteProduct(siteID: sampleSiteID, productID: sampleProductID) { (aResult) in
+            let action = ProductAction.deleteProduct(siteID: sampleSiteID, productID: sampleProductID) { aResult in
                 result = aResult
                 expectation.fulfill()
             }

--- a/Modules/Tests/YosemiteTests/Stores/ProductTagStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductTagStoreTests.swift
@@ -67,7 +67,7 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeAllProductTags` action
         var errorResponse: ProductTagActionError?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
                 errorResponse = error
                 exp.fulfill()
@@ -89,7 +89,7 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeAllProductTags` action
         var errorResponse: ProductTagActionError?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
                 errorResponse = error
                 exp.fulfill()
@@ -111,7 +111,7 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeAllProductTags` action
         var errorResponse: ProductTagActionError?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
                 errorResponse = error
                 exp.fulfill()
@@ -136,7 +136,7 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeAllProductTags` action
         var errorResponse: ProductTagActionError?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
                 errorResponse = error
                 exp.fulfill()
@@ -163,7 +163,7 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeAllProductTags` action
         var errorResponse: ProductTagActionError?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
                 errorResponse = error
                 exp.fulfill()
@@ -182,7 +182,7 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `synchronizeAllProductTags` action
         var errorResponse: ProductTagActionError?
-        waitForExpectation { (exp) in
+        waitForExpectation { exp in
             let action = ProductTagAction.synchronizeAllProductTags(siteID: sampleSiteID) { error in
                 errorResponse = error
                 exp.fulfill()
@@ -201,8 +201,8 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `addProductTags` action
         var result: Result<[Yosemite.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -226,8 +226,8 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `addProductTags` action
         var result: Result<[Networking.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -242,8 +242,8 @@ final class ProductTagStoreTests: XCTestCase {
     func test_addProductTags_returns_success_for_empty_tag_list() throws {
         // When
         var result: Result<[Networking.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: []) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: []) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -264,8 +264,8 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `addProductTags` action
         var result: Result<[Networking.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.addProductTags(siteID: sampleSiteID, tags: ["Round toe", "Flat"]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -286,8 +286,8 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `deleteProductTags` action
         var result: Result<[Yosemite.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -307,8 +307,8 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `deleteProductTags` action
         var result: Result<[Yosemite.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { aResult in
                 result = aResult
                 exp.fulfill()
             }
@@ -327,8 +327,8 @@ final class ProductTagStoreTests: XCTestCase {
 
         // When dispatching a `deleteProductTags` action
         var result: Result<[Yosemite.ProductTag], Error>?
-        waitForExpectation { (exp) in
-            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { (aResult) in
+        waitForExpectation { exp in
+            let action = ProductTagAction.deleteProductTags(siteID: sampleSiteID, ids: [35]) { aResult in
                 result = aResult
                 exp.fulfill()
             }

--- a/Modules/Tests/YosemiteTests/Stores/RefundStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/RefundStoreTests.swift
@@ -179,7 +179,7 @@ class RefundStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/refunds/\(refundID)", filename: "refund-single")
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: refundID) { (refund, error) in
+                                                 refundID: refundID) { refund, error in
             XCTAssertNil(error)
             XCTAssertNotNil(refund)
             XCTAssertEqual(refund, remoteRefund)
@@ -204,7 +204,7 @@ class RefundStoreTests: XCTestCase {
 
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: refundID) { (refund, error) in
+                                                 refundID: refundID) { refund, error in
             XCTAssertNotNil(refund)
             XCTAssertNil(error)
 
@@ -233,7 +233,7 @@ class RefundStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/refunds/\(refundID)", filename: "generic_error")
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: refundID) { (_, error) in
+                                                 refundID: refundID) { _, error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -250,7 +250,7 @@ class RefundStoreTests: XCTestCase {
 
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: refundID) { (_, error) in
+                                                 refundID: refundID) { _, error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -274,7 +274,7 @@ class RefundStoreTests: XCTestCase {
         network.simulateError(requestUrlSuffix: "orders/\(sampleOrderID)/refunds/\(sampleRefundID)", error: NetworkError.notFound())
         let action = RefundAction.retrieveRefund(siteID: sampleSiteID,
                                                  orderID: sampleOrderID,
-                                                 refundID: sampleRefundID) { (refund, error) in
+                                                 refundID: sampleRefundID) { refund, error in
             XCTAssertNotNil(error)
             XCTAssertNil(refund)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.Refund.self), 0)

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -51,7 +51,7 @@ final class SettingStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "settings-general")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
 
-        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 20)
 
@@ -81,7 +81,7 @@ final class SettingStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
 
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "settings-general-alt")
-        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 19)
 
@@ -104,7 +104,7 @@ final class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "settings/general", filename: "generic_error")
-        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -119,7 +119,7 @@ final class SettingStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve general site settings empty response")
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -228,7 +228,7 @@ final class SettingStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "settings/products", filename: "settings-product")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 0)
 
-        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 23)
 
@@ -258,7 +258,7 @@ final class SettingStoreTests: XCTestCase {
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.SiteSetting.self), 2)
 
         network.simulateResponse(requestUrlSuffix: "settings/products", filename: "settings-product-alt")
-        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNil(error)
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.SiteSetting.self), 22)
 
@@ -281,7 +281,7 @@ final class SettingStoreTests: XCTestCase {
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
         network.simulateResponse(requestUrlSuffix: "settings/products", filename: "generic_error")
-        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -296,7 +296,7 @@ final class SettingStoreTests: XCTestCase {
         let expectation = self.expectation(description: "Retrieve product site settings empty response")
         let settingStore = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
-        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { (error) in
+        let action = SettingAction.synchronizeProductSiteSettings(siteID: sampleSiteID) { error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }

--- a/Modules/Tests/YosemiteTests/Stores/ShippingLabelStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ShippingLabelStoreTests.swift
@@ -551,7 +551,7 @@ final class ShippingLabelStoreTests: XCTestCase {
                                                                   orderID: self.sampleOrderID,
                                                                   originAddress: ShippingLabelAddress.fake(),
                                                                   destinationAddress: ShippingLabelAddress.fake(),
-                                                                  packages: [ShippingLabelPackageSelected.fake()]) { (result) in
+                                                                  packages: [ShippingLabelPackageSelected.fake()]) { result in
                 promise(result)
             }
             store.onAction(action)
@@ -574,7 +574,7 @@ final class ShippingLabelStoreTests: XCTestCase {
                                                                   orderID: self.sampleOrderID,
                                                                   originAddress: ShippingLabelAddress.fake(),
                                                                   destinationAddress: ShippingLabelAddress.fake(),
-                                                                  packages: [ShippingLabelPackageSelected.fake()]) { (result) in
+                                                                  packages: [ShippingLabelPackageSelected.fake()]) { result in
                 promise(result)
             }
             store.onAction(action)

--- a/Modules/Tests/YosemiteTests/Stores/SitePostStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SitePostStoreTests.swift
@@ -43,7 +43,7 @@ final class SitePostStoreTests: XCTestCase {
         let postID: Int64 = 7
 
         network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/posts/\(postID)", filename: "site-post")
-        let action = SitePostAction.retrieveSitePostPassword(siteID: sampleSiteID, postID: postID) { (password, error) in
+        let action = SitePostAction.retrieveSitePostPassword(siteID: sampleSiteID, postID: postID) { password, error in
             XCTAssertNil(error)
             XCTAssertNotNil(password)
             XCTAssertEqual(password, "woooooooo!")

--- a/Modules/Tests/YosemiteTests/Stores/TaxStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/TaxStoreTests.swift
@@ -68,7 +68,7 @@ final class TaxStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxClass.self), 0)
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { _, error in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.TaxClass.self), 3)
             XCTAssertNil(error)
 
@@ -90,7 +90,7 @@ final class TaxStoreTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.TaxClass.self), 0)
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { _, error in
             XCTAssertNil(error)
 
             let storedTaxClass = self.viewStorage.loadTaxClass(slug: remoteTaxClass.slug)
@@ -113,7 +113,7 @@ final class TaxStoreTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "generic_error")
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { _, error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -127,7 +127,7 @@ final class TaxStoreTests: XCTestCase {
     func testRetrieveTaxClassesReturnsErrorUponEmptyResponse() {
         let expectation = self.expectation(description: "Retrieve tax class empty response")
 
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (_, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { _, error in
             XCTAssertNotNil(error)
             expectation.fulfill()
         }
@@ -143,7 +143,7 @@ final class TaxStoreTests: XCTestCase {
         let remoteTaxClass = sampleTaxClass()
 
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
-        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { (taxClasses, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: sampleSiteID) { taxClasses, error in
             XCTAssertNil(error)
             XCTAssertNotNil(taxClasses?.first)
             XCTAssertEqual(taxClasses?.first, remoteTaxClass)
@@ -164,7 +164,7 @@ final class TaxStoreTests: XCTestCase {
 
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 2020, taxClass: "standard")
         network.simulateResponse(requestUrlSuffix: "taxes/classes", filename: "taxes-classes")
-        let action = TaxAction.requestMissingTaxClasses(for: product) { (taxClass, _) in
+        let action = TaxAction.requestMissingTaxClasses(for: product) { taxClass, _ in
             XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.TaxClass.self), 3)
 
             XCTAssertEqual(taxClass?.slug, product.taxClass)

--- a/Modules/Tests/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -134,7 +134,7 @@ final class ResultsControllerTests: XCTestCase {
             XCTAssertFalse(didChangeObjectWasCalled)
             expectation.fulfill()
         }
-        resultsController.onDidChangeObject = { (_, _, _, _) in
+        resultsController.onDidChangeObject = { _, _, _, _ in
             didChangeObjectWasCalled = true
         }
 
@@ -152,7 +152,7 @@ final class ResultsControllerTests: XCTestCase {
         let expectation = self.expectation(description: "OnDidChange")
         var didChangeObjectWasCalled = false
 
-        resultsController.onDidChangeObject = { (_, _, _, _) in
+        resultsController.onDidChangeObject = { _, _, _, _ in
             didChangeObjectWasCalled = true
         }
         resultsController.onDidChangeContent = {
@@ -173,7 +173,7 @@ final class ResultsControllerTests: XCTestCase {
         try? resultsController.performFetch()
 
         let expectation = self.expectation(description: "OnDidChange")
-        resultsController.onDidChangeObject = { (_, _, type, newIndexPath) in
+        resultsController.onDidChangeObject = { _, _, type, newIndexPath in
             let expectedIndexPath = IndexPath(row: 0, section: 0)
 
             XCTAssertEqual(type, .insert)
@@ -197,7 +197,7 @@ final class ResultsControllerTests: XCTestCase {
         try? resultsController.performFetch()
 
         let expectation = self.expectation(description: "OnDidChange")
-        resultsController.onDidChangeSection = { (_, _, type) in
+        resultsController.onDidChangeSection = { _, _, type in
             XCTAssertEqual(type, .insert)
             expectation.fulfill()
         }

--- a/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
+++ b/WooCommerce/Classes/Authentication/AppleIDCredentialChecker.swift
@@ -73,7 +73,7 @@ private extension AppleIDCredentialChecker {
         }
 
         // Get the Apple User ID state. If not authorized, log out the account.
-        authenticator.getAppleIDCredentialState(for: appleUserID) { [weak self] (state, error) in
+        authenticator.getAppleIDCredentialState(for: appleUserID) { [weak self] state, error in
             DDLogDebug("checkAppleIDCredentialState: Apple ID state: \(state.rawValue)")
 
             switch state {

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/ULErrorViewController.swift
@@ -197,7 +197,7 @@ private extension ULErrorViewController {
 
         // We need to wait until view did appear to make sure the indicator stays at the correct position
         primaryButtonSubscription = viewModel.isPrimaryButtonLoading.combineLatest(viewDidAppearSubject.prefix(1))
-            .sink { [weak self] (isLoading, _) in
+            .sink { [weak self] isLoading, _ in
                 guard let self else { return }
                 self.primaryButton.isEnabled = !isLoading
                 if isLoading {

--- a/WooCommerce/Classes/Bookings/BookingFilters/SyncableListSelectorView.swift
+++ b/WooCommerce/Classes/Bookings/BookingFilters/SyncableListSelectorView.swift
@@ -79,7 +79,7 @@ private extension SyncableListSelectorView {
             .renderedIf(viewModel.searchQuery.isEmpty)
             .listRowSeparator(.hidden, edges: .top)
 
-            ForEach(Array(items.enumerated()), id: \.element) { (index, item) in
+            ForEach(Array(items.enumerated()), id: \.element) { index, item in
                 optionRow(text: syncable.displayName(for: item),
                           description: syncable.description(for: item),
                           isSelected: selectedItems.contains(where: { $0 == syncable.filterItem(for: item) }),

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -403,7 +403,7 @@ extension PushNotificationsManager {
         func registerForWPComPushNotificationsIfPossible() {
             if stores.isAuthenticatedWithoutWPCom { return }
             // Register in the Dotcom's Infrastructure
-            registerDotcomDevice(with: newToken) { (device, error) in
+            registerDotcomDevice(with: newToken) { device, error in
                 guard let deviceID = device?.deviceID else {
                     DDLogError("⛔️ Dotcom Push Notifications Registration Failure: \(error.debugDescription)")
                     return

--- a/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
+++ b/WooCommerce/Classes/Notifications/UserNotificationsCenterAdapter.swift
@@ -51,7 +51,7 @@ extension UNUserNotificationCenter: UserNotificationsCenterAdapter {
     ///
     func requestAuthorization(queue: DispatchQueue = .main, includesProvisionalAuth: Bool, completion: @escaping (Bool) -> Void) {
         let options: UNAuthorizationOptions = includesProvisionalAuth ? [.badge, .sound, .alert, .provisional]: [.badge, .sound, .alert]
-        requestAuthorization(options: options) { (allowed, _)  in
+        requestAuthorization(options: options) { allowed, _ in
             queue.async {
                 completion(allowed)
             }

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -78,7 +78,7 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
         let configurationDependencies = Publishers.CombineLatest($enablesCrashReports, $account)
 
         let watchDependencies = Publishers.CombineLatest(requiredDependencies, configurationDependencies)
-            .map { (required, configuration) -> WatchDependencies? in
+            .map { required, configuration -> WatchDependencies? in
 
                 let (storeID, storeName, credentials, currencySettings) = required
                 let (enablesCrashReports, account) = configuration

--- a/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
+++ b/WooCommerce/Classes/Tools/AggregateData/AggregateDataHelper.swift
@@ -26,13 +26,13 @@ final class AggregateDataHelper {
         // Creates an array of dictionaries, with the refunded order item ID as the key.
         // Example: [refundedItemID: [item, item], refundedItemID: [item]]
         // Since dictionary keys are unique, this eliminates the duplicate `OrderItemRefund`s.
-        let grouped = Dictionary(grouping: items) { (item) in
+        let grouped = Dictionary(grouping: items) { item in
             // There should always be a refunded item ID (the ID for the refunded `OrderItem`).
             // As a fallback, use the `OrderItemRefund` ID as a unique ID for the refund.
             return item.refundedItemID ?? item.itemID.description
         }
 
-        let unsortedResult = grouped.compactMap { (key, items) -> AggregateOrderItem? in
+        let unsortedResult = grouped.compactMap { key, items -> AggregateOrderItem? in
             // Here we iterate over each group's items
 
             // All items should be equal except for quantity and price, so we pick the first
@@ -106,11 +106,11 @@ final class AggregateDataHelper {
 
         let allItems = convertedItems + refundedProducts
 
-        let grouped = Dictionary(grouping: allItems) { (item) in
+        let grouped = Dictionary(grouping: allItems) { item in
             return item.itemID
         }
 
-        let unsortedResult: [AggregateOrderItem] = grouped.compactMap { (_, items) in
+        let unsortedResult: [AggregateOrderItem] = grouped.compactMap { _, items in
             // Here we iterate over each group's items
 
             // All items should be equal except for quantity and price, so we pick the first

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -70,7 +70,7 @@ private struct CurrentOrderListSyncUseCase {
     @MainActor
     private func fetchFilters() async -> FilterOrderListViewModel.Filters {
         return await withCheckedContinuation { continuation in
-            let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { (result) in
+            let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { result in
                 switch result {
                 case .success(let settings):
                     let filters = FilterOrderListViewModel.Filters(orderStatus: settings.orderStatusesFilter,

--- a/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
+++ b/WooCommerce/Classes/Tools/ImageService/DefaultImageService.swift
@@ -77,7 +77,7 @@ struct DefaultImageService: ImageService {
         imageView.kf.setImage(with: url,
                               placeholder: placeholder,
                               options: options,
-                              progressBlock: progressBlock) { (result) in
+                              progressBlock: progressBlock) { result in
             switch result {
             case .success(let imageResult):
                 let image = imageResult.image

--- a/WooCommerce/Classes/Tools/MapsHelper.swift
+++ b/WooCommerce/Classes/Tools/MapsHelper.swift
@@ -9,7 +9,7 @@ final class MapsHelper {
             completion(.failure(.locationNotFound))
             return
         }
-        CLGeocoder().geocodeAddressString(address) { (placemarksOptional, _) -> Void in
+        CLGeocoder().geocodeAddressString(address) { placemarksOptional, _ -> Void in
             guard let placemarks = placemarksOptional else {
                 completion(.failure(.locationNotFound))
                 return

--- a/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
+++ b/WooCommerce/Classes/Tools/ResultsController+UIKit.swift
@@ -74,7 +74,7 @@ private extension ResultsController {
     /// Sets up all of the Object Events from the inner FRC over to the specified TableView.
     ///
     func startForwardingObjectEvents(to tableView: UITableView, with animations: ResultsTableAnimations) {
-        onDidChangeObject = { [weak tableView] (_, indexPath, type, newIndexPath) in
+        onDidChangeObject = { [weak tableView] _, indexPath, type, newIndexPath in
             guard let `tableView` = tableView else {
                 return
             }
@@ -120,7 +120,7 @@ private extension ResultsController {
     /// Sets up all of the Section Events from the inner FRC over to the specified TableView.
     ///
     func startForwardingSectionEvents(to tableView: UITableView, with animations: ResultsTableAnimations) {
-        onDidChangeSection = { [weak tableView] (_, sectionIndex, type) in
+        onDidChangeSection = { [weak tableView] _, sectionIndex, type in
             guard let `tableView` = tableView else {
                 return
             }

--- a/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
+++ b/WooCommerce/Classes/Tools/Shared Site Settings/SelectedSiteSettings.swift
@@ -69,7 +69,7 @@ extension SelectedSiteSettings {
     /// Setup: ResultsController
     ///
     private func configureResultsController() {
-        resultsController.onDidChangeObject = { [weak self] (object, _, _, _) in
+        resultsController.onDidChangeObject = { [weak self] object, _, _, _ in
             guard let self else { return }
             ServiceLocator.currencySettings.updateCurrencyOptions(with: object)
             self.siteSettings = self.resultsController.fetchedObjects

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -215,7 +215,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
             }
         }
 
-        getUserInformationAndShowPrompt(withName: true, from: viewController) { (success, _) in
+        getUserInformationAndShowPrompt(withName: true, from: viewController) { success, _ in
             completion(success)
         }
     }
@@ -301,7 +301,7 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
             withName = false
         }
 
-        getUserInformationAndShowPrompt(withName: withName, from: controller) { (success, email) in
+        getUserInformationAndShowPrompt(withName: withName, from: controller) { success, email in
             completion(success, email)
         }
     }
@@ -342,7 +342,7 @@ private extension ZendeskManager {
     func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping onUserInformationCompletion) {
         presentInController = viewController
         getUserInformationIfAvailable()
-        promptUserForInformation(withName: withName, from: viewController) { (success, email) in
+        promptUserForInformation(withName: withName, from: viewController) { success, email in
             guard success else {
                 DDLogInfo("No user information to create Zendesk identity with.")
                 completion(false, nil)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/ReceiptActionCoordinator.swift
@@ -14,7 +14,7 @@ struct ReceiptActionCoordinator {
                                                                     source: .local))
 
          await withCheckedContinuation { continuation in
-            let action = ReceiptAction.print(order: order, parameters: params) { (result) in
+            let action = ReceiptAction.print(order: order, parameters: params) { result in
                 switch result {
                 case .success:
                     analytics.track(event: .InPersonPayments.receiptPrintSuccess(countryCode: countryCode,

--- a/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/MainTabViewModel.swift
@@ -112,7 +112,7 @@ private extension MainTabViewModel {
     /// Connect hooks on `ResultsController` and query cached data
     ///
     func configureStatusResultsController() {
-        statusResultsController?.onDidChangeObject = { [weak self] (updatedOrdersStatus, _, _, _) in
+        statusResultsController?.onDidChangeObject = { [weak self] updatedOrdersStatus, _, _, _ in
             self?.processBadgeCount(updatedOrdersStatus)
         }
 

--- a/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ManualTrackingViewModel.swift
@@ -170,7 +170,7 @@ extension AddTrackingViewModel {
     private func loadSelectedShipmentProvider() {
         let siteID = order.siteID
 
-        let action = AppSettingsAction.loadTrackingProvider(siteID: siteID) { [weak self] (provider, providerGroup, error) in
+        let action = AppSettingsAction.loadTrackingProvider(siteID: siteID) { [weak self] provider, providerGroup, error in
             guard let error else {
                 self?.shipmentProvider = provider
                 self?.shipmentProviderGroupName = providerGroup?.name
@@ -283,7 +283,7 @@ extension AddCustomTrackingViewModel {
     private func loadSelectedCustomShipmentProvider() {
         let siteID = order.siteID
 
-        let action = AppSettingsAction.loadCustomTrackingProvider(siteID: siteID) { [weak self] (provider, error) in
+        let action = AppSettingsAction.loadCustomTrackingProvider(siteID: siteID) { [weak self] provider, error in
             guard let error else {
                 self?.providerName = provider?.name
                 self?.trackingLink = provider?.url

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1467,7 +1467,7 @@ extension OrderDetailsDataSource {
 
             /// Shipping Address
             /// Almost always visible to allow editing.
-            let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
+            let orderContainsOnlyVirtualProducts = self.products.filter { product -> Bool in
                 return items.contains(where: { $0.productID == product.productID})
             }.allSatisfy { $0.virtual == true }
 
@@ -1668,7 +1668,7 @@ extension OrderDetailsDataSource {
         var sections: [NoteSection] = []
 
         for order in orderNotes {
-            if sections.contains(where: { (section) -> Bool in
+            if sections.contains(where: { section -> Bool in
                 return Calendar.current.isDate(section.date, inSameDayAs: order.dateCreated) && section.row == .orderNoteHeader
             }) {
                 let orderToAppend = NoteSection(row: .orderNote, date: order.dateCreated, orderNote: order)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -385,7 +385,7 @@ extension OrderDetailsViewModel {
     }
 
     func syncOrder(onCompletion: ((Error?) -> ())? = nil) {
-        syncOrder { [weak self] (order, error) in
+        syncOrder { [weak self] order, error in
             guard let self, let order else {
                 onCompletion?(error)
                 return
@@ -660,7 +660,7 @@ extension OrderDetailsViewModel {
     }
 
     func syncOrder(onCompletion: ((Order?, Error?) -> ())? = nil) {
-        let action = OrderAction.retrieveOrder(siteID: order.siteID, orderID: order.orderID) { (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: order.siteID, orderID: order.orderID) { order, error in
             guard let _ = order else {
                 DDLogError("⛔️ Error synchronizing Order: \(error.debugDescription)")
                 onCompletion?(nil, error)
@@ -674,7 +674,7 @@ extension OrderDetailsViewModel {
     }
 
     func syncNotes(onCompletion: ((Error?) -> ())? = nil) {
-        let action = OrderNoteAction.retrieveOrderNotes(siteID: order.siteID, orderID: order.orderID) { [weak self] (orderNotes, error) in
+        let action = OrderNoteAction.retrieveOrderNotes(siteID: order.siteID, orderID: order.orderID) { [weak self] orderNotes, error in
             guard let orderNotes else {
                 DDLogError("⛔️ Error synchronizing Order Notes: \(error.debugDescription)")
                 self?.orderNotes = []
@@ -692,7 +692,7 @@ extension OrderDetailsViewModel {
     }
 
     func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
-        let action = ProductAction.requestMissingProducts(for: order) { (error) in
+        let action = ProductAction.requestMissingProducts(for: order) { error in
             if let error {
                 DDLogError("⛔️ Error synchronizing Products: \(error)")
                 onCompletion?(error)
@@ -727,7 +727,7 @@ extension OrderDetailsViewModel {
             return
         }
 
-        let action = RefundAction.retrieveRefunds(siteID: order.siteID, orderID: order.orderID, refundIDs: refundIDs, deleteStaleRefunds: true) { (error) in
+        let action = RefundAction.retrieveRefunds(siteID: order.siteID, orderID: order.orderID, refundIDs: refundIDs, deleteStaleRefunds: true) { error in
             if let error {
                 DDLogError("⛔️ Error synchronizing detailed Refunds: \(error)")
                 onCompletion?(error)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderPaymentDetailsViewModel.swift
@@ -67,7 +67,7 @@ final class OrderPaymentDetailsViewModel {
     }
 
     private var feesTotal: Decimal {
-        let subtotal = order.fees.reduce(Constants.decimalZero) { (output, fee) in
+        let subtotal = order.fees.reduce(Constants.decimalZero) { output, fee in
             let feeSubtotal = Decimal(string: fee.total) ?? Constants.decimalZero
             return output + feeSubtotal
         }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -220,7 +220,7 @@ private extension CustomFieldsListViewModel {
     func observePendingChanges() {
         $pendingChanges
             .combineLatest($originalCustomFields)
-            .map { (pendingChanges, originalFields) in
+            .map { pendingChanges, originalFields in
                 return originalFields
                     .filter { field in !pendingChanges.deletedFieldIds.contains(where: { $0 == field.fieldID }) }
                     .map { field in pendingChanges.editedFields.first(where: { $0.fieldID == field.fieldID }) ?? field }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -154,7 +154,7 @@ extension CustomersListViewModel: PaginationTrackerDelegate {
 
         searchTermPublisher
             .combineLatest(searchFilterPublisher.prepend(searchFilter)) // Use configured filter as initial value
-            .sink { [weak self] (searchTerm, searchFilter) in
+            .sink { [weak self] searchTerm, searchFilter in
                 guard let self else { return }
                 self.updatePredicate(searchTerm: searchTerm)
                 self.updateResults()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsWebReport.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsWebReport.swift
@@ -43,7 +43,7 @@ struct AnalyticsWebReport {
             reportQueryParams["before"] = dateFormatter.string(from: endDate)
         }
 
-        reportURLComponents?.queryItems = reportQueryParams.map { (key, value) in
+        reportURLComponents?.queryItems = reportQueryParams.map { key, value in
             URLQueryItem(name: key, value: value)
         }
         return reportURLComponents?.url

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -314,7 +314,7 @@ private extension StatsDataTextFormatter {
     /// Retrieves the visitor count for the provided site stats and a specific interval.
     ///
     static func visitorCount(at selectedIndex: Int, siteStats: SiteVisitStats?) -> Double? {
-        let siteStatsItems = siteStats?.items?.sorted(by: { (lhs, rhs) -> Bool in
+        let siteStatsItems = siteStats?.items?.sorted(by: { lhs, rhs -> Bool in
             return lhs.period < rhs.period
         }) ?? []
         if selectedIndex < siteStatsItems.count {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
@@ -6,7 +6,7 @@ struct StatsIntervalDataParser {
     /// Returns the stats intervals, ordered by date.
     ///
     static func sortStatsIntervals<Stats: WCAnalyticsStats>(from stats: Stats?) -> [Stats.Interval] {
-        return stats?.intervals.sorted(by: { (lhs, rhs) -> Bool in
+        return stats?.intervals.sorted(by: { lhs, rhs -> Bool in
             let siteTimezone = TimeZone.siteTimezone
             return lhs.dateStart(timeZone: siteTimezone) < rhs.dateStart(timeZone: siteTimezone)
         }) ?? []

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -108,7 +108,7 @@ class StoreOnboardingViewModel: ObservableObject {
                 }
                 return true
             }
-            .map { [siteID] (noTasksAvailable, completedDict) in
+            .map { [siteID] noTasksAvailable, completedDict in
                 !(noTasksAvailable || (completedDict[String(siteID)] == true))
             }
             .assign(to: &$canShowInDashboard)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsResultsControllers.swift
@@ -35,7 +35,7 @@ final class CardReaderSettingsResultsControllers {
             onReload()
         }
 
-        paymentGatewayAccountResultsController.onDidChangeObject = { (_, _, _, _) in
+        paymentGatewayAccountResultsController.onDidChangeObject = { _, _, _, _ in
             onReload()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -413,7 +413,7 @@ private extension HelpAndSupportViewController {
             return
         }
 
-        ZendeskProvider.shared.showSupportEmailPrompt(from: navController) { [weak self] (success, _) in
+        ZendeskProvider.shared.showSupportEmailPrompt(from: navController) { [weak self] success, _ in
             guard success else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -271,7 +271,7 @@ private extension StoreStatsPeriodViewModel {
            !orderStats.intervals.isEmpty,
            let items = siteStats?.items,
            items.count > orderStats.intervals.count {
-            let sortedItems = items.sorted(by: { (lhs, rhs) -> Bool in
+            let sortedItems = items.sorted(by: { lhs, rhs -> Bool in
                 return lhs.period < rhs.period
             })
             let matchingItems = Array(sortedItems.suffix(orderStats.intervals.count))

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecEditorViewController.swift
@@ -61,7 +61,7 @@ final class AztecEditorViewController: UIViewController, Editor {
     /// Aztec's Format Bar (toolbar above the keyboard)
     ///
     private lazy var formatBar: Aztec.FormatBar = {
-        let toolbar = formatBarFactory.formatBar() { [weak self] (formatBarItem, formatBar) in
+        let toolbar = formatBarFactory.formatBar() { [weak self] formatBarItem, formatBar in
             guard let self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Editor/FormatBar/Command/Implementation/AztecLinkFormatBarCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/FormatBar/Command/Implementation/AztecLinkFormatBarCommand.swift
@@ -49,7 +49,7 @@ private extension AztecLinkFormatBarCommand {
                                         openInNewWindow: target != nil,
                                         isNewLink: isInsertingNewLink)
         let linkController = LinkSettingsViewController(linkSettings: linkSettings,
-                                                        callback: { (action, settings) in
+                                                        callback: { action, settings in
             self.presenter?.dismiss(animated: true) {
                 richTextView.becomeFirstResponder()
                 switch action {

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -199,7 +199,7 @@ where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.
             return resultsController.object(at: indexPath)
         }
         let objects = resultsController.sections[indexPath.section].objects
-            .sorted(by: { (lhs, rhs) -> Bool in
+            .sorted(by: { lhs, rhs -> Bool in
                 return customResultsSortOrder(lhs, rhs)
             })
         return objects[indexPath.row]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -171,7 +171,7 @@ private extension ShippingLineSelectionDetailsViewModel {
     func observeShippingLineDetailsForUIStates(with currencyFormatter: CurrencyFormatter) {
         formattableAmountViewModel.$amount
             .combineLatest($methodTitle, $selectedMethod)
-            .map { [weak self] (amount, methodTitle, selectedMethod) in
+            .map { [weak self] amount, methodTitle, selectedMethod in
                 guard let self, let amountDecimal = currencyFormatter.convertToDecimal(amount) as? Decimal else {
                     return false
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
@@ -176,7 +176,7 @@ private extension EditableOrderShippingLineViewModel {
             .map { $0.shippingLines }
             .removeDuplicates()
             .combineLatest($shouldShowNonEditableIndicators)
-            .map { [weak self] (shippingLines, isNonEditable) -> [ShippingLineRowViewModel] in
+            .map { [weak self] shippingLines, isNonEditable -> [ShippingLineRowViewModel] in
                 guard let self else { return [] }
                 return shippingLines.compactMap { shippingLine in
                     guard !shippingLine.isDeleted else { return nil }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Order Notes Section/Add Order Note/NewNoteViewController.swift
@@ -66,7 +66,7 @@ class NewNoteViewController: UIViewController {
         let action = OrderNoteAction.addOrderNote(siteID: viewModel.order.siteID,
                                                   orderID: viewModel.orderID,
                                                   isCustomerNote: isCustomerNote,
-                                                  note: noteText) { [weak self] (orderNote, error) in
+                                                  note: noteText) { [weak self] orderNote, error in
             if let error {
                 DDLogError("⛔️ Error adding a note: \(error.localizedDescription)")
                 self?.viewModel.track(.orderNoteAddFailed, withError: error)
@@ -146,7 +146,7 @@ private extension NewNoteViewController {
         let cellViewModel = TextViewTableViewCell.ViewModel(icon: .asideImage,
                                                             iconAccessibilityLabel: iconAccessibilityLabel,
                                                             iconTint: isCustomerNote ? .primary : .textSubtle,
-                                                            onTextChange: { [weak self] (text) in
+                                                            onTextChange: { [weak self] text in
                                                                 self?.navigationItem.rightBarButtonItem?.isEnabled = !text.isEmpty
                                                                 self?.noteText = text
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -239,7 +239,7 @@ private extension OrderDetailsViewController {
             self?.reloadTableViewSectionsAndData()
         }
 
-        viewModel.onCellAction = { [weak self] (actionType, indexPath) in
+        viewModel.onCellAction = { [weak self] actionType, indexPath in
             self?.handleCellAction(actionType, at: indexPath)
         }
 
@@ -680,10 +680,10 @@ private extension OrderDetailsViewController {
                                                 message: Localization.Alert.orderTrashConfirmationMessage,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.orderTrashConfirmationCancelButton,
-                                   style: .cancel) { (_) in
+                                   style: .cancel) { _ in
         }
         let confirm = UIAlertAction(title: Localization.Alert.orderTrashConfirmationConfirmButton,
-                                    style: .default) { [weak self] (_) in
+                                    style: .default) { [weak self] _ in
             self?.trashOrderAction()
         }
         alertController.addAction(cancel)
@@ -782,7 +782,7 @@ extension OrderDetailsViewController: UITableViewDelegate {
         }
 
         let copyActionTitle = NSLocalizedString("Copy", comment: "Copy address text button title — should be one word and as short as possible.")
-        let copyAction = UIContextualAction(style: .normal, title: copyActionTitle) { [weak self] (_, _, success) in
+        let copyAction = UIContextualAction(style: .normal, title: copyActionTitle) { [weak self] _, _, success in
             self?.viewModel.dataSource.copyText(at: indexPath)
             success(true)
         }
@@ -888,7 +888,7 @@ private extension OrderDetailsViewController {
 
         let viewModel = self.viewModel
 
-        statusListViewModel.didApplySelection = { [weak statusList] (selectedStatus) in
+        statusListViewModel.didApplySelection = { [weak statusList] selectedStatus in
             statusList?.dismiss(animated: true) {
                 OrderDetailsViewController.setOrderStatus(to: selectedStatus, viewModel: viewModel)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -100,7 +100,7 @@ private extension OrderLoaderViewController {
             return self.state = .success(order: storedOrder)
         }
 
-        let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { [weak self] (order, error) in
+        let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { [weak self] order, error in
             guard let self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewModel.swift
@@ -276,7 +276,7 @@ private extension ReviewOrderViewModel {
 
         let addressRow: Row? = {
             let orderContainsOnlyVirtualProducts = products
-                .filter { (product) -> Bool in
+                .filter { product -> Bool in
                     order.items.contains(where: { $0.productID == product.productID})
                 }
                 .allSatisfy { $0.virtual == true }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriers.swift
@@ -142,7 +142,7 @@ struct ShippingLabelCarriers_Previews: PreviewProvider {
                                                 originAddress: shippingAddress,
                                                 destinationAddress: shippingAddress,
                                                 packages: [])
-        ShippingLabelCarriers(viewModel: vm) { (_) in
+        ShippingLabelCarriers(viewModel: vm) { _ in
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Carriers and Rates/ShippingLabelCarriersViewModel.swift
@@ -52,7 +52,7 @@ final class ShippingLabelCarriersViewModel: ObservableObject {
     ///
     var ghostRows: [ShippingLabelCarrierRowViewModel] {
         return Array(0..<3).map { _ in
-            ShippingLabelCarrierRowViewModel(rate: sampleGhostRate()) { (_, _, _) in }
+            ShippingLabelCarrierRowViewModel(rate: sampleGhostRate()) { _, _, _ in }
         }
     }
 
@@ -93,7 +93,7 @@ final class ShippingLabelCarriersViewModel: ObservableObject {
                                                         rate: rate,
                                                         signatureRate: signature,
                                                         adultSignatureRate: adultSignature,
-                                                        currencySettings: currencySettings) { [weak self] (rate, signature, adultSignature) in
+                                                        currencySettings: currencySettings) { [weak self] rate, signature, adultSignature in
                     guard let self else { return }
 
                     // update the existing selected rate for the package
@@ -149,7 +149,7 @@ private extension ShippingLabelCarriersViewModel {
                                                               orderID: order.orderID,
                                                               originAddress: originAddress,
                                                               destinationAddress: destinationAddress,
-                                                              packages: packages) { [weak self] (result) in
+                                                              packages: packages) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success(let response):

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Cells/ShippingLabelSummaryTableViewCell.swift
@@ -80,7 +80,7 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
             stackView.removeFromSuperview()
         }
         if rates.isNotEmpty {
-            packageRatesStackViews = rates.enumerated().map { (index, rateText) in
+            packageRatesStackViews = rates.enumerated().map { index, rateText in
                 let titleLabel = UILabel()
                 titleLabel.applyBodyStyle()
                 titleLabel.text = String(format: Localization.packageNumber, index + 1)
@@ -98,7 +98,7 @@ final class ShippingLabelSummaryTableViewCell: UITableViewCell {
                 stackView.addArrangedSubviews([titleLabel, descriptionLabel])
                 return stackView
             }
-            packageRatesStackViews.enumerated().forEach { (index, stackView) in
+            packageRatesStackViews.enumerated().forEach { index, stackView in
                 mainStackView.insertArrangedSubview(stackView, at: index)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -45,7 +45,7 @@ struct ShippingLabelCustomsFormInput: View {
                 ListHeaderView(text: Localization.packageContentSection.uppercased(), alignment: .left)
                     .padding(.horizontal, insets: safeAreaInsets)
 
-                ForEach(Array(viewModel.items.enumerated()), id: \.element) { (index, item) in
+                ForEach(Array(viewModel.items.enumerated()), id: \.element) { index, item in
                     viewModel.itemViewModels.first(where: { $0.productID == item.productID })
                         .map { inputModel in
                             ShippingLabelCustomsFormItemDetails(itemNumber: index + 1,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormList.swift
@@ -63,7 +63,7 @@ struct ShippingLabelCustomsFormList: View {
                         .highlight(on: $isShippingNoticeBannerHighlighted, color: Color(.accent))
                         .id(shippingNoticeBannerID)
 
-                    ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { (index, item) in
+                    ForEach(Array(viewModel.inputViewModels.enumerated()), id: \.offset) { index, item in
                         ShippingLabelCustomsFormInput(isCollapsible: viewModel.multiplePackagesDetected,
                                                       packageNumber: index + 1,
                                                       safeAreaInsets: geometry.safeAreaInsets,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormListViewModel.swift
@@ -109,7 +109,7 @@ private extension ShippingLabelCustomsFormListViewModel {
     /// Observe changes in all customs forms and save their validation states by package ID.
     ///
     func configureFormsValidation() {
-        inputViewModels.enumerated().forEach { (index, viewModel) in
+        inputViewModels.enumerated().forEach { index, viewModel in
             viewModel.$validForm
                 .sink { [weak self] isValid in
                     self?.customsFormValidation[index] = isValid

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -390,10 +390,10 @@ private extension ShippingLabelPackagesFormViewModel {
         resultsControllers = ShippingLabelPackageDetailsResultsControllers(siteID: order.siteID,
                                                                            orderItems: order.items,
                                                                            storageManager: storageManager,
-           onProductReload: { [weak self] (products) in
+           onProductReload: { [weak self] products in
             guard let self else { return }
             self.products = products
-        }, onProductVariationsReload: { [weak self] (productVariations) in
+        }, onProductVariationsReload: { [weak self] productVariations in
             guard let self else { return }
             self.productVariations = productVariations
         })
@@ -407,7 +407,7 @@ private extension ShippingLabelPackagesFormViewModel {
 ///
 private extension ShippingLabelPackagesFormViewModel {
     func syncProducts(onCompletion: ((Error?) -> ())? = nil) {
-        let action = ProductAction.requestMissingProducts(for: order) { (error) in
+        let action = ProductAction.requestMissingProducts(for: order) { error in
             if let error {
                 DDLogError("⛔️ Error synchronizing Products: \(error)")
                 onCompletion?(error)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/ShippingLabelPackageListViewModel.swift
@@ -36,7 +36,7 @@ final class ShippingLabelPackageListViewModel: ObservableObject {
 
     lazy var addNewPackageViewModel = ShippingLabelAddNewPackageViewModel(siteID: siteID,
                                                                           packagesResponse: packagesResponse,
-                                                                          onCompletion: { [weak self] (customPackage, predefinedOption, packagesResponse) in
+                                                                          onCompletion: { [weak self] customPackage, predefinedOption, packagesResponse in
                                                                             guard let self else { return }
                                                                             self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                                                           })
@@ -121,7 +121,7 @@ extension ShippingLabelPackageListViewModel {
 
         addNewPackageViewModel = .init(siteID: siteID,
                                        packagesResponse: packagesResponse,
-                                       onCompletion: { [weak self] (customPackage, predefinedOption, packagesResponse) in
+                                       onCompletion: { [weak self] customPackage, predefinedOption, packagesResponse in
                                          guard let self else { return }
                                          self.handleNewPackage(customPackage, predefinedOption, packagesResponse)
                                        })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -210,26 +210,26 @@ struct ShippingLabelPaymentMethods_Previews: PreviewProvider {
         let accountSettingsWithoutEditPermissions = ShippingLabelPaymentMethodsViewModel.sampleAccountSettings(withPermissions: false)
         let disabledViewModel = ShippingLabelPaymentMethodsViewModel(accountSettings: accountSettingsWithoutEditPermissions)
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { _ in
         })
         .colorScheme(.light)
         .previewDisplayName("Light mode")
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { _ in
         })
         .colorScheme(.dark)
         .previewDisplayName("Dark Mode")
 
-        ShippingLabelPaymentMethods(viewModel: disabledViewModel, completion: { (_) in
+        ShippingLabelPaymentMethods(viewModel: disabledViewModel, completion: { _ in
         })
         .previewDisplayName("Disabled state")
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { _ in
         })
         .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
         .previewDisplayName("Accessibility: Large Font Size")
 
-        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { (_) in
+        ShippingLabelPaymentMethods(viewModel: viewModel, completion: { _ in
         })
         .environment(\.layoutDirection, .rightToLeft)
         .previewDisplayName("Localization: Right-to-Left Layout")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Suggested Address/ShippingLabelSuggestedAddressViewController.swift
@@ -177,7 +177,7 @@ private extension ShippingLabelSuggestedAddressViewController {
             email: email,
             validationError: nil,
             countries: countries,
-            completion: { [weak self] (newShippingLabelAddress) in
+            completion: { [weak self] newShippingLabelAddress in
                 guard let self else { return }
                 self.onCompletion(newShippingLabelAddress)
                 self.navigationController?.popViewController(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -25,7 +25,7 @@ final class ShippingLabelAddressFormViewController: UIViewController {
             shipType: viewModel.type,
             hasContactInfo: !phone.isNilOrEmpty || !email.isNilOrEmpty
         ) { [weak self] in
-            MapsHelper.openAppleMaps(address: self?.viewModel.address?.formattedPostalAddress) { [weak self] (result) in
+            MapsHelper.openAppleMaps(address: self?.viewModel.address?.formattedPostalAddress) { [weak self] result in
                 ServiceLocator.analytics.track(.shippingLabelEditAddressOpenMapButtonTapped)
                 switch result {
                 case .success:
@@ -244,7 +244,7 @@ private extension ShippingLabelAddressFormViewController {
 
     @objc func doneButtonTapped() {
         ServiceLocator.analytics.track(.shippingLabelEditAddressDoneButtonTapped)
-        viewModel.validateAddress(onlyLocally: false) { [weak self] (result) in
+        viewModel.validateAddress(onlyLocally: false) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success:
@@ -260,7 +260,7 @@ private extension ShippingLabelAddressFormViewController {
 
     @objc func confirmButtonTapped() {
         ServiceLocator.analytics.track(.shippingLabelEditAddressUseAddressAsIsButtonTapped)
-        viewModel.validateAddress(onlyLocally: true) { [weak self] (result) in
+        viewModel.validateAddress(onlyLocally: true) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success:
@@ -381,7 +381,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: placeholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
         cell.configure(viewModel: cellViewModel)
@@ -393,7 +393,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: Localization.companyFieldPlaceholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
         cell.configure(viewModel: cellViewModel)
@@ -406,7 +406,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: placeholder,
                                                                      state: .normal,
                                                                      keyboardType: .phonePad,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             let phone = newText?.filter { "0"..."9" ~= $0 }
             self?.viewModel.handleAddressValueChanges(row: row, newValue: phone)
         }
@@ -420,7 +420,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: Localization.addressFieldPlaceholder,
                                                                      state: state,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
         cell.configure(viewModel: cellViewModel)
@@ -432,7 +432,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: Localization.address2FieldPlaceholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
         cell.configure(viewModel: cellViewModel)
@@ -471,7 +471,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: Localization.cityFieldPlaceholder,
                                                                      state: .normal,
                                                                      keyboardType: .default,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
         cell.configure(viewModel: cellViewModel)
@@ -483,7 +483,7 @@ private extension ShippingLabelAddressFormViewController {
                                                                      placeholder: Localization.postcodeFieldPlaceholder,
                                                                      state: .normal,
                                                                      keyboardType: viewModel.isUSAddress ? .phonePad : .namePhonePad,
-                                                                     textFieldAlignment: .leading) { [weak self] (newText) in
+                                                                     textFieldAlignment: .leading) { [weak self] newText in
             self?.viewModel.handleAddressValueChanges(row: row, newValue: newText)
         }
         cell.configure(viewModel: cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewModel.swift
@@ -314,7 +314,7 @@ extension ShippingLabelAddressFormViewModel {
 
         state.isLoading = true
         let addressToBeVerified = ShippingLabelAddressVerification(address: address, type: type)
-        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] (result) in
+        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] result in
             switch result {
             case .success:
                 ServiceLocator.analytics.track(.shippingLabelAddressValidationSucceeded)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -266,7 +266,7 @@ private extension ShippingLabelFormViewController {
                originAddress.phone.isEmpty {
                 return self.displayEditAddressFormVC(address: originAddress, email: nil, validationError: nil, type: .origin)
             }
-            self.viewModel.validateAddress(type: .origin) { [weak self] (validationState, response) in
+            self.viewModel.validateAddress(type: .origin) { [weak self] validationState, response in
                 guard let self else { return }
                 let shippingLabelAddress = self.viewModel.originAddress
                 switch validationState {
@@ -305,7 +305,7 @@ private extension ShippingLabelFormViewController {
                                                      type: .destination)
             }
 
-            self.viewModel.validateAddress(type: .destination) { [weak self] (validationState, response) in
+            self.viewModel.validateAddress(type: .destination) { [weak self] validationState, response in
                 guard let self else { return }
                 let shippingLabelAddress = self.viewModel.destinationAddress
                 switch validationState {
@@ -385,7 +385,7 @@ private extension ShippingLabelFormViewController {
             let discountInfoVC = ShippingLabelDiscountInfoViewController()
             let bottomSheet = BottomSheetViewController(childViewController: discountInfoVC)
             bottomSheet.show(from: self, sourceView: cell)
-        } onSwitchChange: { [weak self] (switchIsOn) in
+        } onSwitchChange: { [weak self] switchIsOn in
             self?.shouldMarkOrderComplete = switchIsOn
         } onButtonTouchUp: { [weak self] in
             guard let self else { return }
@@ -443,7 +443,7 @@ private extension ShippingLabelFormViewController {
             needsPhoneNumberValidation: viewModel.customsFormRequired,
             validationError: validationError,
             countries: viewModel.filteredCountries(for: type),
-            completion: { [weak self] (newShippingLabelAddress) in
+            completion: { [weak self] newShippingLabelAddress in
                 guard let self else { return }
                 switch type {
                 case .origin:
@@ -470,7 +470,7 @@ private extension ShippingLabelFormViewController {
                                                              type: type,
                                                              address: address,
                                                              suggestedAddress: suggestedAddress, email: email,
-                                                             countries: viewModel.countries) { [weak self] (newShippingLabelAddress) in
+                                                             countries: viewModel.countries) { [weak self] newShippingLabelAddress in
             switch type {
             case .origin:
                 self?.viewModel.handleOriginAddressValueChanges(address: newShippingLabelAddress,
@@ -490,7 +490,7 @@ private extension ShippingLabelFormViewController {
                                                     onSelectionCompletion: { [weak self] selectedPackages in
                                                         self?.viewModel.handlePackageDetailsValueChanges(details: selectedPackages)
                                                     },
-                                                    onPackageSyncCompletion: { [weak self] (packagesResponse) in
+                                                    onPackageSyncCompletion: { [weak self] packagesResponse in
                                                       self?.viewModel.handleNewPackagesResponse(packagesResponse: packagesResponse)
                                                     })
         let packagesForm = ShippingLabelPackagesForm(viewModel: vm)
@@ -528,7 +528,7 @@ private extension ShippingLabelFormViewController {
                                                 packages: viewModel.selectedPackages,
                                                 selectedRates: selectedRates)
 
-        let carriersView = ShippingLabelCarriers(viewModel: vm) { [weak self] (selectedRates) in
+        let carriersView = ShippingLabelCarriers(viewModel: vm) { [weak self] selectedRates in
             self?.viewModel.handleCarrierAndRatesValueChanges(selectedRates: selectedRates,
                                                               editable: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -529,7 +529,7 @@ private extension ShippingLabelFormViewModel {
         }
 
         var summarySection: Section?
-        if rows.allSatisfy({ (row) -> Bool in
+        if rows.allSatisfy({ row -> Bool in
             row.dataState == .validated && row.displayMode == .editable
         }) {
             summarySection = Section(title: Localization.orderSummaryHeader.uppercased(),
@@ -743,7 +743,7 @@ private extension ShippingLabelFormViewModel {
 extension ShippingLabelFormViewModel {
     func fetchCountries() {
         try? resultsController.performFetch()
-        let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] (result) in
+        let action = DataAction.synchronizeCountries(siteID: siteID) { [weak self] result in
             guard let self else { return }
             switch result {
             case .success:
@@ -773,7 +773,7 @@ extension ShippingLabelFormViewModel {
 
         updateValidatingAddressState(true, type: type)
 
-        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] (result) in
+        let action = ShippingLabelAction.validateAddress(siteID: siteID, address: addressToBeVerified) { [weak self] result in
 
             guard let self else { return }
             switch result {
@@ -846,7 +846,7 @@ extension ShippingLabelFormViewModel {
             return
         }
 
-        let packages = selectedPackages.enumerated().compactMap { (_, package) -> ShippingLabelPackagePurchase? in
+        let packages = selectedPackages.enumerated().compactMap { _, package -> ShippingLabelPackagePurchase? in
             guard let selectedRate = selectedRates.first(where: { $0.packageID == package.id }),
                   let details = selectedPackagesDetails.first(where: { $0.id == package.id }) else {
                 return nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -108,7 +108,7 @@ private extension PrintShippingLabelCoordinator {
     func presentAirPrint(printData: ShippingLabelPrintData) {
         let printController = UIPrintInteractionController()
         printController.printingItem = printData.data
-        printController.present(animated: true) { [weak self] (_, completed, _) in
+        printController.present(animated: true) { [weak self] _, completed, _ in
             if completed {
                 self?.showCustomsFormPrintingIfNeeded()
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -353,7 +353,7 @@ private extension WooShippingShipmentDetailsViewModel {
             .assign(to: &$shippingService)
 
         $originAddress.combineLatest($destinationAddress)
-            .map { (originAddress, destinationAddress) -> Bool in
+            .map { originAddress, destinationAddress -> Bool in
                 guard let originAddress, let destinationAddress else {
                     return false
                 }
@@ -406,7 +406,7 @@ private extension WooShippingShipmentDetailsViewModel {
                                  newValue: ShippingLabelHazmatCategory?) in
                 return (current: newValue, previous: previous.current)
             }
-            .map { [weak self] (newValue, oldValue) in
+            .map { [weak self] newValue, oldValue in
                 let noticeTitle = newValue != nil ? Localization.hazmatSet : Localization.hazmatRemoved
                 return Notice(title: noticeTitle, actionTitle: Localization.undo, actionHandler: {
                     self?.hazmatCategory = oldValue
@@ -417,7 +417,7 @@ private extension WooShippingShipmentDetailsViewModel {
 
     func observeCustomsForm() {
         customsFormViewModel.$isMissingITN.combineLatest($customsFormRequired)
-            .map { (isMissingITN, customsFormRequired) -> String? in
+            .map { isMissingITN, customsFormRequired -> String? in
                 if customsFormRequired, isMissingITN {
                     return Localization.itnMissing
                 }
@@ -426,7 +426,7 @@ private extension WooShippingShipmentDetailsViewModel {
             .assign(to: &$itnMissingNoticeLabel)
 
         customsFormViewModel.$requiredInformationIsEntered.combineLatest($customsFormRequired)
-            .map { (requiredInfoIsEntered, customsFormRequired) -> Bool in
+            .map { requiredInfoIsEntered, customsFormRequired -> Bool in
                 requiredInfoIsEntered && customsFormRequired
             }
             .assign(to: &$customsInformationIsCompleted)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -250,7 +250,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         if self.carrierPackages.isNotEmpty {
             // sort new packages so they stay in similar order
             // sort only if we already had carrier packages before
-            let sortedCarrierPackages = self.carrierPackages.sorted { (carrierA, carrierB) in
+            let sortedCarrierPackages = self.carrierPackages.sorted { carrierA, carrierB in
                 let carrierAIndex = self.carrierPackages.firstIndex(where: { $0.id == carrierA.id })
                 let carrierBIndex = self.carrierPackages.firstIndex(where: { $0.id == carrierB.id })
                 if let firstI = carrierAIndex, let secondI = carrierBIndex {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -246,7 +246,7 @@ private extension WooShippingServiceViewModel {
     /// Generates the data to display available shipping rates, grouped by carrier ID.
     func generateServiceTabs() {
         serviceTabs = standardRates.grouped(by: { $0.carrierID })
-            .compactMap { (carrierID, rates) -> WooShippingServiceTab? in
+            .compactMap { carrierID, rates -> WooShippingServiceTab? in
                 guard let carrier = WooShippingCarrier(rawValue: carrierID) else {
                     return nil
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -77,7 +77,7 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     private let purchasedIcon = UIImage(systemName: "checkmark.circle.fill")?.withRenderingMode(.alwaysTemplate)
 
     var topTabItems: [TopTabItem<EmptyView>] {
-        shipments.enumerated().map { (index, item) in
+        shipments.enumerated().map { index, item in
             return TopTabItem(name: String.localizedStringWithFormat(Localization.shipmentFormat, index + 1),
                               icon: item.isPurchased ? purchasedIcon : nil,
                               content: { EmptyView() })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -151,7 +151,7 @@ struct WooShippingCreateLabelsView: View {
 
 private extension WooShippingCreateLabelsView {
     var tabs: [TopTabItem<EmptyView>] {
-        viewModel.shipments.enumerated().map { (index, shipment) in
+        viewModel.shipments.enumerated().map { index, shipment in
             TopTabItem(name: String.localizedStringWithFormat(Localization.shipmentFormat, index + 1),
                        icon: shipment.isPurchased ? Layout.purchasedIcon : nil,
                        customAccessibilityValue: shipment.isPurchased ?

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/OrderDatesFilterViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/Date Range Filter/OrderDatesFilterViewController.swift
@@ -102,7 +102,7 @@ extension OrderDatesFilterViewController: UITableViewDelegate {
             // Open the View Controller for selecting a custom range of dates
             //
             let dateRangeFilterVC = DateRangeFilterViewController(startDate: selected?.startDate,
-                                                                  endDate: selected?.endDate) { [weak self] (startDate, endDate) in
+                                                                  endDate: selected?.endDate) { [weak self] startDate, endDate in
                 guard let self else { return }
                 self.selected = OrderDateRangeFilter(filter: .custom, startDate: startDate, endDate: endDate)
                 self.configureRows()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -388,7 +388,7 @@ private extension OrdersRootViewController {
     /// This is useful for stay up to date with the remote statuses, resetting the filters if one of the local status filters was deleted remotely.
     ///
     func configureStatusResultsController() {
-        statusResultsController.onDidChangeObject = { [weak self] (_, _, _, _) in
+        statusResultsController.onDidChangeObject = { [weak self] _, _, _, _ in
             guard let self else { return }
             self.resetFiltersIfAnyStatusFilterIsNoMoreExisting(orderStatuses: self.statusResultsController.fetchedObjects)
         }
@@ -455,7 +455,7 @@ private extension OrdersRootViewController {
     /// Fetch local Orders Settings (eg. status or date range filters stored in Orders settings)
     ///
     func syncLocalOrdersSettings(onCompletion: @escaping (Result<StoredOrderSettings.Setting, Error>) -> Void) {
-        let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { [weak self] (result) in
+        let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { [weak self] result in
             switch result {
             case .success(let settings):
                 self?.filters = FilterOrderListViewModel.Filters(orderStatus: settings.orderStatusesFilter,

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -428,7 +428,7 @@ private extension RefundSubmissionUseCase {
     /// - Parameters:
     ///   - refund: the refund to retrieve details from.
     private func retrieveUpdatedRefundData(refund: Refund) {
-        let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) { (_, error) in
+        let action = RefundAction.retrieveRefund(siteID: details.order.siteID, orderID: details.order.orderID, refundID: refund.refundID) { _, error in
                 if let error {
                     DDLogError("Error retrieving refund: \(String(describing: refund))\nWith Error: \(error)")
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryViewModelBuilder.swift
@@ -23,7 +23,7 @@ extension ProductCategoryListViewModel {
             /// Returns a dictionary  where each key holds a category `parentID` each value an array of subcategories.
             ///
             private static func nodesFromCategories(_ productCategories: [ProductCategory]) -> [Int64: [ProductCategory]] {
-                return productCategories.reduce(into: [Int64: [ProductCategory]]()) { (result, category) in
+                return productCategories.reduce(into: [Int64: [ProductCategory]]()) { result, category in
                     var children = result[category.parentID] ?? []
                     children.append(category)
                     result[category.parentID] = children

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -104,7 +104,7 @@ extension ProductsTabProductTableViewCell {
                 imageService.downloadAndCacheImageForImageView(productImageView,
                                                                with: productURLString,
                                                                placeholder: .productsTabProductCellPlaceholderImage,
-                                                               progressBlock: nil) { [weak self] (image, error) in
+                                                               progressBlock: nil) { [weak self] image, error in
                                                                 let success = image != nil && error == nil
                                                                 if success {
                                                                     self?.productImageView.contentMode = .scaleAspectFill

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Add or Edit File/ProductDownloadFileViewController.swift
@@ -72,7 +72,7 @@ extension ProductDownloadFileViewController {
         menuAlert.view.tintColor = .text
 
         let deleteTitle = Localization.actionSheetDeleteTitle
-        let deleteAction = UIAlertAction(title: deleteTitle, style: .destructive) { [weak self] (_) in
+        let deleteAction = UIAlertAction(title: deleteTitle, style: .destructive) { [weak self] _ in
             ServiceLocator.analytics.track(.productsDownloadableFile, withProperties: ["action": "deleted"])
             self?.onDeletion()
         }
@@ -107,7 +107,7 @@ extension ProductDownloadFileViewController {
         case .edit:
             ServiceLocator.analytics.track(.productsDownloadableFile, withProperties: ["action": "updated"])
         }
-        viewModel.completeUpdating { [weak self] (fileName, fileURL, fileID, hasUnsavedChanges) in
+        viewModel.completeUpdating { [weak self] fileName, fileURL, fileID, hasUnsavedChanges in
              self?.onCompletion(fileName, fileURL, fileID, hasUnsavedChanges)
         }
     }
@@ -163,7 +163,7 @@ private extension ProductDownloadFileViewController {
 
     func configureName(cell: TitleAndTextFieldTableViewCell) {
         let cellViewModel = Product.createDownloadFileNameViewModel(fileName: viewModel.fileName) { [weak self] value in
-            self?.viewModel.handleFileNameChange(value) { [weak self] (isValid) in
+            self?.viewModel.handleFileNameChange(value) { [weak self] isValid in
                 self?.enableDoneButton(isValid)
                 if let indexPath = self?.viewModel.sections.indexPathForRow(.name),
                     let cell = self?.tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell {
@@ -176,7 +176,7 @@ private extension ProductDownloadFileViewController {
 
     func configureURL(cell: TitleAndTextFieldTableViewCell) {
         let cellViewModel = Product.createDownloadFileUrlViewModel(fileUrl: viewModel.fileURL) { [weak self] value in
-            self?.viewModel.handleFileUrlChange(value) { [weak self] (isValid) in
+            self?.viewModel.handleFileUrlChange(value) { [weak self] isValid in
                 self?.enableDoneButton(isValid)
                 if let indexPath = self?.viewModel.sections.indexPathForRow(.url),
                     let cell = self?.tableView.cellForRow(at: indexPath) as? TitleAndTextFieldTableViewCell {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController+Droppable.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController+Droppable.swift
@@ -45,7 +45,7 @@ extension ProductDownloadListViewController: UITableViewDropDelegate {
 
         for item in coordinator.items {
             guard let sourceIndexPathRow = item.sourceIndexPath?.row else { continue }
-            item.dragItem.itemProvider.loadObject(ofClass: ProductDownloadDragAndDrop.self) { [weak self] (object, _) in
+            item.dragItem.itemProvider.loadObject(ofClass: ProductDownloadDragAndDrop.self) { [weak self] object, _ in
                 DispatchQueue.main.async {
                     if let item = object as? ProductDownloadDragAndDrop {
                         self?.viewModel.remove(at: sourceIndexPathRow)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -229,7 +229,7 @@ private extension ProductDownloadListViewController {
     func openDownloadableFile(productDownload: ProductDownload?, indexPath: IndexPath?, formType: ProductDownloadFileViewController.FormType) {
         let viewController = ProductDownloadFileViewController(productDownload: productDownload,
                                                                downloadFileIndex: indexPath?.row,
-                                                               formType: formType) { [weak self] (fileName, fileURL, fileID, hasUnsavedChanges) in
+                                                               formType: formType) { [weak self] fileName, fileURL, fileID, hasUnsavedChanges in
             self?.onAddEditDownloadableFileCompletion(fileName: fileName,
                                                       fileURL: fileURL,
                                                       fileID: fileID,
@@ -287,7 +287,7 @@ private extension ProductDownloadListViewController {
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         menuAlert.view.tintColor = .text
 
-        let downloadSettingsAction = UIAlertAction(title: Localization.downloadSettingsAction, style: .default) { [weak self] (_) in
+        let downloadSettingsAction = UIAlertAction(title: Localization.downloadSettingsAction, style: .default) { [weak self] _ in
             self?.showDownloadableFilesSettings()
         }
         menuAlert.addAction(downloadSettingsAction)
@@ -302,8 +302,7 @@ private extension ProductDownloadListViewController {
     }
 
     func showDownloadableFilesSettings() {
-        let viewController = ProductDownloadSettingsViewController(product: product) { [weak self]
-            (downloadLimit, downloadExpiry, hasUnsavedChanges) in
+        let viewController = ProductDownloadSettingsViewController(product: product) { [weak self]downloadLimit, downloadExpiry, hasUnsavedChanges in
             self?.onDownloadSettingsCompletion(downloadLimit: downloadLimit,
                                                downloadExpiry: downloadExpiry,
                                                hasUnsavedChanges: hasUnsavedChanges)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/Settings/ProductDownloadSettingsViewController.swift
@@ -67,7 +67,7 @@ extension ProductDownloadSettingsViewController {
     }
 
     @objc private func completeUpdating() {
-        viewModel.completeUpdating() { [weak self] (downloadLimit, downloadExpiry, hasUnsavedChanges) in
+        viewModel.completeUpdating() { [weak self] downloadLimit, downloadExpiry, hasUnsavedChanges in
             ServiceLocator.analytics.track(.productDownloadableFilesSettingsChanged)
             self?.onCompletion(downloadLimit, downloadExpiry, hasUnsavedChanges)
         }
@@ -152,7 +152,7 @@ private extension ProductDownloadSettingsViewController {
 
     func configureLimit(cell: TitleAndTextFieldTableViewCell) {
         let cellViewModel = Product.createDownloadLimitViewModel(downloadLimit: viewModel.downloadLimit) { [weak self] value in
-            self?.viewModel.handleDownloadLimitChange(value) { [weak self] (isValid) in
+            self?.viewModel.handleDownloadLimitChange(value) { [weak self] isValid in
                 self?.enableDoneButton(isValid)
                 self?.getDownloadLimitCell()?.textFieldBecomeFirstResponder()
             }
@@ -162,7 +162,7 @@ private extension ProductDownloadSettingsViewController {
 
     func configureExpiry(cell: TitleAndTextFieldTableViewCell) {
         let cellViewModel = Product.createDownloadExpiryViewModel(downloadExpiry: viewModel.downloadExpiry) { [weak self] value in
-            self?.viewModel.handleDownloadExpiryChange(value) { [weak self] (isValid) in
+            self?.viewModel.handleDownloadExpiryChange(value) { [weak self] isValid in
                 self?.enableDoneButton(isValid)
                 self?.getDownloadExpiryCell()?.textFieldBecomeFirstResponder()
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/Add Category/AddEditProductCategoryViewController.swift
@@ -160,7 +160,7 @@ extension AddEditProductCategoryViewController: UITableViewDelegate {
                 siteID: viewModel.siteID,
                 childCategory: viewModel.currentCategory,
                 selectedCategory: viewModel.selectedParentCategory
-            ) { [weak self] (parentCategory) in
+            ) { [weak self] parentCategory in
                 defer {
                     self?.navigationController?.popViewController(animated: true)
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/EditProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/EditProductCategoryListViewController.swift
@@ -120,7 +120,7 @@ extension EditProductCategoryListViewController {
 
     @objc private func addButtonTapped() {
         ServiceLocator.analytics.track(.productCategorySettingsAddButtonTapped)
-        let viewModel = AddEditProductCategoryViewModel(siteID: siteID) { [weak self] (newCategory) in
+        let viewModel = AddEditProductCategoryViewModel(siteID: siteID) { [weak self] newCategory in
             defer {
                 self?.dismiss(animated: true, completion: nil)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModel.swift
@@ -186,7 +186,7 @@ extension ProductPriceSettingsViewModel: ProductPriceSettingsActionHandler {
     // MARK: - Initialization
 
     func retrieveProductTaxClass(completion: @escaping () -> Void) {
-        let action = TaxAction.requestMissingTaxClasses(for: product) { [weak self] (taxClass, _) in
+        let action = TaxAction.requestMissingTaxClasses(for: product) { [weak self] taxClass, _ in
             self?.taxClass = taxClass ?? self?.standardTaxClass
             completion()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -256,7 +256,7 @@ private extension ProductTagsViewController {
     func createNewTagsRemotely() {
         configureRightBarButtonItemAsSpinner()
 
-        let action = ProductTagAction.addProductTags(siteID: product.siteID, tags: allTags) { [weak self] (result) in
+        let action = ProductTagAction.addProductTags(siteID: product.siteID, tags: allTags) { [weak self] result in
             guard let self else {
                 return
             }
@@ -347,7 +347,7 @@ private extension ProductTagsViewController {
         var fetchedTags = fetchedTags
         return tags.compactMap { tagName -> ProductTag? in
             let first = fetchedTags.first(where: { $0.name.lowercased() == tagName.lowercased() })
-            fetchedTags.removeAll(where: { (productTag) -> Bool in
+            fetchedTags.removeAll(where: { productTag -> Bool in
                 first?.name.lowercased() == productTag.name.lowercased()
             })
             return first

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -269,7 +269,7 @@ private extension ProductInventorySettingsViewController {
 
     func configureSKU(cell: TitleAndTextFieldTableViewCell) {
         var cellViewModel = Product.createSKUViewModel(sku: viewModel.sku) { [weak self] value in
-            self?.viewModel.handleSKUChange(value) { [weak self] (isValid, shouldBringUpKeyboard) in
+            self?.viewModel.handleSKUChange(value) { [weak self] isValid, shouldBringUpKeyboard in
                 self?.handleSKUValidation(isValid: isValid, shouldBringUpKeyboard: shouldBringUpKeyboard)
             }
         }
@@ -412,7 +412,7 @@ private extension ProductInventorySettingsViewController {
     }
 
     func onSKUBarcodeScanned(barcode: String) {
-        viewModel.handleSKUFromBarcodeScanner(barcode) { [weak self] (isValid, shouldBringUpKeyboard) in
+        viewModel.handleSKUFromBarcodeScanner(barcode) { [weak self] isValid, shouldBringUpKeyboard in
             self?.handleSKUValidation(isValid: isValid, shouldBringUpKeyboard: shouldBringUpKeyboard)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/LinkedProductListSelectorDataSource.swift
@@ -7,7 +7,7 @@ import Yosemite
 final class LinkedProductListSelectorDataSource: PaginatedListSelectorDataSource {
     typealias StorageModel = StorageProduct
 
-    lazy var customResultsSortOrder: ((Product, Product) -> Bool)? = { [weak self] (lhs, rhs) in
+    lazy var customResultsSortOrder: ((Product, Product) -> Bool)? = { [weak self] lhs, rhs in
         guard let self else {
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductTaxClassListSelectorDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/List Selector Data Source/ProductTaxClassListSelectorDataSource.swift
@@ -43,7 +43,7 @@ struct ProductTaxClassListSelectorDataSource: PaginatedListSelectorDataSource {
     }
 
     func sync(pageNumber: Int, pageSize: Int, onCompletion: ((Result<Bool, Error>) -> Void)?) {
-        let action = TaxAction.retrieveTaxClasses(siteID: siteID) { (_, error) in
+        let action = TaxAction.retrieveTaxClasses(siteID: siteID) { _, error in
             if let error {
                 DDLogError("⛔️ Error synchronizing tax classes: \(error)")
                 onCompletion?(.failure(error))

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsRows.swift
@@ -114,7 +114,7 @@ enum ProductSettingsRows {
             let viewController = ProductVisibilityViewController(
                 settings: settings,
                 showsPasswordProtectedVisibility: passwordProtectedAvailable
-            ) { (productSettings) in
+            ) { productSettings in
                 self.settings.password = productSettings.password
                 self.settings.status = productSettings.status
                 onCompletion(self.settings)
@@ -147,7 +147,7 @@ enum ProductSettingsRows {
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
             ServiceLocator.analytics.track(.productSettingsCatalogVisibilityTapped)
-            let viewController = ProductCatalogVisibilityViewController(settings: settings) { (productSettings) in
+            let viewController = ProductCatalogVisibilityViewController(settings: settings) { productSettings in
                 self.settings.featured = productSettings.featured
                 self.settings.catalogVisibility = productSettings.catalogVisibility
                 onCompletion(self.settings)
@@ -288,7 +288,7 @@ enum ProductSettingsRows {
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
             ServiceLocator.analytics.track(.productSettingsSlugTapped)
-            let viewController = ProductSlugViewController(settings: settings) { (productSettings) in
+            let viewController = ProductSlugViewController(settings: settings) { productSettings in
                 self.settings.slug = productSettings.slug
                 onCompletion(self.settings)
             }
@@ -319,7 +319,7 @@ enum ProductSettingsRows {
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
             ServiceLocator.analytics.track(.productSettingsPurchaseNoteTapped)
-            let viewController = ProductPurchaseNoteViewController(settings: settings) { (productSettings) in
+            let viewController = ProductPurchaseNoteViewController(settings: settings) { productSettings in
                 self.settings.purchaseNote = productSettings.purchaseNote
                 onCompletion(self.settings)
             }
@@ -350,7 +350,7 @@ enum ProductSettingsRows {
 
         func handleTap(sourceViewController: UIViewController, onCompletion: @escaping (ProductSettings) -> Void) {
             ServiceLocator.analytics.track(.productSettingsMenuOrderTapped)
-            let viewController = ProductMenuOrderViewController(settings: settings) { (productSettings) in
+            let viewController = ProductMenuOrderViewController(settings: settings) { productSettings in
                 self.settings.menuOrder = productSettings.menuOrder
                 onCompletion(self.settings)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -47,7 +47,7 @@ final class ProductSettingsViewController: UIViewController {
         viewModel.onReload = {  [weak self] in
             self?.tableView.reloadData()
         }
-        viewModel.onPasswordRetrieved = { [weak self] (passwordRetrieved) in
+        viewModel.onPasswordRetrieved = { [weak self] passwordRetrieved in
             self?.onPasswordCompletion(passwordRetrieved)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewModel.swift
@@ -55,7 +55,7 @@ final class ProductSettingsViewModel {
             /// If user is not on WC 8.1, and if the password is empty/nil,
             /// and user is authenticated with WP.com, enter here, otherwise we skip this.
             else if (product.password == nil || product.password?.isEmpty == true) && ServiceLocator.stores.isAuthenticatedWithoutWPCom == false {
-                retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] (password, error) in
+                retrieveProductPassword(siteID: product.siteID, productID: product.productID) { [weak self] password, error in
                     guard let self else {
                         return
                     }
@@ -76,7 +76,7 @@ final class ProductSettingsViewModel {
     func handleCellTap(at indexPath: IndexPath, sourceViewController: UIViewController) {
         let section = sections[indexPath.section]
         let row = section.rows[indexPath.row]
-        row.handleTap(sourceViewController: sourceViewController) { [weak self] (settings) in
+        row.handleTap(sourceViewController: sourceViewController) { [weak self] settings in
             guard let self else {
                 return
             }
@@ -95,7 +95,7 @@ final class ProductSettingsViewModel {
 // MARK: Syncing data. Yosemite related stuff
 private extension ProductSettingsViewModel {
     func retrieveProductPassword(siteID: Int64, productID: Int64, onCompletion: ((String?, Error?) -> ())? = nil) {
-        let action = SitePostAction.retrieveSitePostPassword(siteID: siteID, postID: productID) { (password, error) in
+        let action = SitePostAction.retrieveSitePostPassword(siteID: siteID, postID: productID) { password, error in
             guard let _ = password else {
                 DDLogError("⛔️ Error fetching product password: \(error.debugDescription)")
                 onCompletion?(nil, error)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Purchase Note/ProductPurchaseNoteViewController.swift
@@ -150,7 +150,7 @@ private extension ProductPurchaseNoteViewController {
 
         let cellViewModel = TextViewTableViewCell.ViewModel(text: productSettings.purchaseNote?.strippedHTML,
                                                             placeholder: placeholder,
-                                                            onTextChange: { [weak self] (text) in
+                                                            onTextChange: { [weak self] text in
             self?.productSettings.purchaseNote = text
         })
         cell.configure(with: cellViewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/Visibility/ProductVisibilityViewController.swift
@@ -240,7 +240,7 @@ private extension ProductVisibilityViewController {
 
         let placeholder = NSLocalizedString("Enter password", comment: "Enter password placeholder in Product Visibility")
         let viewModel = TitleAndTextFieldWithImageTableViewCell.ViewModel(title: row.description, text: productSettings.password,
-                                                                          placeholder: placeholder, image: .visibilityImage) { [weak self] (text) in
+                                                                          placeholder: placeholder, image: .visibilityImage) { [weak self] text in
             cell.rightImageViewIsHidden = text?.isEmpty == false
             self?.productSettings.password = text
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -175,13 +175,13 @@ private extension ProductFormTableViewDataSource {
         else {
             cell.configure(with: productImageStatuses, config: .extendedAddImages(isVariation: isVariation), productUIImageLoader: productUIImageLoader)
         }
-        cell.onImageSelected = { [weak self] (_, _) in
+        cell.onImageSelected = { [weak self] _, _ in
             self?.onAddImage?()
         }
         cell.onAddImage = { [weak self] in
             self?.onAddImage?()
         }
-        cell.onFailedUploadSelected = { [weak self] (asset, error) in
+        cell.onFailedUploadSelected = { [weak self] asset, error in
             self?.onFailedImageUpload?(asset, error)
         }
     }
@@ -210,7 +210,7 @@ private extension ProductFormTableViewDataSource {
                                                                    textViewMinimumHeight: 10.0,
                                                                    shouldDismissOnReturn: true,
                                                                    isScrollEnabled: false,
-                                                                   onNameChange: { [weak self] (newName) in self?.onNameChange?(newName) },
+                                                                   onNameChange: { [weak self] newName in self?.onNameChange?(newName) },
                                                                    style: .headline)
         cell.configure(with: cellViewModel)
         cell.accessibilityLabel = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -22,11 +22,11 @@ extension ProductFormViewController {
                                                 message: body,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.productTypeChangeCancelButton,
-                                   style: .cancel) { (_) in
+                                   style: .cancel) { _ in
                                        completion(false)
                                    }
         let confirm = UIAlertAction(title: Localization.Alert.productTypeChangeConfirmButton,
-                                    style: .default) { (_) in
+                                    style: .default) { _ in
                                         completion(true)
                                     }
         alertController.addAction(cancel)
@@ -72,11 +72,11 @@ extension ProductFormViewController {
                                                 message: Localization.Alert.productDeleteConfirmationMessage,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.productDeleteConfirmationCancelButton,
-                                   style: .cancel) { (_) in
+                                   style: .cancel) { _ in
                                        completion(false)
                                    }
         let confirm = UIAlertAction(title: Localization.Alert.productDeleteConfirmationConfirmButton,
-                                    style: .default) { (_) in
+                                    style: .default) { _ in
                                         completion(true)
                                     }
         alertController.addAction(cancel)
@@ -91,11 +91,11 @@ extension ProductFormViewController {
                                                 message: Localization.Alert.variationDeleteConfirmationMessage,
                                                 preferredStyle: .alert)
         let cancel = UIAlertAction(title: Localization.Alert.variationDeleteConfirmationCancelButton,
-                                   style: .cancel) { (_) in
+                                   style: .cancel) { _ in
             completion(false)
         }
         let confirm = UIAlertAction(title: Localization.Alert.variationDeleteConfirmationConfirmButton,
-                                    style: .default) { (_) in
+                                    style: .default) { _ in
             completion(true)
         }
         alertController.addAction(cancel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -950,7 +950,7 @@ private extension ProductFormViewController {
         }, onAddImage: { [weak self] in
             self?.eventLogger.logImageTapped()
             self?.showProductImages()
-        }, onFailedImageUpload: { [weak self] (asset, error) in
+        }, onFailedImageUpload: { [weak self] asset, error in
             self?.displayImageUploadErrorAlert(error: error, for: asset)
         })
     }
@@ -1235,12 +1235,12 @@ private extension ProductFormViewController {
         let viewController = ProductSettingsViewController(product: product.product,
                                                            password: password,
                                                            formType: viewModel.formType,
-                                                           completion: { [weak self] (productSettings) in
+                                                           completion: { [weak self] productSettings in
             guard let self else {
                 return
             }
             self.viewModel.updateProductSettings(productSettings)
-        }, onPasswordRetrieved: { [weak self] (originalPassword) in
+        }, onPasswordRetrieved: { [weak self] originalPassword in
             self?.viewModel.resetPassword(originalPassword)
         })
         navigationController?.pushViewController(viewController, animated: true)
@@ -1632,7 +1632,7 @@ private extension ProductFormViewController {
             source: .editForm(selected: productType),
             subscriptionProductsEligibilityChecker: subscriptionProductsEligibilityChecker,
             siteCIABEligibilityChecker: siteCIABEligibilityChecker
-        ) { [weak self] (selectedProductType) in
+        ) { [weak self] selectedProductType in
             self?.dismiss(animated: true, completion: nil)
 
             guard let originalProductType = self?.product.productType else {
@@ -1644,7 +1644,7 @@ private extension ProductFormViewController {
                 "to": selectedProductType.productType.rawValue
             ])
 
-            self?.presentProductTypeChangeAlert(for: originalProductType, completion: { (change) in
+            self?.presentProductTypeChangeAlert(for: originalProductType, completion: { change in
                 guard change == true else {
                     return
                 }
@@ -1661,7 +1661,7 @@ private extension ProductFormViewController {
 private extension ProductFormViewController {
     func editShippingSettings() {
         let shippingSettingsViewController = ProductShippingSettingsViewController(product: product) {
-            [weak self] (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
+            [weak self] weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges in
             self?.onEditShippingSettingsCompletion(weight: weight,
                                                    dimensions: dimensions,
                                                    oneTimeShipping: oneTimeShipping,
@@ -1759,7 +1759,7 @@ private extension ProductFormViewController {
             return
         }
 
-        let categoryListViewController = EditProductCategoryListViewController(product: product.product) { [weak self] (categories) in
+        let categoryListViewController = EditProductCategoryListViewController(product: product.product) { [weak self] categories in
             self?.onEditCategoriesCompletion(categories: categories)
         }
         show(categoryListViewController, sender: self)
@@ -1790,7 +1790,7 @@ private extension ProductFormViewController {
             return
         }
 
-        let tagsViewController = ProductTagsViewController(product: product.product) { [weak self] (tags) in
+        let tagsViewController = ProductTagsViewController(product: product.product) { [weak self] tags in
             self?.onEditTagsCompletion(tags: tags)
         }
         show(tagsViewController, sender: self)
@@ -1843,7 +1843,7 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func editLinkedProducts() {
-        let linkedProductsViewController = LinkedProductsViewController(product: product) { [weak self] (upsellIDs, crossSellIDs, hasUnsavedChanges) in
+        let linkedProductsViewController = LinkedProductsViewController(product: product) { [weak self] upsellIDs, crossSellIDs, hasUnsavedChanges in
             self?.onEditLinkedProductsCompletion(upsellIDs: upsellIDs, crossSellIDs: crossSellIDs, hasUnsavedChanges: hasUnsavedChanges)
         }
         navigationController?.pushViewController(linkedProductsViewController, animated: true)
@@ -1946,7 +1946,7 @@ private extension ProductFormViewController {
             return
         }
 
-        let downloadFileListViewController = ProductDownloadListViewController(product: product) { [weak self] (data, hasUnsavedChanges) in
+        let downloadFileListViewController = ProductDownloadListViewController(product: product) { [weak self] data, hasUnsavedChanges in
             self?.onAddEditDownloadsCompletion(data: data, hasUnsavedChanges: hasUnsavedChanges)
         }
         navigationController?.pushViewController(downloadFileListViewController, animated: true)
@@ -2002,7 +2002,7 @@ private extension ProductFormViewController {
             return
         }
 
-        let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel) { [weak self] (attributes) in
+        let attributePickerViewController = AttributePickerViewController(variationModel: productVariationModel) { [weak self] attributes in
             self?.onEditVariationAttributesCompletion(attributes: attributes)
         }
         show(attributePickerViewController, sender: self)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -87,7 +87,7 @@ private extension ProductShippingSettingsViewController {
 
         let action = ProductShippingClassAction
             .retrieveProductShippingClass(siteID: viewModel.product.siteID,
-                                          remoteID: viewModel.product.shippingClassID) { [weak self] (shippingClass, error) in
+                                          remoteID: viewModel.product.shippingClassID) { [weak self] shippingClass, error in
                                             guard let shippingClass, error == nil else {
                                                 return
                                             }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -100,7 +100,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
         }
 
         if let downloadedImage = await withCheckedContinuation({ continuation in
-            _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, _) in
+            _ = imageService.downloadImage(with: url, shouldCacheImage: true) { image, _ in
                 if let image {
                     continuation.resume(returning: image)
                 } else {
@@ -119,7 +119,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
     }
 
     func requestImage(asset: PHAsset, targetSize: CGSize, skipsDegradedImage: Bool, completion: @escaping (UIImage) -> Void) {
-        phAssetImageLoader.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFit, options: nil) { (image, info) in
+        phAssetImageLoader.requestImage(for: asset, targetSize: targetSize, contentMode: .aspectFit, options: nil) { image, info in
             guard let image else {
                 return
             }
@@ -147,7 +147,7 @@ private extension DefaultProductUIImageLoader {
             phAssetImageLoader.requestImage(for: asset,
                                             targetSize: PHImageManagerMaximumSize,
                                             contentMode: .aspectFit,
-                                            options: nil) { [weak self] (image, _) in
+                                            options: nil) { [weak self] image, _ in
                 guard let image, let self else {
                     return
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/Media+WPMediaAsset.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/Media+WPMediaAsset.swift
@@ -13,13 +13,13 @@ extension CancellableMedia: WPMediaAsset {
         // TODO-2073: move image fetching to `WordPressMediaLibraryPickerDataSource` instead of having to use the `ServiceLocator` singleton on a `Media`
         // extension.
         let imageService = ServiceLocator.imageService
-        imageService.retrieveImageFromCache(with: url) { [weak self] (image) in
+        imageService.retrieveImageFromCache(with: url) { [weak self] image in
             if let image {
                 completionHandler(image, nil)
                 return
             }
 
-            self?.cancellableTask = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, error) in
+            self?.cancellableTask = imageService.downloadImage(with: url, shouldCacheImage: true) { image, error in
                 completionHandler(image, error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -220,7 +220,7 @@ extension ProductImagesCollectionViewController {
         let productImagesGalleryViewController = ProductImagesGalleryViewController(images: productImageStatuses.images,
                                                                                     selectedIndex: selectedImageIndex,
                                                                                     isDeletionEnabled: isDeletionEnabled,
-                                                                                    productUIImageLoader: productUIImageLoader) { [weak self] (productImage) in
+                                                                                    productUIImageLoader: productUIImageLoader) { [weak self] productImage in
                                                                                         self?.onDeletion(productImage)
         }
         navigationController?.show(productImagesGalleryViewController, sender: self)

--- a/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/WordPressMediaLibraryPickerDataSource.swift
@@ -127,7 +127,7 @@ extension WordPressMediaLibraryPickerDataSource: WPMediaCollectionDataSource {
 
     func loadData(with options: WPMediaLoadOptions, success successBlock: WPMediaSuccessBlock?, failure failureBlock: WPMediaFailureBlock? = nil) {
         syncingCoordinator.resetInternalState()
-        retrieveMedia(pageNumber: syncingCoordinator.pageFirstIndex, pageSize: Constants.numberOfItemsPerPage) { [weak self] (mediaItems, error) in
+        retrieveMedia(pageNumber: syncingCoordinator.pageFirstIndex, pageSize: Constants.numberOfItemsPerPage) { [weak self] mediaItems, error in
             guard let self else {
                 return
             }
@@ -162,7 +162,7 @@ extension WordPressMediaLibraryPickerDataSource: WPMediaCollectionDataSource {
 
 extension WordPressMediaLibraryPickerDataSource: SyncingCoordinatorDelegate {
     func sync(pageNumber: Int, pageSize: Int, reason: String?, onCompletion: ((Bool) -> Void)?) {
-        retrieveMedia(pageNumber: pageNumber, pageSize: pageSize) { [weak self] (mediaItems, error) in
+        retrieveMedia(pageNumber: pageNumber, pageSize: pageSize) { [weak self] mediaItems, error in
             guard let self else {
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -889,7 +889,7 @@ private extension ProductSelectorViewModel {
     /// Resetting filters from local products settings helps to show the correct products in the main product list screen.
     ///
     func resetFiltersUsingLocalProductsSettings() {
-        let action = AppSettingsAction.loadProductsSettings(siteID: siteID) { [weak self] (result) in
+        let action = AppSettingsAction.loadProductsSettings(siteID: siteID) { [weak self] result in
             guard let self else { return }
 
             switch result {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -947,7 +947,7 @@ private extension ProductsViewController {
     /// If no info are stored (so there is a failure), we resynchronize the syncingCoordinator for updating the screen using the default sort/filters.
     ///
     func syncProductsSettings() {
-        syncLocalProductsSettings { [weak self] (result) in
+        syncLocalProductsSettings { [weak self] result in
             guard let self else { return }
 
             if result.isFailure {
@@ -1475,7 +1475,7 @@ extension ProductsViewController: PaginationTrackerDelegate {
                                                               productStatusFilter: filters.productStatus,
                                                               productTypeFilter: filters.promotableProductType?.productType,
                                                               productCategoryFilter: filters.productCategory,
-                                                              favoriteProduct: filters.favoriteProduct != nil) { (_) in
+                                                              favoriteProduct: filters.favoriteProduct != nil) { _ in
         }
         ServiceLocator.stores.dispatch(action)
     }
@@ -1483,7 +1483,7 @@ extension ProductsViewController: PaginationTrackerDelegate {
     /// Fetch local Products Settings (eg. sort order or filters stored in Products settings)
     ///
     private func syncLocalProductsSettings(onCompletion: @escaping (Result<StoredProductSettings.Setting, Error>) -> Void) {
-        let action = AppSettingsAction.loadProductsSettings(siteID: siteID) { [weak self] (result) in
+        let action = AppSettingsAction.loadProductsSettings(siteID: siteID) { [weak self] result in
             switch result {
             case .success(let settings):
                 self?.syncProductCategoryFilterRemotely(from: settings) { [weak self] settings in

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SegmentedView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SegmentedView.swift
@@ -24,7 +24,7 @@ struct SegmentedView<Content: View>: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            ForEach(0..<views.count, id: \.self) { (index) in
+            ForEach(0..<views.count, id: \.self) { index in
                 VStack(spacing: 0) {
                     getContentView(index)
                     if index == selection {

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewDetailsViewController.swift
@@ -152,7 +152,7 @@ private extension ReviewDetailsViewController {
     /// Synchronizes the Notifications associated to the active WordPress.com account.
     ///
     func synchronizeReview(reviewID: Int64, onCompletion: @escaping () -> Void) {
-        let action = ProductReviewAction.retrieveProductReview(siteID: siteID, reviewID: reviewID) { (_, error) in
+        let action = ProductReviewAction.retrieveProductReview(siteID: siteID, reviewID: reviewID) { _, error in
             if let error {
                 DDLogError("⛔️ Error synchronizing product review [\(reviewID)]: \(error)")
                 ServiceLocator.analytics.track(.reviewLoadFailed,
@@ -451,32 +451,32 @@ private extension ReviewDetailsViewController {
             return [ProductReviewAction.updateApprovalStatus(siteID: siteID,
                                                              reviewID: reviewID,
                                                              isApproved: true,
-                                                             onCompletion: {(_, error) in onCompletion(error)})]
+                                                             onCompletion: {_, error in onCompletion(error)})]
         case .hold:
             return [ProductReviewAction.updateApprovalStatus(siteID: siteID,
                                                              reviewID: reviewID,
                                                              isApproved: false,
-                                                             onCompletion: {(_, error) in onCompletion(error)})]
+                                                             onCompletion: {_, error in onCompletion(error)})]
         case .spam:
             return [ProductReviewAction.updateSpamStatus(siteID: siteID,
                                                              reviewID: reviewID,
                                                              isSpam: true,
-                                                             onCompletion: {(_, error) in onCompletion(error)})]
+                                                             onCompletion: {_, error in onCompletion(error)})]
         case .unspam:
             return [ProductReviewAction.updateSpamStatus(siteID: siteID,
                                                              reviewID: reviewID,
                                                              isSpam: false,
-                                                             onCompletion: {(_, error) in onCompletion(error)})]
+                                                             onCompletion: {_, error in onCompletion(error)})]
         case .trash:
             return [ProductReviewAction.updateTrashStatus(siteID: siteID,
                                                              reviewID: reviewID,
                                                              isTrashed: true,
-                                                             onCompletion: {(_, error) in onCompletion(error)})]
+                                                             onCompletion: {_, error in onCompletion(error)})]
         case .untrash:
             return [ProductReviewAction.updateTrashStatus(siteID: siteID,
                                                              reviewID: reviewID,
                                                              isTrashed: false,
-                                                             onCompletion: {(_, error) in onCompletion(error)})]
+                                                             onCompletion: {_, error in onCompletion(error)})]
         }
     }
 
@@ -491,7 +491,7 @@ private extension ReviewDetailsViewController {
                                        withProperties: ["remote_review_id": productReview.reviewID,
                                                         "remote_note_id": note.noteID])
 
-        let action = NotificationAction.updateReadStatus(noteID: note.noteID, read: true) { (error) in
+        let action = NotificationAction.updateReadStatus(noteID: note.noteID, read: true) { error in
             if let error {
                 DDLogError("⛔️ Error marking single notification as read: \(error)")
                 ServiceLocator.analytics.track(.reviewMarkReadFailed,

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -275,7 +275,7 @@ private extension XCUIElementAttributes {
 
 private extension XCUIElementQuery {
     var networkLoadingIndicators: XCUIElementQuery {
-        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+        let isNetworkLoadingIndicator = NSPredicate { evaluatedObject, _ in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
 
             return element.isNetworkLoadingIndicator
@@ -292,7 +292,7 @@ private extension XCUIElementQuery {
 
         let deviceWidth = app.windows.firstMatch.frame.width
 
-        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+        let isStatusBar = NSPredicate { evaluatedObject, _ in
             guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
 
             return element.isStatusBar(deviceWidth)

--- a/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListSyncManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListSyncManagerTests.swift
@@ -382,7 +382,7 @@ private extension WidgetSiteListSyncManagerTests {
             ("woocommerce_price_thousand_sep", ","),
             ("woocommerce_price_decimal_sep", "."),
             ("woocommerce_price_num_decimals", "2")
-        ].map { (settingID, value) in
+        ].map { settingID, value in
             makeSiteSetting(siteID: siteID, settingID: settingID, value: value, settingGroupKey: settingGroupKey)
         }
     }

--- a/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooConstantsTests.swift
@@ -11,7 +11,7 @@ final class WooConstantsTests: XCTestCase {
         let allTrustedURLs = allTrustedURLPaths.map { $0.asURL() }
 
         // Then
-        zip(allTrustedURLPaths, allTrustedURLs).forEach { (path, url) in
+        zip(allTrustedURLPaths, allTrustedURLs).forEach { path, url in
             XCTAssertEqual(path.asURL().absoluteString, url.absoluteString)
         }
     }

--- a/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DefaultImageServiceTests.swift
@@ -30,7 +30,7 @@ final class DefaultImageServiceTests: XCTestCase {
         // Downloads the image and retrieves it again.
         let waitForDownloadingAndCachingAnImage = expectation(description: "Wait for downloading and caching an image")
         let waitForRetrievingImageAfterDownload = expectation(description: "Wait for retrieving image after the previous download")
-        _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, _) in
+        _ = imageService.downloadImage(with: url, shouldCacheImage: true) { image, _ in
             XCTAssertNotNil(image)
             waitForDownloadingAndCachingAnImage.fulfill()
 
@@ -47,7 +47,7 @@ final class DefaultImageServiceTests: XCTestCase {
         // Downloads the image without caching and retrieves it again.
         let waitForDownloadingAndCachingAnImage = expectation(description: "Wait for downloading an image")
         let waitForRetrievingImageAfterDownload = expectation(description: "Wait for retrieving image after the previous download")
-        _ = imageService.downloadImage(with: url, shouldCacheImage: false) { (image, _) in
+        _ = imageService.downloadImage(with: url, shouldCacheImage: false) { image, _ in
             XCTAssertNotNil(image)
             waitForDownloadingAndCachingAnImage.fulfill()
 
@@ -63,7 +63,7 @@ final class DefaultImageServiceTests: XCTestCase {
     func testCancellingDownloadingAnImage() {
         // Arrange
         let waitForDownloadingAnImage = expectation(description: "Wait for downloading an image")
-        let task = imageService.downloadImage(with: url, shouldCacheImage: true) { (_, _) in
+        let task = imageService.downloadImage(with: url, shouldCacheImage: true) { _, _ in
             waitForDownloadingAnImage.fulfill()
         }
 
@@ -98,7 +98,7 @@ final class DefaultImageServiceTests: XCTestCase {
             .downloadAndCacheImageForImageView(mockImageView,
                                                with: url.absoluteString,
                                                placeholder: mockPlaceholder,
-                                               progressBlock: nil) { (image, _) in
+                                               progressBlock: nil) { image, _ in
                                                 XCTAssertNotNil(image)
                                                 waitForDownloadingAndCachingAnImage.fulfill()
 
@@ -134,7 +134,7 @@ final class DefaultImageServiceTests: XCTestCase {
             .downloadAndCacheImageForImageView(mockImageView,
                                                with: urlStringWithSpecialChars,
                                                placeholder: mockPlaceholder,
-                                               progressBlock: nil) { (image, _) in
+                                               progressBlock: nil) { image, _ in
                 XCTAssertNotNil(image)
                 waitForDownloadingAndCachingAnImage.fulfill()
 

--- a/WooCommerce/WooCommerceTests/Tools/SyncCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/SyncCoordinatorTests.swift
@@ -73,7 +73,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedEffectivelyAttemptsToSynchronizeNextPage() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (page, callback) in
+        delegate.onSync = { page, callback in
             XCTAssertEqual(page, self.secondPageNumber)
             callback?(true)
 
@@ -89,7 +89,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedMarksCacheAsValidOnSuccess() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (_, callback) in
+        delegate.onSync = { _, callback in
             callback?(true)
 
             XCTAssertFalse(self.coordinator.isCacheInvalid(pageNumber: self.secondPageNumber))
@@ -106,7 +106,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedMarksCacheAsValidOnError() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (_, callback) in
+        delegate.onSync = { _, callback in
             callback?(false)
 
             XCTAssertTrue(self.coordinator.isCacheInvalid(pageNumber: self.secondPageNumber))
@@ -122,7 +122,7 @@ class SyncCoordinatorTests: XCTestCase {
     ///
     func testEnsureNextPageIsSynchronizedEffectivelyTracksPagesBeingSynced() {
         let expectation = self.expectation(description: "Sync Callback")
-        delegate.onSync = { (_, callback) in
+        delegate.onSync = { _, callback in
 
             XCTAssertTrue(self.coordinator.isPageBeingSynced(pageNumber: self.secondPageNumber))
             callback?(false)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Coupons/DiscountTypeBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Coupons/DiscountTypeBottomSheetListSelectorCommandTests.swift
@@ -6,7 +6,7 @@ final class DiscountTypeBottomSheetListSelectorCommandTests: XCTestCase {
     func test_callback_is_called_on_selection() {
         // Given
         var selectedActions = [Coupon.DiscountType]()
-        let command = DiscountTypeBottomSheetListSelectorCommand(selected: .percent) { (selected) in
+        let command = DiscountTypeBottomSheetListSelectorCommand(selected: .percent) { selected in
             selectedActions.append(selected)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductTypeBottomSheetListSelectorCommandTests.swift
@@ -97,7 +97,7 @@ final class ProductTypeBottomSheetListSelectorCommandTests: XCTestCase {
         let command = ProductTypeBottomSheetListSelectorCommand(
             source: .editForm(selected: .simple(isVirtual: false)),
             subscriptionProductsEligibilityChecker: subscriptionEligibilityChecker
-        ) { (selected) in
+        ) { selected in
             selectedActions.append(selected)
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/BottomSheetListSelector/ProductsSortOrderBottomSheetListSelectorCommandTests.swift
@@ -7,7 +7,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
         var selectedActions = [ProductsSortOrder]()
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (selected) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { selected in
             selectedActions.append(selected)
         }
         // Action
@@ -19,7 +19,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
     func test_selected_value_after_change() {
         // Arrange
         let selected = ProductsSortOrder.nameAscending
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { (_) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: selected) { _ in
             // noop
         }
         // Assert
@@ -28,7 +28,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
 
     func test_isSelected_returns_true_if_given_the_initial_value() {
         // Arrange
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (_) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { _ in
             // noop
         }
         // Action
@@ -38,7 +38,7 @@ final class ProductsSortOrderBottomSheetListSelectorCommandTests: XCTestCase {
     }
     func test_isSelected_returns_false_if_given_a_different_value() {
         // Arrange
-        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { (_) in
+        let command = ProductsSortOrderBottomSheetListSelectorCommand(selected: .nameAscending) { _ in
             // noop
         }
         // Action

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Inventory/ProductInventorySettingsViewModelTests.swift
@@ -145,7 +145,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         var isSKUValid: Bool?
         var shouldBringUpKeyboard: Bool?
         waitForExpectation { exp in
-            viewModel.handleSKUChange(sku) { (isValid, shouldBringUpKeyboardValue) in
+            viewModel.handleSKUChange(sku) { isValid, shouldBringUpKeyboardValue in
                 isSKUValid = isValid
                 shouldBringUpKeyboard = shouldBringUpKeyboardValue
                 exp.fulfill()
@@ -181,7 +181,7 @@ final class ProductInventorySettingsViewModelTests: XCTestCase {
         var isSKUValid: Bool?
         var shouldBringUpKeyboard: Bool?
         waitForExpectation { exp in
-            viewModel.handleSKUChange(sku) { (isValid, shouldBringUpKeyboardValue) in
+            viewModel.handleSKUChange(sku) { isValid, shouldBringUpKeyboardValue in
                 isSKUValid = isValid
                 shouldBringUpKeyboard = shouldBringUpKeyboardValue
                 exp.fulfill()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewModelTests.swift
@@ -479,7 +479,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { _, _, _, _, _, _, _, _, _, _ in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             XCTAssertEqual(error, .salePriceWithoutRegularPrice)
@@ -503,7 +503,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (_, _, _, _, _, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { _, _, _, _, _, _, _, _, _, _ in
             XCTFail("Completion block should not be called")
         }, onError: { error in
             // Assert
@@ -523,7 +523,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
 
         // Act
         let result = waitFor { promise in
-            viewModel.completeUpdating { (_, _, _, _, _, _, _, _, _, _) in
+            viewModel.completeUpdating { _, _, _, _, _, _, _, _, _, _ in
                 XCTFail("Completion block should not be called")
             } onError: { error in
                 promise(error)
@@ -547,7 +547,7 @@ final class ProductPriceSettingsViewModelTests: XCTestCase {
         viewModel.handleSalePriceChange(salePrice)
 
         let expectation = self.expectation(description: "Wait for error")
-        viewModel.completeUpdating(onCompletion: { (finalRegularPrice, _, _, _, finalSalePrice, _, _, _, _, _) in
+        viewModel.completeUpdating(onCompletion: { finalRegularPrice, _, _, _, finalSalePrice, _, _, _, _, _ in
             expectation.fulfill()
 
             // Assert

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Shipping/ProductShippingSettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Edit Shipping/ProductShippingSettingsViewModelTests.swift
@@ -56,7 +56,7 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         // Act
         let viewModel = ProductShippingSettingsViewModel(product: model)
         waitForExpectation { expectation in
-            viewModel.completeUpdating { (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
+            viewModel.completeUpdating { weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges in
                 // Assert
                 XCTAssertEqual(weight, product.weight)
                 XCTAssertEqual(dimensions, product.dimensions)
@@ -88,7 +88,7 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         let retrievedShippingClass = ProductShippingClass(count: 0, descriptionHTML: nil, name: "60 Days", shippingClassID: 2, siteID: 0, slug: "90-day")
         viewModel.onShippingClassRetrieved(shippingClass: retrievedShippingClass)
         waitForExpectation { expectation in
-            viewModel.completeUpdating { (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
+            viewModel.completeUpdating { weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges in
                 // Assert
                 XCTAssertEqual(weight, product.weight)
                 XCTAssertEqual(dimensions, product.dimensions)
@@ -121,7 +121,7 @@ final class ProductShippingSettingsViewModelTests: XCTestCase {
         viewModel.handleOneTimeShippingChange(true)
         viewModel.handleShippingClassChange(nil)
         waitForExpectation { expectation in
-            viewModel.completeUpdating { (weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges) in
+            viewModel.completeUpdating { weight, dimensions, oneTimeShipping, shippingClass, shippingClassID, hasUnsavedChanges in
                 // Assert
                 XCTAssertEqual(weight, "-1.2")
                 XCTAssertEqual(dimensions, ProductDimensions(length: "", width: "3.2", height: "9.888"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductReviewsViewModelTests.swift
@@ -47,7 +47,7 @@ final class ProductReviewsViewModelTests: XCTestCase {
         let storesManager = MockProductReviewsStoresManager()
         ServiceLocator.setStores(storesManager)
 
-        waitForExpectation { (expectation) in
+        waitForExpectation { expectation in
             viewModel.synchronizeReviews(pageNumber: 1, pageSize: 25, productID: productID) {
                 if storesManager.syncReviewsIsHit {
                     XCTAssertTrue(storesManager.syncReviewsIsHit)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageActionHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductImageActionHandlerTests.swift
@@ -55,7 +55,7 @@ final class ProductImageActionHandlerTests: XCTestCase {
         }
 
         let waitForAssetUpload = self.expectation(description: "Wait for asset upload callback from image upload")
-        assetUploadSubscription = productImageActionHandler.addAssetUploadObserver(self) { (asset, result) in
+        assetUploadSubscription = productImageActionHandler.addAssetUploadObserver(self) { asset, result in
             guard case let .success(productImage) = result else {
                 return XCTFail()
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelAddressFormViewModelTests.swift
@@ -436,7 +436,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (_) in
+        viewModel.validateAddress(onlyLocally: false) { _ in
         }
 
         // Then
@@ -475,7 +475,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (_) in
+        viewModel.validateAddress(onlyLocally: false) { _ in
         }
 
         // Then
@@ -514,7 +514,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (_) in
+        viewModel.validateAddress(onlyLocally: false) { _ in
         }
 
         // Then
@@ -557,7 +557,7 @@ final class ShippingLabelAddressFormViewModelTests: XCTestCase {
                                                           stores: stores,
                                                           validationError: nil,
                                                           countries: [])
-        viewModel.validateAddress(onlyLocally: false) { (_) in
+        viewModel.validateAddress(onlyLocally: false) { _ in
         }
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
@@ -13,7 +13,7 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { (_, _, _) in
+                                                         currencySettings: CurrencySettings()) { _, _, _ in
         }
 
         // Then
@@ -40,7 +40,7 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { (rate, _, _) in
+                                                         currencySettings: CurrencySettings()) { rate, _, _ in
             promise(rate)
         }
             // When
@@ -63,7 +63,7 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { (_, signatureRate, _) in
+                                                         currencySettings: CurrencySettings()) { _, signatureRate, _ in
             promise(signatureRate)
         }
             // When
@@ -86,9 +86,9 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { (_,
-                                                                                                                                    _,
-                                                                                                                                    adultSignatureRate) in
+                                                         currencySettings: CurrencySettings()) { _, 
+                                                                                                                                    _, 
+                                                                                                                                    adultSignatureRate in
             promise(adultSignatureRate)
         }
             // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelCarrierRowViewModelTests.swift
@@ -86,8 +86,8 @@ final class ShippingLabelCarrierRowViewModelTests: XCTestCase {
                                                          rate: MockShippingLabelCarrierRate.makeRate(rate: 40.33),
                                                          signatureRate: MockShippingLabelCarrierRate.makeRate(rate: 45.99),
                                                          adultSignatureRate: MockShippingLabelCarrierRate.makeRate(rate: 51.33),
-                                                         currencySettings: CurrencySettings()) { _, 
-                                                                                                                                    _, 
+                                                         currencySettings: CurrencySettings()) { _,
+                                                                                                                                    _,
                                                                                                                                     adultSignatureRate in
             promise(adultSignatureRate)
         }

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -474,14 +474,14 @@ import WordPressUI
 public extension WordPressAuthenticator {
 
     func getAppleIDCredentialState(for userID: String, completion: @escaping (ASAuthorizationAppleIDProvider.CredentialState, Error?) -> Void) {
-        AppleAuthenticator.sharedInstance.getAppleIDCredentialState(for: userID) { (state, error) in
+        AppleAuthenticator.sharedInstance.getAppleIDCredentialState(for: userID) { state, error in
             // If credentialState == .notFound, error will have a value.
             completion(state, error)
         }
     }
 
     func startObservingAppleIDCredentialRevoked(completion: @escaping () -> Void) {
-        appleIDCredentialObserver = NotificationCenter.default.addObserver(forName: AppleAuthenticator.credentialRevokedNotification, object: nil, queue: nil) { (_) in
+        appleIDCredentialObserver = NotificationCenter.default.addObserver(forName: AppleAuthenticator.credentialRevokedNotification, object: nil, queue: nil) { _ in
             completion()
         }
     }

--- a/WooCommerce/WordPressAuthenticator/Services/LoginFacade.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/LoginFacade.swift
@@ -42,7 +42,7 @@ public extension LoginFacade {
                 if self.tracker.shouldUseLegacyTracker() {
                     WordPressAuthenticator.track(.twoFactorSentSMS)
                 }
-        }) { (_, newNonce) in
+        }) { _, newNonce in
             if let newNonce {
                 loginFields.nonceInfo?.nonceSMS = newNonce
             }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -186,7 +186,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         // Tapping the Sign up text link in "Don't have an account? _Sign up_"
         // will present the 3 button view for signing up.
-        button.on(.touchUpInside) { [weak self] (_) in
+        button.on(.touchUpInside) { [weak self] _ in
             guard let vc = LoginPrologueSignupMethodViewController.instantiate(from: .login) else {
                 WPAuthenticatorLogError("Failed to navigate to LoginPrologueSignupMethodViewController")
                 return
@@ -289,7 +289,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     func fetchSharedWebCredentialsIfAvailable() {
         didRequestSafariSharedCredentials = true
-        SafariCredentialsService.requestSharedWebCredentials { [weak self] (found, username, password) in
+        SafariCredentialsService.requestSharedWebCredentials { [weak self] found, username, password in
             self?.handleFetchedWebCredentials(found, username: username, password: password)
         }
     }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -152,7 +152,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         configureViewLoading(true)
 
         let facade = WordPressXMLRPCAPIFacade()
-        facade.guessXMLRPCURL(forSite: loginFields.siteAddress, success: { [weak self] (url) in
+        facade.guessXMLRPCURL(forSite: loginFields.siteAddress, success: { [weak self] url in
             // Success! We now know that we have a valid XML-RPC endpoint.
             // At this point, we do NOT know if this is a WP.com site or a self-hosted site.
             if let url {
@@ -160,7 +160,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
             }
             // Let's try to grab site info in preparation for the next screen.
             self?.fetchSiteInfo()
-        }, failure: { [weak self] (error) in
+        }, failure: { [weak self] error in
             guard let error, let self else {
                 return
             }
@@ -211,7 +211,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     }
 
     func presentNextControllerIfPossible(siteInfo: WordPressComSiteInfo?) {
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (result) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { result in
             switch result {
             case let .error(error):
                 self.displayError(message: error.localizedDescription)

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -608,7 +608,7 @@ private extension SiteAddressViewController {
             return
         }
 
-        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { (result) in
+        WordPressAuthenticator.shared.delegate?.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: { result in
             switch result {
             case let .error(error):
                 self.displayError(message: error.localizedDescription)

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/HTTPAuthenticationAlertController.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/HTTPAuthenticationAlertController.swift
@@ -46,14 +46,14 @@ open class HTTPAuthenticationAlertController {
 
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button label"),
                                          style: .default,
-                                         handler: { (_) in
+                                         handler: { _ in
                                             executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)
         })
         controller.addAction(cancelAction)
 
         let trustAction = UIAlertAction(title: NSLocalizedString("Trust", comment: "Connect when the SSL certificate is invalid"),
                                         style: .default,
-                                        handler: { (_) in
+                                        handler: { _ in
                                             let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
                                             URLCredentialStorage.shared.setDefaultCredential(credential, for: challenge.protectionSpace)
                                             executeHandlerForChallenge(challenge, disposition: .useCredential, credential: credential)
@@ -69,25 +69,25 @@ open class HTTPAuthenticationAlertController {
                                             message: message,
                                             preferredStyle: .alert)
 
-        controller.addTextField( configurationHandler: { (textField) in
+        controller.addTextField( configurationHandler: { textField in
             textField.placeholder = NSLocalizedString("Username", comment: "Login dialog username placeholder")
         })
 
-        controller.addTextField(configurationHandler: { (textField) in
+        controller.addTextField(configurationHandler: { textField in
             textField.placeholder = NSLocalizedString("Password", comment: "Login dialog password placeholder")
             textField.isSecureTextEntry = true
         })
 
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button label"),
                                          style: .default,
-                                         handler: { (_) in
+                                         handler: { _ in
                                             executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)
         })
         controller.addAction(cancelAction)
 
         let loginAction = UIAlertAction(title: NSLocalizedString("Log In", comment: "Log In button label."),
                                         style: .default,
-                                        handler: { (_) in
+                                        handler: { _ in
                                             guard let username = controller.textFields?.first?.text,
                                                 let password = controller.textFields?.last?.text else {
                                                     executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
@@ -142,7 +142,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
             return
         }
 
-        validateXMLRPCURL(xmlrpcURL, success: success, failure: { (error) in
+        validateXMLRPCURL(xmlrpcURL, success: success, failure: { error in
             // WPAuthenticatorLoggingError(error.localizedDescription)
             if (error.domain == NSURLErrorDomain && error.code == NSURLErrorUserCancelledAuthentication) ||
                 (error.domain == NSURLErrorDomain && error.code == NSURLErrorCannotFindHost) ||
@@ -153,10 +153,10 @@ open class WordPressOrgXMLRPCValidator: NSObject {
             }
             // Try the original given url as an XML-RPC endpoint
             // WPAuthenticatorLoggingError("Try the original given url as an XML-RPC endpoint: \(originalXMLRPCURL)")
-            self.validateXMLRPCURL(originalXMLRPCURL, success: success, failure: { (error) in
+            self.validateXMLRPCURL(originalXMLRPCURL, success: success, failure: { error in
                 // WPAuthenticatorLoggingError(error.localizedDescription)
                 // Fetch the original url and look for the RSD link
-                self.guessXMLRPCURLFromHTMLURL(originalXMLRPCURL, success: success, failure: { (error) in
+                self.guessXMLRPCURLFromHTMLURL(originalXMLRPCURL, success: success, failure: { error in
                     // WPAuthenticatorLoggingError(error.localizedDescription)
 
                     errorHandler(error)
@@ -217,7 +217,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
             return
         }
         let api = WordPressOrgXMLRPCApi(endpoint: url)
-        api.callMethod("system.listMethods", parameters: nil, success: { (responseObject, httpResponse) in
+        api.callMethod("system.listMethods", parameters: nil, success: { responseObject, httpResponse in
                 guard let methods = responseObject as? [String], methods.contains("wp.getUsersBlogs") else {
                     failure(WordPressOrgXMLRPCValidatorError.notWordPressError as NSError)
                         return
@@ -227,7 +227,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
                 } else {
                     failure(WordPressOrgXMLRPCValidatorError.invalid as NSError)
                 }
-            }, failure: { (error, httpResponse) in
+            }, failure: { error, httpResponse in
                 if httpResponse?.url != url {
                     // we where redirected, let's check the answer content
                     if let data = error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String] as? Data,
@@ -267,7 +267,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
 
         var isWpSite = false
         let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
-        let dataTask = session.dataTask(with: htmlURL, completionHandler: { (data, _, error) in
+        let dataTask = session.dataTask(with: htmlURL, completionHandler: { data, _, error in
             if let error {
                 failure(error as NSError)
                 return
@@ -290,7 +290,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
                     failure(WordPressOrgXMLRPCValidatorError.invalid as NSError)
                     return
                 }
-                self.validateXMLRPCURL(newURL, success: success, failure: { (error) in
+                self.validateXMLRPCURL(newURL, success: success, failure: { error in
                     // Try to validate by using the RSD file directly
                     if error.code == 403 || error.code == 405, let xmlrpcValidatorError = error as? WordPressOrgXMLRPCValidatorError {
                         failure(xmlrpcValidatorError as NSError)
@@ -344,7 +344,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
             return
         }
         let session = URLSession(configuration: URLSessionConfiguration.ephemeral)
-        let dataTask = session.dataTask(with: rsdURL, completionHandler: { (data, _, error) in
+        let dataTask = session.dataTask(with: rsdURL, completionHandler: { data, _, error in
             if let error {
                 failure(error as NSError)
                 return

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
@@ -34,12 +34,12 @@ extension AccountServiceRemoteREST {
         ] as [String: AnyObject]
 
         if let connectParameters {
-            params.merge(connectParameters, uniquingKeysWith: { (current, _) in current })
+            params.merge(connectParameters, uniquingKeysWith: { current, _ in current })
         }
 
-        wordPressComRESTAPI.post(path, parameters: params, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: params, success: { _, _ in
             success()
-        }, failure: { (error, _) in
+        }, failure: { error, _ in
             failure(error)
         })
     }
@@ -73,9 +73,9 @@ extension AccountServiceRemoteREST {
             "service": service.rawValue
         ] as [String: AnyObject]
 
-        wordPressComRESTAPI.post(path, parameters: params, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: params, success: { _, _ in
             success()
-        }, failure: { (error, _) in
+        }, failure: { error, _ in
             failure(error)
         })
     }

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/Services/JSONDecoderExtension.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/Services/JSONDecoderExtension.swift
@@ -26,7 +26,7 @@ extension JSONDecoder.DateDecodingStrategy {
     }
 
     static var supportMultipleDateFormats: JSONDecoder.DateDecodingStrategy {
-        return JSONDecoder.DateDecodingStrategy.custom({ (decoder) -> Date in
+        return JSONDecoder.DateDecodingStrategy.custom({ decoder -> Date in
             let container = try decoder.singleValueContainer()
             let dateStr = try container.decode(String.self)
 

--- a/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -58,7 +58,7 @@ class WordPressAuthenticatorTests: XCTestCase {
     // MARK: View Tests
     func testShowLoginForJustWPComPresentsCorrectVC() {
         let presenterSpy = ModalViewControllerPresentingSpy()
-        let expectation = XCTNSPredicateExpectation(predicate: NSPredicate(block: { (_, _) -> Bool in
+        let expectation = XCTNSPredicateExpectation(predicate: NSPredicate(block: { _, _ -> Bool in
             return presenterSpy.presentedVC != nil
         }), object: .none)
 
@@ -70,7 +70,7 @@ class WordPressAuthenticatorTests: XCTestCase {
 
     func testShowLoginForJustWPComSetsMetaProperties() throws {
         let presenterSpy = ModalViewControllerPresentingSpy()
-        let expectation = XCTNSPredicateExpectation(predicate: NSPredicate(block: { (_, _) -> Bool in
+        let expectation = XCTNSPredicateExpectation(predicate: NSPredicate(block: { _, _ -> Bool in
             return presenterSpy.presentedVC != nil
         }), object: .none)
 

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComOAuthClientTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComOAuthClientTests.swift
@@ -39,12 +39,12 @@ class WordPressComOAuthClientTests: XCTestCase {
             password: "fakePass",
             multifactorCode: nil,
             needsMultifactor: { _, _ in XCTFail("This closure should not be called") },
-            success: { (token) in
+            success: { token in
                 expect.fulfill()
                 XCTAssert(!token!.isEmpty, "There should be a token available")
                 XCTAssert(token == "fakeToken", "There should be a token available")
             },
-            failure: { (_) in
+            failure: { _ in
                 expect.fulfill()
                 XCTFail("This call should be successful")
             }
@@ -68,12 +68,12 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should be successful")
             },
-            success: { (token) in
+            success: { token in
                 expect.fulfill()
                 XCTAssert(!token!.isEmpty, "There should be a token available")
                 XCTAssert(token == "fakeToken", "There should be a token available")
             },
-            failure: { (_) in
+            failure: { _ in
                 expect.fulfill()
                 XCTFail("This call should be successful")
             }
@@ -96,11 +96,11 @@ class WordPressComOAuthClientTests: XCTestCase {
             password: "wrongPassword",
             multifactorCode: nil,
             needsMultifactor: { _, _ in XCTFail("This closure should not be called") },
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 expect.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .invalidRequest, "The code should be invalid request")
             }
@@ -126,11 +126,11 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 expect.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .invalidRequest, "The code should be invalid request")
             }
@@ -156,11 +156,11 @@ class WordPressComOAuthClientTests: XCTestCase {
             password: "fakePass",
             multifactorCode: nil,
             needsMultifactor: { _, _ in XCTFail("This closure should not be called") },
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 // Then
                 expect.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .emailLoginNotAllowed, "The error kind should be emailLoginNotAllowed")
@@ -188,11 +188,11 @@ class WordPressComOAuthClientTests: XCTestCase {
             password: "wrongPassword",
             multifactorCode: nil,
             needsMultifactor: { _, _ in XCTFail("This closure should not be called") },
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 expect.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .needsMultifactorCode, "The code should 'be needs multifactor'")
             }
@@ -208,11 +208,11 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            success: { (_) in
+            success: { _ in
                 expectation2.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 expectation2.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .needsMultifactorCode, "The code should be needs multifactor")
             }
@@ -242,11 +242,11 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 expect.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .needsMultifactorCode, "The code should be needs multifactor")
             }
@@ -262,11 +262,11 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            success: { (_) in
+            success: { _ in
                 expectation2.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error) in
+            failure: { error in
                 expectation2.fulfill()
                 XCTAssertEqual(error.authenticationFailureKind, .needsMultifactorCode, "The code should be needs multifactor")
             }
@@ -293,11 +293,11 @@ class WordPressComOAuthClientTests: XCTestCase {
                 XCTAssertEqual(userID, 1234)
                 XCTAssertEqual(nonceInfo.nonceWebauthn, "two_step_nonce_webauthn")
             },
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             },
-            failure: { (_) in
+            failure: { _ in
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             }
@@ -318,7 +318,7 @@ class WordPressComOAuthClientTests: XCTestCase {
         client.requestOneTimeCode(username: "fakeUser", password: "fakePassword",
                                               success: { () in
                                                 expect.fulfill()
-        }, failure: { (_) in
+        }, failure: { _ in
             expect.fulfill()
             XCTFail("This call should be successful")
         })
@@ -336,11 +336,11 @@ class WordPressComOAuthClientTests: XCTestCase {
         let expect = expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.requestSocial2FACode(userID: 0, nonce: "nonce",
-        success: { (newNonce) in
+        success: { newNonce in
             expect.fulfill()
             XCTAssert(!newNonce.isEmpty, "There should be a newNonce available")
             XCTAssert(newNonce == "two_step_nonce_sms", "The newNonce should match")
-        }, failure: { (_, _) in
+        }, failure: { _, _ in
             expect.fulfill()
             XCTFail("This call should be successful")
         })
@@ -360,12 +360,12 @@ class WordPressComOAuthClientTests: XCTestCase {
         client.authenticate(
             socialIDToken: "token",
             service: "google",
-            success: { (token) in
+            success: { token in
                 expect.fulfill()
                 XCTAssert(!token!.isEmpty, "There should be a token available")
                 XCTAssert(token == "bearer_token", "The newNonce should match")
             },
-            needsMultifactor: { (_, _) in
+            needsMultifactor: { _, _ in
                 expect.fulfill()
                 XCTFail("This call should be successful")
             },
@@ -373,7 +373,7 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should be successful")
             },
-            failure: { (_) in
+            failure: { _ in
                 expect.fulfill()
                 XCTFail("This call should be successful")
             }
@@ -394,11 +394,11 @@ class WordPressComOAuthClientTests: XCTestCase {
         client.authenticate(
             socialIDToken: "token",
             service: "google",
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             },
-            needsMultifactor: { (userID, nonceInfo) in
+            needsMultifactor: { userID, nonceInfo in
                 expect.fulfill()
                 XCTAssertEqual(userID, 1)
                 XCTAssertEqual(nonceInfo.nonceBackup, "two_step_nonce_backup")
@@ -408,7 +408,7 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             },
-            failure: { (_) in
+            failure: { _ in
                 expect.fulfill()
                 XCTFail("This call should need multifactor")
             }
@@ -429,11 +429,11 @@ class WordPressComOAuthClientTests: XCTestCase {
         client.authenticate(
             socialIDToken: "token",
             service: "google",
-            success: { (_) in
+            success: { _ in
                 expect.fulfill()
                 XCTFail("This call should invoke user needs connection")
             },
-            needsMultifactor: { (_, _) in
+            needsMultifactor: { _, _ in
                 expect.fulfill()
                 XCTFail("This call should invoke user needs connection")
             },
@@ -441,7 +441,7 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTAssertEqual(email, "email")
             },
-            failure: { (_) in
+            failure: { _ in
                 expect.fulfill()
                 XCTFail("This call should invoke user needs connection")
             }
@@ -460,11 +460,11 @@ class WordPressComOAuthClientTests: XCTestCase {
         let expect = expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.authenticate(socialLoginUserID: 1, authType: "authenticator", twoStepCode: "two_step_code", twoStepNonce: "two_step_nonce",
-                                       success: { (token) in
+                                       success: { token in
                                         expect.fulfill()
                                         XCTAssert(!token!.isEmpty, "There should be a token available")
                                         XCTAssert(token == "bearer_token", "The newNonce should match")
-        }, failure: { (_) in
+        }, failure: { _ in
             expect.fulfill()
             XCTFail("This call should be successful")
         })

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
@@ -93,7 +93,7 @@ class WordPressComRestApiTests: XCTestCase {
             wordPressMediaRoutePath,
             parameters: HTTPRequestBuilderTests.nestedParameters as [String: AnyObject],
             success: { _, _ in expect.fulfill() },
-            failure: { (_, _) in expect.fulfill() }
+            failure: { _, _ in expect.fulfill() }
         )
         wait(for: [expect], timeout: 0.3)
 
@@ -124,7 +124,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTAssert(responseObject is [String: AnyObject], "The response should be a dictionary")
-            }, failure: { (_, _) in
+            }, failure: { _, _ in
                 expect.fulfill()
                 XCTFail("This call should be successfull")
             }
@@ -181,7 +181,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.GET(wordPressMediaRoutePath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, _) in
+            }, failure: { error, _ in
                 expect.fulfill()
                 XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error should a WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiErrorCode.invalidToken.rawValue), "The error code should be invalid token")
@@ -201,7 +201,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.GET(wordPressMediaRoutePath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, _) in
+            }, failure: { error, _ in
                 expect.fulfill()
                 XCTAssert(error.domain == WordPressComRestApiErrorDomain, "The error domain should be WordPressComRestApiErrorDomain")
                 XCTAssert(error.code == Int(WordPressComRestApiErrorCode.responseSerializationFailed.rawValue), "The code should be invalid response serialization")
@@ -221,7 +221,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, _) in
+            }, failure: { error, _ in
                 expect.fulfill()
                 XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiErrorCode.invalidInput.rawValue), "The error code should be invalid input")
@@ -241,7 +241,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, _) in
+            }, failure: { error, _ in
                 expect.fulfill()
                 XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiErrorCode.authorizationRequired.rawValue), "The error code should be AuthorizationRequired")
@@ -259,7 +259,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, _) in
+            }, failure: { error, _ in
                 expect.fulfill()
                 XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiErrorCode.uploadFailed.rawValue), "The error code should be AuthorizationRequired")
@@ -279,7 +279,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [], success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-        }, failure: { (error, _) in
+        }, failure: { error, _ in
             expect.fulfill()
             XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssert(error.code == Int(WordPressComRestApiErrorCode.uploadFailed.rawValue), "The error code should be AuthorizationRequired")
@@ -299,7 +299,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (_, _) in
+            }, failure: { _, _ in
                 expect.fulfill()
             }
         )
@@ -322,7 +322,7 @@ class WordPressComRestApiTests: XCTestCase {
         let filePart = FilePart(parameterName: "media[]", url: mediaURL as URL, fileName: "test-image.jpg", mimeType: "image/jpeg")
         let progress1 = api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (_: AnyObject, _: HTTPURLResponse?) in
                 XCTFail("This call should fail")
-            }, failure: { (error, _) in
+            }, failure: { error, _ in
                 XCTAssert(error.domain == NSURLErrorDomain, "The error domain should be NSURLErrorDomain")
                 XCTAssert(error.code == NSURLErrorCancelled, "The error code should be NSURLErrorCancelled")
             }
@@ -330,7 +330,7 @@ class WordPressComRestApiTests: XCTestCase {
         progress1?.cancel()
         api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
-            }, failure: { (_, _) in
+            }, failure: { _, _ in
                 expect.fulfill()
                 XCTFail("This call should succesful")
             }
@@ -347,7 +347,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-        }, failure: { (error, _) in
+        }, failure: { error, _ in
             expect.fulfill()
             XCTAssertEqual(error.domain, NSURLErrorDomain, "The error domain should be NSURLErrorDomain")
             XCTAssertEqual(error.code, NSURLErrorCancelled, "The error code should be NSURLErrorCancelled")

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressOrgXMLRPCApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressOrgXMLRPCApiTests.swift
@@ -35,7 +35,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         api.callMethod("wp.getPost", parameters: nil, success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTAssert(responseObject is [String: AnyObject], "The response should be a dictionary")
-            }, failure: { (_, _) in
+            }, failure: { _, _ in
                 expect.fulfill()
                 XCTFail("This call should be successfull")
             }
@@ -57,7 +57,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
                 XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.httpErrorStatusCode.rawValue)
                 XCTAssertEqual(error.localizedFailureReason, "An HTTP error code 404 was returned.")
@@ -82,7 +82,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertFalse(error is WordPressOrgXMLRPCApiError)
@@ -109,7 +109,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertTrue(error is WordPressOrgXMLRPCApiError)
@@ -136,7 +136,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertTrue(error is URLError)
@@ -162,7 +162,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
@@ -190,7 +190,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
@@ -221,7 +221,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertEqual(error.domain, XMLParser.errorDomain)
@@ -247,7 +247,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
                 XCTFail("This call should fail")
             },
-            failure: { (error, _) in
+            failure: { error, _ in
                 expect.fulfill()
 
                 XCTAssertEqual(error.domain, WPXMLRPCErrorDomain)
@@ -270,8 +270,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         let progress = api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (_, _) in success.fulfill() },
-            failure: { (_, _) in }
+            success: { _, _ in success.fulfill() },
+            failure: { _, _ in }
         )
 
         let observerCalled = expectation(description: "Progress observer is called")
@@ -298,8 +298,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         let progress = api.callMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (_, _) in },
-            failure: { (_, _) in failure.fulfill() }
+            success: { _, _ in },
+            failure: { _, _ in failure.fulfill() }
         )
 
         let observerCalled = expectation(description: "Progress observer is called")
@@ -326,8 +326,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         let progress = api.streamCallMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (_, _) in success.fulfill() },
-            failure: { (_, _) in }
+            success: { _, _ in success.fulfill() },
+            failure: { _, _ in }
         )
 
         let observerCalled = expectation(description: "Progress observer is called")
@@ -354,8 +354,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         let progress = api.streamCallMethod(
             "wp.getPost",
             parameters: nil,
-            success: { (_, _) in },
-            failure: { (_, _) in failure.fulfill() }
+            success: { _, _ in },
+            failure: { _, _ in failure.fulfill() }
         )
 
         let observerCalled = expectation(description: "Progress observer is called")

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/WordPressComServiceRemoteRestTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/WordPressComServiceRemoteRestTests.swift
@@ -62,10 +62,10 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
                                             andPassword: "fakePassword",
                                             andClientID: "moo",
                                             andClientSecret: "cow",
-                                            success: { (_) in
+                                            success: { _ in
                                                 expect.fulfill()
                                                 XCTFail("This call should fail")
-            }, failure: { (error) in
+            }, failure: { error in
                 expect.fulfill()
                 let error = error! as NSError
                 XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error should a WordPressComRestApiError")


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`unneeded_parentheses_in_closure_argument`](https://realm.github.io/SwiftLint/unneeded_parentheses_in_closure_argument.html) rule.

The rule removes redundant parentheses around closure parameter lists, e.g. `{ (x) in ... }` → `{ x in ... }`.

- `--fix` produced auto-fixes across **214 files**.
- 2 trailing-whitespace side-effects fixed manually.
- 0 suppressions.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
