### PR TITLE
[RSM] Phone POS TTP - Polish: alert suppression, analytics, double-tap and empty-cart guards

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderPriceChangeDetector.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderPriceChangeDetector.swift
@@ -47,14 +47,25 @@ private extension POSOrderPriceChangeDetector {
         default:
             priceString = nil
         }
-        guard let priceString else { return nil }
-        return NSDecimalNumber(string: priceString)
+        // `Decimal(string:)` returns nil for empty/invalid input. `NSDecimalNumber(string:)`
+        // returns `.notANumber`, which raises on subsequent arithmetic — the source of
+        // the production overflow crash this helper has hit.
+        guard let priceString,
+              let decimal = Decimal(string: priceString) else { return nil }
+        return NSDecimalNumber(decimal: decimal)
     }
 
     func priceMatches(_ cartUnitPrice: NSDecimalNumber, orderItem: OrderItem) -> Bool {
         let expectedLineTotal = cartUnitPrice.multiplying(by: NSDecimalNumber(decimal: orderItem.quantity))
-        let exTaxSubtotal = NSDecimalNumber(string: orderItem.subtotal)
-        let taxInclusiveSubtotal = exTaxSubtotal.adding(NSDecimalNumber(string: orderItem.subtotalTax))
+        // If the order's subtotal can't be parsed there's nothing to compare against —
+        // trust the server and don't flag a price change so we don't block checkout.
+        guard let subtotalDecimal = Decimal(string: orderItem.subtotal) else { return true }
+        let exTaxSubtotal = NSDecimalNumber(decimal: subtotalDecimal)
+        // `subtotalTax` is empty for tax-exempt items, fees, or zero-tax jurisdictions.
+        // Treat unparseable / empty as zero rather than letting `.notANumber` propagate
+        // and raise on the `.adding(...)` below.
+        let taxDecimal = Decimal(string: orderItem.subtotalTax) ?? 0
+        let taxInclusiveSubtotal = exTaxSubtotal.adding(NSDecimalNumber(decimal: taxDecimal))
 
         return approximatelyEqual(expectedLineTotal, exTaxSubtotal)
             || approximatelyEqual(expectedLineTotal, taxInclusiveSubtotal)

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -45,15 +45,24 @@ final class POSPaymentModel {
         return false
     }
 
+    /// The connection method of the currently active payment session, or nil
+    /// between sessions. Distinct from `preferredConnectionMethod` (the POS
+    /// session's default): the merchant can pick BT via the "Other payment
+    /// methods" sheet on a TTP-default device, in which case the active
+    /// session is `.bluetooth` even though preferred remains `.tapToPay`.
+    /// This is the field that gates the intermediate-state filter and the
+    /// model-side re-entry guard.
+    private(set) var currentPaymentMethod: CardReaderConnectionMethod?
+
     /// True while a TTP collection session is active — between the merchant
-    /// tapping "Pay with Tap to pay" (which opens the gate) and a terminal
-    /// event resetting it. We suppress the intermediate card states on the
-    /// TTP path so `paymentState.card` stays at `.idle` while Apple's modal
-    /// is up; this flag is therefore the canonical "payment in flight"
-    /// signal for TotalsView's `isStartingPayment` and the model-side
-    /// re-entry guard.
+    /// tapping "Pay with Tap to pay" and a terminal event clearing
+    /// `currentPaymentMethod`. We suppress the intermediate card states on
+    /// the TTP path so `paymentState.card` stays at `.idle` while Apple's
+    /// modal is up; this flag is therefore the canonical "TTP payment in
+    /// flight" signal for TotalsView's `isStartingPayment` reset and the
+    /// model-side re-entry guard.
     var isTapToPaySessionActive: Bool {
-        preferredConnectionMethod == .tapToPay && !isAwaitingExplicitPaymentStart
+        currentPaymentMethod == .tapToPay
     }
 
     // MARK: - Dependencies
@@ -172,13 +181,15 @@ extension POSPaymentModel {
         if preferredConnectionMethod == .tapToPay {
             // Awaiting an explicit method tap from the hero / sheet — leave the
             // gate true so transient Stripe events during pre-connect can't
-            // advance the state machine.
+            // advance the state machine. No `currentPaymentMethod` yet — the
+            // session hasn't actually started.
             connectTapToPayReader()
             return
         }
 
         // BT auto-collect path — events from the connected reader are the
         // intended source of state transitions.
+        currentPaymentMethod = preferredConnectionMethod
         isAwaitingExplicitPaymentStart = false
         await startPaymentFlow(using: preferredConnectionMethod)
     }
@@ -219,8 +230,10 @@ extension POSPaymentModel {
         }
 
         subscribeToPaymentSessionEvents()
-        // Merchant explicitly chose a method — open the gate so subsequent
-        // Stripe Terminal events drive the state machine.
+        // Merchant explicitly chose a method — track it as the active session
+        // method (drives the intermediate-state filter) and open the gate so
+        // subsequent Stripe Terminal events drive the state machine.
+        currentPaymentMethod = method
         isAwaitingExplicitPaymentStart = false
 
         // If a reader is connected via the *other* method, drop it before
@@ -776,6 +789,7 @@ extension POSPaymentModel {
         // Re-arm the TTP gate so re-entering checkout starts clean — `startPayment`
         // will keep it true on the TTP path until the merchant taps a method again.
         isAwaitingExplicitPaymentStart = true
+        currentPaymentMethod = nil
         cancelReaderPreparation()
     }
 
@@ -951,6 +965,7 @@ private extension POSPaymentModel {
             .sink { [weak self] _ in
                 guard let self, self.preferredConnectionMethod == .tapToPay else { return }
                 self.isAwaitingExplicitPaymentStart = true
+                self.currentPaymentMethod = nil
                 self.paymentState.card = .idle
                 self.cardPresentPaymentInlineMessage = nil
                 Task { @MainActor [weak self] in
@@ -987,8 +1002,10 @@ private extension POSPaymentModel {
                 // for a frame. Suppress intermediates here — terminal states
                 // (cardPaymentSuccessful / paymentError) still come through.
                 // The cancel-on-reader path is handled by its dedicated
-                // synchronous reset above.
-                if self.preferredConnectionMethod == .tapToPay,
+                // synchronous reset above. Gated on the *current session's*
+                // method — when the merchant picks BT via the sheet on a
+                // TTP-default device, BT events should drive the UI normally.
+                if self.currentPaymentMethod == .tapToPay,
                    let state = newCardPaymentState {
                     switch state {
                     case .validatingOrder,

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -41,6 +41,10 @@ final class POSPaymentModel {
     /// pre-connect window.
     var isPreparingTapToPay: Bool {
         guard preferredConnectionMethod == .tapToPay else { return false }
+        // If a non-TTP session is in flight (BT picked via the sheet),
+        // we deliberately disconnected TTP — showing "Preparing Tap to Pay…"
+        // would mislead. The BT path drives its own UI from here.
+        if let currentPaymentMethod, currentPaymentMethod != .tapToPay { return false }
         if case .disconnected = cardReaderConnectionStatus { return true }
         return false
     }
@@ -818,7 +822,16 @@ extension POSPaymentModel {
             .filter({ $0 == .disconnected })
             .sink { [weak self] _ in
                 Task { @MainActor [weak self] in
-                    await self?.startPayment()
+                    guard let self else { return }
+                    // The auto-reconnect is for "reader fell off the device"
+                    // scenarios when no payment is in flight. If a session is
+                    // active (e.g. a BT-via-sheet pick on a TTP-default
+                    // device deliberately disconnected TTP first), the
+                    // session manages its own reconnect and we should stay
+                    // out of the way — otherwise we race the session's
+                    // chosen method and confuse the SDK.
+                    guard self.currentPaymentMethod == nil else { return }
+                    await self.startPayment()
                 }
             }
     }
@@ -884,8 +897,15 @@ private extension POSPaymentModel {
                 // connected"). Failures the merchant must actually act on — TTP
                 // entitlement / Apple ToS / location-services / postal-code /
                 // address — still surface so the merchant can resolve them.
-                // iPad / non-TTP phones see all of these as today.
-                if preferredConnectionMethod == .tapToPay {
+                //
+                // Gated on the *current session's* method (or the silent
+                // pre-connect window where no session has been started yet):
+                // when the merchant picks BT via the sheet on a TTP-default
+                // device, the BT discovery alerts have to come through so they
+                // can pick a reader.
+                let isInTransparentTapToPayFlow = currentPaymentMethod == .tapToPay
+                    || (currentPaymentMethod == nil && preferredConnectionMethod == .tapToPay)
+                if isInTransparentTapToPayFlow {
                     switch eventDetails {
                     case .scanningForReaders,
                             .foundReader,
@@ -1067,6 +1087,16 @@ private extension POSPaymentModel {
                           "current scanToPay state: \(paymentState.scanToPay), " +
                           "current markAsPaid state: \(paymentState.markAsPaid)")
                 paymentState.card = cardPaymentState
+                // Card transitioning back to .idle after a non-TTP session
+                // (cancel / disconnect mid-flow) means the session ended —
+                // clear the active-session marker so the next start is
+                // treated as a fresh session and the reader-reconnection
+                // observer is allowed to auto-reconnect TTP if needed.
+                // The TTP cancel path clears this in its dedicated handler;
+                // success / error keep the marker until `reset()` runs.
+                if cardPaymentState == .idle {
+                    self.currentPaymentMethod = nil
+                }
             })
             .store(in: &paymentSessionCancellables)
     }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -923,18 +923,20 @@ private extension POSPaymentModel {
                     }
                 }
 
-                // Generic "couldn't connect" / "couldn't connect (non-retryable)"
-                // failures aren't actionable for the merchant on a TTP-default
-                // device — they fire for transient races (another reader still
-                // connected) and as the residual event after the merchant cancels
-                // a BT scan, redundant with the cancel they just performed. The
-                // merchant can always retry from the sheet or hero, so suppress
-                // these globally on TTP-default devices regardless of which
-                // session is active. BT-default devices keep them.
+                // Generic "couldn't connect" / "scan failed" / "couldn't connect
+                // (non-retryable)" failures aren't actionable for the merchant
+                // on a TTP-default device — they fire for transient races
+                // (another reader still connected, scan racing a reconnect) and
+                // as the residual event after the merchant cancels a BT scan,
+                // redundant with the cancel they just performed. The merchant
+                // can always retry from the sheet or hero, so suppress these
+                // globally on TTP-default devices regardless of which session
+                // is active. BT-default devices keep them.
                 if preferredConnectionMethod == .tapToPay {
                     switch eventDetails {
                     case .connectingFailed,
-                            .connectingFailedNonRetryable:
+                            .connectingFailedNonRetryable,
+                            .scanningFailed:
                         return nil
                     default:
                         break
@@ -1109,16 +1111,17 @@ private extension POSPaymentModel {
                           "current scanToPay state: \(paymentState.scanToPay), " +
                           "current markAsPaid state: \(paymentState.markAsPaid)")
                 paymentState.card = cardPaymentState
-                // Card transitioning back to .idle after a non-TTP session
-                // (cancel / disconnect mid-flow) means the session ended —
-                // clear the active-session marker so the next start is
-                // treated as a fresh session and the reader-reconnection
-                // observer is allowed to auto-reconnect TTP if needed.
-                // The TTP cancel path clears this in its dedicated handler;
-                // success / error keep the marker until `reset()` runs.
-                if cardPaymentState == .idle {
-                    self.currentPaymentMethod = nil
-                }
+                // Don't auto-clear `currentPaymentMethod` on `.idle` — Stripe
+                // emits `.idle` mid-cancel of a BT scan (before the merchant
+                // is back at the hero), and clearing here woke up the
+                // reader-reconnection observer, which then tried to TTP-
+                // reconnect while the BT scan was still tearing down. That
+                // race produced a `.scanningFailed` ("internal service error")
+                // alert. Terminal-only clears: TTP cancel handles itself in
+                // its dedicated handler, BT success / error fall through to
+                // `reset()` when the merchant moves on, and a BT scan dismiss
+                // leaves `currentPaymentMethod = .bluetooth` until the next
+                // `startPayment(WithMethod)` overwrites it or `reset()` runs.
             })
             .store(in: &paymentSessionCancellables)
     }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -58,22 +58,11 @@ final class POSPaymentModel {
     /// model-side re-entry guard.
     private(set) var currentPaymentMethod: CardReaderConnectionMethod?
 
-    /// True while a TTP collection session is active — between the merchant
-    /// tapping "Pay with Tap to pay" and a terminal event clearing
-    /// `currentPaymentMethod`. We suppress the intermediate card states on
-    /// the TTP path so `paymentState.card` stays at `.idle` while Apple's
-    /// modal is up; this flag is therefore the canonical "TTP payment in
-    /// flight" signal for the model-side re-entry guard.
-    var isTapToPaySessionActive: Bool {
-        currentPaymentMethod == .tapToPay
-    }
-
     /// True while *any* collection session is active (TTP or BT). Drives
     /// TotalsView's `isStartingPayment` reset — when this transitions back
     /// to false the merchant's flow has wrapped up (success, error, cancel,
     /// BT scan dismissed, etc.) and the hero CTA + bottom strip can become
-    /// tappable again. `isTapToPaySessionActive` only covered the TTP cancel
-    /// case, so cancelling a BT scan left the buttons disabled.
+    /// tappable again.
     var isPaymentSessionActive: Bool {
         currentPaymentMethod != nil
     }
@@ -231,9 +220,9 @@ extension POSPaymentModel {
         }
         // On TTP we suppress the intermediate card states so `paymentState.card`
         // stays `.idle` for the entire collection session — the guard above
-        // therefore can't catch re-entry there. `isTapToPaySessionActive`
-        // (gate flag based) is the canonical "in flight" check for TTP.
-        if isTapToPaySessionActive {
+        // therefore can't catch re-entry there. `currentPaymentMethod` is the
+        // canonical "in flight" check for TTP.
+        if currentPaymentMethod == .tapToPay {
             DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — TTP session already active")
             return
         }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -909,8 +909,18 @@ private extension POSPaymentModel {
                 // must actually act on — TTP entitlement / Apple ToS /
                 // location-services / postal-code / address — still surface so
                 // the merchant can resolve them.
-                let isInTransparentTapToPayFlow = currentPaymentMethod == .tapToPay
-                    || (currentPaymentMethod == nil && preferredConnectionMethod == .tapToPay)
+                // The merchant can also kick off a BT scan explicitly via
+                // Settings → Hardware → Card readers → Connect card reader,
+                // which goes through `connectCardReader()` and sets
+                // `connectCardReaderTask`. While that task is in flight the
+                // merchant *wants* to see the scan / foundReader / connect
+                // / failure modals, so neither suppression block below
+                // applies — Settings drives its UI off them.
+                let isExplicitConnectInProgress = connectCardReaderTask != nil
+
+                let isInTransparentTapToPayFlow = !isExplicitConnectInProgress
+                    && (currentPaymentMethod == .tapToPay
+                        || (currentPaymentMethod == nil && preferredConnectionMethod == .tapToPay))
                 if isInTransparentTapToPayFlow {
                     switch eventDetails {
                     case .scanningForReaders,
@@ -925,14 +935,12 @@ private extension POSPaymentModel {
 
                 // Generic "couldn't connect" / "scan failed" / "couldn't connect
                 // (non-retryable)" failures aren't actionable for the merchant
-                // on a TTP-default device — they fire for transient races
-                // (another reader still connected, scan racing a reconnect) and
-                // as the residual event after the merchant cancels a BT scan,
-                // redundant with the cancel they just performed. The merchant
-                // can always retry from the sheet or hero, so suppress these
-                // globally on TTP-default devices regardless of which session
-                // is active. BT-default devices keep them.
-                if preferredConnectionMethod == .tapToPay {
+                // on a TTP-default device when the connect was implicit (TTP
+                // pre-connect, BT-via-sheet cancel residual, etc.). When the
+                // merchant explicitly tapped Connect in Settings, they need to
+                // see the failure to know to retry or fix something — keep
+                // those alerts visible. BT-default devices keep them too.
+                if preferredConnectionMethod == .tapToPay && !isExplicitConnectInProgress {
                     switch eventDetails {
                     case .connectingFailed,
                             .connectingFailedNonRetryable,

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -221,7 +221,17 @@ extension POSPaymentModel {
     /// so the reader is warm by the time the merchant taps the hero CTA.
     private func connectTapToPayReader() {
         Task { @MainActor [weak self] in
-            _ = try? await self?.cardPresentPaymentService.connectReader(using: .tapToPay)
+            guard let self else { return }
+            // Stripe Terminal can only hold one active reader. If an old reader
+            // is still attached when we enter POS (a stale TTP / BT session
+            // carried across app launches, or a BT reader from a previous
+            // mode), connecting on top would fail with "another reader is
+            // already connected" and surface a disruptive failure modal —
+            // for a connect the merchant didn't even ask for. Drop it first.
+            if case .connected = cardReaderConnectionStatus {
+                await cardPresentPaymentService.disconnectReader()
+            }
+            _ = try? await cardPresentPaymentService.connectReader(using: .tapToPay)
         }
     }
 
@@ -819,6 +829,30 @@ private extension POSPaymentModel {
                 if case .connectionSuccess = eventDetails,
                    startPaymentOnCardReaderConnection != nil {
                     return nil
+                }
+
+                // On the TTP path the merchant never explicitly initiates a reader
+                // connection — pre-connect on checkout entry and the connect inside
+                // `startPaymentWithMethod` are both transparent. Suppress the entire
+                // discovery / connection lifecycle (scanning, found reader, connecting,
+                // connected, plus the generic "couldn't connect" failure variants
+                // that fire for transient races like "another reader is already
+                // connected"). Failures the merchant must actually act on — TTP
+                // entitlement / Apple ToS / location-services / postal-code /
+                // address — still surface so the merchant can resolve them.
+                // iPad / non-TTP phones see all of these as today.
+                if preferredConnectionMethod == .tapToPay {
+                    switch eventDetails {
+                    case .scanningForReaders,
+                            .foundReader,
+                            .connectingToReader,
+                            .connectionSuccess,
+                            .connectingFailed,
+                            .connectingFailedNonRetryable:
+                        return nil
+                    default:
+                        break
+                    }
                 }
 
                 return alertType

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -172,13 +172,39 @@ extension POSPaymentModel {
     func startPaymentWithMethod(_ method: CardReaderConnectionMethod) async {
         DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus)")
 
+        // Defensive re-entry guard: only kick a fresh flow off the idle state.
+        // If a payment is already mid-flight (preparing, accepting, processing,
+        // success, error), a second call from a stray closure / restored
+        // subscription / SwiftUI re-render could clobber generation tracking
+        // and confuse the Stripe Terminal state machine. The hero / sheet
+        // buttons in `TotalsView` already double-tap-protect via the
+        // `isStartingPayment` gate; this is the model-side belt to that.
+        guard paymentState.card == .idle else {
+            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — card state is \(paymentState.card)")
+            return
+        }
+
+        if method == .tapToPay {
+            analytics.track(.pointOfSaleCheckoutTapToPayTapped)
+        }
+
         subscribeToPaymentSessionEvents()
         // Merchant explicitly chose a method — open the gate so subsequent
         // Stripe Terminal events drive the state machine.
         isAwaitingExplicitPaymentStart = false
 
-        if method == .bluetooth, case .connected = cardReaderConnectionStatus {
-            await cardPresentPaymentService.disconnectReader()
+        // If a reader is connected via the *other* method, drop it before
+        // connecting via the chosen one. Stripe Terminal can only have one
+        // active reader; without the disconnect the new connect would be
+        // rejected. iPad never hits this branch (preferred is always
+        // bluetooth there), so the disconnect is scoped to the phone-with-TTP
+        // method-switch case.
+        if case .connected = cardReaderConnectionStatus {
+            if method == .bluetooth, preferredConnectionMethod == .tapToPay {
+                await cardPresentPaymentService.disconnectReader()
+            } else if method == .tapToPay, preferredConnectionMethod == .bluetooth {
+                await cardPresentPaymentService.disconnectReader()
+            }
         }
 
         if case .disconnected = cardReaderConnectionStatus {

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -45,6 +45,17 @@ final class POSPaymentModel {
         return false
     }
 
+    /// True while a TTP collection session is active — between the merchant
+    /// tapping "Pay with Tap to pay" (which opens the gate) and a terminal
+    /// event resetting it. We suppress the intermediate card states on the
+    /// TTP path so `paymentState.card` stays at `.idle` while Apple's modal
+    /// is up; this flag is therefore the canonical "payment in flight"
+    /// signal for TotalsView's `isStartingPayment` and the model-side
+    /// re-entry guard.
+    var isTapToPaySessionActive: Bool {
+        preferredConnectionMethod == .tapToPay && !isAwaitingExplicitPaymentStart
+    }
+
     // MARK: - Dependencies
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderProvider: POSPaymentOrderProviding
@@ -192,6 +203,14 @@ extension POSPaymentModel {
         // `isStartingPayment` gate; this is the model-side belt to that.
         guard paymentState.card == .idle else {
             DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — card state is \(paymentState.card)")
+            return
+        }
+        // On TTP we suppress the intermediate card states so `paymentState.card`
+        // stays `.idle` for the entire collection session — the guard above
+        // therefore can't catch re-entry there. `isTapToPaySessionActive`
+        // (gate flag based) is the canonical "in flight" check for TTP.
+        if isTapToPaySessionActive {
+            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — TTP session already active")
             return
         }
 
@@ -955,6 +974,36 @@ private extension POSPaymentModel {
 
                 if case .processingPayment = newCardPaymentState {
                     collectOrderPaymentAnalyticsTracker.trackCardReaderTapped()
+                }
+
+                // On the TTP path Apple's modal owns the merchant's UX between
+                // "Pay with Tap to pay" and a terminal event. Letting the
+                // intermediate card states (validatingOrder / preparingReader /
+                // acceptingCard / cardInserted / processingPayment) drive our
+                // own card state is invisible while the modal is on screen,
+                // but on cancel the modal dismisses faster than the
+                // `cancelledOnReader` event arrives, and the merchant sees
+                // our underlying "Tap card" / "Ready for payment" UI flash
+                // for a frame. Suppress intermediates here — terminal states
+                // (cardPaymentSuccessful / paymentError) still come through.
+                // The cancel-on-reader path is handled by its dedicated
+                // synchronous reset above.
+                if self.preferredConnectionMethod == .tapToPay,
+                   let state = newCardPaymentState {
+                    switch state {
+                    case .validatingOrder,
+                            .preparingReader,
+                            .acceptingCard,
+                            .cardInserted,
+                            .processingPayment:
+                        return nil
+                    case .idle,
+                            .cardPaymentSuccessful,
+                            .paymentError,
+                            .validatingOrderError,
+                            .paymentIntentCreationError:
+                        break
+                    }
                 }
 
                 return newCardPaymentState

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -34,6 +34,17 @@ final class POSPaymentModel {
         return false
     }
 
+    /// True while the silent Tap to Pay pre-connect is still in flight: the
+    /// merchant is on the TTP path and the reader hasn't moved out of
+    /// `.disconnected` yet. Drives the hero's "Preparing Tap to Pay…"
+    /// affordance so the merchant gets feedback during the (usually short)
+    /// pre-connect window.
+    var isPreparingTapToPay: Bool {
+        guard preferredConnectionMethod == .tapToPay else { return false }
+        if case .disconnected = cardReaderConnectionStatus { return true }
+        return false
+    }
+
     // MARK: - Dependencies
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let orderProvider: POSPaymentOrderProviding

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -63,10 +63,19 @@ final class POSPaymentModel {
     /// `currentPaymentMethod`. We suppress the intermediate card states on
     /// the TTP path so `paymentState.card` stays at `.idle` while Apple's
     /// modal is up; this flag is therefore the canonical "TTP payment in
-    /// flight" signal for TotalsView's `isStartingPayment` reset and the
-    /// model-side re-entry guard.
+    /// flight" signal for the model-side re-entry guard.
     var isTapToPaySessionActive: Bool {
         currentPaymentMethod == .tapToPay
+    }
+
+    /// True while *any* collection session is active (TTP or BT). Drives
+    /// TotalsView's `isStartingPayment` reset — when this transitions back
+    /// to false the merchant's flow has wrapped up (success, error, cancel,
+    /// BT scan dismissed, etc.) and the hero CTA + bottom strip can become
+    /// tappable again. `isTapToPaySessionActive` only covered the TTP cancel
+    /// case, so cancelling a BT scan left the buttons disabled.
+    var isPaymentSessionActive: Bool {
+        currentPaymentMethod != nil
     }
 
     // MARK: - Dependencies
@@ -890,19 +899,16 @@ private extension POSPaymentModel {
 
                 // On the TTP path the merchant never explicitly initiates a reader
                 // connection — pre-connect on checkout entry and the connect inside
-                // `startPaymentWithMethod` are both transparent. Suppress the entire
-                // discovery / connection lifecycle (scanning, found reader, connecting,
-                // connected, plus the generic "couldn't connect" failure variants
-                // that fire for transient races like "another reader is already
-                // connected"). Failures the merchant must actually act on — TTP
-                // entitlement / Apple ToS / location-services / postal-code /
-                // address — still surface so the merchant can resolve them.
-                //
-                // Gated on the *current session's* method (or the silent
-                // pre-connect window where no session has been started yet):
-                // when the merchant picks BT via the sheet on a TTP-default
-                // device, the BT discovery alerts have to come through so they
-                // can pick a reader.
+                // `startPaymentWithMethod` are both transparent. Suppress the
+                // discovery / connection lifecycle (scanning, found reader,
+                // connecting, connected) when there's no active BT session, so
+                // those modals don't pop up for connections the merchant didn't
+                // request. When a BT-via-sheet session is active we leave the
+                // discovery / connection alerts visible so the merchant can pick
+                // a reader and see connection progress. Failures the merchant
+                // must actually act on — TTP entitlement / Apple ToS /
+                // location-services / postal-code / address — still surface so
+                // the merchant can resolve them.
                 let isInTransparentTapToPayFlow = currentPaymentMethod == .tapToPay
                     || (currentPaymentMethod == nil && preferredConnectionMethod == .tapToPay)
                 if isInTransparentTapToPayFlow {
@@ -910,8 +916,24 @@ private extension POSPaymentModel {
                     case .scanningForReaders,
                             .foundReader,
                             .connectingToReader,
-                            .connectionSuccess,
-                            .connectingFailed,
+                            .connectionSuccess:
+                        return nil
+                    default:
+                        break
+                    }
+                }
+
+                // Generic "couldn't connect" / "couldn't connect (non-retryable)"
+                // failures aren't actionable for the merchant on a TTP-default
+                // device — they fire for transient races (another reader still
+                // connected) and as the residual event after the merchant cancels
+                // a BT scan, redundant with the cancel they just performed. The
+                // merchant can always retry from the sheet or hero, so suppress
+                // these globally on TTP-default devices regardless of which
+                // session is active. BT-default devices keep them.
+                if preferredConnectionMethod == .tapToPay {
+                    switch eventDetails {
+                    case .connectingFailed,
                             .connectingFailedNonRetryable:
                         return nil
                     default:

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 /// they're folded into a richer hero in a follow-up commit.
 struct POSTapToPayHeroView: View {
     let onPayTapped: () -> Void
+    var isPayDisabled: Bool = false
 
     var body: some View {
         VStack(spacing: POSSpacing.large) {
@@ -41,6 +42,7 @@ struct POSTapToPayHeroView: View {
             }
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .padding(.horizontal, POSPadding.medium)
+            .disabled(isPayDisabled)
             .accessibilityIdentifier("pos-tap-to-pay-hero-pay-button")
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -58,7 +58,12 @@ struct POSTapToPayHeroView: View {
             }
             .buttonStyle(POSFilledButtonStyle(size: .normal))
             .padding(.horizontal, POSPadding.medium)
-            .disabled(isPayDisabled)
+            // Disabled while preparing only once the indicator becomes visible
+            // (after the 700ms grace). Fast pre-connects therefore never flicker
+            // the button into a disabled state, and slow pre-connects show the
+            // disabled button alongside the "Preparing…" indicator that
+            // explains why it's not tappable.
+            .disabled(isPayDisabled || isIndicatorVisible)
             .accessibilityIdentifier("pos-tap-to-pay-hero-pay-button")
 
             preparingIndicator

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -12,6 +12,22 @@ import SwiftUI
 struct POSTapToPayHeroView: View {
     let onPayTapped: () -> Void
     var isPayDisabled: Bool = false
+    /// Drives the inline "Preparing Tap to Pay…" indicator. Set true while the
+    /// silent pre-connect is still in flight (`POSPaymentModel.isPreparingTapToPay`).
+    /// The CTA stays tappable — `startPaymentFlow` already handles a tap that
+    /// arrives before the reader connects by waiting for the connection event.
+    var isPreparing: Bool = false
+
+    /// Delays the indicator's first appearance so the common fast-pre-connect
+    /// case (sub-second) doesn't flash a spinner.
+    private static let appearanceDelay: Duration = .milliseconds(700)
+    /// If the pre-connect hasn't finished after this, give up showing the
+    /// indicator. Stops it sitting forever when pre-connect silently fails
+    /// (entitlement / Apple ToS / location-services edge cases the
+    /// `.connectingFailed*` suppression on `POSPaymentModel` swallows).
+    private static let timeout: Duration = .seconds(12)
+
+    @State private var isIndicatorVisible: Bool = false
 
     var body: some View {
         VStack(spacing: POSSpacing.large) {
@@ -44,7 +60,43 @@ struct POSTapToPayHeroView: View {
             .padding(.horizontal, POSPadding.medium)
             .disabled(isPayDisabled)
             .accessibilityIdentifier("pos-tap-to-pay-hero-pay-button")
+
+            preparingIndicator
         }
+        .task(id: isPreparing) {
+            await updateIndicatorVisibility()
+        }
+    }
+
+    @ViewBuilder
+    private var preparingIndicator: some View {
+        HStack(spacing: POSSpacing.small) {
+            ProgressView()
+                .controlSize(.small)
+            Text(Localization.preparing)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+        }
+        .accessibilityElement(children: .combine)
+        .opacity(isIndicatorVisible ? 1 : 0)
+        .animation(.default, value: isIndicatorVisible)
+        .accessibilityHidden(!isIndicatorVisible)
+    }
+
+    private func updateIndicatorVisibility() async {
+        guard isPreparing else {
+            isIndicatorVisible = false
+            return
+        }
+        // Hold for the appearance delay; bail if pre-connect finished first.
+        try? await Task.sleep(for: Self.appearanceDelay)
+        guard !Task.isCancelled, isPreparing else { return }
+        isIndicatorVisible = true
+        // Auto-hide after the timeout so a silently failed pre-connect doesn't
+        // leave the indicator sitting indefinitely.
+        try? await Task.sleep(for: Self.timeout)
+        guard !Task.isCancelled else { return }
+        isIndicatorVisible = false
     }
 }
 
@@ -65,12 +117,22 @@ private extension POSTapToPayHeroView {
             value: "Pay with Tap to pay",
             comment: "Primary CTA shown in the Tap to Pay hero on the POS checkout."
         )
+        static let preparing = NSLocalizedString(
+            "pos.tapToPay.hero.preparing",
+            value: "Preparing Tap to Pay…",
+            comment: "Inline indicator shown under the Tap to Pay CTA while the silent reader pre-connect is in flight."
+        )
     }
 }
 
 #if DEBUG
-#Preview {
+#Preview("Idle") {
     POSTapToPayHeroView(onPayTapped: {})
+        .padding()
+}
+
+#Preview("Preparing") {
+    POSTapToPayHeroView(onPayTapped: {}, isPreparing: true)
         .padding()
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -620,14 +620,16 @@ private extension TotalsView {
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
         guard displayPaymentState.card == .idle && displayPaymentState.cash == .idle else { return false }
-        // Reuse the syncing / reconnecting / zero-total guards from the iPad
-        // pay row so an empty cart can't let the merchant tap "Pay with Tap to
-        // pay" and trip an order-validation error.
-        return totalsViewHelper.shouldShowCollectCashPaymentButton(
-            orderState: posModel.orderState,
-            paymentState: displayPaymentState,
-            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus
-        )
+        // Empty-cart / syncing / reconnecting guards computed directly. We
+        // can't reuse `shouldShowCollectCashPaymentButton` here — that helper
+        // also requires the reader to be disconnected when card state is idle
+        // (an iPad pay-row assumption). On TTP the device is silently
+        // pre-connected, so reusing it would collapse the hero whenever the
+        // pre-connect succeeds.
+        guard case .loaded(let totals) = posModel.orderState else { return false }
+        guard !totals.orderTotalDecimal.isZero else { return false }
+        if case .reconnecting = paymentModel.cardReaderConnectionStatus { return false }
+        return true
     }
 
     /// Cash + Other payment methods stacked outlined buttons rendered below the

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -137,11 +137,23 @@ struct TotalsView: View {
         .onChange(of: paymentModel.isPaymentSessionActive) { _, isActive in
             // The card-state onChange above doesn't always fire when a flow
             // wraps up — TTP filters intermediate states (idle → idle on
-            // cancel is a no-op), and BT scan dismissal never produces a
-            // card-state change at all. This signal goes false on every
-            // session end, so the hero CTA + bottom strip become tappable
-            // again across the board.
+            // cancel is a no-op). When the gate closes after a TTP
+            // cancel-on-reader, this signals "session ended" — release the
+            // double-tap lock so the merchant can tap the hero CTA again.
             if !isActive {
+                isStartingPayment = false
+            }
+        }
+        .onChange(of: paymentModel.cardPresentPaymentAlertViewModel == nil) { _, becameNil in
+            // BT scan cancel doesn't trigger any of the signals above:
+            // `currentPaymentMethod` stays `.bluetooth` (we deliberately stopped
+            // auto-clearing on `.idle` to avoid racing the reader-reconnection
+            // observer), and `paymentState.card` was never non-idle to begin
+            // with. The reliable signal there is the scan alert dismissing —
+            // when the alert goes from non-nil to nil while card is idle the
+            // merchant has stepped out of a connect flow that never reached
+            // collect.
+            if becameNil && paymentModel.paymentState.card == .idle {
                 isStartingPayment = false
             }
         }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -60,7 +60,8 @@ struct TotalsView: View {
 
                     if useTapToPayHeroLayout {
                         POSTapToPayHeroView(onPayTapped: handleTapToPayTapped,
-                                            isPayDisabled: isStartingPayment)
+                                            isPayDisabled: isStartingPayment,
+                                            isPreparing: paymentModel.isPreparingTapToPay)
                     } else if isShowingPaymentView {
                         PaymentViewContent(
                             paymentState: displayPaymentState,

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -134,12 +134,13 @@ struct TotalsView: View {
         .onChange(of: paymentModel.paymentState.cash) {
             isStartingPayment = false
         }
-        .onChange(of: paymentModel.isTapToPaySessionActive) { _, isActive in
-            // TTP path filters intermediate card states, so the card-state
-            // onChange above never fires on cancel (idle → idle). When the
-            // gate closes after a cancel-on-reader, this signals "session
-            // ended" — release the double-tap lock so the merchant can tap
-            // the hero CTA again.
+        .onChange(of: paymentModel.isPaymentSessionActive) { _, isActive in
+            // The card-state onChange above doesn't always fire when a flow
+            // wraps up — TTP filters intermediate states (idle → idle on
+            // cancel is a no-op), and BT scan dismissal never produces a
+            // card-state change at all. This signal goes false on every
+            // session end, so the hero CTA + bottom strip become tappable
+            // again across the board.
             if !isActive {
                 isStartingPayment = false
             }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -134,6 +134,16 @@ struct TotalsView: View {
         .onChange(of: paymentModel.paymentState.cash) {
             isStartingPayment = false
         }
+        .onChange(of: paymentModel.isTapToPaySessionActive) { _, isActive in
+            // TTP path filters intermediate card states, so the card-state
+            // onChange above never fires on cancel (idle → idle). When the
+            // gate closes after a cancel-on-reader, this signals "session
+            // ended" — release the double-tap lock so the merchant can tap
+            // the hero CTA again.
+            if !isActive {
+                isStartingPayment = false
+            }
+        }
         .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
             POSOtherPaymentMethodsSheet(onCardReader: {
                 guard !isStartingPayment else { return }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -23,6 +23,11 @@ struct TotalsView: View {
     // Default true so totals fields would be included in the view hiearchy on first render and animate with TotalsView
     @State private var isShowingTotalsFields: Bool = true
     @State private var isShowingOtherPaymentMethodsSheet: Bool = false
+    /// True between the merchant tapping a hero / bottom-strip button and the
+    /// payment state machine actually leaving idle. Disables the hero CTA and
+    /// the bottom-strip buttons during that brief async window so a quick
+    /// double-tap can't kick off two payment flows.
+    @State private var isStartingPayment: Bool = false
 
     /// Payment state with in-progress secondary methods neutralized.
     /// `.collectingCash` (cash), `.showingQRCode` (scan-to-pay), and `.confirming`/`.processing`
@@ -54,7 +59,8 @@ struct TotalsView: View {
                     Spacer()
 
                     if useTapToPayHeroLayout {
-                        POSTapToPayHeroView(onPayTapped: handleTapToPayTapped)
+                        POSTapToPayHeroView(onPayTapped: handleTapToPayTapped,
+                                            isPayDisabled: isStartingPayment)
                     } else if isShowingPaymentView {
                         PaymentViewContent(
                             paymentState: displayPaymentState,
@@ -117,8 +123,20 @@ struct TotalsView: View {
         .onChange(of: shouldShowTotalsFields) {
             hideTotalsFieldsWithDelay(shouldShowTotalsFields)
         }
+        .onChange(of: paymentModel.paymentState.card) {
+            // Any card state change means the payment state machine has reacted
+            // to the merchant's tap (preparingReader, error, idle after cancel,
+            // etc.). Release the double-tap gate so the buttons become
+            // tappable again whenever the layout decides to show them.
+            isStartingPayment = false
+        }
+        .onChange(of: paymentModel.paymentState.cash) {
+            isStartingPayment = false
+        }
         .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
             POSOtherPaymentMethodsSheet(onCardReader: {
+                guard !isStartingPayment else { return }
+                isStartingPayment = true
                 Task { @MainActor in
                     await paymentModel.startPaymentWithMethod(.bluetooth)
                 }
@@ -315,7 +333,8 @@ private extension TotalsView {
         static let otherPaymentMethodsButtonTitle = NSLocalizedString(
             "pos.totalsView.otherPaymentMethods.button.title",
             value: "Other payment methods",
-            comment: "Title for the Other payment methods button shown alongside the Tap to Pay hero on phone POS checkout.")
+            comment: "Title for the Other payment methods button shown alongside the Tap to Pay hero on phone POS checkout. "
+                + "Tapping it opens a sheet with non-TTP options (currently Card reader).")
     }
 }
 
@@ -592,14 +611,23 @@ private extension TotalsView {
     }
 
     /// True when the merchant should see the Android-style Tap to Pay hero +
-    /// bottom-strip layout: TTP availability has resolved `.available` and no
-    /// payment is currently in progress (idle card + idle cash). When a TTP
-    /// payment kicks off, `paymentState.card` transitions out of `.idle` and the
-    /// existing `PaymentViewContent` flow takes over (preparing / accepting /
+    /// bottom-strip layout: TTP availability has resolved `.available`, no
+    /// payment is currently in progress (idle card + idle cash), and the order
+    /// has a real non-zero total to charge. When a TTP payment kicks off,
+    /// `paymentState.card` transitions out of `.idle` and the existing
+    /// `PaymentViewContent` flow takes over (preparing / accepting /
     /// processing / success / error).
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        return displayPaymentState.card == .idle && displayPaymentState.cash == .idle
+        guard displayPaymentState.card == .idle && displayPaymentState.cash == .idle else { return false }
+        // Reuse the syncing / reconnecting / zero-total guards from the iPad
+        // pay row so an empty cart can't let the merchant tap "Pay with Tap to
+        // pay" and trip an order-validation error.
+        return totalsViewHelper.shouldShowCollectCashPaymentButton(
+            orderState: posModel.orderState,
+            paymentState: displayPaymentState,
+            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus
+        )
     }
 
     /// Cash + Other payment methods stacked outlined buttons rendered below the
@@ -608,11 +636,12 @@ private extension TotalsView {
     @ViewBuilder
     var tapToPayBottomStrip: some View {
         VStack(spacing: POSSpacing.medium) {
-            Button(action: { paymentModel.startCashPayment() }) {
+            Button(action: handleCashPaymentTapped) {
                 Text(Localization.cashPaymentButtonTitle)
                     .font(POSFontStyle.posBodyLargeBold)
             }
             .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .disabled(isStartingPayment)
             .accessibilityIdentifier("pos-cash-payment-button")
 
             Button(action: handleOtherPaymentMethodsTapped) {
@@ -620,6 +649,7 @@ private extension TotalsView {
                     .font(POSFontStyle.posBodyLargeBold)
             }
             .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+            .disabled(isStartingPayment)
             .accessibilityIdentifier("pos-other-payment-methods-button")
         }
         .padding(.horizontal, POSPadding.medium)
@@ -627,9 +657,17 @@ private extension TotalsView {
     }
 
     func handleTapToPayTapped() {
+        guard !isStartingPayment else { return }
+        isStartingPayment = true
         Task { @MainActor in
             await paymentModel.startPaymentWithMethod(.tapToPay)
         }
+    }
+
+    func handleCashPaymentTapped() {
+        guard !isStartingPayment else { return }
+        isStartingPayment = true
+        paymentModel.startCashPayment()
     }
 
     func handleOtherPaymentMethodsTapped() {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderPriceChangeDetectorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderPriceChangeDetectorTests.swift
@@ -125,6 +125,24 @@ struct POSOrderPriceChangeDetectorTests {
         // Then
         #expect(result == true)
     }
+
+    // MARK: - Regression tests
+
+    /// Regression: `subtotalTax = ""` (empty string) previously caused a crash.
+    /// `NSDecimalNumber(string: "")` silently returns `.notANumber`, which raises an
+    /// `NSDecimalNumberOverflowException` when passed to `.adding(...)`. The fix switches
+    /// to `Decimal(string:)` which returns `nil` for empty/invalid input and falls back to 0.
+    @Test func detectsPriceChange_when_subtotalTax_is_empty_string_then_does_not_crash_and_returns_false() {
+        // Given: tax-exempt item where the server returns an empty subtotalTax
+        let cart = makeCart(price: "10.00", productID: 42)
+        let order = makeOrder(productID: 42, quantity: 1, subtotal: "10.00", subtotalTax: "")
+
+        // When: this must not crash (NSDecimalNumber overflow was the regression)
+        let result = sut.detectsPriceChange(cart: cart, order: order)
+
+        // Then: prices match, so no change is flagged
+        #expect(result == false)
+    }
 }
 
 // MARK: - Helpers

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -1468,12 +1468,21 @@ struct POSPaymentModelTests {
         // When: merchant explicitly taps "Tap to Pay" — opens the gate
         await sut.startPaymentWithMethod(.tapToPay)
 
-        // Then: subsequent events now drive the card state machine
+        // Then: events propagate through the now-open gate. The mock's
+        // `collectPayment` auto-fires a `paymentSuccess` event — a terminal
+        // state that reaches `paymentState.card` because the TTP path only
+        // suppresses *intermediate* states (`.acceptingCard`, `.preparingReader`,
+        // etc.) so the merchant's UI doesn't flicker behind Apple's modal.
+        // The `.idle → .cardPaymentSuccessful` transition is unreachable
+        // without an open gate, so observing it here proves propagation.
+        #expect(sut.paymentState.card == .cardPaymentSuccessful)
+
+        // And the TTP intermediate-state filter is active: a subsequent
+        // `acceptingCard` event does not roll state backward.
         service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
             inputMethods: [.tap, .swipe, .insert],
             cancelPayment: {}))
-
-        #expect(sut.paymentState.card == .acceptingCard)
+        #expect(sut.paymentState.card == .cardPaymentSuccessful)
     }
 
     @Test("TTP: cancelledOnReader resets card state to idle and re-arms the gate")
@@ -1493,17 +1502,18 @@ struct POSPaymentModelTests {
 
         await sut.startPayment()
 
-        // Open the gate: merchant taps Tap to Pay
+        // Open the gate: merchant taps Tap to Pay. The mock's `collectPayment`
+        // auto-fires a terminal `paymentSuccess` event (intermediate states are
+        // filtered on TTP — see `subscribeToPaymentSessionEvents`).
         await sut.startPaymentWithMethod(.tapToPay)
-        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
-            inputMethods: [.tap, .swipe, .insert],
-            cancelPayment: {}))
-        #expect(sut.paymentState.card == .acceptingCard)
+        #expect(sut.paymentState.card == .cardPaymentSuccessful)
 
         // When: merchant cancels on reader
         service.paymentEvent = .show(eventDetails: .cancelledOnReader)
 
-        // Then: card state resets to idle AND inline message is cleared
+        // Then: card state resets to idle AND inline message is cleared.
+        // The cancelledOnReader sink runs unconditionally on the TTP path
+        // (no gate check), so cancellation resets even a terminal state.
         #expect(sut.paymentState.card == .idle)
         #expect(sut.cardPresentPaymentInlineMessage == nil)
 
@@ -1567,12 +1577,11 @@ struct POSPaymentModelTests {
 
         await sut.startPayment()
 
-        // Round 1: open gate, reach acceptingCard, then cancel on reader
+        // Round 1: open gate, reach a terminal state, then cancel on reader.
+        // (Intermediates like `.acceptingCard` are filtered on TTP; the mock's
+        // auto-fired `paymentSuccess` is the terminal state that lands.)
         await sut.startPaymentWithMethod(.tapToPay)
-        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
-            inputMethods: [.tap, .swipe, .insert],
-            cancelPayment: {}))
-        #expect(sut.paymentState.card == .acceptingCard)
+        #expect(sut.paymentState.card == .cardPaymentSuccessful)
 
         // When: merchant cancels on reader — gate must close and state must reset
         service.paymentEvent = .show(eventDetails: .cancelledOnReader)
@@ -1580,19 +1589,26 @@ struct POSPaymentModelTests {
         // Then: state is idle immediately
         #expect(sut.paymentState.card == .idle)
 
-        // Round 2: a subsequent startPaymentWithMethod must succeed (gate re-opens)
-        await sut.startPaymentWithMethod(.tapToPay)
-        service.paymentEvent = .show(eventDetails: .tapSwipeOrInsertCard(
-            inputMethods: [.tap, .swipe, .insert],
-            cancelPayment: {}))
+        // Re-attach the mock reader for Round 2. `connectTapToPayReader` (kicked off
+        // by Round 1's `startPayment`) disconnected the mock — the mock's
+        // `connectReader` returns a `.connected` result but doesn't update
+        // `connectedReader`, so the publisher stays at `.disconnected`. Without this
+        // reset, `startPaymentFlow`'s `guard case .connected` would short-circuit and
+        // collectPayment wouldn't fire in Round 2, masking the invariant we're testing.
+        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
 
-        // If the gate was stale (remained open after cancel-then-reopen), this would
-        // fail because subscribeToPaymentSessionEvents would guard-return early.
-        // If the subscriber order were reversed, the card state would have been set to
-        // acceptingCard by the card-state sink before the gate closed, so the reset
-        // to idle would be a no-op and the assertion below would still pass — but the
-        // cancelledOnReader-card state would not be idle between the two rounds.
-        #expect(sut.paymentState.card == .acceptingCard)
+        // Round 2: a subsequent startPaymentWithMethod must succeed (gate re-opens
+        // and the mock auto-fires `paymentSuccess` again).
+        await sut.startPaymentWithMethod(.tapToPay)
+
+        // If subscriber ordering were inverted — card-state sink before
+        // cancelledOnReader sink — `cancelledOnReader` would have advanced
+        // `paymentState.card` past `.idle` (terminal states bypass the filter),
+        // and `startPaymentWithMethod`'s `guard paymentState.card == .idle` would
+        // have short-circuited Round 2, leaving us stuck at the prior terminal
+        // state without the second auto-fired `paymentSuccess` ever running.
+        // Reaching `.cardPaymentSuccessful` again proves Round 2 actually proceeded.
+        #expect(sut.paymentState.card == .cardPaymentSuccessful)
     }
 
     @Test("connectCardReader skips a second call while the first is in flight")


### PR DESCRIPTION
> **Stack order** (review bottom-up):
> 1. Existing phone POS stack (#17062 → #17067)
> 2. #17092 — POSLayoutScale
> 3. #17093 — Pre-TTP checkout & modal polish
> 4. #17094 — TTP foundation
> 5. #17095 — TTP checkout row
> 6. #17096 — TTP hero & sheet
> 7. #17097 — TTP wiring & cancel handling
> 8. **This PR** — TTP polish (top of the stack)

## Description
Stacked on top of #17097. Final round of TTP polish before this stack lands. Three commits:

- **Suppress legacy reader-connection alerts on the TTP path** — the silent TTP pre-connect was firing the iPad-era modal alerts: `Connecting to reader`, `Reader connected`, `Scanning for readers`, `Found reader`. None of those make sense when the merchant didn't ask for a connection. Suppressed when `preferredConnectionMethod == .tapToPay`. BT path keeps them.
- **Polish the hero flow** — bundles five small fixes:
  - Track `pointOfSaleCheckoutTapToPayTapped` when the TTP CTA is tapped (the event was registered in #17095 but not fired anywhere).
  - Disconnect the active reader in either direction when the merchant switches methods (`BT → TTP` or `TTP → BT`) so Stripe Terminal isn't asked to hold two readers at once.
  - Gate the hero on the same syncing / reconnecting / zero-total guards as the iPad pay row so an empty cart can't trip a TTP order-validation error.
  - Disable the hero CTA + the bottom-strip Cash / Other payment methods buttons during the brief tap → state-transition window via an `isStartingPayment` flag, auto-cleared on the next card / cash state change.
  - Defensive re-entry guard in `startPaymentWithMethod`: bail out unless card state is `.idle`, so a stray closure / restored subscription / SwiftUI re-render can't kick a second flow off.

## Test Steps
- Pull the branch (Debug = both flags = `.localDeveloper`).
- **iPhone, TTP available**:
  1. Open POS → checkout. No "Connecting / Connected / Scanning / Found reader" alert ever appears even though the TTP reader silently connects in the background.
  2. Tap "Pay with Tap to pay" twice quickly — second tap is a no-op (button briefly disabled).
  3. Empty-cart checkout — hero hides; can't tap "Pay with Tap to pay" with nothing to charge.
  4. Connect a BT reader via Other payment methods → cancel back to checkout → tap "Pay with Tap to pay". The BT reader disconnects before TTP connects.
  5. From a TTP-active state → Other payment methods → Card reader. TTP disconnects before BT scan.
  6. Tracks: `pos_checkout_tap_to_pay_tapped` fires exactly once per hero CTA tap.
- **iPhone, BT path / iPad**: legacy "Connecting to reader" / "Reader connected" alerts still appear (BT scope unchanged).

## Screenshots
N/A — behaviour change verified live.

---
- [x] No release notes — feature flagged off.