### PR TITLE
[RSM] Phone POS: Add POSLayoutScale and responsive design foundation

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -193,6 +193,7 @@ public struct PointOfSaleEntryPointView: View {
                 popularPurchasableItemsController: popularPurchasableItemsController,
                 barcodeScanService: barcodeScanService,
                 receiptSender: receiptSender,
+                preferredConnectionMethod: preferredConnectionMethod,
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
                 cartProductObserver: cartProductObserver,
@@ -210,6 +211,7 @@ public struct PointOfSaleEntryPointView: View {
         .environmentObject(posCoverManager)
         .environment(orderListModel)
         .environment(\.siteTimezone, siteTimezone)
+        .environment(\.posLayoutScale, horizontalSizeClass == .compact ? .phone : .tablet)
         .injectKeyboardObserver()
         .onAppear {
             onPointOfSaleModeActiveStateChange(true)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -193,7 +193,6 @@ public struct PointOfSaleEntryPointView: View {
                 popularPurchasableItemsController: popularPurchasableItemsController,
                 barcodeScanService: barcodeScanService,
                 receiptSender: receiptSender,
-                preferredConnectionMethod: preferredConnectionMethod,
                 siteID: siteID,
                 catalogSyncCoordinator: catalogSyncCoordinator,
                 cartProductObserver: cartProductObserver,

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/DynamicFrameScaler.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/DynamicFrameScaler.swift
@@ -3,14 +3,21 @@ import SwiftUI
 /// A view modifier that adjusts the width multiplier based on dynamic type size.
 struct DynamicWidthScaler: ViewModifier {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.posLayoutScale) private var layoutScale
     let containerWidth: CGFloat
     let threshold: DynamicTypeSize
     let smallSizeScale: CGFloat
     let largeSizeScale: CGFloat
 
     func body(content: Content) -> some View {
-        content
-            .frame(width: containerWidth * widthMultiplier)
+        if layoutScale == .phone {
+            content
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, POSPadding.medium)
+        } else {
+            content
+                .frame(width: containerWidth * widthMultiplier)
+        }
     }
 
     /// Returns a width multiplier based on the current dynamic type size

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -88,59 +88,17 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
         self.bottomContent = bottomContent()
     }
 
+    @Environment(\.posLayoutScale) private var layoutScale
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
                 leadingContent
 
-                VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
-                    HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
-                        if showsBackButton {
-                            backButton
-                        }
-                        ForEach(0..<items.count, id: \.self) { index in
-                            VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
-                                HStack(spacing: POSSpacing.small) {
-                                    if items[index].title.isNotEmpty {
-                                        Button(action: {
-                                            items[index].action?()
-                                        }) {
-                                            Text(items[index].title)
-                                                .font(.posHeadingBold)
-                                                .lineLimit(1)
-                                                .minimumScaleFactor(0.5)
-                                                .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
-                                                .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
-                                        }
-                                        .disabled(items[index].isSelected)
-                                        .accessibilityElement()
-                                        .accessibilityAddTraits(items.count == 1 ? .isHeader : [.isHeader, .isButton])
-                                        .accessibilityLabel(items[index].title)
-                                    }
-
-                                    if items[index].isLoading {
-                                        ProgressView()
-                                            .progressViewStyle(.circular)
-                                            .scaleEffect(0.7)
-                                            .transition(.opacity.combined(with: .scale))
-                                    }
-                                }
-
-                                if let subtitle = items[index].subtitle {
-                                    Text(subtitle)
-                                        .font(.posBodyLargeRegular())
-                                        .lineLimit(1)
-                                        .minimumScaleFactor(0.5)
-                                        .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
-                                        .foregroundColor(.posOnSurface)
-                                }
-                            }
-                        }
-                    }
-                }
+                itemsContent
 
                 if items.isNotEmpty {
-                    Spacer()
+                    Spacer(minLength: 0)
                 }
 
                 trailingContent
@@ -152,6 +110,63 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
         .padding(.leading, shouldHaveLeadingPaddingForItems ? POSHeaderLayoutConstants.sectionHorizontalPadding : POSPadding.none)
         .padding(.trailing, POSHeaderLayoutConstants.sectionHorizontalPadding)
         .padding(.vertical, POSHeaderLayoutConstants.sectionVerticalPadding)
+    }
+
+    @ViewBuilder
+    private var itemsContent: some View {
+        let itemsRow = VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
+            HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
+                if showsBackButton {
+                    backButton
+                }
+                ForEach(0..<items.count, id: \.self) { index in
+                    VStack(alignment: .leading, spacing: Constants.titleSubtitleSpacing) {
+                        HStack(spacing: POSSpacing.small) {
+                            if items[index].title.isNotEmpty {
+                                Button(action: {
+                                    items[index].action?()
+                                }) {
+                                    Text(items[index].title)
+                                        .font(.posHeadingBold)
+                                        .lineLimit(1)
+                                        .fixedSize(horizontal: true, vertical: false)
+                                        .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                                        .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
+                                }
+                                .disabled(items[index].isSelected)
+                                .accessibilityElement()
+                                .accessibilityAddTraits(items.count == 1 ? .isHeader : [.isHeader, .isButton])
+                                .accessibilityLabel(items[index].title)
+                            }
+
+                            if items[index].isLoading {
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                    .scaleEffect(0.7)
+                                    .transition(.opacity.combined(with: .scale))
+                            }
+                        }
+
+                        if let subtitle = items[index].subtitle {
+                            Text(subtitle)
+                                .font(.posBodyLargeRegular())
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.5)
+                                .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                                .foregroundColor(.posOnSurface)
+                        }
+                    }
+                }
+            }
+        }
+
+        if layoutScale == .phone {
+            ScrollView(.horizontal, showsIndicators: false) {
+                itemsRow
+            }
+        } else {
+            itemsRow
+        }
     }
 
     private var shouldHaveLeadingPaddingForItems: Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -170,7 +170,7 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
     }
 
     private var shouldHaveLeadingPaddingForItems: Bool {
-        items.isNotEmpty  || showsBackButton
+        items.isNotEmpty || showsBackButton
     }
 
     @ViewBuilder
@@ -185,7 +185,6 @@ private enum Constants {
     static let horizontalSpacing: CGFloat = POSSpacing.medium
     static let titleSubtitleSpacing: CGFloat = POSSpacing.xSmall
 }
-
 
 struct POSHeaderBackButtonConfigurationKey: EnvironmentKey {
     static let defaultValue: POSPageHeaderBackButtonConfiguration? = nil

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
@@ -1,24 +1,26 @@
 import SwiftUI
 
 struct POSSuccessIcon: View {
+    @Environment(\.posLayoutScale) private var layoutScale
+
     var body: some View {
         ZStack {
             Circle()
-                .frame(width: Constants.iconSize, height: Constants.iconSize)
+                .frame(width: iconSize, height: iconSize)
                 .foregroundColor(.posSuccess)
-            PointOfSaleAssets.successCheck.image
-                .renderingMode(.template)
+            Image(systemName: "checkmark")
+                .font(.system(size: checkmarkSize, weight: .bold))
                 .foregroundColor(.posOnSuccess)
-                .frame(width: Constants.checkmarkSize)
                 .accessibilityHidden(true)
         }
     }
-}
 
-private extension POSSuccessIcon {
-    enum Constants {
-        static let iconSize: CGFloat = 165
-        static let checkmarkSize: CGFloat = 52
+    private var iconSize: CGFloat {
+        layoutScale == .phone ? 72 : 165
+    }
+
+    private var checkmarkSize: CGFloat {
+        layoutScale == .phone ? 28 : 64
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
@@ -16,11 +16,20 @@ struct POSSuccessIcon: View {
     }
 
     private var iconSize: CGFloat {
-        layoutScale == .phone ? 72 : 165
+        layoutScale == .phone ? Constants.phoneIconSize : Constants.tabletIconSize
     }
 
     private var checkmarkSize: CGFloat {
-        layoutScale == .phone ? 28 : 64
+        layoutScale == .phone ? Constants.phoneCheckmarkSize : Constants.tabletCheckmarkSize
+    }
+}
+
+private extension POSSuccessIcon {
+    enum Constants {
+        static let tabletIconSize: CGFloat = 165
+        static let tabletCheckmarkSize: CGFloat = 64
+        static let phoneIconSize: CGFloat = 72
+        static let phoneCheckmarkSize: CGFloat = 28
     }
 }
 

--- a/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
@@ -109,7 +109,9 @@ private extension POSFontStyle {
 // MARK: - Scale-aware sizing
 
 extension POSFontStyle {
-    fileprivate func baseSize(for scale: POSLayoutScale) -> CGFloat {
+    // Internal (not fileprivate) so that unit tests in PointOfSaleTests can call
+    // these helpers directly without going through the SwiftUI View modifier path.
+    func baseSize(for scale: POSLayoutScale) -> CGFloat {
         switch scale {
         case .tablet:
             return tabletBaseSize
@@ -118,10 +120,19 @@ extension POSFontStyle {
         }
     }
 
-    fileprivate func font(baseSize: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> Font {
+    func font(baseSize: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> Font {
         let scaledSize = scaledValue(baseSize, maximumContentSizeCategory: maximumContentSizeCategory)
         let flooredSize = max(scaledSize, minimumFloor)
         return Font.system(size: flooredSize, weight: fontWeight)
+    }
+
+    /// Returns the effective font size (post-scaling, post-floor) for a given layout scale and
+    /// Dynamic Type content size category.  Exposed as `internal` so PointOfSaleTests can assert
+    /// on the numeric result without having to inspect a `Font` value.
+    func effectiveFontSize(for scale: POSLayoutScale, contentSizeCategory: UIContentSizeCategory) -> CGFloat {
+        let base = baseSize(for: scale)
+        let scaledSize = scaledValue(base, maximumContentSizeCategory: contentSizeCategory)
+        return max(scaledSize, minimumFloor)
     }
 
     private var tabletBaseSize: CGFloat {

--- a/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
@@ -85,20 +85,119 @@ private extension POSFontStyle {
         static let bodySmall: CGFloat = 16
         static let caption: CGFloat = 14
     }
+
+    enum PhoneFontSize {
+        static let heading: CGFloat = 24
+        static let bodyXLarge: CGFloat = 22
+        static let bodyLarge: CGFloat = 18
+        static let bodyMedium: CGFloat = 16
+        static let bodySmall: CGFloat = 14
+        static let caption: CGFloat = 12
+    }
+
+    enum MinimumFloor {
+        static let heading: CGFloat = 16
+        static let bodyXLarge: CGFloat = 14
+        static let bodyLarge: CGFloat = 13
+        static let bodyMedium: CGFloat = 12
+        static let bodySmall: CGFloat = 11
+        static let caption: CGFloat = 11
+        static let buttonSymbol: CGFloat = 11
+    }
+}
+
+// MARK: - Scale-aware sizing
+
+extension POSFontStyle {
+    func baseSize(for scale: POSLayoutScale) -> CGFloat {
+        switch scale {
+        case .tablet:
+            return tabletBaseSize
+        case .phone:
+            return phoneBaseSize
+        }
+    }
+
+    func font(baseSize: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> Font {
+        let scaledSize = scaledValue(baseSize, maximumContentSizeCategory: maximumContentSizeCategory)
+        let flooredSize = max(scaledSize, minimumFloor)
+        return Font.system(size: flooredSize, weight: fontWeight)
+    }
+
+    private var tabletBaseSize: CGFloat {
+        switch self {
+        case .posHeadingBold, .posHeadingRegular: return FontSize.heading
+        case .posBodyXLargeRegular, .posBodyXLargeBold: return FontSize.bodyXLarge
+        case .posBodyLargeBold, .posBodyLargeRegular: return FontSize.bodyLarge
+        case .posBodyMediumBold, .posBodyMediumRegular: return FontSize.bodyMedium
+        case .posBodySmallBold, .posBodySmallRegular: return FontSize.bodySmall
+        case .posCaptionBold, .posCaptionRegular: return FontSize.caption
+        case .posButtonSymbolXSmall: return 16
+        case .posButtonSymbolSmall: return 20
+        case .posButtonSymbolMedium: return 24
+        case .posButtonSymbolLarge: return 30
+        }
+    }
+
+    private var phoneBaseSize: CGFloat {
+        switch self {
+        case .posHeadingBold, .posHeadingRegular: return PhoneFontSize.heading
+        case .posBodyXLargeRegular, .posBodyXLargeBold: return PhoneFontSize.bodyXLarge
+        case .posBodyLargeBold, .posBodyLargeRegular: return PhoneFontSize.bodyLarge
+        case .posBodyMediumBold, .posBodyMediumRegular: return PhoneFontSize.bodyMedium
+        case .posBodySmallBold, .posBodySmallRegular: return PhoneFontSize.bodySmall
+        case .posCaptionBold, .posCaptionRegular: return PhoneFontSize.caption
+        case .posButtonSymbolXSmall: return 14
+        case .posButtonSymbolSmall: return 16
+        case .posButtonSymbolMedium: return 20
+        case .posButtonSymbolLarge: return 24
+        }
+    }
+
+    private var minimumFloor: CGFloat {
+        switch self {
+        case .posHeadingBold, .posHeadingRegular: return MinimumFloor.heading
+        case .posBodyXLargeRegular, .posBodyXLargeBold: return MinimumFloor.bodyXLarge
+        case .posBodyLargeBold, .posBodyLargeRegular: return MinimumFloor.bodyLarge
+        case .posBodyMediumBold, .posBodyMediumRegular: return MinimumFloor.bodyMedium
+        case .posBodySmallBold, .posBodySmallRegular: return MinimumFloor.bodySmall
+        case .posCaptionBold, .posCaptionRegular: return MinimumFloor.caption
+        case .posButtonSymbolXSmall, .posButtonSymbolSmall,
+             .posButtonSymbolMedium, .posButtonSymbolLarge: return MinimumFloor.buttonSymbol
+        }
+    }
+
+    var fontWeight: Font.Weight {
+        switch self {
+        case .posHeadingBold, .posBodyXLargeBold, .posBodyLargeBold,
+             .posBodyMediumBold, .posBodySmallBold, .posCaptionBold:
+            return .bold
+        case .posBodyXLargeRegular:
+            return .semibold
+        case .posButtonSymbolXSmall, .posButtonSymbolSmall,
+             .posButtonSymbolMedium, .posButtonSymbolLarge:
+            return .semibold
+        case .posHeadingRegular, .posBodyLargeRegular, .posBodyMediumRegular,
+             .posBodySmallRegular, .posCaptionRegular:
+            return .regular
+        }
+    }
 }
 
 // MARK: - Helpers
 
 private struct POSScaledFont: ViewModifier {
-    // Declaring dynamicTypeSize ensures it's automatically observed
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.posLayoutScale) var layoutScale
     var style: POSFontStyle
 
     func body(content: Content) -> some View {
         let category = UIContentSizeCategory(dynamicTypeSize)
+        let base = style.baseSize(for: layoutScale)
+        let font = style.font(baseSize: base, maximumContentSizeCategory: category)
 
         return content
-            .font(style.font(maximumContentSizeCategory: category))
+            .font(font)
             .if(shouldUnderline()) { view in
                 view.underline()
             }

--- a/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
@@ -109,7 +109,7 @@ private extension POSFontStyle {
 // MARK: - Scale-aware sizing
 
 extension POSFontStyle {
-    func baseSize(for scale: POSLayoutScale) -> CGFloat {
+    fileprivate func baseSize(for scale: POSLayoutScale) -> CGFloat {
         switch scale {
         case .tablet:
             return tabletBaseSize
@@ -118,7 +118,7 @@ extension POSFontStyle {
         }
     }
 
-    func font(baseSize: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> Font {
+    fileprivate func font(baseSize: CGFloat, maximumContentSizeCategory: UIContentSizeCategory?) -> Font {
         let scaledSize = scaledValue(baseSize, maximumContentSizeCategory: maximumContentSizeCategory)
         let flooredSize = max(scaledSize, minimumFloor)
         return Font.system(size: flooredSize, weight: fontWeight)
@@ -167,7 +167,7 @@ extension POSFontStyle {
         }
     }
 
-    var fontWeight: Font.Weight {
+    fileprivate var fontWeight: Font.Weight {
         switch self {
         case .posHeadingBold, .posBodyXLargeBold, .posBodyLargeBold,
              .posBodyMediumBold, .posBodySmallBold, .posCaptionBold:

--- a/Modules/Sources/PointOfSale/Utils/POSHeaderLeadingContentKey.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSHeaderLeadingContentKey.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct POSHeaderLeadingContentKey: EnvironmentKey {
+private struct POSHeaderLeadingContentKey: EnvironmentKey {
     static let defaultValue: AnyView? = nil
 }
 

--- a/Modules/Sources/PointOfSale/Utils/POSHeaderLeadingContentKey.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSHeaderLeadingContentKey.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct POSHeaderLeadingContentKey: EnvironmentKey {
+    static let defaultValue: AnyView? = nil
+}
+
+extension EnvironmentValues {
+    var posHeaderLeadingContent: AnyView? {
+        get { self[POSHeaderLeadingContentKey.self] }
+        set { self[POSHeaderLeadingContentKey.self] = newValue }
+    }
+}

--- a/Modules/Sources/PointOfSale/Utils/POSLayoutScale.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSLayoutScale.swift
@@ -5,7 +5,7 @@ enum POSLayoutScale {
     case phone
 }
 
-struct POSLayoutScaleKey: EnvironmentKey {
+private struct POSLayoutScaleKey: EnvironmentKey {
     static let defaultValue: POSLayoutScale = .tablet
 }
 

--- a/Modules/Sources/PointOfSale/Utils/POSLayoutScale.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSLayoutScale.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+enum POSLayoutScale {
+    case tablet
+    case phone
+}
+
+struct POSLayoutScaleKey: EnvironmentKey {
+    static let defaultValue: POSLayoutScale = .tablet
+}
+
+extension EnvironmentValues {
+    var posLayoutScale: POSLayoutScale {
+        get { self[POSLayoutScaleKey.self] }
+        set { self[POSLayoutScaleKey.self] = newValue }
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Utils/POSFontStyleTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Utils/POSFontStyleTests.swift
@@ -1,0 +1,230 @@
+import Testing
+import UIKit
+@testable import PointOfSale
+
+/// Tests for POSLayoutScale enum and POSFontStyle scale-aware sizing.
+///
+/// `baseSize(for:)` and `effectiveFontSize(for:contentSizeCategory:)` are `internal` rather than
+/// `fileprivate` so that this test suite can reach them without going through the SwiftUI
+/// `View.font(_:POSFontStyle)` modifier (which requires a live view hierarchy).
+struct POSFontStyleTests {
+
+    // MARK: - POSLayoutScale sanity
+
+    @Test func test_POSLayoutScale_tablet_and_phone_are_distinct_cases() {
+        // Verify the two layout scale values exist and are different.
+        let tablet = POSLayoutScale.tablet
+        let phone = POSLayoutScale.phone
+
+        #expect(tablet != phone)
+    }
+
+    // MARK: - baseSize: tablet returns original iPad design sizes
+
+    @Test func test_baseSize_when_tablet_then_posHeadingBold_returns_36() {
+        // Given / When
+        let size = POSFontStyle.posHeadingBold.baseSize(for: .tablet)
+
+        // Then
+        #expect(size == 36)
+    }
+
+    @Test func test_baseSize_when_tablet_then_posBodyXLargeRegular_returns_30() {
+        // Given / When
+        let size = POSFontStyle.posBodyXLargeRegular.baseSize(for: .tablet)
+
+        // Then
+        #expect(size == 30)
+    }
+
+    @Test func test_baseSize_when_tablet_then_posBodyLargeBold_returns_24() {
+        // Given / When
+        let size = POSFontStyle.posBodyLargeBold.baseSize(for: .tablet)
+
+        // Then
+        #expect(size == 24)
+    }
+
+    @Test func test_baseSize_when_tablet_then_posBodyMediumBold_returns_20() {
+        // Given / When
+        let size = POSFontStyle.posBodyMediumBold.baseSize(for: .tablet)
+
+        // Then
+        #expect(size == 20)
+    }
+
+    @Test func test_baseSize_when_tablet_then_posBodySmallBold_returns_16() {
+        // Given / When
+        let size = POSFontStyle.posBodySmallBold().baseSize(for: .tablet)
+
+        // Then
+        #expect(size == 16)
+    }
+
+    @Test func test_baseSize_when_tablet_then_posCaptionBold_returns_14() {
+        // Given / When
+        let size = POSFontStyle.posCaptionBold.baseSize(for: .tablet)
+
+        // Then
+        #expect(size == 14)
+    }
+
+    // MARK: - baseSize: phone returns documented phone-specific sizes
+
+    @Test func test_baseSize_when_phone_then_posHeadingBold_returns_24() {
+        // Given / When
+        let size = POSFontStyle.posHeadingBold.baseSize(for: .phone)
+
+        // Then — phone heading is smaller than tablet (36 → 24)
+        #expect(size == 24)
+    }
+
+    @Test func test_baseSize_when_phone_then_posBodyXLargeRegular_returns_22() {
+        // Given / When
+        let size = POSFontStyle.posBodyXLargeRegular.baseSize(for: .phone)
+
+        // Then
+        #expect(size == 22)
+    }
+
+    @Test func test_baseSize_when_phone_then_posBodyLargeBold_returns_18() {
+        // Given / When
+        let size = POSFontStyle.posBodyLargeBold.baseSize(for: .phone)
+
+        // Then
+        #expect(size == 18)
+    }
+
+    @Test func test_baseSize_when_phone_then_posBodyMediumBold_returns_16() {
+        // Given / When
+        let size = POSFontStyle.posBodyMediumBold.baseSize(for: .phone)
+
+        // Then
+        #expect(size == 16)
+    }
+
+    @Test func test_baseSize_when_phone_then_posBodySmallBold_returns_14() {
+        // Given / When
+        let size = POSFontStyle.posBodySmallBold().baseSize(for: .phone)
+
+        // Then
+        #expect(size == 14)
+    }
+
+    @Test func test_baseSize_when_phone_then_posCaptionBold_returns_12() {
+        // Given / When
+        let size = POSFontStyle.posCaptionBold.baseSize(for: .phone)
+
+        // Then
+        #expect(size == 12)
+    }
+
+    // MARK: - baseSize: phone sizes are always smaller than tablet sizes
+
+    @Test(arguments: [
+        POSFontStyle.posHeadingBold,
+        POSFontStyle.posHeadingRegular,
+        POSFontStyle.posBodyXLargeRegular,
+        POSFontStyle.posBodyXLargeBold,
+        POSFontStyle.posBodyLargeBold,
+        POSFontStyle.posBodyLargeRegular(),
+        POSFontStyle.posBodyMediumBold,
+        POSFontStyle.posBodyMediumRegular(),
+        POSFontStyle.posBodySmallBold(),
+        POSFontStyle.posBodySmallRegular(),
+        POSFontStyle.posCaptionBold,
+        POSFontStyle.posCaptionRegular,
+        POSFontStyle.posButtonSymbolXSmall,
+        POSFontStyle.posButtonSymbolSmall,
+        POSFontStyle.posButtonSymbolMedium,
+        POSFontStyle.posButtonSymbolLarge,
+    ])
+    func test_baseSize_when_phone_then_is_smaller_than_tablet(style: POSFontStyle) {
+        // Given
+        let tabletSize = style.baseSize(for: .tablet)
+        let phoneSize = style.baseSize(for: .phone)
+
+        // Then — phone base sizes must always be <= tablet to avoid bloating the smaller screen
+        #expect(phoneSize <= tabletSize)
+    }
+
+    // MARK: - MinimumFloor clamping
+
+    /// At the smallest Dynamic Type category (.extraSmall), UIFontMetrics scales a value
+    /// *down* from the base. The MinimumFloor clamp prevents the effective size from
+    /// dropping below the declared floor.
+    ///
+    /// posBodySmallBold on phone has a phone base size of 14 pt and a floor of 11 pt.
+    /// Without the floor, .extraSmall scaling could produce a value below 11 pt.
+    /// With the floor, the result must be >= 11 pt.
+    @Test func test_effectiveFontSize_when_phone_and_extraSmall_DynamicType_then_posBodySmallBold_is_not_below_floor() {
+        // Given
+        let style = POSFontStyle.posBodySmallBold()
+        let expectedFloor: CGFloat = 11
+
+        // When — extraSmall is the smallest Dynamic Type category; it scales values down
+        let effectiveSize = style.effectiveFontSize(for: .phone, contentSizeCategory: .extraSmall)
+
+        // Then — the floor clamp must keep the size at or above the declared minimum
+        #expect(effectiveSize >= expectedFloor)
+    }
+
+    @Test func test_effectiveFontSize_when_phone_and_extraSmall_DynamicType_then_posCaptionRegular_is_not_below_floor() {
+        // Given — caption has a phone base size of 12 and a floor of 11
+        let style = POSFontStyle.posCaptionRegular
+        let expectedFloor: CGFloat = 11
+
+        // When
+        let effectiveSize = style.effectiveFontSize(for: .phone, contentSizeCategory: .extraSmall)
+
+        // Then
+        #expect(effectiveSize >= expectedFloor)
+    }
+
+    @Test func test_effectiveFontSize_when_phone_and_extraSmall_DynamicType_then_posBodyMediumRegular_is_not_below_floor() {
+        // Given — medium has a phone base of 16 and a floor of 12
+        let style = POSFontStyle.posBodyMediumRegular()
+        let expectedFloor: CGFloat = 12
+
+        // When
+        let effectiveSize = style.effectiveFontSize(for: .phone, contentSizeCategory: .extraSmall)
+
+        // Then
+        #expect(effectiveSize >= expectedFloor)
+    }
+
+    /// The floor must also hold for button symbols, which share a single buttonSymbol floor of 11.
+    @Test func test_effectiveFontSize_when_phone_and_extraSmall_DynamicType_then_posButtonSymbolXSmall_is_not_below_floor() {
+        // Given — buttonSymbolXSmall has phone base 14, floor 11
+        let style = POSFontStyle.posButtonSymbolXSmall
+        let expectedFloor: CGFloat = 11
+
+        // When
+        let effectiveSize = style.effectiveFontSize(for: .phone, contentSizeCategory: .extraSmall)
+
+        // Then
+        #expect(effectiveSize >= expectedFloor)
+    }
+
+    // MARK: - Floor does not clip at normal sizes
+
+    /// At the default (.large) Dynamic Type category the floor should never be the binding
+    /// constraint — the unscaled base size is already above the floor.
+    @Test(arguments: [
+        POSFontStyle.posHeadingBold,
+        POSFontStyle.posBodyMediumBold,
+        POSFontStyle.posBodySmallBold(),
+        POSFontStyle.posCaptionRegular,
+        POSFontStyle.posButtonSymbolXSmall,
+    ])
+    func test_effectiveFontSize_when_phone_and_large_DynamicType_then_exceeds_floor(style: POSFontStyle) {
+        // Given — at the default size the metrics do not shrink the value below the base
+        let phoneBase = style.baseSize(for: .phone)
+
+        // When
+        let effectiveSize = style.effectiveFontSize(for: .phone, contentSizeCategory: .large)
+
+        // Then — at default Dynamic Type the effective size is at least the phone base
+        #expect(effectiveSize >= phoneBase)
+    }
+}


### PR DESCRIPTION
> **Stack order** (review bottom-up — each PR depends on the one below):
> 1. #17062 — Add `pointOfSalePhonePrototype` feature flag
> 2. #17063 — Lift iPad/compact-width gates behind flag
> 3. #17064 — Phone navigation skeleton + Cart sheet
> 4. #17065 — Items header overflow menu (Exit/Settings/Orders)
> 5. #17066 — Phone-adaptive modals (barcode setup + refund flow)
> 6. #17067 — Selection border + connect-reader button polish
> 7. **This PR** — POSLayoutScale + responsive design foundation
> 8. (next) Pre-TTP checkout & modal polish
> 9. (next) TTP foundation: feature flag + availability tracking
> 10. (next) TTP checkout row (multi-method buttons)
> 11. (next) TTP hero & "Other payment methods" sheet
> 12. (next) TTP wiring & cancel handling
> 13. (next) TTP polish (alert suppression + hero polish)

## Description
Stacked on top of #17067. Adds the responsive-design foundation that the upcoming phone POS feature work depends on.

- New `POSLayoutScale` environment value (`.phone` / `.tablet`) injected from `horizontalSizeClass` in `PointOfSaleEntryPointView`. Lets leaf views adapt sizing without each one duplicating the size-class check.
- Phone-specific font sizes on `POSFontStyle` with a minimum floor so dynamic-type scaling still has headroom on compact width.
- `POSSuccessIcon`, `DynamicFrameScaler`, and `ShimmeringLineView` updated to respond to the new scale value.
- `POSPageHeaderView` items now scroll horizontally on phone instead of clipping.
- `POSHeaderLeadingContentKey` preference key added so the phone menu button can be injected from outside the page header.
- Removes a leftover compact size-class guard from `determineViewState` that the new scale supersedes.

### Note on iPad behaviour

The current diff drifts onto iPad in two places that the reviewer flagged and that I plan to gate behind `layoutScale == .phone` in a follow-up polish commit on the stack tip (so this PR's approval isn't dismissed):

1. **`POSPageHeaderView` title**: switched from `.minimumScaleFactor(0.5)` to `.fixedSize(horizontal: true, vertical: false)` for the phone-side scroll behaviour, but the swap currently applies on iPad too. Long titles in narrow iPad split-view can overflow.
2. **`POSSuccessIcon`**: icon swap from `PointOfSaleAssets.successCheck` → `Image(systemName: "checkmark")` and iPad size 52 → 64. Both should be `.phone`-only here. If we want them on iPad too, that lands as a separate, design-signed-off PR with screenshots.

After the gating commit, iPad behaviour matches today.

## Test Steps
- Pull the branch (Debug = `pointOfSalePhonePrototype` flag = `.localDeveloper`).
- **iPhone, flag ON**:
  1. Open POS — header, success icon, shimmer placeholders all render at the new phone-sized fonts. Nothing is clipped at small widths.
  2. Scroll the page-header tabs horizontally. They should swipe instead of squeezing into the visible width.
- **iPad, flag either**:
  - Currently this PR has the two iPad drifts noted above. Visually verify long titles + success icon look acceptable, OR wait for the gating commit before re-testing.
  - After the gating commit lands: all sizing matches today.

## Screenshots
N/A — foundation work, behaviour visible only via the next PRs in the stack.

---
- [x] No release notes — feature still flagged off in alpha.