### PR TITLE
Woo Mobile AI: render typed cards and tap-through navigation

### DIFF
--- a/Modules/Sources/WooAIAssistant/Presentation/AssistantChatView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/AssistantChatView.swift
@@ -77,7 +77,8 @@ public struct AssistantChatView: View {
     private var messageList: some View {
         MessageListView(messages: controller.conversation.messages,
                         streamingState: controller.conversation.streamingState,
-                        onPickPrompt: { draft = $0; inputFocused = true })
+                        onPickPrompt: { draft = $0; inputFocused = true },
+                        onSendSuggestion: sendSuggestion)
             .background(
                 Color.clear
                     .contentShape(Rectangle())
@@ -104,6 +105,14 @@ public struct AssistantChatView: View {
         guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         controller.send(prompt)
         draft = ""
+    }
+
+    private func sendSuggestion(_ suggestion: String) {
+        let trimmed = suggestion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        controller.send(trimmed)
+        draft = ""
+        inputFocused = false
     }
 
     private func newConversation() {

--- a/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
@@ -22,8 +22,6 @@ struct ConfirmationCard: View {
             }
             .padding(.horizontal, Layout.padding)
 
-            Divider()
-
             VStack(alignment: .leading, spacing: AssistantSpacing.small) {
                 diffBody
                 if status == .pending {

--- a/Modules/Sources/WooAIAssistant/Presentation/MessageListView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/MessageListView.swift
@@ -5,6 +5,7 @@ struct MessageListView: View {
     let messages: [ChatMessage]
     let streamingState: AssistantConversation.StreamingState
     var onPickPrompt: (String) -> Void = { _ in }
+    var onSendSuggestion: (String) -> Void = { _ in }
 
     @StateObject private var scrollController = ChatScrollController()
     @State private var lastTickTime: Date = .distantPast

--- a/WooCommerce/Classes/AIAssistant/AIAssistantChatScreen.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantChatScreen.swift
@@ -10,13 +10,17 @@ struct AIAssistantChatScreen: View {
 
     @State private var controller: AssistantController?
     @State private var navigationHost: AIAssistantNavigationHost?
+    @State private var externalNavigation: AssistantExternalNavigationProviding?
+    @State private var externalViews: AssistantExternalViewProviding?
     @State private var appPasswordSupportState = ApplicationPasswordsExperimentState()
 
     var body: some View {
         Group {
-            if let navigationHost, let controller {
+            if let navigationHost, let controller, let externalNavigation, let externalViews {
                 AIAssistantChatNavHost(host: navigationHost) {
                     AssistantChatView(controller: controller, onClose: onClose)
+                        .environment(\.assistantExternalNavigation, externalNavigation)
+                        .environment(\.assistantExternalViews, externalViews)
                 }
                 .ignoresSafeArea()
             } else {
@@ -42,5 +46,7 @@ struct AIAssistantChatScreen: View {
         }
         navigationHost = session.navigationHost
         controller = session.controller
+        externalNavigation = session.externalNavigation
+        externalViews = session.externalViews
     }
 }

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalNavigationAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalNavigationAdaptor.swift
@@ -11,13 +11,16 @@ struct AIAssistantExternalNavigationAdaptor: AssistantExternalNavigationProvidin
     private let boundSiteID: Int64
     private let navigationHost: AIAssistantNavigationHost
     private let stores: StoresManager
+    private let timeZone: TimeZone
 
     init(siteID: Int64,
          navigationHost: AIAssistantNavigationHost,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         timeZone: TimeZone = .siteTimezone) {
         self.boundSiteID = siteID
         self.navigationHost = navigationHost
         self.stores = stores
+        self.timeZone = timeZone
     }
 
     // MARK: - Orders
@@ -145,31 +148,35 @@ struct AIAssistantExternalNavigationAdaptor: AssistantExternalNavigationProvidin
     func openAnalyticsHub(payload: AnyCodableJSON) {
         let analyticsHubVC = AnalyticsHubHostingViewController(
             siteID: boundSiteID,
-            timeZone: .siteTimezone,
+            timeZone: timeZone,
             timeRange: timeRange(fromAnalyticsPayload: payload),
             usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()
         )
         push(analyticsHubVC)
     }
 
+    // The analytics screen interprets the range in the site timezone, so parse the
+    // YYYY-MM-DD strings in that same timezone to avoid an off-by-one shift in
+    // negative-UTC stores (e.g. May 4 displayed as May 3 in America/Los_Angeles).
     func timeRange(fromAnalyticsPayload payload: AnyCodableJSON) -> StatsTimeRangeV4 {
+        let formatter = makeISODateFormatter()
         guard let after = payload.assistantString("after"),
               let before = payload.assistantString("before"),
-              let from = Self.isoDateFormatter.date(from: after),
-              let to = Self.isoDateFormatter.date(from: before) else {
+              let from = formatter.date(from: after),
+              let to = formatter.date(from: before) else {
             return .today
         }
         return .custom(from: from, to: to)
     }
 
-    private static let isoDateFormatter: DateFormatter = {
+    private func makeISODateFormatter() -> DateFormatter {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.timeZone = timeZone
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
-    }()
+    }
 
     // MARK: - Helpers
 

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalNavigationAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalNavigationAdaptor.swift
@@ -1,8 +1,9 @@
 import Foundation
+import SwiftUI
 import UIKit
 import Yosemite
 import CocoaLumberjackSwift
-import protocol WooAIAssistant.AssistantExternalNavigationProviding
+import WooAIAssistant
 
 @MainActor
 struct AIAssistantExternalNavigationAdaptor: AssistantExternalNavigationProviding {
@@ -19,70 +20,239 @@ struct AIAssistantExternalNavigationAdaptor: AssistantExternalNavigationProvidin
         self.stores = stores
     }
 
+    // MARK: - Orders
+
     func openOrder(orderID: Int64) {
-        let boundSiteID = self.boundSiteID
-        let navigationHost = self.navigationHost
-        let stores = self.stores
-        Task { @MainActor in
-            guard let order = await Self.fetchOrder(orderID: orderID, boundSiteID: boundSiteID, stores: stores) else { return }
-            let viewModel = OrderDetailsViewModel(order: order)
-            let detailVC = OrderDetailsViewController(viewModel: viewModel)
-            Self.push(detailVC, navigationHost: navigationHost)
-        }
+        let loader = OrderLoaderViewController(orderID: orderID, siteID: boundSiteID)
+        push(loader)
     }
 
-    func openProduct(productID: Int64) {
-        let boundSiteID = self.boundSiteID
-        let navigationHost = self.navigationHost
-        let stores = self.stores
-        Task { @MainActor in
-            guard let product = await Self.fetchProduct(productID: productID, boundSiteID: boundSiteID, stores: stores) else { return }
-            let detailVC = ProductDetailsFactory.productDetails(product: product,
-                                                                 presentationStyle: .navigationStack,
-                                                                 forceReadOnly: false)
-            Self.push(detailVC, navigationHost: navigationHost)
+    func openOrder(orderID: Int64, payload: AnyCodableJSON) {
+        if let order = decode(Order.self, from: payload) {
+            let viewModel = OrderDetailsViewModel(order: order)
+            let detail = OrderDetailsViewController(viewModel: viewModel)
+            push(detail)
+            return
         }
+        openOrder(orderID: orderID)
+    }
+
+    // MARK: - Products
+
+    func openProduct(productID: Int64) {
+        pushLoadingThen(
+            fetch: { await fetchProduct(productID: productID) },
+            detail: { ProductDetailNavigator.shared.makeDestination(product: $0, isReadOnly: false) }
+        )
+    }
+
+    func openProduct(productID: Int64, payload: AnyCodableJSON) {
+        if let product = decode(Product.self, from: payload) {
+            pushProductDetail(for: product)
+            return
+        }
+        openProduct(productID: productID)
     }
 
     func openProductVariation(productID: Int64, variationID: Int64) {
-        DDLogWarn("Assistant openProductVariation is not implemented yet")
+        pushLoadingThen(
+            fetch: { () -> UIViewController? in
+                async let parent = fetchProduct(productID: productID)
+                async let variation = fetchProductVariation(productID: productID, variationID: variationID)
+                guard let parent = await parent, let variation = await variation else { return nil }
+                return await withCheckedContinuation { continuation in
+                    ProductVariationDetailsFactory.productVariationDetails(productVariation: variation,
+                                                                           parentProduct: parent,
+                                                                           presentationStyle: .navigationStack,
+                                                                           forceReadOnly: false) { viewController in
+                        continuation.resume(returning: viewController)
+                    }
+                }
+            },
+            detail: { $0 }
+        )
     }
+
+    private func pushProductDetail(for product: Product) {
+        let detail = ProductDetailNavigator.shared.makeDestination(product: product, isReadOnly: false)
+        push(detail)
+    }
+
+    // MARK: - Customers
 
     func openCustomer(customerID: Int64) {
-        DDLogWarn("Assistant openCustomer is not implemented yet")
+        pushLoadingThen(
+            fetch: { await fetchCustomer(customerID: customerID) },
+            detail: { customer in
+                let viewModel = makeCustomerDetailViewModel(for: customer)
+                return UIHostingController(rootView: CustomerDetailView(viewModel: viewModel))
+            }
+        )
     }
 
-    @MainActor
-    private static func push(_ viewController: UIViewController, navigationHost: AIAssistantNavigationHost) {
+    func openCustomer(customerID: Int64, payload: AnyCodableJSON) {
+        if let customer = decode(Customer.self, from: payload) {
+            pushCustomerDetail(for: customer)
+            return
+        }
+        openCustomer(customerID: customerID)
+    }
+
+    private func pushCustomerDetail(for customer: Customer) {
+        let viewModel = makeCustomerDetailViewModel(for: customer)
+        let hosting = UIHostingController(rootView: CustomerDetailView(viewModel: viewModel))
+        push(hosting)
+    }
+
+    private func makeCustomerDetailViewModel(for customer: Customer) -> CustomerDetailViewModel {
+        let displayName: String = {
+            let combined = [customer.firstName, customer.lastName]
+                .compactMap { $0?.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            if !combined.isEmpty { return combined }
+            if let username = customer.username, !username.isEmpty { return username }
+            return customer.email
+        }()
+        return CustomerDetailViewModel(
+            siteID: customer.siteID,
+            customerID: customer.customerID,
+            name: displayName,
+            dateLastActive: nil,
+            email: nullifyBlank(customer.email),
+            ordersCount: "-",
+            totalSpend: "-",
+            avgOrderValue: "-",
+            username: nullifyBlank(customer.username),
+            dateRegistered: nil,
+            country: nullifyBlank(customer.billing?.country),
+            region: nullifyBlank(customer.billing?.state),
+            city: nullifyBlank(customer.billing?.city),
+            postcode: nullifyBlank(customer.billing?.postcode)
+        )
+    }
+
+    private func nullifyBlank(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespaces),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    // MARK: - Analytics
+
+    func openAnalyticsHub(payload: AnyCodableJSON) {
+        let analyticsHubVC = AnalyticsHubHostingViewController(
+            siteID: boundSiteID,
+            timeZone: .siteTimezone,
+            timeRange: timeRange(fromAnalyticsPayload: payload),
+            usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()
+        )
+        push(analyticsHubVC)
+    }
+
+    func timeRange(fromAnalyticsPayload payload: AnyCodableJSON) -> StatsTimeRangeV4 {
+        guard let after = payload.assistantString("after"),
+              let before = payload.assistantString("before"),
+              let from = Self.isoDateFormatter.date(from: after),
+              let to = Self.isoDateFormatter.date(from: before) else {
+            return .today
+        }
+        return .custom(from: from, to: to)
+    }
+
+    private static let isoDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    // MARK: - Helpers
+
+    private func push(_ viewController: UIViewController) {
         guard let nav = navigationHost.navigationController else { return }
         nav.pushViewController(viewController, animated: true)
     }
 
-    private static func fetchOrder(orderID: Int64, boundSiteID: Int64, stores: StoresManager) async -> Order? {
-        await withCheckedContinuation { continuation in
-            let action = OrderAction.retrieveOrderRemotely(siteID: boundSiteID, orderID: orderID) { result in
-                continuation.resume(returning: unwrap(result, label: "order"))
-            }
-            stores.dispatch(action)
+    // Pushes a placeholder, swaps it once `fetch` resolves. Identity lookup no-ops if the user popped.
+    private func pushLoadingThen<Value>(
+        fetch: @escaping () async -> Value?,
+        detail: @escaping (Value) -> UIViewController
+    ) {
+        let placeholder = AIAssistantLoadingPlaceholderViewController()
+        push(placeholder)
+        Task { @MainActor in
+            guard let value = await fetch() else { return }
+            guard let nav = navigationHost.navigationController else { return }
+            var stack = nav.viewControllers
+            guard let index = stack.firstIndex(where: { $0 === placeholder }) else { return }
+            stack[index] = detail(value)
+            nav.setViewControllers(stack, animated: false)
         }
     }
 
-    private static func fetchProduct(productID: Int64, boundSiteID: Int64, stores: StoresManager) async -> Product? {
+    // Networking model inits read siteID from decoder.userInfo, not the REST response.
+    private func decode<T: Decodable>(_ type: T.Type, from payload: AnyCodableJSON) -> T? {
+        do {
+            let data = try JSONEncoder().encode(payload)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+            decoder.userInfo[.siteID] = boundSiteID
+            return try decoder.decode(type, from: data)
+        } catch {
+            DDLogDebug("AIAssistantExternalNavigationAdaptor: \(type) cache miss \(error)")
+            return nil
+        }
+    }
+
+    private func fetchProduct(productID: Int64) async -> Product? {
         await withCheckedContinuation { continuation in
             let action = ProductAction.retrieveProduct(siteID: boundSiteID, productID: productID) { result in
-                continuation.resume(returning: unwrap(result, label: "product"))
+                switch result {
+                case .success(let product):
+                    continuation.resume(returning: product)
+                case .failure(let error):
+                    DDLogError("AIAssistantExternalNavigationAdaptor failed to fetch product: \(error)")
+                    continuation.resume(returning: nil)
+                }
             }
             stores.dispatch(action)
         }
     }
 
-    private static func unwrap<T, E: Error>(_ result: Result<T, E>, label: String) -> T? {
-        switch result {
-        case .success(let value):
-            return value
-        case .failure(let error):
-            DDLogError("⛔️ AIAssistantExternalNavigationAdaptor failed to fetch \(label): \(error)")
-            return nil
+    private func fetchProductVariation(productID: Int64, variationID: Int64) async -> ProductVariation? {
+        await withCheckedContinuation { continuation in
+            let action = ProductVariationAction.retrieveProductVariation(siteID: boundSiteID,
+                                                                          productID: productID,
+                                                                          variationID: variationID) { result in
+                switch result {
+                case .success(let variation):
+                    continuation.resume(returning: variation)
+                case .failure(let error):
+                    DDLogError("AIAssistantExternalNavigationAdaptor failed to fetch variation: \(error)")
+                    continuation.resume(returning: nil)
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    private func fetchCustomer(customerID: Int64) async -> Customer? {
+        await withCheckedContinuation { continuation in
+            let action = CustomerAction.retrieveCustomer(siteID: boundSiteID, customerID: customerID) { result in
+                switch result {
+                case .success(let value):
+                    continuation.resume(returning: value)
+                case .failure(let error):
+                    DDLogError("AIAssistantExternalNavigationAdaptor failed to fetch customer: \(error)")
+                    continuation.resume(returning: nil)
+                }
+            }
+            stores.dispatch(action)
         }
     }
 }

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
@@ -363,6 +363,7 @@ struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
     private static let rangeDayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale.autoupdatingCurrent
+        formatter.timeZone = TimeZone(identifier: "UTC")
         formatter.dateFormat = "MMM d"
         return formatter
     }()

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
@@ -1,8 +1,472 @@
 import Foundation
 import SwiftUI
-import protocol WooAIAssistant.AssistantExternalViewProviding
+import UIKit
+import Yosemite
+import NetworkingCore
+import WooAIAssistant
+import WooFoundation
 
 struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
 
-    init() {}
+    private let currencySettings: CurrencySettings
+
+    init(currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        self.currencySettings = currencySettings
+    }
+
+    // MARK: - AssistantExternalViewProviding
+
+    @MainActor func orderRow(payload: OrderCardPayload,
+                             showDivider: Bool,
+                             onTap: @escaping @MainActor () -> Void) -> AnyView? {
+        let data = makeOrderRowData(from: payload)
+        return AnyView(
+            LastOrderDashboardRow(data: data, showDivider: showDivider, paddedRow: true, tapHandler: { onTap() })
+        )
+    }
+
+    @MainActor func productRow(payload: ProductCardPayload,
+                               showDivider: Bool,
+                               onTap: @escaping @MainActor () -> Void) -> AnyView? {
+        let data = ProductStockRow.RowData(
+            imageURL: payload.firstImageURL,
+            name: payload.name ?? "",
+            subtitle: productDetails(for: payload),
+            accessoryText: productAccessoryText(for: payload)
+        )
+        return AnyView(ProductStockRow(data: data,
+                                       showDivider: showDivider,
+                                       paddedRow: true,
+                                       tapHandler: { onTap() }))
+    }
+
+    @MainActor func productVariationRow(payload: ProductVariationCardPayload,
+                                        showDivider: Bool,
+                                        onTap: @escaping @MainActor () -> Void) -> AnyView? {
+        let displayName = (payload.name?.isEmpty == false) ? payload.name! : skuOrIDLabel(for: payload)
+        let data = ProductStockRow.RowData(
+            imageURL: payload.firstImageURL,
+            name: displayName,
+            subtitle: variationDetails(for: payload),
+            accessoryText: variationAccessoryText(for: payload)
+        )
+        return AnyView(ProductStockRow(data: data,
+                                       showDivider: showDivider,
+                                       paddedRow: true,
+                                       tapHandler: { onTap() }))
+    }
+
+    @MainActor func customerRow(payload: CustomerCardPayload,
+                                showDivider: Bool,
+                                onTap: @escaping @MainActor () -> Void) -> AnyView? {
+        guard let name = payload.displayName else { return nil }
+        let ordersCountDetail: String? = payload.ordersCount.map { count in
+            count == 1 ? Localization.singleOrder : String(format: Localization.orderCount, NSNumber(value: count))
+        }
+        return AnyView(
+            VStack(spacing: 0) {
+                Button(action: { onTap() }) {
+                    TitleAndSubtitleAndDetailRow(
+                        title: name,
+                        detail: ordersCountDetail,
+                        subtitle: payload.email,
+                        subtitlePlaceholder: Localization.customerNoEmail
+                    )
+                    .padding(.horizontal, Layout.rowHorizontalPadding)
+                    .padding(.vertical, Layout.rowVerticalPadding)
+                }
+                .buttonStyle(AssistantPressableButtonStyle())
+                if showDivider {
+                    Divider().padding(.leading, Layout.rowHorizontalPadding)
+                }
+            }
+        )
+    }
+
+    @MainActor func statsCardView(toolName: String, payload: AnyCodableJSON) -> AnyView? {
+        guard let mapping = StatsCardMapping(toolName: toolName) else {
+            return nil
+        }
+        let totals = payload.assistantObject("totals")
+        let intervals = payload.assistantArray("interval_subtotals") ?? []
+        let currency = totals?.assistantString("currency") ?? payload.assistantString("currency")
+
+        let leadingValue = formatMetric(mapping.leading, totals: totals, currency: currency)
+        let trailingValue = formatMetric(mapping.trailing, totals: totals, currency: currency)
+        let bothMissing = leadingValue == Localization.metricUnavailable
+            && trailingValue == Localization.metricUnavailable
+        guard !bothMissing else {
+            return nil
+        }
+
+        let leadingChartData = chartData(for: mapping.leading, intervals: intervals)
+        let trailingChartData = chartData(for: mapping.trailing, intervals: intervals)
+        let subtitle = formatDateRange(after: payload.assistantString("after"),
+                                       before: payload.assistantString("before"))
+
+        return AnyView(
+            AssistantDashboardCardShell(title: Localization.analyticsTitle,
+                                        iconSystemName: "chart.bar",
+                                        subtitle: subtitle,
+                                        padBody: false) {
+                AnalyticsReportCard(
+                    title: "",
+                    leadingTitle: mapping.leadingTitle,
+                    leadingValue: leadingValue,
+                    leadingDelta: nil,
+                    leadingDeltaColor: nil,
+                    leadingDeltaTextColor: nil,
+                    leadingChartData: leadingChartData,
+                    leadingChartColor: leadingChartData.isEmpty ? nil : .accent,
+                    trailingTitle: mapping.trailingTitle,
+                    trailingValue: trailingValue,
+                    trailingDelta: nil,
+                    trailingDeltaColor: nil,
+                    trailingDeltaTextColor: nil,
+                    trailingChartData: trailingChartData,
+                    trailingChartColor: trailingChartData.isEmpty ? nil : .accent,
+                    reportViewModel: nil,
+                    isRedacted: false,
+                    showSyncError: false,
+                    syncErrorMessage: ""
+                )
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            }
+        )
+    }
+
+    // MARK: - Order rows
+
+    private func makeOrderRowData(from payload: OrderCardPayload) -> LastOrderDashboardRow.RowData {
+        let statusEnum = OrderStatusEnum(rawValue: payload.status ?? "")
+        let formatter = CurrencyFormatter(currencySettings: currencySettings)
+        let total = formatter.formatAmount(payload.total ?? "", with: payload.currency) ?? ""
+        return LastOrderDashboardRow.RowData(
+            number: orderNumberLabel(for: payload),
+            date: formattedDate(for: payload.dateCreated),
+            customerName: customerNameLabel(for: payload),
+            total: total,
+            statusDescription: statusEnum.description,
+            statusBackgroundColor: Color(uiColor: statusEnum.backgroundColor),
+            fulfillmentBadgeText: nil,
+            fulfillmentBadgeBackgroundColor: nil,
+            salesChannelText: nil
+        )
+    }
+
+    private func orderNumberLabel(for payload: OrderCardPayload) -> String {
+        if let number = payload.number, !number.isEmpty {
+            return "#\(number)"
+        }
+        if let id = payload.id {
+            return "#\(id)"
+        }
+        return ""
+    }
+
+    private func customerNameLabel(for payload: OrderCardPayload) -> String {
+        if let name = payload.customerName, !name.isEmpty {
+            return name
+        }
+        return Localization.guestCustomer
+    }
+
+    private func formattedDate(for raw: String?) -> String {
+        guard let raw, let date = parseDate(raw) else { return "" }
+        let isSameYear = date.isSameYear(as: Date())
+        let formatter: DateFormatter = isSameYear ? .monthAndDayFormatter : .mediumLengthLocalizedDateFormatter
+        formatter.timeZone = .siteTimezone
+        return formatter.string(from: date)
+    }
+
+    private func parseDate(_ raw: String) -> Date? {
+        if let date = ISO8601DateFormatter.assistantWithFraction.date(from: raw) { return date }
+        if let date = ISO8601DateFormatter.assistantNoFraction.date(from: raw) { return date }
+        return DateFormatter.assistantWCLocalFallback.date(from: raw)
+    }
+
+    // MARK: - Product rows
+
+    // Mirrors the Products tab: subtitle = stock detail, accessory = formatted price.
+    private func productDetails(for payload: ProductCardPayload) -> String {
+        productStockDetail(stockStatus: payload.stockStatus, stockQuantity: payload.stockQuantity)
+            ?? payload.sku.flatMap { $0.isEmpty ? nil : "SKU: \($0)" }
+            ?? ""
+    }
+
+    private func variationDetails(for payload: ProductVariationCardPayload) -> String {
+        productStockDetail(stockStatus: payload.stockStatus, stockQuantity: payload.stockQuantity)
+            ?? payload.sku.flatMap { $0.isEmpty ? nil : "SKU: \($0)" }
+            ?? ""
+    }
+
+    // Inline count when known so "low stock" queries see the number; otherwise show the status badge.
+    private func productStockDetail(stockStatus: String?, stockQuantity: Double?) -> String? {
+        guard let badge = stockBadgeText(for: stockStatus) else { return nil }
+        guard let quantity = stockQuantity else { return badge }
+        if quantity <= 0 { return Localization.outOfStock }
+        return String(format: Localization.stockCountFormat, formattedStockAccessory(quantity: quantity))
+    }
+
+    private func skuOrIDLabel(for payload: ProductVariationCardPayload) -> String {
+        if let sku = payload.sku, !sku.isEmpty { return sku }
+        if let id = payload.id { return "#\(id)" }
+        return ""
+    }
+
+    private func formattedPrice(raw: String?, currency: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return CurrencyFormatter(currencySettings: currencySettings).formatAmount(raw, with: currency)
+    }
+
+    private func stockBadgeText(for slug: String?) -> String? {
+        guard let slug, !slug.isEmpty else { return nil }
+        switch slug.lowercased() {
+        case "instock":
+            return Localization.inStock
+        case "outofstock":
+            return Localization.outOfStock
+        case "onbackorder":
+            return Localization.onBackorder
+        default:
+            return slug.replacingOccurrences(of: "_", with: " ").capitalized
+        }
+    }
+
+    func productAccessoryText(for payload: ProductCardPayload) -> String {
+        formattedPrice(raw: payload.price ?? payload.regularPrice, currency: nil) ?? ""
+    }
+
+    func variationAccessoryText(for payload: ProductVariationCardPayload) -> String {
+        formattedPrice(raw: payload.price ?? payload.regularPrice, currency: nil) ?? ""
+    }
+
+    private func formattedStockAccessory(quantity: Double) -> String {
+        if quantity <= 0 { return Localization.outOfStock }
+        let rounded = Int(quantity)
+        if Double(rounded) == quantity {
+            let count = NumberFormatter.localizedString(from: NSNumber(value: rounded), number: .none)
+            return String(format: Localization.stockLeft, count)
+        }
+        let count = NumberFormatter.localizedString(from: NSNumber(value: quantity), number: .decimal)
+        return String(format: Localization.stockLeft, count)
+    }
+
+    // MARK: - Analytics card
+
+    private func formatMetric(_ metric: StatsMetric,
+                              totals: AnyCodableJSON?,
+                              currency: String?) -> String {
+        switch metric.kind {
+        case .currency:
+            let formatter = CurrencyFormatter(currencySettings: currencySettings)
+            for key in metric.keys {
+                guard let raw = totals?.assistantString(key) else { continue }
+                if let formatted = formatter.formatAmount(raw, with: currency) {
+                    return formatted
+                }
+            }
+        case .integer:
+            for key in metric.keys {
+                if let value = totals?.assistantInt(key) {
+                    return NumberFormatter.localizedString(from: NSNumber(value: value), number: .none)
+                }
+            }
+        }
+        return Localization.metricUnavailable
+    }
+
+    func testChartData(forKeys keys: [String], payload: AnyCodableJSON) -> [Double] {
+        let intervals = payload.assistantArray("interval_subtotals") ?? []
+        let kind: StatsMetric.Kind = keys.contains("orders_count") ? .integer : .currency
+        return chartData(for: StatsMetric(kind: kind, keys: keys), intervals: intervals)
+    }
+
+    private func chartData(for metric: StatsMetric, intervals: [AnyCodableJSON]) -> [Double] {
+        guard !intervals.isEmpty else { return [] }
+        return intervals.map { interval in
+            let subtotals = interval.assistantObject("subtotals")
+            for key in metric.keys {
+                if let raw = subtotals?.assistantString(key), let value = Double(raw) {
+                    return value
+                }
+                if let value = subtotals?.assistantInt(key) {
+                    return Double(value)
+                }
+            }
+            return 0
+        }
+    }
+
+    func formatDateRange(after: String?, before: String?) -> String? {
+        guard let after, let before,
+              let startDate = Self.isoDateFormatter.date(from: after),
+              let endDate = Self.isoDateFormatter.date(from: before) else {
+            return nil
+        }
+        if Calendar.current.isDate(startDate, inSameDayAs: endDate) {
+            return Self.rangeDayFormatter.string(from: startDate)
+        }
+        let startText = Self.rangeDayFormatter.string(from: startDate)
+        let endText = Self.rangeDayFormatter.string(from: endDate)
+        return "\(startText) - \(endText)"
+    }
+
+    private struct StatsCardMapping {
+        let leadingTitle: String
+        let trailingTitle: String
+        let leading: StatsMetric
+        let trailing: StatsMetric
+
+        init?(toolName: String) {
+            switch toolName {
+            case AnalyticsRevenueTool.name:
+                leadingTitle = Localization.totalSales
+                trailingTitle = Localization.netSales
+                leading = StatsMetric(kind: .currency, keys: ["total_sales", "gross_sales"])
+                trailing = StatsMetric(kind: .currency, keys: ["net_revenue"])
+            case AnalyticsOrdersTool.name:
+                leadingTitle = Localization.totalOrders
+                trailingTitle = Localization.avgOrderValue
+                leading = StatsMetric(kind: .integer, keys: ["orders_count", "num_orders"])
+                trailing = StatsMetric(kind: .currency, keys: ["avg_order_value", "average_order_value"])
+            default:
+                return nil
+            }
+        }
+    }
+
+    private struct StatsMetric {
+        let kind: Kind
+        let keys: [String]
+
+        enum Kind {
+            case currency
+            case integer
+        }
+    }
+
+    private static let isoDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let rangeDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.autoupdatingCurrent
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
+
+    private enum Layout {
+        static let rowHorizontalPadding: CGFloat = 16
+        static let rowVerticalPadding: CGFloat = 12
+    }
+
+    private enum Localization {
+        static let customerNoEmail = NSLocalizedString(
+            "assistant.externalViews.customer.noEmailPlaceholder",
+            value: "No email on file",
+            comment: "Placeholder shown on the assistant customer row when the customer has no email."
+        )
+        static let singleOrder = NSLocalizedString(
+            "assistant.externalViews.customer.orderCount.singular",
+            value: "1 order",
+            comment: "Singular orders-count badge on the assistant customer row."
+        )
+        static let orderCount = NSLocalizedString(
+            "assistant.externalViews.customer.orderCount.plural",
+            value: "%1$@ orders",
+            comment: "Plural orders-count badge on the assistant customer row. %1$@ is the count."
+        )
+        static let analyticsTitle = NSLocalizedString(
+            "assistant.externalViews.stats.shellTitle",
+            value: "Analytics",
+            comment: "Shell title shared by the assistant revenue and orders analytics cards."
+        )
+        static let totalSales = NSLocalizedString(
+            "assistant.externalViews.stats.totalSales",
+            value: "Total Sales",
+            comment: "Leading column title on the assistant revenue analytics card."
+        )
+        static let netSales = NSLocalizedString(
+            "assistant.externalViews.stats.netSales",
+            value: "Net Sales",
+            comment: "Trailing column title on the assistant revenue analytics card."
+        )
+        static let totalOrders = NSLocalizedString(
+            "assistant.externalViews.stats.totalOrders",
+            value: "Total Orders",
+            comment: "Leading column title on the assistant orders analytics card."
+        )
+        static let avgOrderValue = NSLocalizedString(
+            "assistant.externalViews.stats.avgOrderValue",
+            value: "Average Order Value",
+            comment: "Trailing column title on the assistant orders analytics card."
+        )
+        static let metricUnavailable = NSLocalizedString(
+            "assistant.externalViews.stats.metricUnavailable",
+            value: "-",
+            comment: "Placeholder shown on the assistant analytics card when a metric is missing from the tool result."
+        )
+        static let guestCustomer = NSLocalizedString(
+            "assistant.externalViews.order.guestCustomer",
+            value: "Guest",
+            comment: "Customer name shown on the assistant order card when the order has no billing name."
+        )
+        static let inStock = NSLocalizedString(
+            "assistant.externalViews.product.stock.inStock",
+            value: "In stock",
+            comment: "Stock status badge on the assistant product card."
+        )
+        static let outOfStock = NSLocalizedString(
+            "assistant.externalViews.product.stock.outOfStock",
+            value: "Out of stock",
+            comment: "Stock status badge on the assistant product card."
+        )
+        static let onBackorder = NSLocalizedString(
+            "assistant.externalViews.product.stock.onBackorder",
+            value: "On backorder",
+            comment: "Stock status badge on the assistant product card."
+        )
+        static let stockLeft = NSLocalizedString(
+            "assistant.externalViews.product.stock.left",
+            value: "%1$@ left",
+            comment: "Accessory on the assistant product row when stock quantity is known. %1$@ is the count."
+        )
+        static let stockCountFormat = NSLocalizedString(
+            "assistant.externalViews.product.stock.countFormat",
+            value: "%1$@ in stock",
+            comment: "Subtitle on the assistant product row inlining the stock count. %1$@ is the count."
+        )
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let assistantWithFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static let assistantNoFraction: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}
+
+private extension DateFormatter {
+    static let assistantWCLocalFallback: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter
+    }()
 }

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftUI
 import UIKit
 import Yosemite
-import NetworkingCore
 import WooAIAssistant
 import WooFoundation
 
@@ -43,7 +42,12 @@ struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
     @MainActor func productVariationRow(payload: ProductVariationCardPayload,
                                         showDivider: Bool,
                                         onTap: @escaping @MainActor () -> Void) -> AnyView? {
-        let displayName = (payload.name?.isEmpty == false) ? payload.name! : skuOrIDLabel(for: payload)
+        let displayName: String
+        if let name = payload.name, !name.isEmpty {
+            displayName = name
+        } else {
+            displayName = skuOrIDLabel(for: payload)
+        }
         let data = ProductStockRow.RowData(
             imageURL: payload.firstImageURL,
             name: displayName,

--- a/WooCommerce/Classes/AIAssistant/AIAssistantLoadingPlaceholderViewController.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantLoadingPlaceholderViewController.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+// Pushed instantly on chat tap, swapped for the real detail once the fetch resolves.
+final class AIAssistantLoadingPlaceholderViewController: UIViewController {
+
+    private let activityIndicator = UIActivityIndicatorView(style: .large)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Matches OrderDetailsViewController so the swap doesn't flash a different background.
+        view.backgroundColor = .listBackground
+        title = ""
+
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.accessibilityLabel = NSLocalizedString(
+            "aiAssistant.loadingPlaceholder.accessibilityLabel",
+            value: "Loading",
+            comment: "Accessibility label for the loading spinner shown while a chat-linked detail is being fetched"
+        )
+        view.addSubview(activityIndicator)
+
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        activityIndicator.startAnimating()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        activityIndicator.stopAnimating()
+    }
+}

--- a/WooCommerce/Classes/AIAssistant/AIAssistantSessionStore.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantSessionStore.swift
@@ -35,12 +35,17 @@ final class AIAssistantSessionStore {
     struct Session {
         let controller: AssistantController
         let navigationHost: AIAssistantNavigationHost
+        let externalNavigation: AssistantExternalNavigationProviding
+        let externalViews: AssistantExternalViewProviding
     }
 
     func session(for siteID: Int64,
                  makeDependencies: (AIAssistantNavigationHost) -> AIAssistantDependencyAdaptor) -> Session {
         if let cached = entries[siteID] {
-            return Session(controller: cached.controller, navigationHost: cached.navigationHost)
+            return Session(controller: cached.controller,
+                           navigationHost: cached.navigationHost,
+                           externalNavigation: cached.dependencies.externalNavigation,
+                           externalViews: cached.dependencies.externalViews)
         }
         let host = AIAssistantNavigationHost()
         let dependencies = makeDependencies(host)
@@ -53,7 +58,10 @@ final class AIAssistantSessionStore {
         entries[siteID] = Entry(controller: controller,
                                 dependencies: dependencies,
                                 navigationHost: host)
-        return Session(controller: controller, navigationHost: host)
+        return Session(controller: controller,
+                       navigationHost: host,
+                       externalNavigation: dependencies.externalNavigation,
+                       externalViews: dependencies.externalViews)
     }
 
     func dependencies(for siteID: Int64) -> AIAssistantDependencyAdaptor? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsReportCard.swift
@@ -34,11 +34,10 @@ struct AnalyticsReportCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
 
-            if !title.isEmpty {
-                Text(title)
-                    .foregroundColor(Color(.text))
-                    .footnoteStyle()
-            }
+            Text(title)
+                .foregroundColor(Color(.text))
+                .footnoteStyle()
+                .renderedIf(title.isNotEmpty)
 
             HStack(alignment: .top, spacing: Layout.columnOutterSpacing) {
 
@@ -54,21 +53,21 @@ struct AnalyticsReportCard: View {
                         .redacted(reason: isRedacted ? .placeholder : [])
                         .shimmering(active: isRedacted)
 
-                    if leadingDelta != nil || (leadingChartData.isNotEmpty && leadingChartColor != nil) {
-                        AdaptiveStack(horizontalAlignment: .leading) {
-                            if let leadingDelta, let leadingDeltaColor, let leadingDeltaTextColor {
-                                DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor, textColor: leadingDeltaTextColor)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .redacted(reason: isRedacted ? .placeholder : [])
-                                    .shimmering(active: isRedacted)
-                            }
+                    AdaptiveStack(horizontalAlignment: .leading) {
+                        if let leadingDelta, let leadingDeltaColor, let leadingDeltaTextColor {
+                            DeltaTag(value: leadingDelta, backgroundColor: leadingDeltaColor, textColor: leadingDeltaTextColor)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .redacted(reason: isRedacted ? .placeholder : [])
+                                .shimmering(active: isRedacted)
+                        }
 
-                            if leadingChartData.isNotEmpty, let leadingChartColor {
-                                AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingChartColor)
-                                    .frame(width: scaledChartWidth, height: scaledChartWidth / Layout.chartAspectRatio)
-                            }
+                        if leadingChartData.count > 1, let leadingChartColor {
+                            AnalyticsLineChart(dataPoints: leadingChartData, lineChartColor: leadingChartColor)
+                                .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
+                                .frame(maxWidth: scaledChartWidth)
                         }
                     }
+                    .renderedIf(leadingDelta != nil || leadingChartData.count > 1)
 
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -84,21 +83,21 @@ struct AnalyticsReportCard: View {
                         .redacted(reason: isRedacted ? .placeholder : [])
                         .shimmering(active: isRedacted)
 
-                    if trailingDelta != nil || (trailingChartData.isNotEmpty && trailingChartColor != nil) {
-                        AdaptiveStack(horizontalAlignment: .leading) {
-                            if let trailingDelta, let trailingDeltaColor, let trailingDeltaTextColor {
-                                DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor, textColor: trailingDeltaTextColor)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .redacted(reason: isRedacted ? .placeholder : [])
-                                    .shimmering(active: isRedacted)
-                            }
+                    AdaptiveStack(horizontalAlignment: .leading) {
+                        if let trailingDelta, let trailingDeltaColor, let trailingDeltaTextColor {
+                            DeltaTag(value: trailingDelta, backgroundColor: trailingDeltaColor, textColor: trailingDeltaTextColor)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .redacted(reason: isRedacted ? .placeholder : [])
+                                .shimmering(active: isRedacted)
+                        }
 
-                            if trailingChartData.isNotEmpty, let trailingChartColor {
-                                AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingChartColor)
-                                    .frame(width: scaledChartWidth, height: scaledChartWidth / Layout.chartAspectRatio)
-                            }
+                        if trailingChartData.count > 1, let trailingChartColor {
+                            AnalyticsLineChart(dataPoints: trailingChartData, lineChartColor: trailingChartColor)
+                                .aspectRatio(Layout.chartAspectRatio, contentMode: .fit)
+                                .frame(maxWidth: scaledChartWidth)
                         }
                     }
+                    .renderedIf(trailingDelta != nil || trailingChartData.count > 1)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -125,6 +124,7 @@ private extension AnalyticsReportCard {
         static let cardPadding: CGFloat = 16
         static let columnOutterSpacing: CGFloat = 28
         static let columnInnerSpacing: CGFloat = 10
+        static let chartHeight: CGFloat = 32
         static let chartWidth: CGFloat = 72
         static let chartAspectRatio: CGFloat = 2.25
     }

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
@@ -1,0 +1,368 @@
+import Foundation
+import Testing
+import UIKit
+import Yosemite
+import WooAIAssistant
+@testable import WooCommerce
+
+@MainActor
+struct AIAssistantExternalNavigationAdaptorTests {
+
+    @Test
+    func test_openOrder_pushes_a_loader_view_controller_synchronously() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openOrder(orderID: 456)
+
+        // Then
+        #expect(nav.topViewController is OrderLoaderViewController)
+    }
+
+    @Test
+    func test_openProduct_dispatches_retrieve_on_main_thread() async {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openProduct(productID: 789)
+        let captured = await stores.waitForFirstDispatch()
+
+        // Then
+        #expect(captured.action is ProductAction)
+        #expect(captured.wasOnMainThread)
+    }
+
+    @Test
+    func test_openProductVariation_dispatches_retrieve_on_main_thread() async {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openProductVariation(productID: 1, variationID: 2)
+        let captured = await stores.waitForFirstDispatch()
+
+        // Then
+        #expect(captured.action is ProductAction || captured.action is ProductVariationAction)
+        #expect(captured.wasOnMainThread)
+    }
+
+    @Test
+    func test_openCustomer_dispatches_on_main_thread() async {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openCustomer(customerID: 7)
+        let captured = await stores.waitForFirstDispatch()
+
+        // Then
+        #expect(captured.action is CustomerAction)
+        #expect(captured.wasOnMainThread)
+    }
+
+    @Test
+    func test_openProduct_pushes_loading_placeholder_synchronously() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openProduct(productID: 789)
+
+        // Then
+        #expect(nav.topViewController is AIAssistantLoadingPlaceholderViewController)
+    }
+
+    @Test
+    func test_openProductVariation_pushes_loading_placeholder_synchronously() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openProductVariation(productID: 1, variationID: 2)
+
+        // Then
+        #expect(nav.topViewController is AIAssistantLoadingPlaceholderViewController)
+    }
+
+    @Test
+    func test_openCustomer_pushes_loading_placeholder_synchronously() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openCustomer(customerID: 7)
+
+        // Then
+        #expect(nav.topViewController is AIAssistantLoadingPlaceholderViewController)
+    }
+
+    @Test
+    func test_openCustomer_when_fetch_succeeds_then_swaps_placeholder_for_detail() async {
+        // Given
+        let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let customer = Customer(siteID: 123,
+                                customerID: 7,
+                                email: "buyer@example.test",
+                                username: "buyer",
+                                firstName: "Sample",
+                                lastName: "Buyer",
+                                billing: nil,
+                                shipping: nil)
+        stores.stubCustomerFetch = .success(customer)
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openCustomer(customerID: 7)
+        await stores.waitForFirstDispatch()
+        await waitForMainRunLoop()
+
+        // Then
+        #expect(!(nav.topViewController is AIAssistantLoadingPlaceholderViewController))
+        #expect(nav.topViewController is UIHostingController<CustomerDetailView>)
+    }
+
+    @Test
+    func test_openCustomer_when_fetch_returns_nil_then_placeholder_stays() async {
+        // Given
+        let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.stubCustomerFetch = .failure(SampleError.fetchFailed)
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openCustomer(customerID: 7)
+        await stores.waitForFirstDispatch()
+        await waitForMainRunLoop()
+
+        // Then
+        #expect(nav.topViewController is AIAssistantLoadingPlaceholderViewController)
+    }
+
+    @Test
+    func test_openCustomer_when_placeholder_popped_before_fetch_resolves_then_no_swap() async {
+        // Given
+        let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let customer = Customer(siteID: 123,
+                                customerID: 7,
+                                email: "buyer@example.test",
+                                username: nil,
+                                firstName: nil,
+                                lastName: nil,
+                                billing: nil,
+                                shipping: nil)
+        stores.deferCompletion = true
+        stores.stubCustomerFetch = .success(customer)
+        let rootVC = UIViewController()
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: rootVC)
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openCustomer(customerID: 7)
+        await stores.waitForFirstDispatch()
+        nav.setViewControllers([rootVC], animated: false)
+        stores.releaseDeferredCompletion()
+        await waitForMainRunLoop()
+
+        // Then
+        #expect(nav.viewControllers.count == 1)
+        #expect(nav.topViewController === rootVC)
+    }
+
+    @Test
+    func test_openAnalyticsHub_pushes_an_analytics_hub_view_controller() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let nav = UINavigationController(rootViewController: UIViewController())
+        host.attach(nav)
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        sut.openAnalyticsHub(payload: .object([:]))
+
+        // Then
+        #expect(nav.topViewController is AnalyticsHubHostingViewController)
+    }
+
+    @Test
+    func test_timeRange_when_payload_has_iso_dates_then_returns_custom_range() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+        let payload = AnyCodableJSON.object([
+            "after": .string("2026-04-01"),
+            "before": .string("2026-04-30")
+        ])
+
+        // When
+        let range = sut.timeRange(fromAnalyticsPayload: payload)
+
+        // Then
+        guard case .custom = range else {
+            Issue.record("Expected custom range, got \(range)")
+            return
+        }
+    }
+
+    @Test
+    func test_timeRange_when_payload_has_no_dates_then_returns_today() {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
+
+        // When
+        let range = sut.timeRange(fromAnalyticsPayload: .object([:]))
+
+        // Then
+        #expect(range == .today)
+    }
+}
+
+private final class ThreadCapturingStoresManager: MockStoresManager {
+    struct Capture {
+        let action: Action
+        let wasOnMainThread: Bool
+    }
+
+    private var captures: [Capture] = []
+    private var pendingContinuations: [CheckedContinuation<Capture, Never>] = []
+
+    override func dispatch(_ action: Action) {
+        let capture = Capture(action: action, wasOnMainThread: Thread.isMainThread)
+        if let next = pendingContinuations.first {
+            pendingContinuations.removeFirst()
+            next.resume(returning: capture)
+        } else {
+            captures.append(capture)
+        }
+    }
+
+    func waitForFirstDispatch() async -> Capture {
+        if let first = captures.first {
+            return first
+        }
+        return await withCheckedContinuation { continuation in
+            pendingContinuations.append(continuation)
+        }
+    }
+}
+
+private enum SampleError: Error { case fetchFailed }
+
+private final class StubbingStoresManager: MockStoresManager {
+    var stubCustomerFetch: Result<Customer, Error>?
+    var stubProductFetch: Result<Product, Error>?
+    var stubProductVariationFetch: Result<ProductVariation, Error>?
+
+    var deferCompletion = false
+    private var deferredFire: (() -> Void)?
+
+    private var dispatchContinuations: [CheckedContinuation<Void, Never>] = []
+    private var dispatchCount = 0
+
+    override func dispatch(_ action: Action) {
+        dispatchCount += 1
+
+        switch action {
+        case let customerAction as CustomerAction:
+            handle(customerAction)
+        case let productAction as ProductAction:
+            handle(productAction)
+        case let variationAction as ProductVariationAction:
+            handle(variationAction)
+        default:
+            break
+        }
+
+        notifyDispatchObservers()
+    }
+
+    private func handle(_ action: CustomerAction) {
+        guard case let .retrieveCustomer(_, _, onCompletion) = action,
+              let stub = stubCustomerFetch else { return }
+        fireOrDefer { onCompletion(stub) }
+    }
+
+    private func handle(_ action: ProductAction) {
+        guard case let .retrieveProduct(_, _, onCompletion) = action,
+              let stub = stubProductFetch else { return }
+        fireOrDefer { onCompletion(stub) }
+    }
+
+    private func handle(_ action: ProductVariationAction) {
+        guard case let .retrieveProductVariation(_, _, _, onCompletion) = action,
+              let stub = stubProductVariationFetch else { return }
+        fireOrDefer { onCompletion(stub) }
+    }
+
+    private func fireOrDefer(_ work: @escaping () -> Void) {
+        if deferCompletion {
+            deferredFire = work
+        } else {
+            work()
+        }
+    }
+
+    func releaseDeferredCompletion() {
+        let work = deferredFire
+        deferredFire = nil
+        work?()
+    }
+
+    private func notifyDispatchObservers() {
+        let waiters = dispatchContinuations
+        dispatchContinuations.removeAll()
+        for continuation in waiters {
+            continuation.resume()
+        }
+    }
+
+    func waitForFirstDispatch() async {
+        if dispatchCount > 0 { return }
+        await withCheckedContinuation { continuation in
+            dispatchContinuations.append(continuation)
+        }
+    }
+}
+
+@MainActor
+private func waitForMainRunLoop() async {
+    for _ in 0..<3 {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import SwiftUI
 import UIKit
 import Yosemite
 import WooAIAssistant
@@ -11,7 +12,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openOrder_pushes_a_loader_view_controller_synchronously() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
         host.attach(nav)
@@ -27,7 +28,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openProduct_dispatches_retrieve_on_main_thread() async {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
 
@@ -43,7 +44,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openProductVariation_dispatches_retrieve_on_main_thread() async {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
 
@@ -59,7 +60,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openCustomer_dispatches_on_main_thread() async {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
 
@@ -75,7 +76,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openProduct_pushes_loading_placeholder_synchronously() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
         host.attach(nav)
@@ -91,7 +92,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openProductVariation_pushes_loading_placeholder_synchronously() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
         host.attach(nav)
@@ -107,7 +108,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openCustomer_pushes_loading_placeholder_synchronously() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
         host.attach(nav)
@@ -123,7 +124,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openCustomer_when_fetch_succeeds_then_swaps_placeholder_for_detail() async {
         // Given
-        let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = StubbingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let customer = Customer(siteID: 123,
                                 customerID: 7,
                                 email: "buyer@example.test",
@@ -151,7 +152,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openCustomer_when_fetch_returns_nil_then_placeholder_stays() async {
         // Given
-        let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = StubbingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         stores.stubCustomerFetch = .failure(SampleError.first)
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
@@ -170,7 +171,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openCustomer_when_placeholder_popped_before_fetch_resolves_then_no_swap() async {
         // Given
-        let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = StubbingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let customer = Customer(siteID: 123,
                                 customerID: 7,
                                 email: "buyer@example.test",
@@ -202,7 +203,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_openAnalyticsHub_pushes_an_analytics_hub_view_controller() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
         host.attach(nav)
@@ -218,7 +219,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_timeRange_when_payload_has_iso_dates_then_returns_custom_range() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
         let payload = AnyCodableJSON.object([
@@ -239,7 +240,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_timeRange_when_site_timezone_is_negative_utc_then_preserves_payload_dates() throws {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let losAngeles = try #require(TimeZone(identifier: "America/Los_Angeles"))
         let sut = AIAssistantExternalNavigationAdaptor(siteID: 123,
@@ -274,7 +275,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     @Test
     func test_timeRange_when_payload_has_no_dates_then_returns_today() {
         // Given
-        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = ThreadCapturingStoresManager(sessionManager: SessionManager.makeForTesting(authenticated: true))
         let host = AIAssistantNavigationHost()
         let sut = AIAssistantExternalNavigationAdaptor(siteID: 123, navigationHost: host, stores: stores)
 

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
@@ -152,7 +152,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     func test_openCustomer_when_fetch_returns_nil_then_placeholder_stays() async {
         // Given
         let stores = StubbingStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.stubCustomerFetch = .failure(SampleError.fetchFailed)
+        stores.stubCustomerFetch = .failure(SampleError.first)
         let host = AIAssistantNavigationHost()
         let nav = UINavigationController(rootViewController: UIViewController())
         host.attach(nav)
@@ -286,7 +286,7 @@ struct AIAssistantExternalNavigationAdaptorTests {
     }
 }
 
-private final class ThreadCapturingStoresManager: MockStoresManager {
+private final class ThreadCapturingStoresManager: DefaultStoresManager {
     struct Capture {
         let action: Action
         let wasOnMainThread: Bool
@@ -315,9 +315,7 @@ private final class ThreadCapturingStoresManager: MockStoresManager {
     }
 }
 
-private enum SampleError: Error { case fetchFailed }
-
-private final class StubbingStoresManager: MockStoresManager {
+private final class StubbingStoresManager: DefaultStoresManager {
     var stubCustomerFetch: Result<Customer, Error>?
     var stubProductFetch: Result<Product, Error>?
     var stubProductVariationFetch: Result<ProductVariation, Error>?

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalNavigationAdaptorTests.swift
@@ -237,6 +237,41 @@ struct AIAssistantExternalNavigationAdaptorTests {
     }
 
     @Test
+    func test_timeRange_when_site_timezone_is_negative_utc_then_preserves_payload_dates() throws {
+        // Given
+        let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let host = AIAssistantNavigationHost()
+        let losAngeles = try #require(TimeZone(identifier: "America/Los_Angeles"))
+        let sut = AIAssistantExternalNavigationAdaptor(siteID: 123,
+                                                       navigationHost: host,
+                                                       stores: stores,
+                                                       timeZone: losAngeles)
+        let payload = AnyCodableJSON.object([
+            "after": .string("2026-05-04"),
+            "before": .string("2026-05-05")
+        ])
+
+        // When
+        let range = sut.timeRange(fromAnalyticsPayload: payload)
+
+        // Then
+        guard case .custom(let from, let to) = range else {
+            Issue.record("Expected custom range, got \(range)")
+            return
+        }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = losAngeles
+        let fromComponents = calendar.dateComponents([.year, .month, .day], from: from)
+        let toComponents = calendar.dateComponents([.year, .month, .day], from: to)
+        #expect(fromComponents.year == 2026)
+        #expect(fromComponents.month == 5)
+        #expect(fromComponents.day == 4)
+        #expect(toComponents.year == 2026)
+        #expect(toComponents.month == 5)
+        #expect(toComponents.day == 5)
+    }
+
+    @Test
     func test_timeRange_when_payload_has_no_dates_then_returns_today() {
         // Given
         let stores = ThreadCapturingStoresManager(sessionManager: .makeForTesting(authenticated: true))

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalViewsAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalViewsAdaptorTests.swift
@@ -1,0 +1,290 @@
+import Testing
+import WooAIAssistant
+@testable import WooCommerce
+
+@MainActor
+struct AIAssistantExternalViewsAdaptorTests {
+
+    @Test
+    func test_orderRow_when_payload_has_id_then_returns_anyview() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = OrderCardPayload(
+            id: 963,
+            number: "963",
+            status: "processing",
+            total: "31.20",
+            currency: "USD"
+        )
+
+        // When
+        let row = sut.orderRow(payload: payload, showDivider: true, onTap: {})
+
+        // Then
+        #expect(row != nil)
+    }
+
+    @Test
+    func test_productRow_when_payload_has_name_then_returns_anyview() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(
+            id: 101,
+            name: "Hoodie",
+            price: "49.00",
+            stockStatus: "instock"
+        )
+
+        // When
+        let row = sut.productRow(payload: payload, showDivider: true, onTap: {})
+
+        // Then
+        #expect(row != nil)
+    }
+
+    @Test
+    func test_customerRow_when_payload_has_name_fields_then_returns_anyview() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = CustomerCardPayload(
+            id: 7,
+            firstName: "Jane",
+            lastName: "Doe",
+            email: "jane@example.com",
+            ordersCount: 3
+        )
+
+        // When
+        let row = sut.customerRow(payload: payload, showDivider: true, onTap: {})
+
+        // Then
+        #expect(row != nil)
+    }
+
+    @Test
+    func test_customerRow_when_payload_has_no_name_fields_then_returns_nil() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = CustomerCardPayload()
+
+        // When
+        let row = sut.customerRow(payload: payload, showDivider: true, onTap: {})
+
+        // Then
+        #expect(row == nil)
+    }
+
+    @Test
+    func test_statsCardView_when_tool_is_analytics_revenue_with_totals_then_returns_anyview() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object([
+            "totals": .object([
+                "gross_sales": .string("1320.00"),
+                "net_revenue": .string("1248.05"),
+                "currency": .string("USD")
+            ]),
+            "interval_subtotals": .array([])
+        ])
+
+        // When
+        let view = sut.statsCardView(toolName: "analytics_revenue", payload: payload)
+
+        // Then
+        #expect(view != nil)
+    }
+
+    @Test
+    func test_statsCardView_when_tool_is_analytics_orders_with_totals_then_returns_anyview() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object([
+            "totals": .object([
+                "orders_count": .int(184),
+                "avg_order_value": .string("67.84"),
+                "currency": .string("USD")
+            ])
+        ])
+
+        // When
+        let view = sut.statsCardView(toolName: "analytics_orders", payload: payload)
+
+        // Then
+        #expect(view != nil)
+    }
+
+    @Test
+    func test_chartData_when_revenue_intervals_have_total_sales_then_series_matches_each_bucket() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object([
+            "totals": .object([
+                "total_sales": .string("300.00"),
+                "net_revenue": .string("250.00"),
+                "currency": .string("USD")
+            ]),
+            "interval_subtotals": .array([
+                .object(["interval": .string("2026-05-01"),
+                         "subtotals": .object(["total_sales": .double(100.0),
+                                               "net_revenue": .double(80.0)])]),
+                .object(["interval": .string("2026-05-02"),
+                         "subtotals": .object(["total_sales": .double(120.0),
+                                               "net_revenue": .double(95.0)])]),
+                .object(["interval": .string("2026-05-03"),
+                         "subtotals": .object(["total_sales": .double(80.0),
+                                               "net_revenue": .double(75.0)])])
+            ])
+        ])
+
+        // When
+        let view = sut.statsCardView(toolName: "analytics_revenue", payload: payload)
+        let leading = sut.testChartData(forKeys: ["total_sales", "gross_sales"], payload: payload)
+        let trailing = sut.testChartData(forKeys: ["net_revenue"], payload: payload)
+
+        // Then
+        #expect(view != nil)
+        #expect(leading == [100.0, 120.0, 80.0])
+        #expect(trailing == [80.0, 95.0, 75.0])
+    }
+
+    @Test
+    func test_chartData_when_an_interval_is_missing_a_value_then_other_buckets_still_render() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object([
+            "totals": .object([
+                "orders_count": .int(5),
+                "avg_order_value": .string("20.00")
+            ]),
+            "interval_subtotals": .array([
+                .object(["subtotals": .object(["orders_count": .int(2),
+                                               "avg_order_value": .double(10.0)])]),
+                .object(["subtotals": .object(["orders_count": .int(3)])])
+            ])
+        ])
+
+        // When
+        let leading = sut.testChartData(forKeys: ["orders_count"], payload: payload)
+        let trailing = sut.testChartData(forKeys: ["avg_order_value"], payload: payload)
+
+        // Then
+        #expect(leading == [2.0, 3.0])
+        #expect(trailing == [10.0, 0.0])
+    }
+
+    @Test
+    func test_statsCardView_when_tool_is_unrelated_then_returns_nil() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object(["totals": .object(["orders_count": .int(1)])])
+
+        // When
+        let view = sut.statsCardView(toolName: "orders_list", payload: payload)
+
+        // Then
+        #expect(view == nil)
+    }
+
+    @Test
+    func test_statsCardView_when_payload_has_no_totals_or_intervals_then_returns_nil() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object(["unrelated": .string("garbage")])
+
+        // When
+        let view = sut.statsCardView(toolName: "analytics_revenue", payload: payload)
+
+        // Then
+        #expect(view == nil)
+    }
+
+    @Test
+    func test_formatDateRange_when_dates_are_same_then_renders_one_day() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+
+        // When
+        let result = sut.formatDateRange(after: "2026-04-30", before: "2026-04-30")
+
+        // Then
+        #expect(result == "Apr 30")
+    }
+
+    @Test
+    func test_formatDateRange_when_range_spans_multiple_days_then_renders_two_dates() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+
+        // When
+        let result = sut.formatDateRange(after: "2026-04-24", before: "2026-04-30")
+
+        // Then
+        #expect(result == "Apr 24 - Apr 30")
+    }
+
+    @Test
+    func test_formatDateRange_when_either_input_is_nil_then_returns_nil() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+
+        // When
+        let missingAfter = sut.formatDateRange(after: nil, before: "2026-04-30")
+        let missingBefore = sut.formatDateRange(after: "2026-04-24", before: nil)
+
+        // Then
+        #expect(missingAfter == nil)
+        #expect(missingBefore == nil)
+    }
+
+    @Test
+    func test_productAccessoryText_when_price_set_then_returns_formatted_price() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(name: "Hoodie", price: "49.00", stockQuantity: 7)
+
+        // When
+        let text = sut.productAccessoryText(for: payload)
+
+        // Then
+        #expect(text.contains("49"))
+    }
+
+    @Test
+    func test_productAccessoryText_when_only_regular_price_set_then_returns_formatted_regular_price() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(name: "Hoodie", regularPrice: "49.00")
+
+        // When
+        let text = sut.productAccessoryText(for: payload)
+
+        // Then
+        #expect(text.contains("49"))
+    }
+
+    @Test
+    func test_productAccessoryText_when_no_price_then_empty() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(name: "Hoodie")
+
+        // When
+        let text = sut.productAccessoryText(for: payload)
+
+        // Then
+        #expect(text.isEmpty)
+    }
+
+    @Test
+    func test_variationAccessoryText_when_price_set_then_returns_formatted_price() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductVariationCardPayload(id: 1, name: "Red", price: "20.00", stockQuantity: 3)
+
+        // When
+        let text = sut.variationAccessoryText(for: payload)
+
+        // Then
+        #expect(text.contains("20"))
+    }
+}


### PR DESCRIPTION
WOOMOB-2878

Depends on #17068 - when that merges, this PR rebases to trunk automatically.

Second of three stacked PRs. This one wires the typed payload foundation through to the SwiftUI surface: tool results now render as typed entity rows, tapping a card pushes the matching native detail screen with an instant placeholder fallback, the analytics-tap date range fix is in, and the analytics report card layout is tightened. User-facing changes for the empty state and the tightened tool catalog / system prompt land in PR 3, which carries the full manual testing flow and screenshots.

## Why

PR 1 of this stack delivers the typed payload model and the reusable dashboard rows. By itself it changes nothing the merchant sees - the chat still renders every tool result as raw JSON. This PR is what closes that loop: the chat host now embeds the typed rows in place of the JSON dumps, taps route to the host app's native order / product / customer / variation / analytics detail screens, and a few presentation seams that were rough on the parent branch are tightened.

## Key non-obvious decisions

- **Instant placeholder push on tap.** When a merchant taps an entity card, the navigation handler pushes the detail screen immediately with a placeholder view, then loads the entity in the background and swaps in the real content. The alternative - load first, push later - leaves the merchant staring at the chat surface for a beat with no feedback. Lives in `AIAssistantLoadingPlaceholderViewController`. Cancellable on back-stack pop.
- **Analytics date range parses in the site timezone, not UTC.** The `analytics_revenue` tool returns `after`/`before` as `YYYY-MM-DD` strings. Parsing them with `TimeZone(identifier: \"UTC\")` made a US-store May 4 render as May 3 in the analytics screen because the resulting `Date` was midnight UTC, which `startOfDay(timezone: PDT)` rounds down. The adaptor now takes a `timeZone` (default `.siteTimezone`) and threads it through to `AnalyticsHubHostingViewController`. Pinned by `test_timeRange_when_site_timezone_is_negative_utc_then_preserves_payload_dates`.
- **Confirmation card no longer uses a divider line between header and body.** The outer stack spacing already separates the eyebrow / title block from the diff rows; the divider made the card read as two disjoint surfaces.
- **`AnalyticsReportCard` collapses cleanly when the title or delta row is empty.** Replaces nested `if`s with `.renderedIf` modifiers and switches the inline chart frame to `aspectRatio` + `maxWidth` so the chart sizes itself instead of forcing height.
- **`AssistantExternalNavigationProviding` and `AssistantExternalViewProviding` gain new methods with default implementations**, so the assistant module's protocol seam stays the same width while the app target's adaptors carry the new behavior.

## Cross-platform alignment with Android [#15805](https://github.com/woocommerce/woocommerce-android/pull/15805)

| Concept | Android | iOS | Status |
|---|---|---|---|
| `show_cards` reference resolution | `AssistantCardReferenceResolver` resolves typed refs into navigation targets | iOS routes typed payloads through `AssistantExternalNavigationProviding` to native detail screens | Aligned in shape; iOS's instant-placeholder push is a platform-idiomatic addition |
| Tap-through navigation | host app pushes native detail | host app pushes native detail | Aligned |
| Analytics date parsing | site-timezone aware | site-timezone aware (this PR) | Aligned (drift fixed) |

## Tests

Build clean, all module tests pass, SwiftLint clean. New tests: timezone-aware analytics range parsing, navigation adaptor end-to-end (placeholder push + entity-load swap), card host dispatch.

## Reviewer expectation

Sanity - the wiring is mechanical once the foundation in PR 1 is read. Watch for the `AssistantExternalViewProviding` / `AssistantExternalNavigationProviding` protocol expansion (default implementations vs. required methods) and the placeholder-then-real-detail UX path.

Manual testing flow + screenshots live on #17070 (PR 3 of the stack).
