### PR TITLE
Enable SwiftLint rule: sorted_first_last

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,9 @@ only_rules:
   # Prefer `someBool.toggle()` over `someBool = !someBool`.
   - toggle_bool
 
+  # Prefer `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`.
+  - sorted_first_last
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Modules/Sources/Networking/Network/MockNetwork.swift
+++ b/Modules/Sources/Networking/Network/MockNetwork.swift
@@ -180,8 +180,7 @@ private extension MockNetwork {
         } else {
             if let filename = responseMap.filter({ searchPath.hasSuffix($0.key) })
                 // In cases where a suffix is a substring of another suffix, the longer suffix is preferred in matched results.
-                .sorted(by: { $0.key.count > $1.key.count })
-                .first?.value {
+                .max(by: { $0.key.count < $1.key.count })?.value {
                 return filename
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -109,10 +109,9 @@ struct StoreStatsChart: View {
             return
         }
         selectedDate = viewModel.intervals
-            .sorted(by: {
+            .min(by: {
                 abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
-            })
-            .first?.date
+            })?.date
         selectedRevenue = viewModel.intervals.first(where: { $0.date == selectedDate })?.revenue
     }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`sorted_first_last`](https://realm.github.io/SwiftLint/sorted_first_last.html) rule.

The rule prefers `min(by:)` / `max(by:)` over `sorted { ... }.first` / `.last`. This avoids materialising the entire sorted array when only one element is needed.

- See commit message for the violation count and any rewrites.
- The change is type-preserving (`Element?`→`Element?`) — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
