### PR TITLE
Prepare terminal payments before confirmation

### DIFF
--- a/Modules/Sources/Fakes/Hardware.generated.swift
+++ b/Modules/Sources/Fakes/Hardware.generated.swift
@@ -81,7 +81,8 @@ extension Hardware.PaymentIntent {
             amount: .fake(),
             currency: .fake(),
             metadata: .fake(),
-            charges: .fake()
+            charges: .fake(),
+            collectedPaymentMethod: nil
         )
     }
 }

--- a/Modules/Sources/Hardware/CardReader/CardPresentCaptureMethod.swift
+++ b/Modules/Sources/Hardware/CardReader/CardPresentCaptureMethod.swift
@@ -1,0 +1,7 @@
+/// CardPresentCaptureMethod defines supported card-present capture method preferences.
+/// Mirrors supported types from StripeTerminal.CardPresentCaptureMethod https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPCardPresentCaptureMethod.html
+///
+public enum CardPresentCaptureMethod {
+    case manualPreferred
+    case manual
+}

--- a/Modules/Sources/Hardware/CardReader/CardPresentTransactionDetails.swift
+++ b/Modules/Sources/Hardware/CardReader/CardPresentTransactionDetails.swift
@@ -19,6 +19,9 @@ public struct CardPresentTransactionDetails: Codable, Equatable, GeneratedFakeab
     /// The issuing brand of the card.
     public let brand: CardBrand
 
+    /// Card networks available to process the payment, when the reader provides them after collection.
+    public let availableNetworks: [CardBrand]?
+
     /// ID of a card PaymentMethod that may be attached to a Customer for future transactions.
     /// Only present if it was possible to generate a card PaymentMethod.
     public let generatedCard: String?
@@ -42,6 +45,7 @@ public struct CardPresentTransactionDetails: Codable, Equatable, GeneratedFakeab
                 expYear: Int,
                 cardholderName: String?,
                 brand: CardBrand,
+                availableNetworks: [CardBrand]? = nil,
                 generatedCard: String?,
                 receipt: ReceiptDetails?,
                 emvAuthData: String?,
@@ -52,6 +56,7 @@ public struct CardPresentTransactionDetails: Codable, Equatable, GeneratedFakeab
         self.expYear = expYear
         self.cardholderName = cardholderName
         self.brand = brand
+        self.availableNetworks = availableNetworks
         self.generatedCard = generatedCard
         self.receipt = receipt
         self.emvAuthData = emvAuthData
@@ -74,6 +79,7 @@ extension CardPresentTransactionDetails {
         case expYear = "exp_year"
         case cardholderName = "cardholder_name"
         case brand = "brand"
+        case availableNetworks = "available_networks"
         case generatedCard = "generated_card"
         case receipt = "receipt"
         case emvAuthData = "emv_auth_data"

--- a/Modules/Sources/Hardware/CardReader/CardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/CardReaderService.swift
@@ -57,11 +57,20 @@ public protocol CardReaderService {
     /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error>
 
+    /// Captures a payment, running a hook after payment method collection succeeds and before payment confirmation.
+    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
+    func capturePayment(_ parameters: PaymentIntentParameters,
+                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error>
+
     /// Retries the most recent payment intent attempted.
     /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     /// This action continues at the appropriate place in the `capturePayment` flow, but parameters cannot be changed.
     /// If the payment cannot be retried, an appropriate error will immediately return.
     func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error>
+
+    /// Retries the most recent payment intent attempted, running a hook before payment confirmation.
+    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
+    func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error>
 
     /// Cancels a PaymentIntent
     func cancelPaymentIntent() -> Future<Void, Error>
@@ -81,4 +90,15 @@ public protocol CardReaderService {
     /// Use this when the user wants to manually connect a different reader
     /// or cancel the automatic reconnection process.
     func cancelReconnection() -> Future<Void, Error>
+}
+
+public extension CardReaderService {
+    func capturePayment(_ parameters: PaymentIntentParameters,
+                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
+        capturePayment(parameters)
+    }
+
+    func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
+        retryActivePaymentIntent()
+    }
 }

--- a/Modules/Sources/Hardware/CardReader/PaymentIntent.swift
+++ b/Modules/Sources/Hardware/CardReader/PaymentIntent.swift
@@ -27,13 +27,17 @@ public struct PaymentIntent: Identifiable, GeneratedCopiable, GeneratedFakeable 
     // Charges that were created by this PaymentIntent, if any.
     public let charges: [Charge]
 
+    /// Payment method collected for this PaymentIntent before confirmation, if available.
+    public let collectedPaymentMethod: PaymentMethod?
+
     public init(id: String,
                 status: PaymentIntentStatus,
                 created: Date,
                 amount: UInt,
                 currency: String,
                 metadata: [String: String]?,
-                charges: [Charge]) {
+                charges: [Charge],
+                collectedPaymentMethod: PaymentMethod? = nil) {
         self.id = id
         self.status = status
         self.created = created
@@ -41,6 +45,7 @@ public struct PaymentIntent: Identifiable, GeneratedCopiable, GeneratedFakeable 
         self.currency = currency
         self.metadata = metadata
         self.charges = charges
+        self.collectedPaymentMethod = collectedPaymentMethod
     }
 }
 
@@ -133,11 +138,9 @@ public extension PaymentIntent {
 }
 
 public extension PaymentIntent {
-    /// Returns the payment method from a PaymentIntent if available, typically after the payment is processed.
-    /// Before the payment is processed, `nil` is returned.
-    /// - Returns: an optional payment method that is set after the payment is processed.
+    /// Returns the payment method from a PaymentIntent if available, preferring the collected payment method before charges exist.
     func paymentMethod() -> PaymentMethod? {
-        charges.first?.paymentMethod
+        collectedPaymentMethod ?? charges.first?.paymentMethod
     }
 }
 

--- a/Modules/Sources/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Modules/Sources/Hardware/CardReader/PaymentIntentParameters.swift
@@ -49,6 +49,9 @@ public struct PaymentIntentParameters {
     ///
     public let paymentMethodTypes: [PaymentMethodType]
 
+    /// Capture method preference for card-present payments.
+    public let cardPresentCaptureMethod: CardPresentCaptureMethod?
+
     public init(amount: Decimal,
                 currency: String,
                 stripeSmallestCurrencyUnitMultiplier: Decimal,
@@ -57,6 +60,7 @@ public struct PaymentIntentParameters {
                 statementDescription: String? = nil,
                 receiptEmail: String? = nil,
                 paymentMethodTypes: [PaymentMethodType] = [],
+                cardPresentCaptureMethod: CardPresentCaptureMethod? = nil,
                 metadata: [String: String]? = nil) {
         self.amount = amount
         self.currency = currency
@@ -66,6 +70,7 @@ public struct PaymentIntentParameters {
         self.statementDescription = statementDescription
         self.receiptEmail = receiptEmail
         self.paymentMethodTypes = paymentMethodTypes
+        self.cardPresentCaptureMethod = cardPresentCaptureMethod
         self.metadata = metadata
     }
 }
@@ -80,6 +85,7 @@ extension PaymentIntentParameters: Equatable {
         lhs.statementDescription == rhs.statementDescription &&
         lhs.receiptEmail == rhs.receiptEmail &&
         lhs.metadata == rhs.metadata &&
-        lhs.paymentMethodTypes == rhs.paymentMethodTypes
+        lhs.paymentMethodTypes == rhs.paymentMethodTypes &&
+        lhs.cardPresentCaptureMethod == rhs.cardPresentCaptureMethod
     }
 }

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/CardPresentDetails+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/CardPresentDetails+Stripe.swift
@@ -11,6 +11,9 @@ extension CardPresentTransactionDetails {
                   expYear: details.expYear,
                   cardholderName: details.cardholderName,
                   brand: CardBrand(brand: details.brand),
+                  availableNetworks: details.networks?.available?.compactMap {
+                      StripeTerminal.CardBrand(rawValue: $0.intValue).map(CardBrand.init(brand:))
+                  },
                   generatedCard: details.generatedCard,
                   receipt: Hardware.ReceiptDetails(receiptDetails: details.receipt),
                   emvAuthData: details.emvAuthData,
@@ -35,6 +38,7 @@ protocol StripeCardPresentDetails {
     var receipt: StripeTerminal.ReceiptDetails? { get }
     var emvAuthData: String? { get }
     var wallet: StripeTerminal.SCPWallet? { get }
+    var networks: StripeTerminal.SCPNetworks? { get }
     var network: NSNumber? { get }
 }
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
@@ -19,6 +19,7 @@ extension PaymentIntent {
         self.currency = intent.currency
         self.metadata = intent.metadata
         self.charges = intent.charges.map { .init(charge: $0) }
+        self.collectedPaymentMethod = PaymentMethod(method: intent.paymentMethod)
     }
 }
 
@@ -35,6 +36,7 @@ protocol StripePaymentIntent {
     var currency: String { get }
     var metadata: [String: String]? { get }
     var charges: [StripeTerminal.Charge] { get }
+    var paymentMethod: StripeTerminal.PaymentMethod? { get }
 }
 
 /// StripePaymentIntent Conformance

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -53,6 +53,10 @@ private extension Hardware.PaymentIntentParameters {
             builder.setApplicationFeeAmount(applicationFeeForStripe)
         }
 
+        if let cardPresentCaptureMethod {
+            _ = builder.setPaymentMethodOptionsParameters(try createCardPresentPaymentMethodOptions(captureMethod: cardPresentCaptureMethod))
+        }
+
         builder.setReceiptEmail(receiptEmail)
 
         let updatedMetadata = prepareMetadataForStripe(with: cardReaderMetadata)
@@ -60,6 +64,15 @@ private extension Hardware.PaymentIntentParameters {
 
         // Return payment intent built configuration:
         return try builder.build()
+    }
+
+    func createCardPresentPaymentMethodOptions(captureMethod: Hardware.CardPresentCaptureMethod) throws -> PaymentMethodOptionsParameters {
+        let cardPresentParameters = try CardPresentParametersBuilder()
+            .setCaptureMethod(captureMethod.stripeTerminalCardPresentCaptureMethod)
+            .build()
+
+        return try PaymentMethodOptionsParametersBuilder(cardPresentParameters: cardPresentParameters)
+            .build()
     }
 
     /// Updates the existing PaymentIntentParameters metadata with our CardReader metadata, if any.
@@ -88,6 +101,17 @@ private extension PaymentMethodType {
             return .cardPresent
         case .interacPresent:
             return .interacPresent
+        }
+    }
+}
+
+private extension Hardware.CardPresentCaptureMethod {
+    var stripeTerminalCardPresentCaptureMethod: StripeTerminal.CardPresentCaptureMethod {
+        switch self {
+        case .manualPreferred:
+            return .manualPreferred
+        case .manual:
+            return .manual
         }
     }
 }

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
@@ -3,6 +3,35 @@ import StripeTerminal
 
 extension PaymentMethod {
     /// Failable initializer.
+    /// Maps a SCPPaymentMethod to PaymentMethod
+    init?(method: StripeTerminal.PaymentMethod?) {
+        guard let method else {
+            return nil
+        }
+
+        switch method.type {
+        case .card:
+            self = .card
+        case .cardPresent:
+            guard let details = method.cardPresent else {
+                self = .unknown
+                return
+            }
+            self = .cardPresent(details: CardPresentTransactionDetails(details: details))
+        case .interacPresent:
+            guard let details = method.interacPresent else {
+                self = .unknown
+                return
+            }
+            self = .interacPresent(details: CardPresentTransactionDetails(details: details))
+        case .affirm, .wechatPay, .paynow, .paypay, .unknown:
+            self = .unknown
+        @unknown default:
+            self = .unknown
+        }
+    }
+
+    /// Failable initializer.
     /// Maps a SCPPaymentMethodDetails to PaymentMethod
     init?(method: StripeTerminal.PaymentMethodDetails?) {
         guard let method else {

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -343,6 +343,15 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
+        capturePayment(parameters) { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    }
+
+    public func capturePayment(_ parameters: PaymentIntentParameters,
+                               beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
         // The documentation for this protocol method promises that this will produce either
         // a single value or it will fail.
         // This isn't enforced by the type system, but it is guaranteed as long as all the
@@ -355,13 +364,23 @@ extension StripeCardReaderService: CardReaderService {
             }.flatMap { intent in
                 self.collectPaymentMethod(intent: intent)
             }.flatMap { intent in
+                self.prepareForPaymentConfirmation(intent: intent, beforePaymentConfirmation: beforePaymentConfirmation)
+            }.flatMap { intent in
                 self.processPayment(intent: intent)
             }
             .map(PaymentIntent.init(intent:))
-            .eraseToAnyPublisher()
+                .eraseToAnyPublisher()
     }
 
     public func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error> {
+        retryActivePaymentIntent { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    }
+
+    public func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
         guard let activePaymentIntent else {
             return Fail(error: CardReaderServiceError.retryNotPossibleNoActivePayment)
                 .eraseToAnyPublisher()
@@ -369,6 +388,9 @@ extension StripeCardReaderService: CardReaderService {
         switch activePaymentIntent.status {
         case .requiresPaymentMethod:
             return collectPaymentMethod(intent: activePaymentIntent)
+                .flatMap { intent in
+                    self.prepareForPaymentConfirmation(intent: intent, beforePaymentConfirmation: beforePaymentConfirmation)
+                }
                 .flatMap { intent in
                     self.processPayment(intent: intent)
                 }
@@ -386,7 +408,10 @@ extension StripeCardReaderService: CardReaderService {
                 }
                 .eraseToAnyPublisher()
         case .requiresConfirmation:
-            return processPayment(intent: activePaymentIntent)
+            return prepareForPaymentConfirmation(intent: activePaymentIntent, beforePaymentConfirmation: beforePaymentConfirmation)
+                .flatMap { intent in
+                    self.processPayment(intent: intent)
+                }
                 .map(PaymentIntent.init(intent:))
                 .eraseToAnyPublisher()
         case .requiresCapture:
@@ -727,10 +752,14 @@ private extension StripeCardReaderService {
 
     func collectPaymentMethod(intent: StripeTerminal.PaymentIntent) -> AnyPublisher<StripeTerminal.PaymentIntent, Error> {
         let collectPaymentMethodFuture = Future<StripeTerminal.PaymentIntent, Error>() { [weak self] promise in
+            guard let collectConfiguration = self?.collectPaymentIntentConfiguration() else {
+                return promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: .internalServiceError)))
+            }
+
             /// Collect Payment method returns a cancellable
             /// Because we are chaining promises, we need to retain a reference
             /// to this cancellable if we want to cancel
-            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent) { (intent, error) in
+            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent, collectConfig: collectConfiguration) { (intent, error) in
                 if let error {
                     var underlyingError = Self.logAndDecodeError(error)
                     /// the completion block for collectPaymentMethod will be called
@@ -754,6 +783,7 @@ private extension StripeCardReaderService {
 
                 if let intent {
                     self?.paymentCancellable = nil
+                    self?.activePaymentIntent = intent
                     self?.sendReaderEvent(.cardDetailsCollected)
                     promise(.success(intent))
                 }
@@ -773,8 +803,28 @@ private extension StripeCardReaderService {
                     return CardReaderServiceError.paymentMethodCollection(
                         underlyingError: .paymentMethodCollectionTimedOut)
                 })
-                .eraseToAnyPublisher()
+            .eraseToAnyPublisher()
         }
+    }
+
+    func collectPaymentIntentConfiguration() -> StripeTerminal.CollectPaymentIntentConfiguration? {
+        do {
+            let builder = StripeTerminal.CollectPaymentIntentConfigurationBuilder()
+            builder.setUpdatePaymentIntent(true)
+            return try builder.build()
+        } catch {
+            DDLogError("Failed to build CollectPaymentIntentConfiguration. Error:\(error)")
+            return nil
+        }
+    }
+
+    func prepareForPaymentConfirmation(
+        intent: StripeTerminal.PaymentIntent,
+        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
+    ) -> AnyPublisher<StripeTerminal.PaymentIntent, Error> {
+        beforePaymentConfirmation(PaymentIntent(intent: intent))
+            .map { intent }
+            .eraseToAnyPublisher()
     }
 
     func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {

--- a/Modules/Sources/Hardware/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Hardware/Model/Copiable/Models+Copiable.generated.swift
@@ -74,7 +74,8 @@ extension Hardware.PaymentIntent {
         amount: CopiableProp<UInt> = .copy,
         currency: CopiableProp<String> = .copy,
         metadata: NullableCopiableProp<[String: String]> = .copy,
-        charges: CopiableProp<[Charge]> = .copy
+        charges: CopiableProp<[Charge]> = .copy,
+        collectedPaymentMethod: NullableCopiableProp<PaymentMethod> = .copy
     ) -> Hardware.PaymentIntent {
         let id = id ?? self.id
         let status = status ?? self.status
@@ -83,6 +84,7 @@ extension Hardware.PaymentIntent {
         let currency = currency ?? self.currency
         let metadata = metadata ?? self.metadata
         let charges = charges ?? self.charges
+        let collectedPaymentMethod = collectedPaymentMethod ?? self.collectedPaymentMethod
 
         return Hardware.PaymentIntent(
             id: id,
@@ -91,7 +93,8 @@ extension Hardware.PaymentIntent {
             amount: amount,
             currency: currency,
             metadata: metadata,
-            charges: charges
+            charges: charges,
+            collectedPaymentMethod: collectedPaymentMethod
         )
     }
 }

--- a/Modules/Sources/Networking/Model/SiteAPI.swift
+++ b/Modules/Sources/Networking/Model/SiteAPI.swift
@@ -17,6 +17,10 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
     ///
     public let applicationPasswordAvailable: Bool
 
+    /// Available REST API routes.
+    ///
+    public let routes: [String]
+
     /// Highest Woo API version installed on the site
     ///
     public var highestWooVersion: WooAPIVersion {
@@ -59,15 +63,18 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
         let authentication = try? siteAPIContainer.decode(Authentication.self, forKey: .authentication)
         let applicationPasswordAvailable = authentication?.applicationPasswords?.endpoints?.authorization != nil
 
-        self.init(siteID: siteID, namespaces: namespaces, applicationPasswordAvailable: applicationPasswordAvailable)
+        let routes = (try? siteAPIContainer.decodeIfPresent([String: AnyDecodable].self, forKey: .routes))?.keys.sorted() ?? []
+
+        self.init(siteID: siteID, namespaces: namespaces, applicationPasswordAvailable: applicationPasswordAvailable, routes: routes)
     }
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int64, namespaces: [String], applicationPasswordAvailable: Bool) {
+    public init(siteID: Int64, namespaces: [String], applicationPasswordAvailable: Bool, routes: [String] = []) {
         self.siteID = siteID
         self.namespaces = namespaces
         self.applicationPasswordAvailable = applicationPasswordAvailable
+        self.routes = routes
     }
 }
 
@@ -78,6 +85,7 @@ private extension SiteAPI {
 
     enum SiteAPIKeys: String, CodingKey {
         case namespaces
+        case routes
         case authentication
     }
 

--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -35,6 +35,7 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case selfDrivenPushNotificationsM1
     case inPersonPaymentsCountryExpansion
     case inPersonPaymentsCountryExpansionEUExtended
+    case inPersonPaymentsTerminalPaymentPreparation
     case pointOfSaleScanToPay
     case pointOfSaleMarkOrderAsPaid
 
@@ -56,6 +57,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .inPersonPaymentsCountryExpansion
         case "woo_ipp_country_expansion_eu_extended":
             self = .inPersonPaymentsCountryExpansionEUExtended
+        case "woo_ipp_terminal_payment_preparation":
+            self = .inPersonPaymentsTerminalPaymentPreparation
         case "woo_pos_scan_to_pay":
             self = .pointOfSaleScanToPay
         case "woo_pos_mark_order_as_paid":

--- a/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
@@ -37,6 +37,6 @@ private extension SiteAPIRemote {
     }
 
     enum ParameterValues {
-        static let fieldValues: String = "authentication,namespaces"
+        static let fieldValues: String = "authentication,namespaces,routes"
     }
 }

--- a/Modules/Sources/Networking/Remote/WCPayRemote.swift
+++ b/Modules/Sources/Networking/Remote/WCPayRemote.swift
@@ -51,6 +51,33 @@ public class WCPayRemote: Remote {
         return enqueue(request, mapper: mapper)
     }
 
+    /// Prepares a terminal payment before the payment intent is confirmed.
+    /// - Parameters:
+    ///   - siteID: Site for which we'll prepare the payment intent.
+    ///   - orderID: Order for which we are preparing the payment.
+    ///   - paymentIntentID: Stripe Payment Intent ID created using the Terminal SDK.
+    public func prepareTerminalPayment(for siteID: Int64,
+                                       orderID: Int64,
+                                       paymentIntentID: String) -> AnyPublisher<Result<RemotePaymentIntent, Error>, Never> {
+        let path = "\(Path.orders)/\(orderID)/\(Path.prepareTerminalPayment)"
+
+        let parameters = [
+            CaptureOrderPaymentKeys.fields: CaptureOrderPaymentValues.fieldValues,
+            CaptureOrderPaymentKeys.paymentIntentID: paymentIntentID
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+
+        let mapper = RemotePaymentIntentMapper()
+
+        return enqueue(request, mapper: mapper)
+    }
+
     /// Fetches the details of a charge, if available. See https://stripe.com/docs/api/charges/object
     /// Also note that the JSON returned by the WCPay endpoint is an abridged copy of Stripe's response.
     /// - Parameters:
@@ -140,6 +167,7 @@ private extension WCPayRemote {
         static let accounts = "payments/accounts"
         static let orders = "payments/orders"
         static let captureTerminalPayment = "capture_terminal_payment"
+        static let prepareTerminalPayment = "prepare_terminal_payment"
         static let createCustomer = "create_customer"
         static let locations = "payments/terminal/locations/store"
         static let charges = "payments/charges"

--- a/Modules/Sources/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Modules/Sources/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -60,6 +60,8 @@ public enum CardPresentPaymentAction: Action {
     case collectPayment(siteID: Int64,
                         orderID: Int64,
                         parameters: PaymentParameters,
+                        countryCode: String,
+                        terminalPaymentPreparationEnabled: Bool,
                         onCardReaderMessage: (CardReaderEvent) -> Void,
                         onProcessingCompletion: (PaymentIntent) -> Void,
                         onCompletion: (Result<PaymentIntent, Error>) -> Void)
@@ -69,6 +71,8 @@ public enum CardPresentPaymentAction: Action {
 
     case retryPayment(siteID: Int64,
                       orderID: Int64,
+                      countryCode: String,
+                      terminalPaymentPreparationEnabled: Bool,
                       onCardReaderMessage: (CardReaderEvent) -> Void,
                       onProcessingCompletion: (PaymentIntent) -> Void,
                       onCompletion: (Result<PaymentIntent, Error>) -> Void)

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
@@ -23,7 +23,7 @@ struct MockCardPresentPaymentActionHandler: MockActionHandler {
             observeConnectedReaders(onCompletion: onCompletion)
         case .observeCardReaderUpdateState(let onCompletion):
             observeCardReaderUpdateState(onCompletion: onCompletion)
-        case .collectPayment(_, _, _, let onCardReaderMessage, _, _):
+        case .collectPayment(_, _, _, _, _, let onCardReaderMessage, _, _):
             // This immediately brings up the `CardPresentModalTapCard` screen, which is used by
             // `WooCommerceScreenshots` to display it for screenshotting purpose.
             onCardReaderMessage(.waitingForInput([.tap, .swipe, .insert]))

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -247,6 +247,7 @@ public typealias PaymentChannel = Hardware.PaymentChannel
 public typealias PaymentMethod = Hardware.PaymentMethod
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
 public typealias PaymentMethodType = Hardware.PaymentMethodType
+public typealias CardPresentCaptureMethod = Hardware.CardPresentCaptureMethod
 public typealias RefundParameters = Hardware.RefundParameters
 public typealias PaymentIntent = Hardware.PaymentIntent
 public typealias PrintingResult = Hardware.PrintingResult

--- a/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -216,7 +216,7 @@ private enum Constants {
     static let fallbackInPersonPaymentsUrl = URL(string: "https://woocommerce.com/in-person-payments/")!
     static let purchaseReaderForCountryUrlBase = "https://woocommerce.com/products/hardware/"
     static let sharedMinimumIosVersion = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 1)
-    static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0"
+    static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0-test-1"
 }
 
 /// The `@retroactive` attribute is used to apply `Equatable` conformance to `OperatingSystemVersion` from the Foundation module.

--- a/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -13,6 +13,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
 
     /// `contactlessLimitAmount` is the upper limit for card transactions, expressed in the smallest currency unit.
     /// This limit may have different implications depending on the store's territory.
+    /// (see https://support.stripe.com/questions/what-are-the-regional-contactless-limits-for-stripe-terminal-transactions).
     public let contactlessLimitAmount: Int?
 
     /// `minimumOperatingSystemVersionOverride` allows us to override Stripe's `supportsReaders` check
@@ -126,7 +127,6 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 // €50 — Stripe Terminal contactless CVM limit, shared by all
-                // EEA-Euro countries we support (see https://docs.stripe.com/terminal/features/contactless).
                 contactlessLimitAmount: 5000,
                 minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
             )
@@ -143,8 +143,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 ],
                 minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
                 stripeSmallestCurrencyUnitMultiplier: 100,
-                // Stripe Terminal's published contactless limits don't include SG
-                // (see https://docs.stripe.com/terminal/features/contactless), so
+                // Stripe Terminal's published contactless limits don't include SG so
                 // we leave this `nil` to match the US/PR shape and let the reader
                 // apply its own scheme limits.
                 contactlessLimitAmount: nil,
@@ -165,6 +164,23 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 stripeSmallestCurrencyUnitMultiplier: 100,
                 // NZD 200 — Stripe Terminal contactless CVM limit
                 // (see https://docs.stripe.com/terminal/features/contactless).
+                contactlessLimitAmount: 20000,
+                minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
+            )
+        case .AU:
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.AUD],
+                paymentGateways: [WCPayAccount.gatewayID, StripeAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [
+                    .init(plugin: .wcPay, minimumVersion: Constants.minimumWCPayVersionForTerminalPaymentPreparation),
+                    .init(plugin: .stripe, minimumVersion: "6.2.0")
+                ],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                // AUD 200 — Stripe Terminal contactless CVM limit
                 contactlessLimitAmount: 20000,
                 minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
             )
@@ -200,6 +216,7 @@ private enum Constants {
     static let fallbackInPersonPaymentsUrl = URL(string: "https://woocommerce.com/in-person-payments/")!
     static let purchaseReaderForCountryUrlBase = "https://woocommerce.com/products/hardware/"
     static let sharedMinimumIosVersion = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 1)
+    static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0"
 }
 
 /// The `@retroactive` attribute is used to apply `Equatable` conformance to `OperatingSystemVersion` from the Foundation module.

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -108,16 +108,33 @@ public final class CardPresentPaymentStore: Store {
             disconnect(onCompletion: completion)
         case .observeConnectedReaders(let completion):
             observeConnectedReaders(onCompletion: completion)
-        case .collectPayment(let siteID, let orderID, let parameters, let event, let processPaymentCompletion, let completion):
+        case .collectPayment(let siteID,
+                             let orderID,
+                             let parameters,
+                             let countryCode,
+                             let terminalPaymentPreparationEnabled,
+                             let event,
+                             let processPaymentCompletion,
+                             let completion):
             collectPayment(siteID: siteID,
                            orderID: orderID,
                            parameters: parameters,
+                           countryCode: countryCode,
+                           terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
                            onCardReaderMessage: event,
                            onProcessingCompletion: processPaymentCompletion,
                            onCompletion: completion)
-        case .retryPayment(let siteID, let orderID, let event, let processPaymentCompletion, let completion):
+        case .retryPayment(let siteID,
+                           let orderID,
+                           let countryCode,
+                           let terminalPaymentPreparationEnabled,
+                           let event,
+                           let processPaymentCompletion,
+                           let completion):
             retryActivePayment(siteID: siteID,
                                orderID: orderID,
+                               countryCode: countryCode,
+                               terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
                                onCardReaderMessage: event,
                                onProcessingCompletion: processPaymentCompletion,
                                onCompletion: completion)
@@ -270,6 +287,8 @@ private extension CardPresentPaymentStore {
     func collectPayment(siteID: Int64,
                         orderID: Int64,
                         parameters: PaymentParameters,
+                        countryCode: String,
+                        terminalPaymentPreparationEnabled: Bool,
                         onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
@@ -278,7 +297,13 @@ private extension CardPresentPaymentStore {
             onCardReaderMessage(event)
         }
 
-        paymentCancellable = handlePaymentEvents(from: cardReaderService.capturePayment(parameters),
+        paymentCancellable = handlePaymentEvents(from: cardReaderService.capturePayment(parameters) { intent in
+            self.prepareTerminalPayment(siteID: siteID,
+                                        orderID: orderID,
+                                        paymentIntent: intent,
+                                        countryCode: countryCode,
+                                        terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
+        },
                                                  readerEventsSubscription: readerEventsSubscription,
                                                  siteID: siteID,
                                                  orderID: orderID,
@@ -327,6 +352,8 @@ private extension CardPresentPaymentStore {
 
     func retryActivePayment(siteID: Int64,
                             orderID: Int64,
+                            countryCode: String,
+                            terminalPaymentPreparationEnabled: Bool,
                             onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
                             onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                             onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
@@ -334,7 +361,13 @@ private extension CardPresentPaymentStore {
             onCardReaderMessage(event)
         }
 
-        paymentCancellable = handlePaymentEvents(from: cardReaderService.retryActivePaymentIntent(),
+        paymentCancellable = handlePaymentEvents(from: cardReaderService.retryActivePaymentIntent { intent in
+            self.prepareTerminalPayment(siteID: siteID,
+                                        orderID: orderID,
+                                        paymentIntent: intent,
+                                        countryCode: countryCode,
+                                        terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
+        },
                                                  readerEventsSubscription: readerEventsSubscription,
                                                  siteID: siteID,
                                                  orderID: orderID,
@@ -586,6 +619,37 @@ private extension CardPresentPaymentStore {
             .eraseToAnyPublisher()
     }
 
+    /// Prepares a WCPay terminal payment before the Terminal SDK confirms a collected payment intent.
+    func prepareTerminalPayment(siteID: Int64,
+                                orderID: Int64,
+                                paymentIntent: PaymentIntent,
+                                countryCode: String,
+                                terminalPaymentPreparationEnabled: Bool) -> AnyPublisher<Void, Error> {
+        guard usingBackend == .wcPay,
+              terminalPaymentPreparationEnabled,
+              paymentIntent.requiresTerminalPaymentPreparation(countryCode: countryCode) else {
+            return Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+
+        return remote.prepareTerminalPayment(for: siteID, orderID: orderID, paymentIntentID: paymentIntent.id)
+            .tryMap { result in
+                switch result {
+                case .success:
+                    return ()
+                case .failure(let error):
+                    if paymentIntent.canContinueAfterMissingTerminalPaymentPreparationEndpoint(error) {
+                        DDLogInfo("💳 Skipping terminal payment preparation because the WCPay endpoint is unavailable for Interac.")
+                        return ()
+                    }
+                    let error = PaymentsError(underlyingError: error)
+                    throw ServerSidePaymentCaptureError.terminalPaymentPreparation(error: error)
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+
     func fetchCharge(siteID: Int64, chargeID: String, completion: @escaping (Result<WCPayCharge, Error>) -> Void) {
         switch usingBackend {
         case .wcPay:
@@ -608,6 +672,82 @@ private extension CardPresentPaymentStore {
         case .stripe:
             break /// not implemented
         }
+    }
+}
+
+private extension PaymentIntent {
+    func requiresTerminalPaymentPreparation(countryCode: String) -> Bool {
+        switch paymentMethod() {
+        case .interacPresent:
+            return true
+        case .cardPresent(let details):
+            return countryCode.uppercased() == Constants.australiaCountryCode && details.canProcessAsEftposAu
+        default:
+            return false
+        }
+    }
+
+    func canContinueAfterMissingTerminalPaymentPreparationEndpoint(_ error: Error) -> Bool {
+        guard paymentMethod()?.isInteracPresent == true else {
+            return false
+        }
+        return error.isMissingTerminalPaymentPreparationEndpoint
+    }
+
+    enum Constants {
+        static let australiaCountryCode = "AU"
+    }
+}
+
+private extension PaymentMethod {
+    var isInteracPresent: Bool {
+        if case .interacPresent = self {
+            return true
+        }
+        return false
+    }
+}
+
+private extension Error {
+    var isMissingTerminalPaymentPreparationEndpoint: Bool {
+        if let dotcomError = self as? DotcomError {
+            switch dotcomError {
+            case .noRestRoute:
+                return true
+            default:
+                break
+            }
+        }
+
+        if let networkError = self as? NetworkError {
+            switch networkError {
+            case let .notFound(response):
+                return response?.restErrorCode == "rest_no_route"
+            default:
+                break
+            }
+        }
+
+        return false
+    }
+}
+
+private extension Data {
+    var restErrorCode: String? {
+        guard let response = try? JSONDecoder().decode(RESTErrorResponse.self, from: self) else {
+            return nil
+        }
+        return response.code
+    }
+}
+
+private struct RESTErrorResponse: Decodable {
+    let code: String
+}
+
+private extension CardPresentTransactionDetails {
+    var canProcessAsEftposAu: Bool {
+        brand == .eftposAu || availableNetworks?.contains(.eftposAu) == true
     }
 }
 
@@ -702,12 +842,15 @@ private extension CardPresentPaymentStore {
 public enum ServerSidePaymentCaptureError: Error, LocalizedError {
     case paymentIntentNotSuccessful
     case paymentGateway(error: PaymentsError)
+    case terminalPaymentPreparation(error: PaymentsError)
 
     public var errorDescription: String? {
         switch self {
         case .paymentIntentNotSuccessful:
             return "Payment intent not successful"
         case .paymentGateway(error: let error):
+            return error.localizedDescription
+        case .terminalPaymentPreparation(error: let error):
             return error.localizedDescription
         }
     }

--- a/Modules/Tests/HardwareTests/CardBrandTests.swift
+++ b/Modules/Tests/HardwareTests/CardBrandTests.swift
@@ -67,6 +67,13 @@ final class CardBrandTests: XCTestCase {
         XCTAssertEqual(cardBrand, .cartesBancaires)
     }
 
+    func test_card_brand_maps_to_eftpos_au() {
+        let terminalCardBrand = StripeTerminal.CardBrand.eftposAu
+        let cardBrand = CardBrand(brand: terminalCardBrand)
+
+        XCTAssertEqual(cardBrand, .eftposAu)
+    }
+
     func test_card_brand_maps_to_girocard() {
         let terminalCardBrand = StripeTerminal.CardBrand.girocard
         let cardBrand = CardBrand(brand: terminalCardBrand)

--- a/Modules/Tests/HardwareTests/Mocks/MockStripeCardPresentDetails.swift
+++ b/Modules/Tests/HardwareTests/Mocks/MockStripeCardPresentDetails.swift
@@ -13,6 +13,7 @@ struct MockStripeCardPresentDetails {
     public let receipt: StripeTerminal.ReceiptDetails?
     public let emvAuthData: String?
     public let wallet: StripeTerminal.SCPWallet?
+    public let networks: StripeTerminal.SCPNetworks?
     public let network: NSNumber?
 }
 
@@ -27,6 +28,7 @@ extension MockStripeCardPresentDetails {
                                      receipt: nil,
                                      emvAuthData: "authdata",
                                      wallet: nil,
+                                     networks: nil,
                                      network: NSNumber(integerLiteral: 1))
     }
 }

--- a/Modules/Tests/HardwareTests/Mocks/MockStripePaymentIntent.swift
+++ b/Modules/Tests/HardwareTests/Mocks/MockStripePaymentIntent.swift
@@ -11,6 +11,7 @@ struct MockStripePaymentIntent {
     let currency: String
     let metadata: [String: String]?
     let charges: [StripeTerminal.Charge]
+    let paymentMethod: StripeTerminal.PaymentMethod?
 }
 
 extension MockStripePaymentIntent: StripePaymentIntent {
@@ -29,6 +30,7 @@ extension MockStripePaymentIntent {
                                 amount: 100,
                                 currency: "USD",
                                 metadata: nil,
-                                charges: [])
+                                charges: [],
+                                paymentMethod: nil)
     }
 }

--- a/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
@@ -1,5 +1,8 @@
 import XCTest
+import StripeTerminal
 @testable import Hardware
+
+private typealias PaymentIntentParameters = Hardware.PaymentIntentParameters
 
 final class PaymentIntentParametersTests: XCTestCase {
     func test_validEmail_is_saved() {
@@ -136,6 +139,19 @@ final class PaymentIntentParametersTests: XCTestCase {
         let stripeParameters = params.toStripe()
 
         XCTAssertNil(stripeParameters?.statementDescriptor)
+    }
+
+    func test_cardPresentCaptureMethod_sets_cardPresent_capture_method_option() throws {
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "aud",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             paymentMethodTypes: [.cardPresent],
+                                             cardPresentCaptureMethod: .manualPreferred)
+
+        let stripeParameters = try XCTUnwrap(params.toStripe())
+
+        XCTAssertEqual(stripeParameters.paymentMethodOptionsParameters.cardPresentParameters.captureMethod,
+                       NSNumber(value: StripeTerminal.CardPresentCaptureMethod.manualPreferred.rawValue))
     }
 
     func test_cardReaderMetadata_is_passed_to_paymentIntent_when_sent_toStripe_then_stripeParameters_contains_cardReaderMetadata() {

--- a/Modules/Tests/HardwareTests/PaymentIntentTests.swift
+++ b/Modules/Tests/HardwareTests/PaymentIntentTests.swift
@@ -87,4 +87,42 @@ final class PaymentIntentTests: XCTestCase {
         // Then
         XCTAssertEqual(intent.paymentMethod(), .card)
     }
+
+    func test_paymentMethod_prefers_collected_payment_method_before_charges() {
+        let collectedPaymentMethod = PaymentMethod.interacPresent(details: cardPresentDetails(brand: .interac))
+
+        // When
+        let intent = PaymentIntent(id: "",
+                                   status: .processing,
+                                   created: .init(),
+                                   amount: 1201,
+                                   currency: "cad",
+                                   metadata: nil,
+                                   charges: [.init(id: "",
+                                                   amount: 201,
+                                                   currency: "cad",
+                                                   status: .failed,
+                                                   description: nil,
+                                                   metadata: nil,
+                                                   paymentMethod: .card)],
+                                   collectedPaymentMethod: collectedPaymentMethod)
+
+        // Then
+        XCTAssertEqual(intent.paymentMethod(), collectedPaymentMethod)
+    }
+}
+
+private extension PaymentIntentTests {
+    func cardPresentDetails(brand: CardBrand) -> CardPresentTransactionDetails {
+        CardPresentTransactionDetails(last4: "1234",
+                                      expMonth: 12,
+                                      expYear: 2030,
+                                      cardholderName: nil,
+                                      brand: brand,
+                                      generatedCard: nil,
+                                      receipt: nil,
+                                      emvAuthData: nil,
+                                      wallet: nil,
+                                      network: nil)
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/SiteAPIRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SiteAPIRemoteTests.swift
@@ -40,6 +40,10 @@ class SiteAPIRemoteTests: XCTestCase {
         let siteAPI = try result.get()
         XCTAssertEqual(siteAPI.siteID, sampleSiteID)
         XCTAssertEqual(siteAPI.highestWooVersion, WooAPIVersion.mark3)
+        XCTAssertEqual(siteAPI.routes, ["/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"])
+
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
+        XCTAssertEqual(request.parameters["_fields"] as? String, "authentication,namespaces,routes")
     }
 
     /// Verifies that loadAPIInformation properly relays Networking Layer errors.

--- a/Modules/Tests/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -615,6 +615,32 @@ final class WCPayRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    func test_prepareTerminalPayment_sends_request_and_parses_response() throws {
+        let remote = WCPayRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "wcpay-payment-intent-requires-confirmation")
+
+        let result: Result<RemotePaymentIntent, Error> = waitFor { promise in
+            remote.prepareTerminalPayment(for: self.sampleSiteID,
+                                          orderID: self.sampleOrderID,
+                                          paymentIntentID: self.samplePaymentIntentID).sink { result in
+                promise(result)
+            }.store(in: &self.subscriptions)
+        }
+
+        XCTAssertTrue(result.isSuccess)
+        let paymentIntent = try result.get()
+        XCTAssertEqual(paymentIntent.status, .requiresConfirmation)
+        XCTAssertEqual(paymentIntent.id, self.samplePaymentIntentID)
+
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.path, "payments/orders/\(sampleOrderID)/prepare_terminal_payment")
+        XCTAssertEqual(request.parameters["_fields"] as? String, "id,status")
+        XCTAssertEqual(request.parameters["payment_intent_id"] as? String, samplePaymentIntentID)
+    }
+
     func test_loadDefaultReaderLocation_properly_returns_location() throws {
         let remote = WCPayRemote(network: network)
         let expectedLocationID = "tml_0123456789abcd"

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/site-api.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/site-api.json
@@ -12,6 +12,14 @@
             "wp\/v2"
         ],
         "authentication": [],
+        "routes": {
+            "\/wc\/v3\/payments\/orders\/(?P<order_id>\\w+)\/prepare_terminal_payment": {
+                "namespace": "wc\/v3",
+                "methods": [
+                    "POST"
+                ]
+            }
+        },
         "_links": {
             "help": [
                 {

--- a/Modules/Tests/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -155,9 +155,32 @@ final class MockCardReaderService: CardReaderService {
             .eraseToAnyPublisher()
     }
 
+    func capturePayment(_ parameters: PaymentIntentParameters,
+                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
+        capturePayment(parameters)
+            .flatMap { intent in
+                beforePaymentConfirmation(intent)
+                    .map { intent }
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+
     func retryActivePaymentIntent() -> AnyPublisher<Hardware.PaymentIntent, Error> {
         Just(.fake())
             .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    func retryActivePaymentIntent(
+        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
+    ) -> AnyPublisher<Hardware.PaymentIntent, Error> {
+        retryActivePaymentIntent()
+            .flatMap { intent in
+                beforePaymentConfirmation(intent)
+                    .map { intent }
+                    .eraseToAnyPublisher()
+            }
             .eraseToAnyPublisher()
     }
 

--- a/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -130,6 +130,6 @@ class CardPresentConfigurationTests: XCTestCase {
             static let gb = "https://woocommerce.com/products/hardware/GB?utm_medium=woo_ios"
         }
 
-        static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0"
+        static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0-test-1"
     }
 }

--- a/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -100,12 +100,19 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.contactlessLimitAmount, 20000)
     }
 
-    // Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643).
-    func test_configuration_for_Australia_is_unsupported() {
+    func test_configuration_for_Australia() {
         let configuration = CardPresentPaymentsConfiguration(country: .AU)
-        XCTAssertFalse(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.paymentMethods, [])
-        XCTAssertEqual(configuration.currencies, [])
+        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertEqual(configuration.currencies, [.AUD])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay, Constants.PaymentGateway.stripe])
+        XCTAssertEqual(configuration.supportedReaders, [.wisepad3])
+        XCTAssertEqual(configuration.supportedPluginVersions, [
+            .init(plugin: .wcPay, minimumVersion: Constants.minimumWCPayVersionForTerminalPaymentPreparation),
+            .init(plugin: .stripe, minimumVersion: "6.2.0")
+        ])
+        XCTAssertEqual(configuration.minimumAllowedChargeAmount, NSDecimalNumber(string: "0.5"))
+        XCTAssertEqual(configuration.contactlessLimitAmount, 20000)
     }
 
     private enum Constants {
@@ -122,5 +129,7 @@ class CardPresentConfigurationTests: XCTestCase {
             static let ca = "https://woocommerce.com/products/hardware/CA?utm_medium=woo_ios"
             static let gb = "https://woocommerce.com/products/hardware/GB?utm_medium=woo_ios"
         }
+
+        static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0"
     }
 }

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -4,6 +4,7 @@ import Fakes
 import YosemiteTestHelpers
 @testable import Yosemite
 @testable import Networking
+@testable import NetworkingCore
 @testable import Storage
 @testable import Hardware
 
@@ -601,7 +602,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     func test_collectPayment_calls_onProcessingCompletion_but_not_onCompletion_after_card_reader_capturePayment_success() {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher())
@@ -614,7 +615,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "US",
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
 
                 } onProcessingCompletion: { intent in
                     promise(intent)
@@ -634,7 +637,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     func test_collectPayment_calls_onCompletion_after_card_reader_capturePayment_success_and_card_removal_and_site_capturePayment() throws {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher())
@@ -649,7 +652,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "US",
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                 } onCompletion: { result in
                     promise(result)
@@ -661,6 +666,207 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         let finalIntent = try XCTUnwrap(result.get())
         XCTAssertEqual(finalIntent.id, intent.id)
         XCTAssertEqual(finalIntent.status, intent.status)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_prepares_au_eftpos_payment_before_site_capturePayment() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .eftposAu)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "wcpay-payment-intent-requires-confirmation")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "AU",
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_prepares_au_card_payment_with_eftpos_available_before_site_capturePayment() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa,
+                                                                                                    availableNetworks: [.visa, .eftposAu])))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "wcpay-payment-intent-requires-confirmation")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "AU",
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_skips_preparing_au_card_payment_when_eftpos_is_not_available() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa,
+                                                                                                    availableNetworks: [.visa])))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "AU",
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_skips_preparing_interac_payment_when_terminal_payment_preparation_is_disabled() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .interacPresent(details: cardPresentDetails(brand: .interac)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "CAD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "CA",
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_continues_interac_payment_when_prepare_terminal_payment_endpoint_is_missing() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .interacPresent(details: cardPresentDetails(brand: .interac)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateError(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                              error: DotcomError.noRestRoute())
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "CAD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "CA",
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
     }
 
     /// Verifies that `onCompletion` is called with an error after card reader finishes capturing payment, the card is removed successfully
@@ -668,7 +874,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     func test_collectPayment_calls_onCompletion_with_failure_after_card_reader_capturePayment_success_but_site_capturePayment_failure() throws {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         // Success on client-side processing.
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
@@ -685,7 +891,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "US",
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                 } onCompletion: { result in
                     promise(result)
@@ -700,12 +908,48 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         }
     }
 
+    func test_collectPayment_calls_onCompletion_with_failure_when_prepare_terminal_payment_fails_before_processing_completion() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .interacPresent(details: cardPresentDetails(brand: .interac)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "generic_error")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "CA",
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                    XCTFail("`onProcessingCompletion` should only be called after the payment intent is prepared and confirmed.")
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure as? ServerSidePaymentCaptureError)
+        guard case .terminalPaymentPreparation = error else {
+            return XCTFail("Unexpected terminal payment preparation error: \(error)")
+        }
+        XCTAssertFalse(mockCardReaderService.didHitWaitForInsertedCardToBeRemoved)
+    }
+
     /// Verifies that `CardReaderEvent.cardRemovedAfterPaymentCapture` is sent after card reader finishes capturing payment, the card is removed successfully
     /// and before the site captures payment.
     ///
     func test_collectPayment_sends_cardRemovedAfterPaymentCapture_event_after_card_removal_and_before_site_capturePayment_completion() {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         // Success on client-side processing.
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
@@ -722,7 +966,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: self.sampleSiteID,
                                 orderID: self.sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "US",
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                     cardReaderEvents.append(cardReaderEvent)
                     if cardReaderEvent == .cardRemovedAfterClientSidePaymentCapture {
                         promise(())
@@ -756,7 +1002,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: "US",
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                     XCTFail("`onProcessingCompletion` should only be called when payment capture succeeds.")
                 } onCompletion: { result in
@@ -965,5 +1213,26 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         // Then
         XCTAssertNil(mockCardReaderConfigProvider.currentSiteID)
+    }
+
+}
+
+private extension CardPresentPaymentStoreTests {
+    func paymentIntent(collectedPaymentMethod: PaymentMethod?) -> PaymentIntent {
+        PaymentIntent.fake().copy(collectedPaymentMethod: collectedPaymentMethod)
+    }
+
+    func cardPresentDetails(brand: CardBrand, availableNetworks: [CardBrand]? = nil) -> CardPresentTransactionDetails {
+        CardPresentTransactionDetails(last4: "1234",
+                                      expMonth: 12,
+                                      expYear: 2030,
+                                      cardholderName: nil,
+                                      brand: brand,
+                                      availableNetworks: availableNetworks,
+                                      generatedCard: nil,
+                                      receipt: nil,
+                                      emvAuthData: nil,
+                                      wallet: nil,
+                                      network: nil)
     }
 }

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -1170,7 +1170,8 @@ private extension SettingStoreTests {
     func sampleSiteAPIWithWoo() -> Networking.SiteAPI {
         return SiteAPI(siteID: sampleSiteID,
                        namespaces: ["oembed/1.0", "akismet/v1", "jetpack/v4", "wpcom/v2", "wc/v1", "wc/v2", "wc/v3", "wc-pb/v3", "wp/v2"],
-                       applicationPasswordAvailable: false)
+                       applicationPasswordAvailable: false,
+                       routes: ["/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"])
     }
 
     func sampleSiteAPINoWoo() -> Networking.SiteAPI {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOrchestrating {
     private var invalidated: Bool = false
@@ -14,6 +15,8 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: @escaping () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -30,6 +33,8 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
                                            paymentGatewayAccount: paymentGatewayAccount,
                                            paymentMethodTypes: paymentMethodTypes,
                                            stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
+                                           countryCode: countryCode,
+                                           terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
                                            channel: channel,
                                            onPreparingReader: onPreparingReader,
                                            onWaitingForInput: onWaitingForInput,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -96,7 +96,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
 
         let parameters = paymentParameters(order: order,
                                            orderTotal: orderTotal,
-                                           country: paymentGatewayAccount.country,
+                                           accountCountry: paymentGatewayAccount.country,
+                                           configurationCountryCode: countryCode,
                                            statementDescriptor: paymentGatewayAccount.statementDescriptor,
                                            paymentMethodTypes: paymentMethodTypes,
                                            stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
@@ -296,7 +297,8 @@ private extension PaymentCaptureOrchestrator {
 
     func paymentParameters(order: Order,
                            orderTotal: NSDecimalNumber,
-                           country: String,
+                           accountCountry: String,
+                           configurationCountryCode: CountryCode,
                            statementDescriptor: String?,
                            paymentMethodTypes: [PaymentMethodType],
                            stripeSmallestCurrencyUnitMultiplier: Decimal,
@@ -314,11 +316,12 @@ private extension PaymentCaptureOrchestrator {
         return PaymentParameters(amount: orderTotal as Decimal,
                                  currency: order.currency,
                                  stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
-                                 applicationFee: applicationFee(for: orderTotal, country: country),
+                                 applicationFee: applicationFee(for: orderTotal, country: accountCountry),
                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                  statementDescription: statementDescriptor,
                                  receiptEmail: paymentReceiptEmailParameterDeterminer.receiptEmail(from: order),
                                  paymentMethodTypes: paymentMethodTypes,
+                                 cardPresentCaptureMethod: configurationCountryCode == .AU ? .manualPreferred : nil,
                                  metadata: metadata)
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -17,6 +17,8 @@ protocol PaymentCaptureOrchestrating {
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: @escaping () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -72,6 +74,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: @escaping () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -85,7 +89,9 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                                                    onCardInserted: onCardInserted,
                                                    onProcessingMessage: onProcessingMessage,
                                                    onDisplayMessage: onDisplayMessage,
-                                                   onProcessingCompletion: onProcessingCompletion)
+                                                   onProcessingCompletion: onProcessingCompletion,
+                                                   countryCode: countryCode.rawValue,
+                                                   terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
         onPreparingReader()
 
         let parameters = paymentParameters(order: order,
@@ -105,6 +111,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
             siteID: order.siteID,
             orderID: order.orderID,
             parameters: parameters,
+            countryCode: countryCode.rawValue,
+            terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
             onCardReaderMessage: { event in
                 switch event {
                 case .waitingForInput(let inputMethods):
@@ -146,6 +154,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         let retryPaymentAction = CardPresentPaymentAction.retryPayment(
             siteID: order.siteID,
             orderID: order.orderID,
+            countryCode: handlers.countryCode,
+            terminalPaymentPreparationEnabled: handlers.terminalPaymentPreparationEnabled,
             onCardReaderMessage: { event in
                 switch event {
                 case .waitingForInput(let inputMethods):
@@ -391,5 +401,7 @@ private extension PaymentCaptureOrchestrator {
         let onProcessingMessage: () -> Void
         let onDisplayMessage: (String) -> Void
         let onProcessingCompletion: (PaymentIntent) -> Void
+        let countryCode: String
+        let terminalPaymentPreparationEnabled: Bool
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -321,8 +321,17 @@ private extension PaymentCaptureOrchestrator {
                                  statementDescription: statementDescriptor,
                                  receiptEmail: paymentReceiptEmailParameterDeterminer.receiptEmail(from: order),
                                  paymentMethodTypes: paymentMethodTypes,
-                                 cardPresentCaptureMethod: configurationCountryCode == .AU ? .manualPreferred : nil,
+                                 cardPresentCaptureMethod: cardPresentCaptureMethod(for: configurationCountryCode),
                                  metadata: metadata)
+    }
+
+    private func cardPresentCaptureMethod(for countryCode: CountryCode) -> CardPresentCaptureMethod? {
+        switch countryCode {
+        case .AU, .CA:
+            return .manualPreferred
+        default:
+            return nil
+        }
     }
 
     private func applicationFee(for orderTotal: NSDecimalNumber, country: String) -> Decimal? {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -2,9 +2,9 @@ import Foundation
 import Combine
 import Yosemite
 import MessageUI
+import struct Networking.SiteAPI
 import WordPressUI
 import WooFoundation
-import protocol Storage.StorageManagerType
 //TODO: Move to alertprovider (and ideally, remove from this target or translate through Yosemite)
 import enum Hardware.CardReaderServiceError
 import enum Hardware.UnderlyingError
@@ -320,88 +320,159 @@ private extension CollectOrderPaymentUseCase {
                                                                          channel: channel,
                                                                          onCompletion: onCompletion)
             case .success:
-                guard let orderTotal = self.orderTotal else {
-                    onCompletion(.failure(CollectOrderPaymentUseCaseNotValidAmountError.other))
-                    return
+                self.terminalPaymentPreparationEnabled(paymentGatewayAccount: paymentGatewayAccount) { [weak self] terminalPaymentPreparationEnabled in
+                    guard let self else { return }
+                    self.collectPayment(alertProvider: paymentAlerts,
+                                        paymentGatewayAccount: paymentGatewayAccount,
+                                        terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
+                                        channel: channel,
+                                        onCompletion: onCompletion)
                 }
-
-                // Start collect payment process
-                self.paymentOrchestrator.collectPayment(
-                    for: self.order,
-                    orderTotal: orderTotal,
-                    paymentGatewayAccount: paymentGatewayAccount,
-                    paymentMethodTypes: self.configuration.paymentMethods,
-                    stripeSmallestCurrencyUnitMultiplier: self.configuration.stripeSmallestCurrencyUnitMultiplier,
-                    channel: channel,
-                    onPreparingReader: { [weak self] in
-                        self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
-                            self?.cancelPayment(from: .paymentPreparingReader) {
-                                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                            }
-                        }))
-                    },
-                    onWaitingForInput: { [weak self] inputMethods in
-                        guard let self else { return }
-                        self.alertsPresenter.present(
-                            viewModel: paymentAlerts.tapOrInsertCard(
-                                title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
-                                    username: self.order.billingAddress?.firstName),
-                                amount: self.formattedAmount,
-                                inputMethods: inputMethods,
-                                onCancel: { [weak self] in
-                                    self?.cancelPayment(from: .paymentWaitingForInput) {
-                                        onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                                    }
-                                })
-                        )
-                    }, onCardInserted: { [weak self] in
-                        guard let self else { return }
-                        self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
-                            title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
-                                username: self.order.billingAddress?.firstName),
-                            amount: self.formattedAmount,
-                            onCancel: { [weak self] in
-                                self?.cancelPayment(from: .paymentWaitingForInput) {
-                                    onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                                }
-                            })
-                        )
-                    }, onProcessingMessage: { [weak self] in
-                        guard let self else { return }
-                        // Waiting message
-                        self.alertsPresenter.present(
-                            viewModel: paymentAlerts.processingTransaction(
-                                title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
-                                    username: self.order.billingAddress?.firstName)))
-                    }, onDisplayMessage: { [weak self] message in
-                        guard let self else { return }
-                        // Reader messages. EG: Remove Card
-                        self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
-                    }, onProcessingCompletion: { [weak self] intent in
-                        self?.analyticsTracker.trackProcessingCompletion(intent: intent)
-                        self?.markOrderAsPaidIfNeeded(intent: intent)
-                    }, onCompletion: { [weak self] result in
-                        switch result {
-                        case .success(let capturedPaymentData):
-                            self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
-                            onCompletion(.success(capturedPaymentData))
-                        case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
-                            switch cancellationSource {
-                            case .reader:
-                                self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
-                            default:
-                                self?.handlePaymentCancellation(from: .other)
-                            }
-                        case .failure(let error):
-                            self?.checkThenHandlePaymentFailureAndRetryPayment(error,
-                                                                               alertProvider: paymentAlerts,
-                                                                               paymentGatewayAccount: paymentGatewayAccount,
-                                                                               channel: channel,
-                                                                               onCompletion: onCompletion)
-                        }
-                    })
             }
         }
+    }
+
+    func collectPayment(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
+                        paymentGatewayAccount: PaymentGatewayAccount,
+                        terminalPaymentPreparationEnabled: Bool,
+                        channel: PaymentChannel,
+                        onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        guard let orderTotal else {
+            onCompletion(.failure(CollectOrderPaymentUseCaseNotValidAmountError.other))
+            return
+        }
+
+        // Start collect payment process
+        paymentOrchestrator.collectPayment(
+            for: order,
+            orderTotal: orderTotal,
+            paymentGatewayAccount: paymentGatewayAccount,
+            paymentMethodTypes: configuration.paymentMethods,
+            stripeSmallestCurrencyUnitMultiplier: configuration.stripeSmallestCurrencyUnitMultiplier,
+            countryCode: configuration.countryCode,
+            terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
+            channel: channel,
+            onPreparingReader: { [weak self] in
+                self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
+                    self?.cancelPayment(from: .paymentPreparingReader) {
+                        onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                    }
+                }))
+            },
+            onWaitingForInput: { [weak self] inputMethods in
+                guard let self else { return }
+                self.alertsPresenter.present(
+                    viewModel: paymentAlerts.tapOrInsertCard(
+                        title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
+                            username: self.order.billingAddress?.firstName),
+                        amount: self.formattedAmount,
+                        inputMethods: inputMethods,
+                        onCancel: { [weak self] in
+                            self?.cancelPayment(from: .paymentWaitingForInput) {
+                                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                            }
+                        })
+                )
+            }, onCardInserted: { [weak self] in
+                guard let self else { return }
+                self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
+                    title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
+                        username: self.order.billingAddress?.firstName),
+                    amount: self.formattedAmount,
+                    onCancel: { [weak self] in
+                        self?.cancelPayment(from: .paymentWaitingForInput) {
+                            onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                        }
+                    })
+                )
+            }, onProcessingMessage: { [weak self] in
+                guard let self else { return }
+                // Waiting message
+                self.alertsPresenter.present(
+                    viewModel: paymentAlerts.processingTransaction(
+                        title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
+                            username: self.order.billingAddress?.firstName)))
+            }, onDisplayMessage: { [weak self] message in
+                guard let self else { return }
+                // Reader messages. EG: Remove Card
+                self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
+            }, onProcessingCompletion: { [weak self] intent in
+                self?.analyticsTracker.trackProcessingCompletion(intent: intent)
+                self?.markOrderAsPaidIfNeeded(intent: intent)
+            }, onCompletion: { [weak self] result in
+                switch result {
+                case .success(let capturedPaymentData):
+                    self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
+                    onCompletion(.success(capturedPaymentData))
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
+                    switch cancellationSource {
+                    case .reader:
+                        self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
+                    default:
+                        self?.handlePaymentCancellation(from: .other)
+                    }
+                case .failure(let error):
+                    self?.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                       alertProvider: paymentAlerts,
+                                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                                       channel: channel,
+                                                                       onCompletion: onCompletion)
+                }
+            })
+    }
+
+    func terminalPaymentPreparationEnabled(paymentGatewayAccount: PaymentGatewayAccount,
+                                           completion: @escaping (Bool) -> Void) {
+        guard paymentGatewayAccount.gatewayID == WCPayAccount.gatewayID,
+              terminalPaymentPreparationAvailableForConfiguration else {
+            completion(false)
+            return
+        }
+
+        let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(
+            .inPersonPaymentsTerminalPaymentPreparation,
+            defaultValue: false
+        ) { [weak self] isEnabled in
+            guard let self, isEnabled else {
+                completion(false)
+                return
+            }
+            self.terminalPaymentPreparationSupportedBySite(completion: completion)
+        }
+        stores.dispatch(action)
+    }
+
+    var terminalPaymentPreparationAvailableForConfiguration: Bool {
+        switch configuration.countryCode {
+        case .AU, .CA:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func terminalPaymentPreparationSupportedBySite(completion: @escaping (Bool) -> Void) {
+        switch configuration.countryCode {
+        case .AU:
+            completion(true)
+        case .CA:
+            checkTerminalPaymentPreparationRoute(completion: completion)
+        default:
+            completion(false)
+        }
+    }
+
+    func checkTerminalPaymentPreparationRoute(completion: @escaping (Bool) -> Void) {
+        let action = SettingAction.retrieveSiteAPI(siteID: siteID) { result in
+            switch result {
+            case .success(let siteAPI):
+                completion(siteAPI.hasTerminalPaymentPreparationRoute)
+            case .failure(let error):
+                DDLogInfo("💳 Skipping terminal payment preparation because the WCPay endpoint could not be verified: \(error)")
+                completion(false)
+            }
+        }
+        stores.dispatch(action)
     }
 
     /// Tracks the successful payments
@@ -538,8 +609,11 @@ private extension CollectOrderPaymentUseCase {
                                                                                                    })
                                                    }
                                                }
-                                           }, dismissCompletion: {
-                                               onCompletion(.failure(error))
+                                           }, dismissCompletion: { [weak self] in
+                                               guard let self else {
+                                                   return onCompletion(.failure(error))
+                                               }
+                                               self.cancelPaymentAndComplete(with: error, onCompletion: onCompletion)
                                            })
         )
     }
@@ -588,8 +662,11 @@ private extension CollectOrderPaymentUseCase {
                             }
                         }
                     }
-                }, dismissCompletion: {
-                    onCompletion(.failure(error))
+                }, dismissCompletion: { [weak self] in
+                    guard let self else {
+                        return onCompletion(.failure(error))
+                    }
+                    self.cancelPaymentAndComplete(with: error, onCompletion: onCompletion)
                 })
         )
     }
@@ -598,11 +675,16 @@ private extension CollectOrderPaymentUseCase {
                                           paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                           receiptState: CardReaderTransactionFailureAlertReceiptState,
                                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        let dismissCompletion: () -> Void = { [weak self] in
+            guard let self else {
+                return onCompletion(.failure(error))
+            }
+            self.cancelPaymentAndComplete(with: error, onCompletion: onCompletion)
+        }
+
         alertsPresenter.present(viewModel: paymentAlerts.nonRetryableError(error: error,
                                                                            receiptState: receiptState,
-                                                                           dismissCompletion: {
-            onCompletion(.failure(error))
-        }))
+                                                                           dismissCompletion: dismissCompletion))
     }
 
     /// Cancels payment and record analytics.
@@ -614,6 +696,14 @@ private extension CollectOrderPaymentUseCase {
             onCompleted()
         }
     }
+
+    private func cancelPaymentAndComplete(with error: Error,
+                                          onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        paymentOrchestrator.cancelPayment { _ in
+            onCompletion(.failure(error))
+        }
+    }
+
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     ///
@@ -920,6 +1010,20 @@ protocol CardPaymentErrorProtocol: Error {
     var requiresFallbackPaymentMethod: Bool { get }
 }
 
+private extension SiteAPI {
+    var hasTerminalPaymentPreparationRoute: Bool {
+        routes.contains { route in
+            route.hasPrefix(Constants.prepareTerminalPaymentRoutePrefix) &&
+            route.hasSuffix(Constants.prepareTerminalPaymentRouteSuffix)
+        }
+    }
+
+    enum Constants {
+        static let prepareTerminalPaymentRoutePrefix = "/wc/v3/payments/orders/"
+        static let prepareTerminalPaymentRouteSuffix = "/prepare_terminal_payment"
+    }
+}
+
 extension CardReaderServiceError: CardPaymentErrorProtocol {
     var retryApproach: CardPaymentRetryApproach {
         switch self {
@@ -972,6 +1076,21 @@ extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
             return .restart
         case .couldNotRefreshOrder:
             return .reuseIntent
+        }
+    }
+
+    var requiresFallbackPaymentMethod: Bool {
+        false
+    }
+}
+
+extension ServerSidePaymentCaptureError: CardPaymentErrorProtocol {
+    var retryApproach: CardPaymentRetryApproach {
+        switch self {
+        case .terminalPaymentPreparation:
+            return .reuseIntent
+        case .paymentGateway, .paymentIntentNotSuccessful:
+            return .dontRetry
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import WooCommerce
 import Yosemite
+import WooFoundation
 
 final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     var mockCollectPaymentHandler: ((_ onPreparingReader: () -> Void,
@@ -16,12 +17,16 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     var spyCollectPaymentGatewayAccount: PaymentGatewayAccount? = nil
     var spyCollectPaymentMethodTypes: [PaymentMethodType]? = nil
     var spyCollectPaymentStripeSmallestCurrencyUnitMultiplier: Decimal? = nil
+    var spyCollectPaymentCountryCode: CountryCode? = nil
+    var spyTerminalPaymentPreparationEnabled: Bool?
     var spyChannel: PaymentChannel? = nil
     func collectPayment(for order: Order,
                         orderTotal: NSDecimalNumber,
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -35,6 +40,8 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         spyCollectPaymentGatewayAccount = paymentGatewayAccount
         spyCollectPaymentMethodTypes = paymentMethodTypes
         spyCollectPaymentStripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
+        spyCollectPaymentCountryCode = countryCode
+        spyTerminalPaymentPreparationEnabled = terminalPaymentPreparationEnabled
         spyChannel = channel
 
         mockCollectPaymentHandler?(onPreparingReader,

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -119,15 +119,16 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertEqual(loader.configuration.currencies, [.NZD])
     }
 
-    func test_configuration_for_Australia_remains_unsupported_when_expansion_eligible() {
-        // Given - Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643)
+    func test_configuration_for_Australia_is_supported() {
+        // Given
         setupCountry(country: .au)
 
         // When
         let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
 
         // Then
-        XCTAssertFalse(loader.configuration.isSupportedCountry)
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
+        XCTAssertEqual(loader.configuration.currencies, [.AUD])
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -1,8 +1,10 @@
 import Codegen
 import Combine
+import Networking
 import TestKit
 import XCTest
 import Yosemite
+import WooFoundation
 @testable import WooCommerce
 
 @MainActor
@@ -34,7 +36,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         setUpUseCase(order: order)
     }
 
-    private func setUpUseCase(order: Order) {
+    private func setUpUseCase(order: Order, configuration: CardPresentPaymentsConfiguration = Mocks.configuration) {
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .retrieveOrderRemotely(_, _, let completion):
@@ -48,7 +50,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
                                              order: order,
                                              formattedAmount: "1.5",
                                              rootViewController: MockViewControllerPresenting(),
-                                             configuration: Mocks.configuration,
+                                             configuration: configuration,
                                              stores: stores,
                                              paymentOrchestrator: mockPaymentOrchestrator,
                                              alertsPresenter: alertsPresenter,
@@ -96,6 +98,118 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         // Then
         XCTAssert(mockAnalyticsTracker.didCallTrackSuccessfulPayment)
         assertEqual(interacPaymentMethod, mockAnalyticsTracker.spyTrackSuccessfulPaymentCapturedPaymentData?.paymentMethod)
+    }
+
+    func test_collectPayment_enables_terminal_payment_preparation_when_flag_is_enabled_and_route_is_available_for_Canada() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockTerminalPaymentPreparationFeatureFlag(isEnabled: true)
+        mockTerminalPaymentPreparationRoute(isAvailable: true)
+
+        let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: interacPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, true)
+    }
+
+    func test_collectPayment_disables_terminal_payment_preparation_when_flag_is_disabled() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockTerminalPaymentPreparationFeatureFlag(isEnabled: false)
+
+        let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: interacPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, false)
+    }
+
+    func test_collectPayment_disables_terminal_payment_preparation_when_route_is_not_available_for_Canada() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockTerminalPaymentPreparationFeatureFlag(isEnabled: true)
+        mockTerminalPaymentPreparationRoute(isAvailable: false)
+
+        let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: interacPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, false)
+    }
+
+    func test_collectPayment_enables_terminal_payment_preparation_without_checking_route_for_Australia() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .AU)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockTerminalPaymentPreparationFeatureFlag(isEnabled: true)
+        mockUnexpectedTerminalPaymentPreparationRouteCheck()
+
+        let eftposPaymentMethod = PaymentMethod.cardPresent(details: CardPresentTransactionDetails(last4: "0978",
+                                                                                                   expMonth: 12,
+                                                                                                   expYear: 2030,
+                                                                                                   cardholderName: nil,
+                                                                                                   brand: .eftposAu,
+                                                                                                   generatedCard: nil,
+                                                                                                   receipt: nil,
+                                                                                                   emvAuthData: nil,
+                                                                                                   wallet: nil,
+                                                                                                   network: nil))
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: eftposPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: eftposPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, true)
     }
 
     func test_collectPayment_success_with_customer_then_modal_presented_with_email() throws {
@@ -362,6 +476,20 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         XCTAssertEqual(mockPaymentOrchestrator.spyChannel, .pos)
     }
 
+    func test_collectPayment_configured_country_is_passed_to_payment_capture_orchestrator() throws {
+        // When
+        useCase.collectPayment(using: .bluetoothScan,
+                               channel: .storeManagement,
+                               onFailure: { _ in },
+                               onCancel: {},
+                               onPaymentCompletion: {},
+                               onCompleted: {})
+        mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyCollectPaymentCountryCode, .US)
+    }
+
     func test_completion_called_after_alert_presentation() throws {
         receiptEligibilityUseCase.isEligibleForBackendReceipts = true
         let paymentMethod = PaymentMethod.cardPresent(details: .fake())
@@ -469,6 +597,47 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 }
 
 private extension CollectOrderPaymentUseCaseTests {
+    func mockTerminalPaymentPreparationFeatureFlag(isEnabled: Bool) {
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(featureFlag, defaultValue, _, completion):
+                XCTAssertEqual(featureFlag, .inPersonPaymentsTerminalPaymentPreparation)
+                XCTAssertFalse(defaultValue)
+                completion(isEnabled)
+            }
+        }
+    }
+
+    func mockTerminalPaymentPreparationRoute(isAvailable: Bool) {
+        stores.whenReceivingAction(ofType: SettingAction.self) { [defaultSiteID] action in
+            switch action {
+            case let .retrieveSiteAPI(siteID, completion):
+                XCTAssertEqual(siteID, defaultSiteID)
+                completion(.success(SiteAPI(siteID: siteID,
+                                            namespaces: [],
+                                            applicationPasswordAvailable: false,
+                                            routes: isAvailable ? [Mocks.prepareTerminalPaymentRoute] : [])))
+            default:
+                XCTFail("Unexpected setting action: \(action)")
+            }
+        }
+    }
+
+    func mockUnexpectedTerminalPaymentPreparationRouteCheck() {
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveSiteAPI(siteID, completion):
+                XCTFail("AU terminal payment preparation should not depend on the site route list.")
+                completion(.success(SiteAPI(siteID: siteID,
+                                            namespaces: [],
+                                            applicationPasswordAvailable: false,
+                                            routes: [])))
+            default:
+                XCTFail("Unexpected setting action: \(action)")
+            }
+        }
+    }
+
     func mockSuccessfulCardPresentPaymentActions(intent: PaymentIntent, capturedPaymentData: CardPresentCapturedPaymentData) {
         mockPaymentOrchestrator.mockCollectPaymentHandler = { onPreparingReader,
                                                               onWaitingForInput,
@@ -501,5 +670,6 @@ private extension CollectOrderPaymentUseCaseTests {
         static let configuration = CardPresentPaymentsConfiguration(country: .US)
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayAccount: String = "woocommerce-payments"
+        static let prepareTerminalPaymentRoute = "/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -202,6 +202,41 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertEqual(paymentParameters.cardPresentCaptureMethod, .manualPreferred)
     }
 
+    func test_collect_payment_for_CA_sets_manual_preferred_card_present_capture_method() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let paymentParameters = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
+                    promise(parameters)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent, .interacPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .CA,
+                terminalPaymentPreparationEnabled: false,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        XCTAssertEqual(paymentParameters.cardPresentCaptureMethod, .manualPreferred)
+    }
+
     func test_collect_payment_starts_payment_with_valid_parameters() {
         // Given
         let order = Order.fake().copy(siteID: sampleSiteID,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -167,6 +167,41 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertTrue(terminalPaymentPreparationEnabled)
     }
 
+    func test_collect_payment_for_AU_sets_manual_preferred_card_present_capture_method() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let paymentParameters = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
+                    promise(parameters)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: false,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        XCTAssertEqual(paymentParameters.cardPresentCaptureMethod, .manualPreferred)
+    }
+
     func test_collect_payment_starts_payment_with_valid_parameters() {
         // Given
         let order = Order.fake().copy(siteID: sampleSiteID,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Yosemite
+import WooFoundation
 @testable import WooCommerce
 
 final class PaymentCaptureOrchestratorTests: XCTestCase {
@@ -34,7 +35,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let paymentSiteID = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(siteID, _, _, _, _, _) = action {
+                if case let .collectPayment(siteID, _, _, _, _, _, _, _) = action {
                     promise(siteID)
                 }
             }
@@ -45,6 +46,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: PaymentGatewayAccount.fake(),
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -67,7 +70,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let paymentOrderID = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, orderID, _, _, _, _) = action {
+                if case let .collectPayment(_, orderID, _, _, _, _, _, _) = action {
                     promise(orderID)
                 }
             }
@@ -78,6 +81,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: PaymentGatewayAccount.fake(),
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -90,6 +95,76 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
         // Then
         assertEqual(9283, paymentOrderID)
+    }
+
+    func test_collect_payment_passes_configured_country_to_payment_action() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let countryCode = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, _, countryCode, _, _, _, _) = action {
+                    promise(countryCode)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: false,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        assertEqual("AU", countryCode)
+    }
+
+    func test_collect_payment_passes_terminal_payment_preparation_setting_to_payment_action() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let terminalPaymentPreparationEnabled = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, _, _, terminalPaymentPreparationEnabled, _, _, _) = action {
+                    promise(terminalPaymentPreparationEnabled)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: true,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        XCTAssertTrue(terminalPaymentPreparationEnabled)
     }
 
     func test_collect_payment_starts_payment_with_valid_parameters() {
@@ -108,7 +183,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let paymentParameters = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
                     promise(parameters)
                 }
             }
@@ -119,6 +194,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: PaymentGatewayAccount.fake(),
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -163,7 +240,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let parameters: PaymentParameters = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
                     promise(parameters)
                 }
             }
@@ -174,6 +251,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: account,
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -201,7 +280,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let parameters: PaymentParameters = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
                     promise(parameters)
                 }
             }
@@ -212,6 +291,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: account,
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .CA,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },


### PR DESCRIPTION
Part of: RSM-642

## Description

Adds the iOS terminal payment preparation flow used by WooPayments for Interac and AU terminal payments.

This PR:

- Adds API support for preparing terminal PaymentIntents after collection and before confirmation.
- Gates the flow behind the remote `in_person_payments_terminal_payment_preparation` feature flag.
- Requires WooPayments `10.8.0-test-1` for AU, where the plugin endpoint is version-gated.
- Uses Stripe Terminal's card-present `manualPreferred` capture method for AU and CA PaymentIntent creation, leaving fee preparation to the WooPayments endpoint.
- Keeps a safe CA fallback by checking whether the route exists and continuing with the existing flow if older WooPayments installs return 404.
- Enables AU preparation without relying on the route list, because AU availability is already gated by plugin version.
- Cancels terminal collection cleanly when preparation fails before confirmation.
- Adds focused unit coverage for the Interac/AU/CA preparation paths and route fallback behavior.

## Test Steps

1. Connect to a CA WooPayments test store with the preparation endpoint available.
2. Collect an Interac terminal payment.
3. Confirm the app uses `manualPreferred` when creating the PaymentIntent and prepares the PaymentIntent between collect and confirm.
4. Repeat against an older CA WooPayments install without the route and confirm the payment continues through the existing flow.
5. Connect to an AU WooPayments test store on `10.8.0-test-1` or later.
6. Collect an EFTPOS or AU card-present payment and confirm the app uses `manualPreferred` when creating the PaymentIntent and calls the preparation endpoint before confirmation.
7. Force the preparation request to fail and confirm the reader/payment flow is cancelled cleanly after dismissing the error.

## Screenshots

Not applicable; this PR changes the terminal payment flow rather than visible UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
