### PR TITLE
[RSM] Phone POS: Pre-TTP checkout and modal polish

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -11,8 +11,12 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
     @State private var width: CGFloat = 0
 
     private var connectButtonWidth: CGFloat {
-        // iPad: half the container; phone: align with the totals lines (full width minus standard insets).
-        horizontalSizeClass == .compact ? max(width - POSPadding.large * 2, 0) : width * 0.5
+        // iPad: half the container.
+        // Phone: 16pt insets each side, matching the cash button below. TotalsView
+        // drops PaymentViewPaddingModifier's sidePadding to 0 on phone so the parent's
+        // edge is the screen edge — subtracting POSPadding.medium * 2 lands the button
+        // at [16, screenWidth − 16].
+        horizontalSizeClass == .compact ? max(width - POSPadding.medium * 2, 0) : width * 0.5
     }
 
     init(animation: POSCardPresentPaymentInLineMessageAnimation,

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -14,18 +14,25 @@ struct ItemListView: View {
 
     @Binding var selectedItemListType: ItemListType
     @Binding var searchTerm: String
-    /// Optional accessory rendered in the trailing slot of the items list header when not searching.
-    /// Hidden while the Coupons tab is showing the create-coupon button so the trailing slot
-    /// doesn't crowd the Products / Coupons tab titles — that gate lives here because the same
-    /// view also owns `isAddingCouponAllowed`.
-    private let trailingHeaderAccessoryHiddenOnCoupons: AnyView?
+    /// Optional builder rendered in the trailing slot of the items list header when not searching.
+    /// The dashboard uses this to fold the "create coupon" entry into its overflow menu when the
+    /// merchant is on the Coupons tab, without leaking ItemListView's internal state.
+    private let phoneHeaderAccessoryBuilder: ((PhoneHeaderAccessoryContext) -> AnyView)?
 
     init(selectedItemListType: Binding<ItemListType>,
          searchTerm: Binding<String>,
-         trailingHeaderAccessoryHiddenOnCoupons: AnyView? = nil) {
+         phoneHeaderAccessoryBuilder: ((PhoneHeaderAccessoryContext) -> AnyView)? = nil) {
         self._selectedItemListType = selectedItemListType
         self._searchTerm = searchTerm
-        self.trailingHeaderAccessoryHiddenOnCoupons = trailingHeaderAccessoryHiddenOnCoupons
+        self.phoneHeaderAccessoryBuilder = phoneHeaderAccessoryBuilder
+    }
+
+    /// Context handed to the dashboard so the phone overflow menu can fold the
+    /// "create coupon" entry in when the merchant is on the Coupons tab. Avoids
+    /// leaking ItemListView's internal state up to the dashboard.
+    struct PhoneHeaderAccessoryContext {
+        let canCreateCoupon: Bool
+        let onCreateCoupon: () -> Void
     }
 
     private var analyticsTracker: PointOfSaleItemListAnalyticsTracker {
@@ -418,7 +425,12 @@ private extension ItemListView {
                         )
                         .transition(.opacity.combined(with: .move(edge: .trailing)))
                     } else {
-                        createCouponButton
+                        // Tablet keeps the inline + button. On phone (when a header
+                        // accessory builder is provided) the + folds into the overflow
+                        // menu so the menu chip is always visible.
+                        if phoneHeaderAccessoryBuilder == nil {
+                            createCouponButton
+                        }
 
                         POSPageHeaderActionButton(systemName: "magnifyingglass") {
                             analyticsTracker.trackSearchTapped(itemListType: selectedItemListType)
@@ -426,11 +438,17 @@ private extension ItemListView {
                         }
                         .transition(.opacity.combined(with: .scale))
 
-                        // Hidden on the Coupons tab where the createCouponButton already crowds the
-                        // trailing slot, otherwise the Products / Coupons tab titles get squeezed.
-                        if let trailingHeaderAccessoryHiddenOnCoupons, !isAddingCouponAllowed {
-                            trailingHeaderAccessoryHiddenOnCoupons
-                                .transition(.opacity.combined(with: .scale))
+                        if let phoneHeaderAccessoryBuilder {
+                            phoneHeaderAccessoryBuilder(
+                                PhoneHeaderAccessoryContext(
+                                    canCreateCoupon: isAddingCouponAllowed,
+                                    onCreateCoupon: {
+                                        analytics.track(.pointOfSaleCouponsCreateTapped)
+                                        showCouponCreationModal = true
+                                    }
+                                )
+                            )
+                            .transition(.opacity.combined(with: .scale))
                         }
                     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -22,8 +22,7 @@ struct POSRefundConfirmationView: View {
             }
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
     }
 }
 
@@ -81,7 +80,7 @@ private extension POSRefundConfirmationView {
             Button(Localization.backButton, action: onBack)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
-        .padding(POSPadding.xLarge)
+        .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -29,8 +29,7 @@ struct POSRefundDetailView: View {
             }
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
         .posModalFullScreen(horizontalSizeClass == .compact)
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -18,8 +18,7 @@ struct POSRefundErrorView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
         .onAppear {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
                 isViewLoaded = true
@@ -80,7 +79,7 @@ private extension POSRefundErrorView {
             Button(Localization.cancelButton, action: onCancel)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
-        .padding(POSPadding.xLarge)
+        .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
         .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
         .opacity(isViewLoaded ? 1 : 0)
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundItemsSelectionView.swift
@@ -29,20 +29,22 @@ struct POSRefundItemsSelectionView: View {
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
-            headerView
-            itemsHeaderView
+            VStack(spacing: POSSpacing.none) {
+                headerView
+                itemsHeaderView
 
-            Divider()
-                .overlay(Color.posOutlineVariant.opacity(0.5))
+                Divider()
+                    .overlay(Color.posOutlineVariant.opacity(0.5))
 
-            itemsList
+                itemsList
+            }
+            .padding(POSPadding.xLarge)
 
             continueButton
+                .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
         }
-        .padding(POSPadding.xLarge)
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
     }
 }
 
@@ -126,7 +128,6 @@ private extension POSRefundItemsSelectionView {
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .disabled(!hasSelectedItems)
-        .padding(.top, POSPadding.medium)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundLoadingView.swift
@@ -19,8 +19,7 @@ struct POSRefundLoadingView: View {
         .padding(.bottom, POSPadding.xLarge)
         .padding(.top, POSPadding.xxLarge)
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
@@ -19,3 +19,53 @@ enum POSRefundModalLayout {
         sizeClass == .compact ? 0 : cornerRadius
     }
 }
+
+/// Sizes a refund-flow modal: a centered, rounded card on iPad; an edge-to-edge full
+/// screen take-over on phone. Matches the rest of the phone-prototype UI where modal
+/// flows occupy the entire screen rather than appearing as a partial sheet.
+struct POSRefundModalFrameModifier: ViewModifier {
+    let parentSize: CGSize
+    let horizontalSizeClass: UserInterfaceSizeClass?
+
+    func body(content: Content) -> some View {
+        if horizontalSizeClass == .compact {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            content
+                .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius))
+                .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        }
+    }
+}
+
+extension View {
+    func posRefundModalFrame(parentSize: CGSize, horizontalSizeClass: UserInterfaceSizeClass?) -> some View {
+        modifier(POSRefundModalFrameModifier(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass))
+    }
+}
+
+/// Standardizes the bottom-anchored action buttons across the phone POS so refund / totals /
+/// cart all share the same horizontal insets and home-indicator clearance as the phone cart
+/// button. iPad keeps the existing in-card padding so the centered modal still breathes.
+struct POSPhoneFullScreenButtonPaddingModifier: ViewModifier {
+    let horizontalSizeClass: UserInterfaceSizeClass?
+
+    func body(content: Content) -> some View {
+        if horizontalSizeClass == .compact {
+            content
+                .padding(.horizontal, POSPadding.medium)
+                .padding(.top, POSPadding.medium)
+                .padding(.bottom, POSPadding.xxLarge)
+        } else {
+            content
+                .padding(POSPadding.xLarge)
+        }
+    }
+}
+
+extension View {
+    func posPhoneFullScreenButtonPadding(horizontalSizeClass: UserInterfaceSizeClass?) -> some View {
+        modifier(POSPhoneFullScreenButtonPaddingModifier(horizontalSizeClass: horizontalSizeClass))
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundNothingToRefundView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundNothingToRefundView.swift
@@ -13,8 +13,7 @@ struct POSRefundNothingToRefundView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
     }
 }
 
@@ -52,7 +51,7 @@ private extension POSRefundNothingToRefundView {
     var buttonsSection: some View {
         Button(Localization.doneButton, action: onClose)
             .buttonStyle(POSFilledButtonStyle(size: .normal))
-            .padding(POSPadding.xLarge)
+            .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -22,8 +22,7 @@ struct POSRefundReviewView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
     }
 }
 
@@ -127,7 +126,7 @@ private extension POSRefundReviewView {
                     .buttonStyle(POSOutlinedButtonStyle(size: .normal))
             }
         }
-        .padding(POSPadding.xLarge)
+        .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
     }
 
     func summaryRow(label: String, value: String, labelColor: Color, valueColor: Color) -> some View {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -19,8 +19,7 @@ struct POSRefundSuccessView: View {
             buttonsSection
         }
         .background(Color.posSurfaceBright)
-        .clipShape(RoundedRectangle(cornerRadius: POSRefundModalLayout.cornerRadius(for: horizontalSizeClass)))
-        .frame(width: parentSize.width - (POSRefundModalLayout.horizontalPadding(for: horizontalSizeClass) * 2))
+        .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
         .onAppear {
             withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
                 isViewLoaded = true
@@ -90,7 +89,7 @@ private extension POSRefundSuccessView {
             Button(Localization.emailReceiptButton, action: onEmailReceipt)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
-        .padding(POSPadding.xLarge)
+        .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
         .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
         .opacity(isViewLoaded ? 1 : 0)
     }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -216,9 +216,16 @@ struct PointOfSaleDashboardView: View {
             switch posModel.orderStage {
             case .building:
                 VStack(spacing: POSSpacing.none) {
-                    ItemListView(selectedItemListType: $viewStateCoordinator.selectedItemListType,
-                                 searchTerm: $viewStateCoordinator.searchTerm,
-                                 trailingHeaderAccessoryHiddenOnCoupons: AnyView(phoneOverflowMenu))
+                    ItemListView(
+                        selectedItemListType: $viewStateCoordinator.selectedItemListType,
+                        searchTerm: $viewStateCoordinator.searchTerm,
+                        phoneHeaderAccessoryBuilder: { context in
+                            AnyView(phoneOverflowMenu(
+                                canCreateCoupon: context.canCreateCoupon,
+                                onCreateCoupon: context.onCreateCoupon
+                            ))
+                        }
+                    )
                     // Always shown — even with an empty cart — so the flow is always discoverable
                     // and the merchant has a consistent landmark at the bottom of the screen.
                     // Suppressed when a pushed view (e.g. the custom amount form) signals via
@@ -311,8 +318,17 @@ struct PointOfSaleDashboardView: View {
     @State private var phoneShowingBarcodeScannerSetup: Bool = false
     @State private var phoneCartButtonPulse: Bool = false
 
-    private var phoneOverflowMenu: some View {
+    @ViewBuilder
+    private func phoneOverflowMenu(canCreateCoupon: Bool,
+                                   onCreateCoupon: @escaping () -> Void) -> some View {
         Menu {
+            // Top of the menu when on the Coupons tab, so the create-coupon entry
+            // sits at the natural "primary action" slot for that tab.
+            if canCreateCoupon {
+                Button(action: onCreateCoupon) {
+                    Label(Localization.phoneMenuCreateCoupon, systemImage: "plus")
+                }
+            }
             Button {
                 analytics.track(.pointOfSaleExitMenuItemTapped)
                 showExitPOSModal = true
@@ -623,6 +639,11 @@ private extension PointOfSaleDashboardView {
             "pointOfSaleDashboard.phone.menu.accessibilityLabel",
             value: "More options",
             comment: "VoiceOver label for the phone-only Point of Sale overflow menu button."
+        )
+        static let phoneMenuCreateCoupon = NSLocalizedString(
+            "pointOfSaleDashboard.phone.menu.createCoupon",
+            value: "Create coupon",
+            comment: "Phone-only overflow menu item to create a new coupon, shown when the merchant is on the Coupons tab."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -380,7 +380,10 @@ struct PointOfSaleDashboardView: View {
         }
         .buttonStyle(POSFilledButtonStyle(size: .normal))
         .padding(.horizontal, POSPadding.medium)
-        .padding(.vertical, POSPadding.medium)
+        .padding(.top, POSPadding.medium)
+        // Bottom padding clears the home indicator: the parent `phoneContentView` applies
+        // `.ignoresSafeArea()`, so the standard safe-area inset doesn't push the button up.
+        .padding(.bottom, POSPadding.xxLarge)
         // Quick pulse to confirm an item was added — only on count increases, so removing items
         // doesn't bounce the button distractingly. Watches the full cart count (products +
         // custom amounts + coupons) so adding any of those pulses, even though the displayed

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -33,18 +33,23 @@ struct POSRootModalViewModifier: ViewModifier {
                         }
                     // Don't scale/fade in the backdrop
                         .animation(nil, value: modalManager.isPresented)
+                    // Phone full-screen: paint the bright surface as a sibling above the dim
+                    // backdrop so the screen reads as a single solid take-over, with no
+                    // backdrop showing through above the status bar.
+                    if isFullScreen {
+                        Color.posSurfaceBright
+                            .edgesIgnoringSafeArea(.all)
+                            .animation(nil, value: modalManager.isPresented)
+                    }
                     ZStack {
                         modalManager.getContent()
                             .environment(\.posModalParentSize, modalParentSize)
                             .environment(\.posModalDismissAction, { modalManager.dismiss() })
-                            .background(Color.posSurfaceBright)
+                            .background(isFullScreen ? Color.clear : Color.posSurfaceBright)
                             .cornerRadius(isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
                             .posShadow(isFullScreen ? .none : .large,
                                        cornerRadius: isFullScreen ? 0 : POSCornerRadiusStyle.extraLarge.value)
                             .padding(isFullScreen ? POSPadding.none : POSPadding.medium)
-                            // When full-screen we still respect the top safe area so the close
-                            // button (and any header) doesn't sit flush against the status bar /
-                            // notch. The bottom + horizontal edges still extend to the screen.
                             .ignoresSafeArea(.container, edges: isFullScreen ? [.horizontal, .bottom] : [])
                     }
                     .zIndex(1)

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -7,6 +7,7 @@ struct TotalsView: View {
     @Environment(POSPaymentModel.self) private var paymentModel
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.posAnalytics) private var analytics
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private let viewHelper = POSPaymentViewHelper()
     private let totalsViewHelper = TotalsViewHelper()
 
@@ -225,7 +226,12 @@ private extension TotalsView {
                 }
                 if viewHelper.shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
                                                           paymentState: displayPaymentState) {
-                    return .primary
+                    // On phone, drop the 8pt sidePadding so the connect-reader button can
+                    // anchor to the same 16pt screen-edge insets as the cash button below
+                    // (which uses .padding(.horizontal, 16) directly off the screen).
+                    return horizontalSizeClass == .compact
+                        ? PaymentViewLayout(topPadding: nil, bottomPadding: POSPadding.small, sidePadding: 0)
+                        : .primary
                 }
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -226,11 +226,12 @@ private extension TotalsView {
                 }
                 if viewHelper.shouldShowDisconnectedMessage(readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
                                                           paymentState: displayPaymentState) {
-                    // On phone, drop the 8pt sidePadding so the connect-reader button can
-                    // anchor to the same 16pt screen-edge insets as the cash button below
-                    // (which uses .padding(.horizontal, 16) directly off the screen).
+                    // On phone, drop the sidePadding (POSPadding.small) so the connect-reader
+                    // button can anchor to the same POSPadding.medium screen-edge insets as
+                    // the cash button below (which uses .padding(.horizontal, POSPadding.medium)
+                    // directly off the screen).
                     return horizontalSizeClass == .compact
-                        ? PaymentViewLayout(topPadding: nil, bottomPadding: POSPadding.small, sidePadding: 0)
+                        ? PaymentViewLayout(topPadding: nil, bottomPadding: POSPadding.small, sidePadding: POSPadding.none)
                         : .primary
                 }
             }


### PR DESCRIPTION
> **Stack order** (review bottom-up):
> 1. #17062 → #17063 → #17064 → #17065 → #17066 → #17067 (existing phone POS stack)
> 2. #17092 — POSLayoutScale + responsive design foundation
> 3. **This PR** — Pre-TTP checkout & modal polish
> 4. (next) TTP foundation, checkout row, hero/sheet, wiring, polish

## Description
Stacked on top of #17092. Six small visual / cleanup fixes that surfaced while wiring the phone-adaptive checkout — none of them are TTP-specific, so they ship before the TTP feature work goes in.

- **Drop orphan `preferredConnectionMethod` from POS entry** — leftover param from a discarded experiment, no longer wired anywhere.
- **Fill the modal surface above the status bar** — phone-presented sheets ended just under the status bar leaving a coloured gap; extend the surface to the top edge so it reads as a full-screen modal.
- **Clear the home indicator under the cart button** — cart button overlapped the bottom safe-area indicator on phone; pin it just above instead.
- **Fold create-coupon into the items header overflow menu** — coupon entry was a stray button; moves it into the Exit / Settings / Orders overflow already on the items header so the toolbar is consistent across screens.
- **Fill refund modals on phone with cart-style buttons** — the refund flow's primary buttons were inset like the iPad layout; on phone they now match the cart's wide outlined-button style for tap-target parity.
- **Align connect-reader and cash buttons on checkout** — the connect-reader button used different horizontal padding from the Cash button below it; both now share the same insets so the column feels intentional.

## Test Steps
- Pull the branch (Debug = phone POS flag = `.localDeveloper`).
- **iPhone, flag ON**:
  1. Open POS → all modals (settings, refund, barcode setup, coupon-add) — surface fills to status bar top, no white gap.
  2. Cart button — sits just above the home indicator, no overlap.
  3. Items header overflow → contains Exit / Settings / Orders / Add coupon. Tapping Add coupon opens the coupon-add modal.
  4. Refund flow → primary CTA spans wide and matches cart-style outlined buttons.
  5. Checkout (no reader connected) → "Connect your reader" + Cash button align horizontally with matching padding.
- **iPad, flag either**: nothing changed visually.

## Screenshots
N/A — small visual fixes verified live.

---
- [x] No release notes — feature still flagged off in alpha.