### PR TITLE
Handle AI chat escalation with support area routing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -17,6 +17,9 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     ///
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
 
+    /// Retains the support escalation coordinator while the flow is active.
+    ///
+    private var supportEscalationCoordinator: SupportEscalationCoordinator?
 
     init() {
         viewModel = ConnectivityToolViewModel()
@@ -100,8 +103,9 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     }
 
     private func showContactSupportForm(sourceTag: String? = nil,
-                                         additionalTags: [String] = [],
-                                         chatTranscript: String? = nil) {
+                                        additionalTags: [String] = [],
+                                        chatTranscript: String? = nil,
+                                        preselectedArea: SupportFormViewModel.Area? = nil) {
         var attachments: [ZendeskAttachment] = []
 
         if let troubleshootingDescription = viewModel.troubleshootingDescription(),
@@ -123,31 +127,47 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
             ))
         }
 
-        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(sourceTag: sourceTag,
-                                                                                              additionalTags: additionalTags,
-                                                                                              attachments: attachments))
+        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(
+            sourceTag: sourceTag,
+            additionalTags: additionalTags,
+            attachments: attachments,
+            preselectedArea: preselectedArea
+        ))
         supportController.show(from: self)
 
         ServiceLocator.analytics.track(event: .ConnectivityTool.contactSupportTapped())
     }
 
     private func showSupportChat() {
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] transcript in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] transcript, supportAreaInfo in
             self?.navigationController?.popViewController(animated: true)
-            self?.showContactSupportForm(sourceTag: Constants.aiChatEscalationSourceTag,
-                                         additionalTags: Constants.aiChatEscalationAdditionalTags,
-                                         chatTranscript: transcript)
+            self?.handleContactHumanSupport(transcript: transcript, supportAreaInfo: supportAreaInfo)
         }
 
         let chatController = SupportChatHostingController(viewModel: chatViewModel)
         chatController.show(from: self)
     }
-}
 
-private extension ConnectivityToolViewController {
-    enum Constants {
-        static let aiChatEscalationSourceTag = "in_app_support_escalate"
-        static let aiChatEscalationAdditionalTags = ["ai_skip"]
+    private func handleContactHumanSupport(transcript: String, supportAreaInfo: SupportAreaInfo?) {
+        supportEscalationCoordinator = SupportEscalationCoordinator(
+            navigationController: navigationController,
+            additionalAttachmentsProvider: { [weak self] in
+                self?.buildTroubleshootingAttachment() ?? []
+            }
+        )
+        supportEscalationCoordinator?.handleEscalation(transcript: transcript, supportAreaInfo: supportAreaInfo)
+    }
+
+    private func buildTroubleshootingAttachment() -> [ZendeskAttachment] {
+        guard let troubleshootingDescription = viewModel.troubleshootingDescription(),
+              let data = troubleshootingDescription.data(using: .utf8) else {
+            return []
+        }
+        return [ZendeskAttachment(
+            data: data,
+            filename: "connectivitytest_log.txt",
+            contentType: "text/plain"
+        )]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -210,7 +210,7 @@ final class ConnectivityToolViewModel {
     /// Creates a SupportChatViewModel with the current troubleshooting context.
     ///
     @MainActor
-    func makeSupportChatViewModel(onContactHumanSupport: @escaping (_ transcript: String) -> Void) -> SupportChatViewModel {
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping (_ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void) -> SupportChatViewModel {
         var context: [String: Any] = [:]
 
         if let troubleshootingDescription = troubleshootingDescription() {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
@@ -8,6 +8,9 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
 
     private let viewModel: PreLoginConnectivityToolViewModel
 
+    /// Retains the support escalation coordinator while the flow is active.
+    private var supportEscalationCoordinator: SupportEscalationCoordinator?
+
     init(siteURL: URL) {
         viewModel = PreLoginConnectivityToolViewModel(siteURL: siteURL)
         let view = PreLoginConnectivityToolView(viewModel: viewModel)
@@ -31,40 +34,43 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func showContactSupportForm(chatTranscript: String? = nil) {
-        var attachments: [ZendeskAttachment] = []
-
-        if let description = viewModel.troubleshootingDescription(),
-           let data = description.data(using: .utf8) {
-            attachments.append(ZendeskAttachment(
-                data: data,
-                filename: "prelogin_connectivitytest_log.md",
-                contentType: "text/markdown"
-            ))
-        }
-
-        if let transcript = chatTranscript,
-           !transcript.isEmpty,
-           let data = transcript.data(using: .utf8) {
-            attachments.append(ZendeskAttachment(
-                data: data,
-                filename: "support_chat_transcript.txt",
-                contentType: "text/plain"
-            ))
-        }
-
-        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(attachments: attachments))
+    private func showContactSupportForm() {
+        let supportController = SupportFormHostingController(viewModel: SupportFormViewModel(
+            attachments: buildTroubleshootingAttachment()
+        ))
         supportController.show(from: self)
     }
 
     private func showSupportChat() {
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] transcript in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] transcript, supportAreaInfo in
             self?.navigationController?.popViewController(animated: true)
-            self?.showContactSupportForm(chatTranscript: transcript)
+            self?.handleContactHumanSupport(transcript: transcript, supportAreaInfo: supportAreaInfo)
         }
 
         let chatController = SupportChatHostingController(viewModel: chatViewModel)
         chatController.show(from: self)
+    }
+
+    private func handleContactHumanSupport(transcript: String, supportAreaInfo: SupportAreaInfo?) {
+        supportEscalationCoordinator = SupportEscalationCoordinator(
+            navigationController: navigationController,
+            additionalAttachmentsProvider: { [weak self] in
+                self?.buildTroubleshootingAttachment() ?? []
+            }
+        )
+        supportEscalationCoordinator?.handleEscalation(transcript: transcript, supportAreaInfo: supportAreaInfo)
+    }
+
+    private func buildTroubleshootingAttachment() -> [ZendeskAttachment] {
+        guard let description = viewModel.troubleshootingDescription(),
+              let data = description.data(using: .utf8) else {
+            return []
+        }
+        return [ZendeskAttachment(
+            data: data,
+            filename: "prelogin_connectivitytest_log.md",
+            contentType: "text/markdown"
+        )]
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
@@ -184,7 +184,7 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
 
     /// Creates a SupportChatViewModel with the current troubleshooting context.
     ///
-    func makeSupportChatViewModel(onContactHumanSupport: @escaping (_ transcript: String) -> Void) -> SupportChatViewModel {
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping (_ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void) -> SupportChatViewModel {
         var context: [String: Any] = [:]
 
         if let troubleshootingDescription = troubleshootingDescription() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -80,6 +80,9 @@ final class HelpAndSupportViewController: UIViewController {
         isAIChatEnabled: ServiceLocator.featureFlagService.isFeatureFlagEnabled(.aiSupportChat)
     )
 
+    /// Retains the support escalation coordinator while the flow is active.
+    private var supportEscalationCoordinator: SupportEscalationCoordinator?
+
     private var isMacCatalyst: Bool {
         #if targetEnvironment(macCatalyst)
         return true
@@ -479,17 +482,17 @@ private extension HelpAndSupportViewController {
             : .preLogin
         let viewModel = SupportChatViewModel(
             entryPoint: entryPoint,
-            onContactHumanSupport: { [weak self] transcript in
-                self?.navigateToContactSupport(transcript: transcript)
+            onContactHumanSupport: { [weak self] transcript, supportAreaInfo in
+                self?.handleContactHumanSupport(transcript: transcript, supportAreaInfo: supportAreaInfo)
             }
         )
         let controller = SupportChatHostingController(viewModel: viewModel)
         navigationController?.pushViewController(controller, animated: true)
     }
 
-    private func navigateToContactSupport(transcript: String) {
-        let viewController = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag))
-        viewController.show(from: self)
+    private func handleContactHumanSupport(transcript: String, supportAreaInfo: SupportAreaInfo?) {
+        supportEscalationCoordinator = SupportEscalationCoordinator(navigationController: navigationController)
+        supportEscalationCoordinator?.handleEscalation(transcript: transcript, supportAreaInfo: supportAreaInfo)
     }
 
     /// Chat History action
@@ -513,8 +516,8 @@ private extension HelpAndSupportViewController {
             botSlug: summary.botSlug,
             entryPoint: .chatHistory,
             chatID: summary.chatID,
-            onContactHumanSupport: { [weak self] transcript in
-                self?.navigateToContactSupport(transcript: transcript)
+            onContactHumanSupport: { [weak self] transcript, supportAreaInfo in
+                self?.handleContactHumanSupport(transcript: transcript, supportAreaInfo: supportAreaInfo)
             }
         )
         let controller = SupportChatHostingController(viewModel: chatViewModel)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -57,7 +57,9 @@ final class SupportEscalationCoordinator {
             return
         }
 
-        if supportAreaInfo.isHighConfidence {
+        // Only create ticket directly if high confidence AND user identity exists.
+        // Without identity, Zendesk can't send email responses to the user.
+        if supportAreaInfo.isHighConfidence && zendeskProvider.haveUserIdentity {
             createTicketDirectly(with: supportAreaInfo)
         } else {
             showSupportForm(transcript: transcript, preselectedArea: supportAreaInfo.area)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -1,0 +1,155 @@
+import UIKit
+import Yosemite
+import protocol WooFoundation.Analytics
+
+/// Coordinates the support escalation flow from AI chat to Zendesk ticket creation.
+///
+/// Handles routing based on confidence level, navigation to support form,
+/// direct ticket creation, and success/failure UI feedback.
+///
+final class SupportEscalationCoordinator {
+
+    /// Tags used for AI chat escalation tickets.
+    ///
+    private enum Tags {
+        static let sourceTag = "in_app_support_escalate"
+        static let additionalTags = ["ai_skip"]
+    }
+
+    private weak var navigationController: UINavigationController?
+    private let additionalAttachmentsProvider: () -> [ZendeskAttachment]
+    private let zendeskProvider: ZendeskManagerProtocol
+    private let analytics: Analytics
+    private let stores: StoresManager
+
+    /// Creates a new coordinator.
+    ///
+    /// - Parameters:
+    ///   - navigationController: The navigation controller to present from.
+    ///   - additionalAttachmentsProvider: Closure that returns extra attachments (e.g., troubleshooting logs).
+    ///   - zendeskProvider: Zendesk service provider.
+    ///   - analytics: Analytics tracker.
+    ///   - stores: Stores manager for site info.
+    init(navigationController: UINavigationController?,
+         additionalAttachmentsProvider: @escaping () -> [ZendeskAttachment] = { [] },
+         zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
+         analytics: Analytics = ServiceLocator.analytics,
+         stores: StoresManager = ServiceLocator.stores) {
+        self.navigationController = navigationController
+        self.additionalAttachmentsProvider = additionalAttachmentsProvider
+        self.zendeskProvider = zendeskProvider
+        self.analytics = analytics
+        self.stores = stores
+    }
+
+    /// Handles the escalation from AI chat to human support.
+    ///
+    /// Routes based on confidence level:
+    /// - High confidence: Creates ticket directly
+    /// - Otherwise: Shows support form with optional pre-selection
+    ///
+    /// - Parameters:
+    ///   - transcript: The chat transcript.
+    ///   - supportAreaInfo: Optional support area information from AI chat.
+    func handleEscalation(transcript: String, supportAreaInfo: SupportAreaInfo?) {
+        guard let supportAreaInfo else {
+            showSupportForm(transcript: transcript, preselectedArea: nil)
+            return
+        }
+
+        if supportAreaInfo.isHighConfidence {
+            createTicketDirectly(with: supportAreaInfo)
+        } else {
+            showSupportForm(transcript: transcript, preselectedArea: supportAreaInfo.area)
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func showSupportForm(transcript: String, preselectedArea: SupportFormViewModel.Area?) {
+        var attachments = buildTranscriptAttachment(transcript: transcript)
+        attachments.append(contentsOf: additionalAttachmentsProvider())
+
+        let viewModel = SupportFormViewModel(
+            sourceTag: Tags.sourceTag,
+            additionalTags: Tags.additionalTags,
+            attachments: attachments,
+            preselectedArea: preselectedArea
+        )
+        let viewController = SupportFormHostingController(viewModel: viewModel)
+
+        if let navigationController {
+            viewController.show(from: navigationController)
+        }
+    }
+
+    private func createTicketDirectly(with areaInfo: SupportAreaInfo) {
+        guard let presentingVC = navigationController?.topViewController else { return }
+
+        let loadingViewController = InProgressViewController(
+            viewProperties: .init(title: Localization.creatingTicket, message: "")
+        )
+        presentingVC.present(loadingViewController, animated: true)
+
+        var attachments = buildTranscriptAttachment(transcript: areaInfo.transcript)
+        attachments.append(contentsOf: additionalAttachmentsProvider())
+
+        let siteAddress = stores.sessionManager.defaultSite?.url ?? ""
+        let tags = areaInfo.area.datasource.tags + Tags.additionalTags + [Tags.sourceTag]
+        let request = ZendeskSupportRequest(
+            formID: areaInfo.area.datasource.formID,
+            customFields: areaInfo.area.datasource.customFields(siteAddress: siteAddress),
+            tags: tags,
+            subject: SupportFormViewModel.subject(for: areaInfo.areaType),
+            description: areaInfo.firstUserMessage,
+            attachments: attachments
+        )
+
+        zendeskProvider.createSupportRequest(request) { [weak self] result in
+            loadingViewController.dismiss(animated: true) {
+                switch result {
+                case .success:
+                    self?.analytics.track(.supportNewRequestCreated)
+                    self?.showSuccessAndPop()
+                case .failure:
+                    self?.analytics.track(.supportNewRequestFailed)
+                    self?.showSupportForm(transcript: areaInfo.transcript, preselectedArea: areaInfo.area)
+                }
+            }
+        }
+    }
+
+    private func showSuccessAndPop() {
+        let notice = Notice(title: Localization.ticketCreatedSuccess, feedbackType: .success)
+        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        navigationController?.popViewController(animated: true)
+    }
+
+    private func buildTranscriptAttachment(transcript: String) -> [ZendeskAttachment] {
+        guard !transcript.isEmpty, let data = transcript.data(using: .utf8) else {
+            return []
+        }
+        return [ZendeskAttachment(
+            data: data,
+            filename: "support_chat_transcript.txt",
+            contentType: "text/plain"
+        )]
+    }
+}
+
+// MARK: - Localization
+
+private extension SupportEscalationCoordinator {
+    enum Localization {
+        static let creatingTicket = NSLocalizedString(
+            "supportEscalationCoordinator.creatingTicket",
+            value: "Creating support request...",
+            comment: "Loading message shown while creating a support ticket"
+        )
+        static let ticketCreatedSuccess = NSLocalizedString(
+            "supportEscalationCoordinator.ticketCreatedSuccess",
+            value: "Support request created successfully",
+            comment: "Success notice message after support ticket is created"
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -385,7 +385,7 @@ private extension SupportChatView {
         SupportChatView(
             viewModel: SupportChatViewModel(
                 entryPoint: .helpAndSupport,
-                onContactHumanSupport: { _ in }
+                onContactHumanSupport: { _, _ in }
             )
         )
     }
@@ -396,7 +396,7 @@ private extension SupportChatView {
         SupportChatView(
             viewModel: SupportChatViewModel(
                 entryPoint: .connectivityTool,
-                onContactHumanSupport: { _ in }
+                onContactHumanSupport: { _, _ in }
             )
         )
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -155,7 +155,8 @@ final class SupportChatViewModel {
     private let stores: StoresManager
     private var diagnosticsContext: [String: Any]?
     private let initialContext: [String: Any]?
-    private let onContactHumanSupport: (_ transcript: String) -> Void
+    private let onContactHumanSupport: (_ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void
+    private var latestSupportArea: SupportChatSupportArea?
     var onStartJetpackSetup: () -> Void
     private let diagnosticsService: SupportDiagnosticsService
 
@@ -167,7 +168,7 @@ final class SupportChatViewModel {
          initialContext: [String: Any]? = nil,
          diagnosticsService: SupportDiagnosticsService? = nil,
          chatID: Int64? = nil,
-         onContactHumanSupport: @escaping (_ transcript: String) -> Void,
+         onContactHumanSupport: @escaping (_ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void,
          onStartJetpackSetup: @escaping () -> Void = {}) {
         self.botSlug = botSlug
         self.entryPoint = entryPoint
@@ -548,7 +549,33 @@ final class SupportChatViewModel {
     }
 
     func contactHumanSupport() {
-        onContactHumanSupport(generateTranscript())
+        let transcript = generateTranscript()
+        let supportAreaInfo: SupportAreaInfo?
+
+        if let supportArea = latestSupportArea {
+            let mappedArea = SupportFormViewModel.area(for: supportArea.area)
+            let firstUserMessage = extractFirstUserMessage()
+            supportAreaInfo = SupportAreaInfo(
+                areaType: supportArea.area,
+                area: mappedArea,
+                confidence: supportArea.confidence,
+                transcript: transcript,
+                firstUserMessage: firstUserMessage
+            )
+        } else {
+            supportAreaInfo = nil
+        }
+
+        onContactHumanSupport(transcript, supportAreaInfo)
+    }
+
+    private func extractFirstUserMessage() -> String {
+        for message in messages {
+            if message.role == .user, case .text(let text) = message.content {
+                return text
+            }
+        }
+        return ""
     }
 
     private func generateTranscript() -> String {
@@ -605,6 +632,7 @@ final class SupportChatViewModel {
                 /// Skips displaying last bot message when human support is required. User is suggested to contact support manually.
                 if let flags = lastBotMessage.context?.flags, flags.forwardToHumanSupport {
                     shouldPromptHumanSupport = true
+                    latestSupportArea = lastBotMessage.context?.supportArea
                 } else {
                     let assistantMessage = ChatMessage(
                         role: .bot,
@@ -644,12 +672,13 @@ final class SupportChatViewModel {
         switch result {
         case .success(let response):
             sessionID = response.sessionID
-            let rehydrated: [ChatMessage] = response.messages.compactMap { message in
+            let rehydrated: [ChatMessage] = response.messages.compactMap { [weak self] message in
                 // Filter out bot messages flagged for human support
                 if message.role == .bot,
                    let flags = message.context?.flags,
                    flags.forwardToHumanSupport {
-                    shouldPromptHumanSupport = true
+                    self?.shouldPromptHumanSupport = true
+                    self?.latestSupportArea = message.context?.supportArea
                     return nil
                 }
 

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -1,0 +1,274 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+final class SupportEscalationCoordinatorTests: XCTestCase {
+
+    private var zendesk: MockZendeskManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+        zendesk = MockZendeskManager()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        zendesk = nil
+        analyticsProvider = nil
+        analytics = nil
+        super.tearDown()
+    }
+
+    // MARK: - Routing Tests
+
+    func test_handleEscalation_when_supportAreaInfo_is_nil_then_shows_support_form() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: nil)
+
+        // Then - createSupportRequest should not be called, support form should be pushed
+        XCTAssertTrue(zendesk.latestInvokedTags.isEmpty)
+        XCTAssertTrue(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+    }
+
+    func test_handleEscalation_when_high_confidence_and_has_identity_then_creates_ticket_directly() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+        let areaInfo = makeHighConfidenceSupportAreaInfo()
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: areaInfo)
+
+        // Then - createSupportRequest should be called with expected tags
+        XCTAssertTrue(zendesk.latestInvokedTags.contains("in_app_support_escalate"))
+        XCTAssertTrue(zendesk.latestInvokedTags.contains("ai_skip"))
+    }
+
+    func test_handleEscalation_when_high_confidence_but_no_identity_then_shows_support_form() {
+        // Given
+        zendesk.mockIdentity(name: nil, email: nil, haveUserIdentity: false)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+        let areaInfo = makeHighConfidenceSupportAreaInfo()
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: areaInfo)
+
+        // Then - createSupportRequest should not be called, support form should be pushed
+        XCTAssertTrue(zendesk.latestInvokedTags.isEmpty)
+        XCTAssertTrue(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+    }
+
+    func test_handleEscalation_when_medium_confidence_then_shows_support_form() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+        let areaInfo = makeMediumConfidenceSupportAreaInfo()
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: areaInfo)
+
+        // Then - createSupportRequest should not be called, support form should be pushed
+        XCTAssertTrue(zendesk.latestInvokedTags.isEmpty)
+        XCTAssertTrue(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+    }
+
+    func test_handleEscalation_when_low_confidence_then_shows_support_form() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+        let areaInfo = makeLowConfidenceSupportAreaInfo()
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: areaInfo)
+
+        // Then - createSupportRequest should not be called, support form should be pushed
+        XCTAssertTrue(zendesk.latestInvokedTags.isEmpty)
+        XCTAssertTrue(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+    }
+
+    // MARK: - Analytics Tests
+
+    func test_createTicketDirectly_when_succeeds_then_tracks_supportNewRequestCreated() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+        let areaInfo = makeHighConfidenceSupportAreaInfo()
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: areaInfo)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("support_new_request_created"))
+    }
+
+    func test_createTicketDirectly_when_fails_then_tracks_supportNewRequestFailed() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .failure(NSError(domain: "Test", code: 500)))
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController)
+        let areaInfo = makeHighConfidenceSupportAreaInfo()
+
+        // When
+        coordinator.handleEscalation(transcript: "Test transcript", supportAreaInfo: areaInfo)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("support_new_request_failed"))
+    }
+
+    // MARK: - Request Content Tests
+
+    func test_createTicketDirectly_uses_first_user_message_as_description() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        var capturedRequest: ZendeskSupportRequest?
+        let capturingZendesk = CapturingZendeskManager { request in
+            capturedRequest = request
+        }
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = SupportEscalationCoordinator(
+            navigationController: navigationController,
+            zendeskProvider: capturingZendesk,
+            analytics: analytics
+        )
+
+        let areaInfo = SupportAreaInfo(
+            areaType: .mobileApp,
+            area: SupportFormViewModel.area(for: .mobileApp),
+            confidence: .high,
+            transcript: "Full transcript here",
+            firstUserMessage: "My app keeps crashing"
+        )
+
+        // When
+        coordinator.handleEscalation(transcript: "Full transcript", supportAreaInfo: areaInfo)
+
+        // Then
+        XCTAssertEqual(capturedRequest?.description, "My app keeps crashing")
+    }
+
+    func test_createTicketDirectly_uses_area_based_subject() {
+        // Given
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+
+        var capturedRequest: ZendeskSupportRequest?
+        let capturingZendesk = CapturingZendeskManager { request in
+            capturedRequest = request
+        }
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = SupportEscalationCoordinator(
+            navigationController: navigationController,
+            zendeskProvider: capturingZendesk,
+            analytics: analytics
+        )
+
+        let areaInfo = SupportAreaInfo(
+            areaType: .cardReader,
+            area: SupportFormViewModel.area(for: .cardReader),
+            confidence: .high,
+            transcript: "Transcript",
+            firstUserMessage: "Card reader issue"
+        )
+
+        // When
+        coordinator.handleEscalation(transcript: "Transcript", supportAreaInfo: areaInfo)
+
+        // Then
+        XCTAssertEqual(capturedRequest?.subject, "Card Reader Support Request")
+    }
+}
+
+// MARK: - Helpers
+
+private extension SupportEscalationCoordinatorTests {
+    func makeCoordinator(navigationController: UINavigationController? = nil) -> SupportEscalationCoordinator {
+        SupportEscalationCoordinator(
+            navigationController: navigationController,
+            zendeskProvider: zendesk,
+            analytics: analytics
+        )
+    }
+
+    func makeHighConfidenceSupportAreaInfo() -> SupportAreaInfo {
+        SupportAreaInfo(
+            areaType: .mobileApp,
+            area: SupportFormViewModel.area(for: .mobileApp),
+            confidence: .high,
+            transcript: "Test transcript",
+            firstUserMessage: "Help me"
+        )
+    }
+
+    func makeMediumConfidenceSupportAreaInfo() -> SupportAreaInfo {
+        SupportAreaInfo(
+            areaType: .mobileApp,
+            area: SupportFormViewModel.area(for: .mobileApp),
+            confidence: .medium,
+            transcript: "Test transcript",
+            firstUserMessage: "Help me"
+        )
+    }
+
+    func makeLowConfidenceSupportAreaInfo() -> SupportAreaInfo {
+        SupportAreaInfo(
+            areaType: .mobileApp,
+            area: SupportFormViewModel.area(for: .mobileApp),
+            confidence: .low,
+            transcript: "Test transcript",
+            firstUserMessage: "Help me"
+        )
+    }
+}
+
+// MARK: - Capturing Mock
+
+private final class CapturingZendeskManager: ZendeskManagerProtocol {
+    let zendeskEnabled = true
+    let haveUserIdentity = true
+
+    private let onCreateRequest: (ZendeskSupportRequest) -> Void
+
+    init(onCreateRequest: @escaping (ZendeskSupportRequest) -> Void) {
+        self.onCreateRequest = onCreateRequest
+    }
+
+    func createSupportRequest(_ request: ZendeskSupportRequest, onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        onCreateRequest(request)
+        onCompletion(.success(()))
+    }
+
+    func retrieveUserInfoIfAvailable() -> (name: String?, emailAddress: String?) { (nil, nil) }
+    func createIdentity(name: String, email: String) async throws {}
+    func createIdentity(presentIn viewController: UIViewController, completion: @escaping (Bool) -> Void) {}
+    func showHelpCenter(from controller: UIViewController) {}
+    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping onUserInformationCompletion) {}
+    func initialize() {}
+    func reset() {}
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -397,7 +397,7 @@ struct SupportChatViewModelTests {
                 entryPoint: .chatHistory,
                 stores: stores,
                 chatID: chatID,
-                onContactHumanSupport: { _ in }
+                onContactHumanSupport: { _, _ in }
             )
 
             // When
@@ -414,7 +414,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _ in }
+            onContactHumanSupport: { _, _ in }
         )
 
         await confirmation { fetchCompleted in
@@ -470,7 +470,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _ in }
+            onContactHumanSupport: { _, _ in }
         )
 
         await confirmation { fetchCompleted in
@@ -516,7 +516,7 @@ struct SupportChatViewModelTests {
             entryPoint: entryPoint,
             stores: stores,
             diagnosticsService: diagnosticsService,
-            onContactHumanSupport: { _ in }
+            onContactHumanSupport: { _, _ in }
         )
         viewModel.onStartJetpackSetup = onStartJetpackSetup
         return viewModel


### PR DESCRIPTION
## Description
Part 2 of WOOMOB-2989: Integrate support area routing into the AI chat escalation flow.

When a user taps "Contact Support" after an AI chat is flagged:
- **High confidence**: Creates Zendesk ticket directly with area-based subject, first user message as description, and transcript as attachment
- **Non-high confidence**: Shows support form with the area pre-selected

This PR adds:
- `SupportEscalationCoordinator` - handles the entire escalation flow including routing decisions, navigation, and ticket creation
- Updates `SupportChatViewModel` to track support area and pass `SupportAreaInfo` to the callback
- Integrates the coordinator into `HelpAndSupportViewController`, `ConnectivityToolViewController`, and `PreLoginConnectivityToolViewController`

Tags applied to escalated tickets: `["ai_skip", "in_app_support_escalate"]`

**Depends on**: #17071

## Test Steps
1. Enable `aiSupportChat` feature flag
2. Go to Settings > Help > Chat with Support
3. Chat until the bot flags for human support with high confidence area
4. Tap "Contact Support" → ticket should be created automatically
5. Repeat with non-high confidence → form should open with area pre-selected
6. Test from Connectivity Tool as well

## Screenshots


https://github.com/user-attachments/assets/d465f117-16bf-473d-813d-e5ecfbf15cce



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.