### PR TITLE
[RSM] Phone POS TTP - Checkout row with multi-method payment buttons

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSTapToPayAvailabilityController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSTapToPayAvailabilityController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import WooFoundationCore
 
 /// Owns the resolved Tap to Pay availability state for the POS session and exposes it
 /// to views. Kicks off a single async check on init via the injected checker, then holds
@@ -11,13 +12,24 @@ import Observation
     public private(set) var state: POSTapToPayAvailabilityState = .unknown
 
     private let availabilityChecker: POSTapToPayAvailabilityChecking
+    private let analytics: POSAnalyticsProviding?
 
-    public init(availabilityChecker: POSTapToPayAvailabilityChecking) {
+    public init(availabilityChecker: POSTapToPayAvailabilityChecking,
+                analytics: POSAnalyticsProviding? = nil) {
         self.availabilityChecker = availabilityChecker
+        self.analytics = analytics
 
-        Task {
-            self.state = await availabilityChecker.checkAvailability()
+        Task { @MainActor in
+            let resolved = await availabilityChecker.checkAvailability()
+            self.state = resolved
+            self.trackResolved(resolved)
         }
+    }
+
+    private func trackResolved(_ state: POSTapToPayAvailabilityState) {
+        guard case .unavailable(let reason) = state else { return }
+        analytics?.track(.pointOfSaleTapToPayNotAvailable,
+                         parameters: ["reason": reason.rawValue])
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -1,28 +1,20 @@
 import SwiftUI
 
+/// Reader-not-connected message shown in the totals view's payment area.
+///
+/// Quieter "no reader" state — the merchant's actual call to action lives in the
+/// bottom payment-method row (`POSCheckoutPaymentButtonsRow`), which renders a
+/// "Card reader" entry that triggers the connect flow when no reader is connected.
+/// This view used to host its own "Connect your reader" CTA, but moving it into
+/// the row keeps method selection in one place and avoids two competing CTAs.
 struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
     private let viewModel = PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel()
-    private let connectCardReader: () -> Void
     private let animation: POSCardPresentPaymentInLineMessageAnimation
     @AccessibilityFocusState private var isTitleFocused: Bool
     @ScaledMetric private var scale: CGFloat = 1.0
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    @State private var width: CGFloat = 0
-
-    private var connectButtonWidth: CGFloat {
-        // iPad: half the container.
-        // Phone: 16pt insets each side, matching the cash button below. TotalsView
-        // drops PaymentViewPaddingModifier's sidePadding to 0 on phone so the parent's
-        // edge is the screen edge — subtracting POSPadding.medium * 2 lands the button
-        // at [16, screenWidth − 16].
-        horizontalSizeClass == .compact ? max(width - POSPadding.medium * 2, 0) : width * 0.5
-    }
-
-    init(animation: POSCardPresentPaymentInLineMessageAnimation,
-         connectCardReader: @escaping () -> Void) {
+    init(animation: POSCardPresentPaymentInLineMessageAnimation) {
         self.animation = animation
-        self.connectCardReader = connectCardReader
     }
 
     var body: some View {
@@ -47,24 +39,8 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
                     .matchedGeometryEffect(id: animation.messageTransitionId, in: animation.namespace, properties: .position)
             }
             .padding(.horizontal, PointOfSaleCardPresentPaymentLayout.horizontalPadding)
-
-            Spacer()
-                .frame(height: dynamicSpacing(PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing))
-
-            Button {
-                connectCardReader()
-            } label: {
-                Text(viewModel.connectReaderButtonTitle)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
-            }
-            .buttonStyle(POSFilledButtonStyle(size: .normal))
-            .frame(width: connectButtonWidth)
         }
         .frame(maxWidth: .infinity)
-        .measureWidth({ containerWidth in
-            width = containerWidth
-        })
         .multilineTextAlignment(.center)
         .onAppear {
             isTitleFocused = true
@@ -84,7 +60,6 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
 #Preview {
     @Previewable @Namespace var namespace
     PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(
-        animation: .init(namespace: namespace),
-        connectCardReader: {})
+        animation: .init(namespace: namespace))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// Bottom-of-totals payment-method row.
+///
+/// Takes an ordered array of `POSCheckoutPaymentMethod` cases and renders the first as a
+/// filled primary button, the rest as outlined secondary buttons. The TotalsView is
+/// responsible for building the array (which methods, in which order) based on payment
+/// state, reader connection, and feature-flag-gated availability — this view just paints.
+///
+/// Mirrors the Android `WooPosCheckoutPaymentButtons` composable. Lives in its own type
+/// rather than being embedded in TotalsView so the array-driven layout is reviewable in
+/// isolation as TTP and additional payment methods land in later parts.
+struct POSCheckoutPaymentButtonsRow: View {
+    let methods: [POSCheckoutPaymentMethod]
+    let onSelect: (POSCheckoutPaymentMethod) -> Void
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    var body: some View {
+        VStack(spacing: POSSpacing.medium) {
+            ForEach(Array(methods.enumerated()), id: \.element) { index, method in
+                button(for: method, isPrimary: index == 0)
+            }
+        }
+        .padding(.horizontal, POSPadding.medium)
+        // Match the cart button's bottom inset on phone so the row clears the home
+        // indicator. iPad uses safeAreaPadding so the row hugs the side panel's bottom.
+        .if(horizontalSizeClass == .compact) {
+            $0.padding(.bottom, POSPadding.xxLarge)
+        }
+        .if(horizontalSizeClass != .compact) {
+            $0.safeAreaPadding(.bottom, POSPadding.medium)
+        }
+    }
+
+    @ViewBuilder
+    private func button(for method: POSCheckoutPaymentMethod, isPrimary: Bool) -> some View {
+        Button {
+            onSelect(method)
+        } label: {
+            Text(title(for: method))
+                .font(POSFontStyle.posBodyLargeBold)
+        }
+        .layoutPriority(1)
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+        .if(isPrimary) {
+            $0.buttonStyle(POSFilledButtonStyle(size: .normal))
+        }
+        .if(!isPrimary) {
+            $0.buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        }
+        .accessibilityIdentifier(accessibilityIdentifier(for: method))
+    }
+
+    private func title(for method: POSCheckoutPaymentMethod) -> String {
+        switch method {
+        case .tapToPay:
+            return Localization.tapToPay
+        case .cardReader:
+            return Localization.cardReader
+        case .cashPayment:
+            return Localization.cashPayment
+        }
+    }
+
+    private func accessibilityIdentifier(for method: POSCheckoutPaymentMethod) -> String {
+        switch method {
+        case .tapToPay:
+            return "pos-tap-to-pay-button"
+        case .cardReader:
+            return "pos-card-reader-button"
+        case .cashPayment:
+            return "pos-cash-payment-button"
+        }
+    }
+}
+
+private extension POSCheckoutPaymentButtonsRow {
+    enum Localization {
+        static let tapToPay = NSLocalizedString(
+            "pos.checkout.paymentMethod.tapToPay",
+            value: "Tap to Pay",
+            comment: "Title for the Tap to Pay button in the POS checkout payment-method row."
+        )
+        static let cardReader = NSLocalizedString(
+            "pos.checkout.paymentMethod.cardReader",
+            value: "Card reader",
+            comment: "Title for the card-reader button in the POS checkout payment-method row. Tapping it starts the connect-reader flow when no reader is connected."
+        )
+        static let cashPayment = NSLocalizedString(
+            "pos.checkout.paymentMethod.cashPayment",
+            value: "Cash payment",
+            comment: "Title for the cash-payment button in the POS checkout payment-method row."
+        )
+    }
+}
+
+#if DEBUG
+#Preview("Row — Cash only") {
+    POSCheckoutPaymentButtonsRow(methods: [.cashPayment], onSelect: { _ in })
+}
+
+#Preview("Row — Card reader + Cash") {
+    POSCheckoutPaymentButtonsRow(methods: [.cardReader, .cashPayment], onSelect: { _ in })
+}
+
+#Preview("Row — Tap to Pay + Card reader + Cash") {
+    POSCheckoutPaymentButtonsRow(methods: [.tapToPay, .cardReader, .cashPayment], onSelect: { _ in })
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
@@ -85,7 +85,8 @@ private extension POSCheckoutPaymentButtonsRow {
         static let cardReader = NSLocalizedString(
             "pos.checkout.paymentMethod.cardReader",
             value: "Card reader",
-            comment: "Title for the card-reader button in the POS checkout payment-method row. Tapping it starts the connect-reader flow when no reader is connected."
+            comment: "Title for the card-reader button in the POS checkout payment-method row. " +
+                "Tapping it starts the connect-reader flow when no reader is connected."
         )
         static let cashPayment = NSLocalizedString(
             "pos.checkout.paymentMethod.cashPayment",

--- a/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
@@ -39,7 +39,7 @@ struct POSCheckoutPaymentButtonsRow: View {
             onSelect(method)
         } label: {
             Text(title(for: method))
-                .font(POSFontStyle.posBodyLargeBold)
+                .font(.posBodyLargeBold)
         }
         .layoutPriority(1)
         .dynamicTypeSize(...DynamicTypeSize.accessibility1)

--- a/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentMethod.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentMethod.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// A payment method offered in the totals view's bottom buttons row.
+///
+/// Mirrors the Android `WooPosPaymentMethod` enum. Cases are ordered by precedence —
+/// the first method in a `[POSCheckoutPaymentMethod]` array is rendered as the primary
+/// (filled) button; the rest are outlined. The TotalsView builds this array from the
+/// current payment + reader state and any feature flags.
+enum POSCheckoutPaymentMethod: Hashable {
+    /// Apple's built-in (Tap to Pay on iPhone) reader. Phone-only — not surfaced
+    /// when TTP availability resolves to `.unavailable`.
+    case tapToPay
+    /// Bluetooth card reader (Stripe M2, WisePad, etc.). The "Connect your reader" CTA
+    /// also lives behind this method when no reader is connected.
+    case cardReader
+    /// Manually entered cash payment.
+    case cashPayment
+}

--- a/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSPaymentContentView.swift
@@ -277,9 +277,7 @@ struct POSCardPaymentContentView: View {
             }
         } else if viewHelper.shouldShowDisconnectedMessage(readerConnectionStatus: cardReaderConnectionStatus,
                                                     paymentState: paymentState) {
-            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(animation: paymentMessageAnimation) {
-                connectCardReaderAction()
-            }
+            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(animation: paymentMessageAnimation)
         } else if let spinnerMessage = activeSpinnerMessage {
             POSPaymentLoadingView(title: spinnerMessage.title,
                                   message: spinnerMessage.message,

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -201,7 +201,10 @@ public struct PointOfSaleEntryPointView: View {
                 cartProductObserver: cartProductObserver,
                 isLocalCatalogEligible: isLocalCatalogEligible,
                 sunsetWarningChecker: sunsetWarningChecker,
-                tapToPayAvailabilityController: tapToPayAvailabilityChecker.map(POSTapToPayAvailabilityController.init))
+                tapToPayAvailabilityController: tapToPayAvailabilityChecker.map { checker in
+                    POSTapToPayAvailabilityController(availabilityChecker: checker,
+                                                      analytics: services.analytics)
+                })
         }
         .environment(\.posAnalytics, services.analytics)
         .environment(\.posCurrencyProvider, services.currency)

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import SwiftUI
 import WooFoundation
 import Experiments
@@ -520,13 +521,17 @@ private extension TotalsView {
     /// Builds the ordered list of payment methods rendered in the bottom buttons row.
     ///
     /// When the cash button visibility checks fail (syncing, reconnecting, zero total)
-    /// the row is hidden entirely. When the reader is disconnected the merchant gets
-    /// `[.cardReader, .cashPayment]` — tapping Card reader starts the connect flow,
-    /// matching what the in-pane "Connect your reader" CTA used to do. With a reader
-    /// connected the row collapses to `[.cashPayment]`.
+    /// the row is hidden entirely. Otherwise the row is composed from:
     ///
-    /// `.tapToPay` is intentionally absent at this stage and lands in a later part of
-    /// the TTP stack; the row already supports rendering it.
+    /// - `.tapToPay` — prepended when the availability controller has resolved
+    ///   `.available` (device + site eligibility passed and the feature flag is on).
+    ///   First slot, so it renders as the primary (filled) button on phone.
+    /// - `.cardReader` — included when no reader is connected. Tapping it starts the
+    ///   connect flow the in-pane "Connect your reader" CTA used to drive.
+    /// - `.cashPayment` — always last, always present when the row is visible.
+    ///
+    /// `.tapToPay`'s action is intentionally a no-op at this stage — wiring it to
+    /// the actual collection flow happens in a later, focused commit.
     var checkoutPaymentMethods: [POSCheckoutPaymentMethod] {
         guard totalsViewHelper.shouldShowCollectCashPaymentButton(
             orderState: posModel.orderState,
@@ -540,14 +545,26 @@ private extension TotalsView {
             readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
             paymentState: displayPaymentState
         )
-        return isReaderDisconnected ? [.cardReader, .cashPayment] : [.cashPayment]
+        let isTapToPayAvailable = posModel.tapToPayAvailabilityController?.state.isAvailable == true
+
+        var methods: [POSCheckoutPaymentMethod] = []
+        if isTapToPayAvailable {
+            methods.append(.tapToPay)
+        }
+        if isReaderDisconnected {
+            methods.append(.cardReader)
+        }
+        methods.append(.cashPayment)
+        return methods
     }
 
     func handlePaymentMethodSelection(_ method: POSCheckoutPaymentMethod) {
         switch method {
         case .tapToPay:
-            // Wired in a later part of the TTP stack.
-            break
+            // Intentionally a no-op for now. Action wiring (and any architectural
+            // changes it requires) lands in a later, focused commit so the row
+            // composition can be verified in isolation first.
+            DDLogInfo("📱 [TapToPay] row tapped (action wiring pending)")
         case .cardReader:
             paymentModel.connectCardReader()
         case .cashPayment:

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -540,7 +540,6 @@ private extension TotalsView {
         ) else {
             return []
         }
-        let viewHelper = POSPaymentViewHelper()
         let isReaderDisconnected = viewHelper.shouldShowDisconnectedMessage(
             readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
             paymentState: displayPaymentState

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -11,8 +11,6 @@ struct TotalsView: View {
     private let viewHelper = POSPaymentViewHelper()
     private let totalsViewHelper = TotalsViewHelper()
 
-    @State private var isShowingOtherPaymentMethodsPopover: Bool = false
-
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
     /// This makes SwiftUI treat these views as a single entity in the context of animation.
     /// It allows for a simultaneous transition from the shimmering effect to the text fields,
@@ -83,27 +81,12 @@ struct TotalsView: View {
 
                     Spacer()
 
-                    SecondaryPaymentButtons(
-                        orderState: posModel.orderState,
-                        paymentState: displayPaymentState,
-                        cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
-                        isScanToPayEnabled: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
-                        isMarkOrderAsPaidEnabled: featureFlags.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid),
-                        isShowingOtherPaymentMethodsPopover: $isShowingOtherPaymentMethodsPopover,
-                        startCashPaymentAction: { paymentModel.startCashPayment() },
-                        startOtherPaymentMethodsAction: {
-                            analytics.track(.pointOfSaleOtherPaymentMethodsTapped)
-                            isShowingOtherPaymentMethodsPopover = true
-                        },
-                        startScanToPayAction: {
-                            Task { @MainActor in
-                                await paymentModel.startScanToPayPayment()
-                            }
-                        },
-                        startMarkOrderAsPaidAction: {
-                            paymentModel.startMarkAsPaidPayment()
-                        }
-                    )
+                    if !checkoutPaymentMethods.isEmpty {
+                        POSCheckoutPaymentButtonsRow(
+                            methods: checkoutPaymentMethods,
+                            onSelect: handlePaymentMethodSelection
+                        )
+                    }
                 }
                 .scrollVerticallyIfNeeded()
                 .animation(.default, value: isShowingPaymentView)
@@ -309,16 +292,6 @@ private extension TotalsView {
             "pos.totalsView.discountTotal2",
             value: "Discount total",
             comment: "Title for discount total amount field")
-        static let cashPaymentButtonTitle = NSLocalizedString(
-            "pos.totalsView.cash.button.title",
-            value: "Cash payment",
-            comment: "Title for the cash payment button title")
-        static let otherPaymentMethodsButtonTitle = NSLocalizedString(
-            "pos.totalsView.otherPaymentMethods.button.title",
-            value: "Other payment methods",
-            comment: "Title for the Other payment methods button in the Point of Sale checkout. " +
-            "Tapping this button opens a sheet listing alternative payment methods like Scan to Pay " +
-            "or Mark order as paid.")
     }
 }
 
@@ -543,82 +516,43 @@ private struct PaymentViewContent: View {
     }
 }
 
-/// Bottom-of-totals action row with the always-on Cash payment button plus a feature-flagged
-/// "Other payment methods" button rendered side-by-side. When neither secondary payment-method
-/// flag is enabled, the layout collapses to the original single Cash button — the feature flags
-/// gate the second button entirely so App Store builds see no regression vs trunk.
-///
-/// The Other-payment popover is hosted *here*, anchored to its own button, rather than at the
-/// outer view level. SwiftUI's `.popover` requires an anchor view; pinning it to the trigger
-/// gives the merchant a clear "the menu came from this button" relationship and dismisses on
-/// outside tap without the modal-stack optics of the previous bottom-sheet implementation.
-private struct SecondaryPaymentButtons: View {
-    let orderState: PointOfSaleOrderState
-    let paymentState: PointOfSalePaymentState
-    let cardReaderConnectionStatus: CardPresentPaymentReaderConnectionStatus
-    let isScanToPayEnabled: Bool
-    let isMarkOrderAsPaidEnabled: Bool
-    @Binding var isShowingOtherPaymentMethodsPopover: Bool
-    let startCashPaymentAction: () -> Void
-    let startOtherPaymentMethodsAction: () -> Void
-    let startScanToPayAction: () -> Void
-    let startMarkOrderAsPaidAction: () -> Void
-
-    private let viewHelper = TotalsViewHelper()
-
-    private var isAnySecondaryPaymentMethodEnabled: Bool {
-        isScanToPayEnabled || isMarkOrderAsPaidEnabled
+private extension TotalsView {
+    /// Builds the ordered list of payment methods rendered in the bottom buttons row.
+    ///
+    /// When the cash button visibility checks fail (syncing, reconnecting, zero total)
+    /// the row is hidden entirely. When the reader is disconnected the merchant gets
+    /// `[.cardReader, .cashPayment]` — tapping Card reader starts the connect flow,
+    /// matching what the in-pane "Connect your reader" CTA used to do. With a reader
+    /// connected the row collapses to `[.cashPayment]`.
+    ///
+    /// `.tapToPay` is intentionally absent at this stage and lands in a later part of
+    /// the TTP stack; the row already supports rendering it.
+    var checkoutPaymentMethods: [POSCheckoutPaymentMethod] {
+        guard totalsViewHelper.shouldShowCollectCashPaymentButton(
+            orderState: posModel.orderState,
+            paymentState: displayPaymentState,
+            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus
+        ) else {
+            return []
+        }
+        let viewHelper = POSPaymentViewHelper()
+        let isReaderDisconnected = viewHelper.shouldShowDisconnectedMessage(
+            readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
+            paymentState: displayPaymentState
+        )
+        return isReaderDisconnected ? [.cardReader, .cashPayment] : [.cashPayment]
     }
 
-    var body: some View {
-        HStack(spacing: POSSpacing.small) {
-            Button(action: {
-                startCashPaymentAction()
-            }, label: {
-                Text(TotalsView.Localization.cashPaymentButtonTitle)
-                    .font(POSFontStyle.posBodyLargeBold)
-                    .frame(maxWidth: .infinity)
-            })
-            .layoutPriority(1)
-            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-            .accessibilityIdentifier("pos-cash-payment-button")
-
-            Button(action: {
-                startOtherPaymentMethodsAction()
-            }, label: {
-                Text(TotalsView.Localization.otherPaymentMethodsButtonTitle)
-                    .font(POSFontStyle.posBodyLargeBold)
-                    .frame(maxWidth: .infinity)
-            })
-            .layoutPriority(1)
-            .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-            .accessibilityIdentifier("pos-other-payment-methods-button")
-            .popover(isPresented: $isShowingOtherPaymentMethodsPopover,
-                     attachmentAnchor: .point(.top),
-                     arrowEdge: .bottom) {
-                PointOfSaleSecondaryPaymentMethodsPopover(
-                    isScanToPayAvailable: isScanToPayEnabled,
-                    isMarkOrderAsPaidAvailable: isMarkOrderAsPaidEnabled,
-                    onScanToPay: startScanToPayAction,
-                    onMarkOrderAsPaid: startMarkOrderAsPaidAction
-                )
-            }
-            .renderedIf(isAnySecondaryPaymentMethodEnabled)
+    func handlePaymentMethodSelection(_ method: POSCheckoutPaymentMethod) {
+        switch method {
+        case .tapToPay:
+            // Wired in a later part of the TTP stack.
+            break
+        case .cardReader:
+            paymentModel.connectCardReader()
+        case .cashPayment:
+            paymentModel.startCashPayment()
         }
-        .padding(.horizontal, TotalsView.Constants.buttonHorizontalPadding)
-        .safeAreaPadding(.bottom, TotalsView.Constants.cashButtonBottomPadding)
-        // Gate the whole row on the cash visibility envelope. Without this, when the cash
-        // button is hidden (e.g. during card processing) the HStack still applies its
-        // safeAreaPadding(.bottom), reserving space at the bottom of the totals view that
-        // didn't exist before this row was introduced. Other-payment visibility shares the
-        // same envelope, so this single check is enough.
-        .renderedIf(viewHelper.shouldShowCollectCashPaymentButton(
-            orderState: orderState,
-            paymentState: paymentState,
-            cardReaderConnectionStatus: cardReaderConnectionStatus
-        ))
     }
 }
 

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1321,6 +1321,8 @@ public enum WooAnalyticsStat: String {
     case pointOfSalePaymentsOnboardingShown = "payments_onboarding_shown"
     case pointOfSalePaymentsOnboardingDismissed = "payments_onboarding_dismissed"
     case pointOfSaleCardReaderConnectionTapped = "card_reader_connection_tapped"
+    case pointOfSaleCheckoutTapToPayTapped = "checkout_tap_to_pay_tapped"
+    case pointOfSaleTapToPayNotAvailable = "tap_to_pay_not_available"
     case pointOfSaleInteractionWithCustomerStarted = "interaction_with_customer_started"
     case pointOfSaleViewDocsTapped = "view_docs_tapped"
     case pointOfSaleReaderReadyForCardPayment = "reader_ready_for_card_payment"

--- a/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSTapToPayAvailabilityChecker.swift
@@ -51,16 +51,22 @@ final class POSTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
 
 private extension POSTapToPayAvailabilityChecker {
     func deviceSupportsTapToPay() async -> Bool {
+        // `StoresManager.dispatch` asserts main-thread; `withCheckedContinuation`'s
+        // closure runs on whatever thread the awaiter is on, which after a prior
+        // suspension point may be a cooperative background thread. Hop to the main
+        // actor before dispatching.
         await withCheckedContinuation { continuation in
-            let action = CardPresentPaymentAction.checkDeviceSupport(
-                siteID: siteID,
-                cardReaderType: .tapToPay,
-                discoveryMethod: .tapToPay,
-                minimumOperatingSystemVersionOverride: nil
-            ) { isSupported in
-                continuation.resume(returning: isSupported)
+            Task { @MainActor in
+                let action = CardPresentPaymentAction.checkDeviceSupport(
+                    siteID: siteID,
+                    cardReaderType: .tapToPay,
+                    discoveryMethod: .tapToPay,
+                    minimumOperatingSystemVersionOverride: nil
+                ) { isSupported in
+                    continuation.resume(returning: isSupported)
+                }
+                stores.dispatch(action)
             }
-            stores.dispatch(action)
         }
     }
 


### PR DESCRIPTION
> **Stack order** (review bottom-up):
> 1. Existing phone POS stack (#17062 → #17067)
> 2. #17092 — POSLayoutScale
> 3. #17093 — Pre-TTP checkout & modal polish
> 4. #17094 — TTP foundation: feature flag + availability tracking
> 5. **This PR** — TTP checkout row (multi-method buttons + TTP-as-primary)
> 6. (next) TTP hero & "Other payment methods" sheet
> 7. (next) TTP wiring & cancel handling
> 8. (next) TTP polish

## Description
Stacked on top of #17094. Replaces the single Cash button at the bottom of the totals view with a composable row of payment methods, then surfaces Tap to Pay as the primary slot when the availability controller resolves \`.available\`.

Three commits, each visible without the next:

- **Multi-method payment buttons row** — adds \`POSCheckoutPaymentButtonsRow\` + \`POSCheckoutPaymentMethod\` enum. Row composition lives in \`TotalsView.checkoutPaymentMethods\`: gated by the existing \`shouldShowCollectCashPaymentButton\` (zero-total / syncing / reconnecting hide it), and includes \`.cardReader\` when the reader is disconnected, \`.cashPayment\` always last.
- **Foundation polish** — threading hop in \`POSTapToPayAvailabilityChecker.deviceSupportsTapToPay\` (the \`withCheckedContinuation\` body can resume off-main on the non-isolated checker; without the hop the dispatcher's main-thread assert fires on first launch). Adds \`pointOfSaleCheckoutTapToPayTapped\` to \`WooAnalyticsStat\` so the next commit has somewhere to track to.
- **Surface Tap to Pay as primary** — when \`POSTapToPayAvailabilityController.state.isAvailable == true\`, \`.tapToPay\` is prepended to the row so it lands in the primary (filled) slot. \`.tapToPay\`'s \`onSelect\` is intentionally still a \`DDLogInfo\` — the actual TTP collection wires up later in the stack.

### iPad behaviour change

The multi-method row replaces two iPad-specific surfaces. Both are deliberate — the new row is the same shape on phone and iPad:

- **Cash button style.** With a connected reader, the row resolves to \`[.cashPayment]\`, which is index 0 → \`POSFilledButtonStyle\`. The old \`CashPaymentButton\` always used \`POSOutlinedButtonStyle\` on iPad. So in the common iPad case, Cash visually transitions from outlined to filled.
- **"Connect your reader" inline CTA removed.** \`PointOfSaleCardPresentPaymentReaderDisconnectedMessageView\` no longer renders an inline filled CTA — the bottom row's \`Card reader\` entry replaces it. Same wiring (\`paymentModel.connectCardReader()\`), different surface.

If we want iPad to keep its old surface as a deliberate divergence, this can gate on \`horizontalSizeClass == .compact\` instead — flag for review.

Mirrors:
- [woocommerce-android#15838](https://github.com/woocommerce/woocommerce-android/pull/15838), [#15841](https://github.com/woocommerce/woocommerce-android/pull/15841) — Android multi-method row + TTP-as-primary.

## Test Steps
- Pull the branch (Debug = both flags = \`.localDeveloper\`).
- **iPhone, both flags ON, eligible site, supported device, reader disconnected**: Open POS → checkout. Bottom row: \`[Tap to pay (filled), Card reader (outlined), Cash (outlined)]\`. Tapping Tap to pay logs only — no flow yet.
- **iPhone, both flags ON, reader connected (BT)**: Bottom row: \`[Tap to pay (filled), Cash (outlined)]\`. No Card reader entry.
- **iPhone, flag off**: Bottom row is \`[Card reader, Cash]\` when disconnected / \`[Cash]\` when connected (no Tap to pay).
- **iPad**: Bottom row matches phone shape — \`[Cash]\` connected (filled), \`[Card reader, Cash]\` disconnected. **Visual change vs trunk**: Cash on iPad is now filled in the common case; the inline "Connect your reader" CTA is gone.
- **Ineligible / unsupported / empty cart / zero total**: row hides entirely.

## Screenshots
N/A — visual change verified live.

---
- [x] No release notes — feature flagged off.