### PR TITLE
[RSM] Phone POS - Wire Scan to Pay & Mark order as paid into Other payment methods sheet

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -142,7 +142,17 @@ private extension POSOtherPaymentMethodsSheet {
 }
 
 #if DEBUG
-#Preview {
+#Preview("Card reader only") {
     POSOtherPaymentMethodsSheet(onCardReader: {})
+}
+
+#Preview("All methods enabled") {
+    POSOtherPaymentMethodsSheet(
+        onCardReader: {},
+        isScanToPayAvailable: true,
+        onScanToPay: {},
+        isMarkOrderAsPaidAvailable: true,
+        onMarkOrderAsPaid: {}
+    )
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -2,13 +2,17 @@ import SwiftUI
 
 /// Bottom sheet shown when the merchant taps "Other payment methods" on the phone
 /// POS checkout (TTP-available layout). Lists the non-TTP payment methods available
-/// to the merchant — currently Card reader only; Scan to Pay and Mark order as paid
-/// will join here once those features land on this branch.
+/// to the merchant: Card reader, Scan to Pay (when enabled), and Mark order as paid
+/// (when enabled).
 ///
 /// Mirrors the Android phone POS overflow dialog that pairs with the TTP hero
 /// (samiuelson #15842 / #15825).
 struct POSOtherPaymentMethodsSheet: View {
     let onCardReader: () -> Void
+    var isScanToPayAvailable: Bool = false
+    var onScanToPay: (() -> Void)?
+    var isMarkOrderAsPaidAvailable: Bool = false
+    var onMarkOrderAsPaid: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
 
@@ -27,6 +31,26 @@ struct POSOtherPaymentMethodsSheet: View {
                 accessibilityIdentifier: "pos-other-payments-card-reader") {
                 dismiss()
                 onCardReader()
+            }
+
+            if isScanToPayAvailable, let onScanToPay {
+                row(systemImage: "qrcode",
+                    title: Localization.scanToPayTitle,
+                    subtitle: Localization.scanToPaySubtitle,
+                    accessibilityIdentifier: "pos-other-payments-scan-to-pay") {
+                    dismiss()
+                    onScanToPay()
+                }
+            }
+
+            if isMarkOrderAsPaidAvailable, let onMarkOrderAsPaid {
+                row(systemImage: "checkmark.circle",
+                    title: Localization.markAsPaidTitle,
+                    subtitle: Localization.markAsPaidSubtitle,
+                    accessibilityIdentifier: "pos-other-payments-mark-as-paid") {
+                    dismiss()
+                    onMarkOrderAsPaid()
+                }
             }
 
             Spacer(minLength: 0)
@@ -93,6 +117,26 @@ private extension POSOtherPaymentMethodsSheet {
             "pos.otherPaymentMethods.cardReader.subtitle",
             value: "Connect a Bluetooth reader to take card payments.",
             comment: "Row subtitle in the Other Payment Methods sheet for connecting an external Bluetooth card reader."
+        )
+        static let scanToPayTitle = NSLocalizedString(
+            "pos.otherPaymentMethods.scanToPay.title",
+            value: "Scan to pay",
+            comment: "Row title in the Other Payment Methods sheet for collecting payment via a QR code the customer scans."
+        )
+        static let scanToPaySubtitle = NSLocalizedString(
+            "pos.otherPaymentMethods.scanToPay.subtitle",
+            value: "Show a QR code for the customer to pay from their phone.",
+            comment: "Row subtitle in the Other Payment Methods sheet for collecting payment via a QR code the customer scans."
+        )
+        static let markAsPaidTitle = NSLocalizedString(
+            "pos.otherPaymentMethods.markAsPaid.title",
+            value: "Mark order as paid",
+            comment: "Row title in the Other Payment Methods sheet for marking the order paid out-of-band."
+        )
+        static let markAsPaidSubtitle = NSLocalizedString(
+            "pos.otherPaymentMethods.markAsPaid.subtitle",
+            value: "Record payment collected outside this device.",
+            comment: "Row subtitle in the Other Payment Methods sheet for marking the order paid out-of-band."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -158,13 +158,25 @@ struct TotalsView: View {
             }
         }
         .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
-            POSOtherPaymentMethodsSheet(onCardReader: {
-                guard !isStartingPayment else { return }
-                isStartingPayment = true
-                Task { @MainActor in
-                    await paymentModel.startPaymentWithMethod(.bluetooth)
+            POSOtherPaymentMethodsSheet(
+                onCardReader: {
+                    guard !isStartingPayment else { return }
+                    isStartingPayment = true
+                    Task { @MainActor in
+                        await paymentModel.startPaymentWithMethod(.bluetooth)
+                    }
+                },
+                isScanToPayAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
+                onScanToPay: {
+                    Task { @MainActor in
+                        await paymentModel.startScanToPayPayment()
+                    }
+                },
+                isMarkOrderAsPaidAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid),
+                onMarkOrderAsPaid: {
+                    paymentModel.startMarkAsPaidPayment()
                 }
-            })
+            )
             .presentationDetents([.medium])
             .presentationDragIndicator(.visible)
         }


### PR DESCRIPTION
> Rebased onto trunk after the upstream cascade landed. Dropped 3 commits that became redundant (`.toolbar(.hidden)` migrations and the phone-container ScanToPay observer — all already on trunk via independent routes). Kept the 2 net-new commits.

## Description
Stacked directly on trunk. The TTP hero's "Other payment methods" bottom sheet (added in #17096) shipped with only a `Card reader` row. Now that Scan to Pay (#17033) and Mark order as paid (#17032/#17081) are on trunk, this PR wires both into the sheet so they're reachable from the TTP-hero layout on phone POS.

Two commits:

1. **Wire Scan to Pay and Mark order as paid into the Other payment methods sheet** — extends `POSOtherPaymentMethodsSheet` to render `Scan to Pay` and `Mark order as paid` rows alongside `Card reader`, gated on their respective feature flags (`pointOfSaleScanToPay`, `pointOfSaleMarkOrderAsPaid`). Each row dismisses the sheet and calls into `POSPaymentModel`'s existing entry points (`startScanToPayPayment()`, `startMarkAsPaidPayment()`) — same wiring used by the iPad popover, just surfaced through the phone sheet.
2. **Review fix: Add preview for all-methods-enabled state in POSOtherPaymentMethodsSheet** — adds an `#Preview` block exercising the all-rows-enabled layout so the SwiftUI canvas reflects the most-complete state of the sheet.

When TTP isn't available (iPad, ineligible device, flag off), behaviour is unchanged — these methods are surfaced via the existing `POSCheckoutPaymentButtonsRow` / iPad popover.

## Test Steps
- iPhone, `pointOfSaleTapToPay` + `pointOfSaleScanToPay` + `pointOfSaleMarkOrderAsPaid` flags all on: open POS → checkout → tap **Other payment methods**. Sheet shows three rows: Card reader, Scan to Pay, Mark order as paid.
- Tap **Scan to Pay** → sheet dismisses, QR view pushes, polling runs as in #17111.
- Tap **Mark order as paid** → sheet dismisses, confirmation pushes, optional note field renders.
- Toggle `pointOfSaleScanToPay` off: sheet shows Card reader + Mark order as paid only.
- Toggle `pointOfSaleMarkOrderAsPaid` off: sheet shows Card reader + Scan to Pay only.
- iPad / non-TTP phones: behaviour unchanged from trunk.

## Screenshots
N/A — sheet content extension; preview block covers the visual.

---
- [x] No release notes — feature flagged off.