### PR TITLE
Enable SwiftLint rule: contains_over_range_nil_comparison

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,9 @@ only_rules:
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 
+  # Prefer `contains` over `range(of:) != nil` and `range(of:) == nil`.
+  - contains_over_range_nil_comparison
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -428,7 +428,7 @@ import WordPressUI
 
         if isSiteURLSchemeEmpty {
             path = "https://\(path)"
-        } else if path.isWordPressComPath() && path.range(of: "http://") != nil {
+        } else if path.isWordPressComPath() && path.contains("http://") {
             path = path.replacingOccurrences(of: "http://", with: "https://")
         }
 

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCValidator.swift
@@ -231,8 +231,8 @@ open class WordPressOrgXMLRPCValidator: NSObject {
                 if httpResponse?.url != url {
                     // we where redirected, let's check the answer content
                     if let data = error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String] as? Data,
-                        let responseString = String(data: data, encoding: String.Encoding.utf8), responseString.range(of: "<meta name=\"GENERATOR\" content=\"www.dudamobile.com\">") != nil
-                            || responseString.range(of: "dm404Container") != nil {
+                        let responseString = String(data: data, encoding: String.Encoding.utf8), responseString.contains("<meta name=\"GENERATOR\" content=\"www.dudamobile.com\">")
+                            || responseString.contains("dm404Container") {
                         failure(WordPressOrgXMLRPCValidatorError.mobilePluginRedirectedError as NSError)
                         return
                     }

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/RemoteTestCase.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/RemoteTestCase.swift
@@ -88,7 +88,7 @@ extension RemoteTestCase {
         }
 
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { _ in
             var headers: [NSObject: AnyObject]?
 
@@ -109,7 +109,7 @@ extension RemoteTestCase {
     ///
     func stubRemoteResponse(_ endpoint: String, data: Data, contentType: ResponseContentType, status: Int32 = 200) {
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { _ in
             var headers: [NSObject: AnyObject]?
 
@@ -137,7 +137,7 @@ extension RemoteTestCase {
     func stubRemoteResponse(_ endpoint: String, files: [String], contentType: ResponseContentType, status: Int32 = 200) {
         var callCounter = 0
         stub(condition: { request in
-            return request.url?.absoluteString.range(of: endpoint) != nil
+            return request.url?.absoluteString.contains(endpoint) ?? false
         }) { response in
             guard files.indices.contains(callCounter) else {
                 // An extra call was made to this stub and no corresponding response file existed.


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`contains_over_range_nil_comparison`](https://realm.github.io/SwiftLint/contains_over_range_nil_comparison.html) rule.

The rule prefers `s.contains(...)` over `s.range(of:) != nil` (and `== nil`), which is a clarity win.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (Bool→Bool) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
