### PR TITLE
Add store picker to stats widget configuration

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -86,6 +86,9 @@ extension UserDefaults {
 
         /// Whether configurable store stats widgets are enabled
         case configurableStoreStatsWidgetsEnabled
+
+        /// Lightweight store list for configurable store stats widgets
+        case configurableStoreStatsWidgetStores
     }
 }
 

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -72,12 +72,8 @@ enum StoreStatsSnapshotFactory {
                 seenSiteIDs.insert(site.siteID)
                 return true
             }
-            .compactMap { site in
-                let isDefaultStore = site.siteID == defaultID
-                let currencySettingsData = currencySettingsDataBySiteID[site.siteID] ?? (isDefaultStore ? defaultCurrencySettingsData : nil)
-                guard isDefaultStore || currencySettingsData != nil else {
-                    return nil
-                }
+            .map { site in
+                let currencySettingsData = currencySettingsDataBySiteID[site.siteID] ?? defaultCurrencySettingsData
                 return StoreStatsSnapshot(
                     siteID: site.siteID,
                     name: site.name,
@@ -119,8 +115,7 @@ struct StoreStatsSnapshotStore {
     }
 
     func storePickerSnapshots() -> [StoreStatsSnapshot] {
-        let defaultStoreID = defaultStoreID()
-        return snapshots().filter { $0.isSelectableInStorePicker && ($0.siteID == defaultStoreID || $0.currencySettings != nil) }
+        snapshots().filter { $0.isSelectableInStorePicker }
     }
 
     func save(_ snapshots: [StoreStatsSnapshot]) {

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -35,6 +35,38 @@ struct StoreStatsStoredSite: Equatable {
     let isWooCommerceActive: Bool
 }
 
+enum StoreStatsStoreSelection {
+    static let defaultStoreEntityID = "__default_store__"
+
+    static func isDefaultStoreEntityID(_ id: String) -> Bool {
+        id == defaultStoreEntityID
+    }
+
+    static func currencySettings(for selectedStore: StoreStatsSnapshot,
+                                 defaultStoreID: Int64,
+                                 defaultCurrencySettings: CurrencySettings) -> CurrencySettings {
+        guard selectedStore.siteID != defaultStoreID else {
+            return defaultCurrencySettings
+        }
+        // Non-default stores may not have synchronized general settings yet.
+        // Use the default store settings until the selected store settings are available.
+        return selectedStore.currencySettings ?? defaultCurrencySettings
+    }
+
+    static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
+                                      selectedStoreID: String?,
+                                      defaultStoreID: Int64? = nil) -> StoreStatsSnapshot? {
+        let defaultSnapshot = snapshots.first { $0.siteID == defaultStoreID } ?? snapshots.first
+
+        guard let selectedStoreID,
+              isDefaultStoreEntityID(selectedStoreID) == false else {
+            return defaultSnapshot
+        }
+
+        return snapshots.first { $0.appEntityID == selectedStoreID } ?? defaultSnapshot
+    }
+}
+
 enum StoreStatsSnapshotFactory {
     static func snapshots(storedSites: [StoreStatsStoredSite],
                           defaultSite: StoreStatsStoredSite?,

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -131,11 +131,12 @@ struct StoreStatsSnapshotStore {
         let currencySettings = currencySettingsData.flatMap {
             try? JSONDecoder().decode(CurrencySettings.self, from: $0)
         }
+        let timeZone = TimeZone.current
         return StoreStatsSnapshot(
             siteID: storeID,
             name: storeName,
-            timeZoneIdentifier: nil,
-            gmtOffset: 0,
+            timeZoneIdentifier: timeZone.identifier,
+            gmtOffset: Double(timeZone.secondsFromGMT()) / 3600,
             isSelectableInStorePicker: false,
             currencySettings: currencySettings
         )

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -6,7 +6,6 @@ struct StoreStatsSnapshot: Codable, Hashable, Identifiable {
     let name: String
     let timeZoneIdentifier: String?
     let gmtOffset: Double
-    let supportsVisitorStats: Bool
     let isSelectableInStorePicker: Bool
     let currencySettingsData: Data?
 
@@ -41,7 +40,6 @@ struct StoreStatsStoredSite: Equatable {
     let timeZoneIdentifier: String?
     let gmtOffset: Double
     let isWooCommerceActive: Bool
-    let supportsVisitorStats: Bool
 }
 
 enum StoreStatsSnapshotFactory {
@@ -79,7 +77,6 @@ enum StoreStatsSnapshotFactory {
                     name: site.name,
                     timeZoneIdentifier: site.timeZoneIdentifier,
                     gmtOffset: site.gmtOffset,
-                    supportsVisitorStats: site.supportsVisitorStats,
                     isSelectableInStorePicker: true,
                     currencySettingsData: currencySettingsData
                 )
@@ -145,7 +142,6 @@ struct StoreStatsSnapshotStore {
             name: storeName,
             timeZoneIdentifier: nil,
             gmtOffset: 0,
-            supportsVisitorStats: true,
             isSelectableInStorePicker: false,
             currencySettingsData: currencySettingsData
         )

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -7,7 +7,6 @@ struct StoreStatsSnapshot: Codable, Hashable, Identifiable {
     let timeZoneIdentifier: String?
     let gmtOffset: Double
     let supportsVisitorStats: Bool
-    let isDefault: Bool
     let isSelectableInStorePicker: Bool
     let currencySettingsData: Data?
 
@@ -50,6 +49,7 @@ enum StoreStatsSnapshotFactory {
                           defaultSite: StoreStatsStoredSite?,
                           defaultSiteID: Int64?,
                           defaultCurrencySettingsData: Data?,
+                          currencySettingsDataBySiteID: [Int64: Data] = [:],
                           exposesStorePicker: Bool) -> [StoreStatsSnapshot] {
         guard exposesStorePicker else {
             return []
@@ -72,21 +72,27 @@ enum StoreStatsSnapshotFactory {
                 seenSiteIDs.insert(site.siteID)
                 return true
             }
-            .map { site in
-                StoreStatsSnapshot(
+            .compactMap { site in
+                let isDefaultStore = site.siteID == defaultID
+                let currencySettingsData = currencySettingsDataBySiteID[site.siteID] ?? (isDefaultStore ? defaultCurrencySettingsData : nil)
+                guard isDefaultStore || currencySettingsData != nil else {
+                    return nil
+                }
+                return StoreStatsSnapshot(
                     siteID: site.siteID,
                     name: site.name,
                     timeZoneIdentifier: site.timeZoneIdentifier,
                     gmtOffset: site.gmtOffset,
                     supportsVisitorStats: site.supportsVisitorStats,
-                    isDefault: site.siteID == defaultID,
                     isSelectableInStorePicker: true,
-                    currencySettingsData: site.siteID == defaultID ? defaultCurrencySettingsData : nil
+                    currencySettingsData: currencySettingsData
                 )
             }
             .sorted { lhs, rhs in
-                if lhs.isDefault != rhs.isDefault {
-                    return lhs.isDefault
+                let lhsIsDefault = lhs.siteID == defaultID
+                let rhsIsDefault = rhs.siteID == defaultID
+                if lhsIsDefault != rhsIsDefault {
+                    return lhsIsDefault
                 }
                 return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
             }
@@ -113,7 +119,8 @@ struct StoreStatsSnapshotStore {
     }
 
     func storePickerSnapshots() -> [StoreStatsSnapshot] {
-        snapshots().filter { $0.isSelectableInStorePicker }
+        let defaultStoreID = defaultStoreID()
+        return snapshots().filter { $0.isSelectableInStorePicker && ($0.siteID == defaultStoreID || $0.currencySettings != nil) }
     }
 
     func save(_ snapshots: [StoreStatsSnapshot]) {
@@ -125,6 +132,10 @@ struct StoreStatsSnapshotStore {
 
     func defaultStoreName() -> String? {
         defaultStoreSnapshot()?.name
+    }
+
+    func defaultStoreID() -> Int64? {
+        userDefaults?.object(forKey: .defaultStoreID)
     }
 
     private func defaultStoreSnapshot() -> StoreStatsSnapshot? {
@@ -140,7 +151,6 @@ struct StoreStatsSnapshotStore {
             timeZoneIdentifier: nil,
             gmtOffset: 0,
             supportsVisitorStats: true,
-            isDefault: true,
             isSelectableInStorePicker: false,
             currencySettingsData: currencySettingsData
         )

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -39,7 +39,6 @@ enum StoreStatsSnapshotFactory {
     static func snapshots(storedSites: [StoreStatsStoredSite],
                           defaultSite: StoreStatsStoredSite?,
                           defaultSiteID: Int64?,
-                          defaultCurrencySettings: CurrencySettings?,
                           currencySettingsBySiteID: [Int64: CurrencySettings] = [:],
                           exposesStorePicker: Bool) -> [StoreStatsSnapshot] {
         guard exposesStorePicker else {
@@ -64,14 +63,13 @@ enum StoreStatsSnapshotFactory {
                 return true
             }
             .map { site in
-                let currencySettings = currencySettingsBySiteID[site.siteID] ?? defaultCurrencySettings
                 return StoreStatsSnapshot(
                     siteID: site.siteID,
                     name: site.name,
                     timeZoneIdentifier: site.timeZoneIdentifier,
                     gmtOffset: site.gmtOffset,
                     isSelectableInStorePicker: true,
-                    currencySettings: currencySettings
+                    currencySettings: currencySettingsBySiteID[site.siteID]
                 )
             }
             .sorted { lhs, rhs in

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -1,13 +1,13 @@
 import Foundation
 import WooFoundationCore
 
-struct StoreStatsSnapshot: Codable, Hashable, Identifiable {
+struct StoreStatsSnapshot: Codable, Identifiable {
     let siteID: Int64
     let name: String
     let timeZoneIdentifier: String?
     let gmtOffset: Double
     let isSelectableInStorePicker: Bool
-    let currencySettingsData: Data?
+    let currencySettings: CurrencySettings?
 
     var id: Int64 {
         siteID
@@ -25,13 +25,6 @@ struct StoreStatsSnapshot: Codable, Hashable, Identifiable {
         }
         return TimeZone(secondsFromGMT: Int(gmtOffset * 3600)) ?? .current
     }
-
-    var currencySettings: CurrencySettings? {
-        guard let currencySettingsData else {
-            return nil
-        }
-        return try? JSONDecoder().decode(CurrencySettings.self, from: currencySettingsData)
-    }
 }
 
 struct StoreStatsStoredSite: Equatable {
@@ -46,8 +39,8 @@ enum StoreStatsSnapshotFactory {
     static func snapshots(storedSites: [StoreStatsStoredSite],
                           defaultSite: StoreStatsStoredSite?,
                           defaultSiteID: Int64?,
-                          defaultCurrencySettingsData: Data?,
-                          currencySettingsDataBySiteID: [Int64: Data] = [:],
+                          defaultCurrencySettings: CurrencySettings?,
+                          currencySettingsBySiteID: [Int64: CurrencySettings] = [:],
                           exposesStorePicker: Bool) -> [StoreStatsSnapshot] {
         guard exposesStorePicker else {
             return []
@@ -71,14 +64,14 @@ enum StoreStatsSnapshotFactory {
                 return true
             }
             .map { site in
-                let currencySettingsData = currencySettingsDataBySiteID[site.siteID] ?? defaultCurrencySettingsData
+                let currencySettings = currencySettingsBySiteID[site.siteID] ?? defaultCurrencySettings
                 return StoreStatsSnapshot(
                     siteID: site.siteID,
                     name: site.name,
                     timeZoneIdentifier: site.timeZoneIdentifier,
                     gmtOffset: site.gmtOffset,
                     isSelectableInStorePicker: true,
-                    currencySettingsData: currencySettingsData
+                    currencySettings: currencySettings
                 )
             }
             .sorted { lhs, rhs in
@@ -137,13 +130,16 @@ struct StoreStatsSnapshotStore {
         }
 
         let currencySettingsData: Data? = userDefaults?.object(forKey: .defaultStoreCurrencySettings)
+        let currencySettings = currencySettingsData.flatMap {
+            try? JSONDecoder().decode(CurrencySettings.self, from: $0)
+        }
         return StoreStatsSnapshot(
             siteID: storeID,
             name: storeName,
             timeZoneIdentifier: nil,
             gmtOffset: 0,
             isSelectableInStorePicker: false,
-            currencySettingsData: currencySettingsData
+            currencySettings: currencySettings
         )
     }
 }

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -40,15 +40,19 @@ enum StoreStatsSnapshotFactory {
                           defaultSite: StoreStatsStoredSite?,
                           defaultSiteID: Int64?,
                           currencySettingsBySiteID: [Int64: CurrencySettings] = [:],
+                          hiddenStoreIDs: Set<Int64> = [],
                           exposesStorePicker: Bool) -> [StoreStatsSnapshot] {
         guard exposesStorePicker else {
             return []
         }
 
         let defaultID = defaultSiteID ?? defaultSite?.siteID
-        var candidates = storedSites.filter { $0.isWooCommerceActive }
+        var candidates = storedSites.filter { site in
+            site.isWooCommerceActive && hiddenStoreIDs.contains(site.siteID) == false
+        }
         if let defaultSite,
            defaultSite.isWooCommerceActive,
+           hiddenStoreIDs.contains(defaultSite.siteID) == false,
            candidates.contains(where: { $0.siteID == defaultSite.siteID }) == false {
             candidates.append(defaultSite)
         }

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -113,12 +113,7 @@ struct StoreStatsSnapshotStore {
     }
 
     func storePickerSnapshots() -> [StoreStatsSnapshot] {
-        let selectableSnapshots = snapshots().filter { $0.isSelectableInStorePicker }
-        if selectableSnapshots.isEmpty,
-           let defaultStoreSnapshot = defaultStoreSnapshot() {
-            return [defaultStoreSnapshot]
-        }
-        return selectableSnapshots
+        snapshots().filter { $0.isSelectableInStorePicker }
     }
 
     func save(_ snapshots: [StoreStatsSnapshot]) {

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -1,0 +1,153 @@
+import Foundation
+import WooFoundationCore
+
+struct StoreStatsSnapshot: Codable, Hashable, Identifiable {
+    let siteID: Int64
+    let name: String
+    let timeZoneIdentifier: String?
+    let gmtOffset: Double
+    let supportsVisitorStats: Bool
+    let isDefault: Bool
+    let isSelectableInStorePicker: Bool
+    let currencySettingsData: Data?
+
+    var id: Int64 {
+        siteID
+    }
+
+    var appEntityID: String {
+        String(siteID)
+    }
+
+    var timeZone: TimeZone {
+        if let timeZoneIdentifier,
+           !timeZoneIdentifier.isEmpty,
+           let timeZone = TimeZone(identifier: timeZoneIdentifier) {
+            return timeZone
+        }
+        return TimeZone(secondsFromGMT: Int(gmtOffset * 3600)) ?? .current
+    }
+
+    var currencySettings: CurrencySettings? {
+        guard let currencySettingsData else {
+            return nil
+        }
+        return try? JSONDecoder().decode(CurrencySettings.self, from: currencySettingsData)
+    }
+}
+
+struct StoreStatsStoredSite: Equatable {
+    let siteID: Int64
+    let name: String
+    let timeZoneIdentifier: String?
+    let gmtOffset: Double
+    let isWooCommerceActive: Bool
+    let supportsVisitorStats: Bool
+}
+
+enum StoreStatsSnapshotFactory {
+    static func snapshots(storedSites: [StoreStatsStoredSite],
+                          defaultSite: StoreStatsStoredSite?,
+                          defaultSiteID: Int64?,
+                          defaultCurrencySettingsData: Data?,
+                          exposesStorePicker: Bool) -> [StoreStatsSnapshot] {
+        guard exposesStorePicker else {
+            return []
+        }
+
+        let defaultID = defaultSiteID ?? defaultSite?.siteID
+        var candidates = storedSites.filter { $0.isWooCommerceActive }
+        if let defaultSite,
+           defaultSite.isWooCommerceActive,
+           candidates.contains(where: { $0.siteID == defaultSite.siteID }) == false {
+            candidates.append(defaultSite)
+        }
+
+        var seenSiteIDs = Set<Int64>()
+        return candidates
+            .filter { site in
+                guard seenSiteIDs.contains(site.siteID) == false else {
+                    return false
+                }
+                seenSiteIDs.insert(site.siteID)
+                return true
+            }
+            .map { site in
+                StoreStatsSnapshot(
+                    siteID: site.siteID,
+                    name: site.name,
+                    timeZoneIdentifier: site.timeZoneIdentifier,
+                    gmtOffset: site.gmtOffset,
+                    supportsVisitorStats: site.supportsVisitorStats,
+                    isDefault: site.siteID == defaultID,
+                    isSelectableInStorePicker: true,
+                    currencySettingsData: site.siteID == defaultID ? defaultCurrencySettingsData : nil
+                )
+            }
+            .sorted { lhs, rhs in
+                if lhs.isDefault != rhs.isDefault {
+                    return lhs.isDefault
+                }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+}
+
+struct StoreStatsSnapshotStore {
+    private let userDefaults: UserDefaults?
+
+    init(userDefaults: UserDefaults? = .group) {
+        self.userDefaults = userDefaults
+    }
+
+    func snapshots() -> [StoreStatsSnapshot] {
+        guard let data: Data = userDefaults?.object(forKey: .configurableStoreStatsWidgetStores) else {
+            return defaultStoreSnapshot().map { [$0] } ?? []
+        }
+
+        guard let snapshots = try? JSONDecoder().decode([StoreStatsSnapshot].self, from: data) else {
+            return defaultStoreSnapshot().map { [$0] } ?? []
+        }
+
+        return snapshots
+    }
+
+    func storePickerSnapshots() -> [StoreStatsSnapshot] {
+        let selectableSnapshots = snapshots().filter { $0.isSelectableInStorePicker }
+        if selectableSnapshots.isEmpty,
+           let defaultStoreSnapshot = defaultStoreSnapshot() {
+            return [defaultStoreSnapshot]
+        }
+        return selectableSnapshots
+    }
+
+    func save(_ snapshots: [StoreStatsSnapshot]) {
+        guard let data = try? JSONEncoder().encode(snapshots) else {
+            return
+        }
+        userDefaults?.set(data, forKey: .configurableStoreStatsWidgetStores)
+    }
+
+    func defaultStoreName() -> String? {
+        defaultStoreSnapshot()?.name
+    }
+
+    private func defaultStoreSnapshot() -> StoreStatsSnapshot? {
+        guard let storeID: Int64 = userDefaults?.object(forKey: .defaultStoreID),
+              let storeName: String = userDefaults?.object(forKey: .defaultStoreName) else {
+            return nil
+        }
+
+        let currencySettingsData: Data? = userDefaults?.object(forKey: .defaultStoreCurrencySettings)
+        return StoreStatsSnapshot(
+            siteID: storeID,
+            name: storeName,
+            timeZoneIdentifier: nil,
+            gmtOffset: 0,
+            supportsVisitorStats: true,
+            isDefault: true,
+            isSelectableInStorePicker: false,
+            currencySettingsData: currencySettingsData
+        )
+    }
+}

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -9,6 +9,7 @@ import class WidgetKit.WidgetCenter
 import Experiments
 import WordPressAuthenticator
 import enum NetworkingCore.RequestAuthenticationMode
+import class WooFoundation.CurrencySettings
 
 // MARK: - DefaultStoresManager
 //
@@ -45,6 +46,10 @@ class DefaultStoresManager: StoresManager {
     /// Tracks site IDs that are eligible for app password support to prevent duplicate analytics events
     ///
     private var trackedEligibleSites: Set<Int64> = []
+
+    /// Tracks site IDs whose general settings are being synchronized for store stats widget snapshots.
+    ///
+    private var storeStatsWidgetCurrencySettingsSyncSiteIDs: Set<Int64> = []
 
     /// Network switching notification observers
     ///
@@ -897,13 +902,26 @@ private extension DefaultStoresManager {
                                  supportsVisitorStats: site.isJetpackConnected || site.isWordPressComStore)
         }
 
+        let defaultSiteID = siteID ?? defaultSite?.siteID
+        var candidateSiteIDs = Set(storedSites.filter { $0.isWooCommerceActive }.map(\.siteID))
+        if let defaultSite,
+           defaultSite.isWooCommerceActive {
+            candidateSiteIDs.insert(defaultSite.siteID)
+        }
+
         let defaultCurrencySettingsData: Data? = UserDefaults.group?.object(forKey: .defaultStoreCurrencySettings)
+        let currencySettingsDataBySiteID = storeStatsWidgetCurrencySettingsDataBySiteID(candidateSiteIDs: candidateSiteIDs,
+                                                                                       defaultSiteID: defaultSiteID,
+                                                                                       defaultCurrencySettingsData: defaultCurrencySettingsData)
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: defaultSite,
-                                                            defaultSiteID: siteID,
+                                                            defaultSiteID: defaultSiteID,
                                                             defaultCurrencySettingsData: defaultCurrencySettingsData,
+                                                            currencySettingsDataBySiteID: currencySettingsDataBySiteID,
                                                             exposesStorePicker: true)
         StoreStatsSnapshotStore().save(snapshots)
+        synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(candidateSiteIDs: candidateSiteIDs,
+                                                                   currencySettingsDataBySiteID: currencySettingsDataBySiteID)
     }
 
     private var exposesStoreStatsWidgetStorePicker: Bool {
@@ -911,6 +929,70 @@ private extension DefaultStoresManager {
             return true
         }
         return false
+    }
+
+    private func storeStatsWidgetCurrencySettingsDataBySiteID(candidateSiteIDs: Set<Int64>,
+                                                              defaultSiteID: Int64?,
+                                                              defaultCurrencySettingsData: Data?) -> [Int64: Data] {
+        var currencySettingsDataBySiteID: [Int64: Data] = [:]
+        for siteID in candidateSiteIDs {
+            currencySettingsDataBySiteID[siteID] = storeStatsWidgetCurrencySettingsData(for: siteID)
+        }
+
+        if let defaultSiteID,
+           let defaultCurrencySettingsData {
+            currencySettingsDataBySiteID[defaultSiteID] = defaultCurrencySettingsData
+        }
+        return currencySettingsDataBySiteID
+    }
+
+    private func storeStatsWidgetCurrencySettingsData(for siteID: Int64) -> Data? {
+        guard let storedSiteSettings = ServiceLocator.storageManager.viewStorage.loadSiteSettings(siteID: siteID,
+                                                                                                  settingGroupKey: SiteSettingGroup.general.rawValue) else {
+            return nil
+        }
+
+        let siteSettings = storedSiteSettings.map { $0.toReadOnly() }
+        guard hasCurrencySettings(in: siteSettings) else {
+            return nil
+        }
+        return try? JSONEncoder().encode(CurrencySettings(siteSettings: siteSettings))
+    }
+
+    private func hasCurrencySettings(in siteSettings: [SiteSetting]) -> Bool {
+        let requiredSettingIDs: Set<String> = [
+            CurrencySettings.Constants.currencyCodeKey,
+            CurrencySettings.Constants.currencyPositionKey,
+            CurrencySettings.Constants.thousandSeparatorKey,
+            CurrencySettings.Constants.decimalSeparatorKey,
+            CurrencySettings.Constants.numberOfDecimalsKey
+        ]
+        let settingIDs = Set(siteSettings.map(\.settingID))
+        return requiredSettingIDs.isSubset(of: settingIDs)
+    }
+
+    private func synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(candidateSiteIDs: Set<Int64>,
+                                                                            currencySettingsDataBySiteID: [Int64: Data]) {
+        let missingSiteIDs = candidateSiteIDs.filter { currencySettingsDataBySiteID[$0] == nil }
+        for siteID in missingSiteIDs where storeStatsWidgetCurrencySettingsSyncSiteIDs.contains(siteID) == false {
+            storeStatsWidgetCurrencySettingsSyncSiteIDs.insert(siteID)
+            let action = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { [weak self] error in
+                DispatchQueue.main.async {
+                    guard let self else {
+                        return
+                    }
+
+                    self.storeStatsWidgetCurrencySettingsSyncSiteIDs.remove(siteID)
+                    guard error == nil else {
+                        return
+                    }
+
+                    self.updateStoreStatsWidgetStoreSnapshots(with: self.sessionManager.defaultStoreID)
+                    WidgetCenter.shared.reloadAllTimelines()
+                }
+            }
+            dispatch(action)
+        }
     }
 
     func trackSnapshotIfNeeded(siteID: Int64, orderStatuses: [OrderStatus]?, systemPlugins: [SystemPlugin]?) {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -954,7 +954,6 @@ private extension DefaultStoresManager {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: defaultSite,
                                                             defaultSiteID: defaultSiteID,
-                                                            defaultCurrencySettings: defaultCurrencySettings,
                                                             currencySettingsBySiteID: currencySettingsBySiteID,
                                                             exposesStorePicker: true)
         StoreStatsSnapshotStore().save(snapshots)

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -961,7 +961,8 @@ private extension DefaultStoresManager {
                                                             currencySettingsDataBySiteID: currencySettingsDataBySiteID,
                                                             exposesStorePicker: true)
         StoreStatsSnapshotStore().save(snapshots)
-        synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(candidateSiteIDs: candidateSiteIDs,
+        synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(selectedSiteID: defaultSiteID,
+                                                                   candidateSiteIDs: candidateSiteIDs,
                                                                    currencySettingsDataBySiteID: currencySettingsDataBySiteID)
     }
 
@@ -1031,28 +1032,33 @@ private extension DefaultStoresManager {
         return requiredSettingIDs.isSubset(of: settingIDs)
     }
 
-    private func synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(candidateSiteIDs: Set<Int64>,
+    private func synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(selectedSiteID: Int64?,
+                                                                            candidateSiteIDs: Set<Int64>,
                                                                             currencySettingsDataBySiteID: [Int64: Data]) {
-        let missingSiteIDs = candidateSiteIDs.filter { currencySettingsDataBySiteID[$0] == nil }
-        for siteID in missingSiteIDs where storeStatsWidgetCurrencySettingsSyncSiteIDs.contains(siteID) == false {
-            storeStatsWidgetCurrencySettingsSyncSiteIDs.insert(siteID)
-            let action = SettingAction.synchronizeGeneralSiteSettings(siteID: siteID) { [weak self] error in
-                DispatchQueue.main.async {
-                    guard let self else {
-                        return
-                    }
-
-                    self.storeStatsWidgetCurrencySettingsSyncSiteIDs.remove(siteID)
-                    guard error == nil else {
-                        return
-                    }
-
-                    self.updateStoreStatsWidgetStoreSnapshots(with: self.sessionManager.defaultStoreID)
-                    WidgetCenter.shared.reloadAllTimelines()
-                }
-            }
-            dispatch(action)
+        guard let selectedSiteID,
+              candidateSiteIDs.contains(selectedSiteID),
+              currencySettingsDataBySiteID[selectedSiteID] == nil,
+              storeStatsWidgetCurrencySettingsSyncSiteIDs.contains(selectedSiteID) == false else {
+            return
         }
+
+        storeStatsWidgetCurrencySettingsSyncSiteIDs.insert(selectedSiteID)
+        let action = SettingAction.synchronizeGeneralSiteSettings(siteID: selectedSiteID) { [weak self] error in
+            DispatchQueue.main.async {
+                guard let self else {
+                    return
+                }
+
+                self.storeStatsWidgetCurrencySettingsSyncSiteIDs.remove(selectedSiteID)
+                guard error == nil else {
+                    return
+                }
+
+                self.updateStoreStatsWidgetStoreSnapshots(with: selectedSiteID)
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
+        dispatch(action)
     }
 
     func trackSnapshotIfNeeded(siteID: Int64, orderStatuses: [OrderStatus]?, systemPlugins: [SystemPlugin]?) {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -947,20 +947,20 @@ private extension DefaultStoresManager {
             candidateSiteIDs.insert(defaultSite.siteID)
         }
 
-        let defaultCurrencySettingsData: Data? = UserDefaults.group?.object(forKey: .defaultStoreCurrencySettings)
-        let currencySettingsDataBySiteID = storeStatsWidgetCurrencySettingsDataBySiteID(candidateSiteIDs: candidateSiteIDs,
-                                                                                       defaultSiteID: defaultSiteID,
-                                                                                       defaultCurrencySettingsData: defaultCurrencySettingsData)
+        let defaultCurrencySettings = storeStatsWidgetDefaultCurrencySettings()
+        let currencySettingsBySiteID = storeStatsWidgetCurrencySettingsBySiteID(candidateSiteIDs: candidateSiteIDs,
+                                                                               defaultSiteID: defaultSiteID,
+                                                                               defaultCurrencySettings: defaultCurrencySettings)
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: defaultSite,
                                                             defaultSiteID: defaultSiteID,
-                                                            defaultCurrencySettingsData: defaultCurrencySettingsData,
-                                                            currencySettingsDataBySiteID: currencySettingsDataBySiteID,
+                                                            defaultCurrencySettings: defaultCurrencySettings,
+                                                            currencySettingsBySiteID: currencySettingsBySiteID,
                                                             exposesStorePicker: true)
         StoreStatsSnapshotStore().save(snapshots)
         synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(selectedSiteID: defaultSiteID,
                                                                    candidateSiteIDs: candidateSiteIDs,
-                                                                   currencySettingsDataBySiteID: currencySettingsDataBySiteID)
+                                                                   currencySettingsBySiteID: currencySettingsBySiteID)
     }
 
     private func updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: Int64?,
@@ -989,22 +989,29 @@ private extension DefaultStoresManager {
         return false
     }
 
-    private func storeStatsWidgetCurrencySettingsDataBySiteID(candidateSiteIDs: Set<Int64>,
-                                                              defaultSiteID: Int64?,
-                                                              defaultCurrencySettingsData: Data?) -> [Int64: Data] {
-        var currencySettingsDataBySiteID: [Int64: Data] = [:]
+    private func storeStatsWidgetDefaultCurrencySettings() -> CurrencySettings? {
+        let currencySettingsData: Data? = UserDefaults.group?.object(forKey: .defaultStoreCurrencySettings)
+        return currencySettingsData.flatMap {
+            try? JSONDecoder().decode(CurrencySettings.self, from: $0)
+        }
+    }
+
+    private func storeStatsWidgetCurrencySettingsBySiteID(candidateSiteIDs: Set<Int64>,
+                                                          defaultSiteID: Int64?,
+                                                          defaultCurrencySettings: CurrencySettings?) -> [Int64: CurrencySettings] {
+        var currencySettingsBySiteID: [Int64: CurrencySettings] = [:]
         for siteID in candidateSiteIDs {
-            currencySettingsDataBySiteID[siteID] = storeStatsWidgetCurrencySettingsData(for: siteID)
+            currencySettingsBySiteID[siteID] = storeStatsWidgetCurrencySettings(for: siteID)
         }
 
         if let defaultSiteID,
-           let defaultCurrencySettingsData {
-            currencySettingsDataBySiteID[defaultSiteID] = defaultCurrencySettingsData
+           let defaultCurrencySettings {
+            currencySettingsBySiteID[defaultSiteID] = defaultCurrencySettings
         }
-        return currencySettingsDataBySiteID
+        return currencySettingsBySiteID
     }
 
-    private func storeStatsWidgetCurrencySettingsData(for siteID: Int64) -> Data? {
+    private func storeStatsWidgetCurrencySettings(for siteID: Int64) -> CurrencySettings? {
         guard let storedSiteSettings = ServiceLocator.storageManager.viewStorage.loadSiteSettings(siteID: siteID,
                                                                                                   settingGroupKey: SiteSettingGroup.general.rawValue) else {
             return nil
@@ -1014,7 +1021,7 @@ private extension DefaultStoresManager {
         guard hasCurrencySettings(in: siteSettings) else {
             return nil
         }
-        return try? JSONEncoder().encode(CurrencySettings(siteSettings: siteSettings))
+        return CurrencySettings(siteSettings: siteSettings)
     }
 
     private func hasCurrencySettings(in siteSettings: [SiteSetting]) -> Bool {
@@ -1031,10 +1038,10 @@ private extension DefaultStoresManager {
 
     private func synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(selectedSiteID: Int64?,
                                                                             candidateSiteIDs: Set<Int64>,
-                                                                            currencySettingsDataBySiteID: [Int64: Data]) {
+                                                                            currencySettingsBySiteID: [Int64: CurrencySettings]) {
         guard let selectedSiteID,
               candidateSiteIDs.contains(selectedSiteID),
-              currencySettingsDataBySiteID[selectedSiteID] == nil,
+              currencySettingsBySiteID[selectedSiteID] == nil,
               storeStatsWidgetCurrencySettingsSyncSiteIDs.contains(selectedSiteID) == false else {
             return
         }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -184,14 +184,14 @@ class DefaultStoresManager: StoresManager {
     /// Forwards the Action to the current State.
     ///
     func dispatch(_ action: Action) {
-        state.onAction(action)
+        state.onAction(actionWithStoreStatsWidgetSnapshotUpdate(action))
     }
 
     /// Forwards the Actions to the current State.
     ///
     func dispatch(_ actions: [Action]) {
         for action in actions {
-            state.onAction(action)
+            dispatch(action)
         }
     }
 
@@ -876,6 +876,47 @@ private extension DefaultStoresManager {
         WidgetCenter.shared.reloadAllTimelines()
     }
 
+    func actionWithStoreStatsWidgetSnapshotUpdate(_ action: Action) -> Action {
+        guard let accountAction = action as? AccountAction else {
+            return action
+        }
+
+        switch accountAction {
+        case let .loadAndSynchronizeSite(siteID, forcedUpdate, onCompletion):
+            return AccountAction.loadAndSynchronizeSite(siteID: siteID, forcedUpdate: forcedUpdate) { [weak self] result in
+                guard let self, case .success = result else {
+                    onCompletion(result)
+                    return
+                }
+                self.updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: siteID) {
+                    onCompletion(result)
+                }
+            }
+        case let .synchronizeSites(selectedSiteID, onCompletion):
+            return AccountAction.synchronizeSites(selectedSiteID: selectedSiteID) { [weak self] result in
+                guard let self, case .success = result else {
+                    onCompletion(result)
+                    return
+                }
+                self.updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: selectedSiteID) {
+                    onCompletion(result)
+                }
+            }
+        case let .synchronizeSitesAndReturnSelectedSiteInfo(siteAddress, onCompletion):
+            return AccountAction.synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: siteAddress) { [weak self] result in
+                guard let self, case let .success(site) = result else {
+                    onCompletion(result)
+                    return
+                }
+                self.updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: site.siteID) {
+                    onCompletion(result)
+                }
+            }
+        default:
+            return action
+        }
+    }
+
     private func updateStoreStatsWidgetStoreSnapshots(with siteID: Int64?) {
         guard exposesStoreStatsWidgetStorePicker else {
             StoreStatsSnapshotStore().save([])
@@ -922,6 +963,25 @@ private extension DefaultStoresManager {
         StoreStatsSnapshotStore().save(snapshots)
         synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(candidateSiteIDs: candidateSiteIDs,
                                                                    currencySettingsDataBySiteID: currencySettingsDataBySiteID)
+    }
+
+    private func updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: Int64?,
+                                                                                 onCompletion: @escaping () -> Void) {
+        let updateSnapshot = { [weak self] in
+            guard let self else {
+                onCompletion()
+                return
+            }
+            self.updateStoreStatsWidgetStoreSnapshots(with: selectedSiteID ?? self.sessionManager.defaultStoreID)
+            WidgetCenter.shared.reloadAllTimelines()
+            onCompletion()
+        }
+
+        if Thread.isMainThread {
+            updateSnapshot()
+        } else {
+            DispatchQueue.main.async(execute: updateSnapshot)
+        }
     }
 
     private var exposesStoreStatsWidgetStorePicker: Bool {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -865,9 +865,52 @@ private extension DefaultStoresManager {
         UserDefaults.group?[.defaultStoreName] = sessionManager.defaultSite?.name
 
         // Currency Settings are stored in `SelectedSiteSettings.defaultStoreCurrencySettings`
+        updateStoreStatsWidgetStoreSnapshots(with: siteID)
 
         // Reload widgets UI
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private func updateStoreStatsWidgetStoreSnapshots(with siteID: Int64?) {
+        guard exposesStoreStatsWidgetStorePicker else {
+            StoreStatsSnapshotStore().save([])
+            return
+        }
+
+        let storedSites = ServiceLocator.storageManager.viewStorage.loadAllSites()
+            .map { site in
+                let isWordPressComStore = site.isWordPressStore?.boolValue ?? false
+                return StoreStatsStoredSite(siteID: site.siteID,
+                                            name: site.name ?? WooConstants.defaultStoreName,
+                                            timeZoneIdentifier: site.timezone,
+                                            gmtOffset: site.gmtOffset,
+                                            isWooCommerceActive: site.isWooCommerceActive?.boolValue ?? false,
+                                            supportsVisitorStats: site.isJetpackConnected || isWordPressComStore)
+            }
+
+        let defaultSite = sessionManager.defaultSite.map { site in
+            StoreStatsStoredSite(siteID: site.siteID,
+                                 name: site.name,
+                                 timeZoneIdentifier: site.timezone,
+                                 gmtOffset: site.gmtOffset,
+                                 isWooCommerceActive: site.isWooCommerceActive,
+                                 supportsVisitorStats: site.isJetpackConnected || site.isWordPressComStore)
+        }
+
+        let defaultCurrencySettingsData: Data? = UserDefaults.group?.object(forKey: .defaultStoreCurrencySettings)
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: defaultSite,
+                                                            defaultSiteID: siteID,
+                                                            defaultCurrencySettingsData: defaultCurrencySettingsData,
+                                                            exposesStorePicker: true)
+        StoreStatsSnapshotStore().save(snapshots)
+    }
+
+    private var exposesStoreStatsWidgetStorePicker: Bool {
+        if case .wpcom = sessionManager.defaultCredentials {
+            return true
+        }
+        return false
     }
 
     func trackSnapshotIfNeeded(siteID: Int64, orderStatuses: [OrderStatus]?, systemPlugins: [SystemPlugin]?) {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -925,13 +925,11 @@ private extension DefaultStoresManager {
 
         let storedSites = ServiceLocator.storageManager.viewStorage.loadAllSites()
             .map { site in
-                let isWordPressComStore = site.isWordPressStore?.boolValue ?? false
                 return StoreStatsStoredSite(siteID: site.siteID,
                                             name: site.name ?? WooConstants.defaultStoreName,
                                             timeZoneIdentifier: site.timezone,
                                             gmtOffset: site.gmtOffset,
-                                            isWooCommerceActive: site.isWooCommerceActive?.boolValue ?? false,
-                                            supportsVisitorStats: site.isJetpackConnected || isWordPressComStore)
+                                            isWooCommerceActive: site.isWooCommerceActive?.boolValue ?? false)
             }
 
         let defaultSite = sessionManager.defaultSite.map { site in
@@ -939,8 +937,7 @@ private extension DefaultStoresManager {
                                  name: site.name,
                                  timeZoneIdentifier: site.timezone,
                                  gmtOffset: site.gmtOffset,
-                                 isWooCommerceActive: site.isWooCommerceActive,
-                                 supportsVisitorStats: site.isJetpackConnected || site.isWordPressComStore)
+                                 isWooCommerceActive: site.isWooCommerceActive)
         }
 
         let defaultSiteID = siteID ?? defaultSite?.siteID

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -940,10 +940,14 @@ private extension DefaultStoresManager {
                                  isWooCommerceActive: site.isWooCommerceActive)
         }
 
+        let hiddenStoreIDs = Set(defaults.hiddenStoreIDs)
         let defaultSiteID = siteID ?? defaultSite?.siteID
-        var candidateSiteIDs = Set(storedSites.filter { $0.isWooCommerceActive }.map(\.siteID))
+        var candidateSiteIDs = Set(storedSites
+            .filter { $0.isWooCommerceActive && hiddenStoreIDs.contains($0.siteID) == false }
+            .map(\.siteID))
         if let defaultSite,
-           defaultSite.isWooCommerceActive {
+           defaultSite.isWooCommerceActive,
+           hiddenStoreIDs.contains(defaultSite.siteID) == false {
             candidateSiteIDs.insert(defaultSite.siteID)
         }
 
@@ -955,6 +959,7 @@ private extension DefaultStoresManager {
                                                             defaultSite: defaultSite,
                                                             defaultSiteID: defaultSiteID,
                                                             currencySettingsBySiteID: currencySettingsBySiteID,
+                                                            hiddenStoreIDs: hiddenStoreIDs,
                                                             exposesStorePicker: true)
         StoreStatsSnapshotStore().save(snapshots)
         synchronizeMissingStoreStatsWidgetCurrencySettingsIfNeeded(selectedSiteID: defaultSiteID,

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -93,7 +93,7 @@ final class StoreInfoDataService {
     /// it bypasses the parallel previous-period fetch in `fetchStats(for:dateRange:)`.
     ///
     func fetchTodayStats(for storeID: Int64) async throws -> Stats {
-        try await fetchSinglePeriodStats(for: storeID, dateRange: .today(), supportsVisitorStats: true)
+        try await fetchSinglePeriodStats(for: storeID, dateRange: .today())
     }
 
     /// Async function that fetches stats for the given date range together with stats for
@@ -104,11 +104,9 @@ final class StoreInfoDataService {
     /// data without trend badges instead of surfacing an error tile. A current-period
     /// failure still throws — there's no useful render without it.
     ///
-    func fetchStats(for storeID: Int64, dateRange: DateRange, supportsVisitorStats: Bool = true) async throws -> StatsPeriod {
-        async let currentRequest = fetchSinglePeriodStats(for: storeID, dateRange: dateRange, supportsVisitorStats: supportsVisitorStats)
-        async let previousRequest = fetchSinglePeriodStats(for: storeID,
-                                                           dateRange: dateRange.previousPeriod(),
-                                                           supportsVisitorStats: supportsVisitorStats)
+    func fetchStats(for storeID: Int64, dateRange: DateRange) async throws -> StatsPeriod {
+        async let currentRequest = fetchSinglePeriodStats(for: storeID, dateRange: dateRange)
+        async let previousRequest = fetchSinglePeriodStats(for: storeID, dateRange: dateRange.previousPeriod())
         let current = try await currentRequest
         let previous = try? await previousRequest
         return StatsPeriod(current: current, previous: previous)
@@ -117,10 +115,10 @@ final class StoreInfoDataService {
     /// Internal helper that fetches stats for a single date range. The public `fetchStats`
     /// invokes this twice in parallel (current and previous period).
     ///
-    private func fetchSinglePeriodStats(for storeID: Int64, dateRange: DateRange, supportsVisitorStats: Bool) async throws -> Stats {
+    private func fetchSinglePeriodStats(for storeID: Int64, dateRange: DateRange) async throws -> Stats {
         /// If user is authenticated with site credentials only,
         /// fetch revenue and orders and skip visitor stats as its endpoint is not available.
-        guard supportsVisitorStats, !isAuthenticatedWithoutWPCom else {
+        guard !isAuthenticatedWithoutWPCom else {
             return try await statsWithoutVisitors(for: storeID, dateRange: dateRange)
         }
 

--- a/WooCommerce/StoreWidgets/StoreInfoDataService.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoDataService.swift
@@ -93,7 +93,7 @@ final class StoreInfoDataService {
     /// it bypasses the parallel previous-period fetch in `fetchStats(for:dateRange:)`.
     ///
     func fetchTodayStats(for storeID: Int64) async throws -> Stats {
-        try await fetchSinglePeriodStats(for: storeID, dateRange: .today())
+        try await fetchSinglePeriodStats(for: storeID, dateRange: .today(), supportsVisitorStats: true)
     }
 
     /// Async function that fetches stats for the given date range together with stats for
@@ -104,9 +104,11 @@ final class StoreInfoDataService {
     /// data without trend badges instead of surfacing an error tile. A current-period
     /// failure still throws — there's no useful render without it.
     ///
-    func fetchStats(for storeID: Int64, dateRange: DateRange) async throws -> StatsPeriod {
-        async let currentRequest = fetchSinglePeriodStats(for: storeID, dateRange: dateRange)
-        async let previousRequest = fetchSinglePeriodStats(for: storeID, dateRange: dateRange.previousPeriod())
+    func fetchStats(for storeID: Int64, dateRange: DateRange, supportsVisitorStats: Bool = true) async throws -> StatsPeriod {
+        async let currentRequest = fetchSinglePeriodStats(for: storeID, dateRange: dateRange, supportsVisitorStats: supportsVisitorStats)
+        async let previousRequest = fetchSinglePeriodStats(for: storeID,
+                                                           dateRange: dateRange.previousPeriod(),
+                                                           supportsVisitorStats: supportsVisitorStats)
         let current = try await currentRequest
         let previous = try? await previousRequest
         return StatsPeriod(current: current, previous: previous)
@@ -115,10 +117,10 @@ final class StoreInfoDataService {
     /// Internal helper that fetches stats for a single date range. The public `fetchStats`
     /// invokes this twice in parallel (current and previous period).
     ///
-    private func fetchSinglePeriodStats(for storeID: Int64, dateRange: DateRange) async throws -> Stats {
+    private func fetchSinglePeriodStats(for storeID: Int64, dateRange: DateRange, supportsVisitorStats: Bool) async throws -> Stats {
         /// If user is authenticated with site credentials only,
         /// fetch revenue and orders and skip visitor stats as its endpoint is not available.
-        guard !isAuthenticatedWithoutWPCom else {
+        guard supportsVisitorStats, !isAuthenticatedWithoutWPCom else {
             return try await statsWithoutVisitors(for: storeID, dateRange: dateRange)
         }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
@@ -19,6 +19,8 @@ extension StoreInfoProvider: AppIntentTimelineProvider {
             requested: configuration.metrics,
             family: context.family
         )
-        return await loadTimeline(dateRange: configuration.dateRange, metrics: metrics)
+        return await loadTimeline(dateRange: configuration.dateRange,
+                                  metrics: metrics,
+                                  selectedStoreID: configuration.store?.id)
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -341,6 +341,8 @@ extension StoreInfoProvider {
         guard selectedStore.siteID != defaultStoreID else {
             return defaultCurrencySettings
         }
+        // Non-default stores may not have synchronized general settings yet.
+        // Use the default store settings until the selected store settings are available.
         return selectedStore.currencySettings ?? defaultCurrencySettings
     }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -318,17 +318,9 @@ private extension StoreInfoProvider {
             return defaultDependencies
         }
 
-        if selectedStore.siteID == defaultStore.storeID {
-            let storeCurrencySettings = selectedStore.currencySettings ?? defaultStore.storeCurrencySettings
-            return Dependencies(credentials: credentials,
-                                storeID: selectedStore.siteID,
-                                storeName: selectedStore.name,
-                                storeCurrencySettings: storeCurrencySettings,
-                                storeTimeZone: selectedStore.timeZone,
-                                supportsVisitorStats: selectedStore.supportsVisitorStats)
-        }
-
-        let storeCurrencySettings = selectedStore.currencySettings ?? defaultStore.storeCurrencySettings
+        let storeCurrencySettings = currencySettings(for: selectedStore,
+                                                     defaultStoreID: defaultStore.storeID,
+                                                     defaultCurrencySettings: defaultStore.storeCurrencySettings)
         return Dependencies(credentials: credentials,
                             storeID: selectedStore.siteID,
                             storeName: selectedStore.name,
@@ -354,6 +346,15 @@ private extension StoreInfoProvider {
 }
 
 extension StoreInfoProvider {
+    static func currencySettings(for selectedStore: StoreStatsSnapshot,
+                                 defaultStoreID: Int64,
+                                 defaultCurrencySettings: CurrencySettings) -> CurrencySettings {
+        guard selectedStore.siteID != defaultStoreID else {
+            return defaultCurrencySettings
+        }
+        return selectedStore.currencySettings ?? defaultCurrencySettings
+    }
+
     static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
                                       selectedStoreID: StoreStatsStoreEntity.ID?,
                                       defaultStoreID: Int64? = nil) -> StoreStatsSnapshot? {

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -347,21 +347,14 @@ extension StoreInfoProvider {
     static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
                                       selectedStoreID: StoreStatsStoreEntity.ID?,
                                       defaultStoreID: Int64? = nil) -> StoreStatsSnapshot? {
-        let defaultSnapshot = defaultStoreID.flatMap { defaultStoreID in
-            snapshots.first { $0.siteID == defaultStoreID }
-        } ?? snapshots.first
+        let defaultSnapshot = snapshots.first { $0.siteID == defaultStoreID } ?? snapshots.first
 
-        if let selectedStoreID,
-           StoreStatsStoreEntity.isDefaultStoreID(selectedStoreID) {
+        guard let selectedStoreID,
+              StoreStatsStoreEntity.isDefaultStoreID(selectedStoreID) == false else {
             return defaultSnapshot
         }
 
-        if let selectedStoreID,
-           let selectedStore = snapshots.first(where: { $0.appEntityID == selectedStoreID }) {
-            return selectedStore
-        }
-
-        return defaultSnapshot
+        return snapshots.first { $0.appEntityID == selectedStoreID } ?? defaultSnapshot
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -305,38 +305,39 @@ private extension StoreInfoProvider {
             return nil
         }
 
+        let defaultDependencies = Dependencies(credentials: credentials,
+                                               storeID: defaultStore.storeID,
+                                               storeName: defaultStore.storeName,
+                                               storeCurrencySettings: defaultStore.storeCurrencySettings,
+                                               storeTimeZone: defaultStore.storeTimeZone,
+                                               supportsVisitorStats: defaultStore.supportsVisitorStats)
         let snapshots = StoreStatsSnapshotStore().snapshots()
-        guard let selectedStore = selectedStoreSnapshot(from: snapshots, selectedStoreID: selectedStoreID) else {
-            return Dependencies(credentials: credentials,
-                                storeID: defaultStore.storeID,
-                                storeName: defaultStore.storeName,
-                                storeCurrencySettings: defaultStore.storeCurrencySettings,
-                                storeTimeZone: defaultStore.storeTimeZone,
-                                supportsVisitorStats: defaultStore.supportsVisitorStats)
+        guard let selectedStore = selectedStoreSnapshot(from: snapshots,
+                                                        selectedStoreID: selectedStoreID,
+                                                        defaultStoreID: defaultStore.storeID) else {
+            return defaultDependencies
         }
 
-        let storeCurrencySettings = selectedStore.currencySettings ?? defaultStore.storeCurrencySettings
+        if selectedStore.siteID == defaultStore.storeID {
+            let storeCurrencySettings = selectedStore.currencySettings ?? defaultStore.storeCurrencySettings
+            return Dependencies(credentials: credentials,
+                                storeID: selectedStore.siteID,
+                                storeName: selectedStore.name,
+                                storeCurrencySettings: storeCurrencySettings,
+                                storeTimeZone: selectedStore.timeZone,
+                                supportsVisitorStats: selectedStore.supportsVisitorStats)
+        }
+
+        guard let storeCurrencySettings = selectedStore.currencySettings else {
+            return defaultDependencies
+        }
+
         return Dependencies(credentials: credentials,
                             storeID: selectedStore.siteID,
                             storeName: selectedStore.name,
                             storeCurrencySettings: storeCurrencySettings,
                             storeTimeZone: selectedStore.timeZone,
                             supportsVisitorStats: selectedStore.supportsVisitorStats)
-    }
-
-    static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
-                                      selectedStoreID: StoreStatsStoreEntity.ID?) -> StoreStatsSnapshot? {
-        if let selectedStoreID,
-           StoreStatsStoreEntity.isDefaultStoreID(selectedStoreID) {
-            return snapshots.first(where: { $0.isDefault }) ?? snapshots.first
-        }
-
-        if let selectedStoreID,
-           let selectedStore = snapshots.first(where: { $0.appEntityID == selectedStoreID }) {
-            return selectedStore
-        }
-
-        return snapshots.first(where: { $0.isDefault }) ?? snapshots.first
     }
 
     static func defaultStoreMetadata() -> StoreMetadata? {
@@ -352,6 +353,28 @@ private extension StoreInfoProvider {
                              storeCurrencySettings: storeCurrencySettings,
                              storeTimeZone: .current,
                              supportsVisitorStats: true)
+    }
+}
+
+extension StoreInfoProvider {
+    static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
+                                      selectedStoreID: StoreStatsStoreEntity.ID?,
+                                      defaultStoreID: Int64? = nil) -> StoreStatsSnapshot? {
+        let defaultSnapshot = defaultStoreID.flatMap { defaultStoreID in
+            snapshots.first { $0.siteID == defaultStoreID }
+        } ?? snapshots.first
+
+        if let selectedStoreID,
+           StoreStatsStoreEntity.isDefaultStoreID(selectedStoreID) {
+            return defaultSnapshot
+        }
+
+        if let selectedStoreID,
+           let selectedStore = snapshots.first(where: { $0.appEntityID == selectedStoreID }) {
+            return selectedStore
+        }
+
+        return defaultSnapshot
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -126,16 +126,21 @@ final class StoreInfoProvider: TimelineProvider {
     ///
     func loadTimeline(
         dateRange: StoreStatsWidgetDateRange,
-        metrics: [StoreInfoMetricType]
+        metrics: [StoreInfoMetricType],
+        selectedStoreID: StoreStatsStoreEntity.ID? = nil
     ) async -> Timeline<StoreInfoEntry> {
-        guard let dependencies = Self.fetchDependencies() else {
+        guard let dependencies = Self.fetchDependencies(selectedStoreID: selectedStoreID) else {
             return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
         }
 
         let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
-            let statsPeriod = try await service.fetchStats(for: dependencies.storeID, dateRange: dateRange.serviceDateRange)
+            let statsPeriod = try await service.fetchStats(
+                for: dependencies.storeID,
+                dateRange: dateRange.serviceDateRange(timezone: dependencies.storeTimeZone),
+                supportsVisitorStats: dependencies.supportsVisitorStats
+            )
             let entry = Self.dataEntry(
                 for: statsPeriod,
                 dateRange: dateRange,
@@ -260,19 +265,22 @@ private extension StoreInfoProvider {
         let storeID: Int64
         let storeName: String
         let storeCurrencySettings: CurrencySettings
+        let storeTimeZone: TimeZone
+        let supportsVisitorStats: Bool
+    }
+
+    struct StoreMetadata {
+        let storeID: Int64
+        let storeName: String
+        let storeCurrencySettings: CurrencySettings
+        let storeTimeZone: TimeZone
+        let supportsVisitorStats: Bool
     }
 
     /// Fetches the required dependencies from the keychain and the shared users default.
     ///
-    static func fetchDependencies() -> Dependencies? {
+    static func fetchDependencies(selectedStoreID: StoreStatsStoreEntity.ID? = nil) -> Dependencies? {
         let keychain = Keychain(service: WooConstants.keychainServiceName)
-        guard let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
-              let storeName = UserDefaults.group?[.defaultStoreName] as? String,
-              let storeCurrencySettingsData = UserDefaults.group?[.defaultStoreCurrencySettings] as? Data,
-              let storeCurrencySettings = try? JSONDecoder().decode(CurrencySettings.self, from: storeCurrencySettingsData) else {
-            print("⛔️ missing store info")
-            return nil
-        }
         let credentials: Credentials? = {
             if let authToken = keychain[WooConstants.authToken] {
                 return Credentials(authToken: authToken)
@@ -291,10 +299,59 @@ private extension StoreInfoProvider {
             print("⛔️ missing credentials")
             return nil
         }
+
+        guard let defaultStore = defaultStoreMetadata() else {
+            print("⛔️ missing store info")
+            return nil
+        }
+
+        let snapshots = StoreStatsSnapshotStore().snapshots()
+        guard let selectedStore = selectedStoreSnapshot(from: snapshots, selectedStoreID: selectedStoreID) else {
+            return Dependencies(credentials: credentials,
+                                storeID: defaultStore.storeID,
+                                storeName: defaultStore.storeName,
+                                storeCurrencySettings: defaultStore.storeCurrencySettings,
+                                storeTimeZone: defaultStore.storeTimeZone,
+                                supportsVisitorStats: defaultStore.supportsVisitorStats)
+        }
+
+        let storeCurrencySettings = selectedStore.currencySettings ?? defaultStore.storeCurrencySettings
         return Dependencies(credentials: credentials,
-                            storeID: storeID,
-                            storeName: storeName,
-                            storeCurrencySettings: storeCurrencySettings)
+                            storeID: selectedStore.siteID,
+                            storeName: selectedStore.name,
+                            storeCurrencySettings: storeCurrencySettings,
+                            storeTimeZone: selectedStore.timeZone,
+                            supportsVisitorStats: selectedStore.supportsVisitorStats)
+    }
+
+    static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
+                                      selectedStoreID: StoreStatsStoreEntity.ID?) -> StoreStatsSnapshot? {
+        if let selectedStoreID,
+           StoreStatsStoreEntity.isDefaultStoreID(selectedStoreID) {
+            return snapshots.first(where: { $0.isDefault }) ?? snapshots.first
+        }
+
+        if let selectedStoreID,
+           let selectedStore = snapshots.first(where: { $0.appEntityID == selectedStoreID }) {
+            return selectedStore
+        }
+
+        return snapshots.first(where: { $0.isDefault }) ?? snapshots.first
+    }
+
+    static func defaultStoreMetadata() -> StoreMetadata? {
+        guard let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
+              let storeName = UserDefaults.group?[.defaultStoreName] as? String,
+              let storeCurrencySettingsData = UserDefaults.group?[.defaultStoreCurrencySettings] as? Data,
+              let storeCurrencySettings = try? JSONDecoder().decode(CurrencySettings.self, from: storeCurrencySettingsData) else {
+            return nil
+        }
+
+        return StoreMetadata(storeID: storeID,
+                             storeName: storeName,
+                             storeCurrencySettings: storeCurrencySettings,
+                             storeTimeZone: .current,
+                             supportsVisitorStats: true)
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -302,15 +302,15 @@ private extension StoreInfoProvider {
         let defaultDependencies = StoreInfoProviderDependencies(credentials: credentials,
                                                                store: defaultStore)
         let snapshots = StoreStatsSnapshotStore().snapshots()
-        guard let selectedStore = selectedStoreSnapshot(from: snapshots,
-                                                        selectedStoreID: selectedStoreID,
-                                                        defaultStoreID: defaultStore.storeID) else {
+        guard let selectedStore = StoreStatsStoreSelection.selectedStoreSnapshot(from: snapshots,
+                                                                                 selectedStoreID: selectedStoreID,
+                                                                                 defaultStoreID: defaultStore.storeID) else {
             return defaultDependencies
         }
 
-        let storeCurrencySettings = currencySettings(for: selectedStore,
-                                                     defaultStoreID: defaultStore.storeID,
-                                                     defaultCurrencySettings: defaultStore.storeCurrencySettings)
+        let storeCurrencySettings = StoreStatsStoreSelection.currencySettings(for: selectedStore,
+                                                                              defaultStoreID: defaultStore.storeID,
+                                                                              defaultCurrencySettings: defaultStore.storeCurrencySettings)
         let store = StoreMetadata(storeID: selectedStore.siteID,
                                   storeName: selectedStore.name,
                                   storeCurrencySettings: storeCurrencySettings,
@@ -331,32 +331,6 @@ private extension StoreInfoProvider {
                              storeName: storeName,
                              storeCurrencySettings: storeCurrencySettings,
                              storeTimeZone: .current)
-    }
-}
-
-extension StoreInfoProvider {
-    static func currencySettings(for selectedStore: StoreStatsSnapshot,
-                                 defaultStoreID: Int64,
-                                 defaultCurrencySettings: CurrencySettings) -> CurrencySettings {
-        guard selectedStore.siteID != defaultStoreID else {
-            return defaultCurrencySettings
-        }
-        // Non-default stores may not have synchronized general settings yet.
-        // Use the default store settings until the selected store settings are available.
-        return selectedStore.currencySettings ?? defaultCurrencySettings
-    }
-
-    static func selectedStoreSnapshot(from snapshots: [StoreStatsSnapshot],
-                                      selectedStoreID: StoreStatsStoreEntity.ID?,
-                                      defaultStoreID: Int64? = nil) -> StoreStatsSnapshot? {
-        let defaultSnapshot = snapshots.first { $0.siteID == defaultStoreID } ?? snapshots.first
-
-        guard let selectedStoreID,
-              StoreStatsStoreEntity.isDefaultStoreID(selectedStoreID) == false else {
-            return defaultSnapshot
-        }
-
-        return snapshots.first { $0.appEntityID == selectedStoreID } ?? defaultSnapshot
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -138,8 +138,7 @@ final class StoreInfoProvider: TimelineProvider {
         do {
             let statsPeriod = try await service.fetchStats(
                 for: dependencies.store.storeID,
-                dateRange: dateRange.serviceDateRange(timezone: dependencies.store.storeTimeZone),
-                supportsVisitorStats: dependencies.store.supportsVisitorStats
+                dateRange: dateRange.serviceDateRange(timezone: dependencies.store.storeTimeZone)
             )
             let entry = Self.dataEntry(
                 for: statsPeriod,
@@ -270,7 +269,6 @@ private extension StoreInfoProvider {
         let storeName: String
         let storeCurrencySettings: CurrencySettings
         let storeTimeZone: TimeZone
-        let supportsVisitorStats: Bool
     }
 
     /// Fetches the required dependencies from the keychain and the shared users default.
@@ -316,8 +314,7 @@ private extension StoreInfoProvider {
         let store = StoreMetadata(storeID: selectedStore.siteID,
                                   storeName: selectedStore.name,
                                   storeCurrencySettings: storeCurrencySettings,
-                                  storeTimeZone: selectedStore.timeZone,
-                                  supportsVisitorStats: selectedStore.supportsVisitorStats)
+                                  storeTimeZone: selectedStore.timeZone)
         return StoreInfoProviderDependencies(credentials: credentials,
                                              store: store)
     }
@@ -333,8 +330,7 @@ private extension StoreInfoProvider {
         return StoreMetadata(storeID: storeID,
                              storeName: storeName,
                              storeCurrencySettings: storeCurrencySettings,
-                             storeTimeZone: .current,
-                             supportsVisitorStats: true)
+                             storeTimeZone: .current)
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -137,9 +137,9 @@ final class StoreInfoProvider: TimelineProvider {
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
             let statsPeriod = try await service.fetchStats(
-                for: dependencies.storeID,
-                dateRange: dateRange.serviceDateRange(timezone: dependencies.storeTimeZone),
-                supportsVisitorStats: dependencies.supportsVisitorStats
+                for: dependencies.store.storeID,
+                dateRange: dateRange.serviceDateRange(timezone: dependencies.store.storeTimeZone),
+                supportsVisitorStats: dependencies.store.supportsVisitorStats
             )
             let entry = Self.dataEntry(
                 for: statsPeriod,
@@ -260,13 +260,9 @@ private extension StoreInfoProvider {
 
     /// Dependencies needed by the `StoreInfoProvider`
     ///
-    struct Dependencies {
+    struct StoreInfoProviderDependencies {
         let credentials: Credentials
-        let storeID: Int64
-        let storeName: String
-        let storeCurrencySettings: CurrencySettings
-        let storeTimeZone: TimeZone
-        let supportsVisitorStats: Bool
+        let store: StoreMetadata
     }
 
     struct StoreMetadata {
@@ -279,7 +275,7 @@ private extension StoreInfoProvider {
 
     /// Fetches the required dependencies from the keychain and the shared users default.
     ///
-    static func fetchDependencies(selectedStoreID: StoreStatsStoreEntity.ID? = nil) -> Dependencies? {
+    static func fetchDependencies(selectedStoreID: StoreStatsStoreEntity.ID? = nil) -> StoreInfoProviderDependencies? {
         let keychain = Keychain(service: WooConstants.keychainServiceName)
         let credentials: Credentials? = {
             if let authToken = keychain[WooConstants.authToken] {
@@ -305,12 +301,8 @@ private extension StoreInfoProvider {
             return nil
         }
 
-        let defaultDependencies = Dependencies(credentials: credentials,
-                                               storeID: defaultStore.storeID,
-                                               storeName: defaultStore.storeName,
-                                               storeCurrencySettings: defaultStore.storeCurrencySettings,
-                                               storeTimeZone: defaultStore.storeTimeZone,
-                                               supportsVisitorStats: defaultStore.supportsVisitorStats)
+        let defaultDependencies = StoreInfoProviderDependencies(credentials: credentials,
+                                                               store: defaultStore)
         let snapshots = StoreStatsSnapshotStore().snapshots()
         guard let selectedStore = selectedStoreSnapshot(from: snapshots,
                                                         selectedStoreID: selectedStoreID,
@@ -321,12 +313,13 @@ private extension StoreInfoProvider {
         let storeCurrencySettings = currencySettings(for: selectedStore,
                                                      defaultStoreID: defaultStore.storeID,
                                                      defaultCurrencySettings: defaultStore.storeCurrencySettings)
-        return Dependencies(credentials: credentials,
-                            storeID: selectedStore.siteID,
-                            storeName: selectedStore.name,
-                            storeCurrencySettings: storeCurrencySettings,
-                            storeTimeZone: selectedStore.timeZone,
-                            supportsVisitorStats: selectedStore.supportsVisitorStats)
+        let store = StoreMetadata(storeID: selectedStore.siteID,
+                                  storeName: selectedStore.name,
+                                  storeCurrencySettings: storeCurrencySettings,
+                                  storeTimeZone: selectedStore.timeZone,
+                                  supportsVisitorStats: selectedStore.supportsVisitorStats)
+        return StoreInfoProviderDependencies(credentials: credentials,
+                                             store: store)
     }
 
     static func defaultStoreMetadata() -> StoreMetadata? {
@@ -385,8 +378,8 @@ private extension StoreInfoProvider {
     /// array derive from `Stats.placeholderSample` + `legacyMetricsPreset` so the two views of
     /// the same data stay in sync.
     ///
-    static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
-        let currencySettings = dependencies?.storeCurrencySettings ?? CurrencySettings()
+    static func placeholderEntry(for dependencies: StoreInfoProviderDependencies?) -> StoreInfoEntry {
+        let currencySettings = dependencies?.store.storeCurrencySettings ?? CurrencySettings()
         let sample = StoreInfoDataService.Stats.placeholderSample
         let metrics: [StoreInfoMetric] = legacyMetricsPreset.map { type in
             StoreInfoMetric(type: type, value: sample.value(for: type, currencySettings: currencySettings))
@@ -395,7 +388,7 @@ private extension StoreInfoProvider {
         let conversionString = sample.conversion.map(StoreInfoFormatter.formattedConversionString) ?? StoreInfoFormatter.Constants.valuePlaceholderText
         return .data(.init(
             range: StoreStatsWidgetDateRange.today.localizedRangeLabel,
-            name: dependencies?.storeName ?? Localization.myShop,
+            name: dependencies?.store.storeName ?? Localization.myShop,
             revenue: StoreInfoFormatter.formattedAmountString(for: sample.revenue, with: currencySettings),
             revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: sample.revenue, with: currencySettings),
             visitors: visitorsString,
@@ -416,9 +409,9 @@ private extension StoreInfoProvider {
     ///
     static func dataEntry(for statsPeriod: StoreInfoDataService.StatsPeriod,
                           dateRange: StoreStatsWidgetDateRange,
-                          with dependencies: Dependencies,
+                          with dependencies: StoreInfoProviderDependencies,
                           metrics: [StoreInfoMetricType]) -> StoreInfoEntry {
-        let currencySettings = dependencies.storeCurrencySettings
+        let currencySettings = dependencies.store.storeCurrencySettings
         let stats = statsPeriod.current
         let previousStats = statsPeriod.previous
         let resolvedMetrics: [StoreInfoMetric] = metrics.map { type in
@@ -444,7 +437,7 @@ private extension StoreInfoProvider {
 
         return .data(.init(
             range: dateRange.localizedRangeLabel,
-            name: dependencies.storeName,
+            name: dependencies.store.storeName,
             revenue: StoreInfoFormatter.formattedAmountString(for: stats.revenue, with: currencySettings),
             revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: stats.revenue, with: currencySettings),
             visitors: visitorsString,

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -328,10 +328,7 @@ private extension StoreInfoProvider {
                                 supportsVisitorStats: selectedStore.supportsVisitorStats)
         }
 
-        guard let storeCurrencySettings = selectedStore.currencySettings else {
-            return defaultDependencies
-        }
-
+        let storeCurrencySettings = selectedStore.currencySettings ?? defaultStore.storeCurrencySettings
         return Dependencies(credentials: credentials,
                             storeID: selectedStore.siteID,
                             storeName: selectedStore.name,

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -3,12 +3,14 @@ import WidgetKit
 
 /// Configuration intent for the Store Stats widget.
 ///
-/// Surfaces the user-facing widget settings (long-press → Edit Widget). The `store` picker is
-/// added by a later ticket on top of `dateRange` and `metrics`.
+/// Surfaces the user-facing widget settings (long-press → Edit Widget).
 ///
 struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Store Stats"
     static var description = IntentDescription("Choose how the WooCommerce stats widget is displayed.")
+
+    @Parameter(title: "Store")
+    var store: StoreStatsStoreEntity?
 
     @Parameter(title: "Date Range", default: .today)
     var dateRange: StoreStatsWidgetDateRange
@@ -40,6 +42,10 @@ struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
         query: AvailableMetricsQuery()
     )
     var metrics: [StoreInfoMetricType]
+
+    init() {
+        store = StoreStatsStoreEntity.defaultStore
+    }
 }
 
 /// Date ranges supported by the Store Stats widget.
@@ -93,14 +99,75 @@ extension StoreStatsWidgetDateRange {
     /// Maps the user-selected widget range to the primitive parameters consumed by
     /// `StoreInfoDataService.fetchStats(for:dateRange:)`.
     ///
-    var serviceDateRange: StoreInfoDataService.DateRange {
+    func serviceDateRange(timezone: TimeZone = .current) -> StoreInfoDataService.DateRange {
         switch self {
         case .today:
-            return .today()
+            return .today(timezone: timezone)
         case .last7Days:
-            return .last7Days()
+            return .last7Days(timezone: timezone)
         case .last30Days:
-            return .last30Days()
+            return .last30Days(timezone: timezone)
         }
+    }
+}
+
+struct StoreStatsStoreEntity: AppEntity, Hashable {
+    private static let defaultStoreID = "__default_store__"
+    static let defaultStore = StoreStatsStoreEntity(id: defaultStoreID, name: nil)
+
+    static var defaultQuery = StoreStatsStoreQuery()
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Store")
+    }
+
+    let id: String
+    let name: String?
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(displayName)")
+    }
+
+    init(snapshot: StoreStatsSnapshot) {
+        id = snapshot.appEntityID
+        name = snapshot.name
+    }
+
+    init(id: String, name: String?) {
+        self.id = id
+        self.name = name
+    }
+
+    static func isDefaultStoreID(_ id: String) -> Bool {
+        id == defaultStoreID
+    }
+
+    private var displayName: String {
+        if Self.isDefaultStoreID(id),
+           let defaultStoreName = StoreStatsSnapshotStore().defaultStoreName() {
+            return defaultStoreName
+        }
+        return name ?? "Store"
+    }
+}
+
+struct StoreStatsStoreQuery: EntityQuery {
+    func entities(for identifiers: [StoreStatsStoreEntity.ID]) async throws -> [StoreStatsStoreEntity] {
+        let identifiers = Set(identifiers)
+        let entities = StoreStatsSnapshotStore().storePickerSnapshots()
+            .filter { identifiers.contains($0.appEntityID) }
+            .map(StoreStatsStoreEntity.init(snapshot:))
+        guard identifiers.contains(where: StoreStatsStoreEntity.isDefaultStoreID) else {
+            return entities
+        }
+        return [StoreStatsStoreEntity.defaultStore] + entities
+    }
+
+    func suggestedEntities() async throws -> [StoreStatsStoreEntity] {
+        StoreStatsSnapshotStore().storePickerSnapshots().map(StoreStatsStoreEntity.init(snapshot:))
+    }
+
+    func defaultResult() async -> StoreStatsStoreEntity? {
+        StoreStatsStoreEntity.defaultStore
     }
 }

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -112,8 +112,7 @@ extension StoreStatsWidgetDateRange {
 }
 
 struct StoreStatsStoreEntity: AppEntity, Hashable {
-    private static let defaultStoreSentinelID = "__default_store__"
-    static let defaultStore = StoreStatsStoreEntity(id: defaultStoreSentinelID, name: nil)
+    static let defaultStore = StoreStatsStoreEntity(id: StoreStatsStoreSelection.defaultStoreEntityID, name: nil)
 
     static var defaultQuery = StoreStatsStoreQuery()
 
@@ -139,7 +138,7 @@ struct StoreStatsStoreEntity: AppEntity, Hashable {
     }
 
     static func isDefaultStoreID(_ id: String) -> Bool {
-        id == defaultStoreSentinelID
+        StoreStatsStoreSelection.isDefaultStoreEntityID(id)
     }
 
     private var displayName: String {

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -112,8 +112,8 @@ extension StoreStatsWidgetDateRange {
 }
 
 struct StoreStatsStoreEntity: AppEntity, Hashable {
-    private static let defaultStoreID = "__default_store__"
-    static let defaultStore = StoreStatsStoreEntity(id: defaultStoreID, name: nil)
+    private static let defaultStoreSentinelID = "__default_store__"
+    static let defaultStore = StoreStatsStoreEntity(id: defaultStoreSentinelID, name: nil)
 
     static var defaultQuery = StoreStatsStoreQuery()
 
@@ -139,7 +139,7 @@ struct StoreStatsStoreEntity: AppEntity, Hashable {
     }
 
     static func isDefaultStoreID(_ id: String) -> Bool {
-        id == defaultStoreID
+        id == defaultStoreSentinelID
     }
 
     private var displayName: String {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				"Extensions/UserDefaults+Woo.swift",
 				System/WooConstants.swift,
 				Tools/AppLocalizedString.swift,
+				Tools/StoreWidgets/StoreStatsSnapshot.swift,
 			);
 			target = 3F1FA83F28B60125009E246C /* StoreWidgetsExtension */;
 		};

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -120,6 +120,7 @@ struct StoreStatsSnapshotTests {
         // Then
         #expect(snapshots.map(\.siteID) == [123])
         #expect(snapshots[0].name == "Default Store")
+        #expect(snapshots[0].timeZone.identifier == TimeZone.current.identifier)
         #expect(snapshots[0].isSelectableInStorePicker == false)
         #expect(pickerSnapshots.isEmpty)
     }

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -4,11 +4,11 @@ import Testing
 import WooFoundationCore
 
 struct StoreStatsSnapshotTests {
-    @Test func snapshots_whenStorePickerIsExposed_thenKeepsWooStoresWithDefaultFirst() throws {
+    @Test func snapshots_whenStorePickerIsExposed_thenKeepsWooStoresWithDefaultFirst() {
         // Given
-        let defaultCurrencySettingsData = try currencySettingsData(for: .USD)
-        let alphaCurrencySettingsData = try currencySettingsData(for: .EUR)
-        let betaCurrencySettingsData = try currencySettingsData(for: .GBP)
+        let defaultCurrencySettings = currencySettings(for: .USD)
+        let alphaCurrencySettings = currencySettings(for: .EUR)
+        let betaCurrencySettings = currencySettings(for: .GBP)
         let storedSites = [
             StoreStatsStoredSite(siteID: 2,
                                  name: "Beta",
@@ -41,11 +41,11 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: defaultSite,
                                                             defaultSiteID: 3,
-                                                            defaultCurrencySettingsData: defaultCurrencySettingsData,
-                                                            currencySettingsDataBySiteID: [
-                                                                1: alphaCurrencySettingsData,
-                                                                2: betaCurrencySettingsData,
-                                                                3: defaultCurrencySettingsData
+                                                            defaultCurrencySettings: defaultCurrencySettings,
+                                                            currencySettingsBySiteID: [
+                                                                1: alphaCurrencySettings,
+                                                                2: betaCurrencySettings,
+                                                                3: defaultCurrencySettings
                                                             ],
                                                             exposesStorePicker: true)
 
@@ -53,15 +53,15 @@ struct StoreStatsSnapshotTests {
         #expect(snapshots.map(\.siteID) == [3, 1, 2])
         #expect(snapshots.map(\.name) == ["Default", "Alpha", "Beta"])
         #expect(snapshots[0].isSelectableInStorePicker)
-        #expect(snapshots[0].currencySettingsData == defaultCurrencySettingsData)
-        #expect(snapshots[1].currencySettingsData == alphaCurrencySettingsData)
-        #expect(snapshots[2].currencySettingsData == betaCurrencySettingsData)
+        #expect(snapshots[0].currencySettings == defaultCurrencySettings)
+        #expect(snapshots[1].currencySettings == alphaCurrencySettings)
+        #expect(snapshots[2].currencySettings == betaCurrencySettings)
         #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
     }
 
-    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenUsesDefaultCurrencySettings() throws {
+    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenUsesDefaultCurrencySettings() {
         // Given
-        let defaultCurrencySettingsData = try currencySettingsData(for: .USD)
+        let defaultCurrencySettings = currencySettings(for: .USD)
         let storedSites = [
             StoreStatsStoredSite(siteID: 1,
                                  name: "Default",
@@ -79,13 +79,13 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: storedSites[0],
                                                             defaultSiteID: 1,
-                                                            defaultCurrencySettingsData: defaultCurrencySettingsData,
-                                                            currencySettingsDataBySiteID: [1: defaultCurrencySettingsData],
+                                                            defaultCurrencySettings: defaultCurrencySettings,
+                                                            currencySettingsBySiteID: [1: defaultCurrencySettings],
                                                             exposesStorePicker: true)
 
         // Then
         #expect(snapshots.map(\.siteID) == [1, 2])
-        #expect(snapshots[1].currencySettingsData == defaultCurrencySettingsData)
+        #expect(snapshots[1].currencySettings == defaultCurrencySettings)
     }
 
     @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
@@ -102,7 +102,7 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: storedSites[0],
                                                             defaultSiteID: 1,
-                                                            defaultCurrencySettingsData: nil,
+                                                            defaultCurrencySettings: nil,
                                                             exposesStorePicker: false)
 
         // Then
@@ -155,13 +155,13 @@ struct StoreStatsSnapshotTests {
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: true,
-                               currencySettingsData: nil),
+                               currencySettings: nil),
             StoreStatsSnapshot(siteID: 2,
                                name: "Hidden",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: false,
-                               currencySettingsData: nil)
+                               currencySettings: nil)
         ]
         store.save(snapshots)
 
@@ -172,31 +172,31 @@ struct StoreStatsSnapshotTests {
         #expect(pickerSnapshots.map(\.siteID) == [1])
     }
 
-    @Test func storePickerSnapshots_whenSavedNonDefaultStoreHasNoCurrencySettings_thenIncludesStore() throws {
+    @Test func storePickerSnapshots_whenSavedNonDefaultStoreHasNoCurrencySettings_thenIncludesStore() {
         // Given
         let userDefaults = makeUserDefaults()
         userDefaults.set(Int64(1), forKey: .defaultStoreID)
         let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
-        let otherCurrencySettingsData = try currencySettingsData(for: .EUR)
+        let otherCurrencySettings = currencySettings(for: .EUR)
         let snapshots = [
             StoreStatsSnapshot(siteID: 1,
                                name: "Default",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: true,
-                               currencySettingsData: nil),
+                               currencySettings: nil),
             StoreStatsSnapshot(siteID: 2,
                                name: "Other",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: true,
-                               currencySettingsData: nil),
+                               currencySettings: nil),
             StoreStatsSnapshot(siteID: 3,
                                name: "Other with currency",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: true,
-                               currencySettingsData: otherCurrencySettingsData)
+                               currencySettings: otherCurrencySettings)
         ]
         store.save(snapshots)
 
@@ -207,16 +207,16 @@ struct StoreStatsSnapshotTests {
         #expect(pickerSnapshots.map(\.siteID) == [1, 2, 3])
     }
 
-    @Test func currencySettings_whenSelectedStoreIsDefault_thenUsesDefaultCurrencySettings() throws {
+    @Test func currencySettings_whenSelectedStoreIsDefault_thenUsesDefaultCurrencySettings() {
         // Given
-        let staleSnapshotCurrencySettingsData = try currencySettingsData(for: .USD)
+        let staleSnapshotCurrencySettings = currencySettings(for: .USD)
         let defaultCurrencySettings = currencySettings(for: .EUR)
         let selectedStore = StoreStatsSnapshot(siteID: 1,
                                                name: "Default",
                                                timeZoneIdentifier: nil,
                                                gmtOffset: 0,
                                                isSelectableInStorePicker: true,
-                                               currencySettingsData: staleSnapshotCurrencySettingsData)
+                                               currencySettings: staleSnapshotCurrencySettings)
 
         // When
         let resolvedCurrencySettings = StoreInfoProvider.currencySettings(for: selectedStore,
@@ -235,13 +235,13 @@ struct StoreStatsSnapshotTests {
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: true,
-                               currencySettingsData: nil),
+                               currencySettings: nil),
             StoreStatsSnapshot(siteID: 1,
                                name: "Default",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                isSelectableInStorePicker: true,
-                               currencySettingsData: nil)
+                               currencySettings: nil)
         ]
 
         // When
@@ -266,10 +266,6 @@ struct StoreStatsSnapshotTests {
         let userDefaults = UserDefaults(suiteName: suiteName)!
         userDefaults.removePersistentDomain(forName: suiteName)
         return userDefaults
-    }
-
-    private func currencySettingsData(for currencyCode: CurrencyCode) throws -> Data {
-        try JSONEncoder().encode(currencySettings(for: currencyCode))
     }
 
     private func currencySettings(for currencyCode: CurrencyCode) -> CurrencySettings {

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -1,0 +1,196 @@
+@testable import WooCommerce
+import Foundation
+import Testing
+import WooFoundationCore
+
+struct StoreStatsSnapshotTests {
+    @Test func snapshots_whenStorePickerIsExposed_thenKeepsWooStoresWithDefaultFirst() throws {
+        // Given
+        let currencySettingsData = try JSONEncoder().encode(CurrencySettings())
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Beta",
+                                 timeZoneIdentifier: "Europe/Madrid",
+                                 gmtOffset: 1,
+                                 isWooCommerceActive: true,
+                                 supportsVisitorStats: true),
+            StoreStatsStoredSite(siteID: 4,
+                                 name: "No Woo",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: false,
+                                 supportsVisitorStats: true),
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Beta Duplicate",
+                                 timeZoneIdentifier: "Europe/Madrid",
+                                 gmtOffset: 1,
+                                 isWooCommerceActive: true,
+                                 supportsVisitorStats: true),
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Alpha",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true,
+                                 supportsVisitorStats: false)
+        ]
+        let defaultSite = StoreStatsStoredSite(siteID: 3,
+                                               name: "Default",
+                                               timeZoneIdentifier: "America/New_York",
+                                               gmtOffset: -5,
+                                               isWooCommerceActive: true,
+                                               supportsVisitorStats: true)
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: defaultSite,
+                                                            defaultSiteID: 3,
+                                                            defaultCurrencySettingsData: currencySettingsData,
+                                                            exposesStorePicker: true)
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [3, 1, 2])
+        #expect(snapshots.map(\.name) == ["Default", "Alpha", "Beta"])
+        #expect(snapshots[0].isDefault)
+        #expect(snapshots[0].isSelectableInStorePicker)
+        #expect(snapshots[0].currencySettingsData == currencySettingsData)
+        #expect(snapshots[1].supportsVisitorStats == false)
+        #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
+    }
+
+    @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
+        // Given
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Default",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true,
+                                 supportsVisitorStats: false)
+        ]
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: storedSites[0],
+                                                            defaultSiteID: 1,
+                                                            defaultCurrencySettingsData: nil,
+                                                            exposesStorePicker: false)
+
+        // Then
+        #expect(snapshots.isEmpty)
+    }
+
+    @Test func snapshots_whenListIsAbsent_thenFallsBackToDefaultStoreForRendering() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(123), forKey: .defaultStoreID)
+        userDefaults.set("Default Store", forKey: .defaultStoreName)
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+
+        // When
+        let snapshots = store.snapshots()
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [123])
+        #expect(snapshots[0].name == "Default Store")
+        #expect(snapshots[0].isDefault)
+        #expect(snapshots[0].isSelectableInStorePicker == false)
+        #expect(pickerSnapshots.map(\.siteID) == [123])
+        #expect(pickerSnapshots[0].name == "Default Store")
+        #expect(pickerSnapshots[0].isSelectableInStorePicker == false)
+    }
+
+    @Test func storePickerSnapshots_whenSavedListIsEmpty_thenReturnsDefaultStoreFallback() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(123), forKey: .defaultStoreID)
+        userDefaults.set("Default Store", forKey: .defaultStoreName)
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+        store.save([])
+
+        // When
+        let snapshots = store.snapshots()
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(snapshots.isEmpty)
+        #expect(pickerSnapshots.map(\.siteID) == [123])
+        #expect(pickerSnapshots[0].name == "Default Store")
+        #expect(pickerSnapshots[0].isSelectableInStorePicker == false)
+    }
+
+    @Test func storePickerSnapshots_whenSavedListHasSelectableStores_thenReturnsThoseStores() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+        let snapshots = [
+            StoreStatsSnapshot(siteID: 1,
+                               name: "Default",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
+                               isDefault: true,
+                               isSelectableInStorePicker: true,
+                               currencySettingsData: nil),
+            StoreStatsSnapshot(siteID: 2,
+                               name: "Hidden",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
+                               isDefault: false,
+                               isSelectableInStorePicker: false,
+                               currencySettingsData: nil)
+        ]
+        store.save(snapshots)
+
+        // When
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(pickerSnapshots.map(\.siteID) == [1])
+    }
+
+    @Test func selectedStoreSnapshot_whenDefaultStoreEntityIsSelected_thenReturnsDefaultSnapshot() {
+        // Given
+        let snapshots = [
+            StoreStatsSnapshot(siteID: 1,
+                               name: "Default",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
+                               isDefault: true,
+                               isSelectableInStorePicker: true,
+                               currencySettingsData: nil),
+            StoreStatsSnapshot(siteID: 2,
+                               name: "Other",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
+                               isDefault: false,
+                               isSelectableInStorePicker: true,
+                               currencySettingsData: nil)
+        ]
+
+        // When
+        let selectedStore = StoreInfoProvider.selectedStoreSnapshot(from: snapshots,
+                                                                    selectedStoreID: StoreStatsStoreEntity.defaultStore.id)
+
+        // Then
+        #expect(selectedStore?.siteID == 1)
+    }
+
+    @Test func defaultResult_thenReturnsDefaultStoreEntity() async {
+        // When
+        let defaultResult = await StoreStatsStoreQuery().defaultResult()
+
+        // Then
+        #expect(defaultResult?.id == StoreStatsStoreEntity.defaultStore.id)
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "StoreStatsSnapshotTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -86,6 +86,37 @@ struct StoreStatsSnapshotTests {
         #expect(snapshots[1].currencySettings == nil)
     }
 
+    @Test func snapshots_whenStoreIsHidden_thenExcludesHiddenStore() {
+        // Given
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Default",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true),
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Hidden",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true),
+            StoreStatsStoredSite(siteID: 3,
+                                 name: "Visible",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true)
+        ]
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: storedSites[0],
+                                                            defaultSiteID: 1,
+                                                            hiddenStoreIDs: [2],
+                                                            exposesStorePicker: true)
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [1, 3])
+    }
+
     @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
         // Given
         let storedSites = [

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -6,7 +6,9 @@ import WooFoundationCore
 struct StoreStatsSnapshotTests {
     @Test func snapshots_whenStorePickerIsExposed_thenKeepsWooStoresWithDefaultFirst() throws {
         // Given
-        let currencySettingsData = try JSONEncoder().encode(CurrencySettings())
+        let defaultCurrencySettingsData = try currencySettingsData(for: .USD)
+        let alphaCurrencySettingsData = try currencySettingsData(for: .EUR)
+        let betaCurrencySettingsData = try currencySettingsData(for: .GBP)
         let storedSites = [
             StoreStatsStoredSite(siteID: 2,
                                  name: "Beta",
@@ -44,17 +46,53 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: defaultSite,
                                                             defaultSiteID: 3,
-                                                            defaultCurrencySettingsData: currencySettingsData,
+                                                            defaultCurrencySettingsData: defaultCurrencySettingsData,
+                                                            currencySettingsDataBySiteID: [
+                                                                1: alphaCurrencySettingsData,
+                                                                2: betaCurrencySettingsData,
+                                                                3: defaultCurrencySettingsData
+                                                            ],
                                                             exposesStorePicker: true)
 
         // Then
         #expect(snapshots.map(\.siteID) == [3, 1, 2])
         #expect(snapshots.map(\.name) == ["Default", "Alpha", "Beta"])
-        #expect(snapshots[0].isDefault)
         #expect(snapshots[0].isSelectableInStorePicker)
-        #expect(snapshots[0].currencySettingsData == currencySettingsData)
+        #expect(snapshots[0].currencySettingsData == defaultCurrencySettingsData)
+        #expect(snapshots[1].currencySettingsData == alphaCurrencySettingsData)
+        #expect(snapshots[2].currencySettingsData == betaCurrencySettingsData)
         #expect(snapshots[1].supportsVisitorStats == false)
         #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
+    }
+
+    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenExcludesStore() throws {
+        // Given
+        let defaultCurrencySettingsData = try currencySettingsData(for: .USD)
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Default",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true,
+                                 supportsVisitorStats: true),
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Other",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true,
+                                 supportsVisitorStats: true)
+        ]
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: storedSites[0],
+                                                            defaultSiteID: 1,
+                                                            defaultCurrencySettingsData: defaultCurrencySettingsData,
+                                                            currencySettingsDataBySiteID: [1: defaultCurrencySettingsData],
+                                                            exposesStorePicker: true)
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [1])
     }
 
     @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
@@ -93,7 +131,6 @@ struct StoreStatsSnapshotTests {
         // Then
         #expect(snapshots.map(\.siteID) == [123])
         #expect(snapshots[0].name == "Default Store")
-        #expect(snapshots[0].isDefault)
         #expect(snapshots[0].isSelectableInStorePicker == false)
         #expect(pickerSnapshots.isEmpty)
     }
@@ -118,6 +155,7 @@ struct StoreStatsSnapshotTests {
     @Test func storePickerSnapshots_whenSavedListHasSelectableStores_thenReturnsThoseStores() {
         // Given
         let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(1), forKey: .defaultStoreID)
         let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
         let snapshots = [
             StoreStatsSnapshot(siteID: 1,
@@ -125,7 +163,6 @@ struct StoreStatsSnapshotTests {
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                supportsVisitorStats: true,
-                               isDefault: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil),
             StoreStatsSnapshot(siteID: 2,
@@ -133,7 +170,6 @@ struct StoreStatsSnapshotTests {
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                supportsVisitorStats: true,
-                               isDefault: false,
                                isSelectableInStorePicker: false,
                                currencySettingsData: nil)
         ]
@@ -146,15 +182,18 @@ struct StoreStatsSnapshotTests {
         #expect(pickerSnapshots.map(\.siteID) == [1])
     }
 
-    @Test func selectedStoreSnapshot_whenDefaultStoreEntityIsSelected_thenReturnsDefaultSnapshot() {
+    @Test func storePickerSnapshots_whenSavedNonDefaultStoreHasNoCurrencySettings_thenExcludesStore() throws {
         // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(1), forKey: .defaultStoreID)
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+        let otherCurrencySettingsData = try currencySettingsData(for: .EUR)
         let snapshots = [
             StoreStatsSnapshot(siteID: 1,
                                name: "Default",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                supportsVisitorStats: true,
-                               isDefault: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil),
             StoreStatsSnapshot(siteID: 2,
@@ -162,14 +201,48 @@ struct StoreStatsSnapshotTests {
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
                                supportsVisitorStats: true,
-                               isDefault: false,
+                               isSelectableInStorePicker: true,
+                               currencySettingsData: nil),
+            StoreStatsSnapshot(siteID: 3,
+                               name: "Other with currency",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
+                               isSelectableInStorePicker: true,
+                               currencySettingsData: otherCurrencySettingsData)
+        ]
+        store.save(snapshots)
+
+        // When
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(pickerSnapshots.map(\.siteID) == [1, 3])
+    }
+
+    @Test func selectedStoreSnapshot_whenDefaultStoreEntityIsSelected_thenReturnsDefaultSnapshot() {
+        // Given
+        let snapshots = [
+            StoreStatsSnapshot(siteID: 2,
+                               name: "Other",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
+                               isSelectableInStorePicker: true,
+                               currencySettingsData: nil),
+            StoreStatsSnapshot(siteID: 1,
+                               name: "Default",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil)
         ]
 
         // When
         let selectedStore = StoreInfoProvider.selectedStoreSnapshot(from: snapshots,
-                                                                    selectedStoreID: StoreStatsStoreEntity.defaultStore.id)
+                                                                    selectedStoreID: StoreStatsStoreEntity.defaultStore.id,
+                                                                    defaultStoreID: 1)
 
         // Then
         #expect(selectedStore?.siteID == 1)
@@ -188,5 +261,11 @@ struct StoreStatsSnapshotTests {
         let userDefaults = UserDefaults(suiteName: suiteName)!
         userDefaults.removePersistentDomain(forName: suiteName)
         return userDefaults
+    }
+
+    private func currencySettingsData(for currencyCode: CurrencyCode) throws -> Data {
+        let currencySettings = CurrencySettings()
+        currencySettings.currencyCode = currencyCode
+        return try JSONEncoder().encode(currencySettings)
     }
 }

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -14,33 +14,28 @@ struct StoreStatsSnapshotTests {
                                  name: "Beta",
                                  timeZoneIdentifier: "Europe/Madrid",
                                  gmtOffset: 1,
-                                 isWooCommerceActive: true,
-                                 supportsVisitorStats: true),
+                                 isWooCommerceActive: true),
             StoreStatsStoredSite(siteID: 4,
                                  name: "No Woo",
                                  timeZoneIdentifier: "UTC",
                                  gmtOffset: 0,
-                                 isWooCommerceActive: false,
-                                 supportsVisitorStats: true),
+                                 isWooCommerceActive: false),
             StoreStatsStoredSite(siteID: 2,
                                  name: "Beta Duplicate",
                                  timeZoneIdentifier: "Europe/Madrid",
                                  gmtOffset: 1,
-                                 isWooCommerceActive: true,
-                                 supportsVisitorStats: true),
+                                 isWooCommerceActive: true),
             StoreStatsStoredSite(siteID: 1,
                                  name: "Alpha",
                                  timeZoneIdentifier: "UTC",
                                  gmtOffset: 0,
-                                 isWooCommerceActive: true,
-                                 supportsVisitorStats: false)
+                                 isWooCommerceActive: true)
         ]
         let defaultSite = StoreStatsStoredSite(siteID: 3,
                                                name: "Default",
                                                timeZoneIdentifier: "America/New_York",
                                                gmtOffset: -5,
-                                               isWooCommerceActive: true,
-                                               supportsVisitorStats: true)
+                                               isWooCommerceActive: true)
 
         // When
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
@@ -61,7 +56,6 @@ struct StoreStatsSnapshotTests {
         #expect(snapshots[0].currencySettingsData == defaultCurrencySettingsData)
         #expect(snapshots[1].currencySettingsData == alphaCurrencySettingsData)
         #expect(snapshots[2].currencySettingsData == betaCurrencySettingsData)
-        #expect(snapshots[1].supportsVisitorStats == false)
         #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
     }
 
@@ -73,14 +67,12 @@ struct StoreStatsSnapshotTests {
                                  name: "Default",
                                  timeZoneIdentifier: "UTC",
                                  gmtOffset: 0,
-                                 isWooCommerceActive: true,
-                                 supportsVisitorStats: true),
+                                 isWooCommerceActive: true),
             StoreStatsStoredSite(siteID: 2,
                                  name: "Other",
                                  timeZoneIdentifier: "UTC",
                                  gmtOffset: 0,
-                                 isWooCommerceActive: true,
-                                 supportsVisitorStats: true)
+                                 isWooCommerceActive: true)
         ]
 
         // When
@@ -103,8 +95,7 @@ struct StoreStatsSnapshotTests {
                                  name: "Default",
                                  timeZoneIdentifier: "UTC",
                                  gmtOffset: 0,
-                                 isWooCommerceActive: true,
-                                 supportsVisitorStats: false)
+                                 isWooCommerceActive: true)
         ]
 
         // When
@@ -163,14 +154,12 @@ struct StoreStatsSnapshotTests {
                                name: "Default",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil),
             StoreStatsSnapshot(siteID: 2,
                                name: "Hidden",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: false,
                                currencySettingsData: nil)
         ]
@@ -194,21 +183,18 @@ struct StoreStatsSnapshotTests {
                                name: "Default",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil),
             StoreStatsSnapshot(siteID: 2,
                                name: "Other",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil),
             StoreStatsSnapshot(siteID: 3,
                                name: "Other with currency",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: otherCurrencySettingsData)
         ]
@@ -229,7 +215,6 @@ struct StoreStatsSnapshotTests {
                                                name: "Default",
                                                timeZoneIdentifier: nil,
                                                gmtOffset: 0,
-                                               supportsVisitorStats: true,
                                                isSelectableInStorePicker: true,
                                                currencySettingsData: staleSnapshotCurrencySettingsData)
 
@@ -249,14 +234,12 @@ struct StoreStatsSnapshotTests {
                                name: "Other",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil),
             StoreStatsSnapshot(siteID: 1,
                                name: "Default",
                                timeZoneIdentifier: nil,
                                gmtOffset: 0,
-                               supportsVisitorStats: true,
                                isSelectableInStorePicker: true,
                                currencySettingsData: nil)
         ]

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -221,6 +221,27 @@ struct StoreStatsSnapshotTests {
         #expect(pickerSnapshots.map(\.siteID) == [1, 2, 3])
     }
 
+    @Test func currencySettings_whenSelectedStoreIsDefault_thenUsesDefaultCurrencySettings() throws {
+        // Given
+        let staleSnapshotCurrencySettingsData = try currencySettingsData(for: .USD)
+        let defaultCurrencySettings = currencySettings(for: .EUR)
+        let selectedStore = StoreStatsSnapshot(siteID: 1,
+                                               name: "Default",
+                                               timeZoneIdentifier: nil,
+                                               gmtOffset: 0,
+                                               supportsVisitorStats: true,
+                                               isSelectableInStorePicker: true,
+                                               currencySettingsData: staleSnapshotCurrencySettingsData)
+
+        // When
+        let resolvedCurrencySettings = StoreInfoProvider.currencySettings(for: selectedStore,
+                                                                          defaultStoreID: 1,
+                                                                          defaultCurrencySettings: defaultCurrencySettings)
+
+        // Then
+        #expect(resolvedCurrencySettings.currencyCode == .EUR)
+    }
+
     @Test func selectedStoreSnapshot_whenDefaultStoreEntityIsSelected_thenReturnsDefaultSnapshot() {
         // Given
         let snapshots = [
@@ -265,8 +286,12 @@ struct StoreStatsSnapshotTests {
     }
 
     private func currencySettingsData(for currencyCode: CurrencyCode) throws -> Data {
+        try JSONEncoder().encode(currencySettings(for: currencyCode))
+    }
+
+    private func currencySettings(for currencyCode: CurrencyCode) -> CurrencySettings {
         let currencySettings = CurrencySettings()
         currencySettings.currencyCode = currencyCode
-        return try JSONEncoder().encode(currencySettings)
+        return currencySettings
     }
 }

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -95,12 +95,10 @@ struct StoreStatsSnapshotTests {
         #expect(snapshots[0].name == "Default Store")
         #expect(snapshots[0].isDefault)
         #expect(snapshots[0].isSelectableInStorePicker == false)
-        #expect(pickerSnapshots.map(\.siteID) == [123])
-        #expect(pickerSnapshots[0].name == "Default Store")
-        #expect(pickerSnapshots[0].isSelectableInStorePicker == false)
+        #expect(pickerSnapshots.isEmpty)
     }
 
-    @Test func storePickerSnapshots_whenSavedListIsEmpty_thenReturnsDefaultStoreFallback() {
+    @Test func storePickerSnapshots_whenSavedListIsEmpty_thenReturnsNoSelectableStores() {
         // Given
         let userDefaults = makeUserDefaults()
         userDefaults.set(Int64(123), forKey: .defaultStoreID)
@@ -114,9 +112,7 @@ struct StoreStatsSnapshotTests {
 
         // Then
         #expect(snapshots.isEmpty)
-        #expect(pickerSnapshots.map(\.siteID) == [123])
-        #expect(pickerSnapshots[0].name == "Default Store")
-        #expect(pickerSnapshots[0].isSelectableInStorePicker == false)
+        #expect(pickerSnapshots.isEmpty)
     }
 
     @Test func storePickerSnapshots_whenSavedListHasSelectableStores_thenReturnsThoseStores() {

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -41,7 +41,6 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: defaultSite,
                                                             defaultSiteID: 3,
-                                                            defaultCurrencySettings: defaultCurrencySettings,
                                                             currencySettingsBySiteID: [
                                                                 1: alphaCurrencySettings,
                                                                 2: betaCurrencySettings,
@@ -59,7 +58,7 @@ struct StoreStatsSnapshotTests {
         #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
     }
 
-    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenUsesDefaultCurrencySettings() {
+    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenKeepsCurrencySettingsNil() {
         // Given
         let defaultCurrencySettings = currencySettings(for: .USD)
         let storedSites = [
@@ -79,13 +78,12 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: storedSites[0],
                                                             defaultSiteID: 1,
-                                                            defaultCurrencySettings: defaultCurrencySettings,
                                                             currencySettingsBySiteID: [1: defaultCurrencySettings],
                                                             exposesStorePicker: true)
 
         // Then
         #expect(snapshots.map(\.siteID) == [1, 2])
-        #expect(snapshots[1].currencySettings == defaultCurrencySettings)
+        #expect(snapshots[1].currencySettings == nil)
     }
 
     @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
@@ -102,7 +100,6 @@ struct StoreStatsSnapshotTests {
         let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
                                                             defaultSite: storedSites[0],
                                                             defaultSiteID: 1,
-                                                            defaultCurrencySettings: nil,
                                                             exposesStorePicker: false)
 
         // Then
@@ -217,6 +214,25 @@ struct StoreStatsSnapshotTests {
                                                gmtOffset: 0,
                                                isSelectableInStorePicker: true,
                                                currencySettings: staleSnapshotCurrencySettings)
+
+        // When
+        let resolvedCurrencySettings = StoreInfoProvider.currencySettings(for: selectedStore,
+                                                                          defaultStoreID: 1,
+                                                                          defaultCurrencySettings: defaultCurrencySettings)
+
+        // Then
+        #expect(resolvedCurrencySettings.currencyCode == .EUR)
+    }
+
+    @Test func currencySettings_whenSelectedStoreHasNoCurrencySettings_thenUsesDefaultCurrencySettings() {
+        // Given
+        let defaultCurrencySettings = currencySettings(for: .EUR)
+        let selectedStore = StoreStatsSnapshot(siteID: 2,
+                                               name: "Other",
+                                               timeZoneIdentifier: nil,
+                                               gmtOffset: 0,
+                                               isSelectableInStorePicker: true,
+                                               currencySettings: nil)
 
         // When
         let resolvedCurrencySettings = StoreInfoProvider.currencySettings(for: selectedStore,

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -65,7 +65,7 @@ struct StoreStatsSnapshotTests {
         #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
     }
 
-    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenExcludesStore() throws {
+    @Test func snapshots_whenNonDefaultStoreHasNoCurrencySettings_thenUsesDefaultCurrencySettings() throws {
         // Given
         let defaultCurrencySettingsData = try currencySettingsData(for: .USD)
         let storedSites = [
@@ -92,7 +92,8 @@ struct StoreStatsSnapshotTests {
                                                             exposesStorePicker: true)
 
         // Then
-        #expect(snapshots.map(\.siteID) == [1])
+        #expect(snapshots.map(\.siteID) == [1, 2])
+        #expect(snapshots[1].currencySettingsData == defaultCurrencySettingsData)
     }
 
     @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
@@ -182,7 +183,7 @@ struct StoreStatsSnapshotTests {
         #expect(pickerSnapshots.map(\.siteID) == [1])
     }
 
-    @Test func storePickerSnapshots_whenSavedNonDefaultStoreHasNoCurrencySettings_thenExcludesStore() throws {
+    @Test func storePickerSnapshots_whenSavedNonDefaultStoreHasNoCurrencySettings_thenIncludesStore() throws {
         // Given
         let userDefaults = makeUserDefaults()
         userDefaults.set(Int64(1), forKey: .defaultStoreID)
@@ -217,7 +218,7 @@ struct StoreStatsSnapshotTests {
         let pickerSnapshots = store.storePickerSnapshots()
 
         // Then
-        #expect(pickerSnapshots.map(\.siteID) == [1, 3])
+        #expect(pickerSnapshots.map(\.siteID) == [1, 2, 3])
     }
 
     @Test func selectedStoreSnapshot_whenDefaultStoreEntityIsSelected_thenReturnsDefaultSnapshot() {

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -248,9 +248,9 @@ struct StoreStatsSnapshotTests {
                                                currencySettings: staleSnapshotCurrencySettings)
 
         // When
-        let resolvedCurrencySettings = StoreInfoProvider.currencySettings(for: selectedStore,
-                                                                          defaultStoreID: 1,
-                                                                          defaultCurrencySettings: defaultCurrencySettings)
+        let resolvedCurrencySettings = StoreStatsStoreSelection.currencySettings(for: selectedStore,
+                                                                                 defaultStoreID: 1,
+                                                                                 defaultCurrencySettings: defaultCurrencySettings)
 
         // Then
         #expect(resolvedCurrencySettings.currencyCode == .EUR)
@@ -267,9 +267,9 @@ struct StoreStatsSnapshotTests {
                                                currencySettings: nil)
 
         // When
-        let resolvedCurrencySettings = StoreInfoProvider.currencySettings(for: selectedStore,
-                                                                          defaultStoreID: 1,
-                                                                          defaultCurrencySettings: defaultCurrencySettings)
+        let resolvedCurrencySettings = StoreStatsStoreSelection.currencySettings(for: selectedStore,
+                                                                                 defaultStoreID: 1,
+                                                                                 defaultCurrencySettings: defaultCurrencySettings)
 
         // Then
         #expect(resolvedCurrencySettings.currencyCode == .EUR)
@@ -293,20 +293,20 @@ struct StoreStatsSnapshotTests {
         ]
 
         // When
-        let selectedStore = StoreInfoProvider.selectedStoreSnapshot(from: snapshots,
-                                                                    selectedStoreID: StoreStatsStoreEntity.defaultStore.id,
-                                                                    defaultStoreID: 1)
+        let selectedStore = StoreStatsStoreSelection.selectedStoreSnapshot(from: snapshots,
+                                                                          selectedStoreID: StoreStatsStoreSelection.defaultStoreEntityID,
+                                                                          defaultStoreID: 1)
 
         // Then
         #expect(selectedStore?.siteID == 1)
     }
 
-    @Test func defaultResult_thenReturnsDefaultStoreEntity() async {
+    @Test func isDefaultStoreEntityID_whenDefaultEntityIDIsProvided_thenReturnsTrue() {
         // When
-        let defaultResult = await StoreStatsStoreQuery().defaultResult()
+        let isDefaultStoreEntityID = StoreStatsStoreSelection.isDefaultStoreEntityID(StoreStatsStoreSelection.defaultStoreEntityID)
 
         // Then
-        #expect(defaultResult?.id == StoreStatsStoreEntity.defaultStore.id)
+        #expect(isDefaultStoreEntityID)
     }
 
     private func makeUserDefaults() -> UserDefaults {


### PR DESCRIPTION
Part of: WOOMOB-2814

## Description
Adds a Store parameter to the configurable Store Stats widget so WPCom-authenticated users can choose which active WooCommerce store powers a widget.

The app now mirrors a lightweight store snapshot list into shared app group defaults, resolves the selected AppIntent store in the widget timeline provider, uses the selected store timezone for date ranges, and skips visitor stats for stores that do not support that endpoint. The picker returns no selectable stores when the snapshot list is intentionally empty.

Draft note: local review found that non-default selected stores currently fall back to the default store currency settings when formatting currency metrics. That should be confirmed or addressed before marking the PR ready.

## Test Steps
1. Log in with a WPCom account that has multiple active WooCommerce stores.
2. Enable the configurable Store Stats widgets flag if needed.
3. Add a Store Stats widget, open Edit Widget, and confirm the Store field lists selectable stores.
4. Select a non-default store and confirm the widget refreshes stats for that store and uses its timezone for Today / Last 7 Days / Last 30 Days.
5. Verify non-WPCom or empty snapshot states do not expose selectable store options.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.