### PR TITLE
Include system status report in direct ticket creation from AI chat

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -103,6 +103,10 @@ final class ConnectivityToolViewModel {
     ///
     private var activeSystemPlugins: [SystemPlugin] = []
 
+    /// Formatted system status report, cached after the site connectivity test.
+    ///
+    private(set) var formattedSystemStatusReport: String?
+
     /// Whether Jetpack is among the active plugins from the system status report.
     /// Populated after the site connectivity test. Internal for testability.
     ///
@@ -227,6 +231,7 @@ final class ConnectivityToolViewModel {
         return SupportChatViewModel(
             entryPoint: .connectivityTool,
             initialContext: context,
+            systemStatusReport: formattedSystemStatusReport,
             onContactHumanSupport: onContactHumanSupport
         )
     }
@@ -326,6 +331,7 @@ final class ConnectivityToolViewModel {
                 case .success(let report):
                     DDLogInfo("Connectivity Tool: ✅ Site connection")
                     self.activeSystemPlugins = report.activePlugins
+                    self.formattedSystemStatusReport = SystemStatusReportViewModel.formatReport(with: report)
                 case .failure(let error):
                     DDLogError("Connectivity Tool: ❌ Site connection\n\(error)")
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -22,7 +22,7 @@ class SupportFormMetadataProvider {
 
     /// ViewModel to fetch and access the SSR report.
     ///
-    private let systemStatusReportViewModel: SystemStatusReportViewModel?
+    private let systemStatusReportViewModel: SystemStatusReportViewModel
 
     /// Pre-fetched system status report string, if available.
     ///
@@ -41,10 +41,9 @@ class SupportFormMetadataProvider {
         self.connectivityObserver = connectivityObserver
         self.pluginResultsController = Self.createPluginResultsController(sessionManager: sessionManager, storageManager: storageManager)
         self.prefetchedSystemStatusReport = systemStatusReport
-        if systemStatusReport != nil {
-            self.systemStatusReportViewModel = nil
-        } else {
-            self.systemStatusReportViewModel = Self.createSSRViewModel(sessionManager: sessionManager)
+        self.systemStatusReportViewModel = Self.createSSRViewModel(sessionManager: sessionManager)
+        if systemStatusReport == nil {
+            systemStatusReportViewModel.fetchReport()
         }
     }
 
@@ -79,7 +78,7 @@ class SupportFormMetadataProvider {
             ZendeskFieldsIDs.appVersion: Bundle.main.version,
             ZendeskFieldsIDs.deviceFreeSpace: getDeviceFreeSpace(),
             ZendeskFieldsIDs.logs: getLogFile(),
-            ZendeskFieldsIDs.legacyLogs: prefetchedSystemStatusReport ?? systemStatusReportViewModel?.statusReport ?? "",
+            ZendeskFieldsIDs.legacyLogs: prefetchedSystemStatusReport ?? systemStatusReportViewModel.statusReport,
             ZendeskFieldsIDs.currentSite: getCurrentSiteDescription(),
             ZendeskFieldsIDs.sourcePlatform: Constants.sourcePlatform,
             ZendeskFieldsIDs.appLanguage: Locale.preferredLanguage,
@@ -120,7 +119,6 @@ private extension SupportFormMetadataProvider {
     ///
     private static func createSSRViewModel(sessionManager: SessionManagerProtocol) -> SystemStatusReportViewModel {
         let viewModel = SystemStatusReportViewModel(siteID: sessionManager.defaultSite?.siteID ?? 0)
-        viewModel.fetchReport()
         return viewModel
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormMetadataProvider.swift
@@ -22,20 +22,30 @@ class SupportFormMetadataProvider {
 
     /// ViewModel to fetch and access the SSR report.
     ///
-    private let systemStatusReportViewModel: SystemStatusReportViewModel
+    private let systemStatusReportViewModel: SystemStatusReportViewModel?
+
+    /// Pre-fetched system status report string, if available.
+    ///
+    private let prefetchedSystemStatusReport: String?
 
     internal init(applicationLogProvider: ApplicationLogProvider = ServiceLocator.applicationLogProvider,
                   stores: StoresManager = ServiceLocator.stores,
                   sessionManager: SessionManagerProtocol = ServiceLocator.stores.sessionManager,
                   storageManager: StorageManagerType = ServiceLocator.storageManager,
-                  connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver) {
+                  connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
+                  systemStatusReport: String? = nil) {
         self.applicationLogProvider = applicationLogProvider
         self.stores = stores
         self.sessionManager = sessionManager
         self.storageManager = storageManager
         self.connectivityObserver = connectivityObserver
         self.pluginResultsController = Self.createPluginResultsController(sessionManager: sessionManager, storageManager: storageManager)
-        self.systemStatusReportViewModel = Self.createSSRViewModel(sessionManager: sessionManager)
+        self.prefetchedSystemStatusReport = systemStatusReport
+        if systemStatusReport != nil {
+            self.systemStatusReportViewModel = nil
+        } else {
+            self.systemStatusReportViewModel = Self.createSSRViewModel(sessionManager: sessionManager)
+        }
     }
 
     /// Common system & site  tags. Used in Zendesk Forms.
@@ -69,7 +79,7 @@ class SupportFormMetadataProvider {
             ZendeskFieldsIDs.appVersion: Bundle.main.version,
             ZendeskFieldsIDs.deviceFreeSpace: getDeviceFreeSpace(),
             ZendeskFieldsIDs.logs: getLogFile(),
-            ZendeskFieldsIDs.legacyLogs: systemStatusReportViewModel.statusReport,
+            ZendeskFieldsIDs.legacyLogs: prefetchedSystemStatusReport ?? systemStatusReportViewModel?.statusReport ?? "",
             ZendeskFieldsIDs.currentSite: getCurrentSiteDescription(),
             ZendeskFieldsIDs.sourcePlatform: Constants.sourcePlatform,
             ZendeskFieldsIDs.appLanguage: Locale.preferredLanguage,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel+AreaMapping.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel+AreaMapping.swift
@@ -4,8 +4,11 @@ import Foundation
 extension SupportFormViewModel {
     /// Maps API support area type to the corresponding form area.
     ///
-    static func area(for supportAreaType: SupportAreaType) -> Area {
-        let metadataProvider = SupportFormMetadataProvider()
+    /// - Parameters:
+    ///   - supportAreaType: The type of support area.
+    ///   - systemStatusReport: Optional pre-fetched system status report string.
+    static func area(for supportAreaType: SupportAreaType, systemStatusReport: String? = nil) -> Area {
+        let metadataProvider = SupportFormMetadataProvider(systemStatusReport: systemStatusReport)
         switch supportAreaType {
         case .mobileApp:
             return .init(title: Localization.mobileApp, datasource: MobileAppSupportDataSource(metadataProvider: metadataProvider))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
@@ -31,7 +31,7 @@ final class SystemStatusReportViewModel: ObservableObject {
             guard let self else { return }
             switch result {
             case .success(let status):
-                self.statusReport = self.formatReport(with: status)
+                self.statusReport = Self.formatReport(with: status)
             case .failure:
                 self.errorFetchingReport = true
             }
@@ -40,11 +40,11 @@ final class SystemStatusReportViewModel: ObservableObject {
     }
 }
 
-private extension SystemStatusReportViewModel {
+extension SystemStatusReportViewModel {
     /// Format system status to match with Core's report.
     /// Not localizing content and keep English by default.
     ///
-    func formatReport(with systemStatus: SystemStatusReport) -> String {
+    static func formatReport(with systemStatus: SystemStatusReport) -> String {
         var lines = ["### System Status Report generated via the WooCommerce iOS app ###"]
 
         // Environment

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportAreaInfo.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportAreaInfo.swift
@@ -15,7 +15,22 @@ struct SupportAreaInfo {
     /// Full chat transcript.
     let transcript: String
 
+    /// Pre-fetched system status report, if available.
+    let systemStatusReport: String?
+
     var isHighConfidence: Bool {
         confidence == .high
+    }
+
+    init(areaType: SupportAreaType,
+         area: SupportFormViewModel.Area,
+         confidence: SupportAreaConfidence,
+         transcript: String,
+         systemStatusReport: String? = nil) {
+        self.areaType = areaType
+        self.area = area
+        self.confidence = confidence
+        self.transcript = transcript
+        self.systemStatusReport = systemStatusReport
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -164,6 +164,10 @@ final class SupportChatViewModel {
     var onStartJetpackSetup: () -> Void
     private let diagnosticsService: SupportDiagnosticsService
 
+    /// Pre-fetched system status report, if available (e.g., from connectivity tool).
+    ///
+    private let prefetchedSystemStatusReport: String?
+
     // MARK: - Initialization
 
     init(botSlug: String = "woo-workflow-support_mobile_inapp_all_users",
@@ -173,6 +177,7 @@ final class SupportChatViewModel {
          diagnosticsService: SupportDiagnosticsService? = nil,
          chatID: Int64? = nil,
          hasCreatedTicket: Bool = false,
+         systemStatusReport: String? = nil,
          onContactHumanSupport: @escaping (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void,
          onStartJetpackSetup: @escaping () -> Void = {}) {
         self.botSlug = botSlug
@@ -183,6 +188,7 @@ final class SupportChatViewModel {
         self.chatID = chatID
         self.isResumedChat = chatID != nil
         self.hasCreatedTicket = hasCreatedTicket
+        self.prefetchedSystemStatusReport = systemStatusReport
         self.onContactHumanSupport = onContactHumanSupport
         self.onStartJetpackSetup = onStartJetpackSetup
     }
@@ -557,14 +563,16 @@ final class SupportChatViewModel {
     func contactHumanSupport() {
         let transcript = generateTranscript()
         let supportAreaInfo: SupportAreaInfo?
+        let systemStatusReport = prefetchedSystemStatusReport ?? diagnosticsService.formattedSystemStatusReport
 
         if let supportArea = latestSupportArea {
-            let mappedArea = SupportFormViewModel.area(for: supportArea.area)
+            let mappedArea = SupportFormViewModel.area(for: supportArea.area, systemStatusReport: systemStatusReport)
             supportAreaInfo = SupportAreaInfo(
                 areaType: supportArea.area,
                 area: mappedArea,
                 confidence: supportArea.confidence,
-                transcript: transcript
+                transcript: transcript,
+                systemStatusReport: systemStatusReport
             )
         } else {
             supportAreaInfo = nil

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -165,6 +165,10 @@ final class SupportDiagnosticsService {
     ///
     private(set) var activeSystemPlugins: [SystemPlugin] = []
 
+    /// Formatted system status report, cached after site test.
+    ///
+    private(set) var formattedSystemStatusReport: String?
+
     private var isJetpackPluginActive: Bool {
         activeSystemPlugins.contains { $0.plugin.hasPrefix("jetpack/") }
     }
@@ -281,6 +285,7 @@ final class SupportDiagnosticsService {
                 case .success(let report):
                     DDLogInfo("SupportDiagnostics: ✅ Site connection")
                     self.activeSystemPlugins = report.activePlugins
+                    self.formattedSystemStatusReport = SystemStatusReportViewModel.formatReport(with: report)
                     continuation.resume(returning: nil)
                 case .failure(let error):
                     DDLogError("SupportDiagnostics: ❌ Site connection\n\(error)")

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormMetadataProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormMetadataProviderTests.swift
@@ -83,4 +83,26 @@ struct SupportFormMetadataProviderTests {
         // Then
         #expect(!tags.contains("commerce_in_a_box"))
     }
+
+    // MARK: - Pre-fetched System Status Report
+
+    @Test
+    func systemFields_when_prefetched_report_provided_then_uses_prefetched_report() {
+        // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let prefetchedReport = "### Pre-fetched System Status Report ###"
+        let provider = SupportFormMetadataProvider(
+            stores: stores,
+            sessionManager: sessionManager,
+            systemStatusReport: prefetchedReport
+        )
+
+        // When
+        let fields = provider.systemFields()
+
+        // Then
+        let legacyLogsFieldID: Int64 = 22871957
+        #expect(fields[legacyLogsFieldID] == prefetchedReport)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -559,6 +559,64 @@ struct SupportChatViewModelTests {
         #expect(receivedChatID == chatID)
     }
 
+    @Test func test_contactHumanSupport_when_prefetched_systemStatusReport_then_passes_it_in_supportAreaInfo() async {
+        // Given
+        let prefetchedReport = "### Pre-fetched System Status Report ###"
+        var receivedSupportAreaInfo: SupportAreaInfo?
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: "Hello", context: nil),
+                        SupportChatMessage(
+                            messageID: 2,
+                            role: .bot,
+                            content: "Please contact support.",
+                            context: SupportChatMessageContext(
+                                sources: [],
+                                flags: SupportChatFlags(
+                                    forwardToHumanSupport: true,
+                                    cannedResponse: false,
+                                    loggedIn: true,
+                                    branch: nil
+                                ),
+                                supportArea: SupportChatSupportArea(area: .mobileApp, confidence: .high)
+                            )
+                        )
+                    ]
+                )
+                completion(.success(response))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            systemStatusReport: prefetchedReport,
+            onContactHumanSupport: { _, _, supportAreaInfo in
+                receivedSupportAreaInfo = supportAreaInfo
+            }
+        )
+
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // When
+        sut.contactHumanSupport()
+
+        // Then
+        #expect(receivedSupportAreaInfo?.systemStatusReport == prefetchedReport)
+    }
+
     // MARK: - Test Helpers
 
     private func makeSUT(


### PR DESCRIPTION
Closes: WOOMOB-3023

## Description

When users escalate from AI chat to human support with high confidence area detection, tickets are created directly without showing the support form. Previously, these direct tickets were missing the system status report (SSR) that would normally be included when going through the form.

This PR ensures the SSR is included in direct ticket creation by:

1. **Caching the SSR during diagnostics**: When `SupportDiagnosticsService` or `ConnectivityToolViewModel` fetches the system status report during connectivity checks, it now stores the formatted report.

2. **Passing the SSR through the escalation flow**: The pre-fetched report flows from the chat view model → support area info → escalation coordinator → Zendesk ticket custom fields.

3. **Supporting pre-fetched reports in metadata provider**: `SupportFormMetadataProvider` now accepts an optional pre-fetched SSR, avoiding async fetch timing issues.

## Test Steps

1. Open the app and go to Help & Support
2. Start an AI support chat
3. Select an issue type that triggers diagnostics (e.g., "Orders not loading")
4. Wait for diagnostics to complete
5. Send a message that triggers escalation with high confidence
6. Verify the ticket is created directly (alert shows "Request Sent!")
7. Check the Zendesk ticket has the system status report in the "Logs" field

Alternative flow from Connectivity Tool:
1. Go to Settings → Help → Troubleshoot Connection
2. Wait for connectivity tests to complete
3. Tap "Chat with Support"
4. Send a message and escalate
5. Verify the ticket includes the SSR from the connectivity check

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.