### PR TITLE
[RSM] Phone POS TTP - Hero layout + Other payment methods sheet

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+/// Bottom sheet shown when the merchant taps "Other payment methods" on the phone
+/// POS checkout (TTP-available layout). Lists the non-TTP payment methods available
+/// to the merchant — currently Card reader only; Scan to Pay and Mark order as paid
+/// will join here once those features land on this branch.
+///
+/// Mirrors the Android phone POS overflow dialog that pairs with the TTP hero
+/// (samiuelson #15842 / #15825).
+struct POSOtherPaymentMethodsSheet: View {
+    let onCardReader: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: POSSpacing.none) {
+            Text(Localization.title)
+                .font(.posHeadingBold)
+                .foregroundStyle(Color.posOnSurface)
+                .padding(.horizontal, POSPadding.medium)
+                .padding(.top, POSPadding.large)
+                .padding(.bottom, POSPadding.medium)
+
+            row(systemImage: "creditcard",
+                title: Localization.cardReaderTitle,
+                subtitle: Localization.cardReaderSubtitle,
+                accessibilityIdentifier: "pos-other-payments-card-reader") {
+                dismiss()
+                onCardReader()
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.posSurface)
+    }
+
+    @ViewBuilder
+    private func row(systemImage: String,
+                     title: String,
+                     subtitle: String,
+                     accessibilityIdentifier: String,
+                     action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: POSSpacing.medium) {
+                Image(systemName: systemImage)
+                    .font(.posBodyLargeBold)
+                    .foregroundStyle(Color.posPrimary)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
+                    Text(title)
+                        .font(.posBodyMediumBold)
+                        .foregroundStyle(Color.posOnSurface)
+                    Text(subtitle)
+                        .font(.posBodySmallRegular())
+                        .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                        .multilineTextAlignment(.leading)
+                }
+
+                Spacer(minLength: POSSpacing.small)
+            }
+            .padding(POSPadding.medium)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(subtitle)
+    }
+}
+
+private extension POSOtherPaymentMethodsSheet {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.otherPaymentMethods.sheet.title",
+            value: "Other payment methods",
+            comment: "Title of the bottom sheet listing non-Tap-to-Pay payment methods on phone POS checkout."
+        )
+        static let cardReaderTitle = NSLocalizedString(
+            "pos.otherPaymentMethods.cardReader.title",
+            value: "Card reader",
+            comment: "Row title in the Other Payment Methods sheet for connecting an external Bluetooth card reader."
+        )
+        static let cardReaderSubtitle = NSLocalizedString(
+            "pos.otherPaymentMethods.cardReader.subtitle",
+            value: "Connect a Bluetooth reader to take card payments.",
+            comment: "Row subtitle in the Other Payment Methods sheet for connecting an external Bluetooth card reader."
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    POSOtherPaymentMethodsSheet(onCardReader: {})
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -46,7 +46,7 @@ struct POSOtherPaymentMethodsSheet: View {
                 Image(systemName: systemImage)
                     .font(.posBodyLargeBold)
                     .foregroundStyle(Color.posPrimary)
-                    .frame(width: 28)
+                    .frame(width: Constants.iconFrameWidth)
 
                 VStack(alignment: .leading, spacing: POSSpacing.xSmall) {
                     Text(title)
@@ -72,6 +72,12 @@ struct POSOtherPaymentMethodsSheet: View {
 }
 
 private extension POSOtherPaymentMethodsSheet {
+    enum Constants {
+        /// Fixed width for the leading icon in each payment method row. Not a
+        /// POSSpacing token — it sizes the icon column, not a semantic gap.
+        static let iconFrameWidth: CGFloat = 28
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "pos.otherPaymentMethods.sheet.title",

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Top-of-screen Tap to Pay promotion shown on the phone POS checkout when TTP is
+/// available. Mirrors the Android phone POS layout (samiuelson / staskus): the
+/// merchant's primary path is the big "Pay with Tap to pay" CTA; cash and the rest
+/// of the methods live in a smaller two-button strip at the bottom of the totals
+/// view (rendered separately by `TotalsView`).
+///
+/// Idle-state visual only for now. Preparing / collecting / success / error states
+/// are still handled by the existing `POSCardPaymentContentView` modal flow until
+/// they're folded into a richer hero in a follow-up commit.
+struct POSTapToPayHeroView: View {
+    let onPayTapped: () -> Void
+
+    var body: some View {
+        VStack(spacing: POSSpacing.large) {
+            // Placeholder illustration — the Android design uses a layered cards
+            // graphic; the matching iOS asset will swap in here once design provides
+            // it. Using an SF Symbol keeps the layout shaped correctly in the meantime.
+            Image(systemName: "wave.3.right.circle.fill")
+                .font(.system(size: 96, weight: .regular))
+                .foregroundStyle(Color.posPrimary)
+                .accessibilityHidden(true)
+
+            VStack(spacing: POSSpacing.small) {
+                Text(Localization.title)
+                    .font(.posHeadingBold)
+                    .foregroundStyle(Color.posOnSurface)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(Localization.subtitle)
+                    .font(.posBodyLargeRegular())
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, POSPadding.medium)
+
+            Button(action: onPayTapped) {
+                Text(Localization.payButton)
+                    .font(POSFontStyle.posBodyLargeBold)
+            }
+            .buttonStyle(POSFilledButtonStyle(size: .normal))
+            .padding(.horizontal, POSPadding.medium)
+            .accessibilityIdentifier("pos-tap-to-pay-hero-pay-button")
+        }
+    }
+}
+
+private extension POSTapToPayHeroView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.tapToPay.hero.title",
+            value: "Tap to pay",
+            comment: "Title shown in the Tap to Pay hero on the POS checkout."
+        )
+        static let subtitle = NSLocalizedString(
+            "pos.tapToPay.hero.subtitle",
+            value: "Use this device to accept contactless card payments.",
+            comment: "Subtitle shown in the Tap to Pay hero on the POS checkout."
+        )
+        static let payButton = NSLocalizedString(
+            "pos.tapToPay.hero.payButton",
+            value: "Pay with Tap to pay",
+            comment: "Primary CTA shown in the Tap to Pay hero on the POS checkout."
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    POSTapToPayHeroView(onPayTapped: {})
+        .padding()
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -22,6 +22,7 @@ struct TotalsView: View {
     // _should be_ showing, so that we can animate the change.
     // Default true so totals fields would be included in the view hiearchy on first render and animate with TotalsView
     @State private var isShowingTotalsFields: Bool = true
+    @State private var isShowingOtherPaymentMethodsSheet: Bool = false
 
     /// Payment state with in-progress secondary methods neutralized.
     /// `.collectingCash` (cash), `.showingQRCode` (scan-to-pay), and `.confirming`/`.processing`
@@ -115,6 +116,11 @@ struct TotalsView: View {
         }
         .onChange(of: shouldShowTotalsFields) {
             hideTotalsFieldsWithDelay(shouldShowTotalsFields)
+        }
+        .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
+            POSOtherPaymentMethodsSheet(onCardReader: { paymentModel.connectCardReader() })
+                .presentationDetents([.medium])
+                .presentationDragIndicator(.visible)
         }
     }
 
@@ -623,9 +629,7 @@ private extension TotalsView {
     }
 
     func handleOtherPaymentMethodsTapped() {
-        // Intentionally a no-op for now — the overflow sheet (initially just
-        // Card reader) is the next focused commit.
-        DDLogInfo("📱 [TapToPay] Other payment methods tapped (sheet wiring pending)")
+        isShowingOtherPaymentMethodsSheet = true
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -52,7 +52,9 @@ struct TotalsView: View {
                 VStack(alignment: .center) {
                     Spacer()
 
-                    if isShowingPaymentView {
+                    if useTapToPayHeroLayout {
+                        POSTapToPayHeroView(onPayTapped: handleTapToPayTapped)
+                    } else if isShowingPaymentView {
                         PaymentViewContent(
                             paymentState: displayPaymentState,
                             cardReaderViewLayout: cardReaderViewLayout,
@@ -66,7 +68,7 @@ struct TotalsView: View {
                         )
                     }
 
-                    if isShowingPaymentView && isShowingTotalsFields {
+                    if (useTapToPayHeroLayout || isShowingPaymentView) && isShowingTotalsFields {
                         Spacer()
                     }
 
@@ -82,7 +84,9 @@ struct TotalsView: View {
 
                     Spacer()
 
-                    if !checkoutPaymentMethods.isEmpty {
+                    if useTapToPayHeroLayout {
+                        tapToPayBottomStrip
+                    } else if !checkoutPaymentMethods.isEmpty {
                         POSCheckoutPaymentButtonsRow(
                             methods: checkoutPaymentMethods,
                             onSelect: handlePaymentMethodSelection
@@ -91,6 +95,7 @@ struct TotalsView: View {
                 }
                 .scrollVerticallyIfNeeded()
                 .animation(.default, value: isShowingPaymentView)
+                .animation(.default, value: useTapToPayHeroLayout)
             case .error(.other(let message), let handler):
                 PointOfSaleOrderSyncErrorMessageView(message: message, retryHandler: handler)
                     .transition(.opacity)
@@ -293,6 +298,14 @@ private extension TotalsView {
             "pos.totalsView.discountTotal2",
             value: "Discount total",
             comment: "Title for discount total amount field")
+        static let cashPaymentButtonTitle = NSLocalizedString(
+            "pos.totalsView.cash.button.title",
+            value: "Cash payment",
+            comment: "Title for the cash payment button title")
+        static let otherPaymentMethodsButtonTitle = NSLocalizedString(
+            "pos.totalsView.otherPaymentMethods.button.title",
+            value: "Other payment methods",
+            comment: "Title for the Other payment methods button shown alongside the Tap to Pay hero on phone POS checkout. Tapping it opens a sheet with non-TTP options (currently Card reader).")
     }
 }
 
@@ -560,15 +573,59 @@ private extension TotalsView {
     func handlePaymentMethodSelection(_ method: POSCheckoutPaymentMethod) {
         switch method {
         case .tapToPay:
-            // Intentionally a no-op for now. Action wiring (and any architectural
-            // changes it requires) lands in a later, focused commit so the row
-            // composition can be verified in isolation first.
-            DDLogInfo("📱 [TapToPay] row tapped (action wiring pending)")
+            handleTapToPayTapped()
         case .cardReader:
             paymentModel.connectCardReader()
         case .cashPayment:
             paymentModel.startCashPayment()
         }
+    }
+
+    /// True when the merchant should see the Android-style Tap to Pay hero +
+    /// bottom-strip layout: TTP availability has resolved `.available` and no
+    /// payment is currently in progress (idle card + idle cash). When a TTP
+    /// payment kicks off, `paymentState.card` transitions out of `.idle` and the
+    /// existing `PaymentViewContent` flow takes over (preparing / accepting /
+    /// processing / success / error).
+    var useTapToPayHeroLayout: Bool {
+        guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
+        return displayPaymentState.card == .idle && displayPaymentState.cash == .idle
+    }
+
+    /// Cash + Other payment methods stacked outlined buttons rendered below the
+    /// totals when the Tap to Pay hero is showing. Mirrors the Android phone POS
+    /// "Cash + Other payment methods" row from samiuelson #15825.
+    @ViewBuilder
+    var tapToPayBottomStrip: some View {
+        VStack(spacing: POSSpacing.medium) {
+            Button(action: { paymentModel.startCashPayment() }) {
+                Text(Localization.cashPaymentButtonTitle)
+                    .font(POSFontStyle.posBodyLargeBold)
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .accessibilityIdentifier("pos-cash-payment-button")
+
+            Button(action: handleOtherPaymentMethodsTapped) {
+                Text(Localization.otherPaymentMethodsButtonTitle)
+                    .font(POSFontStyle.posBodyLargeBold)
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .accessibilityIdentifier("pos-other-payment-methods-button")
+        }
+        .padding(.horizontal, POSPadding.medium)
+        .padding(.bottom, POSPadding.xxLarge)
+    }
+
+    func handleTapToPayTapped() {
+        // Intentionally a no-op for now — action wiring lands in a later focused
+        // commit so this layout change can be verified in isolation first.
+        DDLogInfo("📱 [TapToPay] hero tapped (action wiring pending)")
+    }
+
+    func handleOtherPaymentMethodsTapped() {
+        // Intentionally a no-op for now — the overflow sheet (initially just
+        // Card reader) is the next focused commit.
+        DDLogInfo("📱 [TapToPay] Other payment methods tapped (sheet wiring pending)")
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -311,7 +311,7 @@ private extension TotalsView {
         static let otherPaymentMethodsButtonTitle = NSLocalizedString(
             "pos.totalsView.otherPaymentMethods.button.title",
             value: "Other payment methods",
-            comment: "Title for the Other payment methods button shown alongside the Tap to Pay hero on phone POS checkout. Tapping it opens a sheet with non-TTP options (currently Card reader).")
+            comment: "Title for the Other payment methods button shown alongside the Tap to Pay hero on phone POS checkout.")
     }
 }
 


### PR DESCRIPTION
> **Stack order** (review bottom-up):
> 1. Existing phone POS stack (#17062 → #17067)
> 2. #17092 — POSLayoutScale
> 3. #17093 — Pre-TTP checkout & modal polish
> 4. #17094 — TTP foundation
> 5. #17095 — TTP checkout row (multi-method)
> 6. **This PR** — TTP hero & "Other payment methods" sheet
> 7. (next) TTP wiring & cancel handling
> 8. (next) TTP polish

## Description
Stacked on top of #17095. Restructures the totals view when TTP is available to match the Android phone POS layout: a top-of-screen hero (illustration + title + subtitle + big "Pay with Tap to pay" CTA) replaces the inline payment view, and the bottom collapses to two outlined buttons — Cash payment and Other payment methods.

- **`POSTapToPayHeroView`** — new hero. Idle-state visuals only; preparing / collecting / success / error still flow through the existing `POSCardPaymentContentView` modal flow until folded into a richer hero in a follow-up. Illustration is an SF Symbol placeholder (`wave.3.right.circle.fill`) until design supplies the layered-cards asset.
- **`POSOtherPaymentMethodsSheet`** — bottom sheet listing non-TTP options. Single row for now (Card reader → `paymentModel.connectCardReader()`); Scan to Pay and Mark order as paid will plug in here once those features land. Presented via `posSheet` with `.medium` detent and a drag indicator.
- **`TotalsView.useTapToPayHeroLayout` gate** — TTP availability resolved `.available` AND no payment in progress (idle card + idle cash). When the merchant taps "Pay with Tap to pay" and collection starts, `paymentState.card` transitions out of `.idle` and the existing `PaymentViewContent` flow takes over.

Action wiring is intentionally deferred — both "Pay with Tap to pay" and the sheet's Card reader row do nothing meaningful yet. Behaviour wires up in #6 of the stack.

Collapses three steps from the Android stack into one focused visual change:

- [woocommerce-android#15841](https://github.com/woocommerce/woocommerce-android/pull/15841) — TTP promoted state in checkout
- [woocommerce-android#15842](https://github.com/woocommerce/woocommerce-android/pull/15842) — TTP in payment row
- [woocommerce-android#15825](https://github.com/woocommerce/woocommerce-android/pull/15825) — Cash + Other payment methods row

When TTP is unavailable (iPad, ineligible, flag off), the existing `POSCheckoutPaymentButtonsRow` layout is unchanged.

## Test Steps
- Pull the branch (Debug = both flags = `.localDeveloper`).
- **iPhone, TTP available, idle**: Open POS → checkout. Hero replaces the inline payment view: SF Symbol icon + "Tap to pay" + subtitle + filled "Pay with Tap to pay" CTA. Bottom: `[Cash payment, Other payment methods]` outlined.
  - Tap "Pay with Tap to pay" — only a log line, no flow yet.
  - Tap "Other payment methods" — bottom sheet opens with a single Card reader row and a drag indicator.
- **iPhone, TTP unavailable / iPad**: layout unchanged from #17095.
- **Empty cart**: hero/strip hide along with the existing row.

## Screenshots
N/A — visual change verified live.

---
- [x] No release notes — feature flagged off.