### PR TITLE
Enable SwiftLint rule: array_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ excluded:
 # Rules – Opt-in only, so we can progressively introduce new ones
 #
 only_rules:
+  # Prefer `Array(xs)` over `xs.map { $0 }`.
+  - array_init
+
   # Colons should be next to the identifier when specifying a type.
   - colon
 

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2589,7 +2589,7 @@ final class ProductStoreTests: XCTestCase {
              store.onAction(action)
          }
 
-         let storedProduct = viewStorage.allObjects(ofType: StorageProduct.self, matching: nil, sortedBy: nil).map { $0 }.first
+         let storedProduct = viewStorage.allObjects(ofType: StorageProduct.self, matching: nil, sortedBy: nil).first
 
          // Then
          XCTAssertTrue(onSuccess)
@@ -2616,7 +2616,7 @@ final class ProductStoreTests: XCTestCase {
              store.onAction(action)
          }
 
-         let storedProduct = viewStorage.allObjects(ofType: StorageProduct.self, matching: nil, sortedBy: nil).map { $0 }.first
+         let storedProduct = viewStorage.allObjects(ofType: StorageProduct.self, matching: nil, sortedBy: nil).first
 
          // Then
          XCTAssertTrue(onSuccess)
@@ -2643,7 +2643,7 @@ final class ProductStoreTests: XCTestCase {
              store.onAction(action)
          }
 
-         let storedProduct = viewStorage.allObjects(ofType: StorageProductVariation.self, matching: nil, sortedBy: nil).map { $0 }.first
+         let storedProduct = viewStorage.allObjects(ofType: StorageProductVariation.self, matching: nil, sortedBy: nil).first
 
          // Then
          XCTAssertTrue(onSuccess)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -254,7 +254,7 @@ private extension PrintShippingLabelViewController {
                 .printingInstructions
             ]
         }
-        return rows.map { $0 }
+        return rows
     }
 
     func configureHeaderText(cell: BasicTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -313,7 +313,7 @@ final class OrdersRootViewController: UIViewController {
             DDLogError("⛔️ Unable to fetch stored statuses for Site \(siteID): \(error)")
         }
 
-        let fetchedStatuses: [OrderStatus] = statusResultsController.fetchedObjects.map { $0 }
+        let fetchedStatuses = Array(statusResultsController.fetchedObjects)
         let allowedStatuses = ciabEligibilityChecker.isCurrentSiteCIAB
             ? CIABOrderStatusMapper.mapFilterOptions(fetchedStatuses)
             : fetchedStatuses

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -313,7 +313,7 @@ final class OrdersRootViewController: UIViewController {
             DDLogError("⛔️ Unable to fetch stored statuses for Site \(siteID): \(error)")
         }
 
-        let fetchedStatuses = Array(statusResultsController.fetchedObjects)
+        let fetchedStatuses = statusResultsController.fetchedObjects
         let allowedStatuses = ciabEligibilityChecker.isCurrentSiteCIAB
             ? CIABOrderStatusMapper.mapFilterOptions(fetchedStatuses)
             : fetchedStatuses


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`array_init`](https://realm.github.io/SwiftLint/array_init.html) rule.

The rule prefers `Array(xs)` over the `xs.map { $0 }` identity transform when converting a sequence into an Array.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
