### PR TITLE
Enable SwiftLint rule: flatmap_over_map_reduce

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -45,6 +45,9 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `string` to `""`.
   - empty_string
 
+  # Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+  - flatmap_over_map_reduce
+
   # When calling the `joined` method on an array of strings, omit an
   # explicit empty-string separator since that is the default.
   - joined_default_parameter

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -54,7 +54,7 @@ private extension DefaultProductFormTableViewModel {
     }
 
     func primaryFieldRows(product: ProductFormDataModel, actions: [ProductFormEditAction]) -> [ProductFormSection.PrimaryFieldRow] {
-        actions.map { action -> [ProductFormSection.PrimaryFieldRow] in
+        actions.flatMap { action -> [ProductFormSection.PrimaryFieldRow] in
             switch action {
             case .images(let editable, let isStorePublic):
                 return [.images(isEditable: editable,
@@ -83,7 +83,7 @@ private extension DefaultProductFormTableViewModel {
             default:
                 fatalError("Unexpected action in the primary section: \(action)")
             }
-        }.reduce([], +)
+        }
     }
 
     func settingsRows(productModel product: ProductFormDataModel, actions: [ProductFormEditAction]) -> [ProductFormSection.SettingsRow] {


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) rule.

The rule prefers `flatMap { ... }` over `map { ... }.reduce([], +)` for flattening nested arrays — this avoids materialising an intermediate array of arrays.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
