### PR TITLE
[WOOMOB-2814] Add WPCOM store picker to Store Stats widget. - bad rebase

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
@@ -19,6 +19,8 @@ extension StoreInfoProvider: AppIntentTimelineProvider {
             requested: configuration.metrics,
             family: context.family
         )
-        return await loadTimeline(dateRange: configuration.dateRange, metrics: metrics)
+        return await loadTimeline(dateRange: configuration.dateRange,
+                                  metrics: metrics,
+                                  selectedStoreID: configuration.store?.id)
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -126,16 +126,20 @@ final class StoreInfoProvider: TimelineProvider {
     ///
     func loadTimeline(
         dateRange: StoreStatsWidgetDateRange,
-        metrics: [StoreInfoMetricType]
+        metrics: [StoreInfoMetricType],
+        selectedStoreID: StoreStatsStoreEntity.ID? = nil
     ) async -> Timeline<StoreInfoEntry> {
-        guard let dependencies = Self.fetchDependencies() else {
+        guard let dependencies = Self.fetchDependencies(selectedStoreID: selectedStoreID) else {
             return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
         }
 
         let reloadDate = Date(timeIntervalSinceNow: reloadInterval)
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
-            let statsPeriod = try await service.fetchStats(for: dependencies.storeID, dateRange: dateRange.serviceDateRange)
+            let statsPeriod = try await service.fetchStats(
+                for: dependencies.store.storeID,
+                dateRange: dateRange.serviceDateRange(timezone: dependencies.store.storeTimeZone)
+            )
             let entry = Self.dataEntry(
                 for: statsPeriod,
                 dateRange: dateRange,
@@ -266,28 +270,26 @@ private extension StoreInfoDataService.Stats {
     }
 }
 
-private extension StoreInfoProvider {
+extension StoreInfoProvider {
 
     /// Dependencies needed by the `StoreInfoProvider`
     ///
-    struct Dependencies {
+    struct StoreInfoProviderDependencies {
         let credentials: Credentials
+        let store: StoreMetadata
+    }
+
+    struct StoreMetadata {
         let storeID: Int64
         let storeName: String
         let storeCurrencySettings: CurrencySettings
+        let storeTimeZone: TimeZone
     }
 
     /// Fetches the required dependencies from the keychain and the shared users default.
     ///
-    static func fetchDependencies() -> Dependencies? {
+    static func fetchDependencies(selectedStoreID: StoreStatsStoreEntity.ID? = nil) -> StoreInfoProviderDependencies? {
         let keychain = Keychain(service: WooConstants.keychainServiceName)
-        guard let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
-              let storeName = UserDefaults.group?[.defaultStoreName] as? String,
-              let storeCurrencySettingsData = UserDefaults.group?[.defaultStoreCurrencySettings] as? Data,
-              let storeCurrencySettings = try? JSONDecoder().decode(CurrencySettings.self, from: storeCurrencySettingsData) else {
-            print("⛔️ missing store info")
-            return nil
-        }
         let credentials: Credentials? = {
             if let authToken = keychain[WooConstants.authToken] {
                 return Credentials(authToken: authToken)
@@ -306,10 +308,54 @@ private extension StoreInfoProvider {
             print("⛔️ missing credentials")
             return nil
         }
-        return Dependencies(credentials: credentials,
-                            storeID: storeID,
-                            storeName: storeName,
-                            storeCurrencySettings: storeCurrencySettings)
+
+        guard let defaultStore = defaultStoreMetadata() else {
+            print("⛔️ missing store info")
+            return nil
+        }
+
+        let selectedStore = selectedStoreMetadata(defaultStore: defaultStore,
+                                                  selectedStoreID: selectedStoreID,
+                                                  sites: WidgetSiteListStore().sites())
+        return StoreInfoProviderDependencies(credentials: credentials,
+                                             store: selectedStore)
+    }
+
+    static func selectedStoreMetadata(defaultStore: StoreMetadata,
+                                      selectedStoreID: StoreStatsStoreEntity.ID?,
+                                      sites: [WidgetSite]) -> StoreMetadata {
+        guard let selectedStoreID,
+              StoreStatsStoreSelection.isDefaultStoreEntityID(selectedStoreID) == false,
+              let selectedSiteID = Int64(selectedStoreID),
+              let selectedSite = sites.first(where: { $0.siteID == selectedSiteID }) else {
+            return defaultStore
+        }
+
+        let currencySettings: CurrencySettings = {
+            guard selectedSite.siteID != defaultStore.storeID else {
+                return defaultStore.storeCurrencySettings
+            }
+            return selectedSite.currencySettings ?? defaultStore.storeCurrencySettings
+        }()
+
+        return StoreMetadata(storeID: selectedSite.siteID,
+                             storeName: selectedSite.name,
+                             storeCurrencySettings: currencySettings,
+                             storeTimeZone: selectedSite.timezone)
+    }
+
+    static func defaultStoreMetadata() -> StoreMetadata? {
+        guard let storeID = UserDefaults.group?[.defaultStoreID] as? Int64,
+              let storeName = UserDefaults.group?[.defaultStoreName] as? String,
+              let storeCurrencySettingsData = UserDefaults.group?[.defaultStoreCurrencySettings] as? Data,
+              let storeCurrencySettings = try? JSONDecoder().decode(CurrencySettings.self, from: storeCurrencySettingsData) else {
+            return nil
+        }
+
+        return StoreMetadata(storeID: storeID,
+                             storeName: storeName,
+                             storeCurrencySettings: storeCurrencySettings,
+                             storeTimeZone: .current)
     }
 }
 
@@ -322,8 +368,8 @@ private extension StoreInfoProvider {
     /// array derive from `Stats.placeholderSample` + `legacyMetricsPreset` so the two views of
     /// the same data stay in sync.
     ///
-    static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
-        let currencySettings = dependencies?.storeCurrencySettings ?? CurrencySettings()
+    static func placeholderEntry(for dependencies: StoreInfoProviderDependencies?) -> StoreInfoEntry {
+        let currencySettings = dependencies?.store.storeCurrencySettings ?? CurrencySettings()
         let sample = StoreInfoDataService.Stats.placeholderSample
         let metrics: [StoreInfoMetric] = legacyMetricsPreset.map { type in
             StoreInfoMetric(type: type, value: sample.value(for: type, currencySettings: currencySettings))
@@ -332,7 +378,7 @@ private extension StoreInfoProvider {
         let conversionString = sample.conversion.map(StoreInfoFormatter.formattedConversionString) ?? StoreInfoFormatter.Constants.valuePlaceholderText
         return .data(.init(
             range: StoreStatsWidgetDateRange.today.localizedRangeLabel,
-            name: dependencies?.storeName ?? Localization.myShop,
+            name: dependencies?.store.storeName ?? Localization.myShop,
             revenue: StoreInfoFormatter.formattedAmountString(for: sample.revenue, with: currencySettings),
             revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: sample.revenue, with: currencySettings),
             visitors: visitorsString,
@@ -353,9 +399,9 @@ private extension StoreInfoProvider {
     ///
     static func dataEntry(for statsPeriod: StoreInfoDataService.StatsPeriod,
                           dateRange: StoreStatsWidgetDateRange,
-                          with dependencies: Dependencies,
+                          with dependencies: StoreInfoProviderDependencies,
                           metrics: [StoreInfoMetricType]) -> StoreInfoEntry {
-        let currencySettings = dependencies.storeCurrencySettings
+        let currencySettings = dependencies.store.storeCurrencySettings
         let stats = statsPeriod.current
         let previousStats = statsPeriod.previous
         let resolvedMetrics: [StoreInfoMetric] = metrics.map { type in
@@ -382,7 +428,7 @@ private extension StoreInfoProvider {
 
         return .data(.init(
             range: dateRange.localizedRangeLabel,
-            name: dependencies.storeName,
+            name: dependencies.store.storeName,
             revenue: StoreInfoFormatter.formattedAmountString(for: stats.revenue, with: currencySettings),
             revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: stats.revenue, with: currencySettings),
             visitors: visitorsString,

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -3,8 +3,7 @@ import WidgetKit
 
 /// Configuration intent for the Store Stats widget.
 ///
-/// Surfaces the user-facing widget settings (long-press → Edit Widget). The `store` picker is
-/// added by a later ticket on top of `dateRange` and `metrics`.
+/// Surfaces the user-facing widget settings (long-press → Edit Widget).
 ///
 struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
     static var title: LocalizedStringResource = "Store Stats"
@@ -22,6 +21,9 @@ struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
         .systemMedium: 4,
         .systemLarge: 7
     ]
+
+    @Parameter(title: "Store")
+    var store: StoreStatsStoreEntity?
 
     @Parameter(title: "Date Range", default: .today)
     var dateRange: StoreStatsWidgetDateRange
@@ -53,4 +55,87 @@ struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
         query: AvailableMetricsQuery()
     )
     var metrics: [StoreInfoMetricType]
+
+    init() {
+        store = StoreStatsStoreEntity.defaultStore
+    }
+}
+
+enum StoreStatsStoreSelection {
+    static let defaultStoreEntityID = "__default_store__"
+
+    static func isDefaultStoreEntityID(_ id: String) -> Bool {
+        id == defaultStoreEntityID
+    }
+
+    static func entityID(for siteID: Int64) -> String {
+        String(siteID)
+    }
+}
+
+struct StoreStatsStoreEntity: AppEntity, Hashable {
+    static let defaultStore = StoreStatsStoreEntity(id: StoreStatsStoreSelection.defaultStoreEntityID, name: nil)
+
+    static var defaultQuery = StoreStatsStoreQuery()
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Store")
+    }
+
+    let id: String
+    let name: String?
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(displayName)")
+    }
+
+    init(site: WidgetSite) {
+        id = StoreStatsStoreSelection.entityID(for: site.siteID)
+        name = site.name
+    }
+
+    init(id: String, name: String?) {
+        self.id = id
+        self.name = name
+    }
+
+    static func isDefaultStoreID(_ id: String) -> Bool {
+        StoreStatsStoreSelection.isDefaultStoreEntityID(id)
+    }
+
+    private var displayName: String {
+        if Self.isDefaultStoreID(id),
+           let defaultStoreName = UserDefaults.group?[.defaultStoreName] as? String {
+            return defaultStoreName
+        }
+        return name ?? "Store"
+    }
+}
+
+struct StoreStatsStoreQuery: EntityQuery {
+    private let siteListStore: WidgetSiteListStore
+
+    init(siteListStore: WidgetSiteListStore = WidgetSiteListStore()) {
+        self.siteListStore = siteListStore
+    }
+
+    func entities(for identifiers: [StoreStatsStoreEntity.ID]) async throws -> [StoreStatsStoreEntity] {
+        let identifiers = Set(identifiers)
+        let entities = siteListStore.sites()
+            .filter { identifiers.contains(StoreStatsStoreSelection.entityID(for: $0.siteID)) }
+            .map(StoreStatsStoreEntity.init(site:))
+
+        guard identifiers.contains(where: StoreStatsStoreEntity.isDefaultStoreID) else {
+            return entities
+        }
+        return [StoreStatsStoreEntity.defaultStore] + entities
+    }
+
+    func suggestedEntities() async throws -> [StoreStatsStoreEntity] {
+        siteListStore.sites().map(StoreStatsStoreEntity.init(site:))
+    }
+
+    func defaultResult() async -> StoreStatsStoreEntity? {
+        StoreStatsStoreEntity.defaultStore
+    }
 }

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -115,6 +115,10 @@ struct StoreStatsStoreEntity: AppEntity, Hashable {
 struct StoreStatsStoreQuery: EntityQuery {
     private let siteListStore: WidgetSiteListStore
 
+    init() {
+        self.init(siteListStore: WidgetSiteListStore())
+    }
+
     init(siteListStore: WidgetSiteListStore = WidgetSiteListStore()) {
         self.siteListStore = siteListStore
     }

--- a/WooCommerce/StoreWidgets/StoreStatsWidgetDateRange+Service.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsWidgetDateRange+Service.swift
@@ -1,15 +1,23 @@
+import Foundation
+
 extension StoreStatsWidgetDateRange {
     /// Maps the user-selected widget range to the primitive parameters consumed by
     /// `StoreInfoDataService.fetchStats(for:dateRange:)`.
     ///
     var serviceDateRange: StoreInfoDataService.DateRange {
+        serviceDateRange()
+    }
+
+    /// Maps the user-selected widget range using the selected store's timezone.
+    ///
+    func serviceDateRange(timezone: TimeZone = .current) -> StoreInfoDataService.DateRange {
         switch self {
         case .today:
-            return .today()
+            return .today(timezone: timezone)
         case .last7Days:
-            return .last7Days()
+            return .last7Days(timezone: timezone)
         case .last30Days:
-            return .last30Days()
+            return .last30Days(timezone: timezone)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/WidgetSiteListStoreTests.swift
@@ -78,3 +78,171 @@ struct WidgetSiteListStoreTests {
         return userDefaults
     }
 }
+
+struct StoreStatsStoreQueryTests {
+
+    @Test func suggested_entities_when_site_list_store_has_sites_then_returns_widget_site_entities() async throws {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let siteListStore = WidgetSiteListStore(userDefaults: userDefaults)
+        siteListStore.save([
+            makeSite(siteID: 1, name: "Default"),
+            makeSite(siteID: 2, name: "Other")
+        ])
+        let sut = StoreStatsStoreQuery(siteListStore: siteListStore)
+
+        // When
+        let entities = try await sut.suggestedEntities()
+
+        // Then
+        #expect(entities.map(\.id) == ["1", "2"])
+        #expect(entities.map(\.name) == ["Default", "Other"])
+    }
+
+    @Test func entities_when_identifiers_include_default_store_then_returns_default_store_and_matching_sites() async throws {
+        // Given
+        let userDefaults = makeUserDefaults()
+        let siteListStore = WidgetSiteListStore(userDefaults: userDefaults)
+        siteListStore.save([
+            makeSite(siteID: 1, name: "Default"),
+            makeSite(siteID: 2, name: "Other")
+        ])
+        let sut = StoreStatsStoreQuery(siteListStore: siteListStore)
+
+        // When
+        let entities = try await sut.entities(for: [
+            StoreStatsStoreSelection.defaultStoreEntityID,
+            "2"
+        ])
+
+        // Then
+        #expect(entities.map(\.id) == [StoreStatsStoreSelection.defaultStoreEntityID, "2"])
+    }
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "StoreStatsStoreQueryTests-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+
+    private func makeSite(siteID: Int64, name: String, currencySettings: CurrencySettings? = nil) -> WidgetSite {
+        WidgetSite(siteID: siteID,
+                   name: name,
+                   timezoneIdentifier: "UTC",
+                   gmtOffset: 0,
+                   currencySettings: currencySettings)
+    }
+}
+
+struct StoreInfoProviderStoreSelectionTests {
+
+    @Test func selected_store_metadata_when_default_store_entity_is_selected_then_returns_default_store() {
+        // Given
+        let defaultStore = makeDefaultStore(currencyCode: .USD)
+        let sites = [makeSite(siteID: 2, name: "Other", currencyCode: .EUR)]
+
+        // When
+        let metadata = StoreInfoProvider.selectedStoreMetadata(defaultStore: defaultStore,
+                                                               selectedStoreID: StoreStatsStoreSelection.defaultStoreEntityID,
+                                                               sites: sites)
+
+        // Then
+        #expect(metadata.storeID == defaultStore.storeID)
+        #expect(metadata.storeName == defaultStore.storeName)
+        #expect(metadata.storeCurrencySettings.currencyCode == .USD)
+    }
+
+    @Test func selected_store_metadata_when_selected_store_id_is_stale_then_returns_default_store() {
+        // Given
+        let defaultStore = makeDefaultStore(currencyCode: .USD)
+        let sites = [makeSite(siteID: 2, name: "Other", currencyCode: .EUR)]
+
+        // When
+        let metadata = StoreInfoProvider.selectedStoreMetadata(defaultStore: defaultStore,
+                                                               selectedStoreID: "999",
+                                                               sites: sites)
+
+        // Then
+        #expect(metadata.storeID == defaultStore.storeID)
+        #expect(metadata.storeName == defaultStore.storeName)
+        #expect(metadata.storeCurrencySettings.currencyCode == .USD)
+    }
+
+    @Test func selected_store_metadata_when_non_default_store_is_selected_then_uses_widget_site_details() {
+        // Given
+        let defaultStore = makeDefaultStore(currencyCode: .USD)
+        let sites = [makeSite(siteID: 2,
+                              name: "Madrid",
+                              timezoneIdentifier: "Europe/Madrid",
+                              gmtOffset: 1,
+                              currencyCode: .EUR)]
+
+        // When
+        let metadata = StoreInfoProvider.selectedStoreMetadata(defaultStore: defaultStore,
+                                                               selectedStoreID: "2",
+                                                               sites: sites)
+
+        // Then
+        #expect(metadata.storeID == 2)
+        #expect(metadata.storeName == "Madrid")
+        #expect(metadata.storeCurrencySettings.currencyCode == .EUR)
+        #expect(metadata.storeTimeZone.identifier == "Europe/Madrid")
+    }
+
+    @Test func selected_store_metadata_when_non_default_store_has_no_currency_settings_then_uses_default_currency_settings() {
+        // Given
+        let defaultStore = makeDefaultStore(currencyCode: .USD)
+        let sites = [makeSite(siteID: 2, name: "Other", currencyCode: nil)]
+
+        // When
+        let metadata = StoreInfoProvider.selectedStoreMetadata(defaultStore: defaultStore,
+                                                               selectedStoreID: "2",
+                                                               sites: sites)
+
+        // Then
+        #expect(metadata.storeID == 2)
+        #expect(metadata.storeCurrencySettings.currencyCode == .USD)
+    }
+
+    @Test func selected_store_metadata_when_default_store_site_is_selected_then_uses_default_currency_settings() {
+        // Given
+        let defaultStore = makeDefaultStore(currencyCode: .USD)
+        let sites = [makeSite(siteID: 1, name: "Default From List", currencyCode: .EUR)]
+
+        // When
+        let metadata = StoreInfoProvider.selectedStoreMetadata(defaultStore: defaultStore,
+                                                               selectedStoreID: "1",
+                                                               sites: sites)
+
+        // Then
+        #expect(metadata.storeID == 1)
+        #expect(metadata.storeName == "Default From List")
+        #expect(metadata.storeCurrencySettings.currencyCode == .USD)
+    }
+
+    private func makeDefaultStore(currencyCode: CurrencyCode) -> StoreInfoProvider.StoreMetadata {
+        StoreInfoProvider.StoreMetadata(storeID: 1,
+                                        storeName: "Default",
+                                        storeCurrencySettings: currencySettings(for: currencyCode),
+                                        storeTimeZone: TimeZone(identifier: "UTC")!)
+    }
+
+    private func makeSite(siteID: Int64,
+                          name: String,
+                          timezoneIdentifier: String = "UTC",
+                          gmtOffset: Double = 0,
+                          currencyCode: CurrencyCode?) -> WidgetSite {
+        WidgetSite(siteID: siteID,
+                   name: name,
+                   timezoneIdentifier: timezoneIdentifier,
+                   gmtOffset: gmtOffset,
+                   currencySettings: currencyCode.map { currencySettings(for: $0) })
+    }
+
+    private func currencySettings(for currencyCode: CurrencyCode) -> CurrencySettings {
+        let currencySettings = CurrencySettings()
+        currencySettings.currencyCode = currencyCode
+        return currencySettings
+    }
+}


### PR DESCRIPTION
## Description

Adds the Store picker UI and selected-store timeline behavior to the configurable Store Stats widget.

This PR is stacked on #17109. The first PR prepares the shared WPCOM store snapshot list; this PR consumes that data in the widget extension so WPCOM-authenticated users can choose which active WooCommerce store powers each widget instance.

### What's added

- `Store` parameter on `StoreStatsConfigurationIntent`, exposed in Edit Widget.
- `StoreStatsStoreEntity` and `StoreStatsStoreQuery` to populate the AppIntent picker from the shared snapshot list.
- Selected-store resolution in `StoreInfoProvider`, including store ID, display name, timezone, and currency settings.
- Store-specific date range handling so Today / Last 7 Days / Last 30 Days use the selected store timezone.
- Currency settings fallback logic: default-store widgets always use the latest default-store settings, while non-default stores use snapshot currency settings when available and fall back to the default store settings when missing.
- General settings sync for selected stores whose currency settings are not available yet, followed by a widget timeline reload after successful sync.
- Unit coverage for selected/default store resolution, currency fallback, empty picker suggestions, and selectable stores with missing currency settings.

### What's not touched

- The sites persistence foundation belongs to #17109 and is not duplicated here.
- The legacy Store Stats widget rendering path and lock-screen widgets continue to use the default store path.
- No new visual widget layout is introduced here; this only wires the Store parameter into the existing configurable widget timeline.

### Notes for reviewers

- **Stacked PR.** Review this against #17109 , not directly against `trunk`.
- **Feature-flagged.** The configurable Store Stats widget is only exposed when `configurableStoreStatsWidgets` is enabled.

Tracking: WOOMOB-2814.

## Test Steps

This PR is only exercisable when the `configurableStoreStatsWidgets` flag is on.

1. Log in with a WPCOM account that has multiple active WooCommerce stores.
2. Add a configurable Store Stats widget and open Edit Widget.
3. Verify the Store field lists selectable active WooCommerce stores.
4. Select a non-default store and verify the widget refreshes stats for that store.
5. Verify Today / Last 7 Days / Last 30 Days use the selected store timezone.
6. Verify currency metrics use the selected store currency settings when available, and fall back gracefully when those settings have not synced yet.
7. Verify non-WPCOM credentials or an intentionally empty snapshot list do not expose selectable store options.

## Screenshots

<img width="404" height="405" alt="Screenshot 2026-05-07 at 13 40 21" src="https://github.com/user-attachments/assets/99e4770d-2e33-4786-9bcd-632c2077fb6f" />

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.