### PR TITLE
[POS] Capture optional order note on Mark as Paid

### DIFF
--- a/Modules/Sources/PointOfSale/Card Present Payments/POSCartMarkAsPaidHandler.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSCartMarkAsPaidHandler.swift
@@ -5,7 +5,7 @@ import struct Yosemite.Order
 struct POSCartMarkAsPaidHandler: POSMarkAsPaidHandling {
     let orderController: PointOfSaleOrderControllerProtocol
 
-    func markOrderAsPaid(for order: Order) async throws {
-        try await orderController.markOrderAsPaidManually()
+    func markOrderAsPaid(for order: Order, note: String?) async throws {
+        try await orderController.markOrderAsPaidManually(note: note)
     }
 }

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSMarkAsPaidHandling.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSMarkAsPaidHandling.swift
@@ -6,5 +6,12 @@ import struct Yosemite.Order
 /// Mirrors the shape of `POSCashPaymentHandling`. The implementation lives in the cart flow's
 /// order controller; tests substitute a mock conforming to this protocol.
 protocol POSMarkAsPaidHandling {
-    func markOrderAsPaid(for order: Order) async throws
+    /// Marks the order as paid manually.
+    ///
+    /// - Parameters:
+    ///   - order: The order to mark as completed.
+    ///   - note: Optional merchant-supplied free-form note (e.g. "Bank transfer from Maria").
+    ///     When non-empty it is attached to the order as a private order note for
+    ///     reconciliation context. Nil/empty preserves existing behaviour.
+    func markOrderAsPaid(for order: Order, note: String?) async throws
 }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -526,7 +526,11 @@ extension POSPaymentModel {
     /// controller. On failure rolls back to the confirmation stage so the merchant can retry.
     /// Analytics for failures fires here (not in the controller) so every failure path —
     /// `provideOrder()` and the handler call alike — funnels through one event.
-    func confirmMarkAsPaidPayment() async throws {
+    ///
+    /// - Parameter note: Optional merchant-supplied free-form note captured by the
+    ///   confirmation view (e.g. "Bank transfer from Maria"). Forwarded to the handler so it
+    ///   can be attached to the order as a private order note for reconciliation context.
+    func confirmMarkAsPaidPayment(note: String? = nil) async throws {
         do {
             let order: Order
             if let currentOrder {
@@ -538,7 +542,7 @@ extension POSPaymentModel {
             }
             analytics.track(.pointOfSaleMarkAsPaidConfirmed)
             paymentState.markAsPaid = .processing
-            try await markAsPaidHandler.markOrderAsPaid(for: order)
+            try await markAsPaidHandler.markOrderAsPaid(for: order, note: note)
             try? await postPaymentStep?()
             markAsPaidPaymentSuccess()
         } catch {

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import Foundation
 import Observation
 import class WooFoundation.VersionHelpers
@@ -40,7 +41,13 @@ protocol PointOfSaleOrderControllerProtocol {
     func sendReceipt(recipientEmail: String) async throws
     func clearOrder()
     func collectCashPayment(changeDueAmount: String?) async throws
-    func markOrderAsPaidManually() async throws
+    /// Marks the order as paid manually.
+    ///
+    /// - Parameter note: Optional merchant-supplied free-form note (e.g. "Bank transfer from
+    ///   Maria"). When non-nil/non-empty it is appended to the order as a private note via
+    ///   `addOrderNote`, separately from the order completion call. The order's payment-method
+    ///   title stays "Other" regardless of the note's content.
+    func markOrderAsPaidManually(note: String?) async throws
     /// Adds the "Customer paid via Scan to Pay" note to the cached order so the merchant has
     /// an audit trail in WP-Admin even if the gateway webhook hasn't flipped the status yet.
     func confirmScanToPayPayment() async throws
@@ -143,7 +150,7 @@ protocol PointOfSaleOrderControllerProtocol {
     }
 
     @MainActor
-    func markOrderAsPaidManually() async throws {
+    func markOrderAsPaidManually(note: String?) async throws {
         guard let order else {
             throw PointOfSaleOrderControllerError.noOrder
         }
@@ -152,6 +159,20 @@ protocol PointOfSaleOrderControllerProtocol {
         // mark-as-paid failure paths (this call, plus `orderProvider.provideOrder()`) funnel
         // through a single event. Re-throw so the model can roll back state.
         try await orderService.markOrderAsCompletedManually(order: order)
+
+        // Order note attaches separately from completion. We only attempt it if the merchant
+        // supplied content; the order completion is the critical path, and a stale note can
+        // be added manually in admin if this network call drops, so we log-and-move-on rather
+        // than throwing the merchant back to a "retry" prompt.
+        let trimmed = note?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard trimmed.isEmpty == false else { return }
+        do {
+            try await orderService.addOrderNote(orderID: order.orderID,
+                                                isCustomerNote: false,
+                                                note: trimmed)
+        } catch {
+            DDLogWarn("⚠️ [MarkAsPaid] Order completed but failed to attach merchant note: \(error)")
+        }
     }
 
     @MainActor

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -84,10 +84,10 @@ struct POSNavigationDestinationMarkAsPaidView: View {
             orderTotal: orderTotal,
             isProcessing: paymentModel.paymentState.markAsPaid == .processing,
             errorMessage: errorMessage,
-            onConfirm: {
+            onConfirm: { note in
                 Task { @MainActor in
                     do {
-                        try await paymentModel.confirmMarkAsPaidPayment()
+                        try await paymentModel.confirmMarkAsPaidPayment(note: note)
                         errorMessage = nil
                     } catch {
                         errorMessage = Localization.failureMessage

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleMarkAsPaidConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleMarkAsPaidConfirmationView.swift
@@ -1,15 +1,26 @@
 import SwiftUI
 
-/// Confirmation alert shown when the merchant taps "Mark order as paid" in the Other payment
-/// methods sheet. Stays inline (modal over the totals view); on confirm it triggers the order
-/// update, transitions to `.processing`, and on success the totals view shows the
-/// paymentSuccess UI driven by `PointOfSaleMarkAsPaidState.paymentSuccess`.
+/// Right-pane confirmation pushed when the merchant taps "Mark order as paid". Capturing an
+/// optional free-form note here gives the merchant somewhere to record what the payment was
+/// (e.g. "Bank transfer from Maria") so the order has reconciliation context in WP-Admin.
+/// On confirm the host triggers the order update; on success the totals view shows the
+/// `paymentSuccess` UI driven by `PointOfSaleMarkAsPaidState.paymentSuccess`.
 struct PointOfSaleMarkAsPaidConfirmationView: View {
     let orderTotal: String
     let isProcessing: Bool
     let errorMessage: String?
-    let onConfirm: () -> Void
+    let onConfirm: (_ note: String?) -> Void
     let onCancel: () -> Void
+
+    /// Optional merchant-supplied free-form note. Empty string is treated as nil downstream —
+    /// see `trimmedNote`.
+    @State private var note: String = ""
+    @FocusState private var isNoteFieldFocused: Bool
+
+    private var trimmedNote: String? {
+        let trimmed = note.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 
     var body: some View {
         VStack(alignment: .center, spacing: POSSpacing.medium) {
@@ -28,6 +39,32 @@ struct PointOfSaleMarkAsPaidConfirmationView: View {
                 .foregroundColor(.posOnSurfaceVariantHighest)
                 .multilineTextAlignment(.center)
 
+            // Optional free-form note. Persisted as a private order note alongside the
+            // mark-as-paid completion, giving the merchant reconciliation context in WP-Admin
+            // (e.g. "Bank transfer from Maria"). Defaults to empty → no note is added and
+            // behaviour matches the previous (note-less) flow exactly.
+            VStack(alignment: .leading, spacing: POSSpacing.small) {
+                Text(Localization.noteFieldLabel)
+                    .font(.posBodySmallBold())
+                    .foregroundColor(.posOnSurfaceVariantHighest)
+                TextField(Localization.notePlaceholder,
+                          text: $note,
+                          axis: .vertical)
+                    .lineLimit(2...4)
+                    .font(.posBodyMediumRegular())
+                    .focused($isNoteFieldFocused)
+                    .textInputAutocapitalization(.sentences)
+                    .autocorrectionDisabled(false)
+                    .submitLabel(.done)
+                    .onSubmit { isNoteFieldFocused = false }
+                    .padding(POSPadding.medium)
+                    .background(Color.posSurfaceContainerLow)
+                    .cornerRadius(POSCornerRadiusStyle.small.value)
+                    .disabled(isProcessing)
+                    .accessibilityIdentifier("pos-mark-as-paid-note-field")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
             if let errorMessage {
                 Text(errorMessage)
                     .font(.posBodySmallRegular())
@@ -36,7 +73,7 @@ struct PointOfSaleMarkAsPaidConfirmationView: View {
             }
 
             VStack(spacing: POSSpacing.small) {
-                Button(action: onConfirm) {
+                Button(action: { onConfirm(trimmedNote) }) {
                     Text(Localization.confirmButton)
                         .font(POSFontStyle.posBodyLargeBold)
                 }
@@ -64,24 +101,35 @@ private extension PointOfSaleMarkAsPaidConfirmationView {
         static let title = NSLocalizedString(
             "pointOfSale.markAsPaid.confirmation.title",
             value: "Mark order as paid?",
-            comment: "Title of the Point of Sale confirmation alert for manually marking an order as paid."
+            comment: "Title of the Point of Sale confirmation for manually marking an order as paid."
         )
         static let message = NSLocalizedString(
             "pointOfSale.markAsPaid.confirmation.message",
             value: "This will mark the %1$@ order as completed. " +
             "Use this only if you've already collected payment another way.",
-            comment: "Body of the Point of Sale confirmation alert for manually marking an order as paid. " +
+            comment: "Body of the Point of Sale confirmation for manually marking an order as paid. " +
             "%1$@ is the formatted order total, e.g. $24.99."
         )
         static let confirmButton = NSLocalizedString(
             "pointOfSale.markAsPaid.confirmation.confirmButton",
             value: "Mark as paid",
-            comment: "Confirmation button on the Point of Sale Mark as paid confirmation alert."
+            comment: "Confirmation button on the Point of Sale Mark as paid confirmation."
         )
         static let cancelButton = NSLocalizedString(
             "pointOfSale.markAsPaid.confirmation.cancelButton",
             value: "Cancel",
-            comment: "Cancel button on the Point of Sale Mark as paid confirmation alert."
+            comment: "Cancel button on the Point of Sale Mark as paid confirmation."
+        )
+        static let noteFieldLabel = NSLocalizedString(
+            "pointOfSale.markAsPaid.confirmation.noteLabel",
+            value: "Add a note (optional)",
+            comment: "Label above the optional note text field on the Point of Sale Mark as paid confirmation, " +
+            "where the merchant can record reconciliation context for the order."
+        )
+        static let notePlaceholder = NSLocalizedString(
+            "pointOfSale.markAsPaid.confirmation.notePlaceholder",
+            value: "e.g. Bank transfer from Maria, ref 4827",
+            comment: "Placeholder shown inside the optional note text field on the Point of Sale Mark as paid confirmation."
         )
     }
 }
@@ -92,7 +140,7 @@ private extension PointOfSaleMarkAsPaidConfirmationView {
         orderTotal: "$24.99",
         isProcessing: false,
         errorMessage: nil,
-        onConfirm: {},
+        onConfirm: { _ in },
         onCancel: {}
     )
     .background(Color.posSurface)
@@ -103,7 +151,7 @@ private extension PointOfSaleMarkAsPaidConfirmationView {
         orderTotal: "$24.99",
         isProcessing: true,
         errorMessage: nil,
-        onConfirm: {},
+        onConfirm: { _ in },
         onCancel: {}
     )
     .background(Color.posSurface)
@@ -114,7 +162,7 @@ private extension PointOfSaleMarkAsPaidConfirmationView {
         orderTotal: "$24.99",
         isProcessing: false,
         errorMessage: "Couldn't update the order. Try again.",
-        onConfirm: {},
+        onConfirm: { _ in },
         onCancel: {}
     )
     .background(Color.posSurface)

--- a/Modules/Sources/PointOfSale/Utils/PointOfSalePreviewOrderController.swift
+++ b/Modules/Sources/PointOfSale/Utils/PointOfSalePreviewOrderController.swift
@@ -27,7 +27,7 @@ class PointOfSalePreviewOrderController: PointOfSaleOrderControllerProtocol {
 
     func collectCashPayment(changeDueAmount: String?) async throws {}
 
-    func markOrderAsPaidManually() async throws {}
+    func markOrderAsPaidManually(note: String?) async throws {}
 
     func confirmScanToPayPayment() async throws {}
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -279,7 +279,7 @@ struct PointOfSaleOrderControllerTests {
 
         // When / Then
         await #expect(performing: {
-            try await sut.markOrderAsPaidManually()
+            try await sut.markOrderAsPaidManually(note: nil)
         }, throws: { error in
             (error as? PointOfSaleOrderController.PointOfSaleOrderControllerError) == .noOrder
         })
@@ -303,7 +303,7 @@ struct PointOfSaleOrderControllerTests {
         mockOrderService.resultToReturn = .success(())
 
         // When
-        try await sut.markOrderAsPaidManually()
+        try await sut.markOrderAsPaidManually(note: nil)
 
         // Then
         #expect(mockOrderService.markOrderAsCompletedManuallyWasCalled == true)
@@ -329,7 +329,7 @@ struct PointOfSaleOrderControllerTests {
         // Failure analytics is fired by `POSPaymentModel.confirmMarkAsPaidPayment()`, not here,
         // so the controller has no analytics responsibility on this path.
         await #expect(performing: {
-            try await sut.markOrderAsPaidManually()
+            try await sut.markOrderAsPaidManually(note: nil)
         }, throws: { error in
             error is OrderServiceError
         })

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSMarkAsPaidHandler.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSMarkAsPaidHandler.swift
@@ -5,11 +5,13 @@ import struct Yosemite.Order
 final class MockPOSMarkAsPaidHandler: POSMarkAsPaidHandling {
     var markOrderAsPaidCalled = false
     var markOrderAsPaidReceivedOrder: Order?
+    var markOrderAsPaidReceivedNote: String?
     var errorToThrow: Error?
 
-    func markOrderAsPaid(for order: Order) async throws {
+    func markOrderAsPaid(for order: Order, note: String?) async throws {
         markOrderAsPaidCalled = true
         markOrderAsPaidReceivedOrder = order
+        markOrderAsPaidReceivedNote = note
         if let error = errorToThrow { throw error }
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleOrderController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleOrderController.swift
@@ -47,9 +47,11 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     }
 
     var markOrderAsPaidManuallyWasCalled = false
+    var markOrderAsPaidManuallyReceivedNote: String?
     var markOrderAsPaidManuallyErrorToThrow: Error?
-    func markOrderAsPaidManually() async throws {
+    func markOrderAsPaidManually(note: String?) async throws {
         markOrderAsPaidManuallyWasCalled = true
+        markOrderAsPaidManuallyReceivedNote = note
         if let markOrderAsPaidManuallyErrorToThrow {
             throw markOrderAsPaidManuallyErrorToThrow
         }


### PR DESCRIPTION
## Description

Adds an optional **"Add a note (optional)"** text field to the Mark as Paid confirmation view so the merchant can record reconciliation context — for example "Bank transfer from Maria, ref 4827" — alongside the order completion. The captured text is attached to the order as a private order note via the existing `addOrderNote` path; the order's `paymentMethodTitle` stays `"Other"` regardless.

This builds on top of [#17080](https://github.com/woocommerce/woocommerce-ios/pull/17080) (the totals-view modal-cleanup refactor). It's stacked there because that PR replaces the modal-alert host with the right-pane `NavigationStack` push, and the new field lives inside that push — adding the field on the doomed modal would be wasted work.

### What changes

- New optional, multi-line `TextField` above the Confirm button on the Mark as Paid confirmation
- Label: **"Add a note (optional)"**
- Placeholder: `e.g. Bank transfer from Maria, ref 4827`
- Empty input → unchanged behaviour, no order note added
- Filled input → trimmed and attached as a **private** order note (`isCustomerNote: false`), visible in the WC admin order timeline
- Order's `paymentMethodTitle` stays `"Other"` so the admin "payment method" column stays consistent across all manually-marked orders, and reports can still aggregate by it

### Why a note (not the payment-method title)

The merchant's mental model when typing in this field is "I want to remember what this payment was". That's a note. Putting prose like "Bank transfer from Maria, ref 4827" into `paymentMethodTitle` would clutter the admin order list's payment-method column with narrative text. The order-note column is where this content belongs — it's already the established place for per-order context, and shows up in the admin timeline that bookkeepers reconcile against.

A free-text field beats a preset picker for v1 because:
- We don't yet have telemetry from merchants in the new countries to know what presets to ship
- Free text covers any market on day one (Bizum, PIX, Wero, account paid, IOU, …)
- Future v2 can add a preset picker informed by the values merchants actually type

### Failure handling

The order note is attached as a follow-up call **after** the order completes:
- If the completion call fails → the merchant retries (existing behaviour, unchanged)
- If the completion succeeds but the note call fails → the order is still completed, we log-and-move-on, the note can be added manually in admin later

This keeps the merchant out of a "retry" prompt for a non-critical write, and biases towards "order is paid" as the source of truth.

### Plumbing changes

- `PointOfSaleOrderControllerProtocol.markOrderAsPaidManually(note:)` — new optional parameter
- `POSMarkAsPaidHandling.markOrderAsPaid(for:note:)` — same
- `POSPaymentModel.confirmMarkAsPaidPayment(note:)` — defaults to `nil` so existing call sites still compile
- `POSNavigationDestinationMarkAsPaidView` (the spike's right-pane wrapper) forwards the captured note through to the model
- `POSOrderService.markOrderAsCompletedManually` is unchanged from trunk — the note flows via the existing `addOrderNote` API, no new service surface
- All mocks updated to match. Existing default behaviour is preserved when no note is supplied.

## Test Steps

iPad simulator, landscape, `localDeveloper` or `alpha` build with both `pointOfSaleScanToPay` and `pointOfSaleMarkOrderAsPaid` enabled.

- [ ] Build a cart, tap Checkout → **Other payment methods** popover → **Mark order as paid**.
- [ ] In the right-pane confirmation view, see the new **"Add a note (optional)"** field above the Confirm button, with placeholder `e.g. Bank transfer from Maria, ref 4827`.
- [ ] Spacing between the field label and the text field is comfortable (not crammed against each other).
- [ ] Leave the field empty and tap **Mark as paid**. Order completes; in WC admin no extra order note is attached (only the standard system note).
- [ ] Repeat with the field filled in (e.g. `Bank transfer from Maria, ref 4827`). Order completes; in WC admin the order timeline shows a private note with that exact text.
- [ ] Type leading/trailing whitespace. Confirm. Whitespace is trimmed before being saved.
- [ ] Type a multi-line note (the field grows to a few lines). Confirm. The full text is saved.
- [ ] Cancel the confirmation; payment state resets to idle, no order update, no note.
- [ ] Force a network failure on the *completion* call. Inline error appears in the confirmation view; merchant can retry or cancel.
- [ ] Force a network failure on the *note* call only (e.g. by toggling airplane mode after completion succeeds). Order is completed; note isn't attached. The merchant doesn't see an error — the order completes silently and the note is recoverable in admin.
- [ ] In WC admin, the "payment method" column always shows **Other** regardless of whether a note was supplied.
- [ ] Disable `pointOfSaleMarkOrderAsPaid` flag → Mark as Paid row hidden in the picker (regression check).

## Screenshots

N/A for now — happy to add a side-by-side once the spike PR (#17080) is approved.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.