### PR TITLE
Add feedback buttons for bot responses in support chat

### DIFF
--- a/Modules/Sources/Networking/Remote/SupportChatRemote.swift
+++ b/Modules/Sources/Networking/Remote/SupportChatRemote.swift
@@ -26,6 +26,16 @@ public protocol SupportChatRemoteProtocol {
     /// - Returns: The full thread in `ts`-ascending order.
     func fetchChat(botSlug: String,
                    chatID: Int64) async throws -> SupportChatResponse
+
+    /// Submits feedback for a specific bot message.
+    ///
+    /// - Parameters:
+    ///   - messageID: Identifier of the message to rate.
+    ///   - sessionID: Session identifier of the chat.
+    ///   - upvoted: `true` for positive feedback (thumbs up), `false` for negative (thumbs down).
+    func submitFeedback(messageID: Int64,
+                        sessionID: String,
+                        upvoted: Bool) async throws
 }
 
 /// Remote for the support chat endpoint (`/wpcom/v2/odie/chat/{bot_slug}`).
@@ -70,6 +80,22 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
         let mapper = SupportChatResponseMapper()
         return try await enqueue(request, mapper: mapper)
     }
+
+    public func submitFeedback(messageID: Int64,
+                               sessionID: String,
+                               upvoted: Bool) async throws {
+        let path = "\(Path.feedback)/\(sessionID)/rate"
+        let parameters: [String: Any] = [
+            ParameterKey.messageID: messageID,
+            ParameterKey.rating: upvoted ? "up" : "down"
+        ]
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
+                                    method: .post,
+                                    path: path,
+                                    parameters: parameters,
+                                    encoding: JSONEncoding.default)
+        _ = try await enqueue(request)
+    }
 }
 
 // MARK: - Constants
@@ -77,11 +103,14 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
 private extension SupportChatRemote {
     enum Path {
         static let chat = "odie/chat"
+        static let feedback = "ai/feedback"
     }
 
     enum ParameterKey {
         static let message = "message"
         static let context = "context"
         static let sessionID = "session_id"
+        static let messageID = "message_id"
+        static let rating = "rating"
     }
 }

--- a/Modules/Sources/Networking/Remote/SupportChatRemote.swift
+++ b/Modules/Sources/Networking/Remote/SupportChatRemote.swift
@@ -30,10 +30,14 @@ public protocol SupportChatRemoteProtocol {
     /// Submits feedback for a specific bot message.
     ///
     /// - Parameters:
+    ///   - botSlug: Assistant slug (e.g. `woo-chat-allusers`).
+    ///   - chatID: Identifier of the chat.
     ///   - messageID: Identifier of the message to rate.
     ///   - sessionID: Session identifier of the chat.
     ///   - upvoted: `true` for positive feedback (thumbs up), `false` for negative (thumbs down).
-    func submitFeedback(messageID: Int64,
+    func submitFeedback(botSlug: String,
+                        chatID: Int64,
+                        messageID: Int64,
                         sessionID: String,
                         upvoted: Bool) async throws
 }
@@ -81,13 +85,15 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
         return try await enqueue(request, mapper: mapper)
     }
 
-    public func submitFeedback(messageID: Int64,
+    public func submitFeedback(botSlug: String,
+                               chatID: Int64,
+                               messageID: Int64,
                                sessionID: String,
                                upvoted: Bool) async throws {
-        let path = "\(Path.feedback)/\(sessionID)/rate"
+        let path = "\(Path.chat)/\(botSlug)/\(chatID)/\(messageID)/feedback"
         let parameters: [String: Any] = [
-            ParameterKey.messageID: messageID,
-            ParameterKey.rating: upvoted ? "up" : "down"
+            ParameterKey.sessionID: sessionID,
+            ParameterKey.ratingValue: upvoted ? 1 : -1
         ]
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .post,
@@ -103,14 +109,12 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
 private extension SupportChatRemote {
     enum Path {
         static let chat = "odie/chat"
-        static let feedback = "ai/feedback"
     }
 
     enum ParameterKey {
         static let message = "message"
         static let context = "context"
         static let sessionID = "session_id"
-        static let messageID = "message_id"
-        static let rating = "rating"
+        static let ratingValue = "rating_value"
     }
 }

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1398,6 +1398,9 @@ public enum WooAnalyticsStat: String {
     case wooShippingPaymentStep = "wcs_payment_step"
     case wooShippingPurchaseStep = "wcs_purchase_step"
     case wooShippingRefundRequested = "wcs_refund_requested"
+
+    // MARK: Support Chat events
+    case supportChatFeedbackSubmitted = "support_chat_feedback_submitted"
 }
 
 extension WooAnalyticsStat {

--- a/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
@@ -83,4 +83,16 @@ public enum SupportChatAction: Action {
     ///   - onCompletion: Delivered on the main thread once the update is persisted.
     case markTicketCreated(chatID: Int64,
                            onCompletion: () -> Void)
+
+    /// Submits feedback for a specific bot message.
+    ///
+    /// - Parameters:
+    ///   - messageID: Identifier of the message to rate.
+    ///   - sessionID: Session identifier of the chat.
+    ///   - upvoted: `true` for positive feedback (thumbs up), `false` for negative (thumbs down).
+    ///   - onCompletion: Called when the feedback submission completes.
+    case submitFeedback(messageID: Int64,
+                        sessionID: String,
+                        upvoted: Bool,
+                        onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
@@ -87,11 +87,15 @@ public enum SupportChatAction: Action {
     /// Submits feedback for a specific bot message.
     ///
     /// - Parameters:
+    ///   - botSlug: Assistant slug (e.g. `woo-chat-allusers`).
+    ///   - chatID: Identifier of the chat.
     ///   - messageID: Identifier of the message to rate.
     ///   - sessionID: Session identifier of the chat.
     ///   - upvoted: `true` for positive feedback (thumbs up), `false` for negative (thumbs down).
     ///   - onCompletion: Called when the feedback submission completes.
-    case submitFeedback(messageID: Int64,
+    case submitFeedback(botSlug: String,
+                        chatID: Int64,
+                        messageID: Int64,
                         sessionID: String,
                         upvoted: Bool,
                         onCompletion: (Result<Void, Error>) -> Void)

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
@@ -24,7 +24,7 @@ struct MockSupportChatActionHandler: MockActionHandler {
             onCompletion()
         case let .markTicketCreated(_, onCompletion):
             onCompletion()
-        case let .submitFeedback(_, _, _, onCompletion):
+        case let .submitFeedback(_, _, _, _, _, onCompletion):
             onCompletion(.success(()))
         }
     }

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
@@ -24,6 +24,8 @@ struct MockSupportChatActionHandler: MockActionHandler {
             onCompletion()
         case let .markTicketCreated(_, onCompletion):
             onCompletion()
+        case let .submitFeedback(_, _, _, onCompletion):
+            onCompletion(.success(()))
         }
     }
 

--- a/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
@@ -52,6 +52,8 @@ public final class SupportChatStore: Store {
             deleteChat(chatID: chatID, onCompletion: onCompletion)
         case let .markTicketCreated(chatID, onCompletion):
             markTicketCreated(chatID: chatID, onCompletion: onCompletion)
+        case let .submitFeedback(messageID, sessionID, upvoted, onCompletion):
+            submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: upvoted, onCompletion: onCompletion)
         }
     }
 }
@@ -90,6 +92,28 @@ private extension SupportChatStore {
 
             await MainActor.run {
                 completion(result)
+            }
+        }
+    }
+
+    func submitFeedback(messageID: Int64,
+                        sessionID: String,
+                        upvoted: Bool,
+                        onCompletion: @escaping (Result<Void, Error>) -> Void) {
+        Task {
+            let result: Result<Void, Error> = await {
+                do {
+                    try await remote.submitFeedback(messageID: messageID,
+                                                    sessionID: sessionID,
+                                                    upvoted: upvoted)
+                    return .success(())
+                } catch {
+                    return .failure(error)
+                }
+            }()
+
+            await MainActor.run {
+                onCompletion(result)
             }
         }
     }

--- a/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
@@ -52,8 +52,8 @@ public final class SupportChatStore: Store {
             deleteChat(chatID: chatID, onCompletion: onCompletion)
         case let .markTicketCreated(chatID, onCompletion):
             markTicketCreated(chatID: chatID, onCompletion: onCompletion)
-        case let .submitFeedback(messageID, sessionID, upvoted, onCompletion):
-            submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: upvoted, onCompletion: onCompletion)
+        case let .submitFeedback(botSlug, chatID, messageID, sessionID, upvoted, onCompletion):
+            submitFeedback(botSlug: botSlug, chatID: chatID, messageID: messageID, sessionID: sessionID, upvoted: upvoted, onCompletion: onCompletion)
         }
     }
 }
@@ -96,14 +96,18 @@ private extension SupportChatStore {
         }
     }
 
-    func submitFeedback(messageID: Int64,
+    func submitFeedback(botSlug: String,
+                        chatID: Int64,
+                        messageID: Int64,
                         sessionID: String,
                         upvoted: Bool,
                         onCompletion: @escaping (Result<Void, Error>) -> Void) {
         Task {
             let result: Result<Void, Error> = await {
                 do {
-                    try await remote.submitFeedback(messageID: messageID,
+                    try await remote.submitFeedback(botSlug: botSlug,
+                                                    chatID: chatID,
+                                                    messageID: messageID,
                                                     sessionID: sessionID,
                                                     upvoted: upvoted)
                     return .success(())

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -362,4 +362,70 @@ struct SupportChatRemoteTests {
             try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
         }
     }
+
+    // MARK: - submitFeedback
+
+    @Test func submitFeedback_posts_to_correct_path() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let messageID: Int64 = 123
+        let sessionID = "session-abc-123"
+        network.simulateResponse(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+                                 filename: "generic_success")
+
+        // When
+        try await remote.submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: true)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? DotcomRequest)
+        #expect(request.path == "ai/feedback/\(sessionID)/rate")
+        #expect(request.method == .post)
+    }
+
+    @Test func submitFeedback_sends_messageID_and_up_rating_in_parameters() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let messageID: Int64 = 123
+        let sessionID = "session-abc-123"
+        network.simulateResponse(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+                                 filename: "generic_success")
+
+        // When
+        try await remote.submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: true)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters["message_id"] as? Int64 == messageID)
+        #expect(parameters["rating"] as? String == "up")
+        #expect(parameters["session_id"] == nil)
+    }
+
+    @Test func submitFeedback_sends_down_rating_in_parameters_when_downvoted() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let messageID: Int64 = 456
+        let sessionID = "session-xyz"
+        network.simulateResponse(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+                                 filename: "generic_success")
+
+        // When
+        try await remote.submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: false)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters["rating"] as? String == "down")
+    }
+
+    @Test func submitFeedback_when_network_errors_then_propagates_error() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let sessionID = "session-abc"
+        network.simulateError(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+                              error: NetworkError.timeout())
+
+        // When / Then
+        await #expect(throws: NetworkError.timeout()) {
+            try await remote.submitFeedback(messageID: 123, sessionID: sessionID, upvoted: true)
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -368,64 +368,72 @@ struct SupportChatRemoteTests {
     @Test func submitFeedback_posts_to_correct_path() async throws {
         // Given
         let remote = SupportChatRemote(network: network)
+        let botSlug = "woo-chat"
+        let chatID: Int64 = 999
         let messageID: Int64 = 123
         let sessionID = "session-abc-123"
-        network.simulateResponse(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)/\(messageID)/feedback",
                                  filename: "generic_success")
 
         // When
-        try await remote.submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: true)
+        try await remote.submitFeedback(botSlug: botSlug, chatID: chatID, messageID: messageID, sessionID: sessionID, upvoted: true)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? DotcomRequest)
-        #expect(request.path == "ai/feedback/\(sessionID)/rate")
+        #expect(request.path == "odie/chat/\(botSlug)/\(chatID)/\(messageID)/feedback")
         #expect(request.method == .post)
     }
 
-    @Test func submitFeedback_sends_messageID_and_up_rating_in_parameters() async throws {
+    @Test func submitFeedback_sends_sessionID_and_positive_ratingValue_in_parameters() async throws {
         // Given
         let remote = SupportChatRemote(network: network)
+        let botSlug = "woo-chat"
+        let chatID: Int64 = 999
         let messageID: Int64 = 123
         let sessionID = "session-abc-123"
-        network.simulateResponse(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)/\(messageID)/feedback",
                                  filename: "generic_success")
 
         // When
-        try await remote.submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: true)
+        try await remote.submitFeedback(botSlug: botSlug, chatID: chatID, messageID: messageID, sessionID: sessionID, upvoted: true)
 
         // Then
         let parameters = try #require(network.queryParametersDictionary)
-        #expect(parameters["message_id"] as? Int64 == messageID)
-        #expect(parameters["rating"] as? String == "up")
-        #expect(parameters["session_id"] == nil)
+        #expect(parameters["session_id"] as? String == sessionID)
+        #expect(parameters["rating_value"] as? Int == 1)
     }
 
-    @Test func submitFeedback_sends_down_rating_in_parameters_when_downvoted() async throws {
+    @Test func submitFeedback_sends_negative_ratingValue_in_parameters_when_downvoted() async throws {
         // Given
         let remote = SupportChatRemote(network: network)
+        let botSlug = "woo-chat"
+        let chatID: Int64 = 888
         let messageID: Int64 = 456
         let sessionID = "session-xyz"
-        network.simulateResponse(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)/\(messageID)/feedback",
                                  filename: "generic_success")
 
         // When
-        try await remote.submitFeedback(messageID: messageID, sessionID: sessionID, upvoted: false)
+        try await remote.submitFeedback(botSlug: botSlug, chatID: chatID, messageID: messageID, sessionID: sessionID, upvoted: false)
 
         // Then
         let parameters = try #require(network.queryParametersDictionary)
-        #expect(parameters["rating"] as? String == "down")
+        #expect(parameters["rating_value"] as? Int == -1)
     }
 
     @Test func submitFeedback_when_network_errors_then_propagates_error() async throws {
         // Given
         let remote = SupportChatRemote(network: network)
+        let botSlug = "woo-chat"
+        let chatID: Int64 = 999
+        let messageID: Int64 = 123
         let sessionID = "session-abc"
-        network.simulateError(requestUrlSuffix: "ai/feedback/\(sessionID)/rate",
+        network.simulateError(requestUrlSuffix: "odie/chat/\(botSlug)/\(chatID)/\(messageID)/feedback",
                               error: NetworkError.timeout())
 
         // When / Then
         await #expect(throws: NetworkError.timeout()) {
-            try await remote.submitFeedback(messageID: 123, sessionID: sessionID, upvoted: true)
+            try await remote.submitFeedback(botSlug: botSlug, chatID: chatID, messageID: messageID, sessionID: sessionID, upvoted: true)
         }
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
@@ -6,9 +6,11 @@ import Foundation
 final class MockSupportChatRemote: SupportChatRemoteProtocol {
     private var sendMessageResult: Result<SupportChatResponse, Error>?
     private var fetchChatResult: Result<SupportChatResponse, Error>?
+    private var submitFeedbackResult: Result<Void, Error> = .success(())
 
     private(set) var sendMessageInvocations: [(botSlug: String, message: String, chatID: Int64?)] = []
     private(set) var fetchChatInvocations: [(botSlug: String, chatID: Int64)] = []
+    private(set) var submitFeedbackInvocations: [(messageID: Int64, sessionID: String, upvoted: Bool)] = []
 
     func whenSendingMessage(thenReturn result: Result<SupportChatResponse, Error>) {
         sendMessageResult = result
@@ -16,6 +18,10 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
 
     func whenFetchingChat(thenReturn result: Result<SupportChatResponse, Error>) {
         fetchChatResult = result
+    }
+
+    func whenSubmittingFeedback(thenReturn result: Result<Void, Error>) {
+        submitFeedbackResult = result
     }
 
     func sendMessage(botSlug: String,
@@ -36,5 +42,10 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
             throw NetworkError.timeout()
         }
         return try result.get()
+    }
+
+    func submitFeedback(messageID: Int64, sessionID: String, upvoted: Bool) async throws {
+        submitFeedbackInvocations.append((messageID, sessionID, upvoted))
+        try submitFeedbackResult.get()
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
@@ -10,7 +10,7 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
 
     private(set) var sendMessageInvocations: [(botSlug: String, message: String, chatID: Int64?)] = []
     private(set) var fetchChatInvocations: [(botSlug: String, chatID: Int64)] = []
-    private(set) var submitFeedbackInvocations: [(messageID: Int64, sessionID: String, upvoted: Bool)] = []
+    private(set) var submitFeedbackInvocations: [(botSlug: String, chatID: Int64, messageID: Int64, sessionID: String, upvoted: Bool)] = []
 
     func whenSendingMessage(thenReturn result: Result<SupportChatResponse, Error>) {
         sendMessageResult = result
@@ -44,8 +44,8 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
         return try result.get()
     }
 
-    func submitFeedback(messageID: Int64, sessionID: String, upvoted: Bool) async throws {
-        submitFeedbackInvocations.append((messageID, sessionID, upvoted))
+    func submitFeedback(botSlug: String, chatID: Int64, messageID: Int64, sessionID: String, upvoted: Bool) async throws {
+        submitFeedbackInvocations.append((botSlug, chatID, messageID, sessionID, upvoted))
         try submitFeedbackResult.get()
     }
 }

--- a/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
@@ -365,7 +365,9 @@ struct SupportChatStoreTests {
 
         // When
         _ = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.submitFeedback(messageID: 123,
+            store.onAction(SupportChatAction.submitFeedback(botSlug: "woo-chat",
+                                                            chatID: 999,
+                                                            messageID: 123,
                                                             sessionID: "session-abc",
                                                             upvoted: true,
                                                             onCompletion: { result in
@@ -376,6 +378,8 @@ struct SupportChatStoreTests {
         // Then
         #expect(remote.submitFeedbackInvocations.count == 1)
         let invocation = try #require(remote.submitFeedbackInvocations.first)
+        #expect(invocation.botSlug == "woo-chat")
+        #expect(invocation.chatID == 999)
         #expect(invocation.messageID == 123)
         #expect(invocation.sessionID == "session-abc")
         #expect(invocation.upvoted == true)
@@ -388,7 +392,9 @@ struct SupportChatStoreTests {
 
         // When
         _ = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.submitFeedback(messageID: 456,
+            store.onAction(SupportChatAction.submitFeedback(botSlug: "woo-chat",
+                                                            chatID: 888,
+                                                            messageID: 456,
                                                             sessionID: "session-xyz",
                                                             upvoted: false,
                                                             onCompletion: { result in
@@ -408,7 +414,9 @@ struct SupportChatStoreTests {
 
         // When
         let result = await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.submitFeedback(messageID: 123,
+            store.onAction(SupportChatAction.submitFeedback(botSlug: "woo-chat",
+                                                            chatID: 999,
+                                                            messageID: 123,
                                                             sessionID: "session-abc",
                                                             upvoted: true,
                                                             onCompletion: { result in

--- a/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
@@ -355,6 +355,75 @@ struct SupportChatStoreTests {
             #expect(error is NetworkError)
         }
     }
+
+    // MARK: - submitFeedback
+
+    @Test func submitFeedback_forwards_to_remote_with_correct_parameters() async throws {
+        // Given
+        let store = makeStore()
+        remote.whenSubmittingFeedback(thenReturn: .success(()))
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.submitFeedback(messageID: 123,
+                                                            sessionID: "session-abc",
+                                                            upvoted: true,
+                                                            onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        #expect(remote.submitFeedbackInvocations.count == 1)
+        let invocation = try #require(remote.submitFeedbackInvocations.first)
+        #expect(invocation.messageID == 123)
+        #expect(invocation.sessionID == "session-abc")
+        #expect(invocation.upvoted == true)
+    }
+
+    @Test func submitFeedback_when_downvoted_then_forwards_false() async throws {
+        // Given
+        let store = makeStore()
+        remote.whenSubmittingFeedback(thenReturn: .success(()))
+
+        // When
+        _ = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.submitFeedback(messageID: 456,
+                                                            sessionID: "session-xyz",
+                                                            upvoted: false,
+                                                            onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        let invocation = try #require(remote.submitFeedbackInvocations.first)
+        #expect(invocation.upvoted == false)
+    }
+
+    @Test func submitFeedback_propagates_remote_errors() async {
+        // Given
+        let store = makeStore()
+        remote.whenSubmittingFeedback(thenReturn: .failure(NetworkError.timeout()))
+
+        // When
+        let result = await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.submitFeedback(messageID: 123,
+                                                            sessionID: "session-abc",
+                                                            upvoted: true,
+                                                            onCompletion: { result in
+                continuation.resume(returning: result)
+            }))
+        }
+
+        // Then
+        switch result {
+        case .success:
+            Issue.record("Expected submitFeedback to propagate a failure")
+        case .failure(let error):
+            #expect(error is NetworkError)
+        }
+    }
 }
 
 // MARK: - Test helper

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+SupportChat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+SupportChat.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum SupportChat {
+        private enum Key: String {
+            case rating
+        }
+
+        static func feedbackSubmitted(upvoted: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .supportChatFeedbackSubmitted,
+                              properties: [Key.rating.rawValue: upvoted ? "up" : "down"])
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatFeedbackRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatFeedbackRow.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct SupportChatFeedbackRow: View {
+    let messageID: Int64
+    let hasRated: Bool
+    let onRate: (Bool) -> Void
+
+    @State private var selectedUpvoted: Bool?
+
+    var body: some View {
+        HStack(spacing: SupportChatLayout.bubblePadding) {
+            if hasRated || selectedUpvoted != nil {
+                ratedState
+            } else {
+                unratedState
+            }
+            Spacer()
+        }
+        .padding(.leading, SupportChatLayout.bubblePadding)
+    }
+
+    private var unratedState: some View {
+        HStack(spacing: 12) {
+            Button {
+                submitRating(upvoted: true)
+            } label: {
+                Image(systemName: "hand.thumbsup")
+                    .foregroundColor(Color(.secondaryLabel))
+            }
+            .accessibilityLabel(Localization.rateHelpful)
+
+            Button {
+                submitRating(upvoted: false)
+            } label: {
+                Image(systemName: "hand.thumbsdown")
+                    .foregroundColor(Color(.secondaryLabel))
+            }
+            .accessibilityLabel(Localization.rateNotHelpful)
+        }
+        .font(.subheadline)
+    }
+
+    @ViewBuilder
+    private var ratedState: some View {
+        let upvoted = selectedUpvoted ?? true
+        HStack(spacing: 6) {
+            Image(systemName: upvoted ? "hand.thumbsup.fill" : "hand.thumbsdown.fill")
+                .foregroundColor(Color(.accent))
+            Text(upvoted ? Localization.helpful : Localization.notHelpful)
+                .font(.caption)
+                .foregroundColor(Color(.secondaryLabel))
+        }
+    }
+
+    private func submitRating(upvoted: Bool) {
+        selectedUpvoted = upvoted
+        onRate(upvoted)
+    }
+}
+
+private extension SupportChatFeedbackRow {
+    enum Localization {
+        static let rateHelpful = NSLocalizedString(
+            "supportChatFeedbackRow.rateHelpful",
+            value: "Rate helpful",
+            comment: "Accessibility label for thumbs up button to rate bot response as helpful"
+        )
+        static let rateNotHelpful = NSLocalizedString(
+            "supportChatFeedbackRow.rateNotHelpful",
+            value: "Rate not helpful",
+            comment: "Accessibility label for thumbs down button to rate bot response as not helpful"
+        )
+        static let helpful = NSLocalizedString(
+            "supportChatFeedbackRow.helpful",
+            value: "Helpful",
+            comment: "Message shown after user rates a bot response as helpful"
+        )
+        static let notHelpful = NSLocalizedString(
+            "supportChatFeedbackRow.notHelpful",
+            value: "Not helpful",
+            comment: "Message shown after user rates a bot response as not helpful"
+        )
+    }
+}
+
+#Preview("Unrated") {
+    SupportChatFeedbackRow(
+        messageID: 123,
+        hasRated: false,
+        onRate: { _ in }
+    )
+    .padding()
+}
+
+#Preview("Rated") {
+    SupportChatFeedbackRow(
+        messageID: 123,
+        hasRated: true,
+        onRate: { _ in }
+    )
+    .padding()
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatFeedbackRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatFeedbackRow.swift
@@ -19,7 +19,7 @@ struct SupportChatFeedbackRow: View {
     }
 
     private var unratedState: some View {
-        HStack(spacing: 12) {
+        HStack {
             Button {
                 onRate(true)
             } label: {
@@ -40,12 +40,13 @@ struct SupportChatFeedbackRow: View {
     }
 
     private func ratedState(upvoted: Bool) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: upvoted ? "hand.thumbsup.fill" : "hand.thumbsdown.fill")
-                .foregroundColor(Color(.accent))
+        Label {
             Text(upvoted ? Localization.helpful : Localization.notHelpful)
                 .font(.caption)
                 .foregroundColor(Color(.secondaryLabel))
+        } icon: {
+            Image(systemName: upvoted ? "hand.thumbsup.fill" : "hand.thumbsdown.fill")
+                .foregroundColor(Color(.accent))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatFeedbackRow.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatFeedbackRow.swift
@@ -2,15 +2,14 @@ import SwiftUI
 
 struct SupportChatFeedbackRow: View {
     let messageID: Int64
-    let hasRated: Bool
+    /// The rating direction if the message has been rated (true = upvoted, false = downvoted), or nil if unrated.
+    let rating: Bool?
     let onRate: (Bool) -> Void
-
-    @State private var selectedUpvoted: Bool?
 
     var body: some View {
         HStack(spacing: SupportChatLayout.bubblePadding) {
-            if hasRated || selectedUpvoted != nil {
-                ratedState
+            if let rating {
+                ratedState(upvoted: rating)
             } else {
                 unratedState
             }
@@ -22,7 +21,7 @@ struct SupportChatFeedbackRow: View {
     private var unratedState: some View {
         HStack(spacing: 12) {
             Button {
-                submitRating(upvoted: true)
+                onRate(true)
             } label: {
                 Image(systemName: "hand.thumbsup")
                     .foregroundColor(Color(.secondaryLabel))
@@ -30,7 +29,7 @@ struct SupportChatFeedbackRow: View {
             .accessibilityLabel(Localization.rateHelpful)
 
             Button {
-                submitRating(upvoted: false)
+                onRate(false)
             } label: {
                 Image(systemName: "hand.thumbsdown")
                     .foregroundColor(Color(.secondaryLabel))
@@ -40,9 +39,7 @@ struct SupportChatFeedbackRow: View {
         .font(.subheadline)
     }
 
-    @ViewBuilder
-    private var ratedState: some View {
-        let upvoted = selectedUpvoted ?? true
+    private func ratedState(upvoted: Bool) -> some View {
         HStack(spacing: 6) {
             Image(systemName: upvoted ? "hand.thumbsup.fill" : "hand.thumbsdown.fill")
                 .foregroundColor(Color(.accent))
@@ -50,11 +47,6 @@ struct SupportChatFeedbackRow: View {
                 .font(.caption)
                 .foregroundColor(Color(.secondaryLabel))
         }
-    }
-
-    private func submitRating(upvoted: Bool) {
-        selectedUpvoted = upvoted
-        onRate(upvoted)
     }
 }
 
@@ -86,16 +78,25 @@ private extension SupportChatFeedbackRow {
 #Preview("Unrated") {
     SupportChatFeedbackRow(
         messageID: 123,
-        hasRated: false,
+        rating: nil,
         onRate: { _ in }
     )
     .padding()
 }
 
-#Preview("Rated") {
+#Preview("Rated Helpful") {
     SupportChatFeedbackRow(
         messageID: 123,
-        hasRated: true,
+        rating: true,
+        onRate: { _ in }
+    )
+    .padding()
+}
+
+#Preview("Rated Not Helpful") {
+    SupportChatFeedbackRow(
+        messageID: 123,
+        rating: false,
         onRate: { _ in }
     )
     .padding()

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -96,7 +96,19 @@ struct SupportChatView: View {
     private func messageRow(for message: SupportChatViewModel.ChatMessage) -> some View {
         switch message.content {
         case .text(let text):
-            SupportChatMessageRow(role: message.role, text: text, failed: message.failed)
+            VStack(alignment: .leading, spacing: 4) {
+                SupportChatMessageRow(role: message.role, text: text, failed: message.failed)
+
+                if message.role == .bot, message.isNewInSession, let messageID = message.messageID {
+                    SupportChatFeedbackRow(
+                        messageID: messageID,
+                        hasRated: viewModel.ratedMessageIDs.contains(messageID),
+                        onRate: { upvoted in
+                            viewModel.submitFeedback(messageID: messageID, upvoted: upvoted)
+                        }
+                    )
+                }
+            }
 
         case .issuePicker(let issues):
             issuePickerBubble(issues: issues)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -102,7 +102,7 @@ struct SupportChatView: View {
                 if message.role == .bot, message.isNewInSession, let messageID = message.messageID {
                     SupportChatFeedbackRow(
                         messageID: messageID,
-                        hasRated: viewModel.ratedMessageIDs.contains(messageID),
+                        rating: viewModel.messageRatings[messageID],
                         onRate: { upvoted in
                             viewModel.submitFeedback(messageID: messageID, upvoted: upvoted)
                         }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -766,7 +766,7 @@ final class SupportChatViewModel {
     /// Marks the message as rated immediately (optimistic UI).
     /// API failures are logged but do not affect the UI since feedback is low-stakes.
     func submitFeedback(messageID: Int64, upvoted: Bool) {
-        guard let sessionID else { return }
+        guard let chatID, let sessionID else { return }
         guard !ratedMessageIDs.contains(messageID) else { return }
 
         ratedMessageIDs.insert(messageID)
@@ -774,6 +774,8 @@ final class SupportChatViewModel {
         analytics.track(event: WooAnalyticsEvent.SupportChat.feedbackSubmitted(upvoted: upvoted))
 
         let action = SupportChatAction.submitFeedback(
+            botSlug: botSlug,
+            chatID: chatID,
             messageID: messageID,
             sessionID: sessionID,
             upvoted: upvoted

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -88,17 +88,26 @@ final class SupportChatViewModel {
         let timestamp: Date
         /// `true` when sending this message failed. Drives the failed-bubble visual indicator.
         let failed: Bool
+        /// Server-assigned message ID for bot messages (used for feedback submission).
+        let messageID: Int64?
+        /// `true` for messages received during the current session (not rehydrated from history).
+        /// Feedback buttons are only shown for new messages.
+        let isNewInSession: Bool
 
         init(id: UUID = UUID(),
              role: SupportChatRole,
              content: MessageContent,
              timestamp: Date = Date(),
-             failed: Bool = false) {
+             failed: Bool = false,
+             messageID: Int64? = nil,
+             isNewInSession: Bool = true) {
             self.id = id
             self.role = role
             self.content = content
             self.timestamp = timestamp
             self.failed = failed
+            self.messageID = messageID
+            self.isNewInSession = isNewInSession
         }
 
         /// Convenience initializer for text messages.
@@ -106,12 +115,16 @@ final class SupportChatViewModel {
              role: SupportChatRole,
              text: String,
              timestamp: Date = Date(),
-             failed: Bool = false) {
+             failed: Bool = false,
+             messageID: Int64? = nil,
+             isNewInSession: Bool = true) {
             self.id = id
             self.role = role
             self.content = .text(text)
             self.timestamp = timestamp
             self.failed = failed
+            self.messageID = messageID
+            self.isNewInSession = isNewInSession
         }
     }
 
@@ -148,6 +161,9 @@ final class SupportChatViewModel {
     /// When true, the escalation button should be hidden.
     private(set) var hasCreatedTicket: Bool = false
 
+    /// Set of message IDs that have already received feedback from the user.
+    private(set) var ratedMessageIDs: Set<Int64> = []
+
     var inputText: String = ""
 
     // MARK: - Private Properties
@@ -157,6 +173,7 @@ final class SupportChatViewModel {
     private let entryPoint: EntryPoint
     private let botSlug: String
     private let stores: StoresManager
+    private let analytics: Analytics
     private var diagnosticsContext: [String: Any]?
     private let initialContext: [String: Any]?
     private let onContactHumanSupport: (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void
@@ -173,6 +190,7 @@ final class SupportChatViewModel {
     init(botSlug: String = "woo-workflow-support_mobile_inapp_all_users",
          entryPoint: EntryPoint,
          stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
          initialContext: [String: Any]? = nil,
          diagnosticsService: SupportDiagnosticsService? = nil,
          chatID: Int64? = nil,
@@ -183,6 +201,7 @@ final class SupportChatViewModel {
         self.botSlug = botSlug
         self.entryPoint = entryPoint
         self.stores = stores
+        self.analytics = analytics
         self.initialContext = initialContext
         self.diagnosticsService = diagnosticsService ?? SupportDiagnosticsService()
         self.chatID = chatID
@@ -639,7 +658,8 @@ final class SupportChatViewModel {
                 } else {
                     let assistantMessage = ChatMessage(
                         role: .bot,
-                        text: lastBotMessage.content
+                        text: lastBotMessage.content,
+                        messageID: lastBotMessage.messageID
                     )
                     messages.append(assistantMessage)
                 }
@@ -687,9 +707,9 @@ final class SupportChatViewModel {
 
                 switch message.role {
                 case .user:
-                    return ChatMessage(role: .user, text: message.content)
+                    return ChatMessage(role: .user, text: message.content, isNewInSession: false)
                 case .bot:
-                    return ChatMessage(role: .bot, text: message.content)
+                    return ChatMessage(role: .bot, text: message.content, messageID: message.messageID, isNewInSession: false)
                 case .unknown:
                     return nil
                 }
@@ -738,6 +758,31 @@ final class SupportChatViewModel {
                                                     onCompletion: {})
             stores.dispatch(action)
         }
+    }
+
+    // MARK: - Feedback
+
+    /// Submits feedback for a bot message.
+    /// Marks the message as rated immediately (optimistic UI).
+    /// API failures are logged but do not affect the UI since feedback is low-stakes.
+    func submitFeedback(messageID: Int64, upvoted: Bool) {
+        guard let sessionID else { return }
+        guard !ratedMessageIDs.contains(messageID) else { return }
+
+        ratedMessageIDs.insert(messageID)
+
+        analytics.track(event: WooAnalyticsEvent.SupportChat.feedbackSubmitted(upvoted: upvoted))
+
+        let action = SupportChatAction.submitFeedback(
+            messageID: messageID,
+            sessionID: sessionID,
+            upvoted: upvoted
+        ) { result in
+            if case .failure(let error) = result {
+                DDLogError("⛔️ Support chat feedback error: \(error)")
+            }
+        }
+        stores.dispatch(action)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -161,8 +161,8 @@ final class SupportChatViewModel {
     /// When true, the escalation button should be hidden.
     private(set) var hasCreatedTicket: Bool = false
 
-    /// Set of message IDs that have already received feedback from the user.
-    private(set) var ratedMessageIDs: Set<Int64> = []
+    /// Maps message IDs to their feedback rating (true = upvoted, false = downvoted).
+    private(set) var messageRatings: [Int64: Bool] = [:]
 
     var inputText: String = ""
 
@@ -767,9 +767,9 @@ final class SupportChatViewModel {
     /// API failures are logged but do not affect the UI since feedback is low-stakes.
     func submitFeedback(messageID: Int64, upvoted: Bool) {
         guard let chatID, let sessionID else { return }
-        guard !ratedMessageIDs.contains(messageID) else { return }
+        guard messageRatings[messageID] == nil else { return }
 
-        ratedMessageIDs.insert(messageID)
+        messageRatings[messageID] = upvoted
 
         analytics.track(event: WooAnalyticsEvent.SupportChat.feedbackSubmitted(upvoted: upvoted))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -624,7 +624,8 @@ struct SupportChatViewModelTests {
         let chatID: Int64 = 123
         let sessionID = "session-1"
         let messageID: Int64 = 456
-        var receivedFeedback: (messageID: Int64, sessionID: String, upvoted: Bool)?
+        let botSlug = "test-bot"
+        var receivedFeedback: (botSlug: String, chatID: Int64, messageID: Int64, sessionID: String, upvoted: Bool)?
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
 
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -633,7 +634,7 @@ struct SupportChatViewModelTests {
                 let response = SupportChatResponse(
                     chatID: chatID,
                     sessionID: sessionID,
-                    botSlug: "test-bot",
+                    botSlug: botSlug,
                     botVersion: "1.0",
                     messages: [
                         SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil),
@@ -641,8 +642,8 @@ struct SupportChatViewModelTests {
                     ]
                 )
                 completion(.success(response))
-            case let .submitFeedback(messageID, sessionID, upvoted, onCompletion):
-                receivedFeedback = (messageID, sessionID, upvoted)
+            case let .submitFeedback(botSlug, chatID, messageID, sessionID, upvoted, onCompletion):
+                receivedFeedback = (botSlug, chatID, messageID, sessionID, upvoted)
                 onCompletion(.success(()))
             default:
                 break
@@ -662,8 +663,10 @@ struct SupportChatViewModelTests {
         sut.submitFeedback(messageID: messageID, upvoted: true)
 
         // Then
-        #expect(receivedFeedback?.sessionID == sessionID)
+        #expect(receivedFeedback?.botSlug == botSlug)
+        #expect(receivedFeedback?.chatID == chatID)
         #expect(receivedFeedback?.messageID == messageID)
+        #expect(receivedFeedback?.sessionID == sessionID)
         #expect(receivedFeedback?.upvoted == true)
     }
 
@@ -687,7 +690,7 @@ struct SupportChatViewModelTests {
                     ]
                 )
                 completion(.success(response))
-            case let .submitFeedback(_, _, _, onCompletion):
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
                 feedbackCallCount += 1
                 onCompletion(.success(()))
             default:
@@ -731,7 +734,7 @@ struct SupportChatViewModelTests {
                     ]
                 )
                 completion(.success(response))
-            case let .submitFeedback(_, _, _, onCompletion):
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
                 onCompletion(.success(()))
             default:
                 break
@@ -774,7 +777,7 @@ struct SupportChatViewModelTests {
                     ]
                 )
                 completion(.success(response))
-            case let .submitFeedback(_, _, _, onCompletion):
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
                 onCompletion(.success(()))
             default:
                 break

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -9,7 +9,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Greeting Tests
 
-    @Test func test_showGreeting_when_entryPoint_is_helpAndSupport_then_shows_issue_picker() {
+    @Test func showGreeting_when_entryPoint_is_helpAndSupport_then_shows_issue_picker() {
         // Given
         let sut = makeSUT(entryPoint: .helpAndSupport)
 
@@ -25,7 +25,7 @@ struct SupportChatViewModelTests {
         }
     }
 
-    @Test func test_showGreeting_when_entryPoint_is_connectivityTool_then_shows_text_greeting() {
+    @Test func showGreeting_when_entryPoint_is_connectivityTool_then_shows_text_greeting() {
         // Given
         let sut = makeSUT(entryPoint: .connectivityTool)
 
@@ -41,7 +41,7 @@ struct SupportChatViewModelTests {
         }
     }
 
-    @Test func test_showGreeting_when_entryPoint_is_connectivityTool_then_state_remains_idle() {
+    @Test func showGreeting_when_entryPoint_is_connectivityTool_then_state_remains_idle() {
         // Given
         let sut = makeSUT(entryPoint: .connectivityTool)
 
@@ -52,7 +52,7 @@ struct SupportChatViewModelTests {
         #expect(sut.state == .idle)
     }
 
-    @Test func test_showGreeting_when_entryPoint_is_preLogin_then_shows_text_greeting() {
+    @Test func showGreeting_when_entryPoint_is_preLogin_then_shows_text_greeting() {
         // Given
         let sut = makeSUT(entryPoint: .preLogin)
 
@@ -69,7 +69,7 @@ struct SupportChatViewModelTests {
         #expect(sut.state == .idle)
     }
 
-    @Test func test_shouldShowInputArea_when_entryPoint_is_preLogin_then_returns_true() {
+    @Test func shouldShowInputArea_when_entryPoint_is_preLogin_then_returns_true() {
         // Given
         let sut = makeSUT(entryPoint: .preLogin)
 
@@ -79,7 +79,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Input Area Visibility Tests
 
-    @Test func test_shouldShowInputArea_when_entryPoint_is_connectivityTool_then_returns_true() {
+    @Test func shouldShowInputArea_when_entryPoint_is_connectivityTool_then_returns_true() {
         // Given
         let sut = makeSUT(entryPoint: .connectivityTool)
 
@@ -87,7 +87,7 @@ struct SupportChatViewModelTests {
         #expect(sut.shouldShowInputArea == true)
     }
 
-    @Test func test_shouldShowInputArea_when_entryPoint_is_helpAndSupport_and_not_proceeded_then_returns_false() {
+    @Test func shouldShowInputArea_when_entryPoint_is_helpAndSupport_and_not_proceeded_then_returns_false() {
         // Given
         let sut = makeSUT(entryPoint: .helpAndSupport)
         sut.showGreeting()
@@ -96,7 +96,7 @@ struct SupportChatViewModelTests {
         #expect(sut.shouldShowInputArea == false)
     }
 
-    @Test func test_shouldShowInputArea_when_proceeded_to_chat_then_returns_true() async {
+    @Test func shouldShowInputArea_when_proceeded_to_chat_then_returns_true() async {
         // Given
         let sut = makeSUT(entryPoint: .helpAndSupport)
         sut.showGreeting()
@@ -109,7 +109,7 @@ struct SupportChatViewModelTests {
         #expect(sut.shouldShowInputArea == true)
     }
 
-    @Test func test_shouldShowInputArea_when_other_selected_then_returns_true() async {
+    @Test func shouldShowInputArea_when_other_selected_then_returns_true() async {
         // Given
         let sut = makeSUT(entryPoint: .helpAndSupport)
         sut.showGreeting()
@@ -123,7 +123,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Issue Selection Tests
 
-    @Test func test_selectIssue_when_other_then_skips_diagnostics_and_shows_greeting() async {
+    @Test func selectIssue_when_other_then_skips_diagnostics_and_shows_greeting() async {
         // Given
         let sut = makeSUT()
         sut.showGreeting()
@@ -141,7 +141,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Proceed to Chat Tests
 
-    @Test func test_proceedToChat_appends_greeting_message() async {
+    @Test func proceedToChat_appends_greeting_message() async {
         // Given
         let sut = makeSUT()
         sut.showGreeting()
@@ -160,7 +160,7 @@ struct SupportChatViewModelTests {
         }
     }
 
-    @Test func test_proceedToChat_sets_hasProceededToChat() async {
+    @Test func proceedToChat_sets_hasProceededToChat() async {
         // Given
         let sut = makeSUT()
         sut.showGreeting()
@@ -176,7 +176,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Send Message Error Handling Tests
 
-    @Test func test_sendMessage_when_failure_with_429_then_state_is_rate_limit_error() async {
+    @Test func sendMessage_when_failure_with_429_then_state_is_rate_limit_error() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -198,7 +198,7 @@ struct SupportChatViewModelTests {
         #expect(message.contains("limit"), "Expected rate-limit copy, got: \(message)")
     }
 
-    @Test func test_sendMessage_when_failure_with_500_then_state_is_generic_error() async {
+    @Test func sendMessage_when_failure_with_500_then_state_is_generic_error() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -220,7 +220,7 @@ struct SupportChatViewModelTests {
         #expect(message.contains("couldn't connect"), "Expected generic copy, got: \(message)")
     }
 
-    @Test func test_sendMessage_when_failure_then_marks_last_user_message_as_failed() async {
+    @Test func sendMessage_when_failure_then_marks_last_user_message_as_failed() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -239,7 +239,7 @@ struct SupportChatViewModelTests {
         #expect(lastUserMessage?.failed == true, "Expected the failed user bubble to be marked")
     }
 
-    @Test func test_sendMessage_when_failure_with_timeout_then_state_is_generic_error() async {
+    @Test func sendMessage_when_failure_with_timeout_then_state_is_generic_error() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -263,7 +263,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Execute Action Tests
 
-    @Test func test_executeAction_enableAnalytics_calls_service_and_reruns_test() async {
+    @Test func executeAction_enableAnalytics_calls_service_and_reruns_test() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         var enableAnalyticsCalled = false
@@ -305,7 +305,7 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
-    @Test func test_executeAction_openNotificationSettings_completes_without_error() async {
+    @Test func executeAction_openNotificationSettings_completes_without_error() async {
         // Given
         let sut = makeSUT()
 
@@ -316,7 +316,7 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
-    @Test func test_executeAction_when_service_throws_then_state_is_error() async {
+    @Test func executeAction_when_service_throws_then_state_is_error() async {
         // Given — enableAnalytics fails
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
@@ -338,7 +338,7 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
-    @Test func test_executeAction_setupJetpack_calls_onStartJetpackSetup() async {
+    @Test func executeAction_setupJetpack_calls_onStartJetpackSetup() async {
         // Given
         var callbackCalled = false
         let sut = makeSUT(onStartJetpackSetup: { callbackCalled = true })
@@ -354,7 +354,7 @@ struct SupportChatViewModelTests {
     // MARK: - Resume Chat Tests
 
     @Test(.timeLimit(.minutes(1)))
-    func test_resumeIfNeeded_when_chat_flagged_for_human_support_then_sets_shouldPromptHumanSupport() async {
+    func resumeIfNeeded_when_chat_flagged_for_human_support_then_sets_shouldPromptHumanSupport() async {
         // Given
         let chatID: Int64 = 123
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -406,7 +406,7 @@ struct SupportChatViewModelTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func test_resumeIfNeeded_when_chat_flagged_for_human_support_then_filters_flagged_message() async {
+    func resumeIfNeeded_when_chat_flagged_for_human_support_then_filters_flagged_message() async {
         // Given
         let chatID: Int64 = 123
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -462,7 +462,7 @@ struct SupportChatViewModelTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func test_resumeIfNeeded_when_chat_not_flagged_then_shouldPromptHumanSupport_is_false() async {
+    func resumeIfNeeded_when_chat_not_flagged_then_shouldPromptHumanSupport_is_false() async {
         // Given
         let chatID: Int64 = 123
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -503,7 +503,7 @@ struct SupportChatViewModelTests {
         #expect(sut.messages.count == 2)
     }
 
-    @Test func test_contactHumanSupport_passes_chatID_in_callback() async {
+    @Test func contactHumanSupport_passes_chatID_in_callback() async {
         // Given
         let chatID: Int64 = 456
         var receivedChatID: Int64?
@@ -559,7 +559,7 @@ struct SupportChatViewModelTests {
         #expect(receivedChatID == chatID)
     }
 
-    @Test func test_contactHumanSupport_when_prefetched_systemStatusReport_then_passes_it_in_supportAreaInfo() async {
+    @Test func contactHumanSupport_when_prefetched_systemStatusReport_then_passes_it_in_supportAreaInfo() async {
         // Given
         let prefetchedReport = "### Pre-fetched System Status Report ###"
         var receivedSupportAreaInfo: SupportAreaInfo?
@@ -619,7 +619,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - Feedback Tests
 
-    @Test func test_submitFeedback_when_valid_messageID_then_dispatches_action() async {
+    @Test func submitFeedback_when_valid_messageID_then_dispatches_action() async {
         // Given
         let chatID: Int64 = 123
         let sessionID = "session-1"
@@ -670,7 +670,7 @@ struct SupportChatViewModelTests {
         #expect(receivedFeedback?.upvoted == true)
     }
 
-    @Test func test_submitFeedback_when_already_rated_then_does_not_dispatch_again() async {
+    @Test func submitFeedback_when_already_rated_then_does_not_dispatch_again() async {
         // Given
         let chatID: Int64 = 123
         let messageID: Int64 = 456
@@ -715,7 +715,7 @@ struct SupportChatViewModelTests {
         #expect(feedbackCallCount == 1)
     }
 
-    @Test func test_submitFeedback_adds_messageID_to_ratedMessageIDs() async {
+    @Test func submitFeedback_adds_messageID_to_ratedMessageIDs() async {
         // Given
         let chatID: Int64 = 123
         let messageID: Int64 = 456
@@ -757,7 +757,7 @@ struct SupportChatViewModelTests {
         #expect(sut.ratedMessageIDs.contains(messageID))
     }
 
-    @Test func test_submitFeedback_tracks_analytics_event() async {
+    @Test func submitFeedback_tracks_analytics_event() async {
         // Given
         let chatID: Int64 = 123
         let messageID: Int64 = 456
@@ -801,7 +801,7 @@ struct SupportChatViewModelTests {
         #expect(analyticsProvider.received(event: "support_chat_feedback_submitted", with: ["rating": "down"]))
     }
 
-    @Test func test_sendMessage_when_success_then_bot_message_has_messageID() async {
+    @Test func sendMessage_when_success_then_bot_message_has_messageID() async {
         // Given
         let messageID: Int64 = 789
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -837,7 +837,7 @@ struct SupportChatViewModelTests {
         #expect(botMessage?.messageID == messageID)
     }
 
-    @Test func test_sendMessage_when_success_then_bot_message_isNewInSession_is_true() async {
+    @Test func sendMessage_when_success_then_bot_message_isNewInSession_is_true() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
 
@@ -873,7 +873,7 @@ struct SupportChatViewModelTests {
     }
 
     @Test(.timeLimit(.minutes(1)))
-    func test_resumeIfNeeded_when_success_then_rehydrated_messages_have_isNewInSession_false() async {
+    func resumeIfNeeded_when_success_then_rehydrated_messages_have_isNewInSession_false() async {
         // Given
         let chatID: Int64 = 123
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -651,6 +651,7 @@ struct SupportChatViewModelTests {
         }
 
         let sut = SupportChatViewModel(
+            botSlug: botSlug,
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
@@ -715,7 +716,7 @@ struct SupportChatViewModelTests {
         #expect(feedbackCallCount == 1)
     }
 
-    @Test func submitFeedback_adds_messageID_to_ratedMessageIDs() async {
+    @Test func submitFeedback_when_upvoted_stores_rating_direction() async {
         // Given
         let chatID: Int64 = 123
         let messageID: Int64 = 456
@@ -754,7 +755,49 @@ struct SupportChatViewModelTests {
         sut.submitFeedback(messageID: messageID, upvoted: true)
 
         // Then
-        #expect(sut.ratedMessageIDs.contains(messageID))
+        #expect(sut.messageRatings[messageID] == true)
+    }
+
+    @Test func submitFeedback_when_downvoted_stores_rating_direction() async {
+        // Given
+        let chatID: Int64 = 123
+        let messageID: Int64 = 456
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: chatID,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Hello", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: false)
+
+        // Then
+        #expect(sut.messageRatings[messageID] == false)
     }
 
     @Test func submitFeedback_tracks_analytics_event() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -617,6 +617,299 @@ struct SupportChatViewModelTests {
         #expect(receivedSupportAreaInfo?.systemStatusReport == prefetchedReport)
     }
 
+    // MARK: - Feedback Tests
+
+    @Test func test_submitFeedback_when_valid_messageID_then_dispatches_action() async {
+        // Given
+        let chatID: Int64 = 123
+        let sessionID = "session-1"
+        let messageID: Int64 = 456
+        var receivedFeedback: (messageID: Int64, sessionID: String, upvoted: Bool)?
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: chatID,
+                    sessionID: sessionID,
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil),
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "How can I help?", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(messageID, sessionID, upvoted, onCompletion):
+                receivedFeedback = (messageID, sessionID, upvoted)
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Help"
+        sut.sendMessage()
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: true)
+
+        // Then
+        #expect(receivedFeedback?.sessionID == sessionID)
+        #expect(receivedFeedback?.messageID == messageID)
+        #expect(receivedFeedback?.upvoted == true)
+    }
+
+    @Test func test_submitFeedback_when_already_rated_then_does_not_dispatch_again() async {
+        // Given
+        let chatID: Int64 = 123
+        let messageID: Int64 = 456
+        var feedbackCallCount = 0
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: chatID,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Hello", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, onCompletion):
+                feedbackCallCount += 1
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // When - rate twice
+        sut.submitFeedback(messageID: messageID, upvoted: true)
+        sut.submitFeedback(messageID: messageID, upvoted: false)
+
+        // Then - only one call
+        #expect(feedbackCallCount == 1)
+    }
+
+    @Test func test_submitFeedback_adds_messageID_to_ratedMessageIDs() async {
+        // Given
+        let chatID: Int64 = 123
+        let messageID: Int64 = 456
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: chatID,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Hello", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: true)
+
+        // Then
+        #expect(sut.ratedMessageIDs.contains(messageID))
+    }
+
+    @Test func test_submitFeedback_tracks_analytics_event() async {
+        // Given
+        let chatID: Int64 = 123
+        let messageID: Int64 = 456
+        let analyticsProvider = MockAnalyticsProvider()
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: chatID,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Hello", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: false)
+
+        // Then
+        #expect(analyticsProvider.receivedEvents.contains("support_chat_feedback_submitted"))
+        #expect(analyticsProvider.received(event: "support_chat_feedback_submitted", with: ["rating": "down"]))
+    }
+
+    @Test func test_sendMessage_when_success_then_bot_message_has_messageID() async {
+        // Given
+        let messageID: Int64 = 789
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: "Hello", context: nil),
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Hi there!", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Hello"
+
+        // When
+        sut.sendMessage()
+
+        // Then
+        let botMessage = sut.messages.first { $0.role == .bot }
+        #expect(botMessage?.messageID == messageID)
+    }
+
+    @Test func test_sendMessage_when_success_then_bot_message_isNewInSession_is_true() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: "Hello", context: nil),
+                        SupportChatMessage(messageID: 2, role: .bot, content: "Hi there!", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .connectivityTool,
+            stores: stores,
+            onContactHumanSupport: { _, _, _ in }
+        )
+        sut.inputText = "Hello"
+
+        // When
+        sut.sendMessage()
+
+        // Then
+        let botMessage = sut.messages.first { $0.role == .bot }
+        #expect(botMessage?.isNewInSession == true)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func test_resumeIfNeeded_when_success_then_rehydrated_messages_have_isNewInSession_false() async {
+        // Given
+        let chatID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .chatHistory,
+            stores: stores,
+            chatID: chatID,
+            onContactHumanSupport: { _, _, _ in }
+        )
+
+        await confirmation { fetchCompleted in
+            stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+                switch action {
+                case let .fetchChat(_, _, completion):
+                    let response = SupportChatResponse(
+                        chatID: chatID,
+                        sessionID: "session-1",
+                        botSlug: "test-bot",
+                        botVersion: "1.0",
+                        messages: [
+                            SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil),
+                            SupportChatMessage(messageID: 2, role: .bot, content: "How can I help?", context: nil)
+                        ]
+                    )
+                    completion(.success(response))
+                    fetchCompleted()
+                default:
+                    break
+                }
+            }
+
+            // When
+            sut.resumeIfNeeded()
+        }
+
+        // Then
+        #expect(sut.messages.allSatisfy { $0.isNewInSession == false })
+    }
+
     // MARK: - Test Helpers
 
     private func makeSUT(


### PR DESCRIPTION
Closes WOOMOB-2935

## Description
Adds thumbs up/down feedback buttons below bot messages in the support chat. Users can rate bot responses as helpful or not helpful, which sends feedback to the backend API.

- Feedback buttons appear only for new bot messages (not rehydrated history)
- After voting, shows "Helpful" or "Not helpful" text with filled icon
- Integrates with `POST /wpcom/v2/odie/chat/{bot_slug}/{chat_id}/{message_id}/feedback` endpoint
- Tracks `support_chat_feedback_submitted` analytics event with rating value

## Test Steps
1. Open support chat and send a message to get a bot response
2. Verify thumbs up/down icons appear below bot text messages
3. Tap thumbs up - verify it highlights with "Helpful" text
4. Tap thumbs down on another message - verify "Not helpful" text appears
5. Verify cannot change vote after submission
6. Verify feedback buttons don't appear on messages from chat history
7. Test the feature when logged out or authenticated with application password. Confirm that you can still vote on responses successfully.

## Screenshots


https://github.com/user-attachments/assets/cb995a46-fcbf-4a56-82fa-1f175a7ee79e



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.