### PR TITLE
Extract error code logic into reusable Error extension

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -243,37 +243,10 @@ private extension Analytics {
         guard let error else {
             return nil
         }
-
-        let nsError = error as NSError
-        let errorCode: String = {
-            if let networkError = error as? NetworkError, let code = networkError.responseCode {
-                return code.description
-            } else if let afError = error as? AFError {
-                if let responseCode = afError.responseCode {
-                    return responseCode.description
-                } else if let underlyingError = afError.underlyingError as? NSError {
-                    return underlyingError.code.description
-                }
-            } else if let loginError = error as? SiteCredentialLoginError {
-                return loginError.underlyingError.code.description
-            }
-            return nsError.code.description
-        }()
-
-        let errorDomain: String = {
-            if let networkError = error as? AFError,
-               let underlyingError = networkError.underlyingError as? NSError {
-                return underlyingError.domain
-            }
-            return nsError.domain
-        }()
-
-        let errorDescription = nsError.description
-
         return [
-            Constants.errorKeyCode: errorCode,
-            Constants.errorKeyDomain: errorDomain,
-            Constants.errorKeyDescription: errorDescription
+            Constants.errorKeyCode: error.errorCode.description,
+            Constants.errorKeyDomain: error.errorDomain,
+            Constants.errorKeyDescription: (error as NSError).description
         ]
     }
 }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -455,21 +455,3 @@ extension JetpackSetupViewModel {
         static let accountConnectionURL = "https://jetpack.wordpress.com/jetpack.authorize"
     }
 }
-
-fileprivate extension Error {
-    var errorCode: Int? {
-        if let error = self as? NetworkError, let code = error.responseCode {
-            return code
-        } else if let error = self as? AFError, let code = error.responseCode {
-            return code
-        } else if case let .unknown(_, _, data) = self as? DotcomError {
-            if let status = data?["status"]?.description {
-                return Int(status)
-            } else {
-                return (self as NSError).code
-            }
-        } else {
-            return (self as NSError).code
-        }
-    }
-}

--- a/WooCommerce/Classes/Extensions/Error+ErrorCode.swift
+++ b/WooCommerce/Classes/Extensions/Error+ErrorCode.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Alamofire
+import enum Networking.NetworkError
+import enum Networking.DotcomError
+
+extension Error {
+    /// Extracts the most relevant error code from the error hierarchy.
+    /// Handles NetworkError, AFError, DotcomError, SiteCredentialLoginError, and falls back to NSError.code.
+    var errorCode: Int {
+        if let networkError = self as? NetworkError, let code = networkError.responseCode {
+            return code
+        } else if let afError = self as? AFError {
+            if let responseCode = afError.responseCode {
+                return responseCode
+            } else if let underlyingError = afError.underlyingError as? NSError {
+                return underlyingError.code
+            }
+        } else if case let .unknown(_, _, data) = self as? DotcomError,
+                  let status = data?["status"]?.description,
+                  let statusCode = Int(status) {
+            return statusCode
+        } else if let loginError = self as? SiteCredentialLoginError {
+            return loginError.underlyingError.code
+        }
+        return (self as NSError).code
+    }
+
+    /// Extracts the error domain, handling AFError's underlying error.
+    var errorDomain: String {
+        if let afError = self as? AFError,
+           let underlyingError = afError.underlyingError as? NSError {
+            return underlyingError.domain
+        }
+        return (self as NSError).domain
+    }
+
+    /// Formatted technical details string including error code and domain.
+    var formattedTechnicalDetails: String {
+        "Error Code: \(errorCode.description), Domain: \(errorDomain)\n\(self)"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -394,7 +394,7 @@ final class ConnectivityToolViewModel {
                     }
                 case .failure(let error):
                     DDLogError("Connectivity Tool: ❌ Analytics setting check failed\n\(error)")
-                    let technicalDetails = String(describing: error)
+                    let technicalDetails = error.formattedTechnicalDetails
                     let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
                         title: Localization.Action.viewDetails,
                         systemImage: SystemImages.viewDetails.rawValue,
@@ -502,7 +502,7 @@ final class ConnectivityToolViewModel {
 
         case (let error, _):
             message = Localization.ErrorMessage.generic
-            let technicalDetails = String(describing: error)
+            let technicalDetails = error.formattedTechnicalDetails
             let viewDetailsTitle = Localization.Action.viewDetails
             let viewDetailsAction = ConnectivityToolCard.ConnectivityState.Action(
                 title: viewDetailsTitle,

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -271,7 +271,7 @@ final class SupportDiagnosticsService {
                 case .failure(let error):
                     DDLogError("SupportDiagnostics: ❌ WPCom connection\n\(error)")
                     continuation.resume(returning: Failure(errorMessage: Localization.Error.wpcomConnection,
-                                                           technicalDetails: String(describing: error)))
+                                                           technicalDetails: error.formattedTechnicalDetails))
                 }
             }
         }
@@ -290,7 +290,7 @@ final class SupportDiagnosticsService {
                 case .failure(let error):
                     DDLogError("SupportDiagnostics: ❌ Site connection\n\(error)")
                     continuation.resume(returning: Failure(errorMessage: self.errorMessage(for: error),
-                                                           technicalDetails: String(describing: error)))
+                                                           technicalDetails: error.formattedTechnicalDetails))
                 }
             }
         }
@@ -303,7 +303,7 @@ final class SupportDiagnosticsService {
             return nil
         } catch {
             DDLogError("SupportDiagnostics: ❌ Site Orders\n\(error)")
-            return Failure(errorMessage: errorMessage(for: error), technicalDetails: String(describing: error))
+            return Failure(errorMessage: errorMessage(for: error), technicalDetails: error.formattedTechnicalDetails)
         }
     }
 
@@ -314,7 +314,7 @@ final class SupportDiagnosticsService {
             return nil
         } catch {
             DDLogError("SupportDiagnostics: ❌ Loading products\n\(error)")
-            return Failure(errorMessage: errorMessage(for: error), technicalDetails: String(describing: error))
+            return Failure(errorMessage: errorMessage(for: error), technicalDetails: error.formattedTechnicalDetails)
         }
     }
 
@@ -334,7 +334,7 @@ final class SupportDiagnosticsService {
                 case .failure(let error):
                     DDLogError("SupportDiagnostics: ❌ Analytics check failed\n\(error)")
                     continuation.resume(returning: Failure(errorMessage: Localization.Error.analyticsCheckFailed,
-                                                           technicalDetails: String(describing: error)))
+                                                           technicalDetails: error.formattedTechnicalDetails))
                 }
             }
             stores.dispatch(action)
@@ -379,7 +379,7 @@ final class SupportDiagnosticsService {
                                suggestedAction: .enableOrderNotifications(settings: settings))
             case .requestFailed(let error):
                 return Failure(errorMessage: Localization.Error.notificationConfigCheckFailed,
-                               technicalDetails: String(describing: error))
+                               technicalDetails: error.formattedTechnicalDetails)
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Extensions/Error+ErrorCodeTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Error+ErrorCodeTests.swift
@@ -1,0 +1,84 @@
+import Testing
+import Alamofire
+import Foundation
+@testable import Networking
+@testable import WooCommerce
+
+struct ErrorErrorCodeTests {
+
+    // MARK: - errorCode Tests
+
+    @Test func errorCode_when_NetworkError_with_responseCode_then_returns_responseCode() {
+        // Given
+        let error: Error = NetworkError.unacceptableStatusCode(statusCode: 401, response: nil)
+
+        // Then
+        #expect(error.errorCode == 401)
+    }
+
+    @Test func errorCode_when_DotcomError_with_status_in_data_then_returns_status() {
+        // Given
+        let error: Error = DotcomError.unknown(code: "error", message: "message", data: ["status": AnyDecodable(403)])
+
+        // Then
+        #expect(error.errorCode == 403)
+    }
+
+    @Test func errorCode_when_AFError_with_responseCode_then_returns_responseCode() {
+        // Given
+        let error: Error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403))
+
+        // Then
+        #expect(error.errorCode == 403)
+    }
+
+    @Test func errorCode_when_AFError_with_underlyingError_then_returns_underlyingErrorCode() {
+        // Given
+        let underlyingError = NSError(domain: "TestDomain", code: 500)
+        let error: Error = AFError.sessionTaskFailed(error: underlyingError)
+
+        // Then
+        #expect(error.errorCode == 500)
+    }
+
+    @Test func errorCode_when_plain_NSError_then_returns_NSError_code() {
+        // Given
+        let error: Error = NSError(domain: "TestDomain", code: 123)
+
+        // Then
+        #expect(error.errorCode == 123)
+    }
+
+    // MARK: - errorDomain Tests
+
+    @Test func errorDomain_when_AFError_with_underlyingError_then_returns_underlyingErrorDomain() {
+        // Given
+        let underlyingError = NSError(domain: "UnderlyingDomain", code: 500)
+        let error: Error = AFError.sessionTaskFailed(error: underlyingError)
+
+        // Then
+        #expect(error.errorDomain == "UnderlyingDomain")
+    }
+
+    @Test func errorDomain_when_plain_NSError_then_returns_NSError_domain() {
+        // Given
+        let error: Error = NSError(domain: "TestDomain", code: 123)
+
+        // Then
+        #expect(error.errorDomain == "TestDomain")
+    }
+
+    // MARK: - formattedTechnicalDetails Tests
+
+    @Test func formattedTechnicalDetails_includes_errorCode_and_domain() {
+        // Given
+        let error: Error = NSError(domain: "TestDomain", code: 404)
+
+        // When
+        let details = error.formattedTechnicalDetails
+
+        // Then
+        #expect(details.contains("Error Code: 404"))
+        #expect(details.contains("Domain: TestDomain"))
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/Error+ErrorCodeTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/Error+ErrorCodeTests.swift
@@ -81,4 +81,39 @@ struct ErrorErrorCodeTests {
         #expect(details.contains("Error Code: 404"))
         #expect(details.contains("Domain: TestDomain"))
     }
+
+    // MARK: - SiteCredentialLoginError Tests
+
+    @Test func errorCode_when_SiteCredentialLoginError_invalidCredentials_then_returns_401() {
+        // Given
+        let error: Error = SiteCredentialLoginError.invalidCredentials
+
+        // Then
+        #expect(error.errorCode == 401)
+    }
+
+    @Test func errorCode_when_SiteCredentialLoginError_inaccessibleLoginPage_then_returns_404() {
+        // Given
+        let error: Error = SiteCredentialLoginError.inaccessibleLoginPage
+
+        // Then
+        #expect(error.errorCode == 404)
+    }
+
+    @Test func errorCode_when_SiteCredentialLoginError_unacceptableStatusCode_then_returns_code() {
+        // Given
+        let error: Error = SiteCredentialLoginError.unacceptableStatusCode(code: 500)
+
+        // Then
+        #expect(error.errorCode == 500)
+    }
+
+    @Test func errorCode_when_SiteCredentialLoginError_genericFailure_then_returns_underlyingErrorCode() {
+        // Given
+        let underlyingError = NSError(domain: "TestDomain", code: 503)
+        let error: Error = SiteCredentialLoginError.genericFailure(underlyingError: underlyingError)
+
+        // Then
+        #expect(error.errorCode == 503)
+    }
 }


### PR DESCRIPTION
## Description

Extracts the error code extraction logic from `WooAnalytics.errorProperties` and `JetpackSetupViewModel` into a reusable `Error` extension. This allows diagnostics services to include structured error codes in technical details.

### Changes:
- **New**: `Error+ErrorCode.swift` - Extension with `errorCode`, `errorDomain`, and `formattedTechnicalDetails` properties
- **Refactored**: `WooAnalytics.errorProperties` to use the new extension
- **Removed**: Duplicate `errorCode` extension from `JetpackSetupViewModel`
- **Updated**: `SupportDiagnosticsService` and `ConnectivityToolViewModel` to use `formattedTechnicalDetails` instead of `String(describing: error)`

The extension handles:
- `NetworkError.responseCode` (HTTP status)
- `AFError.responseCode` and underlying errors
- `DotcomError.unknown` with status in data
- `SiteCredentialLoginError.underlyingError.code`
- Fallback to `NSError.code`

Technical details now show:
```
Error Code: 401, Domain: NSURLErrorDomain
<original error description>
```

## Test Steps

1. Trigger a diagnostic failure (e.g., install a conflicted plugin to your site or add a problematic code snippet).
2. Navigate to Menu > Troubleshoot Connection.
3. When a step fails (e.g. loading products),  observe the technical details shown when tapping "View Details".
4. Verify the error code and domain are displayed.
5. Tap Chat with support, send a message and confirm that the bot takes into account the error detail.

## Screenshots


https://github.com/user-attachments/assets/9544a84e-434a-4049-8ae5-1d4ab999d6e0



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.