### PR TITLE
Fix Add Customer State picker and addresses toggle on iPad

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
+24.8
+-----
+- [*] Customer details: fixed bugs in form when adding a customer on iPad [https://github.com/woocommerce/woocommerce-ios/pull/17074]
+
 24.7
 -----
 - [*] Performance card: pick which order date type drives the totals (paid, placed, or completed) from a bottom sheet. [https://github.com/woocommerce/woocommerce-ios/pull/16988]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/Legacy/LegacyOrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/Legacy/LegacyOrderCustomerSection.swift
@@ -9,7 +9,7 @@ struct LegacyOrderCustomerSection: View {
 
     /// View model for the address form.
     ///
-    @ObservedObject var addressFormViewModel: CreateOrderAddressFormViewModel
+    let addressFormViewModel: CreateOrderAddressFormViewModel
 
     @State private var showAddressForm: Bool = false
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
@@ -9,10 +9,11 @@ import protocol WooFoundation.Analytics
 /// Parent class for AddressFormViewModelProtocol implementations. Holds shared sync/management logic.
 /// Not to be used on its own, so it doesn't conform to AddressFormViewModelProtocol.
 ///
-open class AddressFormViewModel: ObservableObject {
+@Observable
+open class AddressFormViewModel {
     /// ResultsController for stored countries.
     ///
-    private lazy var countriesResultsController: ResultsController<StorageCountry> = {
+    @ObservationIgnored private lazy var countriesResultsController: ResultsController<StorageCountry> = {
         let countriesDescriptor = NSSortDescriptor(key: "name", ascending: true)
         return ResultsController<StorageCountry>(storageManager: storageManager, sortedBy: [countriesDescriptor])
     }()
@@ -47,7 +48,16 @@ open class AddressFormViewModel: ObservableObject {
 
     /// Store for publishers subscriptions
     ///
-    private var subscriptions = Set<AnyCancellable>()
+    @ObservationIgnored private var subscriptions = Set<AnyCancellable>()
+
+    /// Backs `fieldsPublisher` so external Combine consumers continue to receive updates.
+    @ObservationIgnored private let fieldsSubject: CurrentValueSubject<AddressFormFields, Never>
+
+    /// Backs `secondaryFieldsPublisher` so external Combine consumers continue to receive updates.
+    @ObservationIgnored private let secondaryFieldsSubject: CurrentValueSubject<AddressFormFields, Never>
+
+    /// Backs `showPlaceholdersPublisher`.
+    @ObservationIgnored private let showPlaceholdersSubject = CurrentValueSubject<Bool, Never>(false)
 
     init(siteID: Int64,
          address: Address,
@@ -64,12 +74,14 @@ open class AddressFormViewModel: ObservableObject {
         var fields: AddressFormFields = .init(with: originalAddress)
         fields.phoneCountryCode = phoneCountryCode
         self.fields = fields
+        self.fieldsSubject = CurrentValueSubject(fields)
 
         self.secondaryOriginalAddress = secondaryAddress ?? .empty
-        self.secondaryFields = .init(with: secondaryOriginalAddress)
+        let secondaryFields: AddressFormFields = .init(with: secondaryOriginalAddress)
+        self.secondaryFields = secondaryFields
+        self.secondaryFieldsSubject = CurrentValueSubject(secondaryFields)
 
         self.isDoneButtonAlwaysEnabled = isDoneButtonAlwaysEnabled
-        self.navigationTrailingItem = .done(enabled: isDoneButtonAlwaysEnabled)
 
         self.storageManager = storageManager
         self.stores = stores
@@ -81,8 +93,6 @@ open class AddressFormViewModel: ObservableObject {
         onLoadTrigger.first().sink { [weak self] in
             guard let self else { return }
             self.bindSyncTrigger()
-            self.bindNavigationTrailingItemPublisher()
-            self.bindHasPendingChangesPublisher()
 
             self.fetchStoredCountriesAndTriggerSyncIfNeeded()
             self.refreshCountryAndStateObjects()
@@ -103,47 +113,89 @@ open class AddressFormViewModel: ObservableObject {
 
     /// Address form fields
     ///
-    @Published var fields: AddressFormFields
+    var fields: AddressFormFields {
+        didSet {
+            fieldsSubject.send(fields)
+        }
+    }
 
-    /// Emits changes to the AddressFormFields values
+    /// Emits changes to the AddressFormFields values for non-SwiftUI consumers.
     ///
-    var fieldsPublisher: Published<AddressFormFields>.Publisher { $fields }
+    var fieldsPublisher: AnyPublisher<AddressFormFields, Never> { fieldsSubject.eraseToAnyPublisher() }
 
     /// Secondary address form fields
     ///
-    @Published var secondaryFields: AddressFormFields = .init()
+    var secondaryFields: AddressFormFields {
+        didSet {
+            secondaryFieldsSubject.send(secondaryFields)
+        }
+    }
+
+    /// Emits changes to the secondary AddressFormFields values for non-SwiftUI consumers.
+    ///
+    var secondaryFieldsPublisher: AnyPublisher<AddressFormFields, Never> { secondaryFieldsSubject.eraseToAnyPublisher() }
 
     /// Define if address form should be expanded (show second set of fields for different address)
     ///
-    @Published var showDifferentAddressForm: Bool = false
+    var showDifferentAddressForm: Bool = false
 
     /// Trigger to perform any one time setups.
     ///
-    let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
+    @ObservationIgnored let onLoadTrigger: PassthroughSubject<Void, Never> = PassthroughSubject()
 
     /// Tracks if a network request is being performed.
     ///
-    let performingNetworkRequest: CurrentValueSubject<Bool, Never> = .init(false)
+    var performingNetworkRequest: Bool = false
 
     /// Active navigation bar trailing item.
     /// Defaults to a disabled done button.
     ///
-    @Published private(set) var navigationTrailingItem: AddressFormNavigationItem
+    var navigationTrailingItem: AddressFormNavigationItem {
+        guard !performingNetworkRequest else {
+            return .loading
+        }
+
+        guard !fields.useAsToggle else {
+            return .done(enabled: true)
+        }
+
+        guard !isDoneButtonAlwaysEnabled else {
+            return .done(enabled: true)
+        }
+
+        let addressesAreDifferentButSecondAddressSwitchIsDisabled = secondaryOriginalAddress != .empty &&
+            originalAddress != secondaryOriginalAddress &&
+            !showDifferentAddressForm
+
+        return .done(enabled: addressesAreDifferentButSecondAddressSwitchIsDisabled ||
+                     originalAddress != fields.toAddress() ||
+                     secondaryOriginalAddress != secondaryFields.toAddress())
+    }
 
     /// Define if the view should show placeholders instead of the real elements.
     ///
-    @Published private(set) var showPlaceholders: Bool = false
+    private(set) var showPlaceholders: Bool = false {
+        didSet {
+            showPlaceholdersSubject.send(showPlaceholders)
+        }
+    }
+
+    /// Emits changes to `showPlaceholders` for non-SwiftUI consumers (e.g. tests using Combine).
+    ///
+    var showPlaceholdersPublisher: AnyPublisher<Bool, Never> { showPlaceholdersSubject.eraseToAnyPublisher() }
 
     /// Defines the current notice that should be shown.
     /// Defaults to `nil`.
     ///
-    @Published var notice: Notice?
+    var notice: Notice?
 
     /// Whether the address form has any pending (unsaved) changes.
     ///
     /// Returns `true` if there are changes pending to commit. `False` otherwise.
     ///
-    @Published private(set) var hasPendingChanges: Bool = false
+    var hasPendingChanges: Bool {
+        navigationTrailingItem == .done(enabled: true)
+    }
 
     /// Defines if the state field should be defined as a list selector.
     ///
@@ -319,45 +371,6 @@ private extension AddressFormViewModel {
         secondaryFields.refreshCountryAndStateObjects(with: allCountries)
     }
 
-    /// Calculates what navigation trailing item should be shown depending on our internal state.
-    ///
-    func bindNavigationTrailingItemPublisher() {
-        Publishers.CombineLatest4($fields, $secondaryFields, $showDifferentAddressForm, performingNetworkRequest)
-            .map { [isDoneButtonAlwaysEnabled, originalAddress, secondaryOriginalAddress]
-                fields, secondaryFields, showDifferentAddressForm, performingNetworkRequest -> AddressFormNavigationItem in
-                guard !performingNetworkRequest else {
-                    return .loading
-                }
-
-                guard !fields.useAsToggle else {
-                    return .done(enabled: true)
-                }
-
-                guard !isDoneButtonAlwaysEnabled else {
-                    return .done(enabled: true)
-                }
-
-                let addressesAreDifferentButSecondAddressSwitchIsDisabled = secondaryOriginalAddress != .empty &&
-                originalAddress != secondaryOriginalAddress &&
-                !showDifferentAddressForm
-
-                return .done(enabled: addressesAreDifferentButSecondAddressSwitchIsDisabled ||
-                             originalAddress != fields.toAddress() ||
-                             secondaryOriginalAddress != secondaryFields.toAddress())
-            }
-            .assign(to: &$navigationTrailingItem)
-    }
-
-    /// Determines whether the address form has pending changes, based on the navigation trailing item.
-    ///
-    func bindHasPendingChangesPublisher() {
-        $navigationTrailingItem
-            .map {
-                $0 == .done(enabled: true)
-            }
-            .assign(to: &$hasPendingChanges)
-    }
-
     /// Fetches countries from storage, If there are no stored countries, trigger a sync request.
     ///
     func fetchStoredCountriesAndTriggerSyncIfNeeded() {
@@ -391,17 +404,17 @@ private extension AddressFormViewModel {
 
         // Perform `syncCountries` when a sync trigger is requested.
         syncCountriesTrigger
-            .handleEvents(receiveOutput: { // Set `showPlaceholders` to `true` before initiating sync.
-                self.showPlaceholders = true // I could not find a way to assign this using combine operators. :-(
+            .handleEvents(receiveOutput: { [weak self] in // Set `showPlaceholders` to `true` before initiating sync.
+                self?.showPlaceholders = true
             })
             .map { // Sync countries
                 syncCountries
             }
             .switchToLatest()
-            .map { _ in // Set `showPlaceholders` to `false` after sync is done.
-                false
+            .sink { [weak self] _ in // Set `showPlaceholders` to `false` after sync is done.
+                self?.showPlaceholders = false
             }
-            .assign(to: &$showPlaceholders)
+            .store(in: &subscriptions)
     }
 
     /// Creates a publisher that syncs countries into our storage layer.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -3,10 +3,11 @@ import Yosemite
 import Experiments
 import class WordPressShared.EmailFormatValidator
 import protocol Storage.StorageManagerType
+import SwiftUI
 
 /// Protocol to describe viewmodel of editable address
 ///
-protocol AddressFormViewModelProtocol: ObservableObject {
+protocol AddressFormViewModelProtocol: AnyObject, Observable {
 
     /// Site ID
     ///
@@ -202,6 +203,7 @@ struct AddressFormFields {
             }
         }
     }
+
 
     /// Set initial values from Address using the stored countries to compute the current selected country & state.
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -203,7 +203,6 @@ struct AddressFormFields {
         }
     }
 
-
     /// Set initial values from Address using the stored countries to compute the current selected country & state.
     ///
     mutating func refreshCountryAndStateObjects(with allCountries: [Country]) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModelProtocol.swift
@@ -184,10 +184,9 @@ struct AddressFormFields {
         didSet {
             self.country = selectedCountry?.name ?? ""
 
-            // When a country is selected, check if the new country has a state list.
-            // If it has, clear the selected state and its name in fields.
-            // If it doesn't only clear the selected state.
-            if selectedCountry?.states.isEmpty == false {
+            // When the country actually changes, reset both the picked state and the free-text state value
+            // so a previous country's state isn't carried into a different country's address.
+            if oldValue?.code != selectedCountry?.code {
                 self.state = ""
             }
             self.selectedState = nil

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -91,7 +91,7 @@ struct EditOrderAddressForm<ViewModel: AddressFormViewModelProtocol>: View {
 
     /// View Model for the view
     ///
-    @ObservedObject private(set) var viewModel: ViewModel
+    @Bindable private(set) var viewModel: ViewModel
 
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
     @State private var showingCustomerSearch: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -139,7 +139,7 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
         let action = OrderAction.updateOrder(siteID: order.siteID, order: modifiedOrder, giftCard: nil, fields: orderFields) { [weak self] result in
             guard let self else { return }
 
-            self.performingNetworkRequest.send(false)
+            self.performingNetworkRequest = false
             switch result {
             case .success(let updatedOrder):
                 self.onOrderUpdate?(updatedOrder)
@@ -157,7 +157,7 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
             onFinish(result.isSuccess)
         }
 
-        performingNetworkRequest.send(true)
+        performingNetworkRequest = true
         stores.dispatch(action)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CreateOrderAddressFormViewModelTests.swift
@@ -168,7 +168,7 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.secondaryFields.selectedState)
     }
 
-    func test_selecting_country_without_states_nullifies_selectedState_property_but_keeps_state_field() {
+    func test_selecting_country_without_states_nullifies_selectedState_property_and_state_field() {
         // Given
         let newCountry = Country(code: "GB", name: "United Kingdom", states: [])
 
@@ -188,7 +188,7 @@ final class CreateOrderAddressFormViewModelTests: XCTestCase {
         countryViewModel.command.handleSelectedChange(selected: newCountry, viewController: viewController)
 
         // Then
-        XCTAssertEqual(viewModel.secondaryFields.state, "New York")
+        XCTAssertEqual(viewModel.secondaryFields.state, "")
         XCTAssertNil(viewModel.secondaryFields.selectedState)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -354,6 +354,37 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.fields.state, newState.name)
     }
 
+    func test_changing_selectedCountry_to_a_country_without_states_clears_the_state_text() {
+        // Given
+        var fields = AddressFormFields()
+        fields.selectedCountry = Country(code: "US",
+                                         name: "United States",
+                                         states: [StateOfACountry(code: "NY", name: "New York")])
+        fields.selectedState = StateOfACountry(code: "NY", name: "New York")
+        XCTAssertEqual(fields.state, "New York")
+
+        // When
+        fields.selectedCountry = Country(code: "GB", name: "United Kingdom", states: [])
+
+        // Then
+        XCTAssertEqual(fields.state, "")
+        XCTAssertNil(fields.selectedState)
+    }
+
+    func test_re_setting_selectedCountry_to_same_country_preserves_state_text() {
+        // Given
+        var fields = AddressFormFields()
+        let unitedKingdom = Country(code: "GB", name: "United Kingdom", states: [])
+        fields.selectedCountry = unitedKingdom
+        fields.state = "Greater London"
+
+        // When
+        fields.selectedCountry = unitedKingdom
+
+        // Then
+        XCTAssertEqual(fields.state, "Greater London")
+    }
+
     func test_view_model_updates_billing_and_shipping_address_fields_when_use_as_toggle_is_on() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/Addresses/EditOrderAddressFormViewModelTests.swift
@@ -232,7 +232,7 @@ final class EditOrderAddressFormViewModelTests: XCTestCase {
 
         // When
         let showPlaceholdersStates: [Bool] = waitFor { promise in
-            viewModel.$showPlaceholders
+            viewModel.showPlaceholdersPublisher
                 .dropFirst() // Drop initial value
                 .collect(2)  // Expect two state changes
                 .sink { emittedValues in


### PR DESCRIPTION
Closes: WOOMOB-2990

## Description

In the Add Customer form (Order Creation → Add Customer), two bugs were visible on iPad:

1. Picking a country with a known list of states (e.g. India) did **not** switch the State row from a free-text field to a list selector — so merchants couldn't pick from the canonical state list.
2. Toggling "Add a different shipping address" did **not** reveal the secondary address form below.

Both traced to the same root cause: SwiftUI's `@ObservedObject` → view-body re-render path wasn't firing inside the `NavigationView`-presented form on iPad. `@Published` mutations on `AddressFormViewModel.fields` and `showDifferentAddressForm` happened correctly, but the form's body never re-evaluated, so neither the State row nor the toggle's conditional `if` re-rendered.

The fix migrates `AddressFormViewModel` to the Observation framework (`@Observable`). Observation tracks dependencies per-property at body-evaluation time, bypassing the broken `@ObservedObject` subscription graph entirely. Both bugs disappear without per-property workarounds. As a side benefit, the `navigationTrailingItem` and `hasPendingChanges` Combine pipelines collapse into computed properties.

This PR also fixes a related, long-standing logic bug in `AddressFormFields.selectedCountry.didSet`: switching from a states-having country to a no-states country (e.g. India → UK) left the previous country's state value in the now free-text field — leaving e.g. "Andhra Pradesh" sitting in a UK address. The setter now resets the state value on any country change, while preserving free-text input when the same country is re-picked. 

External Combine consumers (`fieldsPublisher` used by `EditableOrderViewModel`, plus one test) keep working through small `CurrentValueSubject`-backed accessors.

## Test Steps

Test on **iPad and iPhone** — the iPad bugs should be gone, and iPhone behavior should be unchanged.

1. **State picker switching** (the headline iPad bug)
   - Open Order Creation → tap **Add Customer**
   - Tap **Country** → select **India**
   - State row should immediately become a list-selector row with a disclosure chevron
   - Tap **State** → confirm picker shows India's states (Andhra Pradesh, etc.) → pick one → it appears in the State row

2. **Different shipping address toggle** (related iPad bug)
   - In the same form, toggle **Add a different shipping address**
   - A second address form (shipping) should appear below the billing form
   - Each form's country/state pickers should work independently — try setting different countries on each

3. **State value clearing on country change** (logic fix)
   - Set country to **India**, pick **Andhra Pradesh** as state
   - Change country to **United Kingdom** → State field should be empty (previously: "Andhra Pradesh" stayed in the field)
   - Set country to **United States**, pick **California**, then change country to **India** → State should be empty and switch to list selector
   - Re-pick the same country with a free-text state already typed → free-text value should be preserved

4. **Editing an existing address with a known state** (regression check)
   - Open an order whose billing address uses India (or any state-having country) from Order Details → tap to edit billing
   - State row should render as a list selector with the saved state already populated

5. **iPhone regression** — repeat 1–4 on iPhone. Everything should work as before.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.