### PR TITLE
[RSM] Phone POS: Phone navigation skeleton + Cart sheet

### DIFF
--- a/Modules/Sources/PointOfSale/Models/Cart.swift
+++ b/Modules/Sources/PointOfSale/Models/Cart.swift
@@ -167,4 +167,10 @@ extension Cart {
     var isNotEmpty: Bool {
         return !isEmpty
     }
+
+    /// Total number of entries in the cart across all entry types
+    /// (purchasable items, coupons, and custom amounts).
+    var totalItemCount: Int {
+        purchasableItems.count + coupons.count + customAmounts.count
+    }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -49,6 +49,6 @@ struct POSNavigationDestinationEmailReceiptView: View {
         }) { email in
             try await paymentModel.sendReceipt(to: email)
         }
-        .navigationBarHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -34,7 +34,7 @@ struct POSNavigationDestinationCashPaymentView: View {
     var body: some View {
         PointOfSaleCollectCashView(orderTotal: orderTotal,
                                    currencySettings: currencyProvider.currencySettings)
-        .navigationBarHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -19,6 +19,7 @@ struct PointOfSaleDashboardView: View {
     @State private var navigationPath: [POSNavigationDestination] = []
     @State private var floatingSize: CGSize = .zero
     @State private var floatingControlSuppressed: Bool = false
+    @State private var phoneShowingCart: Bool = false
 
     private var viewStateCoordinator: PointOfSaleViewStateCoordinator {
         posModel.viewStateCoordinatorForView
@@ -267,8 +268,6 @@ struct PointOfSaleDashboardView: View {
             paymentState: posModel.paymentState
         )
     }
-
-    @State private var phoneShowingCart: Bool = false
 
     private var phoneCartButton: some View {
         Button {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -198,7 +198,114 @@ struct PointOfSaleDashboardView: View {
         POSNavigationRouter(navigationPath: $navigationPath)
     }
 
+    @ViewBuilder
     private var contentView: some View {
+        if isPhoneLayout {
+            phoneContentView
+        } else {
+            tabletContentView
+        }
+    }
+
+    private var isPhoneLayout: Bool {
+        horizontalSizeClass == .compact && featureFlags.isFeatureFlagEnabled(.pointOfSalePhonePrototype)
+    }
+
+    @ViewBuilder
+    private var phoneContentView: some View {
+        @Bindable var viewStateCoordinator = viewStateCoordinator
+        // Building stage: ItemListView (which carries its own NavigationStack for product drill-down)
+        //                 + bottom Cart button — NO outer NavigationStack here, otherwise nested stacks
+        //                 break .navigationDestination resolution for pushed views.
+        // Finalizing stage: a fresh NavigationStack siblinged to (not wrapping) the items list, used
+        //                   for pushing cash payment, email receipt, etc. via navigationPath.
+        Group {
+            switch posModel.orderStage {
+            case .building:
+                VStack(spacing: POSSpacing.none) {
+                    ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
+                                 searchTerm: $viewStateCoordinator.searchTerm)
+                    if posModel.cart.isNotEmpty {
+                        phoneCartButton
+                    }
+                }
+            case .finalizing:
+                NavigationStack(path: $navigationPath) {
+                    TotalsView()
+                        .background(Color.posSurface)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button {
+                                    posModel.addMoreToCart()
+                                } label: {
+                                    Label(Localization.phoneBackToItems, systemImage: "chevron.backward")
+                                }
+                                .disabled(!canExitFinalizingOnPhone)
+                            }
+                        }
+                        .navigationDestination(for: POSNavigationDestination.self) { destination in
+                            switch destination {
+                            case .cashPayment(let orderTotal):
+                                POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
+                            case .emailReceipt:
+                                POSNavigationDestinationEmailReceiptView()
+                            }
+                        }
+                }
+                .environment(\.posNavigationRouter, navigationRouter)
+            }
+        }
+        .onChange(of: posModel.paymentState.cash) { _, newValue in
+            if newValue == .collectingCash,
+               case .loaded(let totals) = posModel.orderState {
+                navigationRouter.pushCash(orderTotal: totals.orderTotal)
+            }
+        }
+        .onChange(of: posModel.orderStage) { _, newStage in
+            // Dismiss the cart sheet automatically when checkout starts so the user lands
+            // on the totals view rather than seeing cart fading away.
+            if newStage == .finalizing {
+                phoneShowingCart = false
+            }
+        }
+        .posSheet(isPresented: $phoneShowingCart) {
+            phoneCartSheetView
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .animation(.default, value: posModel.orderStage)
+        .ignoresSafeArea()
+        .background(Color.posSurface.ignoresSafeArea())
+    }
+
+    private var canExitFinalizingOnPhone: Bool {
+        !CartViewHelper().shouldPreventCartEditing(
+            orderState: posModel.orderState,
+            paymentState: posModel.paymentState
+        )
+    }
+
+    @State private var phoneShowingCart: Bool = false
+
+    private var phoneCartButton: some View {
+        Button {
+            phoneShowingCart = true
+        } label: {
+            Text(String(format: Localization.phoneCart, posModel.cart.purchasableItems.count))
+        }
+        .buttonStyle(POSFilledButtonStyle(size: .normal))
+        .padding(.horizontal, POSPadding.medium)
+        .padding(.vertical, POSPadding.medium)
+        .accessibilityIdentifier("pos-phone-cart-button")
+    }
+
+    private var phoneCartSheetView: some View {
+        // Drag indicator + swipe-down handle dismissal; an explicit close button isn't needed.
+        CartView()
+            .background(Color.posSurface)
+    }
+
+    private var tabletContentView: some View {
         @Bindable var viewStateCoordinator = viewStateCoordinator
         return GeometryReader { geometry in
             // Fixed widths ensure views don't resize during offset-based transitions.
@@ -355,6 +462,16 @@ private extension PointOfSaleDashboardView {
             "pointOfSaleDashboard.support.cancel",
             value: "Cancel",
             comment: "Button to dismiss the support form from the POS dashboard."
+        )
+        static let phoneCart = NSLocalizedString(
+            "pointOfSaleDashboard.phone.cart",
+            value: "Cart (%1$d)",
+            comment: "Phone-only floating button to open the cart from the items list. %1$d is the cart item count."
+        )
+        static let phoneBackToItems = NSLocalizedString(
+            "pointOfSaleDashboard.phone.backToItems",
+            value: "Items",
+            comment: "Phone-only back button title to return from totals to the items list."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -273,7 +273,7 @@ struct PointOfSaleDashboardView: View {
         Button {
             phoneShowingCart = true
         } label: {
-            Text(String(format: Localization.phoneCart, posModel.cart.purchasableItems.count))
+            Text(String(format: Localization.phoneCart, posModel.cart.totalItemCount))
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .padding(.horizontal, POSPadding.medium)

--- a/Modules/Tests/PointOfSaleTests/Models/CartTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/CartTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import PointOfSale
+import struct Yosemite.POSCustomAmount
+import struct Yosemite.POSItemIdentifier
+
+struct CartTests {
+    @Test func test_totalItemCount_when_cart_is_empty_then_returns_zero() {
+        // Given
+        let cart = Cart()
+
+        // When, Then
+        #expect(cart.totalItemCount == 0)
+    }
+
+    @Test func test_totalItemCount_when_cart_has_only_a_coupon_then_count_is_one() {
+        // Given
+        var cart = Cart()
+        cart.coupons = [makeCoupon(code: "FREESHIP")]
+
+        // When, Then
+        #expect(cart.totalItemCount == 1)
+        #expect(cart.isNotEmpty)
+    }
+
+    @Test func test_totalItemCount_when_cart_has_only_a_custom_amount_then_count_is_one() {
+        // Given
+        var cart = Cart()
+        cart.customAmounts = [POSCustomAmount(name: "Service fee", amount: "10.00", isTaxable: true)]
+
+        // When, Then
+        #expect(cart.totalItemCount == 1)
+    }
+
+    @Test func test_totalItemCount_sums_purchasableItems_coupons_and_customAmounts() {
+        // Given
+        var cart = Cart()
+        cart.purchasableItems = [
+            Cart.PurchasableItem.loading(id: UUID()),
+            Cart.PurchasableItem.loading(id: UUID())
+        ]
+        cart.coupons = [makeCoupon(code: "FREESHIP")]
+        cart.customAmounts = [
+            POSCustomAmount(name: "Service fee", amount: "10.00", isTaxable: true),
+            POSCustomAmount(name: "Tip", amount: "5.00", isTaxable: false)
+        ]
+
+        // When, Then
+        #expect(cart.totalItemCount == 5)
+    }
+
+    private func makeCoupon(code: String) -> Cart.CouponItem {
+        Cart.CouponItem(
+            id: UUID(),
+            posItemIdentifier: POSItemIdentifier(underlyingType: .coupon, itemID: 1),
+            code: code,
+            summary: "Free shipping"
+        )
+    }
+}


### PR DESCRIPTION
> **Stack order** (review bottom-up — each PR depends on the one below):
> 1. #17062 — Add `pointOfSalePhonePrototype` feature flag
> 2. #17063 — Lift iPad/compact-width gates behind flag
> 3. #17064 — Phone navigation skeleton + Cart sheet
> 4. #17065 — Items header overflow menu (Exit/Settings/Orders)
> 5. #17066 — Phone-adaptive modals (barcode setup + refund flow)
> 6. #17067 — Selection border + connect-reader button polish (+ recent prototype iteration)

## Description
Stacked on top of #17063.

When the prototype flag is on **and** horizontal size class is `.compact`, the dashboard now renders a phone-specific layout instead of the iPad split view. iPad (`horizontalSizeClass == .regular`) keeps its existing layout via the renamed-but-unchanged \`tabletContentView\`.

Phone layout:
- **Building stage** — \`ItemListView\` (with its own internal \`NavigationStack\` for product drill-down) + a full-width \`Cart (N)\` button at the bottom when the cart has items.
- **Finalizing stage** — a dedicated \`NavigationStack\` siblinged to the items list (mirroring iPad's structure, where items and cart+totals are also siblings, never nested). This stack hosts the cash-payment / email-receipt pushes and a back-to-items toolbar button.
- **Cart** — presented as a \`.posSheet\` with \`.medium\` and \`.large\` detents + visible drag indicator, so the merchant can peek/edit and dismiss with a swipe.

There is intentionally **no outer NavigationStack** in the building stage. An earlier prototype iteration nested one inside \`ItemListView\`'s stack and triggered the SwiftUI yellow-triangle fallback for pushed destinations (cash payment) plus a crash on a second push.

The cash destination wrapper's deprecated \`.navigationBarHidden(true)\` is replaced with \`.toolbar(.hidden, for: .navigationBar)\`. The deprecated form misbehaves under iOS 17 NavigationStack on phone; iPad behavior is unchanged.

Mirrors [woocommerce-android#15665](https://github.com/woocommerce/woocommerce-android/pull/15665) + [#15686](https://github.com/woocommerce/woocommerce-android/pull/15686) + [#15691](https://github.com/woocommerce/woocommerce-android/pull/15691).

## Note for reviewers
The phone `NavigationStack` and `POSNavigationRouter` introduced here are deliberately minimal — only the cash-payment and email-receipt destinations exist at this layer. Later stacked PRs extend both the router and the finalizing-stage `onChange` observers:
- #17112 adds a Scan-to-Pay observer
- #17114 adds a Mark-as-paid destination

Please review this PR as a foundation; expect upstream extensions in the same files.

## Test Steps
- Pull the branch (Debug = \`.localDeveloper\`, flag on by default once #17062 lands).
- **iPhone, flag ON**:
  1. Open POS → items list visible at full width.
  2. Add an item → \"Cart (1)\" button appears at the bottom.
  3. Tap Cart → sheet slides up at medium detent. Drag up → expands to large. Drag down → dismisses.
  4. From cart sheet, tap Checkout → sheet dismisses, totals view shows.
  5. On totals, tap the \"Items\" back button at the top-leading → returns to items list.
  6. From totals, tap Cash payment → cash collection screen pushes in horizontally. Back arrow returns to totals. Repeat tap works (no crash).
  7. From totals, complete a card payment → success screen.
- **iPad, flag either**: dashboard shows the existing dual-pane layout. No regression.
- Toggle the flag off (override panel or local edit) → POS on phone reverts to the unsupported-width behavior introduced in #17063.

## Screenshots
N/A — UI changes verified live.

---
- [x] No release notes — feature still flagged off in alpha.

