### PR TITLE
Show Contact Support entry point when opening flagged chat from history

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -513,8 +513,8 @@ private extension HelpAndSupportViewController {
             botSlug: summary.botSlug,
             entryPoint: .chatHistory,
             chatID: summary.chatID,
-            onContactHumanSupport: { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+            onContactHumanSupport: { [weak self] transcript in
+                self?.navigateToContactSupport(transcript: transcript)
             }
         )
         let controller = SupportChatHostingController(viewModel: chatViewModel)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -617,11 +617,20 @@ final class SupportChatViewModel {
 
     /// Maps a fetched transcript into local `ChatMessage` values. Unknown roles are dropped
     /// rather than rendered as garbage; ordering from the server (ts-ascending) is preserved.
+    /// Bot messages flagged for human support are also filtered out.
     private func handleFetchChatResult(_ result: Result<SupportChatResponse, Error>) {
         switch result {
         case .success(let response):
             sessionID = response.sessionID
             let rehydrated: [ChatMessage] = response.messages.compactMap { message in
+                // Filter out bot messages flagged for human support
+                if message.role == .bot,
+                   let flags = message.context?.flags,
+                   flags.forwardToHumanSupport {
+                    shouldPromptHumanSupport = true
+                    return nil
+                }
+
                 switch message.role {
                 case .user:
                     return ChatMessage(role: .user, text: message.content)

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -241,6 +241,158 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
+    // MARK: - Resume Chat Tests
+
+    @Test(.timeLimit(.minutes(1)))
+    func test_resumeIfNeeded_when_chat_flagged_for_human_support_then_sets_shouldPromptHumanSupport() async {
+        // Given
+        let chatID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        await confirmation { fetchCompleted in
+            stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+                switch action {
+                case let .fetchChat(_, _, completion):
+                    let flaggedMessage = SupportChatMessage(
+                        messageID: 2,
+                        role: .bot,
+                        content: "Please contact support.",
+                        context: SupportChatMessageContext(
+                            sources: [],
+                            flags: SupportChatFlags(
+                                forwardToHumanSupport: true,
+                                cannedResponse: false,
+                                loggedIn: true,
+                                branch: nil
+                            )
+                        )
+                    )
+                    let response = SupportChatResponse(
+                        chatID: chatID,
+                        sessionID: "session-1",
+                        botSlug: "test-bot",
+                        botVersion: "1.0",
+                        messages: [
+                            SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil),
+                            flaggedMessage
+                        ]
+                    )
+                    completion(.success(response))
+                    fetchCompleted()
+                default:
+                    break
+                }
+            }
+            let sut = SupportChatViewModel(
+                entryPoint: .chatHistory,
+                stores: stores,
+                chatID: chatID,
+                onContactHumanSupport: { _ in }
+            )
+
+            // When
+            sut.resumeIfNeeded()
+        }
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func test_resumeIfNeeded_when_chat_flagged_for_human_support_then_filters_flagged_message() async {
+        // Given
+        let chatID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .chatHistory,
+            stores: stores,
+            chatID: chatID,
+            onContactHumanSupport: { _ in }
+        )
+
+        await confirmation { fetchCompleted in
+            stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+                switch action {
+                case let .fetchChat(_, _, completion):
+                    let flaggedMessage = SupportChatMessage(
+                        messageID: 2,
+                        role: .bot,
+                        content: "Please contact support.",
+                        context: SupportChatMessageContext(
+                            sources: [],
+                            flags: SupportChatFlags(
+                                forwardToHumanSupport: true,
+                                cannedResponse: false,
+                                loggedIn: true,
+                                branch: nil
+                            )
+                        )
+                    )
+                    let response = SupportChatResponse(
+                        chatID: chatID,
+                        sessionID: "session-1",
+                        botSlug: "test-bot",
+                        botVersion: "1.0",
+                        messages: [
+                            SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil),
+                            flaggedMessage
+                        ]
+                    )
+                    completion(.success(response))
+                    fetchCompleted()
+                default:
+                    break
+                }
+            }
+
+            // When
+            sut.resumeIfNeeded()
+        }
+
+        // Then
+        #expect(sut.shouldPromptHumanSupport == true)
+        #expect(sut.messages.count == 1)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func test_resumeIfNeeded_when_chat_not_flagged_then_shouldPromptHumanSupport_is_false() async {
+        // Given
+        let chatID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .chatHistory,
+            stores: stores,
+            chatID: chatID,
+            onContactHumanSupport: { _ in }
+        )
+
+        await confirmation { fetchCompleted in
+            stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+                switch action {
+                case let .fetchChat(_, _, completion):
+                    let response = SupportChatResponse(
+                        chatID: chatID,
+                        sessionID: "session-1",
+                        botSlug: "test-bot",
+                        botVersion: "1.0",
+                        messages: [
+                            SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil),
+                            SupportChatMessage(messageID: 2, role: .bot, content: "How can I help?", context: nil)
+                        ]
+                    )
+                    completion(.success(response))
+                    fetchCompleted()
+                default:
+                    break
+                }
+            }
+
+            // When
+            sut.resumeIfNeeded()
+        }
+
+        // Then
+        #expect(sut.shouldPromptHumanSupport == false)
+        #expect(sut.messages.count == 2)
+    }
+
     // MARK: - Test Helpers
 
     private func makeSUT(


### PR DESCRIPTION
Closes: WOOMOB-2986

## Description
When a chat is flagged for human support, opening it from history was still showing the last bot message and the input area. This fix:
- Filters out bot messages flagged with `forwardToHumanSupport` when loading chat history
- Sets `shouldPromptHumanSupport = true` so the Contact Support banner is shown instead of the input area
- Navigates to the contact support form (instead of just dismissing) when tapping Contact Support from a resumed chat

## Test Steps
1. Start a support chat conversation
2. Get the chat flagged for human support (ask for a human agent repeatedly)
3. Close the chat
4. Open the chat from history
5. Verify the flagged bot message is not displayed and the Contact Support banner is shown instead of the input area
6. Tap Contact Support and verify the contact form opens

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.