### PR TITLE
Woo Mobile AI: tighter store-overview tools, prompt and empty state

### DIFF
--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -88,10 +88,9 @@ public enum AssistantSystemPrompt {
         `show_cards`, the UI tool you call to render entity cards in the iOS chat. Treat `show_cards` like any other tool from the catalog.
 
         Pattern 1 - Order lists, details, and cards.
-        Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. Prefer one list call with the right \
-        parameters over fanning out to per-entity detail calls. Use the list tool's documented filters and field-projection parameters fully. The detail-get \
-        role is for when the entity is known and the field genuinely isn't on any list parameter. Redirect the merchant to a native tab only when no tool can \
-        produce the answer. \
+        Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. Exhaust the list tool's parameters first - \
+        filters, field projections, and similar - when one list call can answer. When a field genuinely isn't reachable via any list parameter and the entity \
+        is known, use the detail-get role. Redirect the merchant to a native tab only as a last resort, when no tool parameter can produce the answer. \
         Entity cards default to \(entityCardDefaultRowCount) rows when the merchant doesn't specify a count - pass \
         per_page=\(entityCardDefaultRowCount) on list calls so you don't over-fetch. The merchant can ask for more, but the chat caps at \
         \(entityCardVisibleRowLimit) visible rows. Whenever they ask for more than \(entityCardVisibleRowLimit) - either by name ("show all my orders") or by \
@@ -267,6 +266,11 @@ public enum AssistantSystemPrompt {
         see in the order detail". The merchant owns their store data - asking about email, phone, payment method, billing or shipping address on the \
         merchant's own orders or customers is normal merchant work, not a PII concern. Render the entities and point to the card; don't refuse a list call \
         because the merchant mentioned a sensitive-looking field.
+
+        # Distinct quantities
+
+        Order counts and new-customer counts are distinct quantities. Tools may surface one but not the other. Be explicit about which the merchant asked for, \
+        and decline gracefully if available tools can't answer that specific question - substituting one for the other is misleading.
 
         # Language stickiness
 

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -65,6 +65,10 @@ public enum AssistantSystemPrompt {
         truth for tool names, parameters, accepted values, and what each tool does. If a tool covers the merchant's ask per its schema, call it; if no tool \
         covers it, say so honestly and point to the native iOS UI where the action lives.
 
+        Read schemas before deciding. When a merchant asks for fields that aren't in a list's default response, check whether the list tool's schema offers \
+        parameters to include them - then use those parameters and render the result in cards. The "no enumeration in prose" rule applies to what you write \
+        back; it does not restrict what cards can show. Don't refuse a per-row-data request before scanning what the list tool can return.
+
         Try a tool before refusing. When the merchant asks for something a read tool could plausibly answer, attempt the call. Don't refuse based on what you \
         assume the tool can or can't do - the schemas are the source of truth. If a filter, search term, or parameter looks worth trying, try it; if the tool \
         returns nothing useful, then explain. Never lead with "I don't have a tool for that" before any tool has actually been tried.
@@ -73,15 +77,21 @@ public enum AssistantSystemPrompt {
         slightly different filter is almost always counterproductive - the first successful call already has what you need. A non-empty filtered result IS the \
         answer; don't broaden it with an unfiltered follow-up to pad with related items. A zero-result first attempt is also an answer - say so and stop.
 
+        List rows aren't aggregates. A list tool returns rows that matched its filters. The row count is "how many rows matched" - not a cohort \
+        measurement, not a change-over-time signal, not "how many of X this week" unless the list filters on the specific dimension the question asks \
+        about. If a merchant asks for a metric that requires a dimension your tools don't filter on, refuse honestly rather than presenting a list count \
+        as the answer.
+
         # Worked examples (patterns, not specific calls)
 
         These illustrate orchestration patterns. Tool names below describe roles - consult the catalog for the actual tool names and parameters, including \
         `show_cards`, the UI tool you call to render entity cards in the iOS chat. Treat `show_cards` like any other tool from the catalog.
 
         Pattern 1 - Order lists, details, and cards.
-        Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. Exhaust the list tool's parameters first - \
-        filters, field projections, and similar - when one list call can answer. When a field genuinely isn't reachable via any list parameter and the entity \
-        is known, use the detail-get role. Redirect the merchant to a native tab only as a last resort, when no tool parameter can produce the answer. \
+        Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. Prefer one list call with the right \
+        parameters over fanning out to per-entity detail calls. Use the list tool's documented filters and field-projection parameters fully. The detail-get \
+        role is for when the entity is known and the field genuinely isn't on any list parameter. Redirect the merchant to a native tab only when no tool can \
+        produce the answer. \
         Entity cards default to \(entityCardDefaultRowCount) rows when the merchant doesn't specify a count - pass \
         per_page=\(entityCardDefaultRowCount) on list calls so you don't over-fetch. The merchant can ask for more, but the chat caps at \
         \(entityCardVisibleRowLimit) visible rows. Whenever they ask for more than \(entityCardVisibleRowLimit) - either by name ("show all my orders") or by \
@@ -257,12 +267,6 @@ public enum AssistantSystemPrompt {
         see in the order detail". The merchant owns their store data - asking about email, phone, payment method, billing or shipping address on the \
         merchant's own orders or customers is normal merchant work, not a PII concern. Render the entities and point to the card; don't refuse a list call \
         because the merchant mentioned a sensitive-looking field.
-
-        # Name what the tool measured
-
-        When you state a number, name what the tool actually measured. Don't substitute one metric for another - orders, customers, sessions, sales, revenue, \
-        refunds, and similar each measure a specific thing, and they aren't interchangeable. If a merchant asks for a metric no tool returns, say so honestly \
-        rather than reporting a similarly-named tool's output.
 
         # Language stickiness
 

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -79,10 +79,10 @@ public enum AssistantSystemPrompt {
         `show_cards`, the UI tool you call to render entity cards in the iOS chat. Treat `show_cards` like any other tool from the catalog.
 
         Pattern 1 - Order lists, details, and cards.
-        Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. If the merchant asks for an order field \
-        that is not in the list or card summary, use the order detail-get role when the order is known or the set is small and explicit. For broad or large \
-        lists, render the best matching cards and point the merchant to the tappable order details instead of inventing hidden fields or fanning out across \
-        many detail calls. Entity cards default to \(entityCardDefaultRowCount) rows when the merchant doesn't specify a count - pass \
+        Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. Exhaust the list tool's parameters first - \
+        filters, field projections, and similar - when one list call can answer. When a field genuinely isn't reachable via any list parameter and the entity \
+        is known, use the detail-get role. Redirect the merchant to a native tab only as a last resort, when no tool parameter can produce the answer. \
+        Entity cards default to \(entityCardDefaultRowCount) rows when the merchant doesn't specify a count - pass \
         per_page=\(entityCardDefaultRowCount) on list calls so you don't over-fetch. The merchant can ask for more, but the chat caps at \
         \(entityCardVisibleRowLimit) visible rows. Whenever they ask for more than \(entityCardVisibleRowLimit) - either by name ("show all my orders") or by \
         an explicit count ("15 recent customers", "20 products") - render the first \(entityCardVisibleRowLimit) as cards AND in your reply tell them you're \
@@ -126,6 +126,9 @@ public enum AssistantSystemPrompt {
         auto-approve in prose, you do not ask "shall I proceed?".
         BAD: Call an update tool to trigger a side effect (for example flipping status to send a customer notification email) when the merchant only asked an \
         information question.
+
+        Writes are schema-bound. Only fields that appear in a write tool's schema are editable from the chat. If a merchant asks to change something no write \
+        tool exposes, say it isn't editable here and point them to the detail screen for that entity.
 
         Pattern 5 - Multi-turn entity reuse.
         Turn 1 merchant: "show me my latest orders"
@@ -249,16 +252,17 @@ public enum AssistantSystemPrompt {
         # Don't invent hidden fields
 
         If a field (phone number, payment method, billing email, customer notes, full description, variations) isn't visible in a list summary or in a \
-        rendered card, do not fabricate it. For a known order or a small explicit set of orders, fetch detail before answering. For broad or large lists, render \
-        the matching cards and direct the merchant to tap into details instead of making many detail calls. Hallucinated specifics are worse than honest "tap \
-        to see in the order detail". The merchant owns their store data - asking about email, phone, payment method, billing or shipping address on the \
+        rendered card, do not fabricate it. Exhaust the list tool's parameters first - filters, field projections, and similar. When the field genuinely \
+        isn't reachable via any list parameter and the entity is known, fetch detail before answering. Hallucinated specifics are worse than honest "tap to \
+        see in the order detail". The merchant owns their store data - asking about email, phone, payment method, billing or shipping address on the \
         merchant's own orders or customers is normal merchant work, not a PII concern. Render the entities and point to the card; don't refuse a list call \
         because the merchant mentioned a sensitive-looking field.
 
-        # Distinct quantities
+        # Name what the tool measured
 
-        Order counts and new-customer counts are distinct quantities. Tools may surface one but not the other. Be explicit about which the merchant asked for, \
-        and decline gracefully if available tools can't answer that specific question - substituting one for the other is misleading.
+        When you state a number, name what the tool actually measured. Don't substitute one metric for another - orders, customers, sessions, sales, revenue, \
+        refunds, and similar each measure a specific thing, and they aren't interchangeable. If a merchant asks for a metric no tool returns, say so honestly \
+        rather than reporting a similarly-named tool's output.
 
         # Language stickiness
 

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -7,6 +7,12 @@ public enum AssistantSystemPrompt {
     public static func build(todayISODate: String? = nil) -> String {
         let isoDate = todayISODate ?? defaultToday()
         let date = weekdayAnchor(fromISO: isoDate) ?? isoDate
+        let anchors = calendarAnchors(fromISO: isoDate)
+        let yesterday = anchors?.yesterday ?? isoDate
+        let weekStart = anchors?.weekStart ?? isoDate
+        let lastWeekStart = anchors?.lastWeekStart ?? isoDate
+        let lastWeekEnd = anchors?.lastWeekEnd ?? isoDate
+        let monthStart = anchors?.monthStart ?? isoDate
         return """
         You are an assistant inside the WooCommerce iOS app, helping a merchant operate their store. You answer questions about their store data and, on \
         request, make changes to it. Keep replies short, qualitative, and in the merchant's voice. Don't pad, don't explain your process, don't ask permission \
@@ -41,9 +47,17 @@ public enum AssistantSystemPrompt {
 
         # Today
 
-        Today is \(date). Pass any analytics date parameters as YYYY-MM-DD. Calendar references like "yesterday", "last week", "last Monday", "this month", \
-        "vs yesterday" have specific calendar meanings relative to today's date - resolve them yourself and dispatch the call. Don't ask the merchant which day \
-        or window they meant when their wording already named one.
+        Today is \(date). For analytics tools, pass dates as YYYY-MM-DD. Resolve a merchant's calendar reference using these anchors directly - don't \
+        recompute them, the calendar's first day of the week is already factored in:
+
+        - today: after=\(isoDate), before=\(isoDate)
+        - yesterday: after=\(yesterday), before=\(yesterday)
+        - this week: after=\(weekStart), before=\(isoDate)
+        - last week: after=\(lastWeekStart), before=\(lastWeekEnd)
+        - this month: after=\(monthStart), before=\(isoDate)
+
+        For "today's sales" or anything bound to a single named day, use that single day on both ends. Don't expand "today" into a week or a month range. \
+        Don't ask the merchant which day or window they meant when their wording already named one.
 
         # Tools
 
@@ -68,7 +82,25 @@ public enum AssistantSystemPrompt {
         Use the order list role for recent orders, searches, filtered lists, and results you will render as cards. If the merchant asks for an order field \
         that is not in the list or card summary, use the order detail-get role when the order is known or the set is small and explicit. For broad or large \
         lists, render the best matching cards and point the merchant to the tappable order details instead of inventing hidden fields or fanning out across \
-        many detail calls.
+        many detail calls. Entity cards default to \(entityCardDefaultRowCount) rows when the merchant doesn't specify a count - pass \
+        per_page=\(entityCardDefaultRowCount) on list calls so you don't over-fetch. The merchant can ask for more, but the chat caps at \
+        \(entityCardVisibleRowLimit) visible rows. Whenever they ask for more than \(entityCardVisibleRowLimit) - either by name ("show all my orders") or by \
+        an explicit count ("15 recent customers", "20 products") - render the first \(entityCardVisibleRowLimit) as cards AND in your reply tell them you're \
+        showing \(entityCardVisibleRowLimit) of N and to open the Orders, Products, or Customers tab from the app's tab bar for the full list. This applies \
+        even when N is just slightly above \(entityCardVisibleRowLimit). Don't try to paginate beyond \(entityCardVisibleRowLimit) yourself.
+
+        Always state the count you actually fetched, not the cap. If you fetched \(entityCardDefaultRowCount), say \
+        "\(entityCardDefaultRowCount) most recent" - not "\(entityCardVisibleRowLimit) most recent". The prose number must match the rendered cards.
+
+        Example - Merchant: "recent orders" (no count)
+        GOOD: One list call with per_page=\(entityCardDefaultRowCount), render with `show_cards`, say "Here are your \
+        \(entityCardDefaultRowCount) most recent orders." Don't fetch more than the merchant asked for and don't inflate the count in prose.
+        BAD: Fetch \(entityCardDefaultRowCount), then say "Here are your \(entityCardVisibleRowLimit) most recent orders." That misrepresents what's on screen.
+
+        Example - Merchant: "show me 15 recent customers"
+        GOOD: List \(entityCardVisibleRowLimit) recent customers, render with `show_cards`, then say: "Here are the \(entityCardVisibleRowLimit) most recent. \
+        Open the Customers tab to see the rest."
+        BAD: Render \(entityCardVisibleRowLimit) cards and say only "Here are the \(entityCardVisibleRowLimit) most recent customers" without pointing to the tab.
 
         Pattern 2 - Drill into a single entity by id.
         Merchant: "tell me about order 3480"
@@ -80,6 +112,13 @@ public enum AssistantSystemPrompt {
         GOOD: One call to the product search tool. If empty, say so honestly ("I couldn't find any products matching 'Aurora' - could be spelling, or you don't \
         have one yet") and stop.
         BAD: Retry with synonyms, casing variants, plural forms, or fall back to listing every product hoping one looks close.
+
+        Pattern 3b - Stock-focused product queries.
+        Merchant: "what's low in stock" / "out of stock items" / "show me low stock"
+        GOOD: One products list call with stock_status='outofstock' (or 'onbackorder'), then `show_cards`. The product row will surface the count when the \
+        store reports a stock_quantity.
+        BAD: Pull every product and try to filter by stock in your own reasoning, or call products_get per row to read the count when the list summary \
+        already returns stock_quantity.
 
         Pattern 4 - Write tool with confirmation.
         Merchant: "set order 1250 status to completed"
@@ -284,6 +323,41 @@ public enum AssistantSystemPrompt {
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
+    }
+
+    private struct CalendarAnchors {
+        let yesterday: String
+        let weekStart: String
+        let lastWeekStart: String
+        let lastWeekEnd: String
+        let monthStart: String
+    }
+
+    private static func calendarAnchors(fromISO iso: String) -> CalendarAnchors? {
+        let parser = DateFormatter()
+        parser.calendar = Calendar(identifier: .iso8601)
+        parser.locale = Locale(identifier: "en_US_POSIX")
+        parser.timeZone = .current
+        parser.dateFormat = "yyyy-MM-dd"
+        guard let today = parser.date(from: iso) else { return nil }
+
+        var calendar = Calendar.current
+        calendar.timeZone = .current
+        guard let weekStartDate = calendar.dateInterval(of: .weekOfYear, for: today)?.start,
+              let monthStartDate = calendar.dateInterval(of: .month, for: today)?.start,
+              let yesterdayDate = calendar.date(byAdding: .day, value: -1, to: today),
+              let lastWeekStartDate = calendar.date(byAdding: .day, value: -7, to: weekStartDate),
+              let lastWeekEndDate = calendar.date(byAdding: .day, value: -1, to: weekStartDate) else {
+            return nil
+        }
+
+        return CalendarAnchors(
+            yesterday: parser.string(from: yesterdayDate),
+            weekStart: parser.string(from: weekStartDate),
+            lastWeekStart: parser.string(from: lastWeekStartDate),
+            lastWeekEnd: parser.string(from: lastWeekEndDate),
+            monthStart: parser.string(from: monthStartDate)
+        )
     }
 
     private static func weekdayAnchor(fromISO iso: String) -> String? {

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -149,8 +149,7 @@ public enum AssistantSystemPrompt {
 
         Pattern 6 - Analytics breakdowns.
         Merchant: "revenue by day this week"
-        GOOD: One call to the analytics revenue tool with the appropriate window and a daily-grain parameter. Answer directly with the breakdown in prose; no \
-        cards for analytics numbers.
+        GOOD: One call to the analytics revenue tool with the appropriate window and a daily-grain parameter. Answer directly with the breakdown in prose.
         BAD: Ask "did you want by day or by week?" when the merchant already said "by day".
 
         Pattern 7 - Refusing what the catalog can't do.
@@ -246,8 +245,7 @@ public enum AssistantSystemPrompt {
         the merchant didn't ask for. For long lists (more than 5), pick 1-5 noteworthy entries to render and summarise the rest in prose. Card-rendering is \
         selection, not a dump of every match.
 
-        Don't render cards for analytics, revenue, or aggregate stats - numbers don't have card renderers, describe them in prose. Don't render cards for \
-        settings, concepts, or refusals where no entity is involved.
+        Don't render cards for settings questions, conceptual answers, or refusals where no entity is involved.
 
         After a tool returns data, answer the merchant's actual question. For card-backed entity results, keep prose concise and avoid repeating ids, statuses, \
         owners, totals, dates, or row-by-row fields that belong in cards. For direct non-card, single-field, or analytics questions, answer directly in prose.

--- a/Modules/Sources/WooAIAssistant/Models/ChatMessage.swift
+++ b/Modules/Sources/WooAIAssistant/Models/ChatMessage.swift
@@ -77,6 +77,18 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
 
     public mutating func markCompleted() {
         isStreaming = false
+        trimTrailingWhitespaceFromTextSegments()
+    }
+
+    private mutating func trimTrailingWhitespaceFromTextSegments() {
+        for index in segments.indices {
+            if case .text(let id, let content) = segments[index] {
+                let trimmed = content.trimmedTrailingWhitespace()
+                if trimmed != content {
+                    segments[index] = .text(id: id, content: trimmed)
+                }
+            }
+        }
     }
 
     public mutating func cancelPendingConfirmations() {
@@ -107,5 +119,15 @@ public extension Array where Element == ChatMessage {
     /// chat surface should not show "assistant is thinking" affordances.
     var hasPendingConfirmation: Bool {
         contains { $0.hasPendingConfirmation }
+    }
+}
+
+private extension String {
+    func trimmedTrailingWhitespace() -> String {
+        var result = self
+        while let last = result.last, last.isWhitespace || last.isNewline {
+            result.removeLast()
+        }
+        return result
     }
 }

--- a/Modules/Sources/WooAIAssistant/Presentation/EmptyStateView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/EmptyStateView.swift
@@ -21,23 +21,26 @@ struct EmptyStateView: View {
                 .font(.assistantTitle)
                 .foregroundStyle(Color.primary)
                 .padding(.horizontal, AssistantSpacing.large)
-                .padding(.top, AssistantSpacing.large)
+                .padding(.top, AssistantSpacing.xxLarge)
 
-            VStack(spacing: 0) {
-                ForEach(Array(suggestions.enumerated()), id: \.element.id) { index, item in
-                    SuggestionRow(item: item,
-                                  symbolWidth: Self.symbolWidth,
-                                  onTap: { onPick(item.title) })
-                    if index < suggestions.count - 1 {
-                        Rectangle()
-                            .fill(Color.assistantSeparator.opacity(0.4))
-                            .frame(height: 0.5)
-                            .padding(.leading, Self.dividerLeadingInset)
+            AssistantDashboardCardShell(
+                title: nil,
+                padBody: false
+            ) {
+                VStack(spacing: 0) {
+                    ForEach(Array(suggestions.enumerated()), id: \.element.id) { index, item in
+                        SuggestionRow(item: item,
+                                      symbolWidth: Self.symbolWidth,
+                                      onTap: { onPick(item.title) })
+                        if index < suggestions.count - 1 {
+                            Rectangle()
+                                .fill(Color.assistantSeparator.opacity(0.4))
+                                .frame(height: 0.5)
+                                .padding(.leading, Self.dividerLeadingInset)
+                        }
                     }
                 }
             }
-            .background(Color(.quaternarySystemFill))
-            .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.medium))
             .padding(.horizontal, AssistantSpacing.large)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -45,10 +48,10 @@ struct EmptyStateView: View {
     }
 
     private static let defaultSuggestions: [SuggestionItem] = [
-        SuggestionItem(symbol: "chart.bar.fill", title: Localization.suggestionTodaysSales),
-        SuggestionItem(symbol: "shippingbox.fill", title: Localization.suggestionLowStock),
-        SuggestionItem(symbol: "bag.fill", title: Localization.suggestionRecentOrders),
-        SuggestionItem(symbol: "star.fill", title: Localization.suggestionTopProducts)
+        SuggestionItem(symbol: "chart.bar", title: Localization.suggestionRevenueWeek),
+        SuggestionItem(symbol: "tag", title: Localization.suggestionOutOfStock),
+        SuggestionItem(symbol: "list.bullet.rectangle.portrait", title: Localization.suggestionRecentOrders),
+        SuggestionItem(symbol: "person.2", title: Localization.suggestionNewCustomers)
     ]
 
     private enum Localization {
@@ -57,25 +60,25 @@ struct EmptyStateView: View {
             value: "Ask about your store",
             comment: "Empty state title for the AI Assistant chat"
         )
-        static let suggestionTodaysSales = NSLocalizedString(
-            "assistantChat.empty.suggestion.todaysSales",
-            value: "Today's sales",
-            comment: "Suggested prompt asking the assistant to summarise today's sales"
+        static let suggestionRevenueWeek = NSLocalizedString(
+            "assistantChat.empty.suggestion.revenueWeek",
+            value: "Revenue this week",
+            comment: "Suggested prompt asking the assistant for this week's revenue"
         )
-        static let suggestionLowStock = NSLocalizedString(
-            "assistantChat.empty.suggestion.lowStock",
-            value: "Low-stock items",
-            comment: "Suggested prompt asking the assistant for low-stock products"
+        static let suggestionOutOfStock = NSLocalizedString(
+            "assistantChat.empty.suggestion.outOfStock",
+            value: "Out-of-stock items",
+            comment: "Suggested prompt asking the assistant for products that are out of stock"
         )
         static let suggestionRecentOrders = NSLocalizedString(
             "assistantChat.empty.suggestion.recentOrders",
             value: "Recent orders",
             comment: "Suggested prompt asking the assistant to list recent orders"
         )
-        static let suggestionTopProducts = NSLocalizedString(
-            "assistantChat.empty.suggestion.topProducts",
-            value: "Top products this week",
-            comment: "Suggested prompt asking the assistant for the top-selling products this week"
+        static let suggestionNewCustomers = NSLocalizedString(
+            "assistantChat.empty.suggestion.newCustomers",
+            value: "New customers",
+            comment: "Suggested prompt asking the assistant to list the most recently registered customers"
         )
     }
 }
@@ -98,17 +101,13 @@ private struct SuggestionRow: View {
                     .font(.assistantBody)
                     .foregroundStyle(Color.primary)
                 Spacer(minLength: 0)
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Color.assistantTextFaint)
-                    .accessibilityHidden(true)
             }
             .padding(.horizontal, AssistantSpacing.large)
-            .padding(.vertical, AssistantSpacing.small + 2)
-            .frame(minHeight: 44)
+            .padding(.vertical, AssistantSpacing.medium)
+            .frame(minHeight: 56)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(AssistantPressableButtonStyle())
     }
 }
 

--- a/Modules/Sources/WooAIAssistant/Presentation/InputBar.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/InputBar.swift
@@ -11,6 +11,8 @@ struct InputBar: View {
 
     private static let sendButtonDiameter: CGFloat = 36
     private static let sendButtonHitTarget: CGFloat = 44
+    // 4pt centers the 36pt circle inside the 44pt hit target; trailing matches for symmetry.
+    private static let sendButtonTrailingPadding: CGFloat = 4
 
     var body: some View {
         VStack(alignment: .leading, spacing: AssistantSpacing.small) {
@@ -42,7 +44,7 @@ struct InputBar: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .padding(.trailing, AssistantSpacing.small)
+                .padding(.trailing, Self.sendButtonTrailingPadding)
                 .disabled(buttonDisabled)
                 .accessibilityLabel(showsStop ? Localization.stop : Localization.send)
             }
@@ -91,7 +93,10 @@ struct InputBar: View {
     }
 
     private var pillBackground: Color {
-        Color(.systemBackground)
+        // Dark mode steps up from the chat's true-black background so the pill stays visible.
+        Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark ? .secondarySystemBackground : .systemBackground
+        })
     }
 
     private func actionTapped() {

--- a/Modules/Sources/WooAIAssistant/Presentation/MessageBubble.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/MessageBubble.swift
@@ -15,7 +15,6 @@ struct MessageBubble: View {
                         .transition(.opacity.combined(with: .move(edge: .bottom)))
                 }
             }
-            .animation(.snappy(duration: 0.2), value: renderableGroups.map(\.identifier))
             if message.role == .assistant { Spacer(minLength: AssistantSpacing.xxLarge) }
         }
         .frame(maxWidth: .infinity,

--- a/Modules/Sources/WooAIAssistant/Presentation/MessageListView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/MessageListView.swift
@@ -12,8 +12,8 @@ struct MessageListView: View {
 
     var body: some View {
         if messages.isEmpty {
-            EmptyStateView(onPick: onPickPrompt)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            EmptyStateView(onPick: onSendSuggestion)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         } else {
             ZStack(alignment: .bottomTrailing) {
                 ChatScrollView(controller: scrollController) {

--- a/Modules/Sources/WooAIAssistant/Presentation/ToolActivityPill.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ToolActivityPill.swift
@@ -5,41 +5,14 @@ struct ToolActivityPill: View {
     let toolName: String
     let status: ToolCallStatus
 
-    @State private var isExpanded = false
-
     var body: some View {
-        if hasExpandableSummary {
-            Button(action: toggle) {
-                content
-            }
-            .buttonStyle(.plain)
-        } else {
-            content
-        }
-    }
-
-    private var content: some View {
-        VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
-            HStack(spacing: AssistantSpacing.small) {
-                icon
-                    .accessibilityHidden(true)
-                Text(title)
-                    .font(.assistantCaption)
-                    .foregroundStyle(Color.assistantBubbleAssistantText)
-                Spacer(minLength: 0)
-                if hasExpandableSummary {
-                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(Color.assistantMuted)
-                        .accessibilityHidden(true)
-                }
-            }
-            if isExpanded, case .completed(let summary?) = status {
-                Text(summary)
-                    .font(.assistantMonospaced)
-                    .foregroundStyle(Color.assistantBubbleAssistantText)
-                    .lineLimit(3)
-            }
+        HStack(spacing: AssistantSpacing.small) {
+            icon
+                .accessibilityHidden(true)
+            Text(title)
+                .font(.assistantCaption)
+                .foregroundStyle(Color.assistantBubbleAssistantText)
+            Spacer(minLength: 0)
         }
         .padding(.horizontal, AssistantSpacing.medium)
         .padding(.vertical, AssistantSpacing.small)
@@ -50,18 +23,6 @@ struct ToolActivityPill: View {
             RoundedRectangle(cornerRadius: AssistantRadius.medium)
                 .stroke(Color.assistantSurfaceBorder, lineWidth: 1)
         )
-    }
-
-    private func toggle() {
-        guard hasExpandableSummary else { return }
-        withAnimation(.smooth(duration: AssistantMotion.snap)) {
-            isExpanded.toggle()
-        }
-    }
-
-    private var hasExpandableSummary: Bool {
-        if case .completed(let summary) = status, summary != nil { return true }
-        return false
     }
 
     @ViewBuilder

--- a/Modules/Sources/WooAIAssistant/Presentation/ToolActivityPill.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ToolActivityPill.swift
@@ -43,9 +43,13 @@ struct ToolActivityPill: View {
         }
         .padding(.horizontal, AssistantSpacing.medium)
         .padding(.vertical, AssistantSpacing.small)
-        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
-        .background(Color.assistantToolBackground)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.listForeground(modal: false)))
         .clipShape(RoundedRectangle(cornerRadius: AssistantRadius.medium))
+        .overlay(
+            RoundedRectangle(cornerRadius: AssistantRadius.medium)
+                .stroke(Color.assistantSurfaceBorder, lineWidth: 1)
+        )
     }
 
     private func toggle() {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductSummary.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 enum ProductSummary {
+    // `images` is included so list-card thumbnails match single-product cards; capped downstream.
     static func make(from entity: AnyCodableJSON) -> AnyCodableJSON {
         RESTResponseParsing.project(entity, keys: [
             "id", "name", "sku", "price", "stock_status", "type", "status",
-            "stock_quantity", "regular_price", "sale_price"
+            "stock_quantity", "regular_price", "sale_price", "images"
         ])
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductSummary.swift
@@ -1,11 +1,15 @@
 import Foundation
 
 enum ProductSummary {
-    // `images` is included so list-card thumbnails match single-product cards; capped downstream.
     static func make(from entity: AnyCodableJSON) -> AnyCodableJSON {
-        RESTResponseParsing.project(entity, keys: [
+        let projected = RESTResponseParsing.project(entity, keys: [
             "id", "name", "sku", "price", "stock_status", "type", "status",
             "stock_quantity", "regular_price", "sale_price", "images"
         ])
+        guard case .object(var fields) = projected else { return projected }
+        if case .array(let items) = fields["images"] {
+            fields["images"] = .array(Array(items.prefix(1)))
+        }
+        return .object(fields)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -51,6 +51,11 @@ public enum ProductsListTool {
                     "items": .object(["type": .string("integer")]),
                     "description": .string("Specific product IDs to include.")
                 ]),
+                "stock_status": .object([
+                    "type": .string("string"),
+                    "enum": .array([.string("instock"), .string("outofstock"), .string("onbackorder")]),
+                    "description": .string("Filter by stock status. Use 'outofstock' or 'onbackorder' for low-stock-style queries.")
+                ]),
                 "orderby": .object([
                     "type": .string("string"),
                     "enum": .array([.string("date"), .string("id"), .string("title"),
@@ -82,6 +87,7 @@ public enum ProductsListTool {
         let tag: Int?
         let sku: String?
         let include: [Int]?
+        let stockStatus: String?
         let orderby: String?
         let order: String?
         let page: Int?
@@ -89,6 +95,7 @@ public enum ProductsListTool {
 
         enum CodingKeys: String, CodingKey {
             case search, status, category, tag, sku, include, orderby, order, page
+            case stockStatus = "stock_status"
             case perPage = "per_page"
         }
     }
@@ -110,6 +117,10 @@ public enum ProductsListTool {
         }
         if let include = args.include, !include.isEmpty {
             query["include"] = include.map(String.init).joined(separator: ",")
+        }
+        if let stockStatus = args.stockStatus?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !stockStatus.isEmpty {
+            query["stock_status"] = stockStatus
         }
         if let page = args.page, page > 1 { query["page"] = String(page) }
         return query

--- a/Modules/Tests/WooAIAssistantTests/Models/ChatMessageTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Models/ChatMessageTests.swift
@@ -178,6 +178,79 @@ struct ChatMessageTests {
     }
 
     @Test
+    func test_chatMessage_markCompleted_when_text_has_trailing_newlines_then_trims_them() {
+        // Given
+        let textID = UUID()
+        var message = ChatMessage(role: .assistant,
+                                  segments: [.text(id: textID, content: "Hello world.\n\n\n")],
+                                  isStreaming: true)
+
+        // When
+        message.markCompleted()
+
+        // Then
+        guard case .text(let id, let content) = message.segments[0] else {
+            Issue.record("expected .text, got \(message.segments[0])")
+            return
+        }
+        #expect(id == textID)
+        #expect(content == "Hello world.")
+    }
+
+    @Test
+    func test_chatMessage_markCompleted_when_text_has_trailing_spaces_and_tabs_then_trims_them() {
+        // Given
+        var message = ChatMessage(role: .assistant,
+                                  segments: [.text(id: UUID(), content: "Done.   \t\n")],
+                                  isStreaming: true)
+
+        // When
+        message.markCompleted()
+
+        // Then
+        guard case .text(_, let content) = message.segments[0] else {
+            Issue.record("expected .text, got \(message.segments[0])")
+            return
+        }
+        #expect(content == "Done.")
+    }
+
+    @Test
+    func test_chatMessage_markCompleted_preserves_leading_whitespace() {
+        // Given
+        var message = ChatMessage(role: .assistant,
+                                  segments: [.text(id: UUID(), content: "  Indented start.\n\n")],
+                                  isStreaming: true)
+
+        // When
+        message.markCompleted()
+
+        // Then
+        guard case .text(_, let content) = message.segments[0] else {
+            Issue.record("expected .text, got \(message.segments[0])")
+            return
+        }
+        #expect(content == "  Indented start.")
+    }
+
+    @Test
+    func test_chatMessage_updateText_mid_stream_does_not_trim() {
+        // Given
+        var message = ChatMessage(role: .assistant, isStreaming: true)
+
+        // When
+        message.updateText(appending: "Hello\n")
+        message.updateText(appending: "world.")
+
+        // Then
+        guard case .text(_, let content) = message.segments[0] else {
+            Issue.record("expected .text, got \(message.segments[0])")
+            return
+        }
+        #expect(content == "Hello\nworld.")
+    }
+
+    @Test
     func test_chatMessage_updateConfirmation_when_pending_then_resolves_to_cancelled() {
         // Given
         let proposalID = UUID()

--- a/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/State/AssistantConversationTests.swift
@@ -174,6 +174,45 @@ struct AssistantConversationTests {
     }
 
     @Test
+    func test_apply_when_completed_then_trims_trailing_whitespace_from_text_segments() async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+
+        // When
+        conversation.apply(.textChunk("Hello world."), to: messageID)
+        conversation.apply(.textChunk("\n\n\n"), to: messageID)
+        conversation.apply(.completed(routeConfidence: nil), to: messageID)
+
+        // Then
+        let segments = try #require(conversation.messages.last?.segments)
+        guard case .text(_, let content) = segments[0] else {
+            Issue.record("expected .text, got \(segments[0])")
+            return
+        }
+        #expect(content == "Hello world.")
+    }
+
+    @Test
+    func test_apply_mid_stream_does_not_trim_text() async throws {
+        // Given
+        let conversation = AssistantConversation()
+        let messageID = conversation.beginAssistantMessage()
+
+        // When
+        conversation.apply(.textChunk("Hello\n"), to: messageID)
+        conversation.apply(.textChunk("world."), to: messageID)
+
+        // Then
+        let segments = try #require(conversation.messages.last?.segments)
+        guard case .text(_, let content) = segments[0] else {
+            Issue.record("expected .text, got \(segments[0])")
+            return
+        }
+        #expect(content == "Hello\nworld.")
+    }
+
+    @Test
     func test_apply_when_confirmationRequired_then_pending_segment_is_appended() async throws {
         // Given
         let conversation = AssistantConversation()

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductSummaryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductSummaryTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+struct ProductSummaryTests {
+    @Test
+    func test_make_when_entity_has_multiple_images_then_summary_keeps_only_first_image() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(101),
+            "name": .string("Hoodie"),
+            "images": .array([
+                .object(["id": .int(1), "src": .string("https://example.com/1.jpg")]),
+                .object(["id": .int(2), "src": .string("https://example.com/2.jpg")]),
+                .object(["id": .int(3), "src": .string("https://example.com/3.jpg")])
+            ])
+        ])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .array(let images) = fields["images"] else {
+            Issue.record("expected images array on summary")
+            return
+        }
+        #expect(images.count == 1)
+        #expect(images.first == .object(["id": .int(1), "src": .string("https://example.com/1.jpg")]))
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -31,6 +31,23 @@ struct ProductsListToolTests {
         }
         #expect(fields["count"] == .int(3))
         #expect(fields["ids"] == .array([.int(101), .int(102), .int(103)]))
+        #expect(fields["rows"] == .array([
+            .object(["id": .int(101),
+                     "name": .string("Hoodie"),
+                     "sku": .string("HOOD-1"),
+                     "price": .string("49.00"),
+                     "stock_status": .string("instock")]),
+            .object(["id": .int(102),
+                     "name": .string("Tee"),
+                     "sku": .string("TEE-1"),
+                     "price": .string("19.00"),
+                     "stock_status": .string("outofstock")]),
+            .object(["id": .int(103),
+                     "name": .string("Jacket"),
+                     "sku": .string("JAC-1"),
+                     "price": .string("120.00"),
+                     "stock_status": .string("instock")])
+        ]))
         #expect(fields["stock_status_counts"] == .object([
             "instock": .int(2),
             "outofstock": .int(1)

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
@@ -289,7 +289,15 @@ struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
 
     private func chartData(for metric: StatsMetric, intervals: [AnyCodableJSON]) -> [Double] {
         guard !intervals.isEmpty else { return [] }
-        return intervals.map { interval in
+        let sorted = intervals.enumerated().sorted { lhs, rhs in
+            let lhsKey = chartSortKey(for: lhs.element)
+            let rhsKey = chartSortKey(for: rhs.element)
+            if lhsKey == rhsKey {
+                return lhs.offset < rhs.offset
+            }
+            return lhsKey < rhsKey
+        }.map { $0.element }
+        return sorted.map { interval in
             let subtotals = interval.assistantObject("subtotals")
             for key in metric.keys {
                 if let raw = subtotals?.assistantString(key), let value = Double(raw) {
@@ -301,6 +309,13 @@ struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
             }
             return 0
         }
+    }
+
+    private func chartSortKey(for interval: AnyCodableJSON) -> String {
+        if let date = interval.assistantString("date_start"), !date.isEmpty {
+            return date
+        }
+        return interval.assistantString("interval") ?? ""
     }
 
     func formatDateRange(after: String?, before: String?) -> String? {

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalViewsAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalViewsAdaptorTests.swift
@@ -173,6 +173,35 @@ struct AIAssistantExternalViewsAdaptorTests {
     }
 
     @Test
+    func test_chartData_when_intervals_arrive_in_descending_date_order_then_series_is_sorted_ascending() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = AnyCodableJSON.object([
+            "totals": .object([
+                "total_sales": .string("300.00"),
+                "currency": .string("USD")
+            ]),
+            "interval_subtotals": .array([
+                .object(["interval": .string("2026-05-03"),
+                         "date_start": .string("2026-05-03 00:00:00"),
+                         "subtotals": .object(["total_sales": .double(80.0)])]),
+                .object(["interval": .string("2026-05-02"),
+                         "date_start": .string("2026-05-02 00:00:00"),
+                         "subtotals": .object(["total_sales": .double(120.0)])]),
+                .object(["interval": .string("2026-05-01"),
+                         "date_start": .string("2026-05-01 00:00:00"),
+                         "subtotals": .object(["total_sales": .double(100.0)])])
+            ])
+        ])
+
+        // When
+        let series = sut.testChartData(forKeys: ["total_sales", "gross_sales"], payload: payload)
+
+        // Then
+        #expect(series == [100.0, 120.0, 80.0])
+    }
+
+    @Test
     func test_statsCardView_when_tool_is_unrelated_then_returns_nil() {
         // Given
         let sut = AIAssistantExternalViewsAdaptor()


### PR DESCRIPTION
WOOMOB-2878

Depends on #17069 - when that merges, this PR rebases to trunk automatically.

Third of three stacked PRs. This one is the **user-facing tip** of the stack and the place to verify the full chat experience end-to-end. It tightens the model's behavior for store-overview queries, adds a curated empty state with prompt-on-tap suggestions that teach merchants what to ask, and polishes the chat input bar and tool-activity pill. Earlier PRs (#17068 foundation, #17069 rendering + navigation) are reviewable on their own but the visible chat changes are best evaluated here.

## Why

Two complementary nudges that reshape what a merchant first sees and what the model first does:

- **The empty chat update blank state.** A curated dashboard-shell card lists four entry-point queries that exercise the actual tool catalog (recent orders, top products, today's revenue, low-stock items). Tapping a suggestion fires the prompt directly, so a merchant who doesn't know what the assistant can do isn't staring at a blinking cursor.
- **The system prompt's `Today` paragraph and entity-card section are tightened.** The model now anchors its calendar reasoning, picks tool args that keep card payloads under the row limit, and surfaces stock filters when the merchant asks about inventory. The `stock_status` filter on `products_list` and the `images` field on `ProductSummary` are the catalog-side support for the prompt's new patterns.

## Key non-obvious decisions

- **`InputBar` and `ToolActivityPill` styling tweaks travel with the empty-state commit, not in PR 2.** The empty state, the input bar polish (dark-mode pill background, send-button padding), and the activity-pill border / background are visually one cohesive change. Splitting them across two PRs would leave PR 2 with a half-styled chat that visually drifts from the design.
- **`stock_status` joins the `products_list` filter set.** Without it, a question like \"what's out of stock?\" forced the model to fan out to per-product `products_get` calls. With it, one list call answers the question.
- **`images` is included on `ProductSummary` but capped at one** so the model-visible payload doesn't bloat. Mirrors Android's same constraint.
- **Empty-state suggestion strings are real prompts, not labels.** Tapping them sends the literal string as the merchant's first message, which means the suggestions need to actually trigger a useful tool call. The four chosen are validated against the smoke suite.

## Cross-platform alignment

No direct Android counterpart for this PR - prompt + tool-catalog tightening is per-platform tuning. Android's empty state has been redesigned separately by the design team; not a 1:1.

## Manual testing

Build the app from this branch and run through the menu below. Cards from the chat surface should render correctly, tap-through should push the matching native detail, prior values should appear with strikethrough on confirmation cards, and the empty state should fire the prompt directly when a suggestion is tapped.

| # | Prompt | What to verify |
|---|---|---|
| 1 | open empty chat | Curated empty state appears with four suggestions; input bar is polished (dark-mode pill bg, 44pt send button hit target) |
| 2 | tap any suggestion | Suggestion fires the prompt directly, response includes a typed card |
| 3 | \"show me last 3 orders\" | Typed `OrderCard` rendering, dashboard row reuse |
| 4 | tap one of those orders | Instant placeholder push, then native order detail with real data |
| 5 | \"what are my top products?\" | Typed `ProductCard` with image, stock summary |
| 6 | tap a product | Same navigation flow, product detail |
| 7 | \"what's out of stock?\" | Single `products_list` call with `stock_status` filter (not fan-out) |
| 8 | \"how are sales today?\" | `analytics_revenue` typed card |
| 9 | tap the revenue card | Opens analytics with the **correct date range** (the off-by-one fix from PR 2) |
| 10 | \"update last order to pending and add note 'late'\" | Confirmation card: status row with `~~Processing~~ Pending` strikethrough, customer note row as `Updated` placeholder, no divider between header and body |
| 11 | \"set price of Aurora Hoodie to $89.99\" | Confirmation card with prior price strikethrough |
| 12 | \"set order #1234 to on-hold\" | Status humanized to `On hold` (not `On-Hold`) |
| 13 | \"mark orders #100, #101, #102 as completed\" | Title `Update 3 orders`, single status row, **no prior** (bulk hides priors) |

Screenshots / video added inline above this section after manual run.

## Smoke regression

Smoke run against the post-merge baseline (`gpt-4o-mini`, REST mode, 24 scenarios x 3 samples = 72 turns):

**22 PASS / 2 REGRESSION / 1 FAIL.**

Recoveries vs previous prompt iterations on this branch (the prompt went through three revisions before settling):
- `new_customers_week` recovered after restoring the `# Distinct quantities` section. Model now declines honestly when asked for new-customer counts instead of relabeling `customers_list` row count.
- `orders_with_payment` recovered after restoring stricter Pattern 1 wording ("exhaust list params first"). Model uses `orders_list` with `extra_fields` instead of fanning out to `orders_get x3`.
- `fraud_coaching` PASS (previous run had a server-side moderation flake).
- `search_drilldown` PASS (variance, recovered naturally).

Remaining regressions / fails:

| id | status | what's happening | why |
|---|---|---|---|
| `orders_with_email` | REGRESSION | model refuses "Get order list with customer emails" without calling any tool, redirects to native Orders tab | model-level conservatism on sensitive-looking fields. The protective "merchant owns store data" sentence is in the prompt and was preserved through the rewrite, but `gpt-4o-mini` reads "customer emails" as PII regardless. Could likely be unblocked with a worked example demonstrating the `extra_fields` pattern, but each iteration burns 5+ minutes of smoke time and the broader prompt direction is correct. |
| `spanish` | REGRESSION (1/6 sample) | one sample fanned out 4 list calls vs `max_tool_calls=3` | borderline flake on a single sample, not reproduced across the other two |
| `memory_reference_resolution` | FAIL | `t2` failed `required_tools_any(orders_update)` on 2/6 samples (one used `orders_bulk_update`, one looped on `orders_list`) | continues a baseline FAIL - was failing on `2026-04-30` baseline run too. Not introduced by this branch. Acceptable to ship. |

**Improvements observed (baseline -> HEAD)**
- `customer_drill`: hp 4/9 -> 9/9
- `unknown_setting`: hp 1/3 -> 3/3
- `write_note_then_status`: hp 3/6 -> 6/6 (`order_notes_create` legacy path subsumed by `orders_update` + `customer_note`)
- `search_drilldown` t3: new `stock_status` filter on `products_list` exercised cleanly across all 3 samples (the catalog-side commit's signal)

Run stored at `.claude/skills/woo-ai-smoke/runs/2026-05-05T12-41-35Z_7e41e195e2b_woomob-2878-prompt-restored.jsonl`.

## Videos


https://github.com/user-attachments/assets/effb4da8-9019-4c95-847c-eede9b062ff9

