### PR TITLE
[RSM] Phone POS: Phone-adaptive modals (barcode setup + refund flow)

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
@@ -5,16 +5,22 @@ struct POSBarcodeScannerSetup: View {
     @State private var flowManager: PointOfSaleBarcodeScannerSetupFlowManager
     @Environment(\.posModalParentSize) var parentSize
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     init(isPresented: Binding<Bool>, analytics: POSAnalyticsProviding) {
         self._isPresented = isPresented
         self.flowManager = PointOfSaleBarcodeScannerSetupFlowManager(isPresented: isPresented, analytics: analytics)
     }
 
+    /// On phone the modal is taken to full screen to avoid the cramped iPad-tuned card.
+    private var isCompactWidth: Bool { horizontalSizeClass == .compact }
+    private var widthRatio: CGFloat { isCompactWidth ? 1.0 : Constants.parentWidthRatio }
+    private var heightRatio: CGFloat { isCompactWidth ? 1.0 : Constants.maxParentHeightRatio }
+
     var body: some View {
         AnimatedTransitionContainer(
-            maxWidth: parentSize.width * Constants.parentWidthRatio,
-            maxHeight: parentSize.height * Constants.maxParentHeightRatio,
+            maxWidth: parentSize.width * widthRatio,
+            maxHeight: parentSize.height * heightRatio,
             id: flowManager.currentStepKey
         ) {
             VStack(spacing: POSSpacing.xLarge) {
@@ -45,6 +51,7 @@ struct POSBarcodeScannerSetup: View {
             flowManager.onDisappear()
         }
         .maximumScreenBrightness()
+        .posModalFullScreen(isCompactWidth)
     }
 
     // MARK: - Computed Properties

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -22,7 +22,7 @@ struct POSRefundConfirmationView: View {
             }
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -9,6 +9,7 @@ struct POSRefundConfirmationView: View {
     let onBack: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -22,7 +23,7 @@ struct POSRefundConfirmationView: View {
         }
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -9,6 +9,7 @@ struct POSRefundDetailView: View {
     let onClose: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -29,7 +30,8 @@ struct POSRefundDetailView: View {
         }
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posModalFullScreen(horizontalSizeClass == .compact)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -29,7 +29,7 @@ struct POSRefundDetailView: View {
             }
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
         .posModalFullScreen(horizontalSizeClass == .compact)
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -8,6 +8,7 @@ struct POSRefundErrorView: View {
     let onClose: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var isViewLoaded: Bool = false
 
     var body: some View {
@@ -18,7 +19,7 @@ struct POSRefundErrorView: View {
         }
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
         .onAppear {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
                 isViewLoaded = true

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -18,7 +18,7 @@ struct POSRefundErrorView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
         .onAppear {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -41,7 +41,7 @@ struct POSRefundItemsSelectionView: View {
         }
         .padding(POSPadding.xLarge)
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -8,6 +8,7 @@ struct POSRefundItemsSelectionView: View {
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var refundSelectableItems: [POSRefundSelectableItem] {
         orderListModel.ordersController.refundSelectableItems
@@ -41,7 +42,7 @@ struct POSRefundItemsSelectionView: View {
         .padding(POSPadding.xLarge)
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct POSRefundLoadingView: View {
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         VStack(spacing: POSSpacing.xLarge) {
@@ -19,7 +20,7 @@ struct POSRefundLoadingView: View {
         .padding(.top, POSPadding.xxLarge)
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
@@ -19,7 +19,7 @@ struct POSRefundLoadingView: View {
         .padding(.bottom, POSPadding.xLarge)
         .padding(.top, POSPadding.xxLarge)
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -65,6 +65,7 @@ struct POSRefundModalContentView: View {
     @Binding var modalState: RefundModalState?
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     /// Dismisses the modal directly, bypassing the `onChange(of:)` chain in `POSModalViewModifier`
     /// which can fail to fire when the view is inside a pushed navigation destination.
@@ -87,6 +88,7 @@ struct POSRefundModalContentView: View {
 
     var body: some View {
         content
+            .posModalFullScreen(horizontalSizeClass == .compact)
             .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
                 POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
                     try await orderListModel.sendReceipt(order: order, email: email)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
@@ -11,4 +11,11 @@ enum POSRefundModalLayout {
     static func horizontalPadding(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
         sizeClass == .compact ? 0 : horizontalPadding
     }
+
+    /// Phone presents the modal full-screen via `posModalFullScreen`, so the inner card
+    /// should not be rounded (otherwise an inner-rounded card sits inside a square
+    /// full-screen modal). On iPad the iPad-tuned corner radius is applied.
+    static func cornerRadius(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        sizeClass == .compact ? 0 : cornerRadius
+    }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
@@ -5,4 +5,10 @@ enum POSRefundModalLayout {
     static let horizontalPadding: CGFloat = 148
     static let cornerRadius: CGFloat = POSCornerRadiusStyle.extraLarge.value
     static let progressViewStyle = POSProgressViewStyle(size: 64, lineWidth: 20)
+
+    /// Phone uses 0 horizontal padding so the modal can fill the narrow screen instead of
+    /// shrinking the content to a thin strip with the iPad-tuned 148pt insets.
+    static func horizontalPadding(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        sizeClass == .compact ? 0 : horizontalPadding
+    }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundNothingToRefundView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundNothingToRefundView.swift
@@ -4,6 +4,7 @@ struct POSRefundNothingToRefundView: View {
     let onClose: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -13,7 +14,7 @@ struct POSRefundNothingToRefundView: View {
         }
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundNothingToRefundView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundNothingToRefundView.swift
@@ -13,7 +13,7 @@ struct POSRefundNothingToRefundView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -13,6 +13,7 @@ struct POSRefundReviewView: View {
     let onEditRefund: (() -> Void)?
 
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -22,7 +23,7 @@ struct POSRefundReviewView: View {
         }
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -22,7 +22,7 @@ struct POSRefundReviewView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -9,6 +9,7 @@ struct POSRefundSuccessView: View {
     let onClose: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var isViewLoaded: Bool = false
 
     var body: some View {
@@ -19,7 +20,7 @@ struct POSRefundSuccessView: View {
         }
         .background(Color.posSurfaceBright)
         .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding * 2))
+        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
         .onAppear {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
                 isViewLoaded = true

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -19,7 +19,7 @@ struct POSRefundSuccessView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
         .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
         .onAppear {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {


### PR DESCRIPTION
> **Stack order** (review bottom-up — each PR depends on the one below):
> 1. #17062 — Add `pointOfSalePhonePrototype` feature flag
> 2. #17063 — Lift iPad/compact-width gates behind flag
> 3. #17064 — Phone navigation skeleton + Cart sheet
> 4. #17065 — Items header overflow menu (Exit/Settings/Orders)
> 5. #17066 — Phone-adaptive modals (barcode setup + refund flow)
> 6. #17067 — Selection border + connect-reader button polish (+ recent prototype iteration)

## Description
Stacked on top of #17065.

Two POS flows are presented as iPad-tuned modal cards with fixed insets — the barcode-scanner setup and the refund flow. On a narrow phone width those insets shrink the content into a cramped card or thin strip. On compact horizontal size class they now fill the available screen via \`.posModalFullScreen\`, and the iPad-tuned values collapse to full-bleed:

| Flow | iPad | Phone (compact) |
|---|---|---|
| Barcode scanner setup | 75% width / 90% height ratios | 1.0 / 1.0 |
| Refund flow modals | 148pt horizontal inset | 0pt (via new \`POSRefundModalLayout.horizontalPadding(for:)\`) |

Eight refund views are updated to use the new helper: selection, confirmation, review, success, error, loading, nothing-to-refund, detail. The detail view and the modal content view also apply \`.posModalFullScreen\` so the rounded corners + backdrop margins drop away on phone.

iPad behavior is unchanged — both flows still render as the iPad-tuned card with the original insets.

Mirrors [woocommerce-android#15752](https://github.com/woocommerce/woocommerce-android/pull/15752) + the refund-fullscreen PRs.

## Test Steps
- Pull the branch (Debug = \`.localDeveloper\`).
- **iPhone, flag ON**:
  1. Open POS → Settings → Hardware → Scanner setup. Verify it fills the entire screen with no rounded corners or backdrop margin.
  2. Open POS → Orders → tap a paid order with refundable items → Issue refund. Walk through the items selection / review / confirmation / success steps. Each should fill the screen, no thin-strip rendering.
  3. Same for tapping an existing refund row to view its details — full-screen.
- **iPad, flag either**: both flows render as the existing iPad cards. No regression.

## Screenshots
N/A — UI changes verified live.

---
- [x] No release notes — feature still flagged off in alpha.
