### PR TITLE
Address `redundant_type_annotation` warning

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -78,7 +78,7 @@ final class ServiceLocator {
     /// Mirrors selectable WooCommerce sites into shared app-group `UserDefaults` for the
     /// `StoreWidgetsExtension` site picker. Idle until `start()` is called.
     ///
-    private static var _widgetSiteListSyncManager: WidgetSiteListSyncManager = WidgetSiteListSyncManager()
+    private static var _widgetSiteListSyncManager = WidgetSiteListSyncManager()
 
     /// Currency Settings
     ///


### PR DESCRIPTION
## Description

New PRs fail to pass CI due to `redundant_type_annotation` linter, this PR removes the redundant type in service locator.

```

[2026-05-11T01:05:53Z] ++ docker run --rm -v /var/lib/buildkite-agent/builds/ci-cluster-linter-i-0fec0ca3a450c0cc6-2/automattic/woocommerce-ios:/workspace -w /workspace --entrypoint swiftlint ghcr.io/realm/swiftlint:0.63.2 lint --quiet --reporter relative-path --strict
--
[2026-05-11T01:06:43Z] - `WooCommerce/Classes/ServiceLocator/ServiceLocator.swift:81:50`: Variables should not have redundant type annotation (redundant_type_annotation)
[2026-05-11T01:06:43Z] 2026-05-11 01:06:43 INFO   Reading annotation body from STDIN
[2026-05-11T01:06:43Z] SwiftLint completed with exit code 2
[2026-05-11T01:06:43Z] /var/lib/buildkite-agent/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/automattic-buildkite-linter-0.8.0/lib/linter/handlable.rb:124:in `system': Command failed with exit 2: run_swiftlint (RuntimeError)
[2026-05-11T01:06:43Z] 	from /var/lib/buildkite-agent/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/automattic-buildkite-linter-0.8.0/lib/linter/handlable.rb:124:in `_exec'
[2026-05-11T01:06:43Z] 	from /var/lib/buildkite-agent/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/automattic-buildkite-linter-0.8.0/lib/linter/swiftlint_handler.rb:26:in `handle'
[2026-05-11T01:06:43Z] 	from /var/lib/buildkite-agent/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/automattic-buildkite-linter-0.8.0/lib/linter.rb:30:in `run'
[2026-05-11T01:06:43Z] 	from /var/lib/buildkite-agent/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/automattic-buildkite-linter-0.8.0/bin/linter_command_handler:11:in `<top (required)>'
[2026-05-11T01:06:43Z] 	from /var/lib/buildkite-agent/.rbenv/versions/3.2.2/bin/linter_command_handler:25:in `load'
[2026-05-11T01:06:43Z] 	from /var/lib/buildkite-agent/.rbenv/versions/3.2.2/bin/linter_command_handler:25:in `<main>'
[2026-05-11T01:06:43Z] 🚨 Error: The command exited with status 1
[2026-05-11T01:06:43Z] user command error: running "agent command" shell hook: The agent command hook exited with status 1


```

## Test Steps
CI should pass
