### PR TITLE
Woo Mobile AI: widen tool payloads to answer per-row follow-ups

### DIFF
--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -118,8 +118,8 @@ public enum AssistantSystemPrompt {
         BAD: Render \(entityCardVisibleRowLimit) cards and say only "Here are the \(entityCardVisibleRowLimit) most recent customers" without pointing to the tab.
 
         Pattern 1b - Per-row fields the summary doesn't carry.
-        Merchant: "show me orders with customer emails" / "list customers with phone numbers" / "show products with full descriptions" / "orders by payment \
-        method".
+        Merchant: "show me orders with customer emails" / "list customers with phone numbers" / "show products with full descriptions" / "list orders, what \
+        was each total".
         GOOD: One list tool call, render via `show_cards`, then a short pointer like "Tap any row to see emails." The cards already deep-link into the detail \
         screen where the field lives.
         BAD: Refuse with "I can't show that in chat" or "use the Orders tab" without ever calling the list tool. That defeats the cards entirely and is wrong \

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -213,6 +213,10 @@ public enum AssistantSystemPrompt {
         A new tool call may still be required to answer (e.g. fetching line items the original card didn't carry). That's fine. What's not fine is searching \
         for the pronoun's literal text, or asking the merchant to repeat an entity that's already in your context.
 
+        Same applies to write requests on prior context. "Mark the biggest one as completed", "cancel the most recent", "set the second to draft" resolve the \
+        entity from the prior turn's `show_cards` results, then call the appropriate write tool with that id. Don't refuse a write or punt to the native UI \
+        because the merchant used a superlative or ordinal - the antecedent is already in your context.
+
         Asking for clarification is a last resort, only valid when zero cards or list results have been shown in this conversation.
 
         # Time-window follow-ups
@@ -282,8 +286,10 @@ public enum AssistantSystemPrompt {
         rendered card, do not fabricate it. Exhaust the list tool's parameters first - filters, field projections, and similar. When the field genuinely \
         isn't reachable via any list parameter and the entity is known, fetch detail before answering. Hallucinated specifics are worse than honest "tap to \
         see in the order detail". The merchant owns their store data - asking about email, phone, payment method, billing or shipping address on the \
-        merchant's own orders or customers is normal merchant work, not a PII concern. Render the entities and point to the card; don't refuse a list call \
-        because the merchant mentioned a sensitive-looking field.
+        merchant's own orders or customers is normal merchant work, not a PII concern. When the merchant asks for a list of entities and names a per-row field \
+        the summary doesn't carry, the answer is still a list tool call + `show_cards` + a one-line pointer ("tap any row for billing details", "tap to see the \
+        email"). Refusing the list call, or telling the merchant to open the Orders/Customers tab as a first move, is wrong - the rendered cards are already \
+        tappable into the same detail screen.
 
         # Distinct quantities
 

--- a/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
+++ b/Modules/Sources/WooAIAssistant/Configuration/AssistantSystemPrompt.swift
@@ -117,6 +117,14 @@ public enum AssistantSystemPrompt {
         Open the Customers tab to see the rest."
         BAD: Render \(entityCardVisibleRowLimit) cards and say only "Here are the \(entityCardVisibleRowLimit) most recent customers" without pointing to the tab.
 
+        Pattern 1b - Per-row fields the summary doesn't carry.
+        Merchant: "show me orders with customer emails" / "list customers with phone numbers" / "show products with full descriptions" / "orders by payment \
+        method".
+        GOOD: One list tool call, render via `show_cards`, then a short pointer like "Tap any row to see emails." The cards already deep-link into the detail \
+        screen where the field lives.
+        BAD: Refuse with "I can't show that in chat" or "use the Orders tab" without ever calling the list tool. That defeats the cards entirely and is wrong \
+        even when the named field isn't in the list summary - the rendered cards are tappable into the same detail screen.
+
         Pattern 2 - Drill into a single entity by id.
         Merchant: "tell me about order 3480"
         GOOD: One call to the order detail-get role with that id, then render it with `show_cards`.

--- a/Modules/Sources/WooAIAssistant/Presentation/Cards/EntityCardPayloads.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/Cards/EntityCardPayloads.swift
@@ -95,6 +95,7 @@ public struct ProductCardPayload: Codable, Equatable, Sendable {
     public let type: String?
     public let status: String?
     public let images: [Image]?
+    public let variationsCount: Int?
 
     public struct Image: Codable, Equatable, Sendable {
         public let src: String?
@@ -110,7 +111,8 @@ public struct ProductCardPayload: Codable, Equatable, Sendable {
                 stockQuantity: Double? = nil,
                 type: String? = nil,
                 status: String? = nil,
-                images: [Image]? = nil) {
+                images: [Image]? = nil,
+                variationsCount: Int? = nil) {
         self.id = id
         self.name = name
         self.sku = sku
@@ -122,6 +124,7 @@ public struct ProductCardPayload: Codable, Equatable, Sendable {
         self.type = type
         self.status = status
         self.images = images
+        self.variationsCount = variationsCount
     }
 
     enum CodingKeys: String, CodingKey {
@@ -130,6 +133,7 @@ public struct ProductCardPayload: Codable, Equatable, Sendable {
         case salePrice = "sale_price"
         case stockStatus = "stock_status"
         case stockQuantity = "stock_quantity"
+        case variationsCount = "variations_count"
     }
 
     public var isEmpty: Bool {

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationPreviewBuilder.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationPreviewBuilder.swift
@@ -100,10 +100,10 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
                                 priorValue: isBulk ? nil : priorOrderStatus(in: snapshot,
                                                                             currentValueRaw: status)))
         }
-        if customerNote != nil {
+        if let note = customerNote {
             fields.append(.init(name: "customer_note",
                                 label: .localized(Strings.fieldCustomerNote),
-                                value: .localized(Strings.fieldValueUpdated)))
+                                value: customerNoteValue(note)))
         }
         if let email = billingEmail {
             fields.append(.init(name: "billing_email",
@@ -115,6 +115,16 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
         }
         return fields
     }
+
+    private func customerNoteValue(_ note: String) -> ConfirmationPreviewText {
+        if note.isEmpty { return .localized(Strings.fieldValueUpdated) }
+        if note.count > Self.customerNotePreviewLimit {
+            return .raw(String(note.prefix(Self.customerNotePreviewLimit)) + "...")
+        }
+        return .raw(note)
+    }
+
+    private static let customerNotePreviewLimit = 160
 
     // MARK: - Products
 

--- a/Modules/Sources/WooAIAssistant/Tools/Cards/AnalyticsCardFetch.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Cards/AnalyticsCardFetch.swift
@@ -30,6 +30,12 @@ struct AnalyticsCardFetch: Sendable {
         guard let payload = RESTResponseParsing.decodeJSON(response.data) else {
             return .rejected(.internalError)
         }
-        return .found(AnalyticsStatsSummary.make(from: payload, range: (spec.after, spec.before)))
+        let interval = spec.interval ?? "day"
+        let trimmedCurrency = spec.currency?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currency = (trimmedCurrency?.isEmpty == false) ? trimmedCurrency : nil
+        let comparison = AnalyticsStatsSummary.ComparisonInputs(interval: interval, currency: currency)
+        return .found(AnalyticsStatsSummary.make(from: payload,
+                                                 range: (spec.after, spec.before),
+                                                 comparison: comparison))
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Cards/CardFamily.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Cards/CardFamily.swift
@@ -154,19 +154,50 @@ struct CardFamily: Sendable {
         pathStrategy: .batchedList(path: "wc/v3/orders"),
         summaryKeys: ["id", "number", "status", "total", "currency", "date_created"],
         extraSummary: { entity in
-            guard let billing = RESTResponseParsing.objectField(entity, "billing") else { return [:] }
-            let first = RESTResponseParsing.stringField(billing, "first_name") ?? ""
-            let last = RESTResponseParsing.stringField(billing, "last_name") ?? ""
-            let combined = "\(first) \(last)".trimmingCharacters(in: .whitespaces)
-            return combined.isEmpty ? [:] : ["customer_name": .string(combined)]
+            var extras: [String: AnyCodableJSON] = [:]
+            if let billing = RESTResponseParsing.objectField(entity, "billing") {
+                let first = RESTResponseParsing.stringField(billing, "first_name") ?? ""
+                let last = RESTResponseParsing.stringField(billing, "last_name") ?? ""
+                let combined = "\(first) \(last)".trimmingCharacters(in: .whitespaces)
+                if !combined.isEmpty { extras["customer_name"] = .string(combined) }
+            }
+            if let title = RESTResponseParsing.stringField(entity, "payment_method_title"), !title.isEmpty {
+                extras["payment_method_title"] = .string(title)
+            }
+            if let customerID = RESTResponseParsing.intField(entity, "customer_id"), customerID > 0 {
+                extras["customer_id"] = .int(customerID)
+            }
+            let lineItems = RESTResponseParsing.arrayItems(
+                RESTResponseParsing.objectField(entity, "line_items") ?? .null
+            ) ?? []
+            extras["line_items_count"] = .int(Int64(lineItems.count))
+            extras["line_items"] = .array(lineItems.prefix(showCardsLineItemLimit).map(showCardsLineItem))
+            return extras
         },
         checkTrash: true
     )
 
+    private static let showCardsLineItemLimit = 5
+
+    private static func showCardsLineItem(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let name = RESTResponseParsing.stringField(item, "name") { out["name"] = .string(name) }
+        if let qty = RESTResponseParsing.intField(item, "quantity") { out["quantity"] = .int(qty) }
+        if let sku = RESTResponseParsing.stringField(item, "sku") { out["sku"] = .string(sku) }
+        if let total = RESTResponseParsing.stringField(item, "total") { out["total"] = .string(total) }
+        if let pid = RESTResponseParsing.intField(item, "product_id") { out["product_id"] = .int(pid) }
+        if let vid = RESTResponseParsing.intField(item, "variation_id") { out["variation_id"] = .int(vid) }
+        return .object(out)
+    }
+
     static let product = CardFamily(
         id: .product,
         pathStrategy: .batchedList(path: "wc/v3/products"),
-        summaryKeys: ["id", "name", "sku", "price", "stock_status"],
+        summaryKeys: [
+            "id", "name", "sku", "price", "stock_status",
+            "type", "manage_stock", "on_sale", "stock_quantity"
+        ],
         checkTrash: true
     )
 

--- a/Modules/Sources/WooAIAssistant/Tools/Cards/CardFamily.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Cards/CardFamily.swift
@@ -196,7 +196,8 @@ struct CardFamily: Sendable {
         pathStrategy: .batchedList(path: "wc/v3/products"),
         summaryKeys: [
             "id", "name", "sku", "price", "stock_status",
-            "type", "manage_stock", "on_sale", "stock_quantity"
+            "type", "manage_stock", "on_sale", "stock_quantity",
+            "variations_count"
         ],
         checkTrash: true
     )

--- a/Modules/Sources/WooAIAssistant/Tools/Cards/CardReferenceResolver.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Cards/CardReferenceResolver.swift
@@ -127,12 +127,26 @@ struct CardReferenceResolver: Sendable {
                             summarize: (AnyCodableJSON) -> AnyCodableJSON) -> Resolution {
         switch outcome {
         case .found(let entity):
-            let summary = summarize(entity)
-            let rendered = RenderedCardPayload(family: family, id: id, element: entity)
+            let enriched = Self.enrich(entity, family: family)
+            let summary = summarize(enriched)
+            let rendered = RenderedCardPayload(family: family, id: id, element: enriched)
             return .resolved(family: family, id: id, summary: summary, rendered: rendered)
         case .rejected(let reason):
             return .rejected(family: family, id: id, reason: reason)
         }
+    }
+
+    // WC's product entity exposes the variation list as `variations: [Long]` but never a count.
+    // Callers (model summary + UI card row) read `variations_count`; synthesize it once here so
+    // both downstream paths see the same field without re-deriving it.
+    static func enrich(_ entity: AnyCodableJSON, family: CardFamilyID) -> AnyCodableJSON {
+        guard family == .product, case .object(var dict) = entity, dict["variations_count"] == nil else {
+            return entity
+        }
+        if case .array(let variations) = dict["variations"] ?? .null {
+            dict["variations_count"] = .int(Int64(variations.count))
+        }
+        return .object(dict)
     }
 
     private struct SeenKey: Hashable {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
@@ -53,7 +53,14 @@ public enum AnalyticsOrdersTool {
         let interval: String?
     }
 
+    static let allowedArguments: Set<String> = ["after", "before", "interval"]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
@@ -18,6 +18,12 @@ public enum AnalyticsOrdersTool {
         parameter directly to the implied dimension rather than asking the \
         merchant which window or grain they meant. When a request combines a \
         grouping grain with a date window, interval follows the grouping grain. \
+        For "this period vs last", "vs last week", "compare to last month", \
+        and similar comparison phrasing, set `compare_to=previous_period` on \
+        the SAME call - the response then includes both `totals` for the \
+        requested window AND `previous_period_totals` for the prior window. \
+        Use those two blocks directly. Do NOT issue a second analytics_orders \
+        call for the prior window; the data is already in the first response. \
         Order stats are card-backed: after any successful call for an aggregate \
         order stats question, do not stop with prose; call show_cards with \
         family analytics_stats and an id built from the same after/before/interval \
@@ -44,7 +50,9 @@ public enum AnalyticsOrdersTool {
                 "compare_to": .object([
                     "type": .string("string"),
                     "enum": .array([.string("previous_period")]),
-                    "description": .string("Optional comparison window. Currently only 'previous_period'.")
+                    "description": .string("Set to 'previous_period' for any comparison phrasing (vs last week, " +
+                        "compared to last month, etc.). The response then carries both windows; do NOT issue a " +
+                        "second analytics call for the prior window.")
                 ])
             ]),
             "required": .array([.string("after"), .string("before")])

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
@@ -20,10 +20,14 @@ public enum AnalyticsOrdersTool {
         grouping grain with a date window, interval follows the grouping grain. \
         For "this period vs last", "vs last week", "compare to last month", \
         and similar comparison phrasing, set `compare_to=previous_period` on \
-        the SAME call - the response then includes both `totals` for the \
-        requested window AND `previous_period_totals` for the prior window. \
-        Use those two blocks directly. Do NOT issue a second analytics_orders \
-        call for the prior window; the data is already in the first response. \
+        the SAME call. The response then carries two top-level objects: `totals` \
+        (current window) and `previous_period_totals` (prior window). To answer \
+        the comparison, read each metric you need (`orders_count`, `num_items_sold`, \
+        `total_sales`, `gross_sales`, `avg_order_value`, etc.) once from `totals` \
+        and once from `previous_period_totals`. The prior window's numbers live \
+        ONLY inside `previous_period_totals` - do not look anywhere else for them. \
+        Do NOT issue a second analytics_orders call for the prior window; both \
+        windows are already in this response. \
         Order stats are card-backed: after any successful call for an aggregate \
         order stats question, do not stop with prose; call show_cards with \
         family analytics_stats and an id built from the same after/before/interval \

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsOrdersTool.swift
@@ -40,6 +40,11 @@ public enum AnalyticsOrdersTool {
                     "enum": .array([.string("hour"), .string("day"),
                                     .string("week"), .string("month"), .string("year")]),
                     "description": .string("Bucketing interval; default 'day'.")
+                ]),
+                "compare_to": .object([
+                    "type": .string("string"),
+                    "enum": .array([.string("previous_period")]),
+                    "description": .string("Optional comparison window. Currently only 'previous_period'.")
                 ])
             ]),
             "required": .array([.string("after"), .string("before")])
@@ -51,9 +56,15 @@ public enum AnalyticsOrdersTool {
         let after: String
         let before: String
         let interval: String?
+        let compareTo: String?
+
+        enum CodingKeys: String, CodingKey {
+            case after, before, interval
+            case compareTo = "compare_to"
+        }
     }
 
-    static let allowedArguments: Set<String> = ["after", "before", "interval"]
+    static let allowedArguments: Set<String> = ["after", "before", "interval", "compare_to"]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
         if let failed = ToolArgumentValidation.validate(arguments: arguments,
@@ -66,33 +77,96 @@ public enum AnalyticsOrdersTool {
         case .success(let value): args = value
         case .failure(let failed): return .failed(failed)
         }
+        if let compareTo = args.compareTo, compareTo != "previous_period" {
+            return .failed(.init(toolName: name,
+                                 kind: .invalidToolCall,
+                                 reason: "compare_to must be previous_period"))
+        }
         guard let bounds = AnalyticsDateBounds.bounds(start: args.after, end: args.before) else {
             return .failed(.init(toolName: name,
                                  kind: .invalidToolCall,
                                  reason: "after and before must be YYYY-MM-DD"))
         }
-        let query: [String: String] = [
-            "after": bounds.after,
-            "before": bounds.before,
-            "interval": args.interval ?? "day",
-            "_fields": "totals,intervals"
-        ]
+        let interval = args.interval ?? "day"
+        let primary = await fetchPayload(client: client,
+                                         after: bounds.after,
+                                         before: bounds.before,
+                                         interval: interval)
+        guard case .success(let payload) = primary else {
+            if case .failure(let failed) = primary { return .failed(failed) }
+            return .failed(.init(toolName: name, kind: .toolFailed, reason: "unexpected analytics outcome"))
+        }
 
-        let response = await client.request(method: "GET",
-                                            path: "wc-analytics/reports/orders/stats",
-                                            query: query,
-                                            body: nil)
-        guard HTTPStatusClassification.isSuccess(response.statusCode) else {
-            return .failed(RESTToolDispatch.failed(from: response, toolName: name))
+        var comparison = AnalyticsStatsSummary.ComparisonInputs(interval: interval)
+        if args.compareTo == "previous_period" {
+            comparison = await comparisonInputs(args: args,
+                                                interval: interval,
+                                                client: client)
         }
-        guard let payload = RESTResponseParsing.decodeJSON(response.data) else {
-            return .failed(.init(toolName: name,
-                                 kind: .toolFailed,
-                                 reason: "expected JSON object"))
-        }
-        let summary = AnalyticsStatsSummary.make(from: payload, range: (args.after, args.before))
+
+        let summary = AnalyticsStatsSummary.make(from: payload,
+                                                 range: (args.after, args.before),
+                                                 comparison: comparison)
         return .success(.init(toolName: name,
                               structured: LLMPayloadCap.capped(summary, toolName: name),
                               uiStructured: nil))
+    }
+
+    private enum FetchOutcome {
+        case success(AnyCodableJSON)
+        case failure(ToolResult.Failed)
+    }
+
+    private static func fetchPayload(client: WCRESTClient,
+                                     after: String,
+                                     before: String,
+                                     interval: String) async -> FetchOutcome {
+        let response = await client.request(method: "GET",
+                                            path: "wc-analytics/reports/orders/stats",
+                                            query: [
+                                                "after": after,
+                                                "before": before,
+                                                "interval": interval,
+                                                "_fields": "totals,intervals"
+                                            ],
+                                            body: nil)
+        guard HTTPStatusClassification.isSuccess(response.statusCode) else {
+            return .failure(RESTToolDispatch.failed(from: response, toolName: name))
+        }
+        guard let payload = RESTResponseParsing.decodeJSON(response.data) else {
+            return .failure(.init(toolName: name, kind: .toolFailed, reason: "expected JSON object"))
+        }
+        return .success(payload)
+    }
+
+    private static func comparisonInputs(args: Args,
+                                         interval: String,
+                                         client: WCRESTClient) async -> AnalyticsStatsSummary.ComparisonInputs {
+        guard let previousRange = AnalyticsDateBounds.previousPeriodBounds(after: args.after,
+                                                                           before: args.before),
+              let previousBounds = AnalyticsDateBounds.bounds(start: previousRange.after,
+                                                              end: previousRange.before) else {
+            return AnalyticsStatsSummary.ComparisonInputs(
+                interval: interval,
+                previousPeriodPartial: true,
+                previousPeriodWarning: "Previous period totals could not be fetched."
+            )
+        }
+        let outcome = await fetchPayload(client: client,
+                                         after: previousBounds.after,
+                                         before: previousBounds.before,
+                                         interval: interval)
+        switch outcome {
+        case .success(let payload):
+            let totals = RESTResponseParsing.objectField(payload, "totals")
+            return AnalyticsStatsSummary.ComparisonInputs(interval: interval,
+                                                          previousPeriodTotals: totals)
+        case .failure:
+            return AnalyticsStatsSummary.ComparisonInputs(
+                interval: interval,
+                previousPeriodPartial: true,
+                previousPeriodWarning: "Previous period totals could not be fetched."
+            )
+        }
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
@@ -20,10 +20,14 @@ public enum AnalyticsRevenueTool {
         combines a grouping grain with a date window, interval follows the \
         grouping grain. For "this period vs last", "vs last week", "compare to \
         last month", and similar comparison phrasing, set `compare_to=previous_period` \
-        on the SAME call - the response then includes both `totals` for the \
-        requested window AND `previous_period_totals` for the prior window. \
-        Use those two blocks directly. Do NOT issue a second analytics_revenue \
-        call for the prior window; the data is already in the first response. \
+        on the SAME call. The response then carries two top-level objects: `totals` \
+        (current window) and `previous_period_totals` (prior window). To answer the \
+        comparison, read each metric you need (`net_revenue`, `total_sales`, \
+        `gross_sales`, `total_tax`, etc.) once from `totals` and once from \
+        `previous_period_totals`. The prior window's numbers live ONLY inside \
+        `previous_period_totals` - do not look anywhere else for them. Do NOT issue \
+        a second analytics_revenue call for the prior window; both windows are \
+        already in this response. \
         Revenue/sales stats are card-backed: after any successful call for a \
         revenue or sales stats question, do not stop with prose; call show_cards \
         with family analytics_stats and an id built from the same after/before/ \

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
@@ -59,7 +59,14 @@ public enum AnalyticsRevenueTool {
         let currency: String?
     }
 
+    static let allowedArguments: Set<String> = ["after", "before", "interval", "currency"]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
@@ -45,6 +45,11 @@ public enum AnalyticsRevenueTool {
                 "currency": .object([
                     "type": .string("string"),
                     "description": .string("Optional ISO currency override.")
+                ]),
+                "compare_to": .object([
+                    "type": .string("string"),
+                    "enum": .array([.string("previous_period")]),
+                    "description": .string("Optional comparison window. Currently only 'previous_period'.")
                 ])
             ]),
             "required": .array([.string("after"), .string("before")])
@@ -57,9 +62,17 @@ public enum AnalyticsRevenueTool {
         let before: String
         let interval: String?
         let currency: String?
+        let compareTo: String?
+
+        enum CodingKeys: String, CodingKey {
+            case after, before, interval, currency
+            case compareTo = "compare_to"
+        }
     }
 
-    static let allowedArguments: Set<String> = ["after", "before", "interval", "currency"]
+    static let allowedArguments: Set<String> = [
+        "after", "before", "interval", "currency", "compare_to"
+    ]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
         if let failed = ToolArgumentValidation.validate(arguments: arguments,
@@ -72,36 +85,109 @@ public enum AnalyticsRevenueTool {
         case .success(let value): args = value
         case .failure(let failed): return .failed(failed)
         }
+        if let compareTo = args.compareTo, compareTo != "previous_period" {
+            return .failed(.init(toolName: name,
+                                 kind: .invalidToolCall,
+                                 reason: "compare_to must be previous_period"))
+        }
         guard let bounds = AnalyticsDateBounds.bounds(start: args.after, end: args.before) else {
             return .failed(.init(toolName: name,
                                  kind: .invalidToolCall,
                                  reason: "after and before must be YYYY-MM-DD"))
         }
-        var query: [String: String] = [
-            "after": bounds.after,
-            "before": bounds.before,
-            "interval": args.interval ?? "day",
-            "_fields": "totals,intervals"
-        ]
-        if let currency = args.currency?.trimmingCharacters(in: .whitespacesAndNewlines), !currency.isEmpty {
-            query["currency"] = currency
+        let interval = args.interval ?? "day"
+        let trimmedCurrency = args.currency?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currencyForQuery = (trimmedCurrency?.isEmpty == false) ? trimmedCurrency : nil
+
+        let primary = await fetchPayload(client: client,
+                                         after: bounds.after,
+                                         before: bounds.before,
+                                         interval: interval,
+                                         currency: currencyForQuery)
+        guard case .success(let payload) = primary else {
+            if case .failure(let failed) = primary { return .failed(failed) }
+            return .failed(.init(toolName: name, kind: .toolFailed, reason: "unexpected analytics outcome"))
         }
 
+        var comparison = AnalyticsStatsSummary.ComparisonInputs(interval: interval, currency: currencyForQuery)
+        if args.compareTo == "previous_period" {
+            comparison = await comparisonInputs(args: args,
+                                                interval: interval,
+                                                currency: currencyForQuery,
+                                                client: client)
+        }
+
+        let summary = AnalyticsStatsSummary.make(from: payload,
+                                                 range: (args.after, args.before),
+                                                 comparison: comparison)
+        return .success(.init(toolName: name,
+                              structured: LLMPayloadCap.capped(summary, toolName: name),
+                              uiStructured: nil))
+    }
+
+    private enum FetchOutcome {
+        case success(AnyCodableJSON)
+        case failure(ToolResult.Failed)
+    }
+
+    private static func fetchPayload(client: WCRESTClient,
+                                     after: String,
+                                     before: String,
+                                     interval: String,
+                                     currency: String?) async -> FetchOutcome {
+        var query: [String: String] = [
+            "after": after,
+            "before": before,
+            "interval": interval,
+            "_fields": "totals,intervals"
+        ]
+        if let currency { query["currency"] = currency }
         let response = await client.request(method: "GET",
                                             path: "wc-analytics/reports/revenue/stats",
                                             query: query,
                                             body: nil)
         guard HTTPStatusClassification.isSuccess(response.statusCode) else {
-            return .failed(RESTToolDispatch.failed(from: response, toolName: name))
+            return .failure(RESTToolDispatch.failed(from: response, toolName: name))
         }
         guard let payload = RESTResponseParsing.decodeJSON(response.data) else {
-            return .failed(.init(toolName: name,
-                                 kind: .toolFailed,
-                                 reason: "expected JSON object"))
+            return .failure(.init(toolName: name, kind: .toolFailed, reason: "expected JSON object"))
         }
-        let summary = AnalyticsStatsSummary.make(from: payload, range: (args.after, args.before))
-        return .success(.init(toolName: name,
-                              structured: LLMPayloadCap.capped(summary, toolName: name),
-                              uiStructured: nil))
+        return .success(payload)
+    }
+
+    private static func comparisonInputs(args: Args,
+                                         interval: String,
+                                         currency: String?,
+                                         client: WCRESTClient) async -> AnalyticsStatsSummary.ComparisonInputs {
+        guard let previousRange = AnalyticsDateBounds.previousPeriodBounds(after: args.after,
+                                                                           before: args.before),
+              let previousBounds = AnalyticsDateBounds.bounds(start: previousRange.after,
+                                                              end: previousRange.before) else {
+            return AnalyticsStatsSummary.ComparisonInputs(
+                interval: interval,
+                currency: currency,
+                previousPeriodPartial: true,
+                previousPeriodWarning: "Previous period totals could not be fetched."
+            )
+        }
+        let outcome = await fetchPayload(client: client,
+                                         after: previousBounds.after,
+                                         before: previousBounds.before,
+                                         interval: interval,
+                                         currency: currency)
+        switch outcome {
+        case .success(let payload):
+            let totals = RESTResponseParsing.objectField(payload, "totals")
+            return AnalyticsStatsSummary.ComparisonInputs(interval: interval,
+                                                          currency: currency,
+                                                          previousPeriodTotals: totals)
+        case .failure:
+            return AnalyticsStatsSummary.ComparisonInputs(
+                interval: interval,
+                currency: currency,
+                previousPeriodPartial: true,
+                previousPeriodWarning: "Previous period totals could not be fetched."
+            )
+        }
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsRevenueTool.swift
@@ -18,11 +18,17 @@ public enum AnalyticsRevenueTool {
         `interval` parameter directly to the implied dimension rather than \
         asking the merchant which window or grain they meant. When a request \
         combines a grouping grain with a date window, interval follows the \
-        grouping grain. Revenue/sales stats are card-backed: after any \
-        successful call for a revenue or sales stats question, do not stop with \
-        prose; call show_cards with family analytics_stats and an id built from \
-        the same after/before/interval/currency values. If currency was omitted, \
-        use currency:none in the id.
+        grouping grain. For "this period vs last", "vs last week", "compare to \
+        last month", and similar comparison phrasing, set `compare_to=previous_period` \
+        on the SAME call - the response then includes both `totals` for the \
+        requested window AND `previous_period_totals` for the prior window. \
+        Use those two blocks directly. Do NOT issue a second analytics_revenue \
+        call for the prior window; the data is already in the first response. \
+        Revenue/sales stats are card-backed: after any successful call for a \
+        revenue or sales stats question, do not stop with prose; call show_cards \
+        with family analytics_stats and an id built from the same after/before/ \
+        interval/currency values. If currency was omitted, use currency:none in \
+        the id.
         """,
         parametersSchema: .object([
             "type": .string("object"),
@@ -49,7 +55,9 @@ public enum AnalyticsRevenueTool {
                 "compare_to": .object([
                     "type": .string("string"),
                     "enum": .array([.string("previous_period")]),
-                    "description": .string("Optional comparison window. Currently only 'previous_period'.")
+                    "description": .string("Set to 'previous_period' for any comparison phrasing (vs last week, " +
+                        "compared to last month, etc.). The response then carries both windows; do NOT issue a " +
+                        "second analytics call for the prior window.")
                 ])
             ]),
             "required": .array([.string("after"), .string("before")])

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsStatsSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsStatsSummary.swift
@@ -5,18 +5,53 @@ enum AnalyticsStatsSummary {
     /// `ANALYTICS_STATS_SUMMARY_KEYS`; per-bucket data stays in the rendered
     /// card payload only so a year-by-day query doesn't ship 365 buckets to
     /// the model.
-    static let modelVisibleKeys: [String] = ["after", "before", "totals"]
+    static let modelVisibleKeys: [String] = [
+        "after", "before", "interval", "currency", "totals",
+        "previous_period_totals", "previous_period_partial", "previous_period_warning"
+    ]
 
-    /// Builds the full summary used by the analytics tools' tool result and
-    /// by the card renderer. The `show_cards` resolver projects this down
-    /// to `modelVisibleKeys` before the model sees it via `resolved_refs`.
-    static func make(from payload: AnyCodableJSON, range: (after: String, before: String)) -> AnyCodableJSON {
+    struct ComparisonInputs {
+        let interval: String
+        let currency: String?
+        let previousPeriodTotals: AnyCodableJSON?
+        let previousPeriodPartial: Bool
+        let previousPeriodWarning: String?
+
+        init(interval: String,
+             currency: String? = nil,
+             previousPeriodTotals: AnyCodableJSON? = nil,
+             previousPeriodPartial: Bool = false,
+             previousPeriodWarning: String? = nil) {
+            self.interval = interval
+            self.currency = currency
+            self.previousPeriodTotals = previousPeriodTotals
+            self.previousPeriodPartial = previousPeriodPartial
+            self.previousPeriodWarning = previousPeriodWarning
+        }
+    }
+
+    static func make(from payload: AnyCodableJSON,
+                     range: (after: String, before: String),
+                     comparison: ComparisonInputs) -> AnyCodableJSON {
         var fields: [String: AnyCodableJSON] = [
             "after": .string(range.after),
-            "before": .string(range.before)
+            "before": .string(range.before),
+            "interval": .string(comparison.interval)
         ]
+        if let currency = comparison.currency {
+            fields["currency"] = .string(currency)
+        }
         if let totals = RESTResponseParsing.objectField(payload, "totals") {
             fields["totals"] = totals
+        }
+        if let previous = comparison.previousPeriodTotals {
+            fields["previous_period_totals"] = previous
+        }
+        if comparison.previousPeriodPartial {
+            fields["previous_period_partial"] = .bool(true)
+            if let warning = comparison.previousPeriodWarning {
+                fields["previous_period_warning"] = .string(warning)
+            }
         }
         if let intervals = RESTResponseParsing.arrayItems(RESTResponseParsing.objectField(payload, "intervals") ?? .null) {
             fields["interval_count"] = .int(Int64(intervals.count))

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Customers/CustomersListSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Customers/CustomersListSummary.swift
@@ -6,14 +6,18 @@ enum CustomersListSummary {
         for row in rows {
             guard let id = RESTResponseParsing.intField(row, "id") else { continue }
             var match: [String: AnyCodableJSON] = ["id": .int(id)]
-            if let first = RESTResponseParsing.stringField(row, "first_name") {
-                match["first_name"] = .string(first)
+            putString(row, key: "first_name", into: &match)
+            putString(row, key: "last_name", into: &match)
+            putString(row, key: "email", into: &match)
+            putString(row, key: "username", into: &match)
+            putString(row, key: "date_created", into: &match)
+            putString(row, key: "role", into: &match)
+            putString(row, key: "avatar_url", into: &match)
+            if let billing = compactBilling(row) {
+                match["billing"] = billing
             }
-            if let last = RESTResponseParsing.stringField(row, "last_name") {
-                match["last_name"] = .string(last)
-            }
-            if let email = RESTResponseParsing.stringField(row, "email") {
-                match["email"] = .string(email)
+            if let shipping = compactShipping(row) {
+                match["shipping"] = shipping
             }
             matches.append(.object(match))
         }
@@ -21,5 +25,35 @@ enum CustomersListSummary {
             "count": .int(Int64(rows.count)),
             "matches": .array(matches)
         ])
+    }
+
+    private static func putString(_ row: AnyCodableJSON,
+                                  key: String,
+                                  into match: inout [String: AnyCodableJSON]) {
+        if let value = RESTResponseParsing.stringField(row, key), !value.isEmpty {
+            match[key] = .string(value)
+        }
+    }
+
+    private static func compactBilling(_ row: AnyCodableJSON) -> AnyCodableJSON? {
+        guard let billing = RESTResponseParsing.objectField(row, "billing") else { return nil }
+        var out: [String: AnyCodableJSON] = [:]
+        for key in ["phone", "city", "country"] {
+            if let value = RESTResponseParsing.stringField(billing, key), !value.isEmpty {
+                out[key] = .string(value)
+            }
+        }
+        return out.isEmpty ? nil : .object(out)
+    }
+
+    private static func compactShipping(_ row: AnyCodableJSON) -> AnyCodableJSON? {
+        guard let shipping = RESTResponseParsing.objectField(row, "shipping") else { return nil }
+        var out: [String: AnyCodableJSON] = [:]
+        for key in ["city", "country"] {
+            if let value = RESTResponseParsing.stringField(shipping, key), !value.isEmpty {
+                out[key] = .string(value)
+            }
+        }
+        return out.isEmpty ? nil : .object(out)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Customers/CustomersListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Customers/CustomersListTool.swift
@@ -94,7 +94,16 @@ public enum CustomersListTool {
         return query
     }
 
+    private static let allowedArguments: Set<String> = [
+        "search", "email", "include", "orderby", "order", "page", "per_page"
+    ]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrderSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrderSummary.swift
@@ -1,13 +1,24 @@
 import Foundation
 
 enum OrderSummary {
+    static let detailLineItemLimit = 10
+    static let listLineItemLimit = 5
+    static let adjustmentLineLimit = 10
+    static let customerNoteLimit = 500
+
     static func make(from entity: AnyCodableJSON) -> AnyCodableJSON {
-        let projected = RESTResponseParsing.project(entity,
-                                                    keys: [
-                                                        "id", "number", "status", "total", "currency",
-                                                        "date_created", "payment_method_title"
-                                                    ])
+        orderRow(from: entity, lineItemLimit: detailLineItemLimit)
+    }
+
+    static func orderRow(from entity: AnyCodableJSON, lineItemLimit: Int) -> AnyCodableJSON {
+        let projected = RESTResponseParsing.project(entity, keys: [
+            "id", "number", "status", "total", "currency",
+            "date_created", "date_modified", "payment_method_title",
+            "customer_id", "date_paid", "total_tax",
+            "shipping_total", "discount_total"
+        ])
         guard case .object(var fields) = projected else { return projected }
+
         if let billing = RESTResponseParsing.objectField(entity, "billing") {
             if let name = customerName(from: billing) {
                 fields["customer_name"] = .string(name)
@@ -15,7 +26,44 @@ enum OrderSummary {
             if let email = RESTResponseParsing.stringField(billing, "email") {
                 fields["customer_email"] = .string(email)
             }
+            fields["billing"] = compactAddress(billing, includeEmail: true)
         }
+        if let shipping = RESTResponseParsing.objectField(entity, "shipping") {
+            fields["shipping"] = compactAddress(shipping, includeEmail: false)
+        }
+
+        if let note = RESTResponseParsing.stringField(entity, "customer_note") {
+            let capped = capCustomerNote(note)
+            fields["customer_note"] = .string(capped.value)
+            if capped.truncated {
+                fields["customer_note_truncated"] = .bool(true)
+            }
+        }
+
+        let allLineItems = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "line_items") ?? .null
+        ) ?? []
+        fields["line_items_count"] = .int(Int64(allLineItems.count))
+        if allLineItems.count > lineItemLimit {
+            fields["line_items_truncated"] = .bool(true)
+        }
+        fields["line_items"] = .array(allLineItems.prefix(lineItemLimit).map(compactLineItem))
+
+        let coupons = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "coupon_lines") ?? .null
+        ) ?? []
+        fields["coupon_lines"] = .array(coupons.prefix(adjustmentLineLimit).map(compactCouponLine))
+
+        let fees = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "fee_lines") ?? .null
+        ) ?? []
+        fields["fee_lines"] = .array(fees.prefix(adjustmentLineLimit).map(compactFeeLine))
+
+        let taxes = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "tax_lines") ?? .null
+        ) ?? []
+        fields["tax_lines"] = .array(taxes.prefix(adjustmentLineLimit).map(compactTaxLine))
+
         return .object(fields)
     }
 
@@ -24,5 +72,73 @@ enum OrderSummary {
         let last = RESTResponseParsing.stringField(billing, "last_name") ?? ""
         let combined = "\(first) \(last)".trimmingCharacters(in: .whitespaces)
         return combined.isEmpty ? nil : combined
+    }
+
+    private static func compactAddress(_ source: AnyCodableJSON, includeEmail: Bool) -> AnyCodableJSON {
+        var keys = ["first_name", "last_name", "phone", "city", "state", "postcode", "country"]
+        if includeEmail { keys.insert("email", at: 2) }
+        var out: [String: AnyCodableJSON] = [:]
+        for key in keys {
+            if let raw = RESTResponseParsing.stringField(source, key), !raw.isEmpty {
+                out[key] = .string(raw)
+            }
+        }
+        return .object(out)
+    }
+
+    private static func compactLineItem(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let name = RESTResponseParsing.stringField(item, "name") { out["name"] = .string(name) }
+        if let qty = RESTResponseParsing.intField(item, "quantity") { out["quantity"] = .int(qty) }
+        if let sku = RESTResponseParsing.stringField(item, "sku") { out["sku"] = .string(sku) }
+        if let total = RESTResponseParsing.stringField(item, "total") { out["total"] = .string(total) }
+        if let pid = RESTResponseParsing.intField(item, "product_id") { out["product_id"] = .int(pid) }
+        if let vid = RESTResponseParsing.intField(item, "variation_id") { out["variation_id"] = .int(vid) }
+        return .object(out)
+    }
+
+    private static func compactCouponLine(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let code = RESTResponseParsing.stringField(item, "code") { out["code"] = .string(code) }
+        if let discount = RESTResponseParsing.stringField(item, "discount") { out["discount"] = .string(discount) }
+        if let tax = RESTResponseParsing.stringField(item, "discount_tax") { out["discount_tax"] = .string(tax) }
+        return .object(out)
+    }
+
+    private static func compactFeeLine(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let name = RESTResponseParsing.stringField(item, "name") { out["name"] = .string(name) }
+        if let total = RESTResponseParsing.stringField(item, "total") { out["total"] = .string(total) }
+        if let totalTax = RESTResponseParsing.stringField(item, "total_tax") { out["total_tax"] = .string(totalTax) }
+        if let status = RESTResponseParsing.stringField(item, "tax_status") { out["tax_status"] = .string(status) }
+        return .object(out)
+    }
+
+    private static func compactTaxLine(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let rateID = RESTResponseParsing.intField(item, "rate_id") { out["rate_id"] = .int(rateID) }
+        if let code = RESTResponseParsing.stringField(item, "rate_code") { out["rate_code"] = .string(code) }
+        if let label = RESTResponseParsing.stringField(item, "label") { out["label"] = .string(label) }
+        if let total = RESTResponseParsing.stringField(item, "tax_total") { out["tax_total"] = .string(total) }
+        if let shipping = RESTResponseParsing.stringField(item, "shipping_tax_total") {
+            out["shipping_tax_total"] = .string(shipping)
+        }
+        return .object(out)
+    }
+
+    private struct CappedText {
+        let value: String
+        let truncated: Bool
+    }
+
+    private static func capCustomerNote(_ value: String) -> CappedText {
+        if value.count > customerNoteLimit {
+            return CappedText(value: String(value.prefix(customerNoteLimit)), truncated: true)
+        }
+        return CappedText(value: value, truncated: false)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrderWriteArgumentValidation.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrderWriteArgumentValidation.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// Mirrors Android's OrderWriteArgumentValidation - same constants, same email regex, same error wording.
+enum OrderWriteArgumentValidation {
+    static let customerNoteMaxLength = 1000
+    static let billingEmailMaxLength = 254
+
+    static func validate(customerNote: String?, billingEmail: String?) -> String? {
+        if let note = customerNote, note.count > customerNoteMaxLength {
+            return "customer_note must be at most \(customerNoteMaxLength) characters."
+        }
+        if let email = billingEmail {
+            if email.count > billingEmailMaxLength {
+                return "billing_email must be at most \(billingEmailMaxLength) characters."
+            }
+            if email.range(of: emailPattern, options: .regularExpression) == nil {
+                return "billing_email must be a valid email address."
+            }
+        }
+        return nil
+    }
+
+    private static let emailPattern =
+        "^[a-zA-Z0-9+._%-]{1,256}@" +
+        "[a-zA-Z0-9][a-zA-Z0-9-]{0,64}" +
+        "(\\.[a-zA-Z0-9][a-zA-Z0-9-]{0,25})+$"
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
@@ -75,8 +75,18 @@ public enum OrdersBulkUpdateTool {
     }
 
     private static let allowedStatuses = AllowedOrderUpdateStatuses.values
+    static let allowedArguments: Set<String> = ["ids", "patch"]
+    static let allowedPatchKeys: Set<String> = ["status", "customer_note", "billing_email"]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
+        if let failed = patchKeyRejection(arguments: arguments) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value
@@ -132,5 +142,18 @@ public enum OrdersBulkUpdateTool {
                                                          body: payload,
                                                          client: client,
                                                          toolName: name)
+    }
+
+    private static func patchKeyRejection(arguments: String) -> ToolResult.Failed? {
+        guard let data = arguments.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let patch = parsed["patch"] as? [String: Any] else {
+            return nil
+        }
+        let unknown = patch.keys.filter { !allowedPatchKeys.contains($0) }.sorted()
+        guard !unknown.isEmpty else { return nil }
+        return .init(toolName: name,
+                     kind: .invalidToolCall,
+                     reason: "Unsupported \(name) argument(s): \(unknown.joined(separator: ", "))")
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
@@ -137,11 +137,22 @@ public enum OrdersBulkUpdateTool {
                                  kind: .toolFailed,
                                  reason: "could not serialize batch body"))
         }
+        let patchKeys = patchKeysInOrder(args.patch)
         return await RESTToolDispatch.dispatchBatchWrite(method: "POST",
                                                          path: "wc/v3/orders/batch",
                                                          body: payload,
                                                          client: client,
-                                                         toolName: name)
+                                                         toolName: name,
+                                                         requestedCount: args.ids.count,
+                                                         patchKeys: patchKeys)
+    }
+
+    private static func patchKeysInOrder(_ patch: Patch) -> [String] {
+        var keys: [String] = []
+        if patch.status != nil { keys.append("status") }
+        if patch.customerNote != nil { keys.append("customer_note") }
+        if patch.billingEmail != nil { keys.append("billing_email") }
+        return keys
     }
 
     private static func patchKeyRejection(arguments: String) -> ToolResult.Failed? {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersBulkUpdateTool.swift
@@ -42,8 +42,15 @@ public enum OrdersBulkUpdateTool {
                             "type": .string("string"),
                             "enum": .array(allowedStatuses.sorted().map { .string($0) })
                         ]),
-                        "customer_note": .object(["type": .string("string")]),
-                        "billing_email": .object(["type": .string("string")])
+                        "customer_note": .object([
+                            "type": .string("string"),
+                            "maxLength": .int(Int64(OrderWriteArgumentValidation.customerNoteMaxLength))
+                        ]),
+                        "billing_email": .object([
+                            "type": .string("string"),
+                            "maxLength": .int(Int64(OrderWriteArgumentValidation.billingEmailMaxLength)),
+                            "format": .string("email")
+                        ])
                     ]),
                     "description": .string("Patch applied to every id. At least one field required.")
                 ])
@@ -111,6 +118,10 @@ public enum OrdersBulkUpdateTool {
             return .failed(.init(toolName: name,
                                  kind: .invalidToolCall,
                                  reason: "status must be one of: \(allowedStatuses.sorted().joined(separator: ", "))"))
+        }
+        if let reason = OrderWriteArgumentValidation.validate(customerNote: args.patch.customerNote,
+                                                              billingEmail: args.patch.billingEmail) {
+            return .failed(.init(toolName: name, kind: .invalidToolCall, reason: reason))
         }
         guard args.patch.hasAnyField else {
             return .failed(.init(toolName: name,

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersGetTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersGetTool.swift
@@ -38,7 +38,14 @@ public enum OrdersGetTool {
         let id: Int
     }
 
+    private static let allowedArguments: Set<String> = ["id"]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListSummary.swift
@@ -6,6 +6,7 @@ enum OrdersListSummary {
         var statusCounts: [String: Int] = [:]
         var totals: [Decimal] = []
         var currency: String?
+        var orders: [AnyCodableJSON] = []
 
         for row in rows {
             if let id = RESTResponseParsing.intField(row, "id") {
@@ -20,11 +21,13 @@ enum OrdersListSummary {
             if currency == nil, let value = RESTResponseParsing.stringField(row, "currency") {
                 currency = value
             }
+            orders.append(OrderSummary.orderRow(from: row, lineItemLimit: OrderSummary.listLineItemLimit))
         }
 
         var fields: [String: AnyCodableJSON] = [
             "count": .int(Int64(rows.count)),
             "ids": .array(ids),
+            "orders": .array(orders),
             "status_counts": .object(statusCounts.mapValues { .int(Int64($0)) })
         ]
         if let totalRange = RESTResponseParsing.decimalRange(totals, currency: currency) {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListTool.swift
@@ -117,7 +117,17 @@ public enum OrdersListTool {
         return query
     }
 
+    private static let allowedArguments: Set<String> = [
+        "status", "search", "customer", "include", "after", "before",
+        "orderby", "order", "page", "per_page"
+    ]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersUpdateTool.swift
@@ -63,8 +63,14 @@ public enum OrdersUpdateTool {
     }
 
     private static let allowedStatuses = AllowedOrderUpdateStatuses.values
+    private static let allowedArguments: Set<String> = ["id", "status", "customer_note", "billing_email"]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersUpdateTool.swift
@@ -36,10 +36,13 @@ public enum OrdersUpdateTool {
                 ]),
                 "customer_note": .object([
                     "type": .string("string"),
+                    "maxLength": .int(Int64(OrderWriteArgumentValidation.customerNoteMaxLength)),
                     "description": .string("Internal note shown to the customer in their account.")
                 ]),
                 "billing_email": .object([
                     "type": .string("string"),
+                    "maxLength": .int(Int64(OrderWriteArgumentValidation.billingEmailMaxLength)),
+                    "format": .string("email"),
                     "description": .string("Replacement billing email (mapped to billing.email).")
                 ])
             ]),
@@ -85,6 +88,10 @@ public enum OrdersUpdateTool {
             return .failed(.init(toolName: name,
                                  kind: .invalidToolCall,
                                  reason: "status must be one of: \(allowedStatuses.sorted().joined(separator: ", "))"))
+        }
+        if let reason = OrderWriteArgumentValidation.validate(customerNote: args.customerNote,
+                                                              billingEmail: args.billingEmail) {
+            return .failed(.init(toolName: name, kind: .invalidToolCall, reason: reason))
         }
         var body: [String: Any] = [:]
         if let status = args.status { body["status"] = status }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductResponseLimits.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductResponseLimits.swift
@@ -1,0 +1,7 @@
+enum ProductResponseLimits {
+    static let categoriesLimit = 5
+    static let variationIdsLimit = 20
+    static let attributesLimit = 10
+    static let imagesLimit = 3
+    static let textFieldLimit = 500
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductSummary.swift
@@ -1,15 +1,193 @@
 import Foundation
 
 enum ProductSummary {
+    enum ImageProjection {
+        case array
+        case singleImage
+    }
+
     static func make(from entity: AnyCodableJSON) -> AnyCodableJSON {
+        project(entity, imageProjection: .array)
+    }
+
+    static func listRow(from entity: AnyCodableJSON) -> AnyCodableJSON {
+        project(entity, imageProjection: .singleImage)
+    }
+
+    private static func project(_ entity: AnyCodableJSON, imageProjection: ImageProjection) -> AnyCodableJSON {
         let projected = RESTResponseParsing.project(entity, keys: [
             "id", "name", "sku", "price", "stock_status", "type", "status",
-            "stock_quantity", "regular_price", "sale_price", "images"
+            "stock_quantity", "regular_price", "sale_price",
+            "on_sale", "manage_stock", "date_created", "date_modified",
+            "total_sales", "parent_id", "permalink",
+            "shipping_class", "weight"
         ])
         guard case .object(var fields) = projected else { return projected }
-        if case .array(let items) = fields["images"] {
-            fields["images"] = .array(Array(items.prefix(1)))
+
+        let categories = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "categories") ?? .null
+        ) ?? []
+        fields["categories"] = .array(categories.prefix(ProductResponseLimits.categoriesLimit).map(compactTerm))
+        fields["categories_count"] = .int(Int64(categories.count))
+        if categories.count > ProductResponseLimits.categoriesLimit {
+            fields["categories_truncated"] = .bool(true)
         }
+
+        let tags = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "tags") ?? .null
+        ) ?? []
+        if !tags.isEmpty {
+            fields["tags"] = .array(tags.map(compactTerm))
+        }
+
+        let attributes = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "attributes") ?? .null
+        ) ?? []
+        fields["attributes"] = .array(attributes.prefix(ProductResponseLimits.attributesLimit).map(compactAttribute))
+        if attributes.count > ProductResponseLimits.attributesLimit {
+            fields["attributes_truncated"] = .bool(true)
+        }
+
+        let variations = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "variations") ?? .null
+        ) ?? []
+        fields["variations_count"] = .int(Int64(variations.count))
+        let variationIDs = variations.compactMap { item -> Int64? in
+            switch item {
+            case .int(let value): return value
+            case .double(let value): return Int64(value)
+            default: return nil
+            }
+        }
+        fields["variation_ids"] = .array(variationIDs.prefix(ProductResponseLimits.variationIdsLimit).map { .int($0) })
+        if variationIDs.count > ProductResponseLimits.variationIdsLimit {
+            fields["variation_ids_truncated"] = .bool(true)
+        }
+
+        let images = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "images") ?? .null
+        ) ?? []
+        switch imageProjection {
+        case .array:
+            fields["images"] = .array(images.prefix(ProductResponseLimits.imagesLimit).map(compactImage))
+            if images.count > ProductResponseLimits.imagesLimit {
+                fields["images_truncated"] = .bool(true)
+            }
+        case .singleImage:
+            if let first = images.first {
+                fields["image"] = compactImage(first)
+            }
+        }
+
+        if let description = RESTResponseParsing.stringField(entity, "description") {
+            let capped = capText(description)
+            fields["description"] = .string(capped.value)
+            if capped.truncated {
+                fields["description_truncated"] = .bool(true)
+            }
+        }
+        if let short = RESTResponseParsing.stringField(entity, "short_description") {
+            let capped = capText(short)
+            fields["short_description"] = .string(capped.value)
+            if capped.truncated {
+                fields["short_description_truncated"] = .bool(true)
+            }
+        }
+
+        if let dimensions = RESTResponseParsing.objectField(entity, "dimensions") {
+            fields["dimensions"] = compactDimensions(dimensions)
+        }
+
+        if let crossSell = idArray(from: entity, key: "cross_sell_ids") {
+            fields["cross_sell_ids"] = crossSell
+        }
+        if let upsell = idArray(from: entity, key: "upsell_ids") {
+            fields["upsell_ids"] = upsell
+        }
+        if let related = idArray(from: entity, key: "related_ids") {
+            fields["related_ids"] = related
+        }
+
         return .object(fields)
+    }
+
+    private static func compactTerm(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let name = RESTResponseParsing.stringField(item, "name") { out["name"] = .string(name) }
+        if let slug = RESTResponseParsing.stringField(item, "slug") { out["slug"] = .string(slug) }
+        return .object(out)
+    }
+
+    private static func compactAttribute(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let name = RESTResponseParsing.stringField(item, "name") { out["name"] = .string(name) }
+        if case .object(let dict) = item {
+            if case .bool(let visible) = dict["visible"] {
+                out["visible"] = .bool(visible)
+            }
+            if case .bool(let variation) = dict["variation"] {
+                out["variation"] = .bool(variation)
+            }
+            if case .array(let options) = dict["options"] {
+                out["options"] = .array(options.compactMap { value in
+                    if case .string = value { return value }
+                    return nil
+                })
+            }
+        }
+        return .object(out)
+    }
+
+    private static func compactImage(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let src = RESTResponseParsing.stringField(item, "src"), !src.isEmpty {
+            out["src"] = .string(src)
+        }
+        if let alt = RESTResponseParsing.stringField(item, "alt"), !alt.isEmpty {
+            out["alt"] = .string(alt)
+        }
+        if let name = RESTResponseParsing.stringField(item, "name"), !name.isEmpty {
+            out["name"] = .string(name)
+        }
+        return .object(out)
+    }
+
+    private static func compactDimensions(_ source: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        for key in ["length", "width", "height"] {
+            if let value = RESTResponseParsing.stringField(source, key), !value.isEmpty {
+                out[key] = .string(value)
+            }
+        }
+        return .object(out)
+    }
+
+    private static func idArray(from entity: AnyCodableJSON, key: String) -> AnyCodableJSON? {
+        guard case .array(let raw) = RESTResponseParsing.objectField(entity, key) ?? .null else {
+            return nil
+        }
+        let ids = raw.compactMap { item -> Int64? in
+            switch item {
+            case .int(let value): return value
+            case .double(let value): return Int64(value)
+            default: return nil
+            }
+        }
+        return .array(ids.map { .int($0) })
+    }
+
+    struct CappedText {
+        let value: String
+        let truncated: Bool
+    }
+
+    static func capText(_ value: String) -> CappedText {
+        if value.count > ProductResponseLimits.textFieldLimit {
+            return CappedText(value: String(value.prefix(ProductResponseLimits.textFieldLimit)), truncated: true)
+        }
+        return CappedText(value: value, truncated: false)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationDetailSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationDetailSummary.swift
@@ -10,8 +10,7 @@ enum ProductVariationDetailSummary {
         ])
         guard case .object(var fields) = projected else { return projected }
 
-        // WC variation REST stores parent under parent_id; CardFamily injects
-        // it for the show_cards path so consumers can rely on parent_id.
+        // WC exposes the parent only as parent_id; mirror it into product_id so callers reading either field land on the same value.
         if fields["parent_id"] != nil {
             fields["product_id"] = fields["parent_id"]
         }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationDetailSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationDetailSummary.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+enum ProductVariationDetailSummary {
+    static func make(from entity: AnyCodableJSON) -> AnyCodableJSON {
+        let projected = RESTResponseParsing.project(entity, keys: [
+            "id", "status", "sku", "price", "regular_price", "sale_price",
+            "on_sale", "manage_stock", "stock_quantity", "stock_status",
+            "weight", "tax_class", "date_created", "date_modified",
+            "menu_order", "backorders", "permalink", "parent_id"
+        ])
+        guard case .object(var fields) = projected else { return projected }
+
+        // WC variation REST stores parent under parent_id; CardFamily injects
+        // it for the show_cards path so consumers can rely on parent_id.
+        if fields["parent_id"] != nil {
+            fields["product_id"] = fields["parent_id"]
+        }
+
+        let attributes = RESTResponseParsing.arrayItems(
+            RESTResponseParsing.objectField(entity, "attributes") ?? .null
+        ) ?? []
+        fields["attributes"] = .array(attributes.map(compactAttribute))
+
+        if let image = RESTResponseParsing.objectField(entity, "image") {
+            fields["image"] = compactImage(image)
+        }
+
+        if let description = RESTResponseParsing.stringField(entity, "description") {
+            let capped = ProductSummary.capText(description)
+            fields["description"] = .string(capped.value)
+            if capped.truncated {
+                fields["description_truncated"] = .bool(true)
+            }
+        }
+
+        if let dimensions = RESTResponseParsing.objectField(entity, "dimensions") {
+            fields["dimensions"] = compactDimensions(dimensions)
+        }
+
+        return .object(fields)
+    }
+
+    private static func compactAttribute(_ item: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(item, "id") { out["id"] = .int(id) }
+        if let name = RESTResponseParsing.stringField(item, "name") { out["name"] = .string(name) }
+        if let option = RESTResponseParsing.stringField(item, "option") { out["option"] = .string(option) }
+        return .object(out)
+    }
+
+    private static func compactImage(_ source: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        if let id = RESTResponseParsing.intField(source, "id") { out["id"] = .int(id) }
+        if let src = RESTResponseParsing.stringField(source, "src"), !src.isEmpty {
+            out["src"] = .string(src)
+        }
+        if let alt = RESTResponseParsing.stringField(source, "alt"), !alt.isEmpty {
+            out["alt"] = .string(alt)
+        }
+        if let name = RESTResponseParsing.stringField(source, "name"), !name.isEmpty {
+            out["name"] = .string(name)
+        }
+        return .object(out)
+    }
+
+    private static func compactDimensions(_ source: AnyCodableJSON) -> AnyCodableJSON {
+        var out: [String: AnyCodableJSON] = [:]
+        for key in ["length", "width", "height"] {
+            if let value = RESTResponseParsing.stringField(source, key), !value.isEmpty {
+                out[key] = .string(value)
+            }
+        }
+        return .object(out)
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsBulkUpdateTool.swift
@@ -105,8 +105,21 @@ public enum ProductVariationsBulkUpdateTool {
 
     private static let allowedStatuses = AllowedProductUpdateStatuses.values
     private static let allowedStockStatuses: Set<String> = ["instock", "outofstock", "onbackorder"]
+    static let allowedArguments: Set<String> = ["product_id", "variations"]
+    static let allowedVariationKeys: Set<String> = [
+        "id", "regular_price", "sale_price", "stock_quantity",
+        "stock_status", "sku", "status"
+    ]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
+        if let failed = variationKeyRejection(arguments: arguments) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value
@@ -167,5 +180,24 @@ public enum ProductVariationsBulkUpdateTool {
                                                          body: payload,
                                                          client: client,
                                                          toolName: name)
+    }
+
+    private static func variationKeyRejection(arguments: String) -> ToolResult.Failed? {
+        guard let data = arguments.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let entries = parsed["variations"] as? [[String: Any]] else {
+            return nil
+        }
+        var unknown: Set<String> = []
+        for entry in entries {
+            for key in entry.keys where !allowedVariationKeys.contains(key) {
+                unknown.insert(key)
+            }
+        }
+        guard !unknown.isEmpty else { return nil }
+        let list = unknown.sorted().joined(separator: ", ")
+        return .init(toolName: name,
+                     kind: .invalidToolCall,
+                     reason: "Unsupported \(name) argument(s): \(list)")
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsBulkUpdateTool.swift
@@ -175,11 +175,32 @@ public enum ProductVariationsBulkUpdateTool {
                                  kind: .toolFailed,
                                  reason: "could not serialize batch body"))
         }
+        let patchKeys = patchKeysInOrder(args.variations)
         return await RESTToolDispatch.dispatchBatchWrite(method: "POST",
                                                          path: "wc/v3/products/\(args.productID)/variations/batch",
                                                          body: payload,
                                                          client: client,
-                                                         toolName: name)
+                                                         toolName: name,
+                                                         requestedCount: args.variations.count,
+                                                         patchKeys: patchKeys)
+    }
+
+    private static func patchKeysInOrder(_ variations: [Variation]) -> [String] {
+        var seen: Set<String> = []
+        var keys: [String] = []
+        let canonical = ["regular_price", "sale_price", "stock_quantity", "stock_status", "sku", "status"]
+        for variation in variations {
+            if variation.regularPrice != nil { seen.insert("regular_price") }
+            if variation.salePrice != nil { seen.insert("sale_price") }
+            if variation.stockQuantity != nil { seen.insert("stock_quantity") }
+            if variation.stockStatus != nil { seen.insert("stock_status") }
+            if variation.sku != nil { seen.insert("sku") }
+            if variation.status != nil { seen.insert("status") }
+        }
+        for key in canonical where seen.contains(key) {
+            keys.append(key)
+        }
+        return keys
     }
 
     private static func variationKeyRejection(arguments: String) -> ToolResult.Failed? {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsListSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsListSummary.swift
@@ -3,7 +3,7 @@ import Foundation
 enum ProductVariationsListSummary {
     static func make(productID: Int64, from rows: [AnyCodableJSON]) -> AnyCodableJSON {
         var ids: [AnyCodableJSON] = []
-        var perRow: [AnyCodableJSON] = []
+        var variations: [AnyCodableJSON] = []
         var stockStatusCounts: [String: Int] = [:]
         var prices: [Decimal] = []
 
@@ -17,14 +17,14 @@ enum ProductVariationsListSummary {
             if let price = RESTResponseParsing.decimalField(row, "price") {
                 prices.append(price)
             }
-            perRow.append(ProductSummary.make(from: row))
+            variations.append(ProductVariationDetailSummary.make(from: row))
         }
 
         var fields: [String: AnyCodableJSON] = [
             "product_id": .int(productID),
             "count": .int(Int64(rows.count)),
             "ids": .array(ids),
-            "rows": .array(perRow),
+            "variations": .array(variations),
             "stock_status_counts": .object(stockStatusCounts.mapValues { .int(Int64($0)) })
         ]
         if let priceRange = RESTResponseParsing.decimalRange(prices) {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsListTool.swift
@@ -51,7 +51,14 @@ public enum ProductVariationsListTool {
         }
     }
 
+    private static let allowedArguments: Set<String> = ["product_id", "page", "per_page"]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsUpdateTool.swift
@@ -130,6 +130,6 @@ public enum ProductVariationsUpdateTool {
                                                           client: client,
                                                           toolName: name,
                                                           family: .productVariation,
-                                                          summarize: ProductSummary.make)
+                                                          summarize: ProductVariationDetailSummary.make)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductVariationsUpdateTool.swift
@@ -76,8 +76,17 @@ public enum ProductVariationsUpdateTool {
 
     private static let allowedStatuses = AllowedProductUpdateStatuses.values
     private static let allowedStockStatuses: Set<String> = ["instock", "outofstock", "onbackorder"]
+    private static let allowedArguments: Set<String> = [
+        "product_id", "id", "regular_price", "sale_price",
+        "stock_quantity", "stock_status", "sku", "status"
+    ]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsBulkUpdateTool.swift
@@ -80,8 +80,18 @@ public enum ProductsBulkUpdateTool {
     }
 
     private static let allowedStatuses = AllowedProductUpdateStatuses.values
+    static let allowedArguments: Set<String> = ["ids", "patch"]
+    static let allowedPatchKeys: Set<String> = ["name", "regular_price", "sale_price", "stock_quantity", "status"]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
+        if let failed = patchKeyRejection(arguments: arguments) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value
@@ -133,5 +143,18 @@ public enum ProductsBulkUpdateTool {
                                                          body: payload,
                                                          client: client,
                                                          toolName: name)
+    }
+
+    private static func patchKeyRejection(arguments: String) -> ToolResult.Failed? {
+        guard let data = arguments.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let patch = parsed["patch"] as? [String: Any] else {
+            return nil
+        }
+        let unknown = patch.keys.filter { !allowedPatchKeys.contains($0) }.sorted()
+        guard !unknown.isEmpty else { return nil }
+        return .init(toolName: name,
+                     kind: .invalidToolCall,
+                     reason: "Unsupported \(name) argument(s): \(unknown.joined(separator: ", "))")
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsBulkUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsBulkUpdateTool.swift
@@ -138,11 +138,24 @@ public enum ProductsBulkUpdateTool {
                                  kind: .toolFailed,
                                  reason: "could not serialize batch body"))
         }
+        let patchKeys = patchKeysInOrder(args.patch)
         return await RESTToolDispatch.dispatchBatchWrite(method: "POST",
                                                          path: "wc/v3/products/batch",
                                                          body: payload,
                                                          client: client,
-                                                         toolName: name)
+                                                         toolName: name,
+                                                         requestedCount: args.ids.count,
+                                                         patchKeys: patchKeys)
+    }
+
+    private static func patchKeysInOrder(_ patch: Patch) -> [String] {
+        var keys: [String] = []
+        if patch.name != nil { keys.append("name") }
+        if patch.regularPrice != nil { keys.append("regular_price") }
+        if patch.salePrice != nil { keys.append("sale_price") }
+        if patch.stockQuantity != nil { keys.append("stock_quantity") }
+        if patch.status != nil { keys.append("status") }
+        return keys
     }
 
     private static func patchKeyRejection(arguments: String) -> ToolResult.Failed? {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsGetTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsGetTool.swift
@@ -39,7 +39,14 @@ public enum ProductsGetTool {
         let id: Int
     }
 
+    private static let allowedArguments: Set<String> = ["id"]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListSummary.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 enum ProductsListSummary {
-    static func make(from rows: [AnyCodableJSON]) -> AnyCodableJSON {
+    static func make(from rows: [AnyCodableJSON], canLoadMore: Bool) -> AnyCodableJSON {
         var ids: [AnyCodableJSON] = []
         var stockStatusCounts: [String: Int] = [:]
         var prices: [Decimal] = []
+        var products: [AnyCodableJSON] = []
 
         for row in rows {
             if let id = RESTResponseParsing.intField(row, "id") {
@@ -16,11 +17,14 @@ enum ProductsListSummary {
             if let price = RESTResponseParsing.decimalField(row, "price") {
                 prices.append(price)
             }
+            products.append(ProductSummary.listRow(from: row))
         }
 
         var fields: [String: AnyCodableJSON] = [
             "count": .int(Int64(rows.count)),
             "ids": .array(ids),
+            "products": .array(products),
+            "can_load_more": .bool(canLoadMore),
             "stock_status_counts": .object(stockStatusCounts.mapValues { .int(Int64($0)) })
         ]
         if let priceRange = RESTResponseParsing.decimalRange(prices) {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -151,6 +151,7 @@ public enum ProductsListTool {
         case .success(let value): args = value
         case .failure(let failed): return .failed(failed)
         }
+        let perPage = RESTToolDispatch.clampedPerPage(args.perPage)
         let response = await client.request(method: "GET",
                                             path: "wc/v3/products",
                                             query: query(from: args),
@@ -164,9 +165,18 @@ public enum ProductsListTool {
                                  kind: .toolFailed,
                                  reason: "expected JSON array"))
         }
-        let summary = ProductsListSummary.make(from: rows)
+        let canLoadMore = canLoadMore(rowsCount: rows.count, perPage: perPage, args: args)
+        let summary = ProductsListSummary.make(from: rows, canLoadMore: canLoadMore)
         return .success(.init(toolName: name,
                               structured: LLMPayloadCap.capped(summary, toolName: name),
                               uiStructured: nil))
+    }
+
+    private static func canLoadMore(rowsCount: Int, perPage: Int, args: Args) -> Bool {
+        if let include = args.include, !include.isEmpty {
+            let page = max(1, args.page ?? 1)
+            return include.count > page * perPage
+        }
+        return rowsCount >= perPage
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum ProductsListTool {
 
     public static let name = "products_list"
+    public static let maxIncludeIDs = 100
 
     public static func make() -> RESTTool {
         RESTTool(definition: definition, executor: execute)
@@ -11,7 +12,7 @@ public enum ProductsListTool {
     private static let definition = AITool(
         name: name,
         description: """
-        List products, optionally filtered by status, category, tag, sku, \
+        List products, optionally filtered by status, category, sku, \
         or keyword search. Terse merchant phrases such as "get scarf", \
         "show scarf", "find scarf", or "product scarf" are product searches: \
         use search with the product noun or phrase. For top / best-selling \
@@ -47,10 +48,6 @@ public enum ProductsListTool {
                     "type": .string("integer"),
                     "description": .string("Category ID filter.")
                 ]),
-                "tag": .object([
-                    "type": .string("integer"),
-                    "description": .string("Tag ID filter.")
-                ]),
                 "sku": .object([
                     "type": .string("string"),
                     "description": .string("Exact SKU lookup.")
@@ -58,7 +55,7 @@ public enum ProductsListTool {
                 "include": .object([
                     "type": .string("array"),
                     "items": .object(["type": .string("integer")]),
-                    "description": .string("Specific product IDs to include.")
+                    "description": .string("Specific product IDs to include. Max \(maxIncludeIDs).")
                 ]),
                 "stock_status": .object([
                     "type": .string("string"),
@@ -67,8 +64,7 @@ public enum ProductsListTool {
                 ]),
                 "orderby": .object([
                     "type": .string("string"),
-                    "enum": .array([.string("date"), .string("id"), .string("title"),
-                                    .string("price"), .string("popularity"), .string("rating")]),
+                    "enum": .array([.string("date"), .string("title"), .string("popularity")]),
                     "description": .string("Sort key; default 'date'. Use 'popularity' for top / best-selling products.")
                 ]),
                 "order": .object([
@@ -93,7 +89,6 @@ public enum ProductsListTool {
         let search: String?
         let status: String?
         let category: Int?
-        let tag: Int?
         let sku: String?
         let include: [Int]?
         let stockStatus: String?
@@ -103,24 +98,30 @@ public enum ProductsListTool {
         let perPage: Int?
 
         enum CodingKeys: String, CodingKey {
-            case search, status, category, tag, sku, include, orderby, order, page
+            case search, status, category, sku, include, orderby, order, page
             case stockStatus = "stock_status"
             case perPage = "per_page"
         }
     }
 
+    private static let allowedOrderby: Set<String> = ["date", "title", "popularity"]
+    private static let allowedOrder: Set<String> = ["asc", "desc"]
+
     private static func query(from args: Args) -> [String: String] {
         var query: [String: String] = [
-            "orderby": args.orderby ?? "date",
-            "order": args.order ?? "desc",
             "per_page": String(RESTToolDispatch.clampedPerPage(args.perPage))
         ]
+        if args.include?.isEmpty == false {
+            query["orderby"] = "include"
+        } else {
+            query["orderby"] = args.orderby ?? "date"
+            query["order"] = args.order ?? "desc"
+        }
         if let status = args.status, status != "any" { query["status"] = status }
         if let search = args.search?.trimmingCharacters(in: .whitespacesAndNewlines), !search.isEmpty {
             query["search"] = search
         }
         if let category = args.category { query["category"] = String(category) }
-        if let tag = args.tag { query["tag"] = String(tag) }
         if let sku = args.sku?.trimmingCharacters(in: .whitespacesAndNewlines), !sku.isEmpty {
             query["sku"] = sku
         }
@@ -136,7 +137,7 @@ public enum ProductsListTool {
     }
 
     static let allowedArguments: Set<String> = [
-        "search", "status", "category", "tag", "sku", "include", "stock_status",
+        "search", "status", "category", "sku", "include", "stock_status",
         "orderby", "order", "page", "per_page"
     ]
 
@@ -150,6 +151,9 @@ public enum ProductsListTool {
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value
         case .failure(let failed): return .failed(failed)
+        }
+        if let failed = validateCombinations(args) {
+            return .failed(failed)
         }
         let perPage = RESTToolDispatch.clampedPerPage(args.perPage)
         let response = await client.request(method: "GET",
@@ -170,6 +174,35 @@ public enum ProductsListTool {
         return .success(.init(toolName: name,
                               structured: LLMPayloadCap.capped(summary, toolName: name),
                               uiStructured: nil))
+    }
+
+    private static func validateCombinations(_ args: Args) -> ToolResult.Failed? {
+        if let include = args.include {
+            if include.isEmpty {
+                return failure("include must contain at least one product ID.")
+            }
+            if include.count > maxIncludeIDs {
+                return failure("include can contain at most \(maxIncludeIDs) product IDs.")
+            }
+            let conflicts = (args.search != nil) || (args.sku != nil) || (args.orderby != nil) || (args.order != nil)
+            if conflicts {
+                return failure("include cannot be combined with search, sku, orderby, or order.")
+            }
+        }
+        if (args.orderby != nil || args.order != nil) && (args.search != nil || args.sku != nil) {
+            return failure("orderby and order cannot be combined with search or sku.")
+        }
+        if let orderby = args.orderby, !allowedOrderby.contains(orderby) {
+            return failure("'\(orderby)' is not an allowed orderby.")
+        }
+        if let order = args.order, !allowedOrder.contains(order) {
+            return failure("'\(order)' is not an allowed order.")
+        }
+        return nil
+    }
+
+    private static func failure(_ reason: String) -> ToolResult.Failed {
+        .init(toolName: name, kind: .invalidToolCall, reason: reason)
     }
 
     private static func canLoadMore(rowsCount: Int, perPage: Int, args: Args) -> Bool {

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -135,7 +135,17 @@ public enum ProductsListTool {
         return query
     }
 
+    static let allowedArguments: Set<String> = [
+        "search", "status", "category", "tag", "sku", "include", "stock_status",
+        "orderby", "order", "page", "per_page"
+    ]
+
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -106,6 +106,8 @@ public enum ProductsListTool {
 
     private static let allowedOrderby: Set<String> = ["date", "title", "popularity"]
     private static let allowedOrder: Set<String> = ["asc", "desc"]
+    private static let allowedStatus: Set<String> = ["any", "draft", "pending", "private", "publish"]
+    private static let allowedStockStatus: Set<String> = ["instock", "outofstock", "onbackorder"]
 
     private static func query(from args: Args) -> [String: String] {
         var query: [String: String] = [
@@ -191,6 +193,12 @@ public enum ProductsListTool {
         }
         if (args.orderby != nil || args.order != nil) && (args.search != nil || args.sku != nil) {
             return failure("orderby and order cannot be combined with search or sku.")
+        }
+        if let status = args.status, !allowedStatus.contains(status) {
+            return failure("'\(status)' is not an allowed status.")
+        }
+        if let stockStatus = args.stockStatus, !allowedStockStatus.contains(stockStatus) {
+            return failure("'\(stockStatus)' is not an allowed stock_status.")
         }
         if let orderby = args.orderby, !allowedOrderby.contains(orderby) {
             return failure("'\(orderby)' is not an allowed orderby.")

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
@@ -69,8 +69,16 @@ public enum ProductsUpdateTool {
     }
 
     private static let allowedStatuses = AllowedProductUpdateStatuses.values
+    private static let allowedArguments: Set<String> = [
+        "id", "name", "regular_price", "sale_price", "stock_quantity", "status"
+    ]
 
     private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
         let args: Args
         switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
         case .success(let value): args = value

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/ShowCardsTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/ShowCardsTool.swift
@@ -24,12 +24,16 @@ public enum ShowCardsTool {
         different entity types. Cards render \
         the entity's full detail to the user, but the model-visible result \
         is a compact summary only. Model-visible fields per family: order \
-        has id, number, status, total, currency, date_created, customer_name; \
-        product has id, name, sku, price, stock_status; product_variation \
-        adds parent_id; customer has id, first_name, last_name, email, \
-        orders_count. For any other field (line items, payment method, \
-        billing/shipping address, phone, recent-order details, etc.) use \
-        the appropriate get or list tool from the catalog. Cards rendered \
+        has id, number, status, total, currency, date_created, customer_name, \
+        customer_id, payment_method_title, line_items_count, line_items \
+        (each with id, name, quantity, sku, total, product_id, variation_id - \
+        capped at 5 per order); product has id, name, sku, price, stock_status, \
+        type, manage_stock, on_sale, stock_quantity, variations_count; \
+        product_variation adds parent_id; customer has id, first_name, \
+        last_name, email, orders_count. For any other field (full descriptions, \
+        billing/shipping address, phone, recent-order details beyond the first \
+        five line items, etc.) use the appropriate get or list tool from the \
+        catalog. Cards rendered \
         in this turn remain referenced; reuse their ids in follow-up tool \
         calls. After a successful `analytics_revenue` or `analytics_orders` \
         call, call this tool with family `analytics_stats` and an id using \

--- a/Modules/Sources/WooAIAssistant/Tools/REST/AnalyticsDateBounds.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/AnalyticsDateBounds.swift
@@ -9,6 +9,28 @@ enum AnalyticsDateBounds {
         return ("\(start)T00:00:00", "\(end)T23:59:59")
     }
 
+    /// Anchors `previousBefore` at the day before `after` and walks back the
+    /// same inclusive number of days to mirror how the Woo dashboard's
+    /// "previous period" comparison shifts a date window.
+    static func previousPeriodBounds(after: String,
+                                     before: String) -> (after: String, before: String)? {
+        guard let afterDate = yyyyMMDDFormatter.date(from: after),
+              let beforeDate = yyyyMMDDFormatter.date(from: before) else { return nil }
+        let calendar = Calendar(identifier: .gregorian)
+        var utc = calendar
+        utc.timeZone = TimeZone(identifier: "UTC") ?? .current
+        guard let inclusiveDays = utc.dateComponents([.day], from: afterDate, to: beforeDate).day else {
+            return nil
+        }
+        let totalDays = inclusiveDays + 1
+        guard let previousBefore = utc.date(byAdding: .day, value: -1, to: afterDate),
+              let previousAfter = utc.date(byAdding: .day, value: -(totalDays - 1), to: previousBefore) else {
+            return nil
+        }
+        return (yyyyMMDDFormatter.string(from: previousAfter),
+                yyyyMMDDFormatter.string(from: previousBefore))
+    }
+
     private static let yyyyMMDDFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .gregorian)

--- a/Modules/Sources/WooAIAssistant/Tools/REST/AnalyticsDateBounds.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/AnalyticsDateBounds.swift
@@ -9,9 +9,7 @@ enum AnalyticsDateBounds {
         return ("\(start)T00:00:00", "\(end)T23:59:59")
     }
 
-    /// Anchors `previousBefore` at the day before `after` and walks back the
-    /// same inclusive number of days to mirror how the Woo dashboard's
-    /// "previous period" comparison shifts a date window.
+    /// Mirrors the Woo dashboard "previous period" anchoring: immediately preceding window of the same inclusive day count.
     static func previousPeriodBounds(after: String,
                                      before: String) -> (after: String, before: String)? {
         guard let afterDate = yyyyMMDDFormatter.date(from: after),

--- a/Modules/Sources/WooAIAssistant/Tools/REST/LLMPayloadCap.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/LLMPayloadCap.swift
@@ -7,11 +7,11 @@ enum LLMPayloadCap {
     static let maxBytes = 64_000
 
     /// Returns `value` unchanged if it serializes under the cap, otherwise a
-    /// truncation marker that tells the model the card already answered the
-    /// merchant and explicitly forbids retry. Earlier wording asked the model
-    /// to "narrow the query" and gpt-4o-mini retried with different sort
-    /// params, hit the same cap, and ended up apologizing while a valid card
-    /// sat right above the prose.
+    /// truncation marker that nudges the model toward `show_cards` (or a
+    /// narrower query) without lying about cards being rendered. Earlier
+    /// wording told the model "the data is already in a card", which is
+    /// only true for tools that emit cards inline. None of our current
+    /// tools do.
     static func capped(_ value: AnyCodableJSON, toolName: String) -> AnyCodableJSON {
         let encoder = JSONEncoder()
         guard let data = try? encoder.encode(value), data.count > maxBytes else {
@@ -22,10 +22,11 @@ enum LLMPayloadCap {
             "tool": .string(toolName),
             "original_bytes": .int(Int64(data.count)),
             "instructions": .string(
-                "The full data is ALREADY rendered in a card visible to the merchant. " +
-                "Do NOT call this tool again - a retry will hit the same cap. " +
-                "Do NOT tell the merchant you failed to retrieve anything. " +
-                "Respond with AT MOST one short conversational sentence, or no text at all."
+                "The response exceeded the model payload cap. " +
+                "If you already have entity ids the merchant asked about, call `show_cards` with them and stop. " +
+                "Otherwise narrow the request (smaller per_page, more specific filter) and retry ONCE - retrying with " +
+                "the same parameters will hit the same cap. " +
+                "Do NOT tell the merchant you failed to retrieve anything."
             )
         ])
     }

--- a/Modules/Sources/WooAIAssistant/Tools/REST/RESTPayloadPruning.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/RESTPayloadPruning.swift
@@ -18,8 +18,6 @@ enum RESTPayloadPruning {
         "short_description"
     ]
 
-    private static let maxFreeTextLength = 280
-
     static func prune(_ value: AnyCodableJSON) -> AnyCodableJSON {
         switch value {
         case .object(let dict):
@@ -45,13 +43,9 @@ enum RESTPayloadPruning {
         while let range = stripped.range(of: "<[^>]+>", options: .regularExpression) {
             stripped.removeSubrange(range)
         }
-        let normalized = stripped
+        return stripped
             .replacingOccurrences(of: "&nbsp;", with: " ")
             .replacingOccurrences(of: "&amp;", with: "&")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        if normalized.count > maxFreeTextLength {
-            return String(normalized.prefix(maxFreeTextLength)) + "..."
-        }
-        return normalized
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/REST/RESTPayloadPruning.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/RESTPayloadPruning.swift
@@ -8,7 +8,6 @@ enum RESTPayloadPruning {
         "meta_data",
         "yoast_head",
         "yoast_head_json",
-        "permalink",
         "product_permalink",
         "reviewer_avatar_urls"
     ]

--- a/Modules/Sources/WooAIAssistant/Tools/REST/RESTToolDispatch+Write.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/RESTToolDispatch+Write.swift
@@ -22,11 +22,16 @@ extension RESTToolDispatch {
                                    path: String,
                                    body: Data?,
                                    client: WCRESTClient,
-                                   toolName: String) async -> ToolResult {
+                                   toolName: String,
+                                   requestedCount: Int,
+                                   patchKeys: [String]) async -> ToolResult {
         let response = await client.request(method: method,
                                             path: path,
                                             query: nil,
                                             body: body)
-        return WriteResultMapper.mapBatch(response, toolName: toolName)
+        return WriteResultMapper.mapBatch(response,
+                                          toolName: toolName,
+                                          requestedCount: requestedCount,
+                                          patchKeys: patchKeys)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/REST/ToolArgumentValidation.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/ToolArgumentValidation.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum ToolArgumentValidation {
+    static func validate(arguments: String,
+                         allowed: Set<String>,
+                         toolName: String) -> ToolResult.Failed? {
+        guard let data = arguments.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data),
+              let object = parsed as? [String: Any] else {
+            return nil
+        }
+        return rejection(forKeys: object.keys, allowed: allowed, toolName: toolName)
+    }
+
+    static func validate(patch: AnyCodableJSON,
+                         allowed: Set<String>,
+                         toolName: String) -> ToolResult.Failed? {
+        guard case .object(let dict) = patch else { return nil }
+        return rejection(forKeys: dict.keys, allowed: allowed, toolName: toolName)
+    }
+
+    private static func rejection<Keys: Sequence>(forKeys keys: Keys,
+                                                  allowed: Set<String>,
+                                                  toolName: String) -> ToolResult.Failed?
+    where Keys.Element == String {
+        let unknown = keys.filter { !allowed.contains($0) }.sorted()
+        guard !unknown.isEmpty else { return nil }
+        let list = unknown.joined(separator: ", ")
+        return .init(toolName: toolName,
+                     kind: .invalidToolCall,
+                     reason: "Unsupported \(toolName) argument(s): \(list)")
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/REST/WriteResultMapper.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/REST/WriteResultMapper.swift
@@ -34,7 +34,9 @@ enum WriteResultMapper {
     /// WC's batch endpoint returns 200 even when individual entries fail, so the summary
     /// counts and surfaces per-entry errors rather than trusting the envelope status.
     static func mapBatch(_ response: WCRESTResponse,
-                         toolName: String) -> ToolResult {
+                         toolName: String,
+                         requestedCount: Int,
+                         patchKeys: [String]) -> ToolResult {
         if let unknown = unknownOutcomeFailure(response: response, toolName: toolName) {
             return .failed(unknown)
         }
@@ -56,17 +58,17 @@ enum WriteResultMapper {
                 updatedIDs.append(identifier)
             }
         }
-        var summary: [String: AnyCodableJSON] = [
+        let partialSuccess = !updatedIDs.isEmpty && !failedEntries.isEmpty
+        let summary: [String: AnyCodableJSON] = [
             "tool": .string(toolName),
+            "requested_count": .int(Int64(requestedCount)),
             "updated_count": .int(Int64(updatedIDs.count)),
-            "failed_count": .int(Int64(failedEntries.count))
+            "failed_count": .int(Int64(failedEntries.count)),
+            "partial_success": .bool(partialSuccess),
+            "patch_keys": .array(patchKeys.map { .string($0) }),
+            "updated_ids": .array(updatedIDs.map { .int($0) }),
+            "failed": .array(failedEntries)
         ]
-        if !updatedIDs.isEmpty {
-            summary["updated_ids"] = .array(updatedIDs.map { .int($0) })
-        }
-        if !failedEntries.isEmpty {
-            summary["failed"] = .array(failedEntries)
-        }
         // Batch envelope carries only ids; surfacing per-id cards would render empty entity rows.
         return .success(.init(toolName: toolName,
                               structured: LLMPayloadCap.capped(.object(summary), toolName: toolName),

--- a/Modules/Tests/WooAIAssistantTests/Configuration/AssistantSystemPromptTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Configuration/AssistantSystemPromptTests.swift
@@ -102,6 +102,15 @@ struct AssistantSystemPromptTests {
         #expect(remoteToolNames.allSatisfy { !prompt.contains($0) })
     }
 
+    @Test
+    func test_build_when_called_then_prompt_does_not_mention_extra_fields() {
+        // Given
+        let prompt = AssistantSystemPrompt.build(todayISODate: "2026-04-27")
+
+        // Then
+        #expect(!prompt.contains("extra_fields"))
+    }
+
     private func section(in text: String, from startMarker: String, to endMarker: String) -> Substring {
         guard let start = text.range(of: startMarker)?.lowerBound,
               let end = text.range(of: endMarker, range: start..<text.endIndex)?.lowerBound else {

--- a/Modules/Tests/WooAIAssistantTests/Configuration/AssistantSystemPromptTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Configuration/AssistantSystemPromptTests.swift
@@ -83,6 +83,18 @@ struct AssistantSystemPromptTests {
     }
 
     @Test
+    func test_build_documents_per_row_hidden_field_pattern_as_list_plus_show_cards() {
+        let prompt = AssistantSystemPrompt.build(todayISODate: "2026-04-27")
+        let pattern1bSection = section(in: prompt, from: "Pattern 1b - Per-row fields the summary doesn't carry.", to: "Pattern 2 - Drill into a single entity")
+
+        #expect(pattern1bSection.contains("show me orders with customer emails"))
+        #expect(pattern1bSection.contains("list customers with phone numbers"))
+        #expect(pattern1bSection.contains("One list tool call, render via `show_cards`"))
+        #expect(pattern1bSection.contains("Tap any row to see emails"))
+        #expect(pattern1bSection.contains("without ever calling the list tool"))
+    }
+
+    @Test
     func test_build_directs_writes_resolving_from_prior_context_for_superlatives_and_ordinals() {
         let prompt = AssistantSystemPrompt.build(todayISODate: "2026-04-27")
         let reuseSection = section(in: prompt, from: "# Cross-turn context reuse", to: "Asking for clarification is a last resort")

--- a/Modules/Tests/WooAIAssistantTests/Configuration/AssistantSystemPromptTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Configuration/AssistantSystemPromptTests.swift
@@ -83,6 +83,28 @@ struct AssistantSystemPromptTests {
     }
 
     @Test
+    func test_build_directs_writes_resolving_from_prior_context_for_superlatives_and_ordinals() {
+        let prompt = AssistantSystemPrompt.build(todayISODate: "2026-04-27")
+        let reuseSection = section(in: prompt, from: "# Cross-turn context reuse", to: "Asking for clarification is a last resort")
+
+        #expect(reuseSection.contains("Same applies to write requests on prior context."))
+        #expect(reuseSection.contains("\"Mark the biggest one as completed\""))
+        #expect(reuseSection.contains("Don't refuse a write or punt to the native UI"))
+        #expect(reuseSection.contains("the antecedent is already in your context"))
+    }
+
+    @Test
+    func test_build_directs_list_plus_cards_for_summary_invisible_fields() {
+        let prompt = AssistantSystemPrompt.build(todayISODate: "2026-04-27")
+        let hiddenFieldsSection = section(in: prompt, from: "# Don't invent hidden fields", to: "# Distinct quantities")
+
+        #expect(hiddenFieldsSection.contains("the answer is still a list tool call + `show_cards` + a one-line pointer"))
+        #expect(hiddenFieldsSection.contains("tap any row for billing details"))
+        #expect(hiddenFieldsSection.contains("Refusing the list call, or telling the merchant to open the Orders/Customers tab"))
+        #expect(hiddenFieldsSection.contains("the rendered cards are already tappable"))
+    }
+
+    @Test
     func test_build_keeps_remote_tool_names_out_of_prompt() {
         let prompt = AssistantSystemPrompt.build(todayISODate: "2026-04-27")
         let remoteToolNames = [

--- a/Modules/Tests/WooAIAssistantTests/Presentation/EntityCardPayloadTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/EntityCardPayloadTests.swift
@@ -128,6 +128,38 @@ struct EntityCardPayloadTests {
         #expect(product.isEmpty == false)
     }
 
+    @Test
+    func test_decodeProduct_when_payload_has_variations_count_then_field_is_decoded() {
+        // Given
+        let payload = AnyCodableJSON.object([
+            "id": .int(101),
+            "name": .string("Hoodie"),
+            "type": .string("variable"),
+            "variations_count": .int(15)
+        ])
+
+        // When
+        let product = EntityCardPayload.decodeProduct(payload)
+
+        // Then
+        #expect(product?.variationsCount == 15)
+    }
+
+    @Test
+    func test_decodeProduct_when_payload_has_no_variations_count_then_field_is_nil() {
+        // Given
+        let payload = AnyCodableJSON.object([
+            "id": .int(101),
+            "name": .string("Hoodie")
+        ])
+
+        // When
+        let product = EntityCardPayload.decodeProduct(payload)
+
+        // Then
+        #expect(product?.variationsCount == nil)
+    }
+
     // MARK: - CustomerCardPayload
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationPreviewBuilderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationPreviewBuilderTests.swift
@@ -181,7 +181,7 @@ struct DefaultConfirmationPreviewBuilderTests {
     }
 
     @Test
-    func test_build_when_orders_update_customer_note_then_value_is_capitalized_placeholder() throws {
+    func test_build_when_orders_update_has_customer_note_under_160_chars_then_field_value_is_raw_note_without_priorValue() throws {
         // Given
         let builder = DefaultConfirmationPreviewBuilder()
 
@@ -195,11 +195,88 @@ struct DefaultConfirmationPreviewBuilderTests {
         // Then
         let unwrapped = try #require(preview)
         let field = try #require(unwrapped.fields.first(where: { $0.name == "customer_note" }))
-        guard case .localized(let resource, _) = field.value else {
-            Issue.record("expected customer_note value to be a localized placeholder, got \(field.value)")
-            return
-        }
-        #expect(String(localized: resource) == "Updated")
+        #expect(field.value == .raw("Thanks for the order"))
+        #expect(field.priorValue == nil)
+    }
+
+    @Test
+    func test_build_when_orders_update_has_customer_note_over_160_chars_then_field_value_is_first_160_chars_plus_ellipsis() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let long = String(repeating: "a", count: 200)
+
+        // When
+        let preview = builder.build(
+            toolName: OrdersUpdateTool.name,
+            arguments: #"{"id":42,"customer_note":"\#(long)"}"#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "customer_note" }))
+        let expected = String(repeating: "a", count: 160) + "..."
+        #expect(field.value == .raw(expected))
+    }
+
+    @Test
+    func test_build_when_orders_update_has_customer_note_with_snapshot_present_then_priorValue_is_still_omitted() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let snapshot = ConfirmationSnapshot(currentValues: ["customer_note": .raw("previous note")])
+
+        // When
+        let preview = builder.build(
+            toolName: OrdersUpdateTool.name,
+            arguments: #"{"id":42,"customer_note":"Thanks"}"#,
+            snapshot: snapshot
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "customer_note" }))
+        #expect(field.priorValue == nil)
+    }
+
+    @Test
+    func test_build_when_orders_bulk_update_has_customer_note_then_field_renders_as_truncated_note_with_no_priorValue() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let long = String(repeating: "b", count: 200)
+
+        // When
+        let preview = builder.build(
+            toolName: OrdersBulkUpdateTool.name,
+            arguments: #"{"ids":[1,2],"patch":{"customer_note":"\#(long)"}}"#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "customer_note" }))
+        let expected = String(repeating: "b", count: 160) + "..."
+        #expect(field.value == .raw(expected))
+        #expect(field.priorValue == nil)
+    }
+
+    @Test
+    func test_build_when_orders_update_has_billing_email_and_snapshot_then_field_carries_value_and_priorValue() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let snapshot = ConfirmationSnapshot(currentValues: ["billing_email": .raw("old@example.com")])
+
+        // When
+        let preview = builder.build(
+            toolName: OrdersUpdateTool.name,
+            arguments: #"{"id":42,"billing_email":"new@example.com"}"#,
+            snapshot: snapshot
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "billing_email" }))
+        #expect(field.value == .raw("new@example.com"))
+        #expect(field.priorValue == .raw("old@example.com"))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationPreviewBuilderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationPreviewBuilderTests.swift
@@ -200,6 +200,25 @@ struct DefaultConfirmationPreviewBuilderTests {
     }
 
     @Test
+    func test_build_when_orders_update_has_customer_note_at_exactly_160_chars_then_value_is_unchanged_without_ellipsis() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let exact = String(repeating: "a", count: 160)
+
+        // When
+        let preview = builder.build(
+            toolName: OrdersUpdateTool.name,
+            arguments: #"{"id":42,"customer_note":"\#(exact)"}"#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "customer_note" }))
+        #expect(field.value == .raw(exact))
+    }
+
+    @Test
     func test_build_when_orders_update_has_customer_note_over_160_chars_then_field_value_is_first_160_chars_plus_ellipsis() throws {
         // Given
         let builder = DefaultConfirmationPreviewBuilder()

--- a/Modules/Tests/WooAIAssistantTests/Tools/Cards/CardReferenceResolverTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Cards/CardReferenceResolverTests.swift
@@ -542,6 +542,65 @@ struct CardReferenceResolverTests {
         }
     }
 
+    @Test
+    func test_enrich_when_product_entity_has_variations_array_then_variations_count_is_synthesized() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(99),
+            "name": .string("Hoodie"),
+            "variations": .array([.int(1), .int(2), .int(3)])
+        ])
+
+        // When
+        let enriched = CardReferenceResolver.enrich(entity, family: .product)
+
+        // Then
+        guard case .object(let fields) = enriched else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["variations_count"] == .int(3))
+    }
+
+    @Test
+    func test_enrich_when_product_entity_already_has_variations_count_then_value_is_preserved() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(99),
+            "variations_count": .int(7),
+            "variations": .array([.int(1), .int(2)])
+        ])
+
+        // When
+        let enriched = CardReferenceResolver.enrich(entity, family: .product)
+
+        // Then
+        guard case .object(let fields) = enriched else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["variations_count"] == .int(7))
+    }
+
+    @Test
+    func test_enrich_when_non_product_family_then_entity_unchanged() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(99),
+            "variations": .array([.int(1), .int(2)])
+        ])
+
+        // When
+        let enriched = CardReferenceResolver.enrich(entity, family: .order)
+
+        // Then
+        guard case .object(let fields) = enriched else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["variations_count"] == nil)
+    }
+
     private func isResolved(_ resolution: Resolution, family: CardFamilyID, id: String) -> Bool {
         if case .resolved(let resolvedFamily, let resolvedID, _, _) = resolution {
             return resolvedFamily == family && resolvedID == id

--- a/Modules/Tests/WooAIAssistantTests/Tools/Cards/CardReferenceResolverTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Cards/CardReferenceResolverTests.swift
@@ -458,7 +458,7 @@ struct CardReferenceResolverTests {
         // Per-bucket data is rendered-only; the model-visible summary keeps
         // just the projection keys so a year-by-day query doesn't blow the
         // model context.
-        #expect(Set(fields.keys) == Set(["after", "before", "totals"]))
+        #expect(Set(fields.keys) == Set(["after", "before", "interval", "totals"]))
         #expect(fields["interval_subtotals"] == nil)
         #expect(fields["interval_count"] == nil)
         #expect(rendered.family == .analyticsStats)

--- a/Modules/Tests/WooAIAssistantTests/Tools/Cards/OrderFamilyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Cards/OrderFamilyTests.swift
@@ -36,7 +36,71 @@ struct OrderFamilyTests {
         #expect(fields["currency"] == .string("USD"))
         #expect(fields["date_created"] == .string("2026-04-20T10:00:00"))
         #expect(fields["customer_name"] == .string("Jane Doe"))
-        #expect(fields["line_items"] == nil)
+        #expect(fields["line_items"] == .array([]))
+        #expect(fields["line_items_count"] == .int(0))
+    }
+
+    @Test
+    func test_show_cards_when_order_resolved_then_resolved_ref_summary_includes_payment_method_title_and_customer_id() {
+        // Given
+        let entity: AnyCodableJSON = .object([
+            "id": .int(7),
+            "payment_method_title": .string("Stripe"),
+            "customer_id": .int(99)
+        ])
+
+        // When
+        let summary = CardFamily.order.summarize(entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["payment_method_title"] == .string("Stripe"))
+        #expect(fields["customer_id"] == .int(99))
+    }
+
+    @Test
+    func test_show_cards_when_order_payment_method_title_is_blank_then_field_is_omitted() {
+        // Given
+        let entity: AnyCodableJSON = .object([
+            "id": .int(7),
+            "payment_method_title": .string("")
+        ])
+
+        // When
+        let summary = CardFamily.order.summarize(entity)
+
+        // Then
+        if case .object(let fields) = summary {
+            #expect(fields["payment_method_title"] == nil)
+        } else {
+            Issue.record("expected object")
+        }
+    }
+
+    @Test
+    func test_show_cards_when_order_has_line_items_then_resolved_ref_summary_carries_line_items_capped_at_five() {
+        // Given
+        let items = (1...7).map { idx in
+            AnyCodableJSON.object(["id": .int(Int64(idx)), "name": .string("Item \(idx)"), "quantity": .int(1)])
+        }
+        let entity: AnyCodableJSON = .object([
+            "id": .int(7),
+            "line_items": .array(items)
+        ])
+
+        // When
+        let summary = CardFamily.order.summarize(entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .array(let projected) = fields["line_items"] else {
+            Issue.record("expected line_items array")
+            return
+        }
+        #expect(projected.count == 5)
+        #expect(fields["line_items_count"] == .int(7))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Cards/ProductFamilyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Cards/ProductFamilyTests.swift
@@ -33,4 +33,30 @@ struct ProductFamilyTests {
         #expect(fields["description"] == nil)
         #expect(fields["images"] == nil)
     }
+
+    @Test
+    func test_show_cards_when_product_resolved_then_resolved_ref_summary_includes_type_manage_stock_on_sale_stock_quantity() {
+        // Given
+        let entity: AnyCodableJSON = .object([
+            "id": .int(42),
+            "name": .string("Beanie"),
+            "type": .string("simple"),
+            "manage_stock": .bool(true),
+            "on_sale": .bool(false),
+            "stock_quantity": .int(8)
+        ])
+
+        // When
+        let summary = CardFamily.product.summarize(entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["type"] == .string("simple"))
+        #expect(fields["manage_stock"] == .bool(true))
+        #expect(fields["on_sale"] == .bool(false))
+        #expect(fields["stock_quantity"] == .int(8))
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Cards/ShowCardsToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Cards/ShowCardsToolTests.swift
@@ -153,7 +153,7 @@ struct ShowCardsToolTests {
         // it lives in the rendered card payload only. Mirrors Android #15837.
         #expect(summary["interval_subtotals"] == nil)
         #expect(summary["interval_count"] == nil)
-        #expect(Set(summary.keys) == Set(["after", "before", "totals"]))
+        #expect(Set(summary.keys) == Set(["after", "before", "interval", "totals"]))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsOrdersToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsOrdersToolTests.swift
@@ -90,4 +90,179 @@ struct AnalyticsOrdersToolTests {
         }
         #expect(failed.kind == .upstreamFailure)
     }
+
+    @Test
+    func test_descriptor_when_inspected_then_compare_to_enum_contains_only_previous_period() {
+        // Given
+        let tool = AnalyticsOrdersTool.make()
+
+        // Then
+        guard case .object(let schema) = tool.definition.parametersSchema,
+              case .object(let properties) = schema["properties"],
+              case .object(let compareTo) = properties["compare_to"],
+              case .array(let values) = compareTo["enum"] else {
+            Issue.record("expected compare_to enum")
+            return
+        }
+        #expect(values == [.string("previous_period")])
+    }
+
+    @Test
+    func test_execute_when_compare_to_is_invalid_value_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","compare_to":"last_year"}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("compare_to must be previous_period"))
+    }
+
+    @Test
+    func test_execute_when_compare_to_is_omitted_then_summary_has_no_previous_period_fields() async {
+        // Given
+        let body = #"{"totals": {"orders_count": 1}}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["previous_period_totals"] == nil)
+        #expect(fields["previous_period_partial"] == nil)
+    }
+
+    @Test
+    func test_execute_when_compare_to_is_previous_period_and_secondary_fetch_succeeds_then_previous_period_totals_is_emitted() async {
+        // Given
+        let primary = #"{"totals": {"orders_count": 10}}"#
+        let secondary = #"{"totals": {"orders_count": 5}}"#
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok(primary),
+            StubResponses.ok(secondary)
+        ])
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-05-01","before":"2026-05-07","compare_to":"previous_period"}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        guard case .object(let previous) = fields["previous_period_totals"] else {
+            Issue.record("expected previous_period_totals")
+            return
+        }
+        #expect(previous["orders_count"] == .int(5))
+        #expect(fields["previous_period_partial"] == nil)
+        #expect(await client.calls.count == 2)
+    }
+
+    @Test
+    func test_execute_when_compare_to_is_previous_period_and_secondary_fetch_fails_then_primary_succeeds_with_previous_period_partial_true_and_warning() async {
+        // Given
+        let primary = #"{"totals": {"orders_count": 10}}"#
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok(primary),
+            StubResponses.failure(statusCode: 500)
+        ])
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-05-01","before":"2026-05-07","compare_to":"previous_period"}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["previous_period_partial"] == .bool(true))
+        if case .string(let warning) = fields["previous_period_warning"] {
+            #expect(warning.contains("could not be fetched"))
+        } else {
+            Issue.record("expected previous_period_warning string")
+        }
+        #expect(fields["previous_period_totals"] == nil)
+    }
+
+    @Test
+    func test_execute_when_primary_fetch_fails_then_call_fails_regardless_of_compare_to() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.failure(statusCode: 500))
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-05-01","before":"2026-05-07","compare_to":"previous_period"}"#,
+            client
+        )
+
+        // Then
+        guard case .failed = result else {
+            Issue.record("expected failed")
+            return
+        }
+    }
+
+    @Test
+    func test_summary_when_built_then_interval_is_always_emitted() async {
+        // Given
+        let body = #"{"totals": {"orders_count": 1}}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["interval"] == .string("day"))
+    }
+
+    @Test
+    func test_execute_when_unknown_argument_provided_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = AnalyticsOrdersTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","orderby":"date"}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(await client.calls.isEmpty)
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsRevenueToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsRevenueToolTests.swift
@@ -93,4 +93,74 @@ struct AnalyticsRevenueToolTests {
         }
         #expect(failed.kind == .rateLimit)
     }
+
+    @Test
+    func test_summary_when_currency_provided_then_currency_is_emitted() async {
+        // Given
+        let body = #"{"totals": {"net_revenue": "10.00"}}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = AnalyticsRevenueTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","currency":"USD"}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["currency"] == .string("USD"))
+    }
+
+    @Test
+    func test_execute_when_compare_to_is_previous_period_and_secondary_fetch_succeeds_then_previous_period_totals_is_emitted() async {
+        // Given
+        let primary = #"{"totals": {"net_revenue": "200.00"}}"#
+        let secondary = #"{"totals": {"net_revenue": "100.00"}}"#
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok(primary),
+            StubResponses.ok(secondary)
+        ])
+        let tool = AnalyticsRevenueTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-05-01","before":"2026-05-07","compare_to":"previous_period"}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        guard case .object(let previous) = fields["previous_period_totals"] else {
+            Issue.record("expected previous_period_totals object")
+            return
+        }
+        #expect(previous["net_revenue"] == .string("100.00"))
+    }
+
+    @Test
+    func test_execute_when_compare_to_is_invalid_value_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = AnalyticsRevenueTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","compare_to":"last_year"}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsRevenueToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsRevenueToolTests.swift
@@ -145,6 +145,36 @@ struct AnalyticsRevenueToolTests {
     }
 
     @Test
+    func test_execute_when_compare_to_is_previous_period_and_secondary_fetch_fails_then_primary_succeeds_with_previous_period_partial_true_and_warning() async {
+        // Given
+        let primary = #"{"totals": {"net_revenue": "200.00"}}"#
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok(primary),
+            StubResponses.failure(statusCode: 500)
+        ])
+        let tool = AnalyticsRevenueTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-05-01","before":"2026-05-07","compare_to":"previous_period"}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["previous_period_partial"] == .bool(true))
+        if case .string(let warning) = fields["previous_period_warning"] {
+            #expect(warning.contains("could not be fetched"))
+        } else {
+            Issue.record("expected previous_period_warning string")
+        }
+        #expect(fields["previous_period_totals"] == nil)
+    }
+
+    @Test
     func test_execute_when_compare_to_is_invalid_value_then_invalidToolCall_is_returned() async {
         // Given
         let client = MockWCRESTClient(response: StubResponses.ok("{}"))

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Customers/CustomersListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Customers/CustomersListToolTests.swift
@@ -70,4 +70,146 @@ struct CustomersListToolTests {
         }
         #expect(failed.kind == .auth)
     }
+
+    @Test
+    func test_summary_when_customer_has_username_then_username_is_projected() async throws {
+        // Given
+        let body = """
+        [{"id": 1, "username": "povilas"}]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        #expect(first["username"] == .string("povilas"))
+    }
+
+    @Test
+    func test_summary_when_customer_has_date_created_then_date_created_is_projected() async throws {
+        // Given
+        let body = #"[{"id": 1, "date_created": "2026-04-20T10:00:00"}]"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        #expect(first["date_created"] == .string("2026-04-20T10:00:00"))
+    }
+
+    @Test
+    func test_summary_when_customer_has_billing_phone_city_country_then_billing_object_is_projected() async throws {
+        // Given
+        let body = """
+        [{
+            "id": 1,
+            "billing": {"phone": "+1", "city": "Berlin", "country": "DE", "first_name": "X"}
+        }]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        guard case .object(let billing) = first["billing"] else {
+            Issue.record("expected billing object")
+            return
+        }
+        #expect(billing["phone"] == .string("+1"))
+        #expect(billing["city"] == .string("Berlin"))
+        #expect(billing["country"] == .string("DE"))
+        #expect(billing["first_name"] == nil)
+    }
+
+    @Test
+    func test_summary_when_customer_has_shipping_city_country_then_shipping_object_is_projected() async throws {
+        // Given
+        let body = """
+        [{"id": 1, "shipping": {"city": "Berlin", "country": "DE", "phone": "+1"}}]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        guard case .object(let shipping) = first["shipping"] else {
+            Issue.record("expected shipping object")
+            return
+        }
+        #expect(shipping["city"] == .string("Berlin"))
+        #expect(shipping["country"] == .string("DE"))
+        #expect(shipping["phone"] == nil)
+    }
+
+    @Test
+    func test_summary_when_customer_has_role_and_avatar_then_both_are_projected() async throws {
+        // Given
+        let body = #"[{"id": 1, "role": "customer", "avatar_url": "https://example.com/a.jpg"}]"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        #expect(first["role"] == .string("customer"))
+        #expect(first["avatar_url"] == .string("https://example.com/a.jpg"))
+    }
+
+    @Test
+    func test_summary_when_customer_has_blank_username_then_username_field_is_omitted() async throws {
+        // Given
+        let body = #"[{"id": 1, "username": ""}]"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        #expect(first["username"] == nil)
+    }
+
+    @Test
+    func test_summary_when_customer_present_then_orders_count_and_total_spent_are_not_projected() async throws {
+        // Given
+        let body = #"[{"id": 1, "orders_count": 4, "total_spent": "120.00"}]"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = CustomersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        let first = try firstMatch(in: result)
+        #expect(first["orders_count"] == nil)
+        #expect(first["total_spent"] == nil)
+    }
+
+    private func firstMatch(in result: ToolResult) throws -> [String: AnyCodableJSON] {
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let matches) = fields["matches"],
+              case .object(let first) = matches.first else {
+            Issue.record("expected first match")
+            throw FirstMatchError.missing
+        }
+        return first
+    }
+
+    private enum FirstMatchError: Error { case missing }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrderSummaryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrderSummaryTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct OrderSummaryTests {
+    @Test
+    func test_make_when_order_has_billing_and_shipping_then_addresses_are_projected_with_blank_fields_dropped() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(7),
+            "billing": .object([
+                "first_name": .string("Jane"),
+                "last_name": .string("Doe"),
+                "email": .string("jane@example.com"),
+                "phone": .string(""),
+                "city": .string("Berlin"),
+                "country": .string("DE"),
+                "state": .string(""),
+                "postcode": .string("")
+            ]),
+            "shipping": .object([
+                "first_name": .string("Jane"),
+                "last_name": .string("Doe"),
+                "city": .string("Berlin"),
+                "country": .string("DE")
+            ])
+        ])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .object(let billing) = fields["billing"],
+              case .object(let shipping) = fields["shipping"] else {
+            Issue.record("expected billing and shipping objects")
+            return
+        }
+        #expect(billing["first_name"] == .string("Jane"))
+        #expect(billing["email"] == .string("jane@example.com"))
+        #expect(billing["city"] == .string("Berlin"))
+        #expect(billing["country"] == .string("DE"))
+        #expect(billing["phone"] == nil)
+        #expect(billing["state"] == nil)
+        #expect(billing["postcode"] == nil)
+        #expect(shipping["email"] == nil)
+        #expect(shipping["country"] == .string("DE"))
+    }
+
+    @Test
+    func test_make_when_customer_note_exceeds_500_chars_then_value_is_truncated_and_flag_is_true() {
+        // Given
+        let note = String(repeating: "a", count: 600)
+        let entity = AnyCodableJSON.object(["id": .int(7), "customer_note": .string(note)])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .string(let projected) = fields["customer_note"] else {
+            Issue.record("expected customer_note string")
+            return
+        }
+        #expect(projected.count == 500)
+        #expect(fields["customer_note_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_make_when_customer_note_is_short_then_truncated_flag_is_absent() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(7), "customer_note": .string("Thanks!")])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["customer_note"] == .string("Thanks!"))
+        #expect(fields["customer_note_truncated"] == nil)
+    }
+
+    @Test
+    func test_make_when_order_has_more_than_ten_line_items_then_line_items_truncated_is_true() {
+        // Given
+        let items = (0..<12).map { idx in
+            AnyCodableJSON.object(["id": .int(Int64(idx)), "name": .string("Item \(idx)"), "quantity": .int(1)])
+        }
+        let entity = AnyCodableJSON.object(["id": .int(7), "line_items": .array(items)])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let projected) = fields["line_items"] else {
+            Issue.record("expected line_items array")
+            return
+        }
+        #expect(projected.count == 10)
+        #expect(fields["line_items_count"] == .int(12))
+        #expect(fields["line_items_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_make_when_order_has_no_coupons_then_coupon_lines_field_is_empty_array() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(7)])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["coupon_lines"] == .array([]))
+    }
+
+    @Test
+    func test_make_when_order_has_coupons_then_each_coupon_line_carries_code_and_discount() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(7),
+            "coupon_lines": .array([
+                .object([
+                    "id": .int(11),
+                    "code": .string("SAVE10"),
+                    "discount": .string("5.00"),
+                    "discount_tax": .string("0.50")
+                ])
+            ])
+        ])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let coupons) = fields["coupon_lines"],
+              case .object(let first) = coupons.first else {
+            Issue.record("expected coupon_lines array")
+            return
+        }
+        #expect(first["code"] == .string("SAVE10"))
+        #expect(first["discount"] == .string("5.00"))
+        #expect(first["discount_tax"] == .string("0.50"))
+    }
+
+    @Test
+    func test_make_when_order_has_fees_then_fee_lines_capped_at_ten() {
+        // Given
+        let fees = (0..<15).map { idx in
+            AnyCodableJSON.object([
+                "id": .int(Int64(idx)),
+                "name": .string("Fee \(idx)"),
+                "total": .string("1.00")
+            ])
+        }
+        let entity = AnyCodableJSON.object(["id": .int(7), "fee_lines": .array(fees)])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let projected) = fields["fee_lines"] else {
+            Issue.record("expected fee_lines array")
+            return
+        }
+        #expect(projected.count == 10)
+    }
+
+    @Test
+    func test_make_when_order_has_tax_lines_then_tax_lines_carry_rate_code_and_total() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(7),
+            "tax_lines": .array([
+                .object([
+                    "id": .int(99),
+                    "rate_id": .int(1),
+                    "rate_code": .string("DE-VAT-19"),
+                    "label": .string("VAT"),
+                    "tax_total": .string("19.00"),
+                    "shipping_tax_total": .string("0.95")
+                ])
+            ])
+        ])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let taxes) = fields["tax_lines"],
+              case .object(let first) = taxes.first else {
+            Issue.record("expected tax_lines array")
+            return
+        }
+        #expect(first["rate_code"] == .string("DE-VAT-19"))
+        #expect(first["tax_total"] == .string("19.00"))
+        #expect(first["shipping_tax_total"] == .string("0.95"))
+    }
+
+    @Test
+    func test_orderRow_when_lineItemLimit_is_five_then_only_first_five_returned() {
+        // Given
+        let items = (0..<7).map { idx in
+            AnyCodableJSON.object(["id": .int(Int64(idx))])
+        }
+        let entity = AnyCodableJSON.object(["id": .int(7), "line_items": .array(items)])
+
+        // When
+        let summary = OrderSummary.orderRow(from: entity, lineItemLimit: 5)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let projected) = fields["line_items"] else {
+            Issue.record("expected line_items array")
+            return
+        }
+        #expect(projected.count == 5)
+        #expect(fields["line_items_truncated"] == .bool(true))
+        #expect(fields["line_items_count"] == .int(7))
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersBulkUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersBulkUpdateToolTests.swift
@@ -247,6 +247,24 @@ struct OrdersBulkUpdateToolTests {
     }
 
     @Test
+    func test_execute_when_patch_has_unknown_key_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"discount_total": "9.00"}}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("discount_total"))
+    }
+
+    @Test
     func test_execute_when_response_succeeds_then_failed_is_emitted_as_array_even_when_empty() async {
         // Given
         let body = #"{"update": [{"id": 1, "status": "completed"}]}"#

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersBulkUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersBulkUpdateToolTests.swift
@@ -281,4 +281,63 @@ struct OrdersBulkUpdateToolTests {
         }
         #expect(summary["failed"] == .array([]))
     }
+
+    @Test
+    func test_execute_when_patch_customer_note_exceeds_1000_chars_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersBulkUpdateTool.make()
+        let oversize = String(repeating: "a", count: 1001)
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"customer_note": "\#(oversize)"}}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "customer_note must be at most 1000 characters.")
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_patch_billing_email_exceeds_254_chars_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersBulkUpdateTool.make()
+        let oversize = String(repeating: "a", count: 245) + "@example.com"
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"billing_email": "\#(oversize)"}}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "billing_email must be at most 254 characters.")
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_patch_billing_email_is_malformed_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"billing_email": "not-an-email"}}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "billing_email must be a valid email address.")
+        #expect(await client.calls.isEmpty)
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersBulkUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersBulkUpdateToolTests.swift
@@ -129,4 +129,138 @@ struct OrdersBulkUpdateToolTests {
         }
         #expect(failed.kind == .outcomeUnknown)
     }
+
+    @Test
+    func test_execute_when_all_patch_fields_succeed_then_receipt_includes_requested_count_and_updated_ids() async {
+        // Given
+        let body = #"{"update": [{"id": 1, "status": "completed"}, {"id": 2, "status": "completed"}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1, 2], "patch": {"status": "completed"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["requested_count"] == .int(2))
+        #expect(summary["updated_count"] == .int(2))
+        #expect(summary["updated_ids"] == .array([.int(1), .int(2)]))
+        #expect(summary["partial_success"] == .bool(false))
+    }
+
+    @Test
+    func test_execute_when_some_entries_fail_then_partial_success_is_true() async {
+        // Given
+        let body = #"{"update": [{"id": 1, "status": "completed"}, {"id": 2, "error": {"code": "x"}}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1, 2], "patch": {"status": "completed"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["partial_success"] == .bool(true))
+        #expect(summary["failed_count"] == .int(1))
+    }
+
+    @Test
+    func test_execute_when_all_entries_succeed_then_partial_success_is_false() async {
+        // Given
+        let body = #"{"update": [{"id": 1, "status": "completed"}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"status": "completed"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["partial_success"] == .bool(false))
+    }
+
+    @Test
+    func test_execute_when_no_entries_succeed_then_partial_success_is_false_and_updated_ids_is_empty_array() async {
+        // Given
+        let body = #"{"update": [{"id": 1, "error": {"code": "x"}}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"status": "completed"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["partial_success"] == .bool(false))
+        #expect(summary["updated_ids"] == .array([]))
+    }
+
+    @Test
+    func test_execute_when_patch_has_status_and_customer_note_then_patch_keys_lists_them_in_canonical_order() async {
+        // Given
+        let body = #"{"update": [{"id": 1}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"ids": [1], "patch": {"customer_note": "Hi", "status": "completed"}}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["patch_keys"] == .array([.string("status"), .string("customer_note")]))
+    }
+
+    @Test
+    func test_execute_when_patch_has_only_billing_email_then_patch_keys_contains_only_billing_email() async {
+        // Given
+        let body = #"{"update": [{"id": 1}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"billing_email": "a@b.c"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["patch_keys"] == .array([.string("billing_email")]))
+    }
+
+    @Test
+    func test_execute_when_response_succeeds_then_failed_is_emitted_as_array_even_when_empty() async {
+        // Given
+        let body = #"{"update": [{"id": 1, "status": "completed"}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"status": "completed"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["failed"] == .array([]))
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
@@ -43,7 +43,6 @@ struct OrdersListToolTests {
         }
         #expect(fields["count"] == .int(3))
         #expect(fields["ids"] == .array([.int(3551), .int(3548), .int(3540)]))
-        #expect(fields["rows"] == nil)
         #expect(fields["status_counts"] == .object([
             "completed": .int(1),
             "on-hold": .int(1),
@@ -54,6 +53,108 @@ struct OrdersListToolTests {
             "max": .string("480"),
             "currency": .string("USD")
         ]))
+        guard case .array(let orders) = fields["orders"] else {
+            Issue.record("expected orders array")
+            return
+        }
+        #expect(orders.count == 3)
+    }
+
+    @Test
+    func test_orders_list_when_rows_present_then_orders_array_carries_per_row_widened_fields() async throws {
+        // Given
+        let body = """
+        [
+            {
+                "id": 3551, "number": "3551", "status": "processing", "total": "120.00", "currency": "USD",
+                "payment_method_title": "Stripe",
+                "billing": {"first_name": "Jane", "last_name": "Doe", "email": "j@example.com"},
+                "line_items": [{"id": 1, "name": "A", "quantity": 1}]
+            }
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 1}"#, client)
+
+        // Then
+        guard case .success(let success) = result else {
+            Issue.record("expected success")
+            return
+        }
+        guard case .object(let fields) = success.structured,
+              case .array(let orders) = fields["orders"],
+              case .object(let first) = orders.first else {
+            Issue.record("expected first order object")
+            return
+        }
+        #expect(first["payment_method_title"] == .string("Stripe"))
+        #expect(first["customer_name"] == .string("Jane Doe"))
+        #expect(first["customer_email"] == .string("j@example.com"))
+        guard case .array(let items) = first["line_items"] else {
+            Issue.record("expected line_items")
+            return
+        }
+        #expect(items.count == 1)
+    }
+
+    @Test
+    func test_orders_list_when_row_line_items_exceed_five_then_line_items_truncated_is_true_for_that_row() async throws {
+        // Given
+        let items = (0..<7).map { idx in
+            "{\"id\": \(idx), \"name\": \"Item \(idx)\", \"quantity\": 1}"
+        }.joined(separator: ", ")
+        let body = """
+        [
+            {"id": 1, "status": "processing", "total": "10.00", "currency": "USD", "line_items": [\(items)]}
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let orders) = fields["orders"],
+              case .object(let first) = orders.first,
+              case .array(let lineItems) = first["line_items"] else {
+            Issue.record("expected line_items in first order")
+            return
+        }
+        #expect(lineItems.count == 5)
+        #expect(first["line_items_truncated"] == .bool(true))
+        #expect(first["line_items_count"] == .int(7))
+    }
+
+    @Test
+    func test_orders_list_when_row_customer_note_exceeds_500_chars_then_row_customer_note_truncated_is_true() async throws {
+        // Given
+        let note = String(repeating: "x", count: 600)
+        let body = """
+        [
+            {"id": 1, "status": "processing", "total": "10.00", "currency": "USD", "customer_note": "\(note)"}
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let orders) = fields["orders"],
+              case .object(let first) = orders.first else {
+            Issue.record("expected first order")
+            return
+        }
+        #expect(first["customer_note_truncated"] == .bool(true))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersUpdateToolTests.swift
@@ -145,4 +145,131 @@ struct OrdersUpdateToolTests {
         #expect(failed.kind == .outcomeUnknown)
     }
 
+    @Test
+    func test_descriptor_when_inspected_then_id_is_required_and_status_is_optional() {
+        // Given
+        let tool = OrdersUpdateTool.make()
+
+        // Then
+        guard case .object(let schema) = tool.definition.parametersSchema,
+              case .array(let required) = schema["required"] else {
+            Issue.record("expected schema required array")
+            return
+        }
+        #expect(required == [.string("id")])
+    }
+
+    @Test
+    func test_descriptor_when_inspected_then_status_enum_excludes_refunded() {
+        // Given
+        let tool = OrdersUpdateTool.make()
+
+        // Then
+        guard case .object(let schema) = tool.definition.parametersSchema,
+              case .object(let properties) = schema["properties"],
+              case .object(let status) = properties["status"],
+              case .array(let values) = status["enum"] else {
+            Issue.record("expected status enum")
+            return
+        }
+        let strings = values.compactMap { value -> String? in
+            if case .string(let s) = value { return s }
+            return nil
+        }
+        #expect(!strings.contains("refunded"))
+    }
+
+    @Test
+    func test_execute_when_no_editable_field_provided_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = OrdersUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"id": 1}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+    }
+
+    @Test
+    func test_execute_when_only_customer_note_provided_then_request_body_contains_customer_note_only() async throws {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok(#"{"id":7}"#))
+        let tool = OrdersUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"id": 7, "customer_note": "Thanks"}"#, client)
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success")
+            return
+        }
+        let call = try #require(await client.calls.first)
+        let parsed = try #require(call.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(parsed["customer_note"] as? String == "Thanks")
+        #expect(parsed["status"] == nil)
+        #expect(parsed["billing"] == nil)
+    }
+
+    @Test
+    func test_execute_when_only_billing_email_provided_then_request_body_contains_billing_object_with_email() async throws {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok(#"{"id":7}"#))
+        let tool = OrdersUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"id": 7, "billing_email": "x@y.z"}"#, client)
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success")
+            return
+        }
+        let call = try #require(await client.calls.first)
+        let parsed = try #require(call.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
+        #expect(parsed["status"] == nil)
+        #expect(parsed["customer_note"] == nil)
+        let billing = try #require(parsed["billing"] as? [String: Any])
+        #expect(billing["email"] as? String == "x@y.z")
+    }
+
+    @Test
+    func test_execute_when_status_and_customer_note_provided_then_post_write_summary_includes_widened_fields() async throws {
+        // Given
+        let body = """
+        {
+            "id": 7, "status": "processing", "total": "100.00", "currency": "USD",
+            "customer_note": "Thanks!",
+            "billing": {"first_name": "Jane", "last_name": "Doe", "email": "j@e.com"},
+            "line_items": [{"id": 1, "name": "Item", "quantity": 1}]
+        }
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"id": 7, "status": "processing", "customer_note": "Hi"}"#,
+            client
+        )
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["customer_note"] == .string("Thanks!"))
+        guard case .array(let items) = summary["line_items"] else {
+            Issue.record("expected line_items")
+            return
+        }
+        #expect(items.count == 1)
+    }
+
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersUpdateToolTests.swift
@@ -47,12 +47,9 @@ struct OrdersUpdateToolTests {
     }
 
     @Test
-    func test_ordersUpdate_when_field_outside_allowlist_then_dropped_silently_and_request_excludes_it() async throws {
+    func test_ordersUpdate_when_field_outside_allowlist_then_returns_invalidToolCall() async {
         // Given
-        let body = """
-        {"id": 8, "status": "processing"}
-        """
-        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
         let tool = OrdersUpdateTool.make()
 
         // When
@@ -62,15 +59,14 @@ struct OrdersUpdateToolTests {
         let result = await tool.executor(arguments, client)
 
         // Then
-        guard case .success = result else {
-            Issue.record("expected success, got \(result)")
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
             return
         }
-        let call = try #require(await client.calls.first)
-        let parsed = try #require(call.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
-        #expect(parsed["discount_total"] == nil)
-        #expect(parsed["_method"] == nil)
-        #expect(parsed["status"] as? String == "processing")
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("_method"))
+        #expect(failed.reason.contains("discount_total"))
+        #expect(await client.calls.isEmpty)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersUpdateToolTests.swift
@@ -272,4 +272,63 @@ struct OrdersUpdateToolTests {
         #expect(items.count == 1)
     }
 
+    @Test
+    func test_execute_when_customer_note_exceeds_1000_chars_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = OrdersUpdateTool.make()
+        let oversize = String(repeating: "a", count: 1001)
+
+        // When
+        let result = await tool.executor(#"{"id": 7, "customer_note": "\#(oversize)"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "customer_note must be at most 1000 characters.")
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_billing_email_exceeds_254_chars_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = OrdersUpdateTool.make()
+        let oversize = String(repeating: "a", count: 245) + "@example.com"
+
+        // When
+        let result = await tool.executor(#"{"id": 7, "billing_email": "\#(oversize)"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "billing_email must be at most 254 characters.")
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_billing_email_is_malformed_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
+        let tool = OrdersUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"id": 7, "billing_email": "not-an-email"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason == "billing_email must be a valid email address.")
+        #expect(await client.calls.isEmpty)
+    }
+
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductSummaryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductSummaryTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite(.timeLimit(.minutes(1)))
 struct ProductSummaryTests {
     @Test
-    func test_make_when_entity_has_multiple_images_then_summary_keeps_only_first_image() {
+    func test_make_when_entity_has_multiple_images_then_summary_keeps_first_three_images() {
         // Given
         let entity = AnyCodableJSON.object([
             "id": .int(101),
@@ -13,7 +13,8 @@ struct ProductSummaryTests {
             "images": .array([
                 .object(["id": .int(1), "src": .string("https://example.com/1.jpg")]),
                 .object(["id": .int(2), "src": .string("https://example.com/2.jpg")]),
-                .object(["id": .int(3), "src": .string("https://example.com/3.jpg")])
+                .object(["id": .int(3), "src": .string("https://example.com/3.jpg")]),
+                .object(["id": .int(4), "src": .string("https://example.com/4.jpg")])
             ])
         ])
 
@@ -25,7 +26,222 @@ struct ProductSummaryTests {
             Issue.record("expected images array on summary")
             return
         }
-        #expect(images.count == 1)
-        #expect(images.first == .object(["id": .int(1), "src": .string("https://example.com/1.jpg")]))
+        #expect(images.count == 3)
+        #expect(fields["images_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_product_summary_when_categories_exceed_five_then_only_five_returned_and_truncated_flag_is_true() {
+        // Given
+        let categories = (1...7).map { idx in
+            AnyCodableJSON.object(["id": .int(Int64(idx)), "name": .string("c\(idx)"), "slug": .string("c\(idx)")])
+        }
+        let entity = AnyCodableJSON.object(["id": .int(1), "categories": .array(categories)])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let projected) = fields["categories"] else {
+            Issue.record("expected categories array")
+            return
+        }
+        #expect(projected.count == 5)
+        #expect(fields["categories_count"] == .int(7))
+        #expect(fields["categories_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_product_summary_when_description_exceeds_500_chars_then_value_is_truncated_and_flag_is_true() {
+        // Given
+        let long = String(repeating: "x", count: 600)
+        let entity = AnyCodableJSON.object(["id": .int(1), "description": .string(long)])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .string(let projected) = fields["description"] else {
+            Issue.record("expected description string")
+            return
+        }
+        #expect(projected.count == 500)
+        #expect(fields["description_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_product_summary_when_short_description_is_short_then_truncated_flag_is_absent() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(1), "short_description": .string("Cozy")])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["short_description"] == .string("Cozy"))
+        #expect(fields["short_description_truncated"] == nil)
+    }
+
+    @Test
+    func test_product_summary_when_attributes_present_then_options_array_is_carried_through() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(1),
+            "attributes": .array([
+                .object([
+                    "id": .int(7),
+                    "name": .string("Color"),
+                    "visible": .bool(true),
+                    "variation": .bool(true),
+                    "options": .array([.string("Red"), .string("Blue")])
+                ])
+            ])
+        ])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let attrs) = fields["attributes"],
+              case .object(let first) = attrs.first else {
+            Issue.record("expected attributes array")
+            return
+        }
+        #expect(first["options"] == .array([.string("Red"), .string("Blue")]))
+        #expect(first["visible"] == .bool(true))
+        #expect(first["variation"] == .bool(true))
+    }
+
+    @Test
+    func test_product_summary_when_images_exceed_three_then_only_three_returned_and_truncated_flag_is_true() {
+        // Given
+        let images = (1...5).map { idx in
+            AnyCodableJSON.object(["id": .int(Int64(idx)), "src": .string("u\(idx)")])
+        }
+        let entity = AnyCodableJSON.object(["id": .int(1), "images": .array(images)])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .array(let projected) = fields["images"] else {
+            Issue.record("expected images array")
+            return
+        }
+        #expect(projected.count == 3)
+        #expect(fields["images_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_product_summary_when_dimensions_present_then_length_width_height_are_emitted_as_strings() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(1),
+            "dimensions": .object([
+                "length": .string("10"),
+                "width": .string("20"),
+                "height": .string("30")
+            ])
+        ])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .object(let dim) = fields["dimensions"] else {
+            Issue.record("expected dimensions object")
+            return
+        }
+        #expect(dim["length"] == .string("10"))
+        #expect(dim["width"] == .string("20"))
+        #expect(dim["height"] == .string("30"))
+    }
+
+    @Test
+    func test_product_summary_when_variable_product_has_variations_array_then_variation_ids_truncated_at_twenty_and_count_reflects_total() {
+        // Given
+        let ids = (1...25).map { AnyCodableJSON.int(Int64($0)) }
+        let entity = AnyCodableJSON.object(["id": .int(1), "variations": .array(ids)])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let projected) = fields["variation_ids"] else {
+            Issue.record("expected variation_ids array")
+            return
+        }
+        #expect(projected.count == 20)
+        #expect(fields["variations_count"] == .int(25))
+        #expect(fields["variation_ids_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_product_summary_when_simple_product_then_parent_id_is_zero_and_variation_ids_is_empty_array() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(1), "parent_id": .int(0), "type": .string("simple")])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["parent_id"] == .int(0))
+        #expect(fields["variation_ids"] == .array([]))
+        #expect(fields["variations_count"] == .int(0))
+    }
+
+    @Test
+    func test_product_summary_when_cross_and_upsell_ids_present_then_arrays_are_emitted() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(1),
+            "cross_sell_ids": .array([.int(7), .int(8)]),
+            "upsell_ids": .array([.int(9)])
+        ])
+
+        // When
+        let summary = ProductSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["cross_sell_ids"] == .array([.int(7), .int(8)]))
+        #expect(fields["upsell_ids"] == .array([.int(9)]))
+    }
+
+    @Test
+    func test_listRow_when_entity_has_images_then_first_image_is_projected_as_image_field() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(1),
+            "images": .array([
+                .object(["id": .int(11), "src": .string("a")]),
+                .object(["id": .int(12), "src": .string("b")])
+            ])
+        ])
+
+        // When
+        let summary = ProductSummary.listRow(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .object(let image) = fields["image"] else {
+            Issue.record("expected image object")
+            return
+        }
+        #expect(image["src"] == .string("a"))
+        #expect(fields["images"] == nil)
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationDetailSummaryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationDetailSummaryTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct ProductVariationDetailSummaryTests {
+    @Test
+    func test_make_when_variation_has_attributes_then_each_attribute_carries_name_and_option() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(33),
+            "attributes": .array([
+                .object(["id": .int(7), "name": .string("Color"), "option": .string("Red")])
+            ])
+        ])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let attrs) = fields["attributes"],
+              case .object(let first) = attrs.first else {
+            Issue.record("expected attributes")
+            return
+        }
+        #expect(first["name"] == .string("Color"))
+        #expect(first["option"] == .string("Red"))
+    }
+
+    @Test
+    func test_make_when_variation_description_exceeds_500_chars_then_value_is_truncated_and_flag_is_true() {
+        // Given
+        let long = String(repeating: "z", count: 700)
+        let entity = AnyCodableJSON.object(["id": .int(1), "description": .string(long)])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .string(let projected) = fields["description"] else {
+            Issue.record("expected description")
+            return
+        }
+        #expect(projected.count == 500)
+        #expect(fields["description_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_make_when_variation_has_dimensions_then_length_width_height_are_emitted() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(1),
+            "dimensions": .object([
+                "length": .string("1"),
+                "width": .string("2"),
+                "height": .string("3")
+            ])
+        ])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .object(let dim) = fields["dimensions"] else {
+            Issue.record("expected dimensions")
+            return
+        }
+        #expect(dim["length"] == .string("1"))
+        #expect(dim["width"] == .string("2"))
+        #expect(dim["height"] == .string("3"))
+    }
+
+    @Test
+    func test_make_when_variation_has_image_then_image_is_projected_with_src() {
+        // Given
+        let entity = AnyCodableJSON.object([
+            "id": .int(1),
+            "image": .object(["id": .int(99), "src": .string("https://example.com/v.jpg")])
+        ])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary, case .object(let image) = fields["image"] else {
+            Issue.record("expected image")
+            return
+        }
+        #expect(image["src"] == .string("https://example.com/v.jpg"))
+    }
+
+    @Test
+    func test_make_when_variation_has_no_attributes_then_attributes_is_empty_array() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(1)])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["attributes"] == .array([]))
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationDetailSummaryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationDetailSummaryTests.swift
@@ -91,6 +91,40 @@ struct ProductVariationDetailSummaryTests {
     }
 
     @Test
+    func test_make_when_variation_has_parent_id_then_product_id_mirrors_parent_id() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(202), "parent_id": .int(99)])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["parent_id"] == .int(99))
+        #expect(fields["product_id"] == .int(99))
+    }
+
+    @Test
+    func test_make_when_variation_has_no_parent_id_then_product_id_is_absent() {
+        // Given
+        let entity = AnyCodableJSON.object(["id": .int(202)])
+
+        // When
+        let summary = ProductVariationDetailSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary else {
+            Issue.record("expected object")
+            return
+        }
+        #expect(fields["parent_id"] == nil)
+        #expect(fields["product_id"] == nil)
+    }
+
+    @Test
     func test_make_when_variation_has_no_attributes_then_attributes_is_empty_array() {
         // Given
         let entity = AnyCodableJSON.object(["id": .int(1)])

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationsListToolTests.swift
@@ -80,4 +80,69 @@ struct ProductVariationsListToolTests {
         // Then
         #expect(await client.calls.first?.query["per_page"] == "50")
     }
+
+    @Test
+    func test_variations_list_summary_when_rows_present_then_wrapper_uses_variations_key_with_widened_per_row_shape() async throws {
+        // Given
+        let body = """
+        [
+            {
+                "id": 1001, "stock_status": "instock", "price": "20.00",
+                "attributes": [{"id": 7, "name": "Color", "option": "Red"}],
+                "image": {"id": 9, "src": "v.jpg"}
+            }
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductVariationsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"product_id": 555}"#, client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let variations) = fields["variations"],
+              case .object(let first) = variations.first else {
+            Issue.record("expected variations array")
+            return
+        }
+        #expect(fields["rows"] == nil)
+        guard case .array(let attrs) = first["attributes"], case .object(let firstAttr) = attrs.first else {
+            Issue.record("expected attributes on first variation")
+            return
+        }
+        #expect(firstAttr["option"] == .string("Red"))
+        guard case .object(let image) = first["image"] else {
+            Issue.record("expected image")
+            return
+        }
+        #expect(image["src"] == .string("v.jpg"))
+    }
+
+    @Test
+    func test_variations_list_summary_when_per_row_price_present_then_price_range_uses_widened_rows() async throws {
+        // Given
+        let body = """
+        [
+            {"id": 1, "price": "10.00", "stock_status": "instock"},
+            {"id": 2, "price": "30.00", "stock_status": "instock"}
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductVariationsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"product_id": 555}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(fields["price_range"] == .object([
+            "min": .string("10"),
+            "max": .string("30")
+        ]))
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationsUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductVariationsUpdateToolTests.swift
@@ -88,9 +88,9 @@ struct ProductVariationsUpdateToolTests {
     }
 
     @Test
-    func test_productVariationsUpdate_when_field_outside_allowlist_then_dropped_silently() async throws {
+    func test_productVariationsUpdate_when_field_outside_allowlist_then_returns_invalidToolCall() async {
         // Given
-        let client = MockWCRESTClient(response: StubResponses.ok(#"{"id":33}"#))
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
         let tool = ProductVariationsUpdateTool.make()
 
         // When
@@ -100,15 +100,45 @@ struct ProductVariationsUpdateToolTests {
         let result = await tool.executor(arguments, client)
 
         // Then
-        guard case .success = result else {
-            Issue.record("expected success, got \(result)")
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
             return
         }
-        let call = try #require(await client.calls.first)
-        let parsed = try #require(call.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
-        #expect(parsed["weight"] == nil)
-        #expect(parsed["dimensions"] == nil)
-        #expect(parsed["regular_price"] as? String == "1.00")
+        #expect(failed.kind == .invalidToolCall)
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_variations_update_when_write_succeeds_then_summary_uses_variation_detail_projection_with_attributes_and_image() async throws {
+        // Given
+        let body = """
+        {
+            "id": 33, "regular_price": "29.99", "stock_status": "instock",
+            "attributes": [{"id": 7, "name": "Color", "option": "Red"}],
+            "image": {"id": 9, "src": "v.jpg"}
+        }
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductVariationsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"product_id": 12, "id": 33, "regular_price": "29.99"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        guard case .array(let attrs) = summary["attributes"], case .object(let firstAttr) = attrs.first else {
+            Issue.record("expected attributes")
+            return
+        }
+        #expect(firstAttr["option"] == .string("Red"))
+        guard case .object(let image) = summary["image"] else {
+            Issue.record("expected image")
+            return
+        }
+        #expect(image["src"] == .string("v.jpg"))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsBulkUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsBulkUpdateToolTests.swift
@@ -111,4 +111,52 @@ struct ProductsBulkUpdateToolTests {
         }
         #expect(failed.kind == .outcomeUnknown)
     }
+
+    @Test
+    func test_execute_when_products_bulk_succeeds_then_patch_keys_uses_name_regular_price_sale_price_stock_quantity_status_order() async {
+        // Given
+        let body = #"{"update": [{"id": 10}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsBulkUpdateTool.make()
+
+        // When
+        let arguments = #"""
+        {"ids": [10], "patch": {"status": "draft", "stock_quantity": 5, "sale_price": "9", "regular_price": "10", "name": "X"}}
+        """#
+        let result = await tool.executor(arguments, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["patch_keys"] == .array([
+            .string("name"),
+            .string("regular_price"),
+            .string("sale_price"),
+            .string("stock_quantity"),
+            .string("status")
+        ]))
+    }
+
+    @Test
+    func test_execute_when_products_bulk_succeeds_then_receipt_includes_requested_count_and_updated_ids() async {
+        // Given
+        let body = #"{"update": [{"id": 10, "name": "X"}, {"id": 11, "name": "X"}]}"#
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [10, 11], "patch": {"name": "X"}}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let summary) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(summary["requested_count"] == .int(2))
+        #expect(summary["updated_ids"] == .array([.int(10), .int(11)]))
+        #expect(summary["partial_success"] == .bool(false))
+        #expect(summary["failed"] == .array([]))
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsBulkUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsBulkUpdateToolTests.swift
@@ -140,6 +140,24 @@ struct ProductsBulkUpdateToolTests {
     }
 
     @Test
+    func test_execute_when_patch_has_unknown_key_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsBulkUpdateTool.make()
+
+        // When
+        let result = await tool.executor(#"{"ids": [1], "patch": {"description": "ignored"}}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("description"))
+    }
+
+    @Test
     func test_execute_when_products_bulk_succeeds_then_receipt_includes_requested_count_and_updated_ids() async {
         // Given
         let body = #"{"update": [{"id": 10, "name": "X"}, {"id": 11, "name": "X"}]}"#

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsGetToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsGetToolTests.swift
@@ -54,7 +54,7 @@ struct ProductsGetToolTests {
             #expect(summary["stock_quantity"] == .int(12))
             #expect(summary["regular_price"] == .string("99.00"))
             #expect(summary["sale_price"] == .string("89.00"))
-            #expect(summary["description"] == nil)
+            #expect(summary["description"] == .string("Soft & warm cashmere scarf."))
         } else {
             Issue.record("expected object structured")
         }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsGetToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsGetToolTests.swift
@@ -30,6 +30,7 @@ struct ProductsGetToolTests {
             "stock_quantity": 12,
             "type": "simple",
             "status": "publish",
+            "permalink": "https://example.com/product/scarf",
             "description": "<p>Soft &amp; warm cashmere scarf.</p>",
             "_links": {"self": []},
             "meta_data": [{"id": 1, "key": "_x", "value": "y"}],
@@ -54,6 +55,7 @@ struct ProductsGetToolTests {
             #expect(summary["stock_quantity"] == .int(12))
             #expect(summary["regular_price"] == .string("99.00"))
             #expect(summary["sale_price"] == .string("89.00"))
+            #expect(summary["permalink"] == .string("https://example.com/product/scarf"))
             #expect(summary["description"] == .string("Soft & warm cashmere scarf."))
         } else {
             Issue.record("expected object structured")

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -220,4 +220,177 @@ struct ProductsListToolTests {
         }
         #expect(failed.kind == .auth)
     }
+
+    @Test
+    func test_descriptor_when_inspected_then_supported_query_args_match_android_parity() {
+        // Given
+        let tool = ProductsListTool.make()
+
+        // Then
+        guard case .object(let schema) = tool.definition.parametersSchema,
+              case .object(let properties) = schema["properties"] else {
+            Issue.record("expected schema properties")
+            return
+        }
+        let keys = Set(properties.keys)
+        #expect(keys == [
+            "search", "status", "category", "sku", "include", "stock_status",
+            "orderby", "order", "page", "per_page"
+        ])
+    }
+
+    @Test
+    func test_descriptor_when_inspected_then_tag_is_not_exposed() {
+        // Given
+        let tool = ProductsListTool.make()
+
+        // Then
+        guard case .object(let schema) = tool.definition.parametersSchema,
+              case .object(let properties) = schema["properties"] else {
+            Issue.record("expected schema")
+            return
+        }
+        #expect(properties["tag"] == nil)
+    }
+
+    @Test
+    func test_descriptor_when_inspected_then_orderby_enum_excludes_id_price_rating() {
+        // Given
+        let tool = ProductsListTool.make()
+
+        // Then
+        guard case .object(let schema) = tool.definition.parametersSchema,
+              case .object(let properties) = schema["properties"],
+              case .object(let orderby) = properties["orderby"],
+              case .array(let values) = orderby["enum"] else {
+            Issue.record("expected orderby enum")
+            return
+        }
+        let strings = values.compactMap { value -> String? in
+            if case .string(let s) = value { return s }
+            return nil
+        }
+        #expect(Set(strings) == ["date", "title", "popularity"])
+    }
+
+    @Test
+    func test_execute_when_tag_arg_provided_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"tag": 5}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("tag"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_include_is_empty_array_then_invalidToolCall_with_at_least_one_id_message_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"include": []}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("at least one"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_include_has_more_than_100_ids_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+        let ids = (1...101).map(String.init).joined(separator: ", ")
+
+        // When
+        let result = await tool.executor(#"{"include": [\#(ids)]}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_include_combined_with_search_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"include": [1, 2], "search": "scarf"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("include cannot be combined"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_search_combined_with_orderby_then_invalidToolCall_is_returned() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"search": "tee", "orderby": "popularity"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("orderby and order cannot be combined"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_execute_when_stock_status_is_outofstock_then_query_string_carries_stock_status_outofstock() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        _ = await tool.executor(#"{"stock_status": "outofstock"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["stock_status"] == "outofstock")
+    }
+
+    @Test
+    func test_execute_when_orderby_is_popularity_then_query_string_carries_orderby_popularity() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        _ = await tool.executor(#"{"orderby": "popularity"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["orderby"] == "popularity")
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -393,4 +393,78 @@ struct ProductsListToolTests {
         // Then
         #expect(await client.calls.first?.query["orderby"] == "popularity")
     }
+
+    @Test
+    func test_validateCombinations_when_invalid_status_then_fails() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"status": "trashed"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("trashed"))
+        #expect(failed.reason.contains("not an allowed status"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_validateCombinations_when_invalid_stock_status_then_fails() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"stock_status": "lowstock"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("lowstock"))
+        #expect(failed.reason.contains("not an allowed stock_status"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_validateCombinations_when_valid_status_then_passes() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"status": "draft"}"#, client)
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(await client.calls.first?.query["status"] == "draft")
+    }
+
+    @Test
+    func test_validateCombinations_when_valid_stock_status_then_passes() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"stock_status": "onbackorder"}"#, client)
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(await client.calls.first?.query["stock_status"] == "onbackorder")
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -46,7 +46,6 @@ struct ProductsListToolTests {
         }
         #expect(fields["count"] == .int(3))
         #expect(fields["ids"] == .array([.int(101), .int(102), .int(103)]))
-        #expect(fields["rows"] == nil)
         #expect(fields["stock_status_counts"] == .object([
             "instock": .int(2),
             "outofstock": .int(1)
@@ -55,6 +54,140 @@ struct ProductsListToolTests {
             "min": .string("19"),
             "max": .string("120")
         ]))
+        guard case .array(let products) = fields["products"] else {
+            Issue.record("expected products array")
+            return
+        }
+        #expect(products.count == 3)
+    }
+
+    @Test
+    func test_products_list_summary_when_rows_present_then_products_array_carries_per_row_widened_fields() async throws {
+        // Given
+        let body = """
+        [
+            {
+                "id": 101, "name": "Hoodie", "sku": "HOOD-1", "price": "49.00",
+                "stock_status": "instock",
+                "type": "simple", "status": "publish",
+                "regular_price": "59.00", "sale_price": "49.00", "on_sale": true,
+                "manage_stock": false,
+                "categories": [{"id": 1, "name": "Apparel", "slug": "apparel"}],
+                "images": [{"id": 1, "src": "https://example.com/h.jpg"}]
+            }
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 1}"#, client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let products) = fields["products"],
+              case .object(let first) = products.first else {
+            Issue.record("expected first product object")
+            return
+        }
+        #expect(first["on_sale"] == .bool(true))
+        #expect(first["manage_stock"] == .bool(false))
+        guard case .object(let image) = first["image"] else {
+            Issue.record("expected first product image object")
+            return
+        }
+        #expect(image["src"] == .string("https://example.com/h.jpg"))
+        guard case .array(let categories) = first["categories"], case .object(let firstCat) = categories.first else {
+            Issue.record("expected categories array")
+            return
+        }
+        #expect(firstCat["slug"] == .string("apparel"))
+    }
+
+    @Test
+    func test_products_list_summary_when_row_has_image_array_then_first_image_is_projected_as_image_field() async throws {
+        // Given
+        let body = """
+        [{"id": 1, "images": [{"id": 9, "src": "first.jpg"}, {"id": 10, "src": "second.jpg"}]}]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let products) = fields["products"],
+              case .object(let first) = products.first,
+              case .object(let image) = first["image"] else {
+            Issue.record("expected single image field")
+            return
+        }
+        #expect(image["src"] == .string("first.jpg"))
+        #expect(first["images"] == nil)
+    }
+
+    @Test
+    func test_products_list_summary_when_can_load_more_provided_then_field_is_emitted_in_wrapper() async throws {
+        // Given - 3 rows with per_page=3 means can_load_more=true (rows.count >= per_page)
+        let body = """
+        [{"id": 1}, {"id": 2}, {"id": 3}]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 3}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(fields["can_load_more"] == .bool(true))
+    }
+
+    @Test
+    func test_execute_when_response_carries_per_page_rows_then_can_load_more_is_true() async {
+        // Given
+        let body = """
+        [{"id": 1}, {"id": 2}]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 2}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(fields["can_load_more"] == .bool(true))
+    }
+
+    @Test
+    func test_execute_when_response_has_fewer_rows_than_per_page_then_can_load_more_is_false() async {
+        // Given
+        let body = """
+        [{"id": 1}]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 5}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(fields["can_load_more"] == .bool(false))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
@@ -30,12 +30,9 @@ struct ProductsUpdateToolTests {
     }
 
     @Test
-    func test_productsUpdate_when_field_outside_allowlist_then_dropped_silently() async throws {
+    func test_productsUpdate_when_field_outside_allowlist_then_returns_invalidToolCall() async {
         // Given
-        let body = """
-        {"id": 12, "name": "X", "type": "simple"}
-        """
-        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let client = MockWCRESTClient(response: StubResponses.ok("{}"))
         let tool = ProductsUpdateTool.make()
 
         // When
@@ -45,14 +42,14 @@ struct ProductsUpdateToolTests {
         let result = await tool.executor(arguments, client)
 
         // Then
-        guard case .success = result else {
-            Issue.record("expected success, got \(result)")
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
             return
         }
-        let call = try #require(await client.calls.first)
-        let parsed = try #require(call.body.flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] })
-        #expect(parsed["categories"] == nil)
-        #expect(parsed["tags"] == nil)
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("categories"))
+        #expect(failed.reason.contains("tags"))
+        #expect(await client.calls.isEmpty)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/REST/AnalyticsDateBoundsTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/REST/AnalyticsDateBoundsTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct AnalyticsDateBoundsTests {
+    @Test
+    func test_previous_period_bounds_when_inputs_are_seven_days_then_previous_window_is_immediately_preceding_seven_days() {
+        // Given
+        let after = "2026-05-01"
+        let before = "2026-05-07"
+
+        // When
+        let result = AnalyticsDateBounds.previousPeriodBounds(after: after, before: before)
+
+        // Then
+        #expect(result?.after == "2026-04-24")
+        #expect(result?.before == "2026-04-30")
+    }
+
+    @Test
+    func test_previous_period_bounds_when_inputs_are_single_day_then_previous_window_is_the_day_before() {
+        // Given
+        let after = "2026-05-15"
+        let before = "2026-05-15"
+
+        // When
+        let result = AnalyticsDateBounds.previousPeriodBounds(after: after, before: before)
+
+        // Then
+        #expect(result?.after == "2026-05-14")
+        #expect(result?.before == "2026-05-14")
+    }
+
+    @Test
+    func test_previous_period_bounds_when_inputs_invalid_then_returns_nil() {
+        // Given / When
+        let result = AnalyticsDateBounds.previousPeriodBounds(after: "not-a-date", before: "2026-05-07")
+
+        // Then
+        #expect(result == nil)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/REST/ToolArgumentValidationTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/REST/ToolArgumentValidationTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct ToolArgumentValidationTests {
+    @Test
+    func test_validate_when_args_are_subset_of_allowed_then_nil_is_returned() {
+        // Given
+        let arguments = #"{"id": 42, "status": "completed"}"#
+        let allowed: Set<String> = ["id", "status", "customer_note"]
+
+        // When
+        let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                     allowed: allowed,
+                                                     toolName: "orders_update")
+
+        // Then
+        #expect(failed == nil)
+    }
+
+    @Test
+    func test_validate_when_args_contain_unknown_key_then_failed_with_invalidToolCall_kind_is_returned() {
+        // Given
+        let arguments = #"{"id": 1, "discount_total": "9.00"}"#
+        let allowed: Set<String> = ["id", "status"]
+
+        // When
+        let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                     allowed: allowed,
+                                                     toolName: "orders_update")
+
+        // Then
+        let unwrapped = try? #require(failed)
+        #expect(unwrapped?.kind == .invalidToolCall)
+        #expect(unwrapped?.reason == "Unsupported orders_update argument(s): discount_total")
+    }
+
+    @Test
+    func test_validate_when_args_contain_multiple_unknown_keys_then_message_lists_them_comma_separated() {
+        // Given
+        let arguments = #"{"id": 1, "_method": "delete", "discount_total": "9.00"}"#
+        let allowed: Set<String> = ["id"]
+
+        // When
+        let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                     allowed: allowed,
+                                                     toolName: "orders_update")
+
+        // Then
+        let unwrapped = try? #require(failed)
+        #expect(unwrapped?.reason.contains("_method, discount_total") == true)
+    }
+
+    @Test
+    func test_validate_when_args_are_empty_then_nil_is_returned() {
+        // Given
+        let arguments = "{}"
+        let allowed: Set<String> = ["id"]
+
+        // When
+        let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                     allowed: allowed,
+                                                     toolName: "orders_update")
+
+        // Then
+        #expect(failed == nil)
+    }
+
+    @Test
+    func test_validate_when_arguments_string_is_not_an_object_then_nil_is_returned() {
+        // Given
+        let arguments = "[1, 2, 3]"
+        let allowed: Set<String> = ["id"]
+
+        // When
+        let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                     allowed: allowed,
+                                                     toolName: "orders_update")
+
+        // Then
+        #expect(failed == nil)
+    }
+
+    @Test
+    func test_validate_patch_when_object_has_unknown_key_then_failed_is_returned() {
+        // Given
+        let patch: AnyCodableJSON = .object([
+            "status": .string("completed"),
+            "discount_total": .string("9.00")
+        ])
+
+        // When
+        let failed = ToolArgumentValidation.validate(patch: patch,
+                                                     allowed: ["status", "customer_note"],
+                                                     toolName: "orders_bulk_update")
+
+        // Then
+        let unwrapped = try? #require(failed)
+        #expect(unwrapped?.kind == .invalidToolCall)
+        #expect(unwrapped?.reason.contains("discount_total") == true)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/REST/WriteResultMapperTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/REST/WriteResultMapperTests.swift
@@ -133,7 +133,10 @@ struct WriteResultMapperTests {
         let response = WCRESTResponse(data: Data(body.utf8), statusCode: 200)
 
         // When
-        let result = WriteResultMapper.mapBatch(response, toolName: "products_bulk_update")
+        let result = WriteResultMapper.mapBatch(response,
+                                                toolName: "products_bulk_update",
+                                                requestedCount: 2,
+                                                patchKeys: ["status"])
 
         // Then
         guard case .success(let success) = result else {
@@ -143,11 +146,15 @@ struct WriteResultMapperTests {
         if case .object(let summary) = success.structured {
             #expect(summary["updated_count"] == .int(2))
             #expect(summary["failed_count"] == .int(0))
+            #expect(summary["requested_count"] == .int(2))
+            #expect(summary["partial_success"] == .bool(false))
+            #expect(summary["patch_keys"] == .array([.string("status")]))
             if case .array(let ids) = summary["updated_ids"] {
                 #expect(ids == [.int(1), .int(2)])
             } else {
                 Issue.record("expected updated_ids array")
             }
+            #expect(summary["failed"] == .array([]))
         }
         #expect(success.uiStructured == nil)
     }
@@ -164,7 +171,10 @@ struct WriteResultMapperTests {
         let response = WCRESTResponse(data: Data(body.utf8), statusCode: 200)
 
         // When
-        let result = WriteResultMapper.mapBatch(response, toolName: "products_bulk_update")
+        let result = WriteResultMapper.mapBatch(response,
+                                                toolName: "products_bulk_update",
+                                                requestedCount: 2,
+                                                patchKeys: ["status"])
 
         // Then
         guard case .success(let success) = result else {
@@ -174,6 +184,7 @@ struct WriteResultMapperTests {
         if case .object(let summary) = success.structured {
             #expect(summary["updated_count"] == .int(1))
             #expect(summary["failed_count"] == .int(1))
+            #expect(summary["partial_success"] == .bool(true))
         }
     }
 
@@ -183,7 +194,10 @@ struct WriteResultMapperTests {
         let response = WCRESTResponse(data: Data(), statusCode: 408)
 
         // When
-        let result = WriteResultMapper.mapBatch(response, toolName: "orders_bulk_update")
+        let result = WriteResultMapper.mapBatch(response,
+                                                toolName: "orders_bulk_update",
+                                                requestedCount: 1,
+                                                patchKeys: ["status"])
 
         // Then
         guard case .failed(let failed) = result else {

--- a/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantExternalViewsAdaptor.swift
@@ -193,10 +193,23 @@ struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
     // MARK: - Product rows
 
     // Mirrors the Products tab: subtitle = stock detail, accessory = formatted price.
-    private func productDetails(for payload: ProductCardPayload) -> String {
-        productStockDetail(stockStatus: payload.stockStatus, stockQuantity: payload.stockQuantity)
+    // Variable products append a "· N variations" segment so the merchant sees variation count
+    // without having to drill in.
+    func productDetails(for payload: ProductCardPayload) -> String {
+        let stockOrSKU = productStockDetail(stockStatus: payload.stockStatus, stockQuantity: payload.stockQuantity)
             ?? payload.sku.flatMap { $0.isEmpty ? nil : "SKU: \($0)" }
-            ?? ""
+        return joinWithMiddleDot(stockOrSKU, variationsLabel(count: payload.variationsCount))
+    }
+
+    private func variationsLabel(count: Int?) -> String? {
+        guard let count, count > 0 else { return nil }
+        if count == 1 { return Localization.singleVariation }
+        let formatted = NumberFormatter.localizedString(from: NSNumber(value: count), number: .none)
+        return String(format: Localization.variationsCount, formatted)
+    }
+
+    private func joinWithMiddleDot(_ first: String?, _ second: String?) -> String {
+        [first, second].compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: " \u{00B7} ")
     }
 
     private func variationDetails(for payload: ProductVariationCardPayload) -> String {
@@ -463,6 +476,16 @@ struct AIAssistantExternalViewsAdaptor: AssistantExternalViewProviding {
             "assistant.externalViews.product.stock.countFormat",
             value: "%1$@ in stock",
             comment: "Subtitle on the assistant product row inlining the stock count. %1$@ is the count."
+        )
+        static let singleVariation = NSLocalizedString(
+            "assistant.externalViews.product.variations.singular",
+            value: "1 variation",
+            comment: "Variations badge on the assistant product row when the product has exactly one variation."
+        )
+        static let variationsCount = NSLocalizedString(
+            "assistant.externalViews.product.variations.plural",
+            value: "%1$@ variations",
+            comment: "Variations badge on the assistant product row for variable products. %1$@ is the count."
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalViewsAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantExternalViewsAdaptorTests.swift
@@ -44,6 +44,95 @@ struct AIAssistantExternalViewsAdaptorTests {
     }
 
     @Test
+    func test_productDetails_when_variable_product_with_multiple_variations_then_subtitle_appends_count_with_middle_dot() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(
+            id: 101,
+            name: "Hoodie",
+            stockStatus: "instock",
+            variationsCount: 15
+        )
+
+        // When
+        let subtitle = sut.productDetails(for: payload)
+
+        // Then
+        #expect(subtitle == "In stock \u{00B7} 15 variations")
+    }
+
+    @Test
+    func test_productDetails_when_variable_product_with_single_variation_then_subtitle_uses_singular_phrase() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(
+            id: 101,
+            name: "Hoodie",
+            stockStatus: "instock",
+            variationsCount: 1
+        )
+
+        // When
+        let subtitle = sut.productDetails(for: payload)
+
+        // Then
+        #expect(subtitle == "In stock \u{00B7} 1 variation")
+    }
+
+    @Test
+    func test_productDetails_when_simple_product_then_subtitle_omits_variations_segment() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(
+            id: 101,
+            name: "Hoodie",
+            stockStatus: "instock",
+            variationsCount: nil
+        )
+
+        // When
+        let subtitle = sut.productDetails(for: payload)
+
+        // Then
+        #expect(subtitle == "In stock")
+    }
+
+    @Test
+    func test_productDetails_when_variations_count_is_zero_then_segment_is_omitted() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(
+            id: 101,
+            name: "Hoodie",
+            stockStatus: "outofstock",
+            variationsCount: 0
+        )
+
+        // When
+        let subtitle = sut.productDetails(for: payload)
+
+        // Then
+        #expect(subtitle == "Out of stock")
+    }
+
+    @Test
+    func test_productDetails_when_no_stock_or_sku_but_variations_present_then_subtitle_is_just_variations() {
+        // Given
+        let sut = AIAssistantExternalViewsAdaptor()
+        let payload = ProductCardPayload(
+            id: 101,
+            name: "Hoodie",
+            variationsCount: 3
+        )
+
+        // When
+        let subtitle = sut.productDetails(for: payload)
+
+        // Then
+        #expect(subtitle == "3 variations")
+    }
+
+    @Test
     func test_customerRow_when_payload_has_name_fields_then_returns_anyview() {
         // Given
         let sut = AIAssistantExternalViewsAdaptor()


### PR DESCRIPTION
## Why

The merchant assistant's tool payloads strip almost every per-row field beyond id/name/total, so questions like "show me orders with their emails" or "list customers with phone numbers" force the model to fan out one `*_get` call per row and burn the iteration cap before any card renders. This change widens the model-facing tool payloads, adds a previous-period comparison to analytics, narrows `products_list` to the WC-supported argument shape, surfaces variation count on the AI product card row, and tightens the system prompt around two failure modes that smoke runs surfaced.

## Key non-obvious decisions

- **Rich-by-default rather than `extra_fields` opt-in.** An earlier iteration was opt-in; the model regularly chose to answer from the default (slim) payload instead of predicting that a hidden field existed and requesting it. Returning the widened fields by default removes that prediction step and matches the final shape the counterpart Android PR shipped.
- **`products_list` drops `tag` and narrows `orderby` to date/title/popularity.** Tag and `orderby=id|price|rating` lacked clean WC REST support; rejecting them lets the model fail loudly instead of silently no-op'ing.
- **Analytics comparison failures are partial-success, not transport errors.** When the primary analytics fetch succeeds but the previous-period fetch fails, returning the primary result with `previous_period_partial: true` is far preferable to failing the whole call.
- **Bulk write receipt is structured.** `requested_count`, `partial_success`, `patch_keys`, `updated_ids`, `failed` always emitted. The model needs the structure to decide whether to follow up with a `show_cards` rendering of the updated ids.
- **Confirmation preview shows the truncated new customer note, not the previous one.** Customer notes can be long and customer-authored; rendering both side by side adds noise to the confirmation card. Billing email keeps the before/after pair.
- **Capped text fields ship a `_truncated: true` companion flag.** Without it the model sees a string that looks complete; with it the model can mention "tap to read the full description" in prose.
- **Variation count is synthesized at the resolver.** WC's product entity exposes the variation list as `variations: [Long]` but never a count; deriving `variations_count` once in `CardReferenceResolver` keeps the model summary projection and the rendered card row reading the same field.
- **Payload-cap marker no longer claims "rendered in a card".** Earlier wording told the model the data was already in a card whenever a tool response exceeded 64 KB. None of our current tools render cards inline, so the marker now nudges `show_cards` (or a narrower retry once) instead of pretending a card exists.
- **System prompt covers ordinals/superlatives in write requests and list-with-hidden-field reads.** Both directives addressed smoke-run failure modes during development; `orders_with_email` flipped from a 0/3 cold-decline scenario to 3/3 list+cards+pointer after the Pattern 1b worked example landed.

## Cross-platform alignment with Android [#15854](https://github.com/woocommerce/woocommerce-android/pull/15854)

Verified against Android PR head `cbeddc96`.

| Area | Status |
|---|---|
| Truncation thresholds (10/5/10/500/5/20/10/3/500) | ✅ aligned |
| Bulk receipt fields and patch_keys order | ✅ aligned |
| Allowed status / stock_status / orderby / order enums | ✅ aligned |
| compare_to=previous_period + partial-success branch | ✅ aligned |
| products_list combo validation rules | ✅ aligned |
| Customer list field expansion (no orders_count/total_spent) | ✅ aligned |
| Confirmation preview customer_note (capped 160) + billing_email before/after | ✅ aligned |
| Variations list wrapper key renamed to `variations` | ✅ aligned |
| ToolArgumentValidation helper rejects unknown top-level + patch keys | ✅ aligned |
| Variations count synthesis at resolver | 🟦 iOS-specific (WC entity exposes `variations: [Long]`, never a count field; Android derives differently) |
| System prompt wording for write-on-prior-context + Pattern 1b | 🟦 iOS-ahead (strengthens orchestration patterns iOS smoke surfaced) |
| Payload-cap marker rewording | 🟦 iOS-specific (Android does not have an equivalent context cap) |
| Variation count on AI product card row UI | 🟦 iOS-only (Android product card shape differs) |

## Test Steps

Use an AI Assistant-enabled test store with recent orders, products, customers, and analytics data. Exact names and totals will depend on the store data, but the assistant should use the available tools/cards and should not fail because it lacks hidden optional fields.

1. Ask: "Show me products of my last order."
2. Ask: "Who placed my most recent order, and what else have they ordered?"
3. Ask: "How much revenue did I make this week, and how does it compare to last week?"
4. Ask: "Show recent orders, then tell me which one has the biggest discount."
5. Ask: "Find orders with free shipping and show the customers."

## Tests

543 unit tests, lint clean. Pinning tests added for the tool argument allow-list (top-level + nested patch), every widened summary projection (caps, truncation flags, blank-field omission), the bulk receipt structure, analytics comparison success and failure paths, the confirmation preview customer_note 160-char boundary, ProductVariationDetailSummary's parent_id→product_id mirroring, CardReferenceResolver's variations_count synthesis (positive + idempotent + non-product no-op), the show_cards order/product summary widening, and the system prompt directives.

Smoke run against the demo store (24 scenarios × 3 samples):

- 16 PASS, 0 regressions vs prior baseline.
- 7 FLAKY (cross-sample disagreement, none with a "this PR caused it" signature).
- 2 FAIL: `orders_with_email` flipped FAIL→PASS via the Pattern 1b worked example added in this PR; `memory_reference_resolution` is structural (t1 returns empty rows on the demo fixture, leaving t2's "the biggest one" with no antecedent — separate followup).

## Reviewer expectation

Specialist. The resolver-side variations synthesis, the payload-cap marker rewrite, and the analytics partial-success branch deserve careful read.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.