### PR TITLE
WidgetSiteListSyncManager: mirror selectable sites for store stats widget picker

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -65,6 +65,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ServiceLocator.authenticationManager.initialize()
         stores.initializeAfterDependenciesAreInitialized()
 
+        setupWidgetSiteListSyncIfNeeded()
+
         setupAnalytics(analytics)
         setupCocoaLumberjack()
         setupLibraryLogger()
@@ -281,6 +283,17 @@ extension AppDelegate {
 
     func setupUserNotificationCenter() {
         UNUserNotificationCenter.current().delegate = self
+    }
+
+    /// Starts the widget site list sync manager when the configurable Store Stats widgets
+    /// feature flag is enabled. The manager mirrors the user's selectable WooCommerce sites
+    /// into shared app-group `UserDefaults` for the widget site picker.
+    ///
+    func setupWidgetSiteListSyncIfNeeded() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.configurableStoreStatsWidgets) else {
+            return
+        }
+        ServiceLocator.widgetSiteListSyncManager.start()
     }
 
     /// Set up app review prompt

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -87,6 +87,9 @@ extension UserDefaults {
 
         /// Whether configurable store stats widgets are enabled
         case configurableStoreStatsWidgetsEnabled
+
+        /// Sites available for selection in the configurable store stats widget picker
+        case widgetSelectableSites
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -75,6 +75,11 @@ final class ServiceLocator {
     ///
     private static var _selectedSiteSettings: SelectedSiteSettings = SelectedSiteSettings()
 
+    /// Mirrors selectable WooCommerce sites into shared app-group `UserDefaults` for the
+    /// `StoreWidgetsExtension` site picker. Idle until `start()` is called.
+    ///
+    private static var _widgetSiteListSyncManager: WidgetSiteListSyncManager = WidgetSiteListSyncManager()
+
     /// Currency Settings
     ///
     private static var _currencySettings: CurrencySettings = CurrencySettings()
@@ -232,6 +237,13 @@ final class ServiceLocator {
     /// - Returns: An instance of SelectedSiteSettings.
     static var selectedSiteSettings: SelectedSiteSettings {
         return _selectedSiteSettings
+    }
+
+    /// Provides the access point to the WidgetSiteListSyncManager.
+    /// - Returns: A shared `WidgetSiteListSyncManager` instance. The instance is idle until
+    ///   `start()` is called.
+    static var widgetSiteListSyncManager: WidgetSiteListSyncManager {
+        return _widgetSiteListSyncManager
     }
 
     /// Provides the access point to the Currency Settings for the current Site.

--- a/WooCommerce/Classes/Tools/StoreWidgets/WidgetSite.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/WidgetSite.swift
@@ -1,0 +1,32 @@
+import Foundation
+import WooFoundationCore
+
+/// Lightweight representation of a WooCommerce site, shared between the host app and the
+/// `StoreWidgetsExtension` via app-group `UserDefaults`.
+///
+/// Carries the minimum data the widget needs to render and refresh stats for a selected site:
+/// identification, display name, timezone, and currency settings. `currencySettings` may be
+/// `nil` when general site settings have not been synced yet — the widget should fall back
+/// to the default site's currency settings in that case.
+struct WidgetSite: Codable, Equatable {
+    let siteID: Int64
+    let name: String
+    let timezoneIdentifier: String
+    let gmtOffset: Double
+    let currencySettings: CurrencySettings?
+
+    /// Resolves a usable `TimeZone` from the persisted identifier, falling back to a fixed-offset
+    /// timezone derived from `gmtOffset`, then `.current` if neither yields a valid zone.
+    var timezone: TimeZone {
+        if let timezone = TimeZone(identifier: timezoneIdentifier) {
+            return timezone
+        }
+        return TimeZone(secondsFromGMT: Int(gmtOffset * 3600)) ?? .current
+    }
+}
+
+extension WidgetSite: Identifiable {
+    var id: Int64 {
+        return siteID
+    }
+}

--- a/WooCommerce/Classes/Tools/StoreWidgets/WidgetSiteListStore.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/WidgetSiteListStore.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Read/write wrapper around the shared app-group `UserDefaults` entry that holds the list
+/// of sites available for selection in the configurable Store Stats widget picker.
+///
+/// Used by:
+/// - The host app (write side) via `WidgetSiteListSyncManager`.
+/// - The widget extension (read side) when populating the picker and resolving the selected site.
+///
+/// Returns an empty list when the key is absent or fails to decode. The widget extension is
+/// expected to fall back to the existing default-site keys in that case.
+struct WidgetSiteListStore {
+    private let userDefaults: UserDefaults?
+
+    init(userDefaults: UserDefaults? = .group) {
+        self.userDefaults = userDefaults
+    }
+
+    func sites() -> [WidgetSite] {
+        guard let data: Data = userDefaults?.object(forKey: .widgetSelectableSites),
+              let sites = try? JSONDecoder().decode([WidgetSite].self, from: data) else {
+            return []
+        }
+        return sites
+    }
+
+    func save(_ sites: [WidgetSite]) {
+        guard let data = try? JSONEncoder().encode(sites) else {
+            return
+        }
+        userDefaults?.set(data, forKey: .widgetSelectableSites)
+    }
+
+    func clear() {
+        userDefaults?.removeObject(forKey: .widgetSelectableSites)
+    }
+}

--- a/WooCommerce/Classes/Tools/StoreWidgets/WidgetSiteListSyncManager.swift
+++ b/WooCommerce/Classes/Tools/StoreWidgets/WidgetSiteListSyncManager.swift
@@ -1,0 +1,233 @@
+import Combine
+import Foundation
+import Yosemite
+import WidgetKit
+import WooFoundation
+import protocol Storage.StorageManagerType
+
+/// Mirrors the user's selectable WooCommerce sites into shared app-group `UserDefaults` so the
+/// `StoreWidgetsExtension` can populate its site picker.
+///
+/// Listens to:
+/// - `StorageSite` changes via a `ResultsController`, scoped to active WooCommerce sites.
+/// - `StorageSiteSetting` changes via a `ResultsController`, scoped to general site settings —
+///   the source of currency settings for non-default sites.
+/// - `hiddenStoreIDs` `UserDefaults` changes via KVO — sites hidden in the host app's store
+///   picker are also hidden in the widget picker.
+/// - Default-site changes via `defaultStoreIDPublisher` — controls default-first ordering.
+/// - `.logOutEventReceived` — clears the shared list explicitly.
+///
+/// Site-picker exposure is gated on WPCOM credentials. For any other authentication mode the
+/// shared list is cleared, so the widget picker has no selectable sites and the existing
+/// default-site rendering path is used unchanged.
+final class WidgetSiteListSyncManager {
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
+    private let widgetSiteListStore: WidgetSiteListStore
+    private let userDefaults: UserDefaults
+    private let notificationCenter: NotificationCenter
+
+    private var hasStarted = false
+    private var hiddenStoreIDsObservation: NSKeyValueObservation?
+    private var logOutObserver: NSObjectProtocol?
+    private var subscriptions: Set<AnyCancellable> = []
+
+    private lazy var sitesResultsController: ResultsController<StorageSite> = {
+        let predicate = NSPredicate(format: "isWooCommerceActive == YES")
+        let sortDescriptor = NSSortDescriptor(keyPath: \StorageSite.name, ascending: true)
+        return ResultsController<StorageSite>(storageManager: storageManager,
+                                              matching: predicate,
+                                              sortedBy: [sortDescriptor])
+    }()
+
+    private lazy var siteSettingsResultsController: ResultsController<StorageSiteSetting> = {
+        let predicate = NSPredicate(format: "settingGroupKey ==[c] %@", SiteSettingGroup.general.rawValue)
+        let sortDescriptor = NSSortDescriptor(keyPath: \StorageSiteSetting.siteID, ascending: true)
+        return ResultsController<StorageSiteSetting>(storageManager: storageManager,
+                                                     matching: predicate,
+                                                     sortedBy: [sortDescriptor])
+    }()
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         widgetSiteListStore: WidgetSiteListStore = WidgetSiteListStore(),
+         userDefaults: UserDefaults = .standard,
+         notificationCenter: NotificationCenter = .default) {
+        self.stores = stores
+        self.storageManager = storageManager
+        self.widgetSiteListStore = widgetSiteListStore
+        self.userDefaults = userDefaults
+        self.notificationCenter = notificationCenter
+    }
+
+    deinit {
+        teardownObservers()
+    }
+
+    /// Begins observing storage and writes the initial list. Idempotent.
+    func start() {
+        guard !hasStarted else {
+            return
+        }
+        hasStarted = true
+
+        configureSitesResultsController()
+        configureSiteSettingsResultsController()
+        configureHiddenStoreIDsObservation()
+        configureDefaultStoreIDObservation()
+        configureLogOutObservation()
+
+        rebuildAndPersist()
+    }
+
+    /// Tears down observers and clears the shared list. Idempotent.
+    func stop() {
+        guard hasStarted else {
+            return
+        }
+
+        teardownObservers()
+        hasStarted = false
+
+        widgetSiteListStore.clear()
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}
+
+// MARK: - Observers
+private extension WidgetSiteListSyncManager {
+    func configureSitesResultsController() {
+        sitesResultsController.onDidChangeContent = { [weak self] in
+            self?.rebuildAndPersist()
+        }
+        sitesResultsController.onDidResetContent = { [weak self] in
+            self?.rebuildAndPersist()
+        }
+        try? sitesResultsController.performFetch()
+    }
+
+    func configureSiteSettingsResultsController() {
+        siteSettingsResultsController.onDidChangeContent = { [weak self] in
+            self?.rebuildAndPersist()
+        }
+        siteSettingsResultsController.onDidResetContent = { [weak self] in
+            self?.rebuildAndPersist()
+        }
+        try? siteSettingsResultsController.performFetch()
+    }
+
+    func configureHiddenStoreIDsObservation() {
+        hiddenStoreIDsObservation = userDefaults.observe(\.hiddenStoreIDs, options: [.new]) { [weak self] _, _ in
+            DispatchQueue.main.async {
+                self?.rebuildAndPersist()
+            }
+        }
+    }
+
+    func configureDefaultStoreIDObservation() {
+        stores.sessionManager.defaultStoreIDPublisher
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.rebuildAndPersist()
+            }
+            .store(in: &subscriptions)
+    }
+
+    func configureLogOutObservation() {
+        logOutObserver = notificationCenter.addObserver(forName: .logOutEventReceived,
+                                                        object: nil,
+                                                        queue: .main) { [weak self] _ in
+            self?.widgetSiteListStore.clear()
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+    }
+
+    func teardownObservers() {
+        // Avoid touching the lazy `ResultsController` properties when the manager was never
+        // started — accessing them would force them to instantiate at teardown.
+        if hasStarted {
+            sitesResultsController.onDidChangeContent = nil
+            sitesResultsController.onDidResetContent = nil
+            siteSettingsResultsController.onDidChangeContent = nil
+            siteSettingsResultsController.onDidResetContent = nil
+        }
+        hiddenStoreIDsObservation?.invalidate()
+        hiddenStoreIDsObservation = nil
+        if let logOutObserver {
+            notificationCenter.removeObserver(logOutObserver)
+        }
+        logOutObserver = nil
+        subscriptions.removeAll()
+    }
+}
+
+// MARK: - List rebuild
+private extension WidgetSiteListSyncManager {
+    func rebuildAndPersist() {
+        let sites = buildSites()
+        widgetSiteListStore.save(sites)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    func buildSites() -> [WidgetSite] {
+        guard exposesSiteSelector else {
+            return []
+        }
+
+        let hiddenStoreIDs = Set(userDefaults.hiddenStoreIDs)
+        let defaultStoreID = stores.sessionManager.defaultStoreID
+        let currencySettingsBySiteID = currencySettingsBySiteID()
+
+        return sitesResultsController.fetchedObjects
+            .filter { !hiddenStoreIDs.contains($0.siteID) }
+            .map { site in
+                WidgetSite(siteID: site.siteID,
+                           name: site.name,
+                           timezoneIdentifier: site.timezone,
+                           gmtOffset: site.gmtOffset,
+                           currencySettings: currencySettingsBySiteID[site.siteID])
+            }
+            .sorted { lhs, rhs in
+                let lhsIsDefault = lhs.siteID == defaultStoreID
+                let rhsIsDefault = rhs.siteID == defaultStoreID
+                if lhsIsDefault != rhsIsDefault {
+                    return lhsIsDefault
+                }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    func currencySettingsBySiteID() -> [Int64: CurrencySettings] {
+        let settingsBySiteID = Dictionary(grouping: siteSettingsResultsController.fetchedObjects, by: \.siteID)
+        return settingsBySiteID.compactMapValues { settings in
+            currencySettings(from: settings)
+        }
+    }
+
+    /// Returns `CurrencySettings` only when all keys required by the widget formatter are present
+    /// for this site; otherwise returns `nil` so the widget can fall back to the default site's
+    /// currency settings at render time.
+    func currencySettings(from siteSettings: [SiteSetting]) -> CurrencySettings? {
+        let requiredSettingIDs: Set<String> = [
+            CurrencySettings.Constants.currencyCodeKey,
+            CurrencySettings.Constants.currencyPositionKey,
+            CurrencySettings.Constants.thousandSeparatorKey,
+            CurrencySettings.Constants.decimalSeparatorKey,
+            CurrencySettings.Constants.numberOfDecimalsKey
+        ]
+        let presentSettingIDs = Set(siteSettings.map(\.settingID))
+        guard requiredSettingIDs.isSubset(of: presentSettingIDs) else {
+            return nil
+        }
+        return CurrencySettings(siteSettings: siteSettings)
+    }
+
+    var exposesSiteSelector: Bool {
+        guard case .wpcom = stores.sessionManager.defaultCredentials else {
+            return false
+        }
+        return true
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -286,6 +286,8 @@
 				"Extensions/UserDefaults+Woo.swift",
 				System/WooConstants.swift,
 				Tools/AppLocalizedString.swift,
+				Tools/StoreWidgets/WidgetSite.swift,
+				Tools/StoreWidgets/WidgetSiteListStore.swift,
 			);
 			target = 3F1FA83F28B60125009E246C /* StoreWidgetsExtension */;
 		};

--- a/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListStoreTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+import WooFoundationCore
+@testable import WooCommerce
+
+struct WidgetSiteListStoreTests {
+
+    @Test func sites_when_no_data_is_persisted_then_returns_empty_list() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let sut = WidgetSiteListStore(userDefaults: userDefaults)
+
+        // When
+        let sites = sut.sites()
+
+        // Then
+        #expect(sites.isEmpty)
+    }
+
+    @Test func sites_when_persisted_data_is_invalid_then_returns_empty_list() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        userDefaults.set(Data([0xFF, 0xFE]), forKey: .widgetSelectableSites)
+        let sut = WidgetSiteListStore(userDefaults: userDefaults)
+
+        // When
+        let sites = sut.sites()
+
+        // Then
+        #expect(sites.isEmpty)
+    }
+
+    @Test func save_then_sites_returns_round_tripped_sites() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let sut = WidgetSiteListStore(userDefaults: userDefaults)
+        let sites = [
+            WidgetSite(siteID: 1,
+                       name: "Default",
+                       timezoneIdentifier: "UTC",
+                       gmtOffset: 0,
+                       currencySettings: nil),
+            WidgetSite(siteID: 2,
+                       name: "Other",
+                       timezoneIdentifier: "Europe/Madrid",
+                       gmtOffset: 1,
+                       currencySettings: CurrencySettings())
+        ]
+
+        // When
+        sut.save(sites)
+        let loaded = sut.sites()
+
+        // Then
+        #expect(loaded.map(\.siteID) == [1, 2])
+        #expect(loaded.map(\.name) == ["Default", "Other"])
+    }
+
+    @Test func clear_when_data_is_persisted_then_removes_data() {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let sut = WidgetSiteListStore(userDefaults: userDefaults)
+        sut.save([
+            WidgetSite(siteID: 1, name: "Default", timezoneIdentifier: "UTC", gmtOffset: 0, currencySettings: nil)
+        ])
+
+        // When
+        sut.clear()
+
+        // Then
+        #expect(sut.sites().isEmpty)
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "WidgetSiteListStoreTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+}

--- a/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListSyncManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListSyncManagerTests.swift
@@ -1,0 +1,328 @@
+import Foundation
+import Testing
+import Yosemite
+import WooFoundationCore
+import YosemiteTestHelpers
+@testable import WooCommerce
+
+@MainActor
+@Suite(.timeLimit(.minutes(5)))
+struct WidgetSiteListSyncManagerTests {
+
+    @Test func start_when_wpcom_credentials_then_writes_active_woo_sites() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true),
+            Self.makeSite(siteID: 2, name: "Beta", isWooCommerceActive: true),
+            Self.makeSite(siteID: 3, name: "Non-Woo", isWooCommerceActive: false)
+        ])
+
+        // When
+        context.sut.start()
+
+        // Then
+        let sites = context.widgetSiteListStore.sites()
+        #expect(sites.map(\.siteID) == [1, 2])
+        #expect(sites.map(\.name) == ["Alpha", "Beta"])
+    }
+
+    @Test func start_when_non_wpcom_credentials_then_writes_empty_list() async {
+        // Given
+        let context = makeTestContext(isWPCom: false)
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+
+        // When
+        context.sut.start()
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().isEmpty)
+    }
+
+    @Test func start_when_sites_are_hidden_then_excludes_them() async {
+        // Given
+        let context = makeTestContext()
+        context.userDefaults.saveHiddenStoreIDs([2])
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true),
+            Self.makeSite(siteID: 2, name: "Beta", isWooCommerceActive: true),
+            Self.makeSite(siteID: 3, name: "Gamma", isWooCommerceActive: true)
+        ])
+
+        // When
+        context.sut.start()
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().map(\.siteID) == [1, 3])
+    }
+
+    @Test func start_when_default_site_is_set_then_sorts_default_first() async {
+        // Given
+        let context = makeTestContext(defaultStoreID: 2)
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true),
+            Self.makeSite(siteID: 2, name: "Beta", isWooCommerceActive: true),
+            Self.makeSite(siteID: 3, name: "Gamma", isWooCommerceActive: true)
+        ])
+
+        // When
+        context.sut.start()
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().map(\.siteID) == [2, 1, 3])
+    }
+
+    @Test func start_when_general_site_settings_present_then_includes_currency_settings() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+        await context.insert(siteSettings: Self.makeFullCurrencySiteSettings(siteID: 1, currencyCode: "EUR"))
+
+        // When
+        context.sut.start()
+
+        // Then
+        let sites = context.widgetSiteListStore.sites()
+        #expect(sites.count == 1)
+        #expect(sites[0].currencySettings?.currencyCode == .EUR)
+    }
+
+    @Test func start_when_general_site_settings_partial_then_omits_currency_settings() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+        await context.insert(siteSettings: [
+            Self.makeSiteSetting(siteID: 1, settingID: "woocommerce_currency", value: "EUR")
+        ])
+
+        // When
+        context.sut.start()
+
+        // Then
+        let sites = context.widgetSiteListStore.sites()
+        #expect(sites.count == 1)
+        #expect(sites[0].currencySettings == nil)
+    }
+
+    @Test func start_when_settings_are_in_a_different_group_then_omits_currency_settings() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+        // Insert with a non-general group - manager should ignore.
+        await context.insert(siteSettings: Self.makeFullCurrencySiteSettings(siteID: 1,
+                                                                              currencyCode: "EUR",
+                                                                              settingGroupKey: "advanced"))
+
+        // When
+        context.sut.start()
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().first?.currencySettings == nil)
+    }
+
+    @Test func storage_change_when_site_added_then_rebuilds_list() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+        context.sut.start()
+        #expect(context.widgetSiteListStore.sites().map(\.siteID) == [1])
+
+        // When
+        await context.insert(sites: [
+            Self.makeSite(siteID: 2, name: "Beta", isWooCommerceActive: true)
+        ])
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().map(\.siteID) == [1, 2])
+    }
+
+    @Test func logOut_event_when_received_then_clears_list() async throws {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+        context.sut.start()
+        #expect(context.widgetSiteListStore.sites().isEmpty == false)
+
+        // When
+        context.notificationCenter.post(name: .logOutEventReceived, object: nil)
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().isEmpty)
+    }
+
+    @Test func stop_when_called_after_start_then_clears_list() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+        context.sut.start()
+        #expect(context.widgetSiteListStore.sites().isEmpty == false)
+
+        // When
+        context.sut.stop()
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().isEmpty)
+    }
+
+    @Test func start_when_called_twice_then_does_not_throw_or_duplicate_writes() async {
+        // Given
+        let context = makeTestContext()
+        await context.insert(sites: [
+            Self.makeSite(siteID: 1, name: "Alpha", isWooCommerceActive: true)
+        ])
+
+        // When
+        context.sut.start()
+        context.sut.start()
+
+        // Then
+        #expect(context.widgetSiteListStore.sites().count == 1)
+    }
+}
+
+// MARK: - Test context
+
+private extension WidgetSiteListSyncManagerTests {
+    @MainActor
+    final class TestContext {
+        let storageManager: MockStorageManager
+        let sessionManager: SessionManager
+        let stores: MockStoresManager
+        let userDefaults: UserDefaults
+        let widgetSiteListStore: WidgetSiteListStore
+        let notificationCenter: NotificationCenter
+        let sut: WidgetSiteListSyncManager
+
+        init(storageManager: MockStorageManager,
+             sessionManager: SessionManager,
+             stores: MockStoresManager,
+             userDefaults: UserDefaults,
+             widgetSiteListStore: WidgetSiteListStore,
+             notificationCenter: NotificationCenter,
+             sut: WidgetSiteListSyncManager) {
+            self.storageManager = storageManager
+            self.sessionManager = sessionManager
+            self.stores = stores
+            self.userDefaults = userDefaults
+            self.widgetSiteListStore = widgetSiteListStore
+            self.notificationCenter = notificationCenter
+            self.sut = sut
+        }
+
+        deinit {
+            sut.stop()
+        }
+
+        func insert(sites: [Site]) async {
+            await withCheckedContinuation { continuation in
+                storageManager.performAndSave({ [storageManager] _ in
+                    sites.forEach { storageManager.insertSampleSite(readOnlySite: $0) }
+                }, completion: {
+                    continuation.resume()
+                }, on: .main)
+            }
+        }
+
+        func insert(siteSettings: [SiteSetting]) async {
+            await withCheckedContinuation { continuation in
+                storageManager.performAndSave({ [storageManager] _ in
+                    siteSettings.forEach { storageManager.insertSampleSiteSetting(readOnlySiteSetting: $0) }
+                }, completion: {
+                    continuation.resume()
+                }, on: .main)
+            }
+        }
+    }
+
+    func makeTestContext(isWPCom: Bool = true,
+                         defaultStoreID: Int64? = nil) -> TestContext {
+        let storageManager = MockStorageManager()
+
+        let sessionSuiteName = "WidgetSiteListSyncManagerTests-session-\(UUID().uuidString)"
+        let sessionDefaults = UserDefaults(suiteName: sessionSuiteName)!
+        sessionDefaults.removePersistentDomain(forName: sessionSuiteName)
+        let sessionKeychainName = "com.woocommerce.tests.widget-site-list.\(UUID().uuidString)"
+
+        let sessionManager = SessionManager(defaults: sessionDefaults,
+                                            keychainServiceName: sessionKeychainName)
+        sessionManager.defaultCredentials = isWPCom ? SessionSettings.wpcomCredentials : SessionSettings.wporgCredentials
+        sessionManager.defaultStoreID = defaultStoreID
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        let suiteName = "WidgetSiteListSyncManagerTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        let widgetSiteListStore = WidgetSiteListStore(userDefaults: userDefaults)
+        let notificationCenter = NotificationCenter()
+
+        let sut = WidgetSiteListSyncManager(stores: stores,
+                                            storageManager: storageManager,
+                                            widgetSiteListStore: widgetSiteListStore,
+                                            userDefaults: userDefaults,
+                                            notificationCenter: notificationCenter)
+
+        return TestContext(storageManager: storageManager,
+                           sessionManager: sessionManager,
+                           stores: stores,
+                           userDefaults: userDefaults,
+                           widgetSiteListStore: widgetSiteListStore,
+                           notificationCenter: notificationCenter,
+                           sut: sut)
+    }
+}
+
+// MARK: - Sample factories
+
+private extension WidgetSiteListSyncManagerTests {
+    static func makeSite(siteID: Int64,
+                         name: String,
+                         isWooCommerceActive: Bool,
+                         timezone: String = "UTC",
+                         gmtOffset: Double = 0) -> Site {
+        Site.fake().copy(siteID: siteID,
+                         name: name,
+                         isWooCommerceActive: isWooCommerceActive,
+                         timezone: timezone,
+                         gmtOffset: gmtOffset)
+    }
+
+    static func makeSiteSetting(siteID: Int64,
+                                settingID: String,
+                                value: String,
+                                settingGroupKey: String = SiteSettingGroup.general.rawValue) -> SiteSetting {
+        SiteSetting.fake().copy(siteID: siteID,
+                                settingID: settingID,
+                                value: value,
+                                settingGroupKey: settingGroupKey)
+    }
+
+    static func makeFullCurrencySiteSettings(siteID: Int64,
+                                             currencyCode: String,
+                                             settingGroupKey: String = SiteSettingGroup.general.rawValue) -> [SiteSetting] {
+        [
+            ("woocommerce_currency", currencyCode),
+            ("woocommerce_currency_pos", "left"),
+            ("woocommerce_price_thousand_sep", ","),
+            ("woocommerce_price_decimal_sep", "."),
+            ("woocommerce_price_num_decimals", "2")
+        ].map { (settingID, value) in
+            makeSiteSetting(siteID: siteID, settingID: settingID, value: value, settingGroupKey: settingGroupKey)
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import WooCommerce
+
+struct WidgetSiteTests {
+
+    @Test func timezone_when_identifier_is_valid_then_returns_named_zone() {
+        // Given
+        let site = WidgetSite(siteID: 1,
+                              name: "Site",
+                              timezoneIdentifier: "Europe/Madrid",
+                              gmtOffset: 1,
+                              currencySettings: nil)
+
+        // When
+        let timezone = site.timezone
+
+        // Then
+        #expect(timezone.identifier == "Europe/Madrid")
+    }
+
+    @Test func timezone_when_identifier_is_invalid_then_falls_back_to_gmt_offset() {
+        // Given
+        let site = WidgetSite(siteID: 1,
+                              name: "Site",
+                              timezoneIdentifier: "Not/A/Real/Zone",
+                              gmtOffset: -5,
+                              currencySettings: nil)
+
+        // When
+        let timezone = site.timezone
+
+        // Then
+        #expect(timezone.secondsFromGMT() == Int(-5 * 3600))
+    }
+
+    @Test func timezone_when_identifier_is_empty_then_falls_back_to_gmt_offset() {
+        // Given
+        let site = WidgetSite(siteID: 1,
+                              name: "Site",
+                              timezoneIdentifier: "",
+                              gmtOffset: 2,
+                              currencySettings: nil)
+
+        // When
+        let timezone = site.timezone
+
+        // Then
+        #expect(timezone.secondsFromGMT() == Int(2 * 3600))
+    }
+
+    @Test func encoded_then_decoded_round_trip_preserves_fields() throws {
+        // Given
+        let original = WidgetSite(siteID: 42,
+                                  name: "Test Site",
+                                  timezoneIdentifier: "America/New_York",
+                                  gmtOffset: -5,
+                                  currencySettings: nil)
+
+        // When
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WidgetSite.self, from: data)
+
+        // Then
+        #expect(decoded == original)
+    }
+}


### PR DESCRIPTION
WOOMOB-2815

## Description

Data-prep PR for the upcoming configurable Store Stats widget site picker. The host app mirrors the user's selectable WPCOM Woo sites into shared app-group `UserDefaults` so the widget extension can populate its picker. All wired behind the existing `configurableStoreStatsWidgets` feature flag — no user-facing changes yet. The picker UI on the widget side that consumes this data follows in a second PR.

### What's done

- Adds `WidgetSite` Codable model + `WidgetSiteListStore` read/write wrapper, both shared between the host app and the `StoreWidgetsExtension` via app-group `UserDefaults`.
- Adds `WidgetSiteListSyncManager` (host-app only) — listens to CoreData `StorageSite` and `StorageSiteSetting` via `ResultsController`, KVO on `hiddenStoreIDs`, and the default-store publisher; rebuilds the `[WidgetSite]` list on changes and clears it on `.logOutEventReceived`.
- Adds the new `widgetSelectableSites` UserDefaults key.
- Wires the manager into `ServiceLocator` and starts it from `AppDelegate.willFinishLaunching` via `setupWidgetSiteListSyncIfNeeded()`, gated on `FeatureFlag.configurableStoreStatsWidgets`.
- Unit tests for `WidgetSite`, `WidgetSiteListStore`, and `WidgetSiteListSyncManager` (Swift Testing).

> Non-test diff is ~332 lines, slightly above the 300 Danger threshold; the bulk (~233 lines) is the manager itself, which is one cohesive class.

## Test Steps

The `configurableStoreStatsWidgets` feature flag must be on for the manager to start.

### Manual end-to-end
This requires running both the host app target (writer) and the widget extension target (reader). They're separate processes, so two separate Xcode debugger attachments.

1. In `WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift`, inside `timeline(for:in:)`, add a temporary probe:
    ```swift
    let probe = WidgetSiteListStore().sites()
    print("📥 Widget process saw \(probe.count) selectable site(s): \(probe.map { "\($0.siteID):\($0.name)" })")
    ```
2. Run the host app target from Xcode and complete app setup.
3. Switch the active scheme in Xcode to `StoreWidgetsExtension` and run / attach to the widget process. Refresh a Store Stats widget on the simulator home screen so `getTimeline` fires, then read the printout from the widget process console.

Each of the following host-app actions should reflect in the next widget print:
- [ ] Log in to a WPCOM account with multiple Woo sites → list contains active Woo sites only, current default first.
- [ ] Settings → Switch Store → list re-orders with the new default first.
- [ ] Hide a site from the store list → list excludes it.
- [ ] Log out → list is empty.
- [ ] Log in with non-WPCOM credentials → list is empty.

Remove the temporary probe before merging.

## Screenshots

N/A — no UI changes.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.