### PR TITLE
[RSM] Phone POS - Mark as Paid layout + TTP polish + note tests

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -58,6 +58,17 @@ final class POSPaymentModel {
     /// model-side re-entry guard.
     private(set) var currentPaymentMethod: CardReaderConnectionMethod?
 
+    /// The method of the reader Stripe Terminal currently has connected — or
+    /// nil if no reader is connected. Distinct from `currentPaymentMethod`
+    /// (which tracks an in-flight *payment session*); this one persists
+    /// across `reset()` because the underlying SDK connection persists across
+    /// our payment-model lifecycle too. Used in `connectTapToPayReader` to
+    /// skip the defensive disconnect-first when the reader is already TTP —
+    /// otherwise every checkout re-entry forces an unnecessary
+    /// disconnect-then-reconnect cycle and surfaces the "Preparing Tap to
+    /// Pay…" indicator each time.
+    private(set) var lastConnectedMethod: CardReaderConnectionMethod?
+
     /// True while *any* collection session is active (TTP or BT). Drives
     /// TotalsView's `isStartingPayment` reset — when this transitions back
     /// to false the merchant's flow has wrapped up (success, error, cancel,
@@ -127,6 +138,15 @@ final class POSPaymentModel {
     /// "still loading the URL" from "no URL available".
     private(set) var isPreparingScanToPay: Bool = false
     private var scanToPayPollingTask: Task<Void, Never>?
+
+    /// Coalesces concurrent silent-TTP pre-connect attempts. Without this,
+    /// every call to `connectTapToPayReader` (which can come from
+    /// `startPayment` on checkout entry, `observeReaderReconnection` firing
+    /// on a `.disconnected` event, and re-registrations after back-to-cart
+    /// cycles) kicks off its own `connectReader` Task. Stripe Terminal
+    /// serialises them but the race adds significant latency to the first
+    /// successful connect.
+    private var tapToPayConnectTask: Task<Void, Never>?
 
     init(cardPresentPaymentService: CardPresentPaymentFacade,
          orderProvider: POSPaymentOrderProviding,
@@ -254,7 +274,12 @@ extension POSPaymentModel {
 
         if case .disconnected = cardReaderConnectionStatus {
             Task { @MainActor [weak self] in
-                _ = try? await self?.cardPresentPaymentService.connectReader(using: method)
+                do {
+                    _ = try await self?.cardPresentPaymentService.connectReader(using: method)
+                    self?.lastConnectedMethod = method
+                } catch {
+                    DDLogWarn("🃏 [CardPayment] explicit connect via \(method) failed: \(error)")
+                }
             }
         }
 
@@ -264,19 +289,41 @@ extension POSPaymentModel {
     /// Pre-connects the built-in Tap to Pay reader without starting collection.
     /// Called from `startPayment()` when `preferredConnectionMethod == .tapToPay`,
     /// so the reader is warm by the time the merchant taps the hero CTA.
-    private func connectTapToPayReader() {
-        Task { @MainActor [weak self] in
+    func connectTapToPayReader() {
+        // Coalesce — if a pre-connect Task is already in flight, this is a
+        // no-op. Without this, `startPayment` being called multiple times
+        // during checkout entry (once via `checkOut`, again via
+        // `observeReaderReconnection` firing on the first transient
+        // disconnect) stacks up redundant `connectReader` Tasks that
+        // serialise inside Stripe Terminal and visibly delay the first
+        // successful connect.
+        guard tapToPayConnectTask == nil else { return }
+        tapToPayConnectTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            // Stripe Terminal can only hold one active reader. If an old reader
-            // is still attached when we enter POS (a stale TTP / BT session
-            // carried across app launches, or a BT reader from a previous
-            // mode), connecting on top would fail with "another reader is
-            // already connected" and surface a disruptive failure modal —
-            // for a connect the merchant didn't even ask for. Drop it first.
+            defer { self.tapToPayConnectTask = nil }
+            // Reader already connected via TTP — nothing to do. Re-entering
+            // checkout after a successful payment or after going back to
+            // edit the cart used to force an unnecessary disconnect-then-
+            // reconnect cycle here, surfacing the "Preparing Tap to Pay…"
+            // indicator every time.
+            if case .connected = cardReaderConnectionStatus,
+               lastConnectedMethod == .tapToPay {
+                return
+            }
+            // Stripe Terminal can only hold one active reader. If a *different*
+            // reader is still attached (a stale BT reader from a previous
+            // session, or no record of what method it was), connecting on top
+            // would fail with "another reader is already connected" — for a
+            // connect the merchant didn't even ask for. Drop it first.
             if case .connected = cardReaderConnectionStatus {
                 await cardPresentPaymentService.disconnectReader()
             }
-            _ = try? await cardPresentPaymentService.connectReader(using: .tapToPay)
+            do {
+                _ = try await cardPresentPaymentService.connectReader(using: .tapToPay)
+                lastConnectedMethod = .tapToPay
+            } catch {
+                DDLogWarn("🃏 [CardPayment] silent TTP pre-connect failed: \(error)")
+            }
         }
     }
 
@@ -379,7 +426,12 @@ extension POSPaymentModel {
         guard connectCardReaderTask == nil else { return }
         connectCardReaderTask = Task { @MainActor [weak self] in
             defer { self?.connectCardReaderTask = nil }
-            _ = try? await self?.cardPresentPaymentService.connectReader(using: .bluetooth)
+            do {
+                _ = try await self?.cardPresentPaymentService.connectReader(using: .bluetooth)
+                self?.lastConnectedMethod = .bluetooth
+            } catch {
+                DDLogWarn("🃏 [CardPayment] BT connect failed: \(error)")
+            }
         }
     }
 
@@ -817,6 +869,15 @@ extension POSPaymentModel {
 extension POSPaymentModel {
     func observeReaderReconnection() {
         cardReaderDisconnection = cardPresentPaymentService.readerConnectionStatusPublisher
+            // `removeDuplicates` BEFORE the filter — Stripe Terminal can emit
+            // multiple `.disconnected` values in succession (e.g., during
+            // teardown / re-init), and without dedup the sink fires for each
+            // one. The downstream `startPayment` call kicks off another
+            // pre-connect Task each time, racing every previous one. (The
+            // `tapToPayConnectTask` coalesce on the pre-connect side already
+            // catches most of this, but de-duping here also avoids the
+            // wasted `startPayment` work.)
+            .removeDuplicates()
             .filter({ $0 == .disconnected })
             .sink { [weak self] _ in
                 Task { @MainActor [weak self] in
@@ -847,6 +908,10 @@ private extension POSPaymentModel {
                 guard let self else { return }
                 cardReaderConnectionStatus = connectionStatus
                 if connectionStatus == .disconnected {
+                    // Clear the tracking flag so the next pre-connect can't
+                    // mistakenly think a TTP reader is still attached and
+                    // skip its own connect.
+                    lastConnectedMethod = nil
                     resetTransientCardStateOnDisconnect()
                 }
             })

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -1117,14 +1117,21 @@ private extension POSPaymentModel {
                     case .validatingOrder,
                             .preparingReader,
                             .acceptingCard,
-                            .cardInserted,
-                            .processingPayment:
+                            .cardInserted:
                         return nil
-                    case .idle,
+                    case .processingPayment,
+                            .idle,
                             .cardPaymentSuccessful,
                             .paymentError,
                             .validatingOrderError,
                             .paymentIntentCreationError:
+                        // `.processingPayment` is intentionally let through on
+                        // TTP so the brief window between Apple's modal closing
+                        // and the success card rendering shows the inline
+                        // "Processing payment" message via `PaymentViewContent`
+                        // — matches what the BT reader path does, and avoids
+                        // the merchant seeing the hero with its spinner-in-
+                        // button as the "back to checkout" intermediate.
                         break
                     }
                 }

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -101,7 +101,7 @@ struct POSNavigationDestinationMarkAsPaidView: View {
                 }
             }
         )
-        .navigationBarHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
         // Fill the right pane so the visual transition reads as "totals → confirmation → totals"
         // rather than a card landing on top.
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -56,7 +56,14 @@ struct POSTapToPayHeroView: View {
                 Text(Localization.payButton)
                     .font(POSFontStyle.posBodyLargeBold)
             }
-            .buttonStyle(POSFilledButtonStyle(size: .normal))
+            // `isLoading` is gated on `isPayDisabled` rather than the broader
+            // `isPayDisabled || isIndicatorVisible` below, so the in-button
+            // spinner only shows during the "merchant just tapped, waiting for
+            // Apple's TTP modal to open" gap. While the silent pre-connect
+            // indicator is up the button is disabled (greyed) but the spinner
+            // doesn't show — the inline "Preparing Tap to Pay…" text already
+            // explains the wait there.
+            .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isPayDisabled))
             .padding(.horizontal, POSPadding.medium)
             // Disabled while preparing only once the indicator becomes visible
             // (after the 700ms grace). Fast pre-connects therefore never flicker

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -301,12 +301,14 @@ struct PointOfSaleDashboardView: View {
     /// system nav bar back button.
     private var phoneTotalsContainer: some View {
         VStack(spacing: 0) {
-            if !posModel.paymentState.isSuccess {
-                // On the success state the Checkout header isn't useful — back-to-cart
-                // is already blocked (`shouldPreventCartEditing` returns true on
-                // any payment success) and the success card has its own "New order"
-                // / "Email receipt" CTAs. Hide it so the success screen reads
-                // as a clean confirmation rather than a checkout subscreen.
+            if !posModel.paymentState.shownFullScreen {
+                // Hide the Checkout header on the in-pane states that take
+                // over the totals area: card `processingPayment` /
+                // `paymentError` / `cardPaymentSuccessful`, plus the
+                // success state of cash / scan-to-pay / mark-as-paid. In all
+                // those the merchant is on a focused payment view and the
+                // back-to-cart arrow is already disabled (the cart can't be
+                // edited mid-flow or post-success) — the header is noise.
                 POSPageHeaderView(
                     title: Localization.phoneCheckoutTitle,
                     backButtonConfiguration: .init(

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -301,13 +301,20 @@ struct PointOfSaleDashboardView: View {
     /// system nav bar back button.
     private var phoneTotalsContainer: some View {
         VStack(spacing: 0) {
-            POSPageHeaderView(
-                title: Localization.phoneCheckoutTitle,
-                backButtonConfiguration: .init(
-                    state: canExitFinalizingOnPhone ? .enabled : .disabled,
-                    action: { posModel.addMoreToCart() }
+            if !posModel.paymentState.isSuccess {
+                // On the success state the Checkout header isn't useful — back-to-cart
+                // is already blocked (`shouldPreventCartEditing` returns true on
+                // any payment success) and the success card has its own "New order"
+                // / "Email receipt" CTAs. Hide it so the success screen reads
+                // as a clean confirmation rather than a checkout subscreen.
+                POSPageHeaderView(
+                    title: Localization.phoneCheckoutTitle,
+                    backButtonConfiguration: .init(
+                        state: canExitFinalizingOnPhone ? .enabled : .disabled,
+                        action: { posModel.addMoreToCart() }
+                    )
                 )
-            )
+            }
             TotalsView()
         }
         .background(Color.posSurface)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleMarkAsPaidConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleMarkAsPaidConfirmationView.swift
@@ -23,16 +23,41 @@ struct PointOfSaleMarkAsPaidConfirmationView: View {
     }
 
     var body: some View {
+        // Mirror `PointOfSaleScanToPayView` / `PointOfSaleCollectCashView`:
+        // GeometryReader → ScrollView → VStack. The geometry reader gives the
+        // scroll view explicit width so `POSPageHeaderView` at the top fills
+        // the navigation pane edge-to-edge (the merchant reads it as a top
+        // bar) rather than sizing to its intrinsic content width and ending
+        // up centered + inset behind the 480pt-capped content below it.
+        //
+        // `alignment: .top` on the outer frame matters: cash anchors its header
+        // to the top via Spacers in the inner form VStack, but our content
+        // doesn't have any Spacers (it's a short confirmation form), so without
+        // explicit alignment SwiftUI vertical-centers the children when
+        // `minHeight` makes the VStack taller than they need — pushing the
+        // header down to the middle of the screen.
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(alignment: .center, spacing: POSSpacing.medium) {
+                    POSPageHeaderView(
+                        title: Localization.title,
+                        backButtonConfiguration: .init(state: isProcessing ? .disabled : .enabled,
+                                                       action: onCancel)
+                    )
+                    .frame(maxWidth: .infinity)
+
+                    content
+                }
+                .frame(maxWidth: .infinity, minHeight: geometry.size.height, alignment: .top)
+            }
+        }
+    }
+
+    private var content: some View {
         VStack(alignment: .center, spacing: POSSpacing.medium) {
             Image(systemName: "checkmark.circle")
                 .font(.system(size: 36))
                 .foregroundColor(.posPrimary)
-
-            Text(Localization.title)
-                .font(.posHeadingBold)
-                .foregroundColor(.posOnSurface)
-                .multilineTextAlignment(.center)
-                .accessibilityAddTraits(.isHeader)
 
             Text(String.localizedStringWithFormat(Localization.message, orderTotal))
                 .font(.posBodyMediumRegular())
@@ -55,13 +80,24 @@ struct PointOfSaleMarkAsPaidConfirmationView: View {
                     .focused($isNoteFieldFocused)
                     .textInputAutocapitalization(.sentences)
                     .autocorrectionDisabled(false)
-                    .submitLabel(.done)
-                    .onSubmit { isNoteFieldFocused = false }
                     .padding(POSPadding.medium)
                     .background(Color.posSurfaceContainerLow)
                     .cornerRadius(POSCornerRadiusStyle.small.value)
                     .disabled(isProcessing)
                     .accessibilityIdentifier("pos-mark-as-paid-note-field")
+                    // `axis: .vertical` makes the Return key insert a newline
+                    // rather than fire `.onSubmit`, so a keyboard toolbar Done
+                    // button is the only reliable way to dismiss the keyboard
+                    // on a multi-line TextField.
+                    .toolbar {
+                        ToolbarItemGroup(placement: .keyboard) {
+                            Spacer()
+                            Button(Localization.noteKeyboardDone) {
+                                isNoteFieldFocused = false
+                            }
+                            .accessibilityIdentifier("pos-mark-as-paid-note-keyboard-done")
+                        }
+                    }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -72,23 +108,13 @@ struct PointOfSaleMarkAsPaidConfirmationView: View {
                     .multilineTextAlignment(.center)
             }
 
-            VStack(spacing: POSSpacing.small) {
-                Button(action: { onConfirm(trimmedNote) }) {
-                    Text(Localization.confirmButton)
-                        .font(POSFontStyle.posBodyLargeBold)
-                }
-                .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isProcessing))
-                .disabled(isProcessing)
-                .accessibilityIdentifier("pos-mark-as-paid-confirm-button")
-
-                Button(action: onCancel) {
-                    Text(Localization.cancelButton)
-                        .font(POSFontStyle.posBodyLargeBold)
-                }
-                .buttonStyle(POSOutlinedButtonStyle(size: .normal))
-                .disabled(isProcessing)
-                .accessibilityIdentifier("pos-mark-as-paid-cancel-button")
+            Button(action: { onConfirm(trimmedNote) }) {
+                Text(Localization.confirmButton)
+                    .font(POSFontStyle.posBodyLargeBold)
             }
+            .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isProcessing))
+            .disabled(isProcessing)
+            .accessibilityIdentifier("pos-mark-as-paid-confirm-button")
             .frame(maxWidth: .infinity)
         }
         .padding(POSPadding.large)
@@ -115,11 +141,6 @@ private extension PointOfSaleMarkAsPaidConfirmationView {
             value: "Mark as paid",
             comment: "Confirmation button on the Point of Sale Mark as paid confirmation."
         )
-        static let cancelButton = NSLocalizedString(
-            "pointOfSale.markAsPaid.confirmation.cancelButton",
-            value: "Cancel",
-            comment: "Cancel button on the Point of Sale Mark as paid confirmation."
-        )
         static let noteFieldLabel = NSLocalizedString(
             "pointOfSale.markAsPaid.confirmation.noteLabel",
             value: "Add a note (optional)",
@@ -130,6 +151,11 @@ private extension PointOfSaleMarkAsPaidConfirmationView {
             "pointOfSale.markAsPaid.confirmation.notePlaceholder",
             value: "e.g. Bank transfer from Maria, ref 4827",
             comment: "Placeholder shown inside the optional note text field on the Point of Sale Mark as paid confirmation."
+        )
+        static let noteKeyboardDone = NSLocalizedString(
+            "pointOfSale.markAsPaid.confirmation.noteKeyboardDone",
+            value: "Done",
+            comment: "Keyboard toolbar button that dismisses the optional note text field on the Point of Sale Mark as paid confirmation."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -58,7 +58,19 @@ struct TotalsView: View {
                 VStack(alignment: .center) {
                     Spacer()
 
-                    if useTapToPayHeroLayout {
+                    if shouldPrioritizePaymentViewOverHero {
+                        PaymentViewContent(
+                            paymentState: displayPaymentState,
+                            cardReaderViewLayout: cardReaderViewLayout,
+                            isShowingTotalsFields: isShowingTotalsFields,
+                            backgroundColor: backgroundColor,
+                            orderState: posModel.orderState,
+                            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus,
+                            cardPresentPaymentInlineMessage: paymentModel.cardPresentPaymentInlineMessage,
+                            connectCardReaderAction: paymentModel.connectCardReader,
+                            cancelReconnectionAction: posModel.cancelReconnection
+                        )
+                    } else if useTapToPayHeroLayout {
                         POSTapToPayHeroView(onPayTapped: handleTapToPayTapped,
                                             isPayDisabled: isStartingPayment,
                                             isPreparing: paymentModel.isPreparingTapToPay)
@@ -635,6 +647,30 @@ private extension TotalsView {
     }
 
     /// True when the merchant should see the Android-style Tap to Pay hero +
+    /// True when the card payment has reached a terminal state (success or
+    /// error) after a TTP collection — we want `PaymentViewContent` to take
+    /// over **immediately** so the merchant doesn't briefly see the hero
+    /// fade out + Checkout chrome ghosting through before the success card
+    /// fades in. The default hero → PaymentViewContent priority order is
+    /// fine for every other transition; this short-circuits just the
+    /// terminal-state case.
+    private var shouldPrioritizePaymentViewOverHero: Bool {
+        switch displayPaymentState.card {
+        case .cardPaymentSuccessful,
+                .paymentError,
+                .validatingOrderError,
+                .paymentIntentCreationError:
+            return true
+        case .idle,
+                .acceptingCard,
+                .cardInserted,
+                .validatingOrder,
+                .preparingReader,
+                .processingPayment:
+            return false
+        }
+    }
+
     /// bottom-strip layout: TTP availability has resolved `.available`, no
     /// payment is currently in progress (idle card + idle cash), and the order
     /// has a real non-zero total to charge. When a TTP payment kicks off,

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -647,16 +647,18 @@ private extension TotalsView {
     }
 
     /// True when the merchant should see the Android-style Tap to Pay hero +
-    /// True when the card payment has reached a terminal state (success or
-    /// error) after a TTP collection — we want `PaymentViewContent` to take
-    /// over **immediately** so the merchant doesn't briefly see the hero
-    /// fade out + Checkout chrome ghosting through before the success card
-    /// fades in. The default hero → PaymentViewContent priority order is
-    /// fine for every other transition; this short-circuits just the
-    /// terminal-state case.
+    /// True when the card payment has reached a state that should take over
+    /// the hero immediately: a terminal state (success / error), or the
+    /// `.processingPayment` window between Apple's TTP modal closing and the
+    /// success card rendering. The default hero → PaymentViewContent priority
+    /// order is fine for every other transition; this short-circuits those
+    /// specific cases so the merchant sees the inline "Processing payment" /
+    /// success / error UI immediately rather than the hero fading out + the
+    /// Checkout chrome ghosting through.
     private var shouldPrioritizePaymentViewOverHero: Bool {
         switch displayPaymentState.card {
-        case .cardPaymentSuccessful,
+        case .processingPayment,
+                .cardPaymentSuccessful,
                 .paymentError,
                 .validatingOrderError,
                 .paymentIntentCreationError:
@@ -665,8 +667,7 @@ private extension TotalsView {
                 .acceptingCard,
                 .cardInserted,
                 .validatingOrder,
-                .preparingReader,
-                .processingPayment:
+                .preparingReader:
             return false
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -681,6 +681,15 @@ private extension TotalsView {
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
         guard displayPaymentState.card == .idle && displayPaymentState.cash == .idle else { return false }
+        // Also gate on scanToPay / markAsPaid being idle. After a successful
+        // payment via either of those the totals view renders their success
+        // UI via `PaymentViewContent` — we don't want the hero showing on
+        // top of (or instead of) that. Critically, without this the merchant
+        // could tap "Pay with Tap to pay" while `paymentState.markAsPaid`
+        // is still `.paymentSuccess`, and the card-state subscription's
+        // `markAsPaid != .idle` guard would silently swallow every Stripe
+        // event — the button disables but nothing happens.
+        guard displayPaymentState.scanToPay == .idle && displayPaymentState.markAsPaid == .idle else { return false }
         // Empty-cart / syncing / reconnecting guards computed directly. We
         // can't reuse `shouldShowCollectCashPaymentButton` here — that helper
         // also requires the reader to be disconnected when card state is idle

--- a/Modules/Sources/PointOfSale/ViewHelpers/CartViewHelper.swift
+++ b/Modules/Sources/PointOfSale/ViewHelpers/CartViewHelper.swift
@@ -16,6 +16,15 @@ struct CartViewHelper {
         guard paymentState.card.allowsCartEditing else {
             return true
         }
+        // Cash / Scan to Pay / Mark as Paid block cart editing while their flow
+        // is mid-progress (showing the QR view, confirming, processing) AND
+        // while their success UI is up on the totals view. Without this, the
+        // "back to cart" arrow on the phone Checkout header stays enabled on
+        // top of the success screen, and tapping it would let the merchant
+        // re-edit an order that's already been paid.
+        if paymentState.cash != .idle { return true }
+        if paymentState.scanToPay != .idle { return true }
+        if paymentState.markAsPaid != .idle { return true }
         return orderState.isSyncing
     }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -310,6 +310,77 @@ struct PointOfSaleOrderControllerTests {
         #expect(mockOrderService.spyMarkOrderAsCompletedManuallyOrder?.orderID == 42)
     }
 
+    @Test func markOrderAsPaidManually_with_non_empty_note_calls_addOrderNote_with_trimmed_note() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptSender: mockReceiptSender,
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+
+        let orderItem = OrderItem.fake()
+        let fakeOrder = Order.fake().copy(orderID: 99, items: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+        await sut.syncOrder(for: Cart(purchasableItems: [makeItem()]), retryHandler: {})
+
+        mockOrderService.resultToReturn = .success(())
+
+        // When
+        try await sut.markOrderAsPaidManually(note: "  Payment received in cash  ")
+
+        // Then
+        #expect(mockOrderService.addOrderNoteWasCalled == true)
+        #expect(mockOrderService.spyAddOrderNoteOrderID == 99)
+        #expect(mockOrderService.spyAddOrderNoteText == "Payment received in cash")
+        #expect(mockOrderService.spyAddOrderNoteIsCustomerNote == false)
+    }
+
+    @Test func markOrderAsPaidManually_with_whitespace_only_note_does_not_call_addOrderNote() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptSender: mockReceiptSender,
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+
+        let orderItem = OrderItem.fake()
+        let fakeOrder = Order.fake().copy(items: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+        await sut.syncOrder(for: Cart(purchasableItems: [makeItem()]), retryHandler: {})
+
+        mockOrderService.resultToReturn = .success(())
+
+        // When
+        try await sut.markOrderAsPaidManually(note: "   ")
+
+        // Then
+        #expect(mockOrderService.markOrderAsCompletedManuallyWasCalled == true)
+        #expect(mockOrderService.addOrderNoteWasCalled == false)
+    }
+
+    @Test func markOrderAsPaidManually_when_addOrderNote_fails_still_completes_order() async throws {
+        // Given
+        struct NoteAttachmentError: Error {}
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptSender: mockReceiptSender,
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+
+        let orderItem = OrderItem.fake()
+        let fakeOrder = Order.fake().copy(items: [orderItem])
+        mockOrderService.orderToReturn = fakeOrder
+        await sut.syncOrder(for: Cart(purchasableItems: [makeItem()]), retryHandler: {})
+
+        // markOrderAsCompletedManually succeeds via resultToReturn; addOrderNote fails via its own override.
+        mockOrderService.resultToReturn = .success(())
+        mockOrderService.addOrderNoteResult = .failure(NoteAttachmentError())
+
+        // When — must NOT throw even though addOrderNote fails
+        try await sut.markOrderAsPaidManually(note: "Cash payment")
+
+        // Then — order was marked complete and note attachment was attempted but its error was swallowed
+        #expect(mockOrderService.markOrderAsCompletedManuallyWasCalled == true)
+        #expect(mockOrderService.addOrderNoteWasCalled == true)
+    }
+
     @Test func markOrderAsPaidManually_when_orderService_throws_then_rethrows() async throws {
         // Given
         struct OrderServiceError: Error {}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderService.swift
@@ -112,12 +112,14 @@ class MockPOSOrderService: POSOrderServiceProtocol {
     var spyAddOrderNoteOrderID: Int64?
     var spyAddOrderNoteIsCustomerNote: Bool?
     var spyAddOrderNoteText: String?
+    /// When non-nil, overrides `resultToReturn` for `addOrderNote` calls only.
+    var addOrderNoteResult: Result<Void, Error>?
     func addOrderNote(orderID: Int64, isCustomerNote: Bool, note: String) async throws {
         addOrderNoteWasCalled = true
         spyAddOrderNoteOrderID = orderID
         spyAddOrderNoteIsCustomerNote = isCustomerNote
         spyAddOrderNoteText = note
-        switch resultToReturn {
+        switch addOrderNoteResult ?? resultToReturn {
         case .success:
             return
         case .failure(let error):


### PR DESCRIPTION
> Rebased onto trunk after the upstream cascade landed. Squashed 25 commits down to 11 (dropped 14 redundant ones — most were either already on trunk via independent merges, or interdependent Mark-as-Paid layout iterations that I collapsed into a single end-state commit).

## Description
Stacked directly on trunk. Combines three threads that landed together on the original branch:

**Mark as Paid view restructure** (1 commit, squashed from 9). Restructures `PointOfSaleMarkAsPaidConfirmationView` to match the Cash & Scan to Pay layout pattern: `GeometryReader → ScrollView → VStack` with a top `POSPageHeaderView` that fills the navigation pane, replacing the inline title + Cancel button with a header back button + Confirm-only button. Adds a keyboard toolbar Done button (the `.vertical` TextField doesn't fire `.onSubmit` on Return).

**TTP polish** (8 commits). Improvements to the silent Tap to Pay flow:
- Coalesce concurrent pre-connect attempts via `tapToPayConnectTask`; skip the redundant disconnect-then-reconnect cycle when a TTP reader is already up (tracked via `lastConnectedMethod`).
- Hero CTA shows a loading spinner between merchant tap and Apple modal opening.
- Render `PaymentViewContent` immediately on TTP terminal states (no flicker through hero on success/error).
- Surface "Processing payment" UI between Apple TTP modal close and the success card appearing.
- Hide the in-pane Checkout header on processing / error / payment-success states (the merchant is on a focused payment view, the back-arrow is already disabled mid-flow, the header is noise).
- Disable back-to-cart arrow when any secondary method is in flight or successful.
- Gate the TTP hero on `scanToPay` and `markAsPaid` idle states too — previously the hero would peek through while a secondary method was active.

**Note attachment tests** (1 commit). Adds tests for note attachment in `PointOfSaleOrderController.markOrderAsPaidManually(...)` — verifies the optional note flows through to the order update call.

**Toolbar deprecation cleanup** (1 commit). Migrates the MarkAsPaid destination in `POSNavigationRouter` to `.toolbar(.hidden, for: .navigationBar)` (ScanToPay + EmailReceipt landed via independent PRs).

## Dropped commits (verified redundant on trunk)

| Dropped | Why |
|---|---|
| `15b8cd0608` orphan `preferredConnectionMethod` removal | already on trunk via `e5eb8b0c78` |
| `a94273d9b1` Wire scanToPay nav on phone container | trunk's `fd4091713c` extracted shared modifier handles this |
| `045d0dc28d` Push Scan to Pay view on phone container | same as above |
| `7c6a6463e1` Wire ScanToPay + MarkAsPaid into sheet | shipped in #17112 instead |
| `5cf1414fb8` + `4faac908e1` TTP connecting/scanning alert suppression | already on trunk inside the consolidated TTP alert filter |
| `fab937b7c1` diagnostic log | meant to be temporary; the immediately-following commit already strips it |
| `580ef01ec1` Review fix: orphaned doc comment | the orphan only existed in an intermediate state of the branch |
| `e93f64c876` SwiftLint parens fix | the parens were introduced by a commit we squashed; the squash writes them without parens directly |
| 9 Mark as Paid iteration commits | squashed into one end-state commit (see above) |
| 4 cherry-picks that have trunk twins | identical content, dropped to avoid noise |

## Test Steps
- iPhone, `pointOfSaleTapToPay` + `pointOfSaleMarkOrderAsPaid` flags on. Open POS → checkout.
- **Mark as Paid layout.** Tap Other payment methods → Mark order as paid. Pushes a view with the back-arrow header at the top, scrollable content, a note text field with keyboard Done button, and a single Confirm button. Tap the back-arrow during processing — disabled. After processing, the totals view shows the payment-success UI.
- **TTP hero loading spinner.** Tap "Pay with Tap to Pay" — the CTA shows a loading spinner until the Apple modal opens.
- **TTP terminal states.** Complete a TTP payment → success card renders immediately, no hero flicker. Cancel a TTP payment → hero returns, no flicker.
- **"Processing payment" affordance.** After tapping a card in the Apple modal, observe the brief "Processing payment" affordance between Apple's modal closing and the success card appearing.
- **Checkout header hidden.** During processing / error / success, the in-pane "Checkout" header is hidden. During cash/scan-to-pay/mark-as-paid success states too.
- **Back-arrow disabled.** While a secondary method is in flight, the back-to-cart arrow is disabled.
- **TTP hero gating.** Trigger scan-to-pay or mark-as-paid → TTP hero hides (it used to peek through).
- **Pre-connect coalescing.** Re-enter checkout multiple times — only one Apple modal preparation runs at a time. The "Preparing Tap to Pay…" indicator does NOT appear on every re-entry (it skips if the reader is already TTP-connected).

## Screenshots
N/A — covered by the test plan flows.

---
- [x] No release notes — feature flagged off.