### PR TITLE
[RSM] Phone POS: Items header overflow menu (Exit/Settings/Orders)

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -14,14 +14,18 @@ struct ItemListView: View {
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
-    private let trailingHeaderAccessory: AnyView?
+    /// Optional accessory rendered in the trailing slot of the items list header when not searching.
+    /// Hidden while the Coupons tab is showing the create-coupon button so the trailing slot
+    /// doesn't crowd the Products / Coupons tab titles — that gate lives here because the same
+    /// view also owns `isAddingCouponAllowed`.
+    private let trailingHeaderAccessoryHiddenOnCoupons: AnyView?
 
     init(selectedItemListType: Binding<ItemListType>,
          searchTerm: Binding<String>,
-         trailingHeaderAccessory: AnyView? = nil) {
+         trailingHeaderAccessoryHiddenOnCoupons: AnyView? = nil) {
         self._selectedItemListType = selectedItemListType
         self._searchTerm = searchTerm
-        self.trailingHeaderAccessory = trailingHeaderAccessory
+        self.trailingHeaderAccessoryHiddenOnCoupons = trailingHeaderAccessoryHiddenOnCoupons
     }
 
     private var analyticsTracker: PointOfSaleItemListAnalyticsTracker {
@@ -414,8 +418,8 @@ private extension ItemListView {
 
                         // Hidden on the Coupons tab where the createCouponButton already crowds the
                         // trailing slot, otherwise the Products / Coupons tab titles get squeezed.
-                        if let trailingHeaderAccessory, !isAddingCouponAllowed {
-                            trailingHeaderAccessory
+                        if let trailingHeaderAccessoryHiddenOnCoupons, !isAddingCouponAllowed {
+                            trailingHeaderAccessoryHiddenOnCoupons
                                 .transition(.opacity.combined(with: .scale))
                         }
                     }

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -14,6 +14,15 @@ struct ItemListView: View {
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
+    private let trailingHeaderAccessory: AnyView?
+
+    init(selectedItemListType: Binding<ItemListType>,
+         searchTerm: Binding<String>,
+         trailingHeaderAccessory: AnyView? = nil) {
+        self._selectedItemListType = selectedItemListType
+        self._searchTerm = searchTerm
+        self.trailingHeaderAccessory = trailingHeaderAccessory
+    }
 
     private var analyticsTracker: PointOfSaleItemListAnalyticsTracker {
         PointOfSaleItemListAnalyticsTracker(
@@ -402,6 +411,13 @@ private extension ItemListView {
                             setSearch(true)
                         }
                         .transition(.opacity.combined(with: .scale))
+
+                        // Hidden on the Coupons tab where the createCouponButton already crowds the
+                        // trailing slot, otherwise the Products / Coupons tab titles get squeezed.
+                        if let trailingHeaderAccessory, !isAddingCouponAllowed {
+                            trailingHeaderAccessory
+                                .transition(.opacity.combined(with: .scale))
+                        }
                     }
 
                 }

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -80,7 +80,7 @@ private extension POSFloatingControlView {
             )
         }
         .accessibilityIdentifier("pos-exit-menu-item")
-        if horizontalSizeClass == .regular {
+        if horizontalSizeClass == .regular || featureFlags.isFeatureFlagEnabled(.pointOfSalePhonePrototype) {
             Button {
                 analytics.track(.pointOfSaleSettingsMenuItemTapped)
                 showSettings = true

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -271,7 +271,6 @@ struct PointOfSaleDashboardView: View {
         )
     }
 
-    @State private var phoneShowingCart: Bool = false
     @State private var phoneShowOrders: Bool = false
 
     private var phoneOverflowMenu: some View {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -298,6 +298,7 @@ struct PointOfSaleDashboardView: View {
                     Image(systemName: "ellipsis")
                         .font(.posButtonSymbolSmall)
                         .foregroundColor(.posOnSurface)
+                        .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
                 }
                 .frame(width: POSHeaderLayoutConstants.minHeight, height: POSHeaderLayoutConstants.minHeight)
                 .fixedSize()

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -21,6 +21,11 @@ struct PointOfSaleDashboardView: View {
     @State private var floatingControlSuppressed: Bool = false
     @State private var phoneShowingCart: Bool = false
 
+    /// Tracks Dynamic Type scaling for the phone overflow menu chip so it grows in sync with
+    /// the adjacent `POSPageHeaderActionButton` (search) at large content sizes. Same 1.0…1.2x
+    /// clamp around `POSHeaderLayoutConstants.minHeight` as `POSPageHeaderActionButton`.
+    @ScaledMetric private var phoneOverflowMenuScaledSize: CGFloat = POSHeaderLayoutConstants.minHeight
+
     private var viewStateCoordinator: PointOfSaleViewStateCoordinator {
         posModel.viewStateCoordinatorForView
     }
@@ -212,7 +217,7 @@ struct PointOfSaleDashboardView: View {
                 VStack(spacing: POSSpacing.none) {
                     ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
                                  searchTerm: $viewStateCoordinator.searchTerm,
-                                 trailingHeaderAccessory: AnyView(phoneOverflowMenu))
+                                 trailingHeaderAccessoryHiddenOnCoupons: AnyView(phoneOverflowMenu))
                     if posModel.cart.isNotEmpty {
                         phoneCartButton
                     }
@@ -300,11 +305,16 @@ struct PointOfSaleDashboardView: View {
                         .foregroundColor(.posOnSurface)
                         .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
                 }
-                .frame(width: POSHeaderLayoutConstants.minHeight, height: POSHeaderLayoutConstants.minHeight)
+                .frame(width: phoneOverflowMenuConstrainedSize, height: phoneOverflowMenuConstrainedSize)
                 .fixedSize()
         }
         .accessibilityLabel(Localization.phoneMenuAccessibilityLabel)
         .accessibilityIdentifier("pos-phone-overflow-menu")
+    }
+
+    private var phoneOverflowMenuConstrainedSize: CGFloat {
+        max(POSHeaderLayoutConstants.minHeight,
+            min(phoneOverflowMenuScaledSize, POSHeaderLayoutConstants.minHeight * 1.2))
     }
 
     private var phoneCartButton: some View {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -115,7 +115,7 @@ struct PointOfSaleDashboardView: View {
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
             .accessibilitySortPriority(1)
-            .renderedIf(viewState.showsFloatingControl && !floatingControlSuppressed)
+            .renderedIf(viewState.showsFloatingControl && !isPhoneLayout && !floatingControlSuppressed)
 
             POSConnectivityView()
         }
@@ -208,7 +208,8 @@ struct PointOfSaleDashboardView: View {
             case .building:
                 VStack(spacing: POSSpacing.none) {
                     ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
-                                 searchTerm: $viewStateCoordinator.searchTerm)
+                                 searchTerm: $viewStateCoordinator.searchTerm,
+                                 trailingHeaderAccessory: AnyView(phoneOverflowMenu))
                     if posModel.cart.isNotEmpty {
                         phoneCartButton
                     }
@@ -260,6 +261,48 @@ struct PointOfSaleDashboardView: View {
             orderState: posModel.orderState,
             paymentState: posModel.paymentState
         )
+    }
+
+    @State private var phoneShowingCart: Bool = false
+    @State private var phoneShowOrders: Bool = false
+
+    private var phoneOverflowMenu: some View {
+        Menu {
+            Button {
+                analytics.track(.pointOfSaleExitMenuItemTapped)
+                showExitPOSModal = true
+            } label: {
+                Label(Localization.phoneMenuExit, systemImage: "rectangle.portrait.and.arrow.forward")
+            }
+            Button {
+                analytics.track(.pointOfSaleSettingsMenuItemTapped)
+                showSettings = true
+            } label: {
+                Label(Localization.phoneMenuSettings, systemImage: "gearshape")
+            }
+            if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
+                Button {
+                    analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
+                    phoneShowOrders = true
+                } label: {
+                    Label(Localization.phoneMenuOrders, systemImage: "text.document")
+                }
+            }
+        } label: {
+            Circle()
+                .foregroundColor(.posSurfaceContainerLow)
+                .overlay {
+                    Image(systemName: "ellipsis")
+                        .font(.posButtonSymbolSmall)
+                        .foregroundColor(.posOnSurface)
+                }
+                .frame(width: POSHeaderLayoutConstants.minHeight, height: POSHeaderLayoutConstants.minHeight)
+                .fixedSize()
+        }
+        .accessibilityIdentifier("pos-phone-overflow-menu")
+        .posFullScreenCover(isPresented: $phoneShowOrders) {
+            POSOrdersView(isPresented: $phoneShowOrders)
+        }
     }
 
     private var phoneCartButton: some View {
@@ -462,6 +505,21 @@ private extension PointOfSaleDashboardView {
             "pointOfSaleDashboard.phone.backToItems",
             value: "Items",
             comment: "Phone-only back button title to return from totals to the items list."
+        )
+        static let phoneMenuExit = NSLocalizedString(
+            "pointOfSaleDashboard.phone.menu.exit",
+            value: "Exit POS",
+            comment: "Phone-only overflow menu item to exit Point of Sale."
+        )
+        static let phoneMenuSettings = NSLocalizedString(
+            "pointOfSaleDashboard.phone.menu.settings",
+            value: "Settings",
+            comment: "Phone-only overflow menu item to open Point of Sale settings."
+        )
+        static let phoneMenuOrders = NSLocalizedString(
+            "pointOfSaleDashboard.phone.menu.orders",
+            value: "Orders",
+            comment: "Phone-only overflow menu item to open the historical orders view."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -156,6 +156,9 @@ struct PointOfSaleDashboardView: View {
         .posFullScreenCover(isPresented: $showSettings) {
             POSSettingsView(settingsController: posModel.settingsController)
         }
+        .posFullScreenCover(isPresented: $phoneShowOrders) {
+            POSOrdersView(isPresented: $phoneShowOrders)
+        }
         .onChange(of: showSettings) { oldValue, newValue in
             guard !newValue, oldValue else { return }
             Task {
@@ -299,10 +302,8 @@ struct PointOfSaleDashboardView: View {
                 .frame(width: POSHeaderLayoutConstants.minHeight, height: POSHeaderLayoutConstants.minHeight)
                 .fixedSize()
         }
+        .accessibilityLabel(Localization.phoneMenuAccessibilityLabel)
         .accessibilityIdentifier("pos-phone-overflow-menu")
-        .posFullScreenCover(isPresented: $phoneShowOrders) {
-            POSOrdersView(isPresented: $phoneShowOrders)
-        }
     }
 
     private var phoneCartButton: some View {
@@ -520,6 +521,11 @@ private extension PointOfSaleDashboardView {
             "pointOfSaleDashboard.phone.menu.orders",
             value: "Orders",
             comment: "Phone-only overflow menu item to open the historical orders view."
+        )
+        static let phoneMenuAccessibilityLabel = NSLocalizedString(
+            "pointOfSaleDashboard.phone.menu.accessibilityLabel",
+            value: "More options",
+            comment: "VoiceOver label for the phone-only Point of Sale overflow menu button."
         )
     }
 }


### PR DESCRIPTION
> **Stack order** (review bottom-up — each PR depends on the one below):
> 1. #17062 — Add `pointOfSalePhonePrototype` feature flag
> 2. #17063 — Lift iPad/compact-width gates behind flag
> 3. #17064 — Phone navigation skeleton + Cart sheet
> 4. #17065 — Items header overflow menu (Exit/Settings/Orders)
> 5. #17066 — Phone-adaptive modals (barcode setup + refund flow)
> 6. #17067 — Selection border + connect-reader button polish (+ recent prototype iteration)

## Description
Stacked on top of #17064.

Adds a phone-only overflow menu (ellipsis chip) to the items list header. Tapping it opens a `Menu` with three actions:
- **Exit POS** — opens the existing exit confirmation alert
- **Settings** — opens \`POSSettingsView\` full-screen (already adapts to compact via \`POSNavigationSplitView\`)
- **Orders** — opens \`POSOrdersView\` full-screen (gated by the existing \`pointOfSaleHistoricalOrdersi1\` flag)

The chip is **hidden on the Coupons tab** where the create-coupon button already crowds the trailing slot — otherwise the Products / Coupons titles get squeezed.

### Implementation notes
- \`ItemListView\` gains an optional \`trailingHeaderAccessory: AnyView?\` parameter rendered alongside search/coupon buttons. Existing call sites default to \`nil\`; iPad behavior is unchanged.
- \`POSFloatingControlView\`'s Settings/Orders gates were \`horizontalSizeClass == .regular\` only; they're lifted when the prototype flag is on so the menu has items to show on phone.
- The 80×80 \`POSFloatingControlView\` itself is suppressed on phone (\`!isPhoneLayout\`) — it would overlap the bottom Cart button introduced in #17064.

Mirrors part of [woocommerce-android#15731](https://github.com/woocommerce/woocommerce-android/pull/15731).

## Test Steps
- Pull the branch (Debug = \`.localDeveloper\`).
- **iPhone, flag ON**:
  1. Open POS → ellipsis chip is visible at the top-right of the items list, alongside the search button.
  2. Tap chip → Menu shows Exit POS, Settings, Orders (Orders only if its flag is on).
  3. Tap Settings → opens POS settings full-screen, back returns to items.
  4. Tap Orders → opens orders list full-screen, back returns.
  5. Tap Exit POS → confirmation modal appears, can dismiss or confirm.
  6. Switch to Coupons tab → the ellipsis chip disappears (because the create-coupon button is shown there).
  7. Verify the bottom-leading floating control (the iPad ellipsis bubble) is **not** visible.
- **iPad, flag either**: floating control still visible bottom-leading, no extra chip in the items header. No regression.

## Screenshots
N/A — UI changes verified live.

---
- [x] No release notes — feature still flagged off in alpha.
