### PR TITLE
[WOOMOB-2815] Prepare WPCOM store data for Store Stats widget

### DIFF
--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -86,6 +86,9 @@ extension UserDefaults {
 
         /// Whether configurable store stats widgets are enabled
         case configurableStoreStatsWidgetsEnabled
+
+        /// Lightweight store list for configurable store stats widgets
+        case configurableStoreStatsWidgetStores
     }
 }
 

--- a/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/StoreStatsSnapshot.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+struct StoreStatsSnapshot: Codable, Identifiable {
+    let siteID: Int64
+    let name: String
+    let timeZoneIdentifier: String?
+    let gmtOffset: Double
+    let isSelectableInStorePicker: Bool
+
+    var id: Int64 {
+        siteID
+    }
+
+    var appEntityID: String {
+        String(siteID)
+    }
+
+    var timeZone: TimeZone {
+        if let timeZoneIdentifier,
+           !timeZoneIdentifier.isEmpty,
+           let timeZone = TimeZone(identifier: timeZoneIdentifier) {
+            return timeZone
+        }
+        return TimeZone(secondsFromGMT: Int(gmtOffset * 3600)) ?? .current
+    }
+}
+
+struct StoreStatsStoredSite: Equatable {
+    let siteID: Int64
+    let name: String
+    let timeZoneIdentifier: String?
+    let gmtOffset: Double
+    let isWooCommerceActive: Bool
+}
+
+enum StoreStatsSnapshotFactory {
+    static func snapshots(storedSites: [StoreStatsStoredSite],
+                          defaultSite: StoreStatsStoredSite?,
+                          defaultSiteID: Int64?,
+                          hiddenStoreIDs: Set<Int64> = [],
+                          exposesStorePicker: Bool) -> [StoreStatsSnapshot] {
+        guard exposesStorePicker else {
+            return []
+        }
+
+        let defaultID = defaultSiteID ?? defaultSite?.siteID
+        var candidates = storedSites.filter { site in
+            site.isWooCommerceActive && hiddenStoreIDs.contains(site.siteID) == false
+        }
+        if let defaultSite,
+           defaultSite.isWooCommerceActive,
+           hiddenStoreIDs.contains(defaultSite.siteID) == false,
+           candidates.contains(where: { $0.siteID == defaultSite.siteID }) == false {
+            candidates.append(defaultSite)
+        }
+
+        var seenSiteIDs = Set<Int64>()
+        return candidates
+            .filter { site in
+                guard seenSiteIDs.contains(site.siteID) == false else {
+                    return false
+                }
+                seenSiteIDs.insert(site.siteID)
+                return true
+            }
+            .map { site in
+                return StoreStatsSnapshot(
+                    siteID: site.siteID,
+                    name: site.name,
+                    timeZoneIdentifier: site.timeZoneIdentifier,
+                    gmtOffset: site.gmtOffset,
+                    isSelectableInStorePicker: true
+                )
+            }
+            .sorted { lhs, rhs in
+                let lhsIsDefault = lhs.siteID == defaultID
+                let rhsIsDefault = rhs.siteID == defaultID
+                if lhsIsDefault != rhsIsDefault {
+                    return lhsIsDefault
+                }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+}
+
+struct StoreStatsSnapshotStore {
+    private let userDefaults: UserDefaults?
+
+    init(userDefaults: UserDefaults? = .group) {
+        self.userDefaults = userDefaults
+    }
+
+    func snapshots() -> [StoreStatsSnapshot] {
+        guard let data: Data = userDefaults?.object(forKey: .configurableStoreStatsWidgetStores) else {
+            return defaultStoreSnapshot().map { [$0] } ?? []
+        }
+
+        guard let snapshots = try? JSONDecoder().decode([StoreStatsSnapshot].self, from: data) else {
+            return defaultStoreSnapshot().map { [$0] } ?? []
+        }
+
+        return snapshots
+    }
+
+    func storePickerSnapshots() -> [StoreStatsSnapshot] {
+        snapshots().filter { $0.isSelectableInStorePicker }
+    }
+
+    func save(_ snapshots: [StoreStatsSnapshot]) {
+        guard let data = try? JSONEncoder().encode(snapshots) else {
+            return
+        }
+        userDefaults?.set(data, forKey: .configurableStoreStatsWidgetStores)
+    }
+
+    func defaultStoreName() -> String? {
+        defaultStoreSnapshot()?.name
+    }
+
+    func defaultStoreID() -> Int64? {
+        userDefaults?.object(forKey: .defaultStoreID)
+    }
+
+    private func defaultStoreSnapshot() -> StoreStatsSnapshot? {
+        guard let storeID: Int64 = userDefaults?.object(forKey: .defaultStoreID),
+              let storeName: String = userDefaults?.object(forKey: .defaultStoreName) else {
+            return nil
+        }
+
+        let timeZone = TimeZone.current
+        return StoreStatsSnapshot(
+            siteID: storeID,
+            name: storeName,
+            timeZoneIdentifier: timeZone.identifier,
+            gmtOffset: Double(timeZone.secondsFromGMT()) / 3600,
+            isSelectableInStorePicker: false
+        )
+    }
+}

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -179,14 +179,14 @@ class DefaultStoresManager: StoresManager {
     /// Forwards the Action to the current State.
     ///
     func dispatch(_ action: Action) {
-        state.onAction(action)
+        state.onAction(actionWithStoreStatsWidgetSnapshotUpdate(action))
     }
 
     /// Forwards the Actions to the current State.
     ///
     func dispatch(_ actions: [Action]) {
         for action in actions {
-            state.onAction(action)
+            dispatch(action)
         }
     }
 
@@ -865,9 +865,110 @@ private extension DefaultStoresManager {
         UserDefaults.group?[.defaultStoreName] = sessionManager.defaultSite?.name
 
         // Currency Settings are stored in `SelectedSiteSettings.defaultStoreCurrencySettings`
+        updateStoreStatsWidgetStoreSnapshots(with: siteID)
 
         // Reload widgets UI
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func actionWithStoreStatsWidgetSnapshotUpdate(_ action: Action) -> Action {
+        guard let accountAction = action as? AccountAction else {
+            return action
+        }
+
+        switch accountAction {
+        case let .loadAndSynchronizeSite(siteID, forcedUpdate, onCompletion):
+            return AccountAction.loadAndSynchronizeSite(siteID: siteID, forcedUpdate: forcedUpdate) { [weak self] result in
+                guard let self, case .success = result else {
+                    onCompletion(result)
+                    return
+                }
+                self.updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: siteID) {
+                    onCompletion(result)
+                }
+            }
+        case let .synchronizeSites(selectedSiteID, onCompletion):
+            return AccountAction.synchronizeSites(selectedSiteID: selectedSiteID) { [weak self] result in
+                guard let self, case .success = result else {
+                    onCompletion(result)
+                    return
+                }
+                self.updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: selectedSiteID) {
+                    onCompletion(result)
+                }
+            }
+        case let .synchronizeSitesAndReturnSelectedSiteInfo(siteAddress, onCompletion):
+            return AccountAction.synchronizeSitesAndReturnSelectedSiteInfo(siteAddress: siteAddress) { [weak self] result in
+                guard let self, case let .success(site) = result else {
+                    onCompletion(result)
+                    return
+                }
+                self.updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: site.siteID) {
+                    onCompletion(result)
+                }
+            }
+        default:
+            return action
+        }
+    }
+
+    private func updateStoreStatsWidgetStoreSnapshots(with siteID: Int64?) {
+        guard exposesStoreStatsWidgetStorePicker else {
+            StoreStatsSnapshotStore().save([])
+            return
+        }
+
+        let storedSites = ServiceLocator.storageManager.viewStorage.loadAllSites()
+            .map { site in
+                return StoreStatsStoredSite(siteID: site.siteID,
+                                            name: site.name ?? WooConstants.defaultStoreName,
+                                            timeZoneIdentifier: site.timezone,
+                                            gmtOffset: site.gmtOffset,
+                                            isWooCommerceActive: site.isWooCommerceActive?.boolValue ?? false)
+            }
+
+        let defaultSite = sessionManager.defaultSite.map { site in
+            StoreStatsStoredSite(siteID: site.siteID,
+                                 name: site.name,
+                                 timeZoneIdentifier: site.timezone,
+                                 gmtOffset: site.gmtOffset,
+                                 isWooCommerceActive: site.isWooCommerceActive)
+        }
+
+        let hiddenStoreIDs = Set(defaults.hiddenStoreIDs)
+        let defaultSiteID = siteID ?? defaultSite?.siteID
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: defaultSite,
+                                                            defaultSiteID: defaultSiteID,
+                                                            hiddenStoreIDs: hiddenStoreIDs,
+                                                            exposesStorePicker: true)
+        StoreStatsSnapshotStore().save(snapshots)
+    }
+
+    private func updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization(selectedSiteID: Int64?,
+                                                                                 onCompletion: @escaping () -> Void) {
+        let updateSnapshot = { [weak self] in
+            guard let self else {
+                onCompletion()
+                return
+            }
+            self.updateStoreStatsWidgetStoreSnapshots(with: selectedSiteID ?? self.sessionManager.defaultStoreID)
+            WidgetCenter.shared.reloadAllTimelines()
+            onCompletion()
+        }
+
+        if Thread.isMainThread {
+            updateSnapshot()
+        } else {
+            DispatchQueue.main.async(execute: updateSnapshot)
+        }
+    }
+
+    private var exposesStoreStatsWidgetStorePicker: Bool {
+        if case .wpcom = sessionManager.defaultCredentials {
+            return true
+        }
+        return false
     }
 
     func trackSnapshotIfNeeded(siteID: Int64, orderStatuses: [OrderStatus]?, systemPlugins: [SystemPlugin]?) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 				"Extensions/UserDefaults+Woo.swift",
 				System/WooConstants.swift,
 				Tools/AppLocalizedString.swift,
+				Tools/StoreWidgets/StoreStatsSnapshot.swift,
 			);
 			target = 3F1FA83F28B60125009E246C /* StoreWidgetsExtension */;
 		};

--- a/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/StoreStatsSnapshotTests.swift
@@ -1,0 +1,168 @@
+@testable import WooCommerce
+import Foundation
+import Testing
+
+struct StoreStatsSnapshotTests {
+    @Test func snapshots_whenStorePickerIsExposed_thenKeepsWooStoresWithDefaultFirst() {
+        // Given
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Beta",
+                                 timeZoneIdentifier: "Europe/Madrid",
+                                 gmtOffset: 1,
+                                 isWooCommerceActive: true),
+            StoreStatsStoredSite(siteID: 4,
+                                 name: "No Woo",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: false),
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Beta Duplicate",
+                                 timeZoneIdentifier: "Europe/Madrid",
+                                 gmtOffset: 1,
+                                 isWooCommerceActive: true),
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Alpha",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true)
+        ]
+        let defaultSite = StoreStatsStoredSite(siteID: 3,
+                                               name: "Default",
+                                               timeZoneIdentifier: "America/New_York",
+                                               gmtOffset: -5,
+                                               isWooCommerceActive: true)
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: defaultSite,
+                                                            defaultSiteID: 3,
+                                                            exposesStorePicker: true)
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [3, 1, 2])
+        #expect(snapshots.map(\.name) == ["Default", "Alpha", "Beta"])
+        #expect(snapshots[0].isSelectableInStorePicker)
+        #expect(snapshots[2].timeZone == TimeZone(identifier: "Europe/Madrid"))
+    }
+
+    @Test func snapshots_whenStoreIsHidden_thenExcludesHiddenStore() {
+        // Given
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Default",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true),
+            StoreStatsStoredSite(siteID: 2,
+                                 name: "Hidden",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true),
+            StoreStatsStoredSite(siteID: 3,
+                                 name: "Visible",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true)
+        ]
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: storedSites[0],
+                                                            defaultSiteID: 1,
+                                                            hiddenStoreIDs: [2],
+                                                            exposesStorePicker: true)
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [1, 3])
+    }
+
+    @Test func snapshots_whenStorePickerIsNotExposed_thenReturnsEmptyList() {
+        // Given
+        let storedSites = [
+            StoreStatsStoredSite(siteID: 1,
+                                 name: "Default",
+                                 timeZoneIdentifier: "UTC",
+                                 gmtOffset: 0,
+                                 isWooCommerceActive: true)
+        ]
+
+        // When
+        let snapshots = StoreStatsSnapshotFactory.snapshots(storedSites: storedSites,
+                                                            defaultSite: storedSites[0],
+                                                            defaultSiteID: 1,
+                                                            exposesStorePicker: false)
+
+        // Then
+        #expect(snapshots.isEmpty)
+    }
+
+    @Test func snapshots_whenListIsAbsent_thenFallsBackToDefaultStoreForRendering() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(123), forKey: .defaultStoreID)
+        userDefaults.set("Default Store", forKey: .defaultStoreName)
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+
+        // When
+        let snapshots = store.snapshots()
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(snapshots.map(\.siteID) == [123])
+        #expect(snapshots[0].name == "Default Store")
+        #expect(snapshots[0].timeZone.identifier == TimeZone.current.identifier)
+        #expect(snapshots[0].isSelectableInStorePicker == false)
+        #expect(pickerSnapshots.isEmpty)
+    }
+
+    @Test func storePickerSnapshots_whenSavedListIsEmpty_thenReturnsNoSelectableStores() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(123), forKey: .defaultStoreID)
+        userDefaults.set("Default Store", forKey: .defaultStoreName)
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+        store.save([])
+
+        // When
+        let snapshots = store.snapshots()
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(snapshots.isEmpty)
+        #expect(pickerSnapshots.isEmpty)
+    }
+
+    @Test func storePickerSnapshots_whenSavedListHasSelectableStores_thenReturnsThoseStores() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Int64(1), forKey: .defaultStoreID)
+        let store = StoreStatsSnapshotStore(userDefaults: userDefaults)
+        let snapshots = [
+            StoreStatsSnapshot(siteID: 1,
+                               name: "Default",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               isSelectableInStorePicker: true),
+            StoreStatsSnapshot(siteID: 2,
+                               name: "Hidden",
+                               timeZoneIdentifier: nil,
+                               gmtOffset: 0,
+                               isSelectableInStorePicker: false)
+        ]
+        store.save(snapshots)
+
+        // When
+        let pickerSnapshots = store.storePickerSnapshots()
+
+        // Then
+        #expect(pickerSnapshots.map(\.siteID) == [1])
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "StoreStatsSnapshotTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}


### PR DESCRIPTION
## Description

Prepares the shared store data needed for the configurable Store Stats widget to support WPCOM store selection in a follow-up PR.

This PR mirrors a lightweight list of active WooCommerce stores into the shared app group defaults so the widget extension can read it later without reaching into app-only storage. It refreshes the snapshot after default store updates and successful WPCOM site syncs, keeps the default store first, filters out hidden or non-WooCommerce sites, and preserves the existing default-store fallback for rendering when no snapshot list has been saved yet.

### What's added

- `StoreStatsSnapshot` and `StoreStatsSnapshotStore` — a small codable snapshot contract for widget-readable store metadata.
- `StoreStatsSnapshotFactory` — filters active WooCommerce stores, removes duplicates, excludes hidden stores, and sorts the default store first.
- `DefaultStoresManager` snapshot refresh hooks after widget/default-store updates and successful WPCOM site synchronization.
- App group defaults key for the persisted snapshot list.
- Unit coverage for ordering, filtering, hidden stores, empty snapshot states, default fallback, and selectable picker snapshots.

### DefaultStoresManager changes

`DefaultStoresManager` is the one app-layer place in this PR that has enough context to build the widget snapshot safely: it can see the current credentials, the selected/default site, hidden stores, and the synchronized site list in storage.

- `updateAndReloadWidgetInformation(with:)` now refreshes the store snapshot immediately after writing the default widget store ID/name into the shared app group. This keeps the existing default-store widget path and the new snapshot list in sync before WidgetKit timelines reload.
- `dispatch(_:)` now passes actions through `actionWithStoreStatsWidgetSnapshotUpdate(_:)`. Only site-list synchronization `AccountAction`s are wrapped; all other actions are forwarded unchanged.
- The wrapped account actions update the snapshot only after successful `loadAndSynchronizeSite`, `synchronizeSites`, or `synchronizeSitesAndReturnSelectedSiteInfo` completions. Failure paths call the original completion without changing the saved snapshot, so stale or partial sync data is not written into app group defaults.
- `dispatch(_ actions:)` now calls `dispatch(action)` for each item so batched actions get the same wrapping behavior as single actions.
- `updateStoreStatsWidgetStoreSnapshots(with:)` maps storage `Site` records plus the current `sessionManager.defaultSite` into lightweight `StoreStatsStoredSite` values, applies hidden-store filtering, keeps the selected/default site as the first snapshot through the factory, and saves the encoded snapshot list to shared defaults.
- `exposesStoreStatsWidgetStorePicker` gates snapshot exposure to WPCOM credentials. For non-WPCOM credentials, it intentionally saves an empty list so the follow-up picker has no selectable stores.
- `updateStoreStatsWidgetStoreSnapshotsAfterSiteListSynchronization` marshals the snapshot write and `WidgetCenter.shared.reloadAllTimelines()` to the main thread when needed, then calls the original action completion. This keeps WidgetKit refresh behavior tied to the snapshot update while preserving the existing action completion contract.

### What's not touched

- No Store parameter is exposed in Edit Widget yet. UI is handled here: https://github.com/woocommerce/woocommerce-ios/pull/17083
- No `AppEntity` / `EntityQuery` picker UI is added here.
- No selected-store timeline fetching, selected-store timezone use, or selected-store currency resolution is added here; that is handled by the stacked WOOMOB-2814 PR.
- The legacy Store Stats widget rendering path and lock-screen widgets are unchanged.

### Notes for reviewers

- This is the data-preparation PR for the WPCOM store picker stack. On non-WPCOM credentials, the snapshot list is intentionally saved empty so no stores are exposed to the future picker.

Tracking: WOOMOB-2815.

## Test Steps

1. Log in with a WPCOM account that has multiple active WooCommerce stores.
2. Trigger a site sync or switch the default store.
3. Verify the shared app group value for `configurableStoreStatsWidgetStores` contains active, non-hidden WooCommerce stores with the default store first.
4. Hide one store from the app's store list, sync again, and verify that store is no longer included in the saved snapshot list.
5. Log in with non-WPCOM credentials and verify the saved snapshot list is empty.

## Screenshots

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.