### PR TITLE
Match SupportChatAction.sendMessage 6-tuple in tests

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -180,7 +180,7 @@ struct SupportChatViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
-            if case let .sendMessage(_, _, _, _, completion) = action {
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
                 completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 429, response: nil)))
             }
         }
@@ -202,7 +202,7 @@ struct SupportChatViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
-            if case let .sendMessage(_, _, _, _, completion) = action {
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
                 completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 500, response: nil)))
             }
         }
@@ -224,7 +224,7 @@ struct SupportChatViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
-            if case let .sendMessage(_, _, _, _, completion) = action {
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
                 completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 500, response: nil)))
             }
         }
@@ -243,7 +243,7 @@ struct SupportChatViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
-            if case let .sendMessage(_, _, _, _, completion) = action {
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
                 completion(.failure(NetworkError.timeout(response: nil)))
             }
         }


### PR DESCRIPTION
I noticed that [CI fails](https://buildkite.com/automattic/woocommerce-ios/builds/36736/canvas?sid=019df675-ed73-41d5-8bce-d052cd099209&tab=output) on the latest `trunk`, `45a89357e0b28d01e20941caba5db967e84ac00d`, while working on https://github.com/woocommerce/woocommerce-ios/pull/17057.

This AI generate fix should address the issue.

## Summary

`SupportChatAction.sendMessage` recently grew a `sessionID: String?` associated value (commit 8d9503bc, _Send session ID when sending followup messages_). `SupportChatStore.swift` and `MockSupportChatActionHandler.swift` were updated as part of that change, but `SupportChatViewModelTests.swift` was missed and still pattern-matches the old 5-tuple shape:

```swift
if case let .sendMessage(_, _, _, _, completion) = action { ... }
```

The mismatched arity makes Swift give up on type inference for the surrounding closure, surfacing as four "type of expression is ambiguous without a type annotation" errors at the `stores.whenReceivingAction(ofType: SupportChatAction.self) { action in` lines (182, 204, 226, 245).

This PR adds the missing `_,` to bring the four pattern matches in line with the case's current six associated values.

## Test plan

- [ ] CI build is green (the test target compiles).

🤖 Generated with [Claude Code](https://claude.ai/code)