### PR TITLE
[RSM] Phone POS TTP - Explicit method selection wiring + cancel handling

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -812,6 +812,26 @@ private extension POSPaymentModel {
             })
             .store(in: &paymentSessionCancellables)
 
+        // TTP cancel-on-reader → drop back to the idle hero. Without this the
+        // card state machine stays stuck on `.acceptingCard` / `.preparingReader`
+        // (the standard `PointOfSaleCardPaymentState(from:)` mapper returns nil
+        // for cancelledOnReader, leaving the previous state in place) and neither
+        // the hero nor the inline view renders.
+        cardPresentPaymentService.paymentEventPublisher
+            .filter { event in
+                if case .show(.cancelledOnReader) = event { return true }
+                return false
+            }
+            .sink { [weak self] _ in
+                guard let self, self.preferredConnectionMethod == .tapToPay else { return }
+                Task { @MainActor [weak self] in
+                    try? await self?.cardPresentPaymentService.cancelPayment()
+                    self?.paymentState.card = .idle
+                    self?.cardPresentPaymentInlineMessage = nil
+                }
+            }
+            .store(in: &paymentSessionCancellables)
+
         // Payment events -> card payment state
         cardPresentPaymentService.paymentEventPublisher
             .compactMap { [weak self] paymentEvent -> PointOfSaleCardPaymentState? in
@@ -877,6 +897,15 @@ private extension POSPaymentModel {
     }
 
     func mapCardPresentPaymentEventToMessageType(_ event: CardPresentPaymentEvent) -> PointOfSaleCardPresentPaymentMessageType? {
+        // On the TTP path a merchant-cancelled-on-reader event drops the merchant
+        // back to the idle hero rather than the legacy iPad "Payment canceled /
+        // Try payment again" screen — Android does the same. Suppress the inline
+        // message here; `handleCancelledOnReaderForTapToPay` resets card state.
+        if preferredConnectionMethod == .tapToPay,
+           case .show(.cancelledOnReader) = event {
+            return nil
+        }
+
         guard case let .show(eventDetails) = event,
               case let .message(messageType) = presentationStyle(for: eventDetails) else {
             return nil

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -61,7 +61,7 @@ final class POSPaymentModel {
     /// reader on checkout — collection is gated behind an explicit method tap
     /// from the buttons row / hero via `startPaymentWithMethod(_:)`, so the
     /// merchant's selection drives which method actually runs.
-    let preferredConnectionMethod: CardReaderConnectionMethod
+    private let preferredConnectionMethod: CardReaderConnectionMethod
 
     // MARK: - Internal
     private var startPaymentOnCardReaderConnection: AnyCancellable?
@@ -193,7 +193,7 @@ extension POSPaymentModel {
     /// Pre-connects the built-in Tap to Pay reader without starting collection.
     /// Called from `startPayment()` when `preferredConnectionMethod == .tapToPay`,
     /// so the reader is warm by the time the merchant taps the hero CTA.
-    func connectTapToPayReader() {
+    private func connectTapToPayReader() {
         Task { @MainActor [weak self] in
             _ = try? await self?.cardPresentPaymentService.connectReader(using: .tapToPay)
         }
@@ -938,7 +938,7 @@ private extension POSPaymentModel {
         // On the TTP path a merchant-cancelled-on-reader event drops the merchant
         // back to the idle hero rather than the legacy iPad "Payment canceled /
         // Try payment again" screen — Android does the same. Suppress the inline
-        // message here; `handleCancelledOnReaderForTapToPay` resets card state.
+        // message here; the cancelledOnReader sink in subscribeToPaymentSessionEvents resets card state.
         if preferredConnectionMethod == .tapToPay,
            case .show(.cancelledOnReader) = event {
             return nil

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -836,11 +836,13 @@ private extension POSPaymentModel {
             })
             .store(in: &paymentSessionCancellables)
 
-        // TTP cancel-on-reader → drop back to the idle hero. Re-arms the gate so
-        // any stray Stripe Terminal events arriving during the cancel teardown
-        // (transient `.tapSwipeOrInsertCard` etc.) can't flicker the card state
-        // back out of `.idle`. The gate stays true until the next
-        // `startPaymentWithMethod`.
+        // TTP cancel-on-reader → drop back to the idle hero. Synchronously closes
+        // the gate, resets `paymentState.card` to `.idle`, and clears the inline
+        // message in the same run loop the event arrives on, so a stray
+        // `.tapSwipeOrInsertCard` arriving immediately after (or the previous
+        // one's cached state) can't keep the "Tap card" message visible. The
+        // actual Stripe cancel runs in a fire-and-forget Task — it's async, but
+        // we don't need to wait for it before flipping back to the hero.
         cardPresentPaymentService.paymentEventPublisher
             .filter { event in
                 if case .show(.cancelledOnReader) = event { return true }
@@ -849,10 +851,10 @@ private extension POSPaymentModel {
             .sink { [weak self] _ in
                 guard let self, self.preferredConnectionMethod == .tapToPay else { return }
                 self.isAwaitingExplicitPaymentStart = true
+                self.paymentState.card = .idle
+                self.cardPresentPaymentInlineMessage = nil
                 Task { @MainActor [weak self] in
                     try? await self?.cardPresentPaymentService.cancelPayment()
-                    self?.paymentState.card = .idle
-                    self?.cardPresentPaymentInlineMessage = nil
                 }
             }
             .store(in: &paymentSessionCancellables)

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -72,6 +72,16 @@ final class POSPaymentModel {
     private var startPaymentGeneration: Int = 0
     private var cardPaymentCancelTask: Task<Void, Never>?
     private var connectCardReaderTask: Task<Void, Never>?
+
+    /// On the TTP path, payment state should only advance when the merchant has
+    /// explicitly tapped a method (hero CTA or Other payment methods sheet row).
+    /// Otherwise stale Stripe Terminal events that arrive during Apple's modal
+    /// teardown / cancel sequence flip `paymentState.card` back to states like
+    /// `.acceptingCard` for a frame and yank the hero away. This gate, set true
+    /// at init and after a TTP cancel, blocks event-driven updates until the
+    /// next `startPaymentWithMethod`. Always false on the Bluetooth path so
+    /// auto-collect-on-connect keeps working as today.
+    private var isAwaitingExplicitPaymentStart: Bool = true
     private var onOnboardingCancellation: (() -> Void)?
     private var cancellables: Set<AnyCancellable> = []
     private var paymentSessionCancellables: Set<AnyCancellable> = []
@@ -138,10 +148,16 @@ extension POSPaymentModel {
         subscribeToPaymentSessionEvents()
 
         if preferredConnectionMethod == .tapToPay {
+            // Awaiting an explicit method tap from the hero / sheet — leave the
+            // gate true so transient Stripe events during pre-connect can't
+            // advance the state machine.
             connectTapToPayReader()
             return
         }
 
+        // BT auto-collect path — events from the connected reader are the
+        // intended source of state transitions.
+        isAwaitingExplicitPaymentStart = false
         await startPaymentFlow(using: preferredConnectionMethod)
     }
 
@@ -157,6 +173,9 @@ extension POSPaymentModel {
         DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus)")
 
         subscribeToPaymentSessionEvents()
+        // Merchant explicitly chose a method — open the gate so subsequent
+        // Stripe Terminal events drive the state machine.
+        isAwaitingExplicitPaymentStart = false
 
         if method == .bluetooth, case .connected = cardReaderConnectionStatus {
             await cardPresentPaymentService.disconnectReader()
@@ -688,6 +707,9 @@ extension POSPaymentModel {
         formattedOrderTotalPrice = nil
         scanToPayURL = nil
         isPreparingScanToPay = false
+        // Re-arm the TTP gate so re-entering checkout starts clean — `startPayment`
+        // will keep it true on the TTP path until the merchant taps a method again.
+        isAwaitingExplicitPaymentStart = true
         cancelReaderPreparation()
     }
 
@@ -805,18 +827,20 @@ private extension POSPaymentModel {
         // Payment events -> inline message (payment status in the totals view)
         cardPresentPaymentService.paymentEventPublisher
             .map { [weak self] event -> PointOfSaleCardPresentPaymentMessageType? in
-                self?.mapCardPresentPaymentEventToMessageType(event)
+                guard let self else { return nil }
+                guard self.shouldPropagatePaymentEvent else { return nil }
+                return self.mapCardPresentPaymentEventToMessageType(event)
             }
             .sink(receiveValue: { [weak self] message in
                 self?.cardPresentPaymentInlineMessage = message
             })
             .store(in: &paymentSessionCancellables)
 
-        // TTP cancel-on-reader → drop back to the idle hero. Without this the
-        // card state machine stays stuck on `.acceptingCard` / `.preparingReader`
-        // (the standard `PointOfSaleCardPaymentState(from:)` mapper returns nil
-        // for cancelledOnReader, leaving the previous state in place) and neither
-        // the hero nor the inline view renders.
+        // TTP cancel-on-reader → drop back to the idle hero. Re-arms the gate so
+        // any stray Stripe Terminal events arriving during the cancel teardown
+        // (transient `.tapSwipeOrInsertCard` etc.) can't flicker the card state
+        // back out of `.idle`. The gate stays true until the next
+        // `startPaymentWithMethod`.
         cardPresentPaymentService.paymentEventPublisher
             .filter { event in
                 if case .show(.cancelledOnReader) = event { return true }
@@ -824,6 +848,7 @@ private extension POSPaymentModel {
             }
             .sink { [weak self] _ in
                 guard let self, self.preferredConnectionMethod == .tapToPay else { return }
+                self.isAwaitingExplicitPaymentStart = true
                 Task { @MainActor [weak self] in
                     try? await self?.cardPresentPaymentService.cancelPayment()
                     self?.paymentState.card = .idle
@@ -836,6 +861,7 @@ private extension POSPaymentModel {
         cardPresentPaymentService.paymentEventPublisher
             .compactMap { [weak self] paymentEvent -> PointOfSaleCardPaymentState? in
                 guard let self else { return nil }
+                guard self.shouldPropagatePaymentEvent else { return nil }
 
                 let newCardPaymentState = PointOfSaleCardPaymentState(from: paymentEvent,
                                                                       using: presentationStyleDeterminerDependencies)
@@ -894,6 +920,16 @@ private extension POSPaymentModel {
                 paymentState.card = cardPaymentState
             })
             .store(in: &paymentSessionCancellables)
+    }
+
+    /// True when payment events are allowed to drive `cardPresentPaymentInlineMessage`
+    /// and `paymentState.card`. On the BT path it's always true. On the TTP path it's
+    /// false until the merchant explicitly taps a method, and re-armed back to false
+    /// after a cancel-on-reader so transient events during the cancel teardown can't
+    /// flicker the card state.
+    var shouldPropagatePaymentEvent: Bool {
+        guard preferredConnectionMethod == .tapToPay else { return true }
+        return !isAwaitingExplicitPaymentStart
     }
 
     func mapCardPresentPaymentEventToMessageType(_ event: CardPresentPaymentEvent) -> PointOfSaleCardPresentPaymentMessageType? {

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -843,6 +843,16 @@ private extension POSPaymentModel {
         // one's cached state) can't keep the "Tap card" message visible. The
         // actual Stripe cancel runs in a fire-and-forget Task — it's async, but
         // we don't need to wait for it before flipping back to the hero.
+        //
+        // ⚠️ SUBSCRIPTION ORDER IS LOAD-BEARING — DO NOT REORDER ⚠️
+        // This sink MUST be subscribed before the "Payment events -> card payment state"
+        // sink below. Combine delivers to subscribers in subscription order. When a
+        // `cancelledOnReader` event arrives, both sinks receive it synchronously in the
+        // same run loop. The gate (`isAwaitingExplicitPaymentStart`) must flip to `true`
+        // HERE, before the card-state sink evaluates `shouldPropagatePaymentEvent` — so
+        // that sink short-circuits and does NOT overwrite `paymentState.card`. Reversing
+        // the order would let the card-state sink run first, advancing state to e.g.
+        // `.acceptingCard` for a frame before this sink resets it to `.idle`.
         cardPresentPaymentService.paymentEventPublisher
             .filter { event in
                 if case .show(.cancelledOnReader) = event { return true }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -52,6 +52,17 @@ final class POSPaymentModel {
     /// Cadence for scan-to-pay polling. Defaults to 3 seconds; tests override to fire instantly.
     private let scanToPayPollInterval: TimeInterval
 
+    /// The reader connection method this POS session should use as its default.
+    ///
+    /// `.bluetooth` (iPad / phone without TTP eligibility) keeps the classic
+    /// auto-collect-on-connect behaviour: when the merchant enters checkout
+    /// `startPayment()` waits for any BT reader to come up and collects via that.
+    /// `.tapToPay` (phone with TTP eligibility) only pre-connects the built-in
+    /// reader on checkout — collection is gated behind an explicit method tap
+    /// from the buttons row / hero via `startPaymentWithMethod(_:)`, so the
+    /// merchant's selection drives which method actually runs.
+    let preferredConnectionMethod: CardReaderConnectionMethod
+
     // MARK: - Internal
     private var startPaymentOnCardReaderConnection: AnyCancellable?
     private var cardReaderDisconnection: AnyCancellable?
@@ -87,6 +98,7 @@ final class POSPaymentModel {
          collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking,
          celebration: PaymentCaptureCelebrationProtocol = PaymentCaptureCelebration(),
          scanToPayPollInterval: TimeInterval = 3,
+         preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
          paymentState: PointOfSalePaymentState = .idle) {
         self.cardPresentPaymentService = cardPresentPaymentService
         self.orderProvider = orderProvider
@@ -101,6 +113,7 @@ final class POSPaymentModel {
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
         self.celebration = celebration
         self.scanToPayPollInterval = scanToPayPollInterval
+        self.preferredConnectionMethod = preferredConnectionMethod
         self.paymentState = paymentState
 
         publishCardReaderConnectionStatus()
@@ -111,13 +124,67 @@ final class POSPaymentModel {
 
 // MARK: - Card Payment Methods
 extension POSPaymentModel {
-    /// Cancels any existing payment on the shared reader, then starts a new payment.
-    /// Collects immediately if a reader is connected; otherwise waits for connection.
+    /// Called by the aggregate model when checkout opens.
+    ///
+    /// Bluetooth path: runs the auto-collect-on-connect flow that's been there forever
+    /// — wait for any reader to come up, then collect via that.
+    ///
+    /// Tap to Pay path: only pre-connects the built-in reader. Collection is gated
+    /// behind an explicit `startPaymentWithMethod(.tapToPay)` from the hero CTA so
+    /// the merchant's selection drives the actual flow — no auto-collect to race.
     func startPayment() async {
         DDLogInfo("🃏 [CardPayment] startPayment called — card state: \(paymentState.card), cash state: \(paymentState.cash)")
 
         subscribeToPaymentSessionEvents()
 
+        if preferredConnectionMethod == .tapToPay {
+            connectTapToPayReader()
+            return
+        }
+
+        await startPaymentFlow(using: preferredConnectionMethod)
+    }
+
+    /// Starts payment with an explicit connection method, used when the merchant
+    /// picks Tap to Pay or Card reader from the totals checkout buttons / sheet.
+    ///
+    /// Switches readers if needed (TTP connected and the merchant picks Bluetooth
+    /// triggers a disconnect first), kicks off a connect with the chosen method if
+    /// disconnected, then runs the same auto-collect-on-connect flow Bluetooth uses
+    /// — but threaded through with the explicit method so the eventual collect
+    /// targets the reader that's actually coming up.
+    func startPaymentWithMethod(_ method: CardReaderConnectionMethod) async {
+        DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus)")
+
+        subscribeToPaymentSessionEvents()
+
+        if method == .bluetooth, case .connected = cardReaderConnectionStatus {
+            await cardPresentPaymentService.disconnectReader()
+        }
+
+        if case .disconnected = cardReaderConnectionStatus {
+            Task { @MainActor [weak self] in
+                _ = try? await self?.cardPresentPaymentService.connectReader(using: method)
+            }
+        }
+
+        await startPaymentFlow(using: method)
+    }
+
+    /// Pre-connects the built-in Tap to Pay reader without starting collection.
+    /// Called from `startPayment()` when `preferredConnectionMethod == .tapToPay`,
+    /// so the reader is warm by the time the merchant taps the hero CTA.
+    func connectTapToPayReader() {
+        Task { @MainActor [weak self] in
+            _ = try? await self?.cardPresentPaymentService.connectReader(using: .tapToPay)
+        }
+    }
+
+    /// Runs the auto-collect-on-connect flow for the given method.
+    /// Cancels any existing payment, then collects immediately if a reader is
+    /// already connected — otherwise sets up a one-shot subscription that fires
+    /// when one connects.
+    private func startPaymentFlow(using method: CardReaderConnectionMethod) async {
         // Invalidate stale `startPaymentOnCardReaderConnection` callbacks
         // so only the latest subscription can reach `collectCardPayment`.
         startPaymentGeneration += 1
@@ -129,7 +196,7 @@ extension POSPaymentModel {
         guard case .connected = cardReaderConnectionStatus else {
             DDLogInfo("🃏 [CardPayment] reader not connected, waiting for connection")
             startPaymentOnCardReaderConnection?.cancel()
-            return startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
+            startPaymentOnCardReaderConnection = cardPresentPaymentService.readerConnectionStatusPublisher
                 .filter { status in
                     switch status {
                     case .connected:
@@ -139,24 +206,25 @@ extension POSPaymentModel {
                     }
                 }
                 .removeDuplicates()
-                .sink { [weak self, generation] _ in
+                .sink { [weak self, generation, method] _ in
                     Task { @MainActor [weak self] in
                         guard self?.startPaymentGeneration == generation else { return }
-                        await self?.cancelThenCollectCardPayment(generation: generation)
+                        await self?.cancelThenCollectCardPayment(generation: generation, using: method)
                     }
                 }
+            return
         }
 
         // Reader is connected — cancel any stale payment, then collect.
         startPaymentOnCardReaderConnection?.cancel()
         startPaymentOnCardReaderConnection = nil
-        await cancelThenCollectCardPayment(generation: generation)
+        await cancelThenCollectCardPayment(generation: generation, using: method)
     }
 
-    /// Cancels any stale payment on the reader, then collects.
+    /// Cancels any stale payment on the reader, then collects via the given method.
     /// The generation check after the cancel guards against a newer
     /// `startPayment()` call that may have started during the await.
-    private func cancelThenCollectCardPayment(generation: Int) async {
+    private func cancelThenCollectCardPayment(generation: Int, using method: CardReaderConnectionMethod) async {
         try? await cardPresentPaymentService.cancelPayment()
         DDLogInfo("🃏 [CardPayment] startPayment cancel completed — card state: \(paymentState.card), cash state: \(paymentState.cash)")
 
@@ -166,24 +234,24 @@ extension POSPaymentModel {
         }
 
         DDLogInfo("🃏 [CardPayment] startPayment proceeding to collectCardPayment")
-        await collectCardPayment()
+        await collectCardPayment(using: method)
     }
 
-    private func collectCardPayment() async {
-        DDLogInfo("🃏 [CardPayment] collectCardPayment called — card state: \(paymentState.card), cash state: \(paymentState.cash)")
+    private func collectCardPayment(using method: CardReaderConnectionMethod) async {
+        DDLogInfo("🃏 [CardPayment] collectCardPayment(\(method)) called — card state: \(paymentState.card), cash state: \(paymentState.cash)")
         do {
             let paymentOrder = try await orderProvider.provideOrder()
             currentOrder = paymentOrder.order
             formattedOrderTotalPrice = paymentOrder.formattedTotal
             guard paymentOrder.totalDecimal > 0 else { return }
-            try await collectPayment(for: paymentOrder.order)
+            try await collectPayment(for: paymentOrder.order, using: method)
         } catch {
             DDLogError("Error taking payment: \(error)")
         }
     }
 
-    private func collectPayment(for order: Order) async throws {
-        _ = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth, channel: .pos)
+    private func collectPayment(for order: Order, using method: CardReaderConnectionMethod) async throws {
+        _ = try await cardPresentPaymentService.collectPayment(for: order, using: method, channel: .pos)
     }
 
     func cancelThenCollectPayment() {
@@ -203,7 +271,7 @@ extension POSPaymentModel {
         guard case .connected = cardReaderConnectionStatus else {
             return
         }
-        await collectCardPayment()
+        await collectCardPayment(using: preferredConnectionMethod)
     }
 
     func connectCardReader() {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -145,7 +145,8 @@ protocol PointOfSaleAggregateModelProtocol {
          cartProductObserver: POSCartProductObserving? = nil,
          isLocalCatalogEligible: Bool = false,
          sunsetWarningChecker: POSSunsetWarningChecking? = nil,
-         tapToPayAvailabilityController: POSTapToPayAvailabilityController? = nil) {
+         tapToPayAvailabilityController: POSTapToPayAvailabilityController? = nil,
+         preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth) {
         self.entryPointController = entryPointController
         self.purchasableItemsController = itemsController
         self.purchasableItemsSearchController = purchasableItemsSearchController
@@ -187,6 +188,7 @@ protocol PointOfSaleAggregateModelProtocol {
                 }),
             analytics: analytics,
             collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
+            preferredConnectionMethod: preferredConnectionMethod,
             paymentState: paymentState)
         weakSelf = self
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -52,6 +52,7 @@ public struct PointOfSaleEntryPointView: View {
     private let isLocalCatalogEligible: Bool
     private let sunsetWarningChecker: POSSunsetWarningChecking?
     private let tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking?
+    private let preferredConnectionMethod: CardReaderConnectionMethod
 
     /// periphery: ignore - public in preparation of move to POS module
     public init(siteID: Int64,
@@ -79,6 +80,7 @@ public struct PointOfSaleEntryPointView: View {
          isLocalCatalogEligible: Bool,
          sunsetWarningChecker: POSSunsetWarningChecking? = nil,
          tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking? = nil,
+         preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
@@ -165,6 +167,7 @@ public struct PointOfSaleEntryPointView: View {
         self.isLocalCatalogEligible = isLocalCatalogEligible
         self.sunsetWarningChecker = sunsetWarningChecker
         self.tapToPayAvailabilityChecker = tapToPayAvailabilityChecker
+        self.preferredConnectionMethod = preferredConnectionMethod
     }
 
     public var body: some View {
@@ -204,7 +207,8 @@ public struct PointOfSaleEntryPointView: View {
                 tapToPayAvailabilityController: tapToPayAvailabilityChecker.map { checker in
                     POSTapToPayAvailabilityController(availabilityChecker: checker,
                                                       analytics: services.analytics)
-                })
+                },
+                preferredConnectionMethod: preferredConnectionMethod)
         }
         .environment(\.posAnalytics, services.analytics)
         .environment(\.posCurrencyProvider, services.currency)

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -118,9 +118,13 @@ struct TotalsView: View {
             hideTotalsFieldsWithDelay(shouldShowTotalsFields)
         }
         .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
-            POSOtherPaymentMethodsSheet(onCardReader: { paymentModel.connectCardReader() })
-                .presentationDetents([.medium])
-                .presentationDragIndicator(.visible)
+            POSOtherPaymentMethodsSheet(onCardReader: {
+                Task { @MainActor in
+                    await paymentModel.startPaymentWithMethod(.bluetooth)
+                }
+            })
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
         }
     }
 
@@ -623,9 +627,9 @@ private extension TotalsView {
     }
 
     func handleTapToPayTapped() {
-        // Intentionally a no-op for now — action wiring lands in a later focused
-        // commit so this layout change can be verified in isolation first.
-        DDLogInfo("📱 [TapToPay] hero tapped (action wiring pending)")
+        Task { @MainActor in
+            await paymentModel.startPaymentWithMethod(.tapToPay)
+        }
     }
 
     func handleOtherPaymentMethodsTapped() {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -1415,6 +1415,186 @@ struct POSPaymentModelTests {
         #expect(service.connectReaderCallCount == 2)
     }
 
+    // MARK: - TTP Explicit Payment Start Gate
+
+    @Test("TTP: events before startPaymentWithMethod are suppressed by the gate")
+    @MainActor
+    func startPaymentWithMethod_TTP_when_event_arrives_before_explicit_start_then_card_state_stays_idle() async {
+        // Given
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .tapToPay)
+
+        // When: startPayment pre-connects but does NOT open the gate
+        await sut.startPayment()
+
+        // Then: a payment event arriving before the merchant taps a method is suppressed
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+
+        #expect(sut.paymentState.card == .idle)
+        #expect(sut.cardPresentPaymentInlineMessage == nil)
+    }
+
+    @Test("TTP: events after startPaymentWithMethod(.tapToPay) are propagated")
+    @MainActor
+    func startPaymentWithMethod_TTP_when_event_arrives_after_explicit_start_then_card_state_updates() async {
+        // Given
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .tapToPay)
+
+        await sut.startPayment()
+
+        // Confirm gate is closed: event before explicit start is suppressed
+        service.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
+        #expect(sut.paymentState.card == .idle)
+
+        // When: merchant explicitly taps "Tap to Pay" — opens the gate
+        await sut.startPaymentWithMethod(.tapToPay)
+
+        // Then: subsequent events now drive the card state machine
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+
+        #expect(sut.paymentState.card == .acceptingCard)
+    }
+
+    @Test("TTP: cancelledOnReader resets card state to idle and re-arms the gate")
+    @MainActor
+    func cancelledOnReader_TTP_when_event_arrives_then_card_state_resets_and_gate_re_arms() async {
+        // Given
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .tapToPay)
+
+        await sut.startPayment()
+
+        // Open the gate: merchant taps Tap to Pay
+        await sut.startPaymentWithMethod(.tapToPay)
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+        #expect(sut.paymentState.card == .acceptingCard)
+
+        // When: merchant cancels on reader
+        service.paymentEvent = .show(eventDetails: .cancelledOnReader)
+
+        // Then: card state resets to idle AND inline message is cleared
+        #expect(sut.paymentState.card == .idle)
+        #expect(sut.cardPresentPaymentInlineMessage == nil)
+
+        // And the gate is re-armed: events are suppressed again until next explicit tap
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+        #expect(sut.paymentState.card == .idle)
+    }
+
+    @Test("BT: events are always propagated without waiting for startPaymentWithMethod")
+    @MainActor
+    func startPayment_BT_when_event_arrives_then_card_state_updates_without_explicit_start() async {
+        // Given: Bluetooth path — gate is never applied
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .bluetooth)
+
+        // When: start payment (BT path opens gate immediately)
+        await sut.startPayment()
+
+        // Then: events propagate without needing startPaymentWithMethod
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+
+        #expect(sut.paymentState.card == .acceptingCard)
+    }
+
+    // MARK: - Subscriber Ordering Regression
+
+    @Test("TTP: after cancelledOnReader a subsequent startPaymentWithMethod opens the gate cleanly")
+    @MainActor
+    func cancelledOnReader_TTP_when_subsequent_startPaymentWithMethod_then_gate_is_open_not_stale() async {
+        // This test is a regression guard for the subscriber-ordering invariant in
+        // subscribeToPaymentSessionEvents: the cancelledOnReader sink MUST close the
+        // gate (isAwaitingExplicitPaymentStart = true) before the card-state sink
+        // evaluates shouldPropagatePaymentEvent. If the two sinks are ever reordered,
+        // the card-state sink would run first and the cancelledOnReader event would
+        // advance paymentState.card to a non-idle state before the gate closes,
+        // causing the subsequent startPaymentWithMethod to see a stale (open) gate.
+
+        // Given
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .tapToPay)
+
+        await sut.startPayment()
+
+        // Round 1: open gate, reach acceptingCard, then cancel on reader
+        await sut.startPaymentWithMethod(.tapToPay)
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+        #expect(sut.paymentState.card == .acceptingCard)
+
+        // When: merchant cancels on reader — gate must close and state must reset
+        service.paymentEvent = .show(eventDetails: .cancelledOnReader)
+
+        // Then: state is idle immediately
+        #expect(sut.paymentState.card == .idle)
+
+        // Round 2: a subsequent startPaymentWithMethod must succeed (gate re-opens)
+        await sut.startPaymentWithMethod(.tapToPay)
+        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
+            inputMethods: [.tap, .swipe, .insert],
+            cancelPayment: {}))
+
+        // If the gate was stale (remained open after cancel-then-reopen), this would
+        // fail because subscribeToPaymentSessionEvents would guard-return early.
+        // If the subscriber order were reversed, the card state would have been set to
+        // acceptingCard by the card-state sink before the gate closed, so the reset
+        // to idle would be a no-op and the assertion below would still pass — but the
+        // cancelledOnReader-card state would not be idle between the two rounds.
+        #expect(sut.paymentState.card == .acceptingCard)
+    }
+
     @Test("connectCardReader skips a second call while the first is in flight")
     @MainActor
     func test_connectCardReader_when_called_again_while_in_flight_then_skips_second() async {
@@ -1469,6 +1649,7 @@ private func makePaymentController(
     collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
     celebration: PaymentCaptureCelebrationProtocol = MockPaymentCaptureCelebration(),
     scanToPayPollInterval: TimeInterval = 3,
+    preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
     paymentState: PointOfSalePaymentState = .idle
 ) -> POSPaymentModel {
     POSPaymentModel(
@@ -1485,5 +1666,6 @@ private func makePaymentController(
         collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
         celebration: celebration,
         scanToPayPollInterval: scanToPayPollInterval,
+        preferredConnectionMethod: preferredConnectionMethod,
         paymentState: paymentState)
 }

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -271,6 +271,23 @@ private extension POSTabCoordinator {
                     itemProvider = PointOfSaleItemServiceScreenshotMock()
                 }
 
+                // Resolve TTP eligibility once, up front, so we can hand the right
+                // preferred method down to POSPaymentModel. The same checker is also
+                // passed in for the availability controller that drives the buttons /
+                // hero, but POSPaymentModel needs the answer synchronously to know
+                // whether to skip the BT auto-collect on checkout entry.
+                let tapToPayAvailabilityChecker = POSTapToPayAvailabilityChecker(
+                    siteID: siteID,
+                    eligibilityService: POSEligibilityService()
+                )
+                let preferredConnectionMethod: CardReaderConnectionMethod
+                switch await tapToPayAvailabilityChecker.checkAvailability() {
+                case .available:
+                    preferredConnectionMethod = .tapToPay
+                case .unknown, .unavailable:
+                    preferredConnectionMethod = .bluetooth
+                }
+
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: createItemFetchStrategyFactory(isLocalCatalogEnabled: isLocalCatalogEligible),
@@ -305,10 +322,8 @@ private extension POSTabCoordinator {
                     catalogSyncCoordinator: catalogSyncCoordinator,
                     isLocalCatalogEligible: isLocalCatalogEligible,
                     sunsetWarningChecker: sunsetWarningChecker,
-                    tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecker(
-                        siteID: siteID,
-                        eligibilityService: POSEligibilityService()
-                    ),
+                    tapToPayAvailabilityChecker: tapToPayAvailabilityChecker,
+                    preferredConnectionMethod: preferredConnectionMethod,
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )


### PR DESCRIPTION
> **Stack order** (review bottom-up):
> 1. Existing phone POS stack (#17062 → #17067)
> 2. #17092 — POSLayoutScale
> 3. #17093 — Pre-TTP checkout & modal polish
> 4. #17094 — TTP foundation
> 5. #17095 — TTP checkout row
> 6. #17096 — TTP hero & sheet
> 7. **This PR** — TTP wiring & cancel handling
> 8. (next) TTP polish

## Description
Stacked on top of #17096. Wires the hero CTA + "Other payment methods" sheet through to actual `POSPaymentModel` collection, using an explicit-method-selection model instead of the legacy auto-collect-on-connect. Plus the cancel UX changes that pair with TTP.

Four commits:

- **Wire explicit method selection through `POSPaymentModel`** — adds `preferredConnectionMethod: CardReaderConnectionMethod` (immutable, set by `POSTabCoordinator` based on the synchronous TTP availability check) and `startPaymentWithMethod(_:)`. On the phone-with-TTP path `startPayment()` only pre-connects the built-in reader and bails — collection waits for the merchant's explicit hero / sheet tap. On iPad / TTP-unavailable, the existing BT auto-collect-on-connect path is unchanged. Switches readers if needed (TTP→BT or BT→TTP triggers a disconnect first).
- **Skip "Payment canceled" screen on TTP cancel** — when the merchant dismisses Apple's TTP modal, suppress the legacy iPad "Payment canceled / Try payment again" inline message. Cancel drops back to the idle hero, mirroring Android.
- **Gate event-driven state on explicit selection** — adds `isAwaitingExplicitPaymentStart` + `shouldPropagatePaymentEvent` so transient Stripe Terminal events during the TTP pre-connect (and right after a cancel teardown) can't drive `paymentState.card` or `cardPresentPaymentInlineMessage`. BT path is always allowed through; only TTP gates.
- **Reset state synchronously on cancel-on-reader** — the cancel handler closes the gate (`isAwaitingExplicitPaymentStart = true`), resets `paymentState.card = .idle`, and clears the inline message in the same run loop the event arrives on. Stops a stale `.tapSwipeOrInsertCard` from flickering the "Tap card" message visible after cancel.

The legacy "Reader connected / Connecting / Scanning / Found reader" alerts that fire when the silent TTP pre-connect happens are addressed in the next PR (#7) of the stack.

Mirrors:
- [woocommerce-android#15843](https://github.com/woocommerce/woocommerce-android/pull/15843), [#15844](https://github.com/woocommerce/woocommerce-android/pull/15844) — Android TTP collection wiring.

## Test Steps
- Pull the branch (Debug = both flags = `.localDeveloper`).
- **iPhone, TTP available, eligible site, supported device**:
  1. Open POS → add an item → checkout. Hero shows "Pay with Tap to pay".
  2. Tap "Pay with Tap to pay" → Apple's TTP modal appears → tap to charge a test card → success.
  3. Repeat, this time **dismiss** Apple's modal. Should drop straight back to the hero — NO "Payment canceled / Try payment again" screen, NO "Tap card" message stuck on screen.
  4. Open Other payment methods → tap Card reader → BT scan kicks off as expected.
  5. After connecting BT, navigate back to checkout → tap Card reader again → behaves like today's BT auto-collect.
  6. From a BT-connected state, open Other payment methods, tap Card reader (still BT) → confirm no double-connect.
- **iPad, BT path**: behaves exactly as today (auto-collect on connect).

## Screenshots
N/A — behaviour change.

---
- [x] No release notes — feature flagged off.