### PR TITLE
Enable SwiftLint zero-violation rules (contains_over_filter_count, last_where)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -52,6 +52,9 @@ only_rules:
   # explicit empty-string separator since that is the default.
   - joined_default_parameter
 
+  # Prefer `last(where:)` over `filter { }.last`.
+  - last_where
+
   - line_length
 
   # MARK comment should be in valid format.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over `filter(where:).count`.
+  - contains_over_filter_count
+
   # Prefer `contains` over using `filter(where:).isEmpty`.
   - contains_over_filter_is_empty
 


### PR DESCRIPTION
## Summary

Bundles two zero-violation SwiftLint rule enables into a single PR to reduce reviewer churn.

Both rules:

- have **0 violations** in the current codebase, so each is a `.swiftlint.yml`-only change;
- guard against the corresponding pattern landing in future code.

Rules in this bundle, one commit each:

- [`contains_over_filter_count`](https://realm.github.io/SwiftLint/contains_over_filter_count.html) — prefer `xs.contains { ... }` over `xs.filter { ... }.count > 0` (and `== 0` / `!= 0`).
- [`last_where`](https://realm.github.io/SwiftLint/last_where.html) — prefer `xs.last { ... }` over `xs.filter { ... }.last`.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Supersedes

- #17045 — Enable SwiftLint rule: contains_over_filter_count
- #17049 — Enable SwiftLint rule: last_where

The superseded PRs will be closed with a backlink to this one.

## Test plan

- [ ] CI build is green.
- [ ] `bundle exec rake lint` is clean.

🤖 Generated with [Claude Code](https://claude.ai/code)