### PR TITLE
[AI Support Chat] Hide contact support when AI chat flag is enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -139,21 +139,32 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     }
 
     private func showSupportChat() {
+        var viewModelHolder: SupportChatViewModel?
         let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo in
             self?.navigationController?.popViewController(animated: true)
-            self?.handleContactHumanSupport(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
+            self?.handleContactHumanSupport(chatID: chatID,
+                                            transcript: transcript,
+                                            supportAreaInfo: supportAreaInfo,
+                                            onTicketCreated: { [weak viewModelHolder] in
+                                                viewModelHolder?.markChatTicketCreated()
+                                            })
         }
+        viewModelHolder = chatViewModel
 
         let chatController = SupportChatHostingController(viewModel: chatViewModel)
         chatController.show(from: self)
     }
 
-    private func handleContactHumanSupport(chatID: Int64?, transcript: String, supportAreaInfo: SupportAreaInfo?) {
+    private func handleContactHumanSupport(chatID: Int64?,
+                                           transcript: String,
+                                           supportAreaInfo: SupportAreaInfo?,
+                                           onTicketCreated: @escaping () -> Void) {
         supportEscalationCoordinator = SupportEscalationCoordinator(
             navigationController: navigationController,
             additionalAttachmentsProvider: { [weak self] in
                 self?.buildTroubleshootingAttachment() ?? []
-            }
+            },
+            onTicketCreated: onTicketCreated
         )
         supportEscalationCoordinator?.handleEscalation(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
@@ -42,21 +42,32 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
     }
 
     private func showSupportChat() {
+        var viewModelHolder: SupportChatViewModel?
         let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo in
             self?.navigationController?.popViewController(animated: true)
-            self?.handleContactHumanSupport(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
+            self?.handleContactHumanSupport(chatID: chatID,
+                                            transcript: transcript,
+                                            supportAreaInfo: supportAreaInfo,
+                                            onTicketCreated: { [weak viewModelHolder] in
+                                                viewModelHolder?.markChatTicketCreated()
+                                            })
         }
+        viewModelHolder = chatViewModel
 
         let chatController = SupportChatHostingController(viewModel: chatViewModel)
         chatController.show(from: self)
     }
 
-    private func handleContactHumanSupport(chatID: Int64?, transcript: String, supportAreaInfo: SupportAreaInfo?) {
+    private func handleContactHumanSupport(chatID: Int64?,
+                                           transcript: String,
+                                           supportAreaInfo: SupportAreaInfo?,
+                                           onTicketCreated: @escaping () -> Void) {
         supportEscalationCoordinator = SupportEscalationCoordinator(
             navigationController: navigationController,
             additionalAttachmentsProvider: { [weak self] in
                 self?.buildTroubleshootingAttachment() ?? []
-            }
+            },
+            onTicketCreated: onTicketCreated
         )
         supportEscalationCoordinator?.handleEscalation(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -480,18 +480,29 @@ private extension HelpAndSupportViewController {
         let entryPoint: SupportChatViewModel.EntryPoint = ServiceLocator.stores.isAuthenticated
             ? .helpAndSupport
             : .preLogin
+        var viewModelHolder: SupportChatViewModel?
         let viewModel = SupportChatViewModel(
             entryPoint: entryPoint,
             onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo in
-                self?.handleContactHumanSupport(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
+                self?.handleContactHumanSupport(chatID: chatID,
+                                                transcript: transcript,
+                                                supportAreaInfo: supportAreaInfo,
+                                                onTicketCreated: { [weak viewModelHolder] in
+                                                    viewModelHolder?.markChatTicketCreated()
+                                                })
             }
         )
+        viewModelHolder = viewModel
         let controller = SupportChatHostingController(viewModel: viewModel)
         navigationController?.pushViewController(controller, animated: true)
     }
 
-    private func handleContactHumanSupport(chatID: Int64?, transcript: String, supportAreaInfo: SupportAreaInfo?) {
-        supportEscalationCoordinator = SupportEscalationCoordinator(navigationController: navigationController)
+    private func handleContactHumanSupport(chatID: Int64?,
+                                           transcript: String,
+                                           supportAreaInfo: SupportAreaInfo?,
+                                           onTicketCreated: @escaping () -> Void) {
+        supportEscalationCoordinator = SupportEscalationCoordinator(navigationController: navigationController,
+                                                                    onTicketCreated: onTicketCreated)
         supportEscalationCoordinator?.handleEscalation(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
     }
 
@@ -512,15 +523,22 @@ private extension HelpAndSupportViewController {
     /// Pushes the support chat UI seeded with a prior `chatID` so the conversation
     /// continues on the assistant's side when the merchant sends the next message.
     private func resumeChat(for summary: SupportChatSummary) {
+        var viewModelHolder: SupportChatViewModel?
         let chatViewModel = SupportChatViewModel(
             botSlug: summary.botSlug,
             entryPoint: .chatHistory,
             chatID: summary.chatID,
             hasCreatedTicket: summary.hasCreatedTicket,
             onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo in
-                self?.handleContactHumanSupport(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo)
+                self?.handleContactHumanSupport(chatID: chatID,
+                                                transcript: transcript,
+                                                supportAreaInfo: supportAreaInfo,
+                                                onTicketCreated: { [weak viewModelHolder] in
+                                                    viewModelHolder?.markChatTicketCreated()
+                                                })
             }
         )
+        viewModelHolder = chatViewModel
         let controller = SupportChatHostingController(viewModel: chatViewModel)
         navigationController?.pushViewController(controller, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -32,7 +32,10 @@ struct HelpAndSupportViewModel {
             return [.helpCenter]
         }
 
-        var rows: [HelpAndSupportRow] = [.helpCenter, .contactSupport, .contactEmail, .applicationLog]
+        var rows: [HelpAndSupportRow] = [.helpCenter, .contactEmail, .applicationLog]
+        if !isAIChatEnabled {
+            rows.insert(.contactSupport, at: 1)
+        }
         if isAuthenticated {
             rows.append(.systemStatusReport)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -21,6 +21,7 @@ final class SupportEscalationCoordinator {
     private let zendeskProvider: ZendeskManagerProtocol
     private let analytics: Analytics
     private let stores: StoresManager
+    private let onTicketCreated: (() -> Void)?
 
     /// The chat ID to update when a ticket is created. Set via `handleEscalation`.
     private var chatID: Int64?
@@ -33,16 +34,21 @@ final class SupportEscalationCoordinator {
     ///   - zendeskProvider: Zendesk service provider.
     ///   - analytics: Analytics tracker.
     ///   - stores: Stores manager for site info.
+    ///   - onTicketCreated: Optional callback invoked after a Zendesk ticket is successfully created
+    ///     (either via the form path or the high-confidence direct path), so the chat surface can
+    ///     update its in-session state.
     init(navigationController: UINavigationController?,
          additionalAttachmentsProvider: @escaping () -> [ZendeskAttachment] = { [] },
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analytics: Analytics = ServiceLocator.analytics,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         onTicketCreated: (() -> Void)? = nil) {
         self.navigationController = navigationController
         self.additionalAttachmentsProvider = additionalAttachmentsProvider
         self.zendeskProvider = zendeskProvider
         self.analytics = analytics
         self.stores = stores
+        self.onTicketCreated = onTicketCreated
     }
 
     /// Handles the escalation from AI chat to human support.
@@ -97,6 +103,7 @@ final class SupportEscalationCoordinator {
             prefilledDescription: prefilledDescription,
             onTicketCreated: { [weak self] in
                 self?.persistTicketCreated()
+                self?.onTicketCreated?()
             }
         )
         let viewController = SupportFormHostingController(viewModel: viewModel)
@@ -134,6 +141,7 @@ final class SupportEscalationCoordinator {
                 case .success:
                     self?.analytics.track(.supportNewRequestCreated)
                     self?.persistTicketCreated()
+                    self?.onTicketCreated?()
                     self?.showSuccessAndPop()
                 case .failure:
                     self?.analytics.track(.supportNewRequestFailed)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -11,6 +11,18 @@ struct SupportChatView: View {
             .background(Color(.listBackground))
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if viewModel.canEscalateToHumanSupport {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            viewModel.contactHumanSupport()
+                        } label: {
+                            Image(systemName: "person.fill.questionmark")
+                                .accessibilityLabel(Localization.toolbarContactSupport)
+                        }
+                    }
+                }
+            }
             .alert(
                 Localization.errorTitle,
                 isPresented: .init(
@@ -366,6 +378,11 @@ private extension SupportChatView {
             "supportChatView.contactSupport",
             value: "Contact Support",
             comment: "Button to contact human support from the chat"
+        )
+        static let toolbarContactSupport = NSLocalizedString(
+            "supportChatView.toolbar.contactSupport",
+            value: "Contact Support",
+            comment: "Trailing toolbar button on the AI support chat that lets the merchant escalate to human support"
         )
         static let issuePickerHeader = NSLocalizedString(
             "supportChatView.issuePickerHeader",

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -161,6 +161,12 @@ final class SupportChatViewModel {
     /// When true, the escalation button should be hidden.
     private(set) var hasCreatedTicket: Bool = false
 
+    /// `true` once the merchant has typed and sent at least one message via the input field.
+    /// Distinct from `messages.contains(where: { $0.role == .user })`, which is also flipped
+    /// by issue-picker selections — we want the human-support entry to surface only after the
+    /// merchant has actually described their problem.
+    private(set) var hasSentChatMessage: Bool = false
+
     /// Flips `hasCreatedTicket` so the chat surface (toolbar icon, inline banner) updates in real time
     /// after the escalation coordinator successfully creates a Zendesk ticket. Storage is updated separately
     /// by the coordinator via `SupportChatAction.markTicketCreated`.
@@ -170,12 +176,12 @@ final class SupportChatViewModel {
 
     /// Whether the trailing toolbar entry point to human support should be visible.
     /// Shown once the merchant has reached the free-chat phase (past the issue picker / diagnostics)
-    /// AND has sent at least one message, and only while no ticket has been created yet.
+    /// AND has typed and sent at least one message, and only while no ticket has been created yet.
     var canEscalateToHumanSupport: Bool {
         guard shouldShowInputArea, !hasCreatedTicket else {
             return false
         }
-        return messages.contains(where: { $0.role == .user })
+        return hasSentChatMessage
     }
 
     /// Maps message IDs to their feedback rating (true = upvoted, false = downvoted).
@@ -567,6 +573,7 @@ final class SupportChatViewModel {
 
         let userMessage = ChatMessage(role: .user, text: trimmedText)
         messages.append(userMessage)
+        hasSentChatMessage = true
         inputText = ""
         state = .sending
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -148,6 +148,12 @@ final class SupportChatViewModel {
     /// When true, the escalation button should be hidden.
     private(set) var hasCreatedTicket: Bool = false
 
+    /// Whether the trailing toolbar entry point to human support should be visible.
+    /// Shown after the merchant has sent at least one message and no ticket has been created yet.
+    var canEscalateToHumanSupport: Bool {
+        messages.contains(where: { $0.role == .user }) && !hasCreatedTicket
+    }
+
     var inputText: String = ""
 
     // MARK: - Private Properties

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -149,9 +149,13 @@ final class SupportChatViewModel {
     private(set) var hasCreatedTicket: Bool = false
 
     /// Whether the trailing toolbar entry point to human support should be visible.
-    /// Shown after the merchant has sent at least one message and no ticket has been created yet.
+    /// Shown once the merchant has reached the free-chat phase (past the issue picker / diagnostics)
+    /// AND has sent at least one message, and only while no ticket has been created yet.
     var canEscalateToHumanSupport: Bool {
-        messages.contains(where: { $0.role == .user }) && !hasCreatedTicket
+        guard shouldShowInputArea, !hasCreatedTicket else {
+            return false
+        }
+        return messages.contains(where: { $0.role == .user })
     }
 
     var inputText: String = ""

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -148,6 +148,13 @@ final class SupportChatViewModel {
     /// When true, the escalation button should be hidden.
     private(set) var hasCreatedTicket: Bool = false
 
+    /// Flips `hasCreatedTicket` so the chat surface (toolbar icon, inline banner) updates in real time
+    /// after the escalation coordinator successfully creates a Zendesk ticket. Storage is updated separately
+    /// by the coordinator via `SupportChatAction.markTicketCreated`.
+    func markChatTicketCreated() {
+        hasCreatedTicket = true
+    }
+
     /// Whether the trailing toolbar entry point to human support should be visible.
     /// Shown once the merchant has reached the free-chat phase (past the issue picker / diagnostics)
     /// AND has sent at least one message, and only while no ticket has been created yet.

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -573,7 +573,6 @@ final class SupportChatViewModel {
 
         let userMessage = ChatMessage(role: .user, text: trimmedText)
         messages.append(userMessage)
-        hasSentChatMessage = true
         inputText = ""
         state = .sending
 
@@ -595,6 +594,7 @@ final class SupportChatViewModel {
             sessionID: sessionID,
             context: context
         ) { [weak self] result in
+            self?.hasSentChatMessage = true
             self?.handleSendMessageResult(result,
                                           wasNewChat: wasNewChat,
                                           firstUserMessage: firstUserMessage)
@@ -675,10 +675,12 @@ final class SupportChatViewModel {
                                 firstUserMessage: firstUserMessage)
 
             if let lastBotMessage = response.messages.last(where: { $0.role == .bot }) {
+                /// Retrieves the last detected support area
+                latestSupportArea = lastBotMessage.context?.supportArea
+
                 /// Skips displaying last bot message when human support is required. User is suggested to contact support manually.
                 if let flags = lastBotMessage.context?.flags, flags.forwardToHumanSupport {
                     shouldPromptHumanSupport = true
-                    latestSupportArea = lastBotMessage.context?.supportArea
                 } else {
                     let assistantMessage = ChatMessage(
                         role: .bot,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -125,4 +125,36 @@ final class HelpAndSupportViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(rows.isEmpty)
     }
+
+    func test_given_ai_chat_enabled_when_getting_rows_then_contact_support_is_hidden() {
+        // Given
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true,
+                                                isZendeskEnabled: true,
+                                                isMacCatalyst: false,
+                                                isAIChatEnabled: true)
+
+        // When
+        let rows = viewModel.getRows()
+
+        // Then
+        XCTAssertFalse(rows.contains(.contactSupport))
+        XCTAssertTrue(rows.contains(.aiSupportChat))
+        XCTAssertTrue(rows.contains(.chatHistory))
+    }
+
+    func test_given_ai_chat_disabled_when_getting_rows_then_contact_support_is_shown() {
+        // Given
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true,
+                                                isZendeskEnabled: true,
+                                                isMacCatalyst: false,
+                                                isAIChatEnabled: false)
+
+        // When
+        let rows = viewModel.getRows()
+
+        // Then
+        XCTAssertTrue(rows.contains(.contactSupport))
+        XCTAssertFalse(rows.contains(.aiSupportChat))
+        XCTAssertFalse(rows.contains(.chatHistory))
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -656,6 +656,36 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == true)
     }
 
+    @Test func test_canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_until_proceedToChat() async {
+        // Given — helpAndSupport entry shows issue picker first; input area is hidden
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in
+            // Leave sendMessage pending; we only care about state transitions in the VM.
+        }
+        let sut = makeSUT(entryPoint: .helpAndSupport, stores: stores)
+        sut.showGreeting()
+
+        // When — proceed straight to chat without picking an issue
+        sut.proceedToChat()
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == true)
+    }
+
+    @Test func test_canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_when_input_area_is_hidden() {
+        // Given — helpAndSupport entry shows the issue picker; input area is hidden until proceedToChat
+        let sut = makeSUT(entryPoint: .helpAndSupport)
+
+        // When
+        sut.showGreeting()
+
+        // Then — even if there are messages, the toolbar must stay hidden during the picker phase
+        #expect(sut.shouldShowInputArea == false)
+        #expect(sut.canEscalateToHumanSupport == false)
+    }
+
     @Test func test_canEscalateToHumanSupport_is_false_when_hasCreatedTicket_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -619,7 +619,7 @@ struct SupportChatViewModelTests {
 
     // MARK: - canEscalateToHumanSupport Tests
 
-    @Test func test_canEscalateToHumanSupport_is_false_initially() {
+    @Test func canEscalateToHumanSupport_is_false_initially() {
         // Given
         let sut = makeSUT(entryPoint: .connectivityTool)
 
@@ -627,7 +627,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
-    @Test func test_canEscalateToHumanSupport_is_false_when_only_bot_greeting_exists() {
+    @Test func canEscalateToHumanSupport_is_false_when_only_bot_greeting_exists() {
         // Given
         let sut = makeSUT(entryPoint: .connectivityTool)
 
@@ -639,7 +639,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
-    @Test func test_canEscalateToHumanSupport_becomes_true_after_first_user_message_is_sent() async {
+    @Test func canEscalateToHumanSupport_becomes_true_after_first_user_message_is_sent() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -656,7 +656,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == true)
     }
 
-    @Test func test_canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_until_proceedToChat() async {
+    @Test func canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_until_proceedToChat() async {
         // Given — helpAndSupport entry shows issue picker first; input area is hidden
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in
@@ -674,7 +674,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == true)
     }
 
-    @Test func test_canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_when_input_area_is_hidden() {
+    @Test func canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_when_input_area_is_hidden() {
         // Given — helpAndSupport entry shows the issue picker; input area is hidden until proceedToChat
         let sut = makeSUT(entryPoint: .helpAndSupport)
 
@@ -686,7 +686,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
-    @Test func test_markChatTicketCreated_flips_hasCreatedTicket_and_hides_toolbar() {
+    @Test func markChatTicketCreated_flips_hasCreatedTicket_and_hides_toolbar() {
         // Given — a live chat with at least one user message so the toolbar would otherwise be visible
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in }
@@ -703,7 +703,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
-    @Test func test_canEscalateToHumanSupport_is_false_when_hasCreatedTicket_is_true() {
+    @Test func canEscalateToHumanSupport_is_false_when_hasCreatedTicket_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         let sut = SupportChatViewModel(

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -665,9 +665,43 @@ struct SupportChatViewModelTests {
         let sut = makeSUT(entryPoint: .helpAndSupport, stores: stores)
         sut.showGreeting()
 
-        // When — proceed straight to chat without picking an issue
+        // When — proceed to chat
         sut.proceedToChat()
+
+        // Then — input area is visible, but the merchant has not typed anything yet
+        #expect(sut.shouldShowInputArea == true)
+        #expect(sut.canEscalateToHumanSupport == false)
+
+        // When — merchant actually types and sends a message
         sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == true)
+    }
+
+    @Test func canEscalateToHumanSupport_is_false_after_helpAndSupport_picker_selection_until_user_types() async {
+        // Reviewer scenario (PR #17102 / WOOMOB-3033): tapping an issue picker option appends a
+        // user-role message ("Loading orders" etc.). The toolbar entry must wait until the merchant
+        // actually describes the problem via the input field — picker taps don't count.
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in
+            // Leave sendMessage pending; only state transitions matter here.
+        }
+        let sut = makeSUT(entryPoint: .helpAndSupport, stores: stores)
+        sut.showGreeting()
+
+        // When — pick the no-diagnostics path so we land in chat without manual `proceedToChat`
+        await sut.selectIssue(.other)
+
+        // Then — chat surface is in free-chat phase, picker tap added a user message,
+        // but the merchant has NOT typed via the input field yet
+        #expect(sut.hasProceededToChat == true)
+        #expect(sut.messages.contains(where: { $0.role == .user }))
+        #expect(sut.canEscalateToHumanSupport == false)
+
+        // When — merchant types and sends
+        sut.inputText = "Help, my orders aren't loading"
         sut.sendMessage()
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -686,6 +686,23 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
+    @Test func test_markChatTicketCreated_flips_hasCreatedTicket_and_hides_toolbar() {
+        // Given — a live chat with at least one user message so the toolbar would otherwise be visible
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in }
+        let sut = makeSUT(entryPoint: .preLogin, stores: stores)
+        sut.inputText = "Hello"
+        sut.sendMessage()
+        #expect(sut.canEscalateToHumanSupport == true)
+
+        // When
+        sut.markChatTicketCreated()
+
+        // Then
+        #expect(sut.hasCreatedTicket == true)
+        #expect(sut.canEscalateToHumanSupport == false)
+    }
+
     @Test func test_canEscalateToHumanSupport_is_false_when_hasCreatedTicket_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -617,6 +617,63 @@ struct SupportChatViewModelTests {
         #expect(receivedSupportAreaInfo?.systemStatusReport == prefetchedReport)
     }
 
+    // MARK: - canEscalateToHumanSupport Tests
+
+    @Test func test_canEscalateToHumanSupport_is_false_initially() {
+        // Given
+        let sut = makeSUT(entryPoint: .connectivityTool)
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == false)
+    }
+
+    @Test func test_canEscalateToHumanSupport_is_false_when_only_bot_greeting_exists() {
+        // Given
+        let sut = makeSUT(entryPoint: .connectivityTool)
+
+        // When
+        sut.showGreeting()
+
+        // Then
+        #expect(sut.messages.contains(where: { $0.role == .bot }))
+        #expect(sut.canEscalateToHumanSupport == false)
+    }
+
+    @Test func test_canEscalateToHumanSupport_becomes_true_after_first_user_message_is_sent() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            // Leave sendMessage pending — the user bubble is appended synchronously before the network call completes.
+            _ = action
+        }
+        let sut = makeSUT(entryPoint: .preLogin, stores: stores)
+
+        // When
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == true)
+    }
+
+    @Test func test_canEscalateToHumanSupport_is_false_when_hasCreatedTicket_is_true() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .preLogin,
+            stores: stores,
+            hasCreatedTicket: true,
+            onContactHumanSupport: { _, _, _ in }
+        )
+
+        // When — append a user message so the only failing condition is hasCreatedTicket
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == false)
+    }
+
     // MARK: - Test Helpers
 
     private func makeSUT(

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -643,8 +643,25 @@ struct SupportChatViewModelTests {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
-            // Leave sendMessage pending — the user bubble is appended synchronously before the network call completes.
-            _ = action
+            completeSendMessageSuccessfully(action)
+        }
+        let sut = makeSUT(entryPoint: .preLogin, stores: stores)
+
+        // When
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == true)
+    }
+
+    @Test func canEscalateToHumanSupport_becomes_true_when_sending_message_fails() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            if case let .sendMessage(_, _, _, _, _, completion) = action {
+                completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 500, response: nil)))
+            }
         }
         let sut = makeSUT(entryPoint: .preLogin, stores: stores)
 
@@ -659,8 +676,8 @@ struct SupportChatViewModelTests {
     @Test func canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_until_proceedToChat() async {
         // Given — helpAndSupport entry shows issue picker first; input area is hidden
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in
-            // Leave sendMessage pending; we only care about state transitions in the VM.
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            completeSendMessageSuccessfully(action)
         }
         let sut = makeSUT(entryPoint: .helpAndSupport, stores: stores)
         sut.showGreeting()
@@ -685,8 +702,8 @@ struct SupportChatViewModelTests {
         // user-role message ("Loading orders" etc.). The toolbar entry must wait until the merchant
         // actually describes the problem via the input field — picker taps don't count.
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in
-            // Leave sendMessage pending; only state transitions matter here.
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            completeSendMessageSuccessfully(action)
         }
         let sut = makeSUT(entryPoint: .helpAndSupport, stores: stores)
         sut.showGreeting()
@@ -723,7 +740,9 @@ struct SupportChatViewModelTests {
     @Test func markChatTicketCreated_flips_hasCreatedTicket_and_hides_toolbar() {
         // Given — a live chat with at least one user message so the toolbar would otherwise be visible
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
-        stores.whenReceivingAction(ofType: SupportChatAction.self) { _ in }
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            completeSendMessageSuccessfully(action)
+        }
         let sut = makeSUT(entryPoint: .preLogin, stores: stores)
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -740,6 +759,9 @@ struct SupportChatViewModelTests {
     @Test func canEscalateToHumanSupport_is_false_when_hasCreatedTicket_is_true() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            completeSendMessageSuccessfully(action)
+        }
         let sut = SupportChatViewModel(
             entryPoint: .preLogin,
             stores: stores,
@@ -1111,5 +1133,23 @@ struct SupportChatViewModelTests {
         )
         viewModel.onStartJetpackSetup = onStartJetpackSetup
         return viewModel
+    }
+
+    private func completeSendMessageSuccessfully(_ action: SupportChatAction) {
+        guard case let .sendMessage(botSlug, message, _, _, _, completion) = action else {
+            return
+        }
+
+        let response = SupportChatResponse(
+            chatID: 123,
+            sessionID: "session-1",
+            botSlug: botSlug,
+            botVersion: "1.0",
+            messages: [
+                SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                SupportChatMessage(messageID: 2, role: .bot, content: "How can I help?", context: nil)
+            ]
+        )
+        completion(.success(response))
     }
 }


### PR DESCRIPTION
Closes WOOMOB-3033

## Description
If feature flag for AI chat is enabled:
- Hide the Contact Support entry point from Help screen.
- Add an entry point for human support in the top right of AI chat screen. Show this only after they send at least one message to the bot.

## Test Steps
1. Navigate to Settings > Help
2. Note that `Contact Support` row is not there, in favor of `Chat with Support` at the bottom, and the `Chat history` rows
3. Start a new chat
4. Observe the contact support icon appearing after the first message is sent
5. The icon redirects you to the legacy `Contact Support` view
6. After ticket creation, we hide the support icon again. For easier debugging I just forced this state in `SupportChatView` L:47 via:

```diff
.onChange(of: viewModel.messages.contains(where: { $0.role == .user })) { _, didSend in
  guard didSend, !viewModel.hasCreatedTicket else { return }
    Task { @MainActor in
      try? await Task.sleep(for: .seconds(4))
      viewModel.markChatTicketCreated()
    }
}
```

## Screenshots
| Flag false | Flag true |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-08 at 15 12 24" src="https://github.com/user-attachments/assets/49c1314b-7080-4f9e-a9e3-bd84cc438f2c" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-08 at 14 48 12" src="https://github.com/user-attachments/assets/4b4c9d1d-d585-450b-a857-01bce03b1d0d" /> | 

| No messages | First message | After ticket creation |
|--------|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-08 at 15 18 45" src="https://github.com/user-attachments/assets/2522fcec-8896-4722-8c22-e1d7dba6bccf" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-08 at 15 20 55" src="https://github.com/user-attachments/assets/9441e020-b9af-4fe2-81c2-d81b67741729" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-08 at 15 36 16" src="https://github.com/user-attachments/assets/51299109-7db0-40a3-b784-fba7d831f5bf" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
