### PR TITLE
Align AI Assistant dashboard eligibility with Android

### DIFF
--- a/WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantEligibilityChecker.swift
@@ -1,6 +1,5 @@
 import Experiments
 import Foundation
-import enum NetworkingCore.Credentials
 import struct Yosemite.Site
 
 protocol AIAssistantEligibilityCheckerProtocol {
@@ -9,21 +8,16 @@ protocol AIAssistantEligibilityCheckerProtocol {
 
 struct AIAssistantEligibilityChecker: AIAssistantEligibilityCheckerProtocol {
     private let featureFlagService: FeatureFlagService
-    private let credentialsProvider: () -> Credentials?
 
-    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         credentialsProvider: @escaping () -> Credentials? = { ServiceLocator.stores.sessionManager.defaultCredentials }) {
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.featureFlagService = featureFlagService
-        self.credentialsProvider = credentialsProvider
     }
 
     func isEligible(for site: Site?) -> Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.wooAIAssistant), let site else {
+        guard featureFlagService.isFeatureFlagEnabled(.wooAIAssistant) else {
             return false
         }
-        guard case .wpcom = credentialsProvider() else {
-            return false
-        }
+        guard let site else { return false }
         return site.isWordPressComStore || site.isAIAssistantFeatureActive
     }
 }

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
@@ -1,19 +1,18 @@
 import Experiments
 import Testing
 import Yosemite
-import enum NetworkingCore.Credentials
 @testable import WooCommerce
 
 @Suite(.timeLimit(.minutes(1)))
 struct AIAssistantEligibilityCheckerTests {
 
     @Test
-    func test_isEligible_when_flag_off_then_false() {
+    func test_isEligible_when_feature_flag_off_then_returns_false() {
         // Given
         let flagService = MockFeatureFlagService()
         flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = false
-        let sut = makeSUT(flagService: flagService, credentials: .wpcomFake)
-        let site = Site.fake().copy(isWordPressComStore: true)
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
+        let site = Site.fake().copy(isAIAssistantFeatureActive: true, isWordPressComStore: true)
 
         // When
         let result = sut.isEligible(for: site)
@@ -23,11 +22,11 @@ struct AIAssistantEligibilityCheckerTests {
     }
 
     @Test
-    func test_isEligible_when_site_nil_then_false() {
+    func test_isEligible_when_feature_flag_on_and_site_nil_then_returns_false() {
         // Given
         let flagService = MockFeatureFlagService()
         flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .wpcomFake)
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
 
         // When
         let result = sut.isEligible(for: nil)
@@ -37,11 +36,11 @@ struct AIAssistantEligibilityCheckerTests {
     }
 
     @Test
-    func test_isEligible_when_wpcom_site_then_true() {
+    func test_isEligible_when_feature_flag_on_and_site_is_wpcom_then_returns_true() {
         // Given
         let flagService = MockFeatureFlagService()
         flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .wpcomFake)
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
         let site = Site.fake().copy(isAIAssistantFeatureActive: false,
                                     isJetpackConnected: false,
                                     isWordPressComStore: true)
@@ -54,79 +53,11 @@ struct AIAssistantEligibilityCheckerTests {
     }
 
     @Test
-    func test_isEligible_when_jetpack_connected_only_with_wpcom_credentials_then_false() {
+    func test_isEligible_when_feature_flag_on_and_site_has_ai_feature_active_then_returns_true() {
         // Given
         let flagService = MockFeatureFlagService()
         flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .wpcomFake)
-        let site = Site.fake().copy(isAIAssistantFeatureActive: false,
-                                    isJetpackConnected: true,
-                                    isWordPressComStore: false)
-
-        // When
-        let result = sut.isEligible(for: site)
-
-        // Then
-        #expect(result == false)
-    }
-
-    @Test
-    func test_isEligible_when_wpcom_store_with_application_password_credentials_then_false() {
-        // Given
-        let flagService = MockFeatureFlagService()
-        flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .applicationPasswordFake)
-        let site = Site.fake().copy(isAIAssistantFeatureActive: false,
-                                    isJetpackConnected: true,
-                                    isWordPressComStore: true)
-
-        // When
-        let result = sut.isEligible(for: site)
-
-        // Then
-        #expect(result == false)
-    }
-
-    @Test
-    func test_isEligible_when_wpcom_store_with_wporg_credentials_then_false() {
-        // Given
-        let flagService = MockFeatureFlagService()
-        flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .wporgFake)
-        let site = Site.fake().copy(isAIAssistantFeatureActive: false,
-                                    isJetpackConnected: true,
-                                    isWordPressComStore: true)
-
-        // When
-        let result = sut.isEligible(for: site)
-
-        // Then
-        #expect(result == false)
-    }
-
-    @Test
-    func test_isEligible_when_wpcom_store_with_no_credentials_then_false() {
-        // Given
-        let flagService = MockFeatureFlagService()
-        flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: nil)
-        let site = Site.fake().copy(isAIAssistantFeatureActive: false,
-                                    isJetpackConnected: true,
-                                    isWordPressComStore: true)
-
-        // When
-        let result = sut.isEligible(for: site)
-
-        // Then
-        #expect(result == false)
-    }
-
-    @Test
-    func test_isEligible_when_isAIAssistantFeatureActive_then_true() {
-        // Given
-        let flagService = MockFeatureFlagService()
-        flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .wpcomFake)
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
         let site = Site.fake().copy(isAIAssistantFeatureActive: true,
                                     isJetpackConnected: false,
                                     isWordPressComStore: false)
@@ -139,13 +70,13 @@ struct AIAssistantEligibilityCheckerTests {
     }
 
     @Test
-    func test_isEligible_when_self_hosted_no_jetpack_then_false() {
+    func test_isEligible_when_feature_flag_on_and_site_is_jetpack_only_then_returns_false() {
         // Given
         let flagService = MockFeatureFlagService()
         flagService.isFeatureFlagEnabledReturnValue[.wooAIAssistant] = true
-        let sut = makeSUT(flagService: flagService, credentials: .wpcomFake)
+        let sut = AIAssistantEligibilityChecker(featureFlagService: flagService)
         let site = Site.fake().copy(isAIAssistantFeatureActive: false,
-                                    isJetpackConnected: false,
+                                    isJetpackConnected: true,
                                     isWordPressComStore: false)
 
         // When
@@ -154,22 +85,4 @@ struct AIAssistantEligibilityCheckerTests {
         // Then
         #expect(result == false)
     }
-}
-
-private func makeSUT(flagService: MockFeatureFlagService,
-                     credentials: Credentials?) -> AIAssistantEligibilityChecker {
-    AIAssistantEligibilityChecker(featureFlagService: flagService,
-                                  credentialsProvider: { credentials })
-}
-
-private extension Credentials {
-    static let wpcomFake: Credentials = .wpcom(username: "user",
-                                               authToken: "token",
-                                               siteAddress: "https://example.com")
-    static let wporgFake: Credentials = .wporg(username: "user",
-                                               password: "password",
-                                               siteAddress: "https://example.com")
-    static let applicationPasswordFake: Credentials = .applicationPassword(username: "user",
-                                                                           password: "password",
-                                                                           siteAddress: "https://example.com")
 }


### PR DESCRIPTION
## Why

The AI Assistant dashboard eligibility check on iOS carried an explicit credentials gate (`guard case .wpcom = credentialsProvider()`) that no other AI eligibility checker on iOS uses. The gate was redundant: app-password sessions go through `WordPressSite.asSite`, which hardcodes `isWordPressComStore = false` and `isAIAssistantFeatureActive = false`, so the underlying predicate already returned `false` for those merchants. Dropping the gate brings this checker in line with `ProductCreationAIEligibilityChecker`, `ProductFormAIEligibilityChecker`, and `ShareProductAIEligibilityChecker`, and produces the same eligibility decision Android does for any given site.

## Key non-obvious decisions

- The `credentialsProvider` init parameter and the `import enum NetworkingCore.Credentials` are dropped entirely. Nothing in the app passed `credentialsProvider:` explicitly; the default value was the only call path. Keeping the parameter purely as belt-and-suspenders would have made this checker the only AI eligibility predicate on iOS that reads credentials, which is the opposite of the project pattern.
- App-password merchants on AI-eligible stores still do not see the dashboard entry after this change. The hiding mechanism moves from "explicit credentials check" to "natural Site model placeholders," and the user-visible behavior is identical. Once site-local JWT routing lands on trunk, the eligibility predicate will need a follow-up to start surfacing the entry for app-password sessions.
- The five-case test matrix includes a regression guard for the long-removed `|| site.isJetpackConnected` branch (case 5: Jetpack-connected non-WPCom site without the AI plan returns `false`). That case is cheap to keep and prevents the broader gate from creeping back in.

## Cross-platform alignment with Android [#15855](https://github.com/woocommerce/woocommerce-android/pull/15855)

| Concern | iOS this PR | Android #15855 | Status |
|---|---|---|---|
| Eligibility predicate | `site.isWordPressComStore \|\| site.isAIAssistantFeatureActive` | `site.isWPComAtomic \|\| planActiveFeatures.contains(\"ai-assistant\")` | aligned |
| Feature flag gate | `wooAIAssistant` (Experiments) | `FeatureFlag.AI_ASSISTANT` (FeatureFlagRepository) | aligned |
| Auth-mode gating | Indirect, via Site model placeholders for app-password sessions | Indirect, via SiteModel population from WPCom-side metadata | aligned |
| Test matrix shape | Five-case matrix mirroring Android | `AIAssistantEligibilityCheckerTest.kt` source | aligned |

## Test Steps

1. Enable the `wooAIAssistant` feature flag locally.
2. Sign in via WordPress.com to a WooCommerce store hosted on WordPress.com (Business / eCommerce plan, or any store with the `ai-assistant` plan feature active). Open the My Store dashboard and confirm the AI Assistant entry is shown.
3. Sign out, then sign in to the same store via application password. Open the My Store dashboard and confirm the AI Assistant entry is not shown.
4. Run `WooCommerceTests/AIAssistantEligibilityCheckerTests` and confirm all five cases pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.