### PR TITLE
Add support chat resolution controls

### DIFF
--- a/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
+++ b/Modules/Sources/Networking/Model/SupportChat/SupportChatResponse.swift
@@ -80,11 +80,16 @@ public struct SupportChatMessageContext: Decodable, Equatable {
     public let sources: [SupportChatSource]
     public let flags: SupportChatFlags?
     public let supportArea: SupportChatSupportArea?
+    public let isResolved: Bool
 
-    public init(sources: [SupportChatSource], flags: SupportChatFlags?, supportArea: SupportChatSupportArea? = nil) {
+    public init(sources: [SupportChatSource],
+                flags: SupportChatFlags?,
+                supportArea: SupportChatSupportArea? = nil,
+                isResolved: Bool = false) {
         self.sources = sources
         self.flags = flags
         self.supportArea = supportArea
+        self.isResolved = isResolved
     }
 
     public init(from decoder: Decoder) throws {
@@ -92,12 +97,14 @@ public struct SupportChatMessageContext: Decodable, Equatable {
         self.sources = (try? container.decode([SupportChatSource].self, forKey: .sources)) ?? []
         self.flags = try? container.decode(SupportChatFlags.self, forKey: .flags)
         self.supportArea = try? container.decode(SupportChatSupportArea.self, forKey: .supportArea)
+        self.isResolved = (try? container.decode(Bool.self, forKey: .isResolved)) ?? false
     }
 
     enum CodingKeys: String, CodingKey {
         case sources
         case flags
         case supportArea = "support_area"
+        case isResolved = "is_resolved"
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -227,6 +227,23 @@ struct SupportChatRemoteTests {
         #expect(supportArea.isHighConfidence == true)
     }
 
+    @Test func sendMessage_when_response_has_is_resolved_then_value_is_decoded() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "odie/chat/\(botSlug)",
+                                 filename: "support-chat-with-support-area")
+
+        // When
+        let response = try await remote.sendMessage(botSlug: botSlug,
+                                                    message: "My card reader won't connect",
+                                                    chatID: nil,
+                                                    sessionID: nil,
+                                                    context: nil)
+
+        // Then
+        #expect(response.messages.first?.context?.isResolved == true)
+    }
+
     @Test func sendMessage_when_response_lacks_support_area_then_support_area_is_nil() async throws {
         // Given
         let remote = SupportChatRemote(network: network)
@@ -243,6 +260,7 @@ struct SupportChatRemoteTests {
         // Then
         let context = try #require(response.messages.first?.context)
         #expect(context.supportArea == nil)
+        #expect(context.isResolved == false)
     }
 
     // MARK: - Error paths

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-with-support-area.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/support-chat-with-support-area.json
@@ -20,7 +20,8 @@
                     "area": "card-reader",
                     "topic": "woo_mobile_issue_card_reader",
                     "confidence": "high"
-                }
+                },
+                "is_resolved": true
             }
         }
     ]

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -136,7 +136,7 @@ struct SupportChatView: View {
             VStack(alignment: .leading, spacing: 4) {
                 SupportChatMessageRow(role: message.role, text: text, failed: message.failed)
 
-                if message.role == .bot, message.isNewInSession, let messageID = message.messageID {
+                if message.shouldShowFeedbackButtons, let messageID = message.messageID {
                     SupportChatFeedbackRow(
                         messageID: messageID,
                         rating: viewModel.messageRatings[messageID],

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct SupportChatView: View {
     @Bindable var viewModel: SupportChatViewModel
     @FocusState private var isInputFocused: Bool
+    @State private var isResolutionConfirmationPresented = false
 
     var body: some View {
         chatView
@@ -12,8 +13,8 @@ struct SupportChatView: View {
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                if viewModel.canEscalateToHumanSupport {
-                    ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    if viewModel.canEscalateToHumanSupport {
                         Button {
                             viewModel.contactHumanSupport()
                         } label: {
@@ -21,8 +22,30 @@ struct SupportChatView: View {
                                 .accessibilityLabel(Localization.toolbarContactSupport)
                         }
                     }
+
+                    if viewModel.shouldShowResolvedButton {
+                        Button {
+                            isResolutionConfirmationPresented = true
+                        } label: {
+                            Image(systemName: "checkmark")
+                                .accessibilityLabel(Localization.toolbarMarkResolved)
+                        }
+                    }
                 }
             }
+            .alert(
+                Localization.markResolvedConfirmationTitle,
+                isPresented: $isResolutionConfirmationPresented,
+                actions: {
+                    Button(Localization.markResolvedConfirmationConfirm) {
+                        viewModel.markChatResolved()
+                    }
+                    Button(Localization.dismiss, role: .cancel) {}
+                },
+                message: {
+                    Text(Localization.markResolvedConfirmationMessage)
+                }
+            )
             .alert(
                 Localization.errorTitle,
                 isPresented: .init(
@@ -54,6 +77,8 @@ struct SupportChatView: View {
 
             if viewModel.hasCreatedTicket {
                 ticketCreatedBanner
+            } else if viewModel.isChatResolved {
+                chatResolvedBanner
             } else if viewModel.shouldPromptHumanSupport {
                 humanSupportBanner
             } else if viewModel.shouldShowInputArea {
@@ -299,6 +324,19 @@ struct SupportChatView: View {
         .background(Color(.listBackground))
     }
 
+    // MARK: - Chat Resolved Banner
+
+    private var chatResolvedBanner: some View {
+        VStack(spacing: SupportChatLayout.bannerSpacing) {
+            Text(Localization.chatResolvedMessage)
+                .font(.subheadline)
+                .foregroundColor(Color(.secondaryLabel))
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .background(Color(.listBackground))
+    }
+
     // MARK: - Input Area
 
     private var inputArea: some View {
@@ -386,6 +424,11 @@ private extension SupportChatView {
             value: "A support ticket has been created for this chat. We'll respond via email.",
             comment: "Message shown when a support ticket has already been created for this chat"
         )
+        static let chatResolvedMessage = NSLocalizedString(
+            "supportChatView.chatResolvedMessage",
+            value: "This chat has been marked as resolved.",
+            comment: "Message shown when the merchant has marked a support chat as resolved"
+        )
         static let contactSupport = NSLocalizedString(
             "supportChatView.contactSupport",
             value: "Contact Support",
@@ -395,6 +438,26 @@ private extension SupportChatView {
             "supportChatView.toolbar.contactSupport",
             value: "Contact Support",
             comment: "Trailing toolbar button on the AI support chat that lets the merchant escalate to human support"
+        )
+        static let toolbarMarkResolved = NSLocalizedString(
+            "supportChatView.toolbar.markResolved",
+            value: "Mark Resolved",
+            comment: "Trailing toolbar button on the AI support chat that lets the merchant mark the chat as resolved"
+        )
+        static let markResolvedConfirmationTitle = NSLocalizedString(
+            "supportChatView.markResolvedConfirmation.title",
+            value: "Mark chat as resolved?",
+            comment: "Title for the confirmation alert before marking a support chat as resolved"
+        )
+        static let markResolvedConfirmationMessage = NSLocalizedString(
+            "supportChatView.markResolvedConfirmation.message",
+            value: "This will close the chat actions for this conversation.",
+            comment: "Message for the confirmation alert before marking a support chat as resolved"
+        )
+        static let markResolvedConfirmationConfirm = NSLocalizedString(
+            "supportChatView.markResolvedConfirmation.confirm",
+            value: "Mark Resolved",
+            comment: "Confirmation button for marking a support chat as resolved"
         )
         static let issuePickerHeader = NSLocalizedString(
             "supportChatView.issuePickerHeader",

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -147,6 +147,9 @@ struct SupportChatView: View {
                 }
             }
 
+        case .resolvedPrompt:
+            SupportChatMessageRow(role: message.role, text: message.content.text ?? "", failed: false)
+
         case .issuePicker(let issues):
             issuePickerBubble(issues: issues)
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -95,6 +95,9 @@ final class SupportChatViewModel {
         /// `true` for messages received during the current session (not rehydrated from history).
         /// Feedback buttons are only shown for new messages.
         let isNewInSession: Bool
+        var shouldShowFeedbackButtons: Bool {
+            role == .bot && isNewInSession && isResolved == false && messageID != nil
+        }
 
         init(id: UUID = UUID(),
              role: SupportChatRole,
@@ -723,6 +726,10 @@ final class SupportChatViewModel {
                         isResolved: lastBotMessage.context?.isResolved ?? false
                     )
                     messages.append(assistantMessage)
+
+                    if assistantMessage.isResolved {
+                        appendResolvedPromptIfNeeded()
+                    }
                 }
             }
 
@@ -780,6 +787,11 @@ final class SupportChatViewModel {
                 }
             }
             messages = rehydrated
+
+            if latestBotResponse?.isResolved == true {
+                appendResolvedPromptIfNeeded()
+            }
+
             state = .idle
 
         case .failure(let error):
@@ -825,6 +837,19 @@ final class SupportChatViewModel {
         }
     }
 
+    private func appendResolvedPromptIfNeeded() {
+        guard isChatResolved == false else {
+            return
+        }
+
+        if case let .text(text) = messages.last?.content,
+           text == Localization.resolvedPromptMessage {
+            return
+        }
+
+        messages.append(ChatMessage(role: .bot, text: Localization.resolvedPromptMessage))
+    }
+
     // MARK: - Feedback
 
     /// Submits feedback for a bot message.
@@ -835,6 +860,10 @@ final class SupportChatViewModel {
         guard messageRatings[messageID] == nil else { return }
 
         messageRatings[messageID] = upvoted
+
+        if upvoted, latestBotResponse?.messageID == messageID {
+            appendResolvedPromptIfNeeded()
+        }
 
         analytics.track(event: WooAnalyticsEvent.SupportChat.feedbackSubmitted(upvoted: upvoted))
 
@@ -851,6 +880,10 @@ final class SupportChatViewModel {
         }
         stores.dispatch(action)
     }
+
+    private var latestBotResponse: ChatMessage? {
+        messages.last { $0.role == .bot && $0.messageID != nil }
+    }
 }
 
 // MARK: - Localization
@@ -866,6 +899,11 @@ private extension SupportChatViewModel {
             "supportChatViewModel.postDiagnosticsGreeting",
             value: "Please describe your issue in more detail so I can help.",
             comment: "Message prompting user to describe their issue after diagnostics"
+        )
+        static let resolvedPromptMessage = NSLocalizedString(
+            "supportChatViewModel.resolvedPromptMessage",
+            value: "Please mark the chat as resolved if your problem is resolved, or leave a message if you have other questions.",
+            comment: "Message shown by the bot when a support chat answer appears to have solved the merchant's issue"
         )
         static let errorMessage = NSLocalizedString(
             "supportChatViewModel.errorMessage",

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -59,6 +59,8 @@ final class SupportChatViewModel {
         case diagnosticsSuccess
         /// A test failed - show failure with optional action
         case diagnosticsFailure(SupportDiagnosticsService.Result)
+        /// Prompts the merchant to mark the chat resolved after a helpful answer.
+        case resolvedPrompt
 
         static func == (lhs: MessageContent, rhs: MessageContent) -> Bool {
             switch (lhs, rhs) {
@@ -73,8 +75,21 @@ final class SupportChatViewModel {
                 return true
             case (.diagnosticsFailure(let l), .diagnosticsFailure(let r)):
                 return l == r
+            case (.resolvedPrompt, .resolvedPrompt):
+                return true
             default:
                 return false
+            }
+        }
+
+        var text: String? {
+            switch self {
+            case .text(let text):
+                return text
+            case .resolvedPrompt:
+                return Localization.resolvedPromptMessage
+            default:
+                return nil
             }
         }
     }
@@ -688,6 +703,8 @@ final class SupportChatViewModel {
                 contentText = "[All diagnostics passed]"
             case .diagnosticsFailure(let result):
                 contentText = "[Diagnostics failed: \(result.test.title) - \(result.errorMessage ?? "Unknown error")]"
+            case .resolvedPrompt:
+                contentText = Localization.resolvedPromptMessage
             }
 
             return "[\(timestamp)] \(roleName): \(contentText)"
@@ -842,12 +859,11 @@ final class SupportChatViewModel {
             return
         }
 
-        if case let .text(text) = messages.last?.content,
-           text == Localization.resolvedPromptMessage {
+        if messages.contains(where: { $0.content == .resolvedPrompt }) {
             return
         }
 
-        messages.append(ChatMessage(role: .bot, text: Localization.resolvedPromptMessage))
+        messages.append(ChatMessage(role: .bot, content: .resolvedPrompt))
     }
 
     // MARK: - Feedback

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -172,6 +172,7 @@ final class SupportChatViewModel {
     /// by issue-picker selections — we want the human-support entry to surface only after the
     /// merchant has actually described their problem.
     private(set) var hasSentChatMessage: Bool = false
+    private(set) var isChatResolved: Bool = false
 
     /// Flips `hasCreatedTicket` so the chat surface (toolbar icon, inline banner) updates in real time
     /// after the escalation coordinator successfully creates a Zendesk ticket. Storage is updated separately
@@ -180,18 +181,22 @@ final class SupportChatViewModel {
         hasCreatedTicket = true
     }
 
+    func markChatResolved() {
+        isChatResolved = true
+    }
+
     /// Whether the trailing toolbar entry point to human support should be visible.
     /// Shown once the merchant has reached the free-chat phase (past the issue picker / diagnostics)
     /// AND has typed and sent at least one message, and only while no ticket has been created yet.
     var canEscalateToHumanSupport: Bool {
-        guard shouldShowInputArea, !hasCreatedTicket else {
+        guard shouldShowInputArea, !hasCreatedTicket, !isChatResolved else {
             return false
         }
         return hasSentChatMessage
     }
 
     var shouldShowResolvedButton: Bool {
-        guard shouldPromptHumanSupport == false else {
+        guard shouldPromptHumanSupport == false, isChatResolved == false else {
             return false
         }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -90,6 +90,8 @@ final class SupportChatViewModel {
         let failed: Bool
         /// Server-assigned message ID for bot messages (used for feedback submission).
         let messageID: Int64?
+        /// Whether the bot marked the issue as resolved for this message.
+        let isResolved: Bool
         /// `true` for messages received during the current session (not rehydrated from history).
         /// Feedback buttons are only shown for new messages.
         let isNewInSession: Bool
@@ -100,6 +102,7 @@ final class SupportChatViewModel {
              timestamp: Date = Date(),
              failed: Bool = false,
              messageID: Int64? = nil,
+             isResolved: Bool = false,
              isNewInSession: Bool = true) {
             self.id = id
             self.role = role
@@ -107,6 +110,7 @@ final class SupportChatViewModel {
             self.timestamp = timestamp
             self.failed = failed
             self.messageID = messageID
+            self.isResolved = isResolved
             self.isNewInSession = isNewInSession
         }
 
@@ -117,6 +121,7 @@ final class SupportChatViewModel {
              timestamp: Date = Date(),
              failed: Bool = false,
              messageID: Int64? = nil,
+             isResolved: Bool = false,
              isNewInSession: Bool = true) {
             self.id = id
             self.role = role
@@ -124,6 +129,7 @@ final class SupportChatViewModel {
             self.timestamp = timestamp
             self.failed = failed
             self.messageID = messageID
+            self.isResolved = isResolved
             self.isNewInSession = isNewInSession
         }
     }
@@ -182,6 +188,28 @@ final class SupportChatViewModel {
             return false
         }
         return hasSentChatMessage
+    }
+
+    var shouldShowResolvedButton: Bool {
+        guard shouldPromptHumanSupport == false else {
+            return false
+        }
+
+        let botResponses = messages.filter { $0.role == .bot && $0.messageID != nil }
+
+        guard let lastBotResponse = botResponses.last else {
+            return false
+        }
+
+        if lastBotResponse.isResolved {
+            return true
+        }
+
+        if let messageID = lastBotResponse.messageID, messageRatings[messageID] == true {
+            return true
+        }
+
+        return botResponses.count >= 2
     }
 
     /// Maps message IDs to their feedback rating (true = upvoted, false = downvoted).
@@ -686,7 +714,8 @@ final class SupportChatViewModel {
                     let assistantMessage = ChatMessage(
                         role: .bot,
                         text: lastBotMessage.content,
-                        messageID: lastBotMessage.messageID
+                        messageID: lastBotMessage.messageID,
+                        isResolved: lastBotMessage.context?.isResolved ?? false
                     )
                     messages.append(assistantMessage)
                 }
@@ -736,7 +765,11 @@ final class SupportChatViewModel {
                 case .user:
                     return ChatMessage(role: .user, text: message.content, isNewInSession: false)
                 case .bot:
-                    return ChatMessage(role: .bot, text: message.content, messageID: message.messageID, isNewInSession: false)
+                    return ChatMessage(role: .bot,
+                                       text: message.content,
+                                       messageID: message.messageID,
+                                       isResolved: message.context?.isResolved ?? false,
+                                       isNewInSession: false)
                 case .unknown:
                     return nil
                 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -869,7 +869,7 @@ struct SupportChatViewModelTests {
         #expect(sut.shouldShowResolvedButton == true)
     }
 
-    @Test func sendMessage_when_last_bot_message_is_resolved_then_appends_resolved_prompt() async {
+    @Test func sendMessage_when_last_bot_message_is_resolved_then_appends_resolved_prompt() async throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -901,13 +901,13 @@ struct SupportChatViewModelTests {
         sut.sendMessage()
 
         // Then
-        let prompt = try? #require(sut.messages.last)
-        #expect(prompt?.role == .bot)
-        #expect(prompt?.messageID == nil)
-        #expect(prompt?.textContent?.contains("mark the chat as resolved") == true)
+        let prompt = try #require(sut.messages.last)
+        #expect(prompt.role == .bot)
+        #expect(prompt.messageID == nil)
+        #expect(prompt.content == .resolvedPrompt)
     }
 
-    @Test func submitFeedback_when_upvoting_last_bot_message_then_appends_resolved_prompt() async {
+    @Test func submitFeedback_when_upvoting_last_bot_message_then_appends_resolved_prompt() async throws {
         // Given
         let messageID: Int64 = 2
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
@@ -939,10 +939,52 @@ struct SupportChatViewModelTests {
         sut.submitFeedback(messageID: messageID, upvoted: true)
 
         // Then
-        let prompt = try? #require(sut.messages.last)
-        #expect(prompt?.role == .bot)
-        #expect(prompt?.messageID == nil)
-        #expect(prompt?.textContent?.contains("mark the chat as resolved") == true)
+        let prompt = try #require(sut.messages.last)
+        #expect(prompt.role == .bot)
+        #expect(prompt.messageID == nil)
+        #expect(prompt.content == .resolvedPrompt)
+    }
+
+    @Test func submitFeedback_when_resolved_prompt_already_exists_then_does_not_append_duplicate_prompt() async {
+        // Given
+        let messageID: Int64 = 2
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, message, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                        SupportChatMessage(
+                            messageID: messageID,
+                            role: .bot,
+                            content: "Glad that helped.",
+                            context: SupportChatMessageContext(sources: [], flags: nil, isResolved: true)
+                        )
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+        sut.inputText = "That fixed it"
+        sut.sendMessage()
+        let promptCount = sut.messages.filter { $0.content == .resolvedPrompt }.count
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: true)
+
+        // Then
+        #expect(promptCount == 1)
+        #expect(sut.messages.filter { $0.content == .resolvedPrompt }.count == 1)
     }
 
     @Test func shouldShowResolvedButton_when_last_bot_message_is_downvoted_then_returns_false() async {
@@ -1503,14 +1545,5 @@ struct SupportChatViewModelTests {
             ]
         )
         completion(.success(response))
-    }
-}
-
-private extension SupportChatViewModel.ChatMessage {
-    var textContent: String? {
-        guard case let .text(text) = content else {
-            return nil
-        }
-        return text
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -869,6 +869,82 @@ struct SupportChatViewModelTests {
         #expect(sut.shouldShowResolvedButton == true)
     }
 
+    @Test func sendMessage_when_last_bot_message_is_resolved_then_appends_resolved_prompt() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            guard case let .sendMessage(_, message, _, _, _, completion) = action else {
+                return
+            }
+
+            let response = SupportChatResponse(
+                chatID: 123,
+                sessionID: "session-1",
+                botSlug: "test-bot",
+                botVersion: "1.0",
+                messages: [
+                    SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                    SupportChatMessage(
+                        messageID: 2,
+                        role: .bot,
+                        content: "Glad that helped.",
+                        context: SupportChatMessageContext(sources: [], flags: nil, isResolved: true)
+                    )
+                ]
+            )
+            completion(.success(response))
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+
+        // When
+        sut.inputText = "That fixed it"
+        sut.sendMessage()
+
+        // Then
+        let prompt = try? #require(sut.messages.last)
+        #expect(prompt?.role == .bot)
+        #expect(prompt?.messageID == nil)
+        #expect(prompt?.textContent?.contains("mark the chat as resolved") == true)
+    }
+
+    @Test func submitFeedback_when_upvoting_last_bot_message_then_appends_resolved_prompt() async {
+        // Given
+        let messageID: Int64 = 2
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, message, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Try this.", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+        sut.inputText = "Help"
+        sut.sendMessage()
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: true)
+
+        // Then
+        let prompt = try? #require(sut.messages.last)
+        #expect(prompt?.role == .bot)
+        #expect(prompt?.messageID == nil)
+        #expect(prompt?.textContent?.contains("mark the chat as resolved") == true)
+    }
+
     @Test func shouldShowResolvedButton_when_last_bot_message_is_downvoted_then_returns_false() async {
         // Given
         let messageID: Int64 = 2
@@ -1041,6 +1117,19 @@ struct SupportChatViewModelTests {
     }
 
     // MARK: - Feedback Tests
+
+    @Test func chatMessage_shouldShowFeedbackButtons_when_bot_message_is_resolved_then_returns_false() {
+        // Given
+        let message = SupportChatViewModel.ChatMessage(
+            role: .bot,
+            text: "This should solve the issue.",
+            messageID: 123,
+            isResolved: true
+        )
+
+        // Then
+        #expect(message.shouldShowFeedbackButtons == false)
+    }
 
     @Test func submitFeedback_when_valid_messageID_then_dispatches_action() async {
         // Given
@@ -1414,5 +1503,14 @@ struct SupportChatViewModelTests {
             ]
         )
         completion(.success(response))
+    }
+}
+
+private extension SupportChatViewModel.ChatMessage {
+    var textContent: String? {
+        guard case let .text(text) = content else {
+            return nil
+        }
+        return text
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -778,6 +778,24 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
+    @Test func canEscalateToHumanSupport_is_false_when_chat_is_resolved() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            completeSendMessageSuccessfully(action)
+        }
+        let sut = makeSUT(entryPoint: .preLogin, stores: stores)
+        sut.inputText = "Hello"
+        sut.sendMessage()
+        #expect(sut.canEscalateToHumanSupport == true)
+
+        // When
+        sut.markChatResolved()
+
+        // Then
+        #expect(sut.canEscalateToHumanSupport == false)
+    }
+
     // MARK: - Resolved Button Tests
 
     @Test func shouldShowResolvedButton_when_last_bot_message_is_resolved_then_returns_true() async {
@@ -981,6 +999,44 @@ struct SupportChatViewModelTests {
 
         // Then
         #expect(sut.shouldPromptHumanSupport == true)
+        #expect(sut.shouldShowResolvedButton == false)
+    }
+
+    @Test func markChatResolved_when_shouldShowResolvedButton_then_hides_resolved_button() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            guard case let .sendMessage(_, message, _, _, _, completion) = action else {
+                return
+            }
+
+            let response = SupportChatResponse(
+                chatID: 123,
+                sessionID: "session-1",
+                botSlug: "test-bot",
+                botVersion: "1.0",
+                messages: [
+                    SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                    SupportChatMessage(
+                        messageID: 2,
+                        role: .bot,
+                        content: "Glad that helped.",
+                        context: SupportChatMessageContext(sources: [], flags: nil, isResolved: true)
+                    )
+                ]
+            )
+            completion(.success(response))
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+        sut.inputText = "That fixed it"
+        sut.sendMessage()
+        #expect(sut.shouldShowResolvedButton == true)
+
+        // When
+        sut.markChatResolved()
+
+        // Then
+        #expect(sut.isChatResolved == true)
         #expect(sut.shouldShowResolvedButton == false)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -778,6 +778,212 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == false)
     }
 
+    // MARK: - Resolved Button Tests
+
+    @Test func shouldShowResolvedButton_when_last_bot_message_is_resolved_then_returns_true() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            guard case let .sendMessage(_, message, _, _, _, completion) = action else {
+                return
+            }
+
+            let response = SupportChatResponse(
+                chatID: 123,
+                sessionID: "session-1",
+                botSlug: "test-bot",
+                botVersion: "1.0",
+                messages: [
+                    SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                    SupportChatMessage(
+                        messageID: 2,
+                        role: .bot,
+                        content: "Glad that helped.",
+                        context: SupportChatMessageContext(sources: [], flags: nil, isResolved: true)
+                    )
+                ]
+            )
+            completion(.success(response))
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+
+        // When
+        sut.inputText = "That fixed it"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.shouldShowResolvedButton == true)
+    }
+
+    @Test func shouldShowResolvedButton_when_last_bot_message_is_upvoted_then_returns_true() async {
+        // Given
+        let messageID: Int64 = 2
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, message, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Try this.", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+        sut.inputText = "Help"
+        sut.sendMessage()
+        #expect(sut.shouldShowResolvedButton == false)
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: true)
+
+        // Then
+        #expect(sut.shouldShowResolvedButton == true)
+    }
+
+    @Test func shouldShowResolvedButton_when_last_bot_message_is_downvoted_then_returns_false() async {
+        // Given
+        let messageID: Int64 = 2
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, message, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: message, context: nil),
+                        SupportChatMessage(messageID: messageID, role: .bot, content: "Try this.", context: nil)
+                    ]
+                )
+                completion(.success(response))
+            case let .submitFeedback(_, _, _, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+        sut.inputText = "Help"
+        sut.sendMessage()
+
+        // When
+        sut.submitFeedback(messageID: messageID, upvoted: false)
+
+        // Then
+        #expect(sut.shouldShowResolvedButton == false)
+    }
+
+    @Test func shouldShowResolvedButton_when_two_bot_responses_excluding_greeting_and_issue_picker_then_returns_true() async {
+        // Given
+        var botMessageID: Int64 = 1
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            guard case let .sendMessage(_, message, _, _, _, completion) = action else {
+                return
+            }
+
+            botMessageID += 1
+            let response = SupportChatResponse(
+                chatID: 123,
+                sessionID: "session-1",
+                botSlug: "test-bot",
+                botVersion: "1.0",
+                messages: [
+                    SupportChatMessage(messageID: botMessageID - 1, role: .user, content: message, context: nil),
+                    SupportChatMessage(messageID: botMessageID, role: .bot, content: "Bot response", context: nil)
+                ]
+            )
+            completion(.success(response))
+        }
+        let sut = makeSUT(entryPoint: .helpAndSupport, stores: stores)
+        sut.showGreeting()
+        await sut.selectIssue(.other)
+
+        // When
+        sut.inputText = "First question"
+        sut.sendMessage()
+        #expect(sut.shouldShowResolvedButton == false)
+
+        sut.inputText = "Follow up"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.shouldShowResolvedButton == true)
+    }
+
+    @Test func shouldShowResolvedButton_when_shouldPromptHumanSupport_then_returns_false() async {
+        // Given
+        var sendCount = 0
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            guard case let .sendMessage(_, message, _, _, _, completion) = action else {
+                return
+            }
+
+            sendCount += 1
+            let response: SupportChatResponse
+            if sendCount <= 2 {
+                response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: Int64(sendCount * 2 - 1), role: .user, content: message, context: nil),
+                        SupportChatMessage(messageID: Int64(sendCount * 2), role: .bot, content: "Bot response", context: nil)
+                    ]
+                )
+            } else {
+                response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 5, role: .user, content: message, context: nil),
+                        SupportChatMessage(
+                            messageID: 6,
+                            role: .bot,
+                            content: "Contact support.",
+                            context: SupportChatMessageContext(
+                                sources: [],
+                                flags: SupportChatFlags(forwardToHumanSupport: true, cannedResponse: false, loggedIn: true, branch: nil)
+                            )
+                        )
+                    ]
+                )
+            }
+            completion(.success(response))
+        }
+        let sut = makeSUT(entryPoint: .connectivityTool, stores: stores)
+        sut.inputText = "First question"
+        sut.sendMessage()
+        sut.inputText = "Follow up"
+        sut.sendMessage()
+        #expect(sut.shouldShowResolvedButton == true)
+
+        // When
+        sut.inputText = "Still need help"
+        sut.sendMessage()
+
+        // Then
+        #expect(sut.shouldPromptHumanSupport == true)
+        #expect(sut.shouldShowResolvedButton == false)
+    }
+
     // MARK: - Feedback Tests
 
     @Test func submitFeedback_when_valid_messageID_then_dispatches_action() async {


### PR DESCRIPTION
Part of WOOMOB-3056

## Description
Adds support for `is_resolved` on support chat bot message context and uses it to surface chat resolution controls. The chat now shows a toolbar action to mark a conversation as resolved when the latest bot response indicates resolution, when the merchant upvotes the latest bot response, or after enough bot responses have occurred without a human-support prompt. Marking the chat as resolved is confirmed with an alert, hides escalation actions, and shows a resolved-state banner at the bottom of the chat.

This also adds a bot follow-up prompt asking the merchant to mark the chat resolved or continue with more questions, and keeps feedback buttons hidden for bot responses that are already marked resolved.

Persistence for resolution state will be handled in a subsequent PR.

## Test Steps
1. Open the support chat flow and send a message that indicate resolution to trigger a bot response with `is_resolved = true`. 
2. Verify the response does not show feedback buttons and the toolbar shows the Contact Support button followed by the checkmark resolve button when applicable.
3. Tap the resolve button, confirm the alert, and verify the chat shows the resolved message at the bottom and no longer offers human support escalation.
4. In a chat where the latest bot response is not marked resolved, upvote the latest bot response and verify the resolve prompt and toolbar resolve action appear.
5. Repeat the step but do not indicate resolution or upvote bot message. Confirm that the mark resolved button shows up after you send 2 responses.

## Screenshots


https://github.com/user-attachments/assets/5d80b143-1d0e-4b37-b0b6-ace1b7448e58



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.