### PR TITLE
[RSM] Phone POS TTP - Foundation: feature flag + availability tracking

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -105,6 +105,10 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .pointOfSaleMarkOrderAsPaid:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .pointOfSaleTapToPay:
+            // Behind the flag while the TTP integration lands. localDeveloper-only so
+            // alpha and beta keep showing only Cash + Card reader for now.
+            return buildConfig == .localDeveloper
         case .selfDrivenPushToken:
             return false
         case .clientSideDashboardBanner:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -221,6 +221,12 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case pointOfSaleMarkOrderAsPaid
 
+    /// Enables Tap to Pay as a payment method in Point of Sale on phone.
+    /// When enabled and the device + site support TTP, the totals view promotes "Tap to Pay"
+    /// as the primary payment method. Mirrors the Android `WOO_POS_TAP_TO_PAY` flag.
+    ///
+    case pointOfSaleTapToPay
+
     /// Enables self driven push token registration
     ///
     case selfDrivenPushToken

--- a/Modules/Sources/PointOfSale/Card Present Payments/POSTapToPayAvailabilityChecking.swift
+++ b/Modules/Sources/PointOfSale/Card Present Payments/POSTapToPayAvailabilityChecking.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Whether the device + site can use Apple's Tap to Pay reader for POS payments.
+///
+/// `unknown` while the check is in flight, then resolves to `available` or
+/// `unavailable(reason:)`. The reason is plumbed up to analytics so we can spot
+/// merchants who can't access TTP from their device or site.
+public enum POSTapToPayAvailabilityState: Equatable {
+    case unknown
+    case available
+    case unavailable(reason: POSTapToPayUnavailableReason)
+}
+
+public enum POSTapToPayUnavailableReason: String, Equatable {
+    /// The build is not enabling the POS phone TTP feature flag.
+    case featureFlagDisabled
+    /// The device hardware doesn't support TTP (e.g. older iPhone, iPad).
+    case deviceNotSupported
+    /// The store's country / payment plugin doesn't support TTP yet.
+    case siteNotEligible
+}
+
+/// Checks whether the device + site can use Apple Tap to Pay for POS payments.
+public protocol POSTapToPayAvailabilityChecking {
+    /// Resolves to `.available` only when the feature flag is on, the device
+    /// supports the built-in reader, and the site's country + plugin status
+    /// allow it. Otherwise resolves to `.unavailable(reason:)`.
+    func checkAvailability() async -> POSTapToPayAvailabilityState
+}

--- a/Modules/Sources/PointOfSale/Controllers/POSTapToPayAvailabilityController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSTapToPayAvailabilityController.swift
@@ -15,7 +15,7 @@ import Observation
     public init(availabilityChecker: POSTapToPayAvailabilityChecking) {
         self.availabilityChecker = availabilityChecker
 
-        Task { @MainActor in
+        Task {
             self.state = await availabilityChecker.checkAvailability()
         }
     }

--- a/Modules/Sources/PointOfSale/Controllers/POSTapToPayAvailabilityController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSTapToPayAvailabilityController.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Observation
+
+/// Owns the resolved Tap to Pay availability state for the POS session and exposes it
+/// to views. Kicks off a single async check on init via the injected checker, then holds
+/// the result for the rest of the session.
+///
+/// Designed so future PRs can read `state` to gate UI (multi-method buttons row,
+/// pre-connect on checkout, etc.) without each view re-running the eligibility check.
+@Observable @MainActor public final class POSTapToPayAvailabilityController {
+    public private(set) var state: POSTapToPayAvailabilityState = .unknown
+
+    private let availabilityChecker: POSTapToPayAvailabilityChecking
+
+    public init(availabilityChecker: POSTapToPayAvailabilityChecking) {
+        self.availabilityChecker = availabilityChecker
+
+        Task { @MainActor in
+            self.state = await availabilityChecker.checkAvailability()
+        }
+    }
+}
+
+public extension POSTapToPayAvailabilityState {
+    var isAvailable: Bool {
+        if case .available = self { return true }
+        return false
+    }
+}

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -92,7 +92,7 @@ protocol PointOfSaleAggregateModelProtocol {
     /// Resolves whether Tap to Pay is available for the current device + site. Optional
     /// so existing callers (previews, tests) keep working — when nil the rest of POS
     /// behaves as if TTP is not available.
-    let tapToPayAvailabilityController: POSTapToPayAvailabilityController?
+    private(set) var tapToPayAvailabilityController: POSTapToPayAvailabilityController?
 
     private var cancellables: Set<AnyCancellable> = []
 

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -89,6 +89,11 @@ protocol PointOfSaleAggregateModelProtocol {
     /// Checker for whether the store needs a POS sunset warning (WC < 10.5)
     private let sunsetWarningChecker: POSSunsetWarningChecking?
 
+    /// Resolves whether Tap to Pay is available for the current device + site. Optional
+    /// so existing callers (previews, tests) keep working — when nil the rest of POS
+    /// behaves as if TTP is not available.
+    let tapToPayAvailabilityController: POSTapToPayAvailabilityController?
+
     private var cancellables: Set<AnyCancellable> = []
 
     // Private storage of the concrete coordinator
@@ -139,7 +144,8 @@ protocol PointOfSaleAggregateModelProtocol {
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = nil,
          cartProductObserver: POSCartProductObserving? = nil,
          isLocalCatalogEligible: Bool = false,
-         sunsetWarningChecker: POSSunsetWarningChecking? = nil) {
+         sunsetWarningChecker: POSSunsetWarningChecking? = nil,
+         tapToPayAvailabilityController: POSTapToPayAvailabilityController? = nil) {
         self.entryPointController = entryPointController
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -159,6 +165,7 @@ protocol PointOfSaleAggregateModelProtocol {
         self.cartProductObserver = cartProductObserver
         self.isLocalCatalogEligible = isLocalCatalogEligible
         self.sunsetWarningChecker = sunsetWarningChecker
+        self.tapToPayAvailabilityController = tapToPayAvailabilityController
 
         // Payment controller is created with cart-specific dependencies.
         // The weak self captures below are safe because paymentModel is owned by self.

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -51,6 +51,7 @@ public struct PointOfSaleEntryPointView: View {
     private let cartProductObserver: POSCartProductObserving?
     private let isLocalCatalogEligible: Bool
     private let sunsetWarningChecker: POSSunsetWarningChecking?
+    private let tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking?
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -77,6 +78,7 @@ public struct PointOfSaleEntryPointView: View {
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?,
          isLocalCatalogEligible: Bool,
          sunsetWarningChecker: POSSunsetWarningChecking? = nil,
+         tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking? = nil,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
@@ -162,6 +164,7 @@ public struct PointOfSaleEntryPointView: View {
         self.catalogSyncCoordinator = catalogSyncCoordinator
         self.isLocalCatalogEligible = isLocalCatalogEligible
         self.sunsetWarningChecker = sunsetWarningChecker
+        self.tapToPayAvailabilityChecker = tapToPayAvailabilityChecker
     }
 
     public var body: some View {
@@ -197,7 +200,8 @@ public struct PointOfSaleEntryPointView: View {
                 catalogSyncCoordinator: catalogSyncCoordinator,
                 cartProductObserver: cartProductObserver,
                 isLocalCatalogEligible: isLocalCatalogEligible,
-                sunsetWarningChecker: sunsetWarningChecker)
+                sunsetWarningChecker: sunsetWarningChecker,
+                tapToPayAvailabilityController: tapToPayAvailabilityChecker.map(POSTapToPayAvailabilityController.init))
         }
         .environment(\.posAnalytics, services.analytics)
         .environment(\.posCurrencyProvider, services.currency)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSTapToPayAvailabilityControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSTapToPayAvailabilityControllerTests.swift
@@ -1,0 +1,148 @@
+import Testing
+import Foundation
+import Observation
+@testable import PointOfSale
+
+@Suite(.timeLimit(.minutes(5)))
+@MainActor
+struct POSTapToPayAvailabilityControllerTests {
+
+    // MARK: - Initial State
+
+    @Test func init_then_state_is_unknown() {
+        // Given
+        let checker = MockPOSTapToPayAvailabilityChecker()
+        // Checker never completes during synchronous init inspection
+
+        // When
+        let sut = POSTapToPayAvailabilityController(availabilityChecker: checker)
+
+        // Then
+        #expect(sut.state == .unknown)
+    }
+
+    // MARK: - State Resolved to Available
+
+    @Test func checkAvailability_when_checker_returns_available_then_state_transitions_to_available() async {
+        // Given
+        let checker = MockPOSTapToPayAvailabilityChecker()
+        checker.resultToReturn = .available
+
+        // When
+        let sut = POSTapToPayAvailabilityController(availabilityChecker: checker)
+
+        // Then – wait for the background Task in init to resolve the state
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.state
+            } onChange: {
+                Task { @MainActor in
+                    if case .available = sut.state {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+
+        #expect(sut.state == .available)
+    }
+
+    // MARK: - State Resolved to Unavailable
+
+    @Test func checkAvailability_when_checker_returns_featureFlagDisabled_then_state_transitions_to_unavailable_featureFlagDisabled() async {
+        // Given
+        let checker = MockPOSTapToPayAvailabilityChecker()
+        checker.resultToReturn = .unavailable(reason: .featureFlagDisabled)
+
+        // When
+        let sut = POSTapToPayAvailabilityController(availabilityChecker: checker)
+
+        // Then
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.state
+            } onChange: {
+                Task { @MainActor in
+                    if case .unavailable = sut.state {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+
+        #expect(sut.state == .unavailable(reason: .featureFlagDisabled))
+    }
+
+    @Test func checkAvailability_when_checker_returns_deviceNotSupported_then_state_transitions_to_unavailable_deviceNotSupported() async {
+        // Given
+        let checker = MockPOSTapToPayAvailabilityChecker()
+        checker.resultToReturn = .unavailable(reason: .deviceNotSupported)
+
+        // When
+        let sut = POSTapToPayAvailabilityController(availabilityChecker: checker)
+
+        // Then
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.state
+            } onChange: {
+                Task { @MainActor in
+                    if case .unavailable = sut.state {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+
+        #expect(sut.state == .unavailable(reason: .deviceNotSupported))
+    }
+
+    @Test func checkAvailability_when_checker_returns_siteNotEligible_then_state_transitions_to_unavailable_siteNotEligible() async {
+        // Given
+        let checker = MockPOSTapToPayAvailabilityChecker()
+        checker.resultToReturn = .unavailable(reason: .siteNotEligible)
+
+        // When
+        let sut = POSTapToPayAvailabilityController(availabilityChecker: checker)
+
+        // Then
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.state
+            } onChange: {
+                Task { @MainActor in
+                    if case .unavailable = sut.state {
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+
+        #expect(sut.state == .unavailable(reason: .siteNotEligible))
+    }
+
+    // MARK: - Checker invocation
+
+    @Test func init_then_calls_checker_exactly_once() async {
+        // Given
+        let checker = MockPOSTapToPayAvailabilityChecker()
+        checker.resultToReturn = .available
+
+        // When
+        let sut = POSTapToPayAvailabilityController(availabilityChecker: checker)
+
+        // Wait for init Task to complete
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.state
+            } onChange: {
+                Task { @MainActor in
+                    continuation.resume()
+                }
+            }
+        }
+
+        // Then
+        #expect(checker.checkAvailabilityCallCount == 1)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSTapToPayAvailabilityChecker.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSTapToPayAvailabilityChecker.swift
@@ -1,0 +1,15 @@
+import Foundation
+@testable import PointOfSale
+
+final class MockPOSTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
+    /// Configures the result returned by `checkAvailability()`.
+    var resultToReturn: POSTapToPayAvailabilityState = .available
+
+    /// Records how many times `checkAvailability()` was called.
+    var checkAvailabilityCallCount = 0
+
+    func checkAvailability() async -> POSTapToPayAvailabilityState {
+        checkAvailabilityCallCount += 1
+        return resultToReturn
+    }
+}

--- a/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
@@ -1,0 +1,73 @@
+import Foundation
+import PointOfSale
+import enum Experiments.FeatureFlag
+import protocol Experiments.FeatureFlagService
+import enum Yosemite.CardPresentPaymentAction
+import enum Yosemite.CardReaderDiscoveryMethod
+import enum Hardware.CardReaderType
+import protocol Yosemite.StoresManager
+import protocol Yosemite.POSEligibilityServiceProtocol
+
+/// Resolves Tap to Pay availability for the current POS session.
+///
+/// Three gates, evaluated in order — fail fast on whichever is first to deny:
+/// 1. The `pointOfSaleTapToPay` feature flag (cheapest check, shortcuts the rest).
+/// 2. Device support — Stripe's `Terminal.shared.supportsReaders(of: .appleBuiltIn, ...)`,
+///    dispatched via `CardPresentPaymentAction.checkDeviceSupport`.
+/// 3. Site eligibility — proxied off cached POS tab visibility, which is itself driven
+///    by IPP/country eligibility checks in `POSTabVisibilityChecker`.
+///
+/// One-shot — `POSTapToPayAvailabilityController` calls `checkAvailability()` once on
+/// POS entry and holds the result for the rest of the session.
+final class POSTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+    private let eligibilityService: POSEligibilityServiceProtocol
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         eligibilityService: POSEligibilityServiceProtocol) {
+        self.siteID = siteID
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+        self.eligibilityService = eligibilityService
+    }
+
+    func checkAvailability() async -> POSTapToPayAvailabilityState {
+        guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleTapToPay) else {
+            return .unavailable(reason: .featureFlagDisabled)
+        }
+        guard await deviceSupportsTapToPay() else {
+            return .unavailable(reason: .deviceNotSupported)
+        }
+        guard siteIsEligibleForTapToPay() else {
+            return .unavailable(reason: .siteNotEligible)
+        }
+        return .available
+    }
+}
+
+private extension POSTapToPayAvailabilityChecker {
+    func deviceSupportsTapToPay() async -> Bool {
+        await withCheckedContinuation { continuation in
+            let action = CardPresentPaymentAction.checkDeviceSupport(
+                siteID: siteID,
+                cardReaderType: .tapToPay,
+                discoveryMethod: .tapToPay,
+                minimumOperatingSystemVersionOverride: nil
+            ) { isSupported in
+                continuation.resume(returning: isSupported)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// POS only renders when the site is IPP-eligible (see `POSTabVisibilityChecker`),
+    /// and the result is cached per-site once that check runs. Reusing it here avoids a
+    /// duplicate eligibility roundtrip on every POS entry.
+    func siteIsEligibleForTapToPay() -> Bool {
+        eligibilityService.loadCachedPOSTabVisibility(siteID: siteID) ?? false
+    }
+}

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -305,6 +305,10 @@ private extension POSTabCoordinator {
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
                     sunsetWarningChecker: sunsetWarningChecker,
+                    tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecker(
+                        siteID: siteID,
+                        eligibilityService: POSEligibilityService()
+                    ),
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )

--- a/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
@@ -4,6 +4,7 @@ import Experiments
 import Yosemite
 @testable import WooCommerce
 
+@MainActor
 @Suite(.timeLimit(.minutes(5)))
 struct POSTapToPayAvailabilityCheckerTests {
 

--- a/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSTapToPayAvailabilityCheckerTests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+import Experiments
+import Yosemite
+@testable import WooCommerce
+
+@Suite(.timeLimit(.minutes(5)))
+struct POSTapToPayAvailabilityCheckerTests {
+
+    private let siteID: Int64 = 123
+
+    // MARK: - Feature Flag Gate
+
+    @Test func checkAvailability_when_featureFlag_disabled_then_returns_featureFlagDisabled() async {
+        // Given
+        let featureFlags = MockFeatureFlagService()
+        featureFlags.isFeatureFlagEnabledReturnValue[.pointOfSaleTapToPay] = false
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then
+        #expect(result == .unavailable(reason: .featureFlagDisabled))
+    }
+
+    @Test func checkAvailability_when_featureFlag_disabled_then_does_not_dispatch_device_check() async {
+        // Given
+        let featureFlags = MockFeatureFlagService()
+        featureFlags.isFeatureFlagEnabledReturnValue[.pointOfSaleTapToPay] = false
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        var deviceCheckDispatched = false
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport = action {
+                deviceCheckDispatched = true
+            }
+        }
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores)
+
+        // When
+        _ = await sut.checkAvailability()
+
+        // Then
+        #expect(deviceCheckDispatched == false)
+    }
+
+    // MARK: - Device Support Gate
+
+    @Test func checkAvailability_when_featureFlag_on_but_device_not_supported_then_returns_deviceNotSupported() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport(_, _, _, _, let completion) = action {
+                completion(false)
+            }
+        }
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachedTabVisibility[123] = true
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, eligibilityService: eligibilityService)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then
+        #expect(result == .unavailable(reason: .deviceNotSupported))
+    }
+
+    @Test func checkAvailability_when_device_not_supported_then_does_not_check_site_eligibility() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport(_, _, _, _, let completion) = action {
+                completion(false)
+            }
+        }
+        let eligibilityService = MockPOSEligibilityService()
+        // No cached visibility set — if eligibility were checked, loadCachedPOSTabVisibility returns nil → false
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, eligibilityService: eligibilityService)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then — result is deviceNotSupported (not siteNotEligible), confirming eligibility was not the gate
+        #expect(result == .unavailable(reason: .deviceNotSupported))
+    }
+
+    // MARK: - Site Eligibility Gate
+
+    @Test func checkAvailability_when_featureFlag_on_device_supported_but_site_not_eligible_then_returns_siteNotEligible() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport(_, _, _, _, let completion) = action {
+                completion(true)
+            }
+        }
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachedTabVisibility[siteID] = false
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, eligibilityService: eligibilityService)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then
+        #expect(result == .unavailable(reason: .siteNotEligible))
+    }
+
+    @Test func checkAvailability_when_site_eligibility_nil_cached_then_returns_siteNotEligible() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport(_, _, _, _, let completion) = action {
+                completion(true)
+            }
+        }
+        let eligibilityService = MockPOSEligibilityService()
+        // cachedTabVisibility has no entry for siteID → returns nil → treated as ineligible
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, eligibilityService: eligibilityService)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then
+        #expect(result == .unavailable(reason: .siteNotEligible))
+    }
+
+    // MARK: - All Gates Pass
+
+    @Test func checkAvailability_when_all_gates_pass_then_returns_available() async {
+        // Given
+        let featureFlags = makeEnabledFeatureFlags()
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+            if case .checkDeviceSupport(_, _, _, _, let completion) = action {
+                completion(true)
+            }
+        }
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachedTabVisibility[siteID] = true
+        let sut = makeSUT(featureFlagService: featureFlags, stores: stores, eligibilityService: eligibilityService)
+
+        // When
+        let result = await sut.checkAvailability()
+
+        // Then
+        #expect(result == .available)
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSTapToPayAvailabilityCheckerTests {
+    func makeEnabledFeatureFlags() -> MockFeatureFlagService {
+        let service = MockFeatureFlagService()
+        service.isFeatureFlagEnabledReturnValue[.pointOfSaleTapToPay] = true
+        return service
+    }
+
+    func makeSUT(
+        featureFlagService: MockFeatureFlagService = MockFeatureFlagService(),
+        stores: MockStoresManager = MockStoresManager(sessionManager: .makeForTesting()),
+        eligibilityService: MockPOSEligibilityService = MockPOSEligibilityService()
+    ) -> POSTapToPayAvailabilityChecker {
+        POSTapToPayAvailabilityChecker(
+            siteID: siteID,
+            stores: stores,
+            featureFlagService: featureFlagService,
+            eligibilityService: eligibilityService
+        )
+    }
+}


### PR DESCRIPTION
> **Stack order** (review bottom-up):
> 1. Existing phone POS stack (#17062 → #17067)
> 2. #17092 — POSLayoutScale + responsive design foundation
> 3. #17093 — Pre-TTP checkout & modal polish
> 4. **This PR** — TTP foundation: feature flag + availability tracking
> 5. (next) TTP checkout row (multi-method buttons)
> 6. (next) TTP hero & "Other payment methods" sheet
> 7. (next) TTP wiring & cancel handling
> 8. (next) TTP polish (alert suppression + hero polish)

## Description
Stacked on top of #17093. First piece of the iOS Tap to Pay (TTP) work that mirrors the Android phone POS stack (samiuelson #15825 onwards). Pure infrastructure — no UI changes yet.

- **`pointOfSaleTapToPay` feature flag** added to `FeatureFlag` and `DefaultFeatureFlagService` (`localDeveloper` only). All TTP behaviour lands behind this flag.
- **`POSTapToPayAvailabilityChecking` protocol + `POSTapToPayAvailabilityState` enum** in the PointOfSale module. Checker resolves to `.unknown` / `.available` / `.unavailable(reason:)` covering feature-flag, device-support, and site-eligibility checks.
- **`POSTapToPayAvailabilityController`** — `@Observable @MainActor` controller wrapping the checker, exposes the resolved state to the UI. The resolved state (available / unavailable with reason) is held for the rest of the POS session and will be read by downstream PRs to gate UI.
- **`POSTapToPayAvailabilityChecker`** in the app target. Implements feature-flag → device support → site eligibility, dispatching `CardPresentPaymentAction.checkDeviceSupport` to Yosemite. Wraps `stores.dispatch` in `Task { @MainActor in }` because `withCheckedContinuation` may resume off-main on the non-isolated checker.

Note: analytics events (`pointOfSaleTapToPayNotAvailable`, `pointOfSaleCheckoutTapToPayTapped`) are added in later stacked PRs (#17095 / #17098), not in this one.

Mirrors:
- [woocommerce-android#15825](https://github.com/woocommerce/woocommerce-android/pull/15825) — Android TTP availability foundation.

## Test Steps
- Pull the branch. Set `pointOfSalePhonePrototype` and `pointOfSaleTapToPay` flags to `.localDeveloper` in `DefaultFeatureFlagService`.
- Open POS — no behaviour changes yet (UI wires up in later PRs in the stack). The availability check runs silently in the background and the resolved state is stored in `POSTapToPayAvailabilityController`.
- Analytics tracking is not yet wired; Tracks events will appear in later PRs.

## Screenshots
N/A — no UI yet.

---
- [x] No release notes — feature flagged off (`pointOfSaleTapToPay` is `localDeveloper` only).