### PR TITLE
[RSM] Phone POS: Selection border + connect-reader button polish

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -6,8 +6,14 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
     private let animation: POSCardPresentPaymentInLineMessageAnimation
     @AccessibilityFocusState private var isTitleFocused: Bool
     @ScaledMetric private var scale: CGFloat = 1.0
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var width: CGFloat = 0
+
+    private var connectButtonWidth: CGFloat {
+        // iPad: half the container; phone: align with the totals lines (full width minus standard insets).
+        horizontalSizeClass == .compact ? max(width - POSPadding.large * 2, 0) : width * 0.5
+    }
 
     init(animation: POSCardPresentPaymentInLineMessageAnimation,
          connectCardReader: @escaping () -> Void) {
@@ -45,9 +51,11 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
                 connectCardReader()
             } label: {
                 Text(viewModel.connectReaderButtonTitle)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
             }
             .buttonStyle(POSFilledButtonStyle(size: .normal))
-            .frame(width: width * 0.5)
+            .frame(width: connectButtonWidth)
         }
         .frame(maxWidth: .infinity)
         .measureWidth({ containerWidth in

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -6,6 +6,7 @@ struct PointOfSalePaymentSuccessView: View {
     let successAction: PaymentFlowAction
     let onSuccessScreenBarcodeScanned: ((Result<String, HIDBarcodeParserError>) -> Void)?
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var isViewLoaded: Bool = false
     @AccessibilityFocusState private var isTitleFocused: Bool
@@ -79,8 +80,16 @@ struct PointOfSalePaymentSuccessView: View {
 
                 Spacer().frame(height: POSSpacing.xxLarge)
 
+                // iPad: buttons take half the screen width (count:2 span:1).
+                // Phone: half the screen width is ~190pt, too narrow for "New order" /
+                // "Email receipt" — let them span the container minus standard insets instead.
                 PaymentsActionButtons(successAction: successAction)
-                    .containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
+                    .if(horizontalSizeClass != .compact) { view in
+                        view.containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
+                    }
+                    .if(horizontalSizeClass == .compact) { view in
+                        view.padding(.horizontal, POSPadding.large)
+                    }
                     .frame(maxWidth: .infinity, alignment: .center)
                     .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
                     .opacity(isViewLoaded ? 1 : 0)

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -6,7 +6,6 @@ struct CartView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posCurrencyProvider) private var currencyProvider
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private let viewHelper = CartViewHelper()
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -61,19 +60,12 @@ struct CartView: View {
                 }
             }
             .ignoresSafeArea(.posContainerRegionToIgnore, edges: .bottom)
-            // On phone the cart itself is presented as a sheet, and `.posModal` renders via the
-            // root modal manager which sits *behind* sheets — so the barcode setup would appear
-            // dimmed under the cart with an unresponsive close button. Switch to a fullscreen
-            // cover for compact width so it sits above the cart sheet correctly.
-            .if(horizontalSizeClass == .compact) { view in
-                view.posFullScreenCover(isPresented: $showBarcodeScanningModal) {
-                    POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
-                }
-            }
-            .if(horizontalSizeClass != .compact) { view in
-                view.posModal(isPresented: $showBarcodeScanningModal) {
-                    POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
-                }
+            // Always presented via a fullscreen cover (not a posModal) because on phone the cart
+            // itself is a sheet, and the root modal manager sits *behind* sheets — the setup
+            // would appear dimmed under the cart with an unresponsive close button. iPad picks
+            // up the cover too, which is a sensible presentation there as well.
+            .posFullScreenCover(isPresented: $showBarcodeScanningModal) {
+                POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
             }
             // Cart-side edit only: the add path pushes from the products list and tracks
             // its own `mode: .add` analytics inline in `ItemListView`.

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -6,7 +6,15 @@ struct CartView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posCurrencyProvider) private var currencyProvider
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private let viewHelper = CartViewHelper()
+
+    /// Optional override for triggering the barcode-scanner setup from outside CartView.
+    /// On phone this lets the dashboard host the scanner cover *above* the cart sheet (the cart
+    /// sheet's POSSheet binding hides itself whenever a descendant cover is presented, which
+    /// otherwise tears CartView down and the inner cover with it). On iPad this is nil and
+    /// the cover is presented from CartView directly.
+    var onPresentBarcodeScannerSetup: (() -> Void)? = nil
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
 
@@ -60,11 +68,10 @@ struct CartView: View {
                 }
             }
             .ignoresSafeArea(.posContainerRegionToIgnore, edges: .bottom)
-            // Always presented via a fullscreen cover (not a posModal) because on phone the cart
-            // itself is a sheet, and the root modal manager sits *behind* sheets — the setup
-            // would appear dimmed under the cart with an unresponsive close button. iPad picks
-            // up the cover too, which is a sensible presentation there as well.
-            .posFullScreenCover(isPresented: $showBarcodeScanningModal) {
+            // iPad path only — on phone the dashboard hosts the cover above the cart sheet via
+            // `onPresentBarcodeScannerSetup`, otherwise POSSheet's coverManager interaction would
+            // tear CartView down before the cover fully presents.
+            .posModal(isPresented: $showBarcodeScanningModal) {
                 POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
             }
             // Cart-side edit only: the add path pushes from the products list and tracks
@@ -270,7 +277,11 @@ private extension CartView {
                 }
                 Button(action: {
                     analytics.track(.pointOfSaleEmptyCartSetupScannerTapped)
-                    showBarcodeScanningModal = true
+                    if let onPresentBarcodeScannerSetup {
+                        onPresentBarcodeScannerSetup()
+                    } else {
+                        showBarcodeScanningModal = true
+                    }
                 }, label: {
                     HStack {
                         Text(Localization.barcodeScanningSetup)

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -6,6 +6,7 @@ struct CartView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posCurrencyProvider) private var currencyProvider
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private let viewHelper = CartViewHelper()
 
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
@@ -60,8 +61,19 @@ struct CartView: View {
                 }
             }
             .ignoresSafeArea(.posContainerRegionToIgnore, edges: .bottom)
-            .posModal(isPresented: $showBarcodeScanningModal) {
-                POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
+            // On phone the cart itself is presented as a sheet, and `.posModal` renders via the
+            // root modal manager which sits *behind* sheets — so the barcode setup would appear
+            // dimmed under the cart with an unresponsive close button. Switch to a fullscreen
+            // cover for compact width so it sits above the cart sheet correctly.
+            .if(horizontalSizeClass == .compact) { view in
+                view.posFullScreenCover(isPresented: $showBarcodeScanningModal) {
+                    POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
+                }
+            }
+            .if(horizontalSizeClass != .compact) { view in
+                view.posModal(isPresented: $showBarcodeScanningModal) {
+                    POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
+                }
             }
             // Cart-side edit only: the add path pushes from the products list and tracks
             // its own `mode: .add` analytics inline in `ItemListView`.

--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -76,19 +76,26 @@ struct CartView: View {
             }
             // Cart-side edit only: the add path pushes from the products list and tracks
             // its own `mode: .add` analytics inline in `ItemListView`.
-            .posFullScreenCover(item: $posModel.editingCustomAmount) { customAmount in
-                AddCustomAmountView(
-                    currencySettings: currencyProvider.currencySettings,
-                    editing: customAmount,
-                    backButtonStyle: .close,
-                    // Explicit-dismiss path (back button + post-submit). System-driven dismissal
-                    // already nils the `item` binding; this closure handles the user-driven cases
-                    // where `submit()` calls `onDismiss()` to close the cover.
-                    onDismiss: { posModel.editingCustomAmount = nil },
-                    onSubmit: { updated in
-                        posModel.upsertCustomAmount(updated, mode: .edit)
-                    }
-                )
+            //
+            // iPad-only here. On phone the cart is presented as a sheet; presenting a
+            // .posFullScreenCover from inside it triggers POSSheet's coverManager check
+            // and the sheet dismisses CartView along with the cover. The dashboard hosts
+            // the same cover for compact width via `posModel.editingCustomAmount` directly.
+            .if(horizontalSizeClass != .compact) { view in
+                view.posFullScreenCover(item: $posModel.editingCustomAmount) { customAmount in
+                    AddCustomAmountView(
+                        currencySettings: currencyProvider.currencySettings,
+                        editing: customAmount,
+                        backButtonStyle: .close,
+                        // Explicit-dismiss path (back button + post-submit). System-driven dismissal
+                        // already nils the `item` binding; this closure handles the user-driven cases
+                        // where `submit()` calls `onDismiss()` to close the cover.
+                        onDismiss: { posModel.editingCustomAmount = nil },
+                        onSubmit: { updated in
+                            posModel.upsertCustomAmount(updated, mode: .edit)
+                        }
+                    )
+                }
             }
             .animation(Constants.cartAnimation, value: posModel.cart.isEmpty)
             .frame(maxWidth: .infinity)

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -61,7 +61,17 @@ struct ItemListView: View {
 
     private var isBarcodeScanningEnabled: Binding<Bool> {
         Binding(
-            get: { !isSearching && !modalManager.isPresented && !sheetManager.isPresented && !coverManager.isPresented },
+            // Also gated on `isAddingCustomAmount` — that form is pushed via NavigationStack
+            // (not a sheet/cover) so none of the manager flags flip, and typing in its text
+            // field would otherwise feed each character to the HID barcode listener and add
+            // bogus rows to the cart.
+            get: {
+                !isSearching
+                && !modalManager.isPresented
+                && !sheetManager.isPresented
+                && !coverManager.isPresented
+                && !isAddingCustomAmount
+            },
             set: { _ in }
         )
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -514,9 +514,13 @@ private extension POSOrderDetailsView {
     func actionsSection(setup: OrderDetailsActionsSetup) -> some View {
         if let primary = setup.primary {
             HStack(spacing: POSSpacing.large) {
-                Button(primary.title, action: handler(for: primary))
-                    .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
-                    .accessibilityHint(primary.accessibilityHint)
+                Button(action: handler(for: primary)) {
+                    Text(primary.title)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.5)
+                }
+                .buttonStyle(POSFilledButtonStyle(size: .extraSmall))
+                .accessibilityHint(primary.accessibilityHint)
             }
         }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -193,9 +193,16 @@ private struct POSOrderRowView: View {
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var minHeight: CGFloat {
         min(Constants.orderCardMinHeight * scale, Constants.maximumOrderCardHeight)
+    }
+
+    /// Suppress the selection border on compact widths — there is no adjacent detail pane on phone,
+    /// so the border indicates nothing useful and looks like a stray visual artifact.
+    private var showsSelectionBorder: Bool {
+        isSelected && horizontalSizeClass == .regular
     }
 
     var body: some View {
@@ -211,7 +218,7 @@ private struct POSOrderRowView: View {
         .background(Color.posSurfaceContainerLowest)
         .posItemCardBorderStyles()
         .overlay {
-            if isSelected {
+            if showsSelectionBorder {
                 RoundedRectangle(cornerRadius: POSCornerRadiusStyle.medium.value)
                     .stroke(Color.posOnSurface, lineWidth: 2)
             }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -36,7 +36,7 @@ private extension POSRefundConfirmationView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.5)
+                .minimumScaleFactor(0.7)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -36,6 +36,7 @@ private extension POSRefundConfirmationView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
+                .minimumScaleFactor(0.5)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -36,7 +36,7 @@ private extension POSRefundConfirmationView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(horizontalSizeClass == .compact ? 0.7 : 1.0)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -44,7 +44,7 @@ private extension POSRefundDetailView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(horizontalSizeClass == .compact ? 0.7 : 1.0)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -44,7 +44,7 @@ private extension POSRefundDetailView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.5)
+                .minimumScaleFactor(0.7)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -44,6 +44,7 @@ private extension POSRefundDetailView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
+                .minimumScaleFactor(0.5)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -55,7 +55,7 @@ private extension POSRefundItemsSelectionView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.5)
+                .minimumScaleFactor(0.7)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -55,7 +55,7 @@ private extension POSRefundItemsSelectionView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(horizontalSizeClass == .compact ? 0.7 : 1.0)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -55,6 +55,7 @@ private extension POSRefundItemsSelectionView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
+                .minimumScaleFactor(0.5)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -36,6 +36,7 @@ private extension POSRefundReviewView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
+                .minimumScaleFactor(0.5)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -36,7 +36,7 @@ private extension POSRefundReviewView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(horizontalSizeClass == .compact ? 0.7 : 1.0)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -36,7 +36,7 @@ private extension POSRefundReviewView {
                 .font(.posHeadingBold)
                 .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                 .lineLimit(1)
-                .minimumScaleFactor(0.5)
+                .minimumScaleFactor(0.7)
             Spacer()
             Button {
                 onClose()

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleCollectCashView.swift
@@ -114,6 +114,8 @@ struct PointOfSaleCollectCashView: View {
                             }
                         }, label: {
                             Text(Localization.markPaymentCompletedButtonTitle)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
                         })
                         .measureFrame {
                             buttonFrame = $0

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -328,6 +328,12 @@ struct PointOfSaleDashboardView: View {
             min(phoneOverflowMenuScaledSize, POSHeaderLayoutConstants.minHeight * 1.2))
     }
 
+    /// Total cart size — products + coupons — used to drive the cart-button pulse so adding
+    /// a coupon also gives visual feedback even though the displayed number stays products-only.
+    private var phoneCartTotalCount: Int {
+        posModel.cart.purchasableItems.count + posModel.cart.coupons.count
+    }
+
     private var phoneCartButton: some View {
         Button {
             phoneShowingCart = true
@@ -343,9 +349,11 @@ struct PointOfSaleDashboardView: View {
         .padding(.horizontal, POSPadding.medium)
         .padding(.vertical, POSPadding.medium)
         // Quick pulse to confirm an item was added — only on count increases, so removing items
-        // doesn't bounce the button distractingly.
+        // doesn't bounce the button distractingly. Watches the full cart count (products +
+        // coupons) so adding a coupon also pulses, even though the displayed number is
+        // products-only.
         .scaleEffect(phoneCartButtonPulse ? 1.04 : 1.0)
-        .onChange(of: posModel.cart.purchasableItems.count) { oldValue, newValue in
+        .onChange(of: phoneCartTotalCount) { oldValue, newValue in
             guard newValue > oldValue else { return }
             withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) {
                 phoneCartButtonPulse = true

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -221,7 +221,10 @@ struct PointOfSaleDashboardView: View {
                                  trailingHeaderAccessoryHiddenOnCoupons: AnyView(phoneOverflowMenu))
                     // Always shown — even with an empty cart — so the flow is always discoverable
                     // and the merchant has a consistent landmark at the bottom of the screen.
+                    // Suppressed when a pushed view (e.g. the custom amount form) signals via
+                    // POSHidesFloatingControlPreferenceKey that overlays should hide.
                     phoneCartButton
+                        .renderedIf(!floatingControlSuppressed)
                 }
             case .finalizing:
                 NavigationStack(path: $navigationPath) {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -252,27 +252,30 @@ struct PointOfSaleDashboardView: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
-        .posFullScreenCover(isPresented: $phoneShowingBarcodeScannerSetup) {
-            POSBarcodeScannerSetup(isPresented: $phoneShowingBarcodeScannerSetup, analytics: analytics)
-        }
-        // CartView's edit-custom-amount cover is gated to iPad — on phone we present it
-        // here, at the dashboard level, so it sits above the cart sheet (and the cart sheet's
-        // POSSheet binding can dismiss without tearing down the cover host).
+        // Phone-only covers presented at the dashboard level:
+        //  - Barcode scanner setup, triggered from the cart sheet.
+        //  - Edit-custom-amount, hosted here so it sits above the cart sheet (CartView's
+        //    edit cover is gated to iPad, and POSSheet dismissal can tear down covers
+        //    that live inside the sheet's content).
         .if(isPhoneLayout) { view in
-            view.posFullScreenCover(item: Binding(
-                get: { posModel.editingCustomAmount },
-                set: { posModel.editingCustomAmount = $0 }
-            )) { customAmount in
-                AddCustomAmountView(
-                    currencySettings: currencyProvider.currencySettings,
-                    editing: customAmount,
-                    backButtonStyle: .close,
-                    onDismiss: { posModel.editingCustomAmount = nil },
-                    onSubmit: { updated in
-                        posModel.upsertCustomAmount(updated, mode: .edit)
-                    }
-                )
-            }
+            view
+                .posFullScreenCover(isPresented: $phoneShowingBarcodeScannerSetup) {
+                    POSBarcodeScannerSetup(isPresented: $phoneShowingBarcodeScannerSetup, analytics: analytics)
+                }
+                .posFullScreenCover(item: Binding(
+                    get: { posModel.editingCustomAmount },
+                    set: { posModel.editingCustomAmount = $0 }
+                )) { customAmount in
+                    AddCustomAmountView(
+                        currencySettings: currencyProvider.currencySettings,
+                        editing: customAmount,
+                        backButtonStyle: .close,
+                        onDismiss: { posModel.editingCustomAmount = nil },
+                        onSubmit: { updated in
+                            posModel.upsertCustomAmount(updated, mode: .edit)
+                        }
+                    )
+                }
         }
         .animation(.default, value: posModel.orderStage)
         .ignoresSafeArea()

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -218,24 +218,13 @@ struct PointOfSaleDashboardView: View {
                     ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
                                  searchTerm: $viewStateCoordinator.searchTerm,
                                  trailingHeaderAccessoryHiddenOnCoupons: AnyView(phoneOverflowMenu))
-                    if posModel.cart.isNotEmpty {
-                        phoneCartButton
-                    }
+                    // Always shown — even with an empty cart — so the flow is always discoverable
+                    // and the merchant has a consistent landmark at the bottom of the screen.
+                    phoneCartButton
                 }
             case .finalizing:
                 NavigationStack(path: $navigationPath) {
-                    TotalsView()
-                        .background(Color.posSurface)
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button {
-                                    posModel.addMoreToCart()
-                                } label: {
-                                    Label(Localization.phoneBackToItems, systemImage: "chevron.backward")
-                                }
-                                .disabled(!canExitFinalizingOnPhone)
-                            }
-                        }
+                    phoneTotalsContainer
                         .posNavigationDestinations()
                 }
                 .environment(\.posNavigationRouter, navigationRouter)
@@ -269,6 +258,24 @@ struct PointOfSaleDashboardView: View {
             orderState: posModel.orderState,
             paymentState: posModel.paymentState
         )
+    }
+
+    /// Wraps `TotalsView` with an in-screen `POSPageHeaderView` back button so the phone totals
+    /// view follows the same pattern as cash payment, settings, and orders — instead of a
+    /// system nav bar back button.
+    private var phoneTotalsContainer: some View {
+        VStack(spacing: 0) {
+            POSPageHeaderView(
+                title: Localization.phoneCheckoutTitle,
+                backButtonConfiguration: .init(
+                    state: canExitFinalizingOnPhone ? .enabled : .disabled,
+                    action: { posModel.addMoreToCart() }
+                )
+            )
+            TotalsView()
+        }
+        .background(Color.posSurface)
+        .toolbar(.hidden, for: .navigationBar)
     }
 
     @State private var phoneShowOrders: Bool = false
@@ -321,6 +328,8 @@ struct PointOfSaleDashboardView: View {
             phoneShowingCart = true
         } label: {
             Text(String(format: Localization.phoneCart, posModel.cart.totalItemCount))
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .padding(.horizontal, POSPadding.medium)
@@ -512,10 +521,10 @@ private extension PointOfSaleDashboardView {
             value: "Cart (%1$d)",
             comment: "Phone-only floating button to open the cart from the items list. %1$d is the cart item count."
         )
-        static let phoneBackToItems = NSLocalizedString(
-            "pointOfSaleDashboard.phone.backToItems",
-            value: "Items",
-            comment: "Phone-only back button title to return from totals to the items list."
+        static let phoneCheckoutTitle = NSLocalizedString(
+            "pointOfSaleDashboard.phone.checkoutTitle",
+            value: "Checkout",
+            comment: "Phone-only header title shown above the totals view during checkout."
         )
         static let phoneMenuExit = NSLocalizedString(
             "pointOfSaleDashboard.phone.menu.exit",

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -348,30 +348,37 @@ struct PointOfSaleDashboardView: View {
             min(phoneOverflowMenuScaledSize, POSHeaderLayoutConstants.minHeight * 1.2))
     }
 
-    /// Total cart size — products + coupons — used to drive the cart-button pulse so adding
-    /// a coupon also gives visual feedback even though the displayed number stays products-only.
+    /// Tangible items shown in the cart count — products + custom amounts.
+    /// Coupons are tracked separately and pulse-only (see below).
+    private var phoneCartItemsCount: Int {
+        posModel.cart.purchasableItems.count + posModel.cart.customAmounts.count
+    }
+
+    /// Total cart size — products + custom amounts + coupons — used to drive the cart-button
+    /// pulse so adding a coupon also gives visual feedback even though the displayed number
+    /// stays items-only.
     private var phoneCartTotalCount: Int {
-        posModel.cart.purchasableItems.count + posModel.cart.coupons.count
+        phoneCartItemsCount + posModel.cart.coupons.count
     }
 
     private var phoneCartButton: some View {
         Button {
             phoneShowingCart = true
         } label: {
-            Text(String(format: Localization.phoneCart, posModel.cart.totalItemCount))
+            Text(String(format: Localization.phoneCart, phoneCartItemsCount))
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
                 // Number flips smoothly between values instead of snapping.
                 .contentTransition(.numericText())
-                .animation(.snappy(duration: 0.25), value: posModel.cart.purchasableItems.count)
+                .animation(.snappy(duration: 0.25), value: phoneCartItemsCount)
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .padding(.horizontal, POSPadding.medium)
         .padding(.vertical, POSPadding.medium)
         // Quick pulse to confirm an item was added — only on count increases, so removing items
         // doesn't bounce the button distractingly. Watches the full cart count (products +
-        // coupons) so adding a coupon also pulses, even though the displayed number is
-        // products-only.
+        // custom amounts + coupons) so adding any of those pulses, even though the displayed
+        // number stays items-only (no coupons).
         .scaleEffect(phoneCartButtonPulse ? 1.04 : 1.0)
         .onChange(of: phoneCartTotalCount) { oldValue, newValue in
             guard newValue > oldValue else { return }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -283,6 +283,7 @@ struct PointOfSaleDashboardView: View {
 
     @State private var phoneShowOrders: Bool = false
     @State private var phoneShowingBarcodeScannerSetup: Bool = false
+    @State private var phoneCartButtonPulse: Bool = false
 
     private var phoneOverflowMenu: some View {
         Menu {
@@ -334,10 +335,27 @@ struct PointOfSaleDashboardView: View {
             Text(String(format: Localization.phoneCart, posModel.cart.totalItemCount))
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
+                // Number flips smoothly between values instead of snapping.
+                .contentTransition(.numericText())
+                .animation(.snappy(duration: 0.25), value: posModel.cart.purchasableItems.count)
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .padding(.horizontal, POSPadding.medium)
         .padding(.vertical, POSPadding.medium)
+        // Quick pulse to confirm an item was added — only on count increases, so removing items
+        // doesn't bounce the button distractingly.
+        .scaleEffect(phoneCartButtonPulse ? 1.04 : 1.0)
+        .onChange(of: posModel.cart.purchasableItems.count) { oldValue, newValue in
+            guard newValue > oldValue else { return }
+            withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) {
+                phoneCartButtonPulse = true
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                    phoneCartButtonPulse = false
+                }
+            }
+        }
         .accessibilityIdentifier("pos-phone-cart-button")
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -5,6 +5,7 @@ struct PointOfSaleDashboardView: View {
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.posCurrencyProvider) private var currencyProvider
     @Environment(\.posExternalViews) private var externalViews
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.dismiss) private var dismiss
@@ -250,6 +251,25 @@ struct PointOfSaleDashboardView: View {
         }
         .posFullScreenCover(isPresented: $phoneShowingBarcodeScannerSetup) {
             POSBarcodeScannerSetup(isPresented: $phoneShowingBarcodeScannerSetup, analytics: analytics)
+        }
+        // CartView's edit-custom-amount cover is gated to iPad — on phone we present it
+        // here, at the dashboard level, so it sits above the cart sheet (and the cart sheet's
+        // POSSheet binding can dismiss without tearing down the cover host).
+        .if(isPhoneLayout) { view in
+            view.posFullScreenCover(item: Binding(
+                get: { posModel.editingCustomAmount },
+                set: { posModel.editingCustomAmount = $0 }
+            )) { customAmount in
+                AddCustomAmountView(
+                    currencySettings: currencyProvider.currencySettings,
+                    editing: customAmount,
+                    backButtonStyle: .close,
+                    onDismiss: { posModel.editingCustomAmount = nil },
+                    onSubmit: { updated in
+                        posModel.upsertCustomAmount(updated, mode: .edit)
+                    }
+                )
+            }
         }
         .animation(.default, value: posModel.orderStage)
         .ignoresSafeArea()

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -248,6 +248,9 @@ struct PointOfSaleDashboardView: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
+        .posFullScreenCover(isPresented: $phoneShowingBarcodeScannerSetup) {
+            POSBarcodeScannerSetup(isPresented: $phoneShowingBarcodeScannerSetup, analytics: analytics)
+        }
         .animation(.default, value: posModel.orderStage)
         .ignoresSafeArea()
         .background(Color.posSurface.ignoresSafeArea())
@@ -279,6 +282,7 @@ struct PointOfSaleDashboardView: View {
     }
 
     @State private var phoneShowOrders: Bool = false
+    @State private var phoneShowingBarcodeScannerSetup: Bool = false
 
     private var phoneOverflowMenu: some View {
         Menu {
@@ -339,7 +343,19 @@ struct PointOfSaleDashboardView: View {
 
     private var phoneCartSheetView: some View {
         // Drag indicator + swipe-down handle dismissal; an explicit close button isn't needed.
-        CartView()
+        // The barcode-scanner trigger is lifted to the dashboard level (via the closure here)
+        // so it presents above the cart sheet rather than being torn down by POSSheet's
+        // coverManager interaction.
+        var cart = CartView()
+        cart.onPresentBarcodeScannerSetup = {
+            phoneShowingCart = false
+            // Tiny delay so the cart sheet finishes dismissing before the cover presents,
+            // otherwise iOS rejects the simultaneous transitions and nothing shows.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                phoneShowingBarcodeScannerSetup = true
+            }
+        }
+        return cart
             .background(Color.posSurface)
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -2,10 +2,17 @@ import SwiftUI
 
 struct POSRootModalViewModifier: ViewModifier {
     @EnvironmentObject var modalManager: POSModalManager
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var modalParentSize: CGSize = UIScreen.main.bounds.size
 
     private let animationDuration = Constants.animationDuration
     private let scaleTransitionAmount = Constants.scaleTransitionAmount
+
+    /// On phone we standardize the modal experience: every posModal renders as a full-screen
+    /// take-over rather than a centered card, matching the rest of the phone-prototype UI.
+    private var isFullScreen: Bool {
+        modalManager.isFullScreen || horizontalSizeClass == .compact
+    }
 
     func body(content: Content) -> some View {
         content
@@ -31,11 +38,14 @@ struct POSRootModalViewModifier: ViewModifier {
                             .environment(\.posModalParentSize, modalParentSize)
                             .environment(\.posModalDismissAction, { modalManager.dismiss() })
                             .background(Color.posSurfaceBright)
-                            .cornerRadius(modalManager.isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
-                            .posShadow(modalManager.isFullScreen ? .none : .large,
-                                       cornerRadius: modalManager.isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
-                            .padding(modalManager.isFullScreen ? POSPadding.none : POSPadding.medium)
-                            .ignoresSafeArea(.container, edges: modalManager.isFullScreen ? .all : [])
+                            .cornerRadius(isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
+                            .posShadow(isFullScreen ? .none : .large,
+                                       cornerRadius: isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
+                            .padding(isFullScreen ? POSPadding.none : POSPadding.medium)
+                            // When full-screen we still respect the top safe area so the close
+                            // button (and any header) doesn't sit flush against the status bar /
+                            // notch. The bottom + horizontal edges still extend to the screen.
+                            .ignoresSafeArea(.container, edges: isFullScreen ? [.horizontal, .bottom] : [])
                     }
                     .zIndex(1)
                     // Scale the modal container in and out, fading appropriately.

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -389,6 +389,7 @@ private struct SubtotalFieldView: View {
     let title: String
     let formattedPrice: String?
     let shimmeringActive: Bool
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         content
@@ -400,7 +401,7 @@ private struct SubtotalFieldView: View {
     private var content: some View {
         if shimmeringActive {
             ShimmeringLineView(
-                width: TotalsView.Constants.shimmeringWidth,
+                width: horizontalSizeClass == .compact ? nil : TotalsView.Constants.shimmeringWidth,
                 height: TotalsView.Constants.subtotalsShimmeringHeight
             )
         } else {
@@ -420,6 +421,7 @@ private struct SubtotalFieldView: View {
 private struct TotalFieldView: View {
     let formattedPrice: String?
     let shimmeringActive: Bool
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         content
@@ -431,7 +433,7 @@ private struct TotalFieldView: View {
     private var content: some View {
         if shimmeringActive {
             ShimmeringLineView(
-                width: TotalsView.Constants.shimmeringWidth,
+                width: horizontalSizeClass == .compact ? nil : TotalsView.Constants.shimmeringWidth,
                 height: TotalsView.Constants.totalShimmeringHeight
             )
         } else {
@@ -452,15 +454,26 @@ private struct TotalFieldView: View {
 }
 
 private struct ShimmeringLineView: View {
-    let width: CGFloat
+    /// When nil, the bar stretches to the available container width (used on phone, where the
+    /// fixed iPad-tuned width would render asymmetrically inside a centered HStack).
+    let width: CGFloat?
     let height: CGFloat
 
     var body: some View {
-        Color.posOnSurfaceVariantLowest
-            .frame(width: width, height: height)
-            .fixedSize(horizontal: true, vertical: true)
-            .shimmering(active: true)
-            .cornerRadius(TotalsView.Constants.shimmeringCornerRadius)
+        if let width {
+            Color.posOnSurfaceVariantLowest
+                .frame(width: width, height: height)
+                .fixedSize(horizontal: true, vertical: true)
+                .shimmering(active: true)
+                .cornerRadius(TotalsView.Constants.shimmeringCornerRadius)
+        } else {
+            Color.posOnSurfaceVariantLowest
+                .frame(maxWidth: .infinity)
+                .frame(height: height)
+                .shimmering(active: true)
+                .cornerRadius(TotalsView.Constants.shimmeringCornerRadius)
+                .padding(.horizontal, POSPadding.medium)
+        }
     }
 }
 


### PR DESCRIPTION
> **Stack order** (review bottom-up — each PR depends on the one below):
> 1. #17062 — Add `pointOfSalePhonePrototype` feature flag
> 2. #17063 — Lift iPad/compact-width gates behind flag
> 3. #17064 — Phone navigation skeleton + Cart sheet
> 4. #17065 — Items header overflow menu (Exit/Settings/Orders)
> 5. #17066 — Phone-adaptive modals (barcode setup + refund flow)
> 6. #17067 — Selection border + connect-reader button polish (+ recent prototype iteration)

## Description
Stacked on top of #17066. The final piece of the phone POS scaffolding — two small visual fixes for compact width.

### POSOrderListView — order list selection border
Order rows have a 2pt selection border so the iPad split view shows which row drives the right detail pane. There is no detail pane on phone (the existing \`POSNavigationSplitView\` already adapts to compact by sliding to a full-screen detail), so the border indicates nothing useful and reads as a stray artifact. Suppressed when \`horizontalSizeClass != .regular\`.

### PointOfSaleCardPresentPaymentReaderDisconnectedMessageView — connect-reader button
The "Connect your reader" button was sized at \`width * 0.5\`, and on a narrow phone the label wrapped to three lines. The label now uses \`.lineLimit(1)\` + \`.minimumScaleFactor(0.5)\` so it shrinks to fit instead of wrapping. On phone the button itself spans the container minus standard insets (\`width - POSPadding.large * 2\`) so it aligns with the totals lines below it. iPad keeps the original \`width * 0.5\`.

Mirrors parts of [woocommerce-android#15723](https://github.com/woocommerce/woocommerce-android/pull/15723) + [#15788](https://github.com/woocommerce/woocommerce-android/pull/15788).

## Test Steps
- Pull the branch (Debug = \`.localDeveloper\`).
- **iPhone, flag ON**:
  1. Open POS → Orders → tap an order. The list slides to the detail. No 2pt black border on the originating row in the (briefly visible) list.
  2. Open POS → start a new order with no card reader connected → tap Cash payment → cancel back to totals. The reader-disconnected inline message shows. Verify the "Connect your reader" button text is on a single line and the button spans wider than half-width (aligned with the totals/subtotal text).
- **iPad, flag either**: Order rows still get the selection border in the split view; connect-reader button still sized at half-width. No regression.

## Screenshots
N/A — UI changes verified live.

---
- [x] No release notes — feature still flagged off in alpha.
