### PR TITLE
Send support chat topic as escalation tag

### DIFF
--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -151,14 +151,16 @@ public enum SupportAreaType: String, Decodable, Equatable {
 ///
 public struct SupportChatSupportArea: Decodable, Equatable {
     public let area: SupportAreaType
+    public let topic: String?
     public let confidence: SupportAreaConfidence
 
     public var isHighConfidence: Bool {
         confidence == .high
     }
 
-    public init(area: SupportAreaType, confidence: SupportAreaConfidence) {
+    public init(area: SupportAreaType, topic: String? = nil, confidence: SupportAreaConfidence) {
         self.area = area
+        self.topic = topic
         self.confidence = confidence
     }
 }

--- a/Modules/Tests/NetworkingTests/Model/SupportChatSupportAreaTests.swift
+++ b/Modules/Tests/NetworkingTests/Model/SupportChatSupportAreaTests.swift
@@ -95,6 +95,7 @@ struct SupportChatSupportAreaTests {
         let json = """
         {
             "area": "woopayments",
+            "topic": "woo_mobile_issue_orders",
             "confidence": "medium"
         }
         """
@@ -105,7 +106,25 @@ struct SupportChatSupportAreaTests {
 
         // Then
         #expect(result.area == .wooPayments)
+        #expect(result.topic == "woo_mobile_issue_orders")
         #expect(result.confidence == .medium)
         #expect(result.isHighConfidence == false)
+    }
+
+    @Test func supportArea_decodes_without_topic() throws {
+        // Given
+        let json = """
+        {
+            "area": "woopayments",
+            "confidence": "medium"
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+
+        // When
+        let result = try JSONDecoder().decode(SupportChatSupportArea.self, from: data)
+
+        // Then
+        #expect(result.topic == nil)
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -222,6 +222,7 @@ struct SupportChatRemoteTests {
         // Then
         let supportArea = try #require(response.messages.first?.context?.supportArea)
         #expect(supportArea.area == .cardReader)
+        #expect(supportArea.topic == "woo_mobile_issue_card_reader")
         #expect(supportArea.confidence == .high)
         #expect(supportArea.isHighConfidence == true)
     }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-with-support-area.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-with-support-area.json
@@ -18,6 +18,7 @@
                 },
                 "support_area": {
                     "area": "card-reader",
+                    "topic": "woo_mobile_issue_card_reader",
                     "confidence": "high"
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -96,7 +96,7 @@ final class SupportEscalationCoordinator {
 
         let viewModel = SupportFormViewModel(
             sourceTag: Tags.sourceTag,
-            additionalTags: Tags.additionalTags,
+            additionalTags: additionalTags(for: supportAreaInfo),
             attachments: attachments,
             preselectedArea: supportAreaInfo?.area,
             prefilledSubject: prefilledSubject,
@@ -125,7 +125,7 @@ final class SupportEscalationCoordinator {
         let attachments = additionalAttachmentsProvider()
 
         let siteAddress = stores.sessionManager.defaultSite?.url ?? ""
-        let tags = areaInfo.area.datasource.tags + Tags.additionalTags + [Tags.sourceTag]
+        let tags = areaInfo.area.datasource.tags + additionalTags(for: areaInfo) + [Tags.sourceTag]
         let request = ZendeskSupportRequest(
             formID: areaInfo.area.datasource.formID,
             customFields: areaInfo.area.datasource.customFields(siteAddress: siteAddress),
@@ -172,6 +172,14 @@ final class SupportEscalationCoordinator {
         guard let chatID else { return }
         let action = SupportChatAction.markTicketCreated(chatID: chatID) { }
         stores.dispatch(action)
+    }
+
+    private func additionalTags(for supportAreaInfo: SupportAreaInfo?) -> [String] {
+        var tags = Tags.additionalTags
+        if let topic = supportAreaInfo?.topic, topic.isNotEmpty {
+            tags.append(topic)
+        }
+        return tags
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportAreaInfo.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportAreaInfo.swift
@@ -12,6 +12,9 @@ struct SupportAreaInfo {
     /// The confidence level of the area classification.
     let confidence: SupportAreaConfidence
 
+    /// The support topic returned by the bot for ticket tagging.
+    let topic: String?
+
     /// Full chat transcript.
     let transcript: String
 
@@ -25,11 +28,13 @@ struct SupportAreaInfo {
     init(areaType: SupportAreaType,
          area: SupportFormViewModel.Area,
          confidence: SupportAreaConfidence,
+         topic: String? = nil,
          transcript: String,
          systemStatusReport: String? = nil) {
         self.areaType = areaType
         self.area = area
         self.confidence = confidence
+        self.topic = topic
         self.transcript = transcript
         self.systemStatusReport = systemStatusReport
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -614,6 +614,7 @@ final class SupportChatViewModel {
                 areaType: supportArea.area,
                 area: mappedArea,
                 confidence: supportArea.confidence,
+                topic: supportArea.topic,
                 transcript: transcript,
                 systemStatusReport: systemStatusReport
             )

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -40,6 +40,7 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.contains("in_app_support_escalate"))
         #expect(zendesk.latestInvokedTags.contains("ai_skip"))
+        #expect(zendesk.latestInvokedTags.contains("woo_mobile_issue_orders"))
     }
 
     @Test func handleEscalation_when_high_confidence_but_no_identity_then_shows_support_form() {
@@ -200,6 +201,7 @@ private extension SupportEscalationCoordinatorTests {
             areaType: .mobileApp,
             area: SupportFormViewModel.area(for: .mobileApp),
             confidence: .high,
+            topic: "woo_mobile_issue_orders",
             transcript: "Test transcript"
         )
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -587,7 +587,7 @@ struct SupportChatViewModelTests {
                                     loggedIn: true,
                                     branch: nil
                                 ),
-                                supportArea: SupportChatSupportArea(area: .mobileApp, confidence: .high)
+                                supportArea: SupportChatSupportArea(area: .mobileApp, topic: "woo_mobile_issue_orders", confidence: .high)
                             )
                         )
                     ]
@@ -614,6 +614,7 @@ struct SupportChatViewModelTests {
         sut.contactHumanSupport()
 
         // Then
+        #expect(receivedSupportAreaInfo?.topic == "woo_mobile_issue_orders")
         #expect(receivedSupportAreaInfo?.systemStatusReport == prefetchedReport)
     }
 


### PR DESCRIPTION
WOOMOB-3032

## Description
Adds support for the `support_area.topic` value returned by the support chat bot and carries it through escalation metadata.

When a support escalation is created, the topic is appended as an additional Zendesk tag alongside the existing AI escalation tags. This applies to both direct high-confidence ticket creation and the support form path.

The topic list can be found here: phcsdm-3jA-p2#comment-2447

## Test Steps
1. Start a support chat response that includes a support area topic, for example `woo_mobile_issue_orders`.
2. Escalate the chat to human support.
3. Verify the created Zendesk request includes the support topic as an additional tag.
4. Verify existing responses without `topic` still decode and escalate normally.

Automated coverage added for support area topic decoding, passing the topic through `SupportAreaInfo`, and appending it to escalation tags.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.