### PR TITLE
[RSM] Phone POS: Lift iPad/compact-width gates behind flag

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -8,6 +8,7 @@ struct PointOfSaleDashboardView: View {
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posCurrencyProvider) private var currencyProvider
     @Environment(\.posExternalViews) private var externalViews
+    @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.dismiss) private var dismiss
     @Environment(\.keyboardObserver) private var keyboardObserver
 
@@ -55,7 +56,8 @@ struct PointOfSaleDashboardView: View {
         PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: posModel.entryPointController.eligibilityState,
             itemsContainerState: itemsViewState.containerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: featureFlags.isFeatureFlagEnabled(.pointOfSalePhonePrototype)
         )
     }
 

--- a/Modules/Sources/PointOfSale/ViewHelpers/PointOfSaleDashboardViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/PointOfSaleDashboardViewHelper.swift
@@ -5,11 +5,14 @@ struct PointOfSaleDashboardViewHelper {
     static func determineViewState(
         eligibilityState: POSEligibilityState?,
         itemsContainerState: ItemsContainerState,
-        horizontalSizeClass: UserInterfaceSizeClass?
+        horizontalSizeClass: UserInterfaceSizeClass?,
+        isPhonePrototypeEnabled: Bool = false
     ) -> PointOfSaleDashboardView.ViewState {
 
-        guard case .regular = horizontalSizeClass else {
-            return .unsupportedWidth
+        if !isPhonePrototypeEnabled {
+            guard case .regular = horizontalSizeClass else {
+                return .unsupportedWidth
+            }
         }
 
         guard let eligibilityState else {

--- a/Modules/Sources/PointOfSale/ViewHelpers/PointOfSaleDashboardViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/PointOfSaleDashboardViewHelper.swift
@@ -6,13 +6,11 @@ struct PointOfSaleDashboardViewHelper {
         eligibilityState: POSEligibilityState?,
         itemsContainerState: ItemsContainerState,
         horizontalSizeClass: UserInterfaceSizeClass?,
-        isPhonePrototypeEnabled: Bool = false
+        isPhonePrototypeEnabled: Bool
     ) -> PointOfSaleDashboardView.ViewState {
 
-        if !isPhonePrototypeEnabled {
-            guard case .regular = horizontalSizeClass else {
-                return .unsupportedWidth
-            }
+        guard isPhonePrototypeEnabled || horizontalSizeClass == .regular else {
+            return .unsupportedWidth
         }
 
         guard let eligibilityState else {

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
@@ -18,7 +18,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -35,7 +36,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -54,7 +56,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -79,7 +82,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -98,7 +102,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -115,7 +120,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -145,7 +151,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -164,7 +171,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -181,7 +189,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then
@@ -198,7 +207,8 @@ struct PointOfSaleDashboardViewHelperTests {
         let result = PointOfSaleDashboardViewHelper.determineViewState(
             eligibilityState: eligibilityState,
             itemsContainerState: itemsContainerState,
-            horizontalSizeClass: horizontalSizeClass
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: false
         )
 
         // Then

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/PointOfSaleDashboardViewHelperTests.swift
@@ -205,6 +205,103 @@ struct PointOfSaleDashboardViewHelperTests {
         #expect(result == .ineligible(reason: .featureSwitchDisabled))
     }
 
+    // MARK: - Phone Prototype Flag Tests
+
+    @Test func determineViewState_when_phonePrototype_flag_enabled_and_compact_returns_content() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: true
+        )
+
+        // Then
+        #expect(result == .content)
+    }
+
+    @Test func determineViewState_when_phonePrototype_flag_enabled_and_nil_sizeClass_returns_content() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass? = nil
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: true
+        )
+
+        // Then
+        #expect(result == .content)
+    }
+
+    @Test func determineViewState_when_phonePrototype_flag_enabled_and_ineligible_returns_ineligible() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .ineligible(reason: .featureSwitchDisabled)
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: true
+        )
+
+        // Then
+        #expect(result == .ineligible(reason: .featureSwitchDisabled))
+    }
+
+    @Test func determineViewState_when_phonePrototype_flag_enabled_and_nil_eligibility_returns_loading() async throws {
+        // Given
+        let eligibilityState: POSEligibilityState? = nil
+        let itemsContainerState: ItemsContainerState = .content
+        let horizontalSizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: true
+        )
+
+        // Then
+        #expect(result == .loading())
+    }
+
+    @Test(arguments: [
+        PointOfSaleErrorState.errorOnLoadingProducts(),
+        PointOfSaleErrorState.errorOnLoadingVariations(),
+        PointOfSaleErrorState.errorOnLoadingCoupons()
+    ])
+    func determineViewState_when_phonePrototype_flag_enabled_and_error_returns_error(errorState: PointOfSaleErrorState) async throws {
+        // Given
+        let eligibilityState: POSEligibilityState = .eligible
+        let itemsContainerState: ItemsContainerState = .error(errorState)
+        let horizontalSizeClass: UserInterfaceSizeClass = .compact
+
+        // When
+        let result = PointOfSaleDashboardViewHelper.determineViewState(
+            eligibilityState: eligibilityState,
+            itemsContainerState: itemsContainerState,
+            horizontalSizeClass: horizontalSizeClass,
+            isPhonePrototypeEnabled: true
+        )
+
+        // Then
+        #expect(result == .error(errorState))
+    }
+
     // MARK: - Floating Control Tests
 
     @Test(arguments: [

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -63,7 +63,8 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
 
     /// Checks the final visibility of the POS tab.
     func checkVisibility() async -> Bool {
-        guard userInterfaceIdiom == .pad else {
+        let phonePrototypeEnabled = featureFlagService.isFeatureFlagEnabled(.pointOfSalePhonePrototype)
+        guard userInterfaceIdiom == .pad || phonePrototypeEnabled else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -52,7 +52,7 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         eligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) ?? false
     }
 
-    /// Checks the initial visibility without the `POSTabVisibilityChecker` instsance
+    /// Checks the initial visibility without the `POSTabVisibilityChecker` instance
     /// Used for the initial state check when a site instance hasn't been loaded but a `siteID` is available
     static func checkInitialVisibility(
         for siteID: Int64,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -228,6 +228,25 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == false)
     }
 
+    @Test func is_visible_when_device_is_phone_and_phonePrototype_flag_enabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+    }
+
     @Test func checkVisibility_returns_expected_result_after_site_settings_available() async throws {
         // Given - no site settings are immediately available (empty stream that will emit values later)
         let featureFlagService = MockFeatureFlagService()


### PR DESCRIPTION
> **Stack order** (review bottom-up — each PR depends on the one below):
> 1. #17062 — Add `pointOfSalePhonePrototype` feature flag
> 2. #17063 — Lift iPad/compact-width gates behind flag
> 3. #17064 — Phone navigation skeleton + Cart sheet
> 4. #17065 — Items header overflow menu (Exit/Settings/Orders)
> 5. #17066 — Phone-adaptive modals (barcode setup + refund flow)
> 6. #17067 — Selection border + connect-reader button polish (+ recent prototype iteration)

## Description
Stacked on top of #17062.

Two gates currently prevent POS from rendering on iPhone:
- `POSTabVisibilityChecker.checkVisibility()` returns `false` when `userInterfaceIdiom != .pad`
- `PointOfSaleDashboardViewHelper.determineViewState()` returns `.unsupportedWidth` when `horizontalSizeClass != .regular`

When the `pointOfSalePhonePrototype` flag is on, both gates are bypassed. With the flag off, behavior is identical to trunk for both iPad and phone.

This is groundwork: with the flag on, POS now opens on iPhone but the layout is still the iPad split view rendered into a narrow viewport (i.e. visibly broken). Phone-specific navigation and UI follow in stacked PRs.

Mirrors part of [woocommerce-android#15665](https://github.com/woocommerce/woocommerce-android/pull/15665).

## Test Steps
- Pull the branch (Debug = `.localDeveloper`).
- **iPhone, flag ON** (default in Debug): POS tab shows up. Tap it; the dashboard renders the iPad split layout in a narrow viewport — looks broken, expected at this stage.
- **iPhone, flag OFF** (toggle in feature flag override panel, or change `DefaultFeatureFlagService` locally): POS tab should not appear; if it appears via cache, the dashboard still shows the "unsupported width" message. Behavior matches trunk.
- **iPad, flag either**: dashboard shows the existing dual-pane layout. No regression.

## Screenshots
N/A — intermediate state, not user-facing.

---
- [x] No release notes — internal flag groundwork.
