### PR TITLE
[WOOMOB-3046] Reset Performance card chart selection on revenue switch, PTR, and order type save

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -326,7 +326,8 @@ private extension StorePerformanceView {
         if let chartViewModel = viewModel.chartViewModel,
            chartViewModel.hasRevenue {
             VStack {
-                StoreStatsChart(viewModel: chartViewModel) { selectedIndex in
+                StoreStatsChart(viewModel: chartViewModel,
+                                resetSignal: viewModel.chartSelectionResetPublisher) { selectedIndex in
                     viewModel.didSelectStatsInterval(at: selectedIndex)
                 }
                 .frame(height: Layout.chartViewHeight)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -87,6 +87,13 @@ final class StorePerformanceViewModel: ObservableObject {
     private var waitingTracker: WaitingTimeTracker?
     private let syncingDidFinishPublisher = PassthroughSubject<Error?, Never>()
 
+    /// Fires whenever the chart should drop any selected point (revenue switch, PTR, order type save).
+    /// Drives `StoreStatsChart.onReceive` so its local `@State` stays in sync with the header.
+    private let chartSelectionResetSubject = PassthroughSubject<Void, Never>()
+    var chartSelectionResetPublisher: AnyPublisher<Void, Never> {
+        chartSelectionResetSubject.eraseToAnyPublisher()
+    }
+
     // To check whether the tab is showing the visitors and conversion views as redacted for custom range.
     // This redaction is only shown on Custom Range tab with WordPress.com or Jetpack connected sites,
     // while Jetpack CP sites has its own redacted for Jetpack state, and non-Jetpack sites simply has them empty.
@@ -178,6 +185,9 @@ final class StorePerformanceViewModel: ObservableObject {
         chartValueSelectedEventsSubject.send(index)
         periodViewModel?.selectedIntervalIndex = index
         shouldHighlightStats = index != nil
+        if index == nil {
+            chartSelectionResetSubject.send()
+        }
 
         if unavailableVisitStatsDueToCustomRange {
             // If time range is less than 2 days, redact data when selected and show when deselected.
@@ -210,6 +220,11 @@ final class StorePerformanceViewModel: ObservableObject {
             updateSiteVisitStatMode()
 
             return
+        }
+
+        if forceRefresh {
+            // Forced refresh replaces the dataset; any selected point becomes meaningless.
+            didSelectStatsInterval(at: nil)
         }
 
         syncingData = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -1,4 +1,5 @@
 import Charts
+import Combine
 import SwiftUI
 
 /// Chart for store performance built with Swift Charts.
@@ -12,9 +13,15 @@ struct StoreStatsChart: View {
     @State private var selectedRevenue: Double?
     @State private var selectedIndex: Int?
 
+    /// Fires from the parent when the highlighted point should drop (revenue switch, PTR,
+    /// order type save). Lets the chart's local state stay in sync without lifting it up.
+    private let resetSignal: AnyPublisher<Void, Never>
+
     init(viewModel: StoreStatsChartViewModel,
+         resetSignal: AnyPublisher<Void, Never>,
          onIntervalSelected: @escaping (Int?) -> Void) {
         self.viewModel = viewModel
+        self.resetSignal = resetSignal
         self.onIntervalSelected = onIntervalSelected
     }
 
@@ -94,6 +101,11 @@ struct StoreStatsChart: View {
             }
         }
         .padding(Constants.chartPadding)
+        .onReceive(resetSignal) {
+            selectedIndex = nil
+            selectedDate = nil
+            selectedRevenue = nil
+        }
     }
 
     private func updateSelectedDate(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
@@ -193,7 +205,8 @@ private extension StoreStatsChartViewModel {
 
 #Preview {
     StoreStatsChart(viewModel: .init(intervals: StoreStatsChartViewModel.sampleDataForThisWeek,
-                                     timeRange: .thisWeek)) { _ in }
+                                     timeRange: .thisWeek),
+                    resetSignal: Empty<Void, Never>().eraseToAnyPublisher()) { _ in }
 }
 
 #endif

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -888,6 +888,107 @@ final class StorePerformanceViewModelTests: XCTestCase {
         XCTAssertEqual(properties["option"] as? String, "gross")
         XCTAssertEqual(properties["type"] as? String, "dashboard_stats")
     }
+
+    @MainActor
+    func test_didSelectStatsInterval_emits_chart_selection_reset_signal_only_when_index_is_nil() {
+        // Given
+        let viewModel = StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init())
+        var resetCount = 0
+        let cancellable = viewModel.chartSelectionResetPublisher.sink { resetCount += 1 }
+
+        // When — selecting a point should not fire the signal.
+        viewModel.didSelectStatsInterval(at: 1)
+
+        // Then
+        XCTAssertEqual(resetCount, 0)
+
+        // When — clearing the selection should fire it.
+        viewModel.didSelectStatsInterval(at: nil)
+
+        // Then
+        XCTAssertEqual(resetCount, 1)
+
+        cancellable.cancel()
+    }
+
+    @MainActor
+    func test_reloadDataIfNeeded_when_forceRefresh_then_clears_chart_selection() async {
+        // Given — a chart point is selected (PTR baseline).
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        mockSyncAllStats(with: stores)
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        viewModel.didSelectStatsInterval(at: 1)
+        XCTAssertTrue(viewModel.shouldHighlightStats)
+        var resetCount = 0
+        let cancellable = viewModel.chartSelectionResetPublisher.sink { resetCount += 1 }
+
+        // When
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
+
+        // Then — header reverts and the chart reset signal fired exactly once.
+        XCTAssertFalse(viewModel.shouldHighlightStats)
+        XCTAssertEqual(resetCount, 1)
+
+        cancellable.cancel()
+    }
+
+    @MainActor
+    func test_reloadDataIfNeeded_when_data_is_fresh_then_does_not_clear_chart_selection() async {
+        // Given — a chart point is selected and the cached timestamp is fresh.
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        mockSyncAllStats(with: stores)
+        let viewModel = StorePerformanceViewModel(siteID: 123, stores: stores, usageTracksEventEmitter: .init())
+        viewModel.didSelectStatsInterval(at: 1)
+        XCTAssertTrue(viewModel.shouldHighlightStats)
+        DashboardTimestampStore.saveTimestamp(.now, for: .performance, at: viewModel.timeRange.timestampRange)
+        var resetCount = 0
+        let cancellable = viewModel.chartSelectionResetPublisher.sink { resetCount += 1 }
+
+        // When — non-forced reload short-circuits.
+        await viewModel.reloadDataIfNeeded(forceRefresh: false)
+
+        // Then — selection preserved; only forced refreshes invalidate it.
+        XCTAssertTrue(viewModel.shouldHighlightStats)
+        XCTAssertEqual(resetCount, 0)
+
+        cancellable.cancel()
+        DashboardTimestampStore.removeTimestamp(for: .performance, at: viewModel.timeRange.timestampRange)
+    }
+
+    @MainActor
+    func test_handleOrderTypeSelection_when_save_succeeds_then_clears_chart_selection() async {
+        // Given — a chart point is selected before the merchant changes the order type.
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .retrieveAnalyticsOrderDateType(_, let onCompletion):
+                onCompletion(.success(.paid))
+            case let .updateAnalyticsOrderDateType(_, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        mockSyncAllStats(with: stores)
+        let viewModel = StorePerformanceViewModel(siteID: 123,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  usageTracksEventEmitter: .init())
+        viewModel.didSelectStatsInterval(at: 1)
+        XCTAssertTrue(viewModel.shouldHighlightStats)
+        var resetCount = 0
+        let cancellable = viewModel.chartSelectionResetPublisher.sink { resetCount += 1 }
+
+        // When
+        let shouldDismiss = await viewModel.handleOrderTypeSelection(.completed)
+
+        // Then — successful save triggers the post-save force refresh, which clears selection.
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertFalse(viewModel.shouldHighlightStats)
+        XCTAssertEqual(resetCount, 1)
+
+        cancellable.cancel()
+    }
 }
 
 // MARK: - Private helpers


### PR DESCRIPTION
WOOMOB-3046

### Targeting `release/24.7`

## Description

More bug context in p1778056356604369-slack-C03L1NF1EA3

The Performance card's chart highlight could drift out of sync with the card header on three transitions: switching the revenue type, pulling to refresh, and saving a new order date type. Either the chart kept a stale highlight while the header reverted, or the header kept the highlight color and selected-date label while the chart cleared itself.

`StoreStatsChart` keeps its highlight in private `@State` while `StorePerformanceViewModel` tracks `shouldHighlightStats` / `selectedIntervalIndex` independently, and not all transitions reset both sides. Fix is a small Combine signal: the view model exposes a `PassthroughSubject<Void, Never>` that fires from `didSelectStatsInterval(at: nil)`. The chart subscribes via `.onReceive` and resets its local `@State`. A new `didSelectStatsInterval(at: nil)` call at the start of the forced-refresh path covers PTR and the post-save refresh after an order type change.

Changes:
- Add `chartSelectionResetPublisher` to `StorePerformanceViewModel`; emit on every `didSelectStatsInterval(at: nil)`.
- Clear chart selection at the start of `reloadDataIfNeeded(forceRefresh: true)`.
- Subscribe `StoreStatsChart` to the reset signal via `.onReceive`.

## Test Steps
- Open Dashboard, pick a Performance card time range with revenue, tap a chart point so the header highlight color and the selected-date label appear.
- Tap a different segment in the revenue type selector and confirm the chart highlight clears and the header reverts to the period total.
- Tap a chart point again, pull the dashboard down to refresh, and confirm both the chart highlight and the header reset.
- Tap a chart point again, open the order type bottom sheet via the chevron under the order count, pick a different option, and confirm the chart highlight, the header text color, the selected-date label, and the selected interval values all clear.
- Confirm tapping the same chart point twice still toggles the selection off, and switching time ranges still works as before.

## Screenshots

N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.