### PR TITLE
Keep POS custom amount entry row visible during checkout transition

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -67,7 +67,6 @@ struct ItemListView: View {
         ItemListViewHelper().shouldShowCustomAmountEntryRow(
             itemListType: itemListType,
             isCustomAmountsFeatureEnabled: featureFlags.isFeatureFlagEnabled(.pointOfSaleCustomAmounts),
-            orderStage: posModel.orderStage,
             isSearching: isSearching
         )
     }

--- a/Modules/Sources/PointOfSale/ViewHelpers/ItemListViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/ItemListViewHelper.swift
@@ -4,17 +4,20 @@ struct ItemListViewHelper {
     /// Whether the products list should show the entry row that opens the
     /// custom amount form.
     ///
-    /// Custom amounts only make sense while the merchant is building an order in the
-    /// products tab. The Coupons tab and the search surface reuse the same list view
-    /// for unrelated content, and the row is hidden during checkout to keep the
-    /// finalizing UI focused.
+    /// Custom amounts only make sense in the products tab. The Coupons tab and the
+    /// search surface reuse the same list view for unrelated content, so the row
+    /// is gated to non-searching products.
+    ///
+    /// `orderStage` is intentionally not part of this decision: at `.finalizing`
+    /// the products list slides off-screen via the dashboard offset (or is replaced
+    /// entirely on phone), so hiding the row here was redundant and produced a
+    /// visible flash — the row vanished synchronously while the slide animation
+    /// was still running, leaving an empty slot at the top of the list mid-transition.
     func shouldShowCustomAmountEntryRow(itemListType: ItemListType,
                                         isCustomAmountsFeatureEnabled: Bool,
-                                        orderStage: PointOfSaleOrderStage,
                                         isSearching: Bool) -> Bool {
         guard case .products = itemListType else { return false }
         guard isCustomAmountsFeatureEnabled else { return false }
-        guard orderStage == .building else { return false }
         return !isSearching
     }
 }

--- a/Modules/Tests/PointOfSaleTests/ViewHelpers/ItemListViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/ViewHelpers/ItemListViewHelperTests.swift
@@ -7,13 +7,12 @@ struct ItemListViewHelperTests {
 
     @Test func shouldShowCustomAmountEntryRow_when_all_conditions_met_then_true() {
         // Given
-        // sut configured with the products tab, feature flag on, building stage, and not searching.
+        // sut configured with the products tab, feature flag on, and not searching.
 
         // When
         let result = sut.shouldShowCustomAmountEntryRow(
             itemListType: .products(),
             isCustomAmountsFeatureEnabled: true,
-            orderStage: .building,
             isSearching: false
         )
 
@@ -29,7 +28,6 @@ struct ItemListViewHelperTests {
         let result = sut.shouldShowCustomAmountEntryRow(
             itemListType: .coupons(),
             isCustomAmountsFeatureEnabled: true,
-            orderStage: .building,
             isSearching: false
         )
 
@@ -45,23 +43,6 @@ struct ItemListViewHelperTests {
         let result = sut.shouldShowCustomAmountEntryRow(
             itemListType: .products(),
             isCustomAmountsFeatureEnabled: false,
-            orderStage: .building,
-            isSearching: false
-        )
-
-        // Then
-        #expect(result == false)
-    }
-
-    @Test func shouldShowCustomAmountEntryRow_when_order_finalizing_then_false() {
-        // Given
-        // sut configured with the finalizing stage; all other axes match the success case.
-
-        // When
-        let result = sut.shouldShowCustomAmountEntryRow(
-            itemListType: .products(),
-            isCustomAmountsFeatureEnabled: true,
-            orderStage: .finalizing,
             isSearching: false
         )
 
@@ -77,7 +58,6 @@ struct ItemListViewHelperTests {
         let result = sut.shouldShowCustomAmountEntryRow(
             itemListType: .products(),
             isCustomAmountsFeatureEnabled: true,
-            orderStage: .building,
             isSearching: true
         )
 


### PR DESCRIPTION
## Description
The "Custom amount" entry row at the top of the POS products list was disappearing the moment the merchant tapped Check out, while the dashboard's slide-off animation was still running. That left a visible empty slot at the top of the products list for the duration of the transition.

The hide on `.finalizing` was redundant: at that stage the products list slides off-screen on iPad, and is replaced entirely by the totals view on phone, so the row isn't reachable either way. Drop the `orderStage` argument from `ItemListViewHelper.shouldShowCustomAmountEntryRow` and its call site in `ItemListView`.

The `_when_order_finalizing_then_false` test case is removed (no longer applicable); the other four test cases lose the now-unused `orderStage` argument.

## Test Steps
On a `localDeveloper` or `alpha` build with the POS custom amounts flag on:

1. Open POS → Products tab. Add at least one product to the cart.
2. Tap **Check out**. Watch the products list slide off-screen.
3. **Expected**: the "Custom amount" entry row stays in place at the top of the list throughout the slide animation, like every other row in the list.
4. **Before this change**: the row would vanish synchronously the instant `.finalizing` started, leaving a blank slot above the first product for the ~300 ms slide.

Behaviour at the destination is unchanged — at `.finalizing` the products list is fully off-screen, so the row's continued presence has no user impact there.

## Screenshots
N/A — visual fix only observable in motion.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.