### PR TITLE
Persist support chat resolved state

### DIFF
--- a/Modules/Sources/Networking/Remote/SupportChatRemote.swift
+++ b/Modules/Sources/Networking/Remote/SupportChatRemote.swift
@@ -23,9 +23,11 @@ public protocol SupportChatRemoteProtocol {
     /// - Parameters:
     ///   - botSlug: Assistant slug the chat was created against.
     ///   - chatID: Identifier returned by a previous `sendMessage` call.
+    ///   - sessionID: Optional session identifier required by unauthenticated chats.
     /// - Returns: The full thread in `ts`-ascending order.
     func fetchChat(botSlug: String,
-                   chatID: Int64) async throws -> SupportChatResponse
+                   chatID: Int64,
+                   sessionID: String?) async throws -> SupportChatResponse
 
     /// Submits feedback for a specific bot message.
     ///
@@ -76,11 +78,17 @@ public final class SupportChatRemote: Remote, SupportChatRemoteProtocol {
     }
 
     public func fetchChat(botSlug: String,
-                          chatID: Int64) async throws -> SupportChatResponse {
+                          chatID: Int64,
+                          sessionID: String?) async throws -> SupportChatResponse {
         let path = "\(Path.chat)/\(botSlug)/\(chatID)"
+        var parameters: [String: Any] = [:]
+        if let sessionID {
+            parameters[ParameterKey.sessionID] = sessionID
+        }
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .get,
-                                    path: path)
+                                    path: path,
+                                    parameters: parameters)
         let mapper = SupportChatResponseMapper()
         return try await enqueue(request, mapper: mapper)
     }

--- a/Modules/Sources/Storage/Model/MIGRATIONS.md
+++ b/Modules/Sources/Storage/Model/MIGRATIONS.md
@@ -3,6 +3,8 @@
 This file documents changes in the WCiOS Storage data model. Please explain any changes to the data model as well as any custom migrations.
 
 ## Model 138 (Release 24.8.0.0)
+- @itsmeichigo 2026-05-12
+  - Added `sessionID` and `isResolved` attributes to `StoredSupportChat` entity.
 - @itsmeichigo 2026-05-06
   - Added `hasCreatedTicket` attribute to `StoredSupportChat` entity.
 

--- a/Modules/Sources/Storage/Model/StoredSupportChat+CoreDataProperties.swift
+++ b/Modules/Sources/Storage/Model/StoredSupportChat+CoreDataProperties.swift
@@ -12,7 +12,9 @@ extension StoredSupportChat {
     @NSManaged public var siteID: Int64
     @NSManaged public var wpcomUserID: Int64
     @NSManaged public var botSlug: String?
+    @NSManaged public var sessionID: String?
     @NSManaged public var hasCreatedTicket: Bool
+    @NSManaged public var isResolved: Bool
     @NSManaged public var title: String?
     @NSManaged public var createdAt: Date?
     @NSManaged public var updatedAt: Date?

--- a/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 138.xcdatamodel/contents
+++ b/Modules/Sources/Storage/Resources/WooCommerce.xcdatamodeld/Model 138.xcdatamodel/contents
@@ -1025,6 +1025,8 @@
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="hasCreatedTicket" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isResolved" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="sessionID" optional="YES" attributeType="String"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="wpcomUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SupportChatAction.swift
@@ -24,9 +24,11 @@ public enum SupportChatAction: Action {
     /// - Parameters:
     ///   - botSlug: Assistant slug the chat was created against.
     ///   - chatID: Identifier returned by a previous `sendMessage`.
+    ///   - sessionID: Optional session identifier required by unauthenticated chats.
     ///   - completion: Called on the main thread with every turn (user + bot) in ascending order.
     case fetchChat(botSlug: String,
                    chatID: Int64,
+                   sessionID: String?,
                    completion: (Result<SupportChatResponse, Error>) -> Void)
 
     /// Persists a new chat bookmark so the merchant can revisit it later.
@@ -39,12 +41,14 @@ public enum SupportChatAction: Action {
     ///   - siteID: Primary scoping key. Must be non-zero for post-login chats.
     ///   - wpcomUserID: Secondary identifier. Pass `0` for non-WPCom-authenticated users.
     ///   - botSlug: Assistant slug backing the chat.
+    ///   - sessionID: Session identifier returned by the assistant.
     ///   - firstUserMessage: Used to derive the chat's title. Trimmed and clamped to 50 chars.
     ///   - onCompletion: Delivered on the main thread once the row is persisted.
     case registerChat(chatID: Int64,
                       siteID: Int64,
                       wpcomUserID: Int64,
                       botSlug: String,
+                      sessionID: String?,
                       firstUserMessage: String,
                       onCompletion: () -> Void)
 
@@ -54,8 +58,10 @@ public enum SupportChatAction: Action {
     ///
     /// - Parameters:
     ///   - chatID: Identifier of the chat to bump.
+    ///   - sessionID: Optional latest session identifier to persist for resumed unauthenticated fetches.
     ///   - onCompletion: Delivered on the main thread once the bump is persisted.
     case touchChat(chatID: Int64,
+                   sessionID: String?,
                    onCompletion: () -> Void)
 
     /// Loads all locally-persisted chat bookmarks for a site, sorted newest first.
@@ -83,6 +89,16 @@ public enum SupportChatAction: Action {
     ///   - onCompletion: Delivered on the main thread once the update is persisted.
     case markTicketCreated(chatID: Int64,
                            onCompletion: () -> Void)
+
+    /// Marks an existing chat as resolved.
+    ///
+    /// Called after the merchant confirms the support chat resolved their issue.
+    ///
+    /// - Parameters:
+    ///   - chatID: Identifier of the chat to update.
+    ///   - onCompletion: Delivered on the main thread once the update is persisted.
+    case markResolved(chatID: Int64,
+                      onCompletion: () -> Void)
 
     /// Submits feedback for a specific bot message.
     ///

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSupportChatActionHandler.swift
@@ -12,17 +12,19 @@ struct MockSupportChatActionHandler: MockActionHandler {
         switch action {
         case let .sendMessage(_, _, _, _, _, completion):
             completion(.success(Self.emptyResponse))
-        case let .fetchChat(_, _, completion):
+        case let .fetchChat(_, _, _, completion):
             completion(.success(Self.emptyResponse))
-        case let .registerChat(_, _, _, _, _, onCompletion):
+        case let .registerChat(_, _, _, _, _, _, onCompletion):
             onCompletion()
-        case let .touchChat(_, onCompletion):
+        case let .touchChat(_, _, onCompletion):
             onCompletion()
         case let .loadChatHistory(_, onCompletion):
             onCompletion([])
         case let .deleteChat(_, onCompletion):
             onCompletion()
         case let .markTicketCreated(_, onCompletion):
+            onCompletion()
+        case let .markResolved(_, onCompletion):
             onCompletion()
         case let .submitFeedback(_, _, _, _, _, onCompletion):
             onCompletion(.success(()))

--- a/Modules/Sources/Yosemite/Model/Storage/StoredSupportChat+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/StoredSupportChat+ReadOnlyConvertible.swift
@@ -13,7 +13,9 @@ extension Storage.StoredSupportChat: ReadOnlyConvertible {
         siteID = summary.siteID
         wpcomUserID = summary.wpcomUserID
         botSlug = summary.botSlug
+        sessionID = summary.sessionID
         hasCreatedTicket = summary.hasCreatedTicket
+        isResolved = summary.isResolved
         title = summary.title
         createdAt = summary.createdAt
         updatedAt = summary.updatedAt
@@ -26,7 +28,9 @@ extension Storage.StoredSupportChat: ReadOnlyConvertible {
                            siteID: siteID,
                            wpcomUserID: wpcomUserID,
                            botSlug: botSlug ?? "",
+                           sessionID: sessionID,
                            hasCreatedTicket: hasCreatedTicket,
+                           isResolved: isResolved,
                            title: title,
                            createdAt: createdAt ?? Date(),
                            updatedAt: updatedAt ?? Date())

--- a/Modules/Sources/Yosemite/Model/SupportChatSummary.swift
+++ b/Modules/Sources/Yosemite/Model/SupportChatSummary.swift
@@ -11,7 +11,9 @@ public struct SupportChatSummary: Equatable {
     public let siteID: Int64
     public let wpcomUserID: Int64
     public let botSlug: String
+    public let sessionID: String?
     public let hasCreatedTicket: Bool
+    public let isResolved: Bool
     public let title: String?
     public let createdAt: Date
     public let updatedAt: Date
@@ -20,7 +22,9 @@ public struct SupportChatSummary: Equatable {
                 siteID: Int64,
                 wpcomUserID: Int64,
                 botSlug: String,
+                sessionID: String? = nil,
                 hasCreatedTicket: Bool,
+                isResolved: Bool = false,
                 title: String?,
                 createdAt: Date,
                 updatedAt: Date) {
@@ -28,7 +32,9 @@ public struct SupportChatSummary: Equatable {
         self.siteID = siteID
         self.wpcomUserID = wpcomUserID
         self.botSlug = botSlug
+        self.sessionID = sessionID
         self.hasCreatedTicket = hasCreatedTicket
+        self.isResolved = isResolved
         self.title = title
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SupportChatStore.swift
@@ -35,23 +35,26 @@ public final class SupportChatStore: Store {
         switch action {
         case let .sendMessage(botSlug, message, chatID, sessionID, context, completion):
             sendMessage(botSlug: botSlug, message: message, chatID: chatID, sessionID: sessionID, context: context, completion: completion)
-        case let .fetchChat(botSlug, chatID, completion):
-            fetchChat(botSlug: botSlug, chatID: chatID, completion: completion)
-        case let .registerChat(chatID, siteID, wpcomUserID, botSlug, firstUserMessage, onCompletion):
+        case let .fetchChat(botSlug, chatID, sessionID, completion):
+            fetchChat(botSlug: botSlug, chatID: chatID, sessionID: sessionID, completion: completion)
+        case let .registerChat(chatID, siteID, wpcomUserID, botSlug, sessionID, firstUserMessage, onCompletion):
             registerChat(chatID: chatID,
                          siteID: siteID,
                          wpcomUserID: wpcomUserID,
                          botSlug: botSlug,
+                         sessionID: sessionID,
                          firstUserMessage: firstUserMessage,
                          onCompletion: onCompletion)
-        case let .touchChat(chatID, onCompletion):
-            touchChat(chatID: chatID, onCompletion: onCompletion)
+        case let .touchChat(chatID, sessionID, onCompletion):
+            touchChat(chatID: chatID, sessionID: sessionID, onCompletion: onCompletion)
         case let .loadChatHistory(siteID, onCompletion):
             loadChatHistory(siteID: siteID, onCompletion: onCompletion)
         case let .deleteChat(chatID, onCompletion):
             deleteChat(chatID: chatID, onCompletion: onCompletion)
         case let .markTicketCreated(chatID, onCompletion):
             markTicketCreated(chatID: chatID, onCompletion: onCompletion)
+        case let .markResolved(chatID, onCompletion):
+            markResolved(chatID: chatID, onCompletion: onCompletion)
         case let .submitFeedback(botSlug, chatID, messageID, sessionID, upvoted, onCompletion):
             submitFeedback(botSlug: botSlug, chatID: chatID, messageID: messageID, sessionID: sessionID, upvoted: upvoted, onCompletion: onCompletion)
         }
@@ -84,10 +87,11 @@ private extension SupportChatStore {
 
     func fetchChat(botSlug: String,
                    chatID: Int64,
+                   sessionID: String?,
                    completion: @escaping (Result<SupportChatResponse, Error>) -> Void) {
         Task {
             let result = await Result {
-                try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+                try await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: sessionID)
             }
 
             await MainActor.run {
@@ -131,6 +135,7 @@ private extension SupportChatStore {
                       siteID: Int64,
                       wpcomUserID: Int64,
                       botSlug: String,
+                      sessionID: String?,
                       firstUserMessage: String,
                       onCompletion: @escaping () -> Void) {
         let title = Self.deriveTitle(from: firstUserMessage)
@@ -146,6 +151,7 @@ private extension SupportChatStore {
             chat.siteID = siteID
             chat.wpcomUserID = wpcomUserID
             chat.botSlug = botSlug
+            chat.sessionID = sessionID
             chat.title = title
             chat.createdAt = now
             chat.updatedAt = now
@@ -154,12 +160,15 @@ private extension SupportChatStore {
         }, on: .main)
     }
 
-    func touchChat(chatID: Int64, onCompletion: @escaping () -> Void) {
+    func touchChat(chatID: Int64, sessionID: String?, onCompletion: @escaping () -> Void) {
         let now = Date()
         storageManager.performAndSave({ storage in
             guard let chat = storage.loadSupportChat(chatID: chatID) else {
                 // Idempotent — row may have been deleted between turns.
                 return
+            }
+            if let sessionID {
+                chat.sessionID = sessionID
             }
             chat.updatedAt = now
         }, completion: {
@@ -189,6 +198,17 @@ private extension SupportChatStore {
                 return
             }
             chat.hasCreatedTicket = true
+        }, completion: {
+            onCompletion()
+        }, on: .main)
+    }
+
+    func markResolved(chatID: Int64, onCompletion: @escaping () -> Void) {
+        storageManager.performAndSave({ storage in
+            guard let chat = storage.loadSupportChat(chatID: chatID) else {
+                return
+            }
+            chat.isResolved = true
         }, completion: {
             onCompletion()
         }, on: .main)

--- a/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SupportChatRemoteTests.swift
@@ -303,12 +303,26 @@ struct SupportChatRemoteTests {
         let chatID: Int64 = 4522824
 
         // When
-        _ = try? await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+        _ = try? await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: nil)
 
         // Then
         let request = try #require(network.requestsForResponseData.first as? DotcomRequest)
         #expect(request.path == "odie/chat/\(botSlug)/\(chatID)")
         #expect(request.method == .get)
+    }
+
+    @Test func fetchChat_when_sessionID_provided_then_sends_sessionID_in_request_parameters() async throws {
+        // Given
+        let remote = SupportChatRemote(network: network)
+        let chatID: Int64 = 4522824
+        let sessionID = "session-abc"
+
+        // When
+        _ = try? await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: sessionID)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters["session_id"] as? String == sessionID)
     }
 
     @Test func fetchChat_when_response_is_valid_then_returns_every_turn_in_order() async throws {
@@ -319,7 +333,7 @@ struct SupportChatRemoteTests {
                                  filename: "support-chat-fetch-chat")
 
         // When
-        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: nil)
 
         // Then
         #expect(response.chatID == chatID)
@@ -335,7 +349,7 @@ struct SupportChatRemoteTests {
                                  filename: "support-chat-fetch-chat")
 
         // When
-        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: nil)
 
         // Then
         let firstMessage = try #require(response.messages.first)
@@ -351,7 +365,7 @@ struct SupportChatRemoteTests {
                                  filename: "support-chat-fetch-chat")
 
         // When
-        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+        let response = try await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: nil)
 
         // Then — the failsafe decoder produces empty sources + nil flags rather than throwing.
         let userMessageContext = try #require(response.messages.first?.context)
@@ -365,7 +379,7 @@ struct SupportChatRemoteTests {
 
         // When / Then
         await #expect(throws: NetworkError.notFound()) {
-            try await remote.fetchChat(botSlug: botSlug, chatID: 4522824)
+            try await remote.fetchChat(botSlug: botSlug, chatID: 4522824, sessionID: nil)
         }
     }
 
@@ -378,7 +392,7 @@ struct SupportChatRemoteTests {
 
         // When / Then
         await #expect(throws: NetworkError.timeout()) {
-            try await remote.fetchChat(botSlug: botSlug, chatID: chatID)
+            try await remote.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: nil)
         }
     }
 

--- a/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
+++ b/Modules/Tests/StorageTests/CoreData/MigrationTests.swift
@@ -2711,7 +2711,7 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(migratedTotals.value(forKey: "grossSales") as? NSDecimalNumber, NSDecimalNumber(value: 750))
     }
 
-    func test_migrating_from_137_to_138_adds_hasCreatedTicket_attribute_to_StoredSupportChat() throws {
+    func test_migrating_from_137_to_138_adds_new_attributes_to_StoredSupportChat() throws {
         // Given
         let sourceContainer = try startPersistentContainer("Model 137")
         let sourceContext = sourceContainer.viewContext
@@ -2728,6 +2728,8 @@ final class MigrationTests: XCTestCase {
         try sourceContext.save()
 
         XCTAssertNil(chat.entity.attributesByName["hasCreatedTicket"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(chat.entity.attributesByName["sessionID"], "Precondition. Attribute does not exist.")
+        XCTAssertNil(chat.entity.attributesByName["isResolved"], "Precondition. Attribute does not exist.")
 
         // When
         let targetContainer = try migrate(sourceContainer, to: "Model 138")
@@ -2737,15 +2739,23 @@ final class MigrationTests: XCTestCase {
         let migratedChat = try XCTUnwrap(targetContext.first(entityName: "StoredSupportChat"))
 
         XCTAssertNotNil(migratedChat.entity.attributesByName["hasCreatedTicket"])
+        XCTAssertNotNil(migratedChat.entity.attributesByName["sessionID"])
+        XCTAssertNotNil(migratedChat.entity.attributesByName["isResolved"])
 
-        // Default value should be false.
+        // Default values.
         XCTAssertEqual(migratedChat.value(forKey: "hasCreatedTicket") as? Bool, false)
+        XCTAssertNil(migratedChat.value(forKey: "sessionID"))
+        XCTAssertEqual(migratedChat.value(forKey: "isResolved") as? Bool, false)
 
-        // Verify a value can be set and saved.
+        // Verify values can be set and saved.
         migratedChat.setValue(true, forKey: "hasCreatedTicket")
+        migratedChat.setValue("session-abc", forKey: "sessionID")
+        migratedChat.setValue(true, forKey: "isResolved")
         try targetContext.save()
 
         XCTAssertEqual(migratedChat.value(forKey: "hasCreatedTicket") as? Bool, true)
+        XCTAssertEqual(migratedChat.value(forKey: "sessionID") as? String, "session-abc")
+        XCTAssertEqual(migratedChat.value(forKey: "isResolved") as? Bool, true)
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSupportChatRemote.swift
@@ -9,7 +9,7 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
     private var submitFeedbackResult: Result<Void, Error> = .success(())
 
     private(set) var sendMessageInvocations: [(botSlug: String, message: String, chatID: Int64?)] = []
-    private(set) var fetchChatInvocations: [(botSlug: String, chatID: Int64)] = []
+    private(set) var fetchChatInvocations: [(botSlug: String, chatID: Int64, sessionID: String?)] = []
     private(set) var submitFeedbackInvocations: [(botSlug: String, chatID: Int64, messageID: Int64, sessionID: String, upvoted: Bool)] = []
 
     func whenSendingMessage(thenReturn result: Result<SupportChatResponse, Error>) {
@@ -36,8 +36,8 @@ final class MockSupportChatRemote: SupportChatRemoteProtocol {
         return try result.get()
     }
 
-    func fetchChat(botSlug: String, chatID: Int64) async throws -> SupportChatResponse {
-        fetchChatInvocations.append((botSlug, chatID))
+    func fetchChat(botSlug: String, chatID: Int64, sessionID: String?) async throws -> SupportChatResponse {
+        fetchChatInvocations.append((botSlug, chatID, sessionID))
         guard let result = fetchChatResult else {
             throw NetworkError.timeout()
         }

--- a/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SupportChatStoreTests.swift
@@ -39,6 +39,7 @@ struct SupportChatStoreTests {
         // Given
         let store = makeStore()
         let chatID: Int64 = 4242
+        let sessionID = "session-abc"
 
         // When
         await withCheckedContinuation { continuation in
@@ -46,6 +47,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: sessionID,
                                                           firstUserMessage: "How do I configure shipping?",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -57,6 +59,8 @@ struct SupportChatStoreTests {
         #expect(stored.siteID == sampleSiteID)
         #expect(stored.wpcomUserID == sampleWPComUserID)
         #expect(stored.botSlug == sampleBotSlug)
+        #expect(stored.sessionID == sessionID)
+        #expect(stored.isResolved == false)
         #expect(stored.title == "How do I configure shipping?")
         #expect(stored.createdAt != nil)
         #expect(stored.updatedAt != nil)
@@ -71,6 +75,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "first",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -82,6 +87,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "second",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -103,6 +109,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: longMessage,
                                                           onCompletion: { continuation.resume() }))
         }
@@ -125,6 +132,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "hi",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -135,7 +143,7 @@ struct SupportChatStoreTests {
 
         // When
         await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.touchChat(chatID: chatID, onCompletion: { continuation.resume() }))
+            store.onAction(SupportChatAction.touchChat(chatID: chatID, sessionID: nil, onCompletion: { continuation.resume() }))
         }
 
         // Then
@@ -149,11 +157,35 @@ struct SupportChatStoreTests {
 
         // When — touch a chatID that was never registered.
         await withCheckedContinuation { continuation in
-            store.onAction(SupportChatAction.touchChat(chatID: 9999, onCompletion: { continuation.resume() }))
+            store.onAction(SupportChatAction.touchChat(chatID: 9999, sessionID: nil, onCompletion: { continuation.resume() }))
         }
 
         // Then — idempotent: no row created.
         #expect(storedChatCount == 0)
+    }
+
+    @Test func touchChat_when_sessionID_provided_then_updates_sessionID() async throws {
+        // Given
+        let store = makeStore()
+        let chatID: Int64 = 4242
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          sessionID: nil,
+                                                          firstUserMessage: "hi",
+                                                          onCompletion: { continuation.resume() }))
+        }
+
+        // When
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.touchChat(chatID: chatID, sessionID: "session-new", onCompletion: { continuation.resume() }))
+        }
+
+        // Then
+        let stored = try #require(viewStorage.loadSupportChat(chatID: chatID))
+        #expect(stored.sessionID == "session-new")
     }
 
     // MARK: - loadChatHistory
@@ -167,6 +199,7 @@ struct SupportChatStoreTests {
                                                               siteID: sampleSiteID,
                                                               wpcomUserID: sampleWPComUserID,
                                                               botSlug: sampleBotSlug,
+                                                              sessionID: nil,
                                                               firstUserMessage: "chat \(chatID)",
                                                               onCompletion: { continuation.resume() }))
             }
@@ -193,6 +226,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "ours",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -201,6 +235,7 @@ struct SupportChatStoreTests {
                                                           siteID: otherSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "theirs",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -242,6 +277,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "hi",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -280,6 +316,7 @@ struct SupportChatStoreTests {
                                                           siteID: sampleSiteID,
                                                           wpcomUserID: sampleWPComUserID,
                                                           botSlug: sampleBotSlug,
+                                                          sessionID: nil,
                                                           firstUserMessage: "hi",
                                                           onCompletion: { continuation.resume() }))
         }
@@ -310,17 +347,61 @@ struct SupportChatStoreTests {
         #expect(storedChatCount == 0)
     }
 
-    // MARK: - fetchChat
+    // MARK: - markResolved
 
-    @Test func fetchChat_forwards_to_remote_with_botSlug_and_chatID() async throws {
+    @Test func markResolved_sets_isResolved_on_existing_row() async throws {
         // Given
         let store = makeStore()
+        let chatID: Int64 = 4242
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.registerChat(chatID: chatID,
+                                                          siteID: sampleSiteID,
+                                                          wpcomUserID: sampleWPComUserID,
+                                                          botSlug: sampleBotSlug,
+                                                          sessionID: nil,
+                                                          firstUserMessage: "hi",
+                                                          onCompletion: { continuation.resume() }))
+        }
+        #expect(viewStorage.loadSupportChat(chatID: chatID)?.isResolved == false)
+
+        // When
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.markResolved(chatID: chatID,
+                                                          onCompletion: { continuation.resume() }))
+        }
+
+        // Then
+        let stored = try #require(viewStorage.loadSupportChat(chatID: chatID))
+        #expect(stored.isResolved == true)
+    }
+
+    @Test func markResolved_when_row_does_not_exist_then_completes_without_error() async {
+        // Given
+        let store = makeStore()
+
+        // When
+        await withCheckedContinuation { continuation in
+            store.onAction(SupportChatAction.markResolved(chatID: 9999,
+                                                          onCompletion: { continuation.resume() }))
+        }
+
+        // Then
+        #expect(storedChatCount == 0)
+    }
+
+    // MARK: - fetchChat
+
+    @Test func fetchChat_forwards_to_remote_with_botSlug_chatID_and_sessionID() async throws {
+        // Given
+        let store = makeStore()
+        let sessionID = "session-abc"
         remote.whenFetchingChat(thenReturn: .success(.fake()))
 
         // When
         _ = await withCheckedContinuation { continuation in
             store.onAction(SupportChatAction.fetchChat(botSlug: sampleBotSlug,
                                                        chatID: 4242,
+                                                       sessionID: sessionID,
                                                        completion: { result in
                 continuation.resume(returning: result)
             }))
@@ -331,6 +412,7 @@ struct SupportChatStoreTests {
         let invocation = try #require(remote.fetchChatInvocations.first)
         #expect(invocation.botSlug == sampleBotSlug)
         #expect(invocation.chatID == 4242)
+        #expect(invocation.sessionID == sessionID)
     }
 
     @Test func fetchChat_propagates_remote_errors() async {
@@ -342,6 +424,7 @@ struct SupportChatStoreTests {
         let result = await withCheckedContinuation { continuation in
             store.onAction(SupportChatAction.fetchChat(botSlug: sampleBotSlug,
                                                        chatID: 4242,
+                                                       sessionID: nil,
                                                        completion: { result in
                 continuation.resume(returning: result)
             }))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -528,7 +528,9 @@ private extension HelpAndSupportViewController {
             botSlug: summary.botSlug,
             entryPoint: .chatHistory,
             chatID: summary.chatID,
+            sessionID: summary.sessionID,
             hasCreatedTicket: summary.hasCreatedTicket,
+            isChatResolved: summary.isResolved,
             onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo in
                 self?.handleContactHumanSupport(chatID: chatID,
                                                 transcript: transcript,

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -186,6 +186,12 @@ final class SupportChatViewModel {
 
     func markChatResolved() {
         isChatResolved = true
+
+        guard let chatID else {
+            return
+        }
+        let action = SupportChatAction.markResolved(chatID: chatID, onCompletion: {})
+        stores.dispatch(action)
     }
 
     /// Whether the trailing toolbar entry point to human support should be visible.
@@ -253,7 +259,9 @@ final class SupportChatViewModel {
          initialContext: [String: Any]? = nil,
          diagnosticsService: SupportDiagnosticsService? = nil,
          chatID: Int64? = nil,
+         sessionID: String? = nil,
          hasCreatedTicket: Bool = false,
+         isChatResolved: Bool = false,
          systemStatusReport: String? = nil,
          onContactHumanSupport: @escaping (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?) -> Void,
          onStartJetpackSetup: @escaping () -> Void = {}) {
@@ -264,8 +272,10 @@ final class SupportChatViewModel {
         self.initialContext = initialContext
         self.diagnosticsService = diagnosticsService ?? SupportDiagnosticsService()
         self.chatID = chatID
+        self.sessionID = sessionID
         self.isResumedChat = chatID != nil
         self.hasCreatedTicket = hasCreatedTicket
+        self.isChatResolved = isChatResolved
         self.prefetchedSystemStatusReport = systemStatusReport
         self.onContactHumanSupport = onContactHumanSupport
         self.onStartJetpackSetup = onStartJetpackSetup
@@ -596,7 +606,7 @@ final class SupportChatViewModel {
         guard messages.isEmpty else { return }
         state = .sending
 
-        let action = SupportChatAction.fetchChat(botSlug: botSlug, chatID: chatID) { [weak self] result in
+        let action = SupportChatAction.fetchChat(botSlug: botSlug, chatID: chatID, sessionID: sessionID) { [weak self] result in
             self?.handleFetchChatResult(result)
         }
         stores.dispatch(action)
@@ -827,11 +837,13 @@ final class SupportChatViewModel {
                                                        siteID: siteID,
                                                        wpcomUserID: wpcomUserID,
                                                        botSlug: botSlug,
+                                                       sessionID: response.sessionID,
                                                        firstUserMessage: firstUserMessage,
                                                        onCompletion: {})
             stores.dispatch(action)
         } else {
             let action = SupportChatAction.touchChat(chatID: response.chatID,
+                                                    sessionID: response.sessionID,
                                                     onCompletion: {})
             stores.dispatch(action)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -362,7 +362,7 @@ struct SupportChatViewModelTests {
         await confirmation { fetchCompleted in
             stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
                 switch action {
-                case let .fetchChat(_, _, completion):
+                case let .fetchChat(_, _, _, completion):
                     let flaggedMessage = SupportChatMessage(
                         messageID: 2,
                         role: .bot,
@@ -420,7 +420,7 @@ struct SupportChatViewModelTests {
         await confirmation { fetchCompleted in
             stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
                 switch action {
-                case let .fetchChat(_, _, completion):
+                case let .fetchChat(_, _, _, completion):
                     let flaggedMessage = SupportChatMessage(
                         messageID: 2,
                         role: .bot,
@@ -476,7 +476,7 @@ struct SupportChatViewModelTests {
         await confirmation { fetchCompleted in
             stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
                 switch action {
-                case let .fetchChat(_, _, completion):
+                case let .fetchChat(_, _, _, completion):
                     let response = SupportChatResponse(
                         chatID: chatID,
                         sessionID: "session-1",
@@ -1442,7 +1442,7 @@ struct SupportChatViewModelTests {
         await confirmation { fetchCompleted in
             stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
                 switch action {
-                case let .fetchChat(_, _, completion):
+                case let .fetchChat(_, _, _, completion):
                     let response = SupportChatResponse(
                         chatID: chatID,
                         sessionID: "session-1",
@@ -1466,6 +1466,74 @@ struct SupportChatViewModelTests {
 
         // Then
         #expect(sut.messages.allSatisfy { $0.isNewInSession == false })
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func resumeIfNeeded_when_sessionID_is_available_then_passes_sessionID_to_fetchChat() async {
+        // Given
+        let chatID: Int64 = 123
+        let sessionID = "session-abc"
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .chatHistory,
+            stores: stores,
+            chatID: chatID,
+            sessionID: sessionID,
+            onContactHumanSupport: { _, _, _ in }
+        )
+        var receivedSessionID: String?
+
+        await confirmation { fetchCompleted in
+            stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+                switch action {
+                case let .fetchChat(_, _, sessionID, completion):
+                    receivedSessionID = sessionID
+                    completion(.success(SupportChatResponse(
+                        chatID: chatID,
+                        sessionID: "session-new",
+                        botSlug: "test-bot",
+                        botVersion: "1.0",
+                        messages: []
+                    )))
+                    fetchCompleted()
+                default:
+                    break
+                }
+            }
+
+            // When
+            sut.resumeIfNeeded()
+        }
+
+        // Then
+        #expect(receivedSessionID == sessionID)
+    }
+
+    @Test func markChatResolved_when_chatID_exists_then_dispatches_markResolved_action() {
+        // Given
+        let chatID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .chatHistory,
+            stores: stores,
+            chatID: chatID,
+            onContactHumanSupport: { _, _, _ in }
+        )
+        var receivedChatID: Int64?
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            guard case let .markResolved(chatID, onCompletion) = action else {
+                return
+            }
+            receivedChatID = chatID
+            onCompletion()
+        }
+
+        // When
+        sut.markChatResolved()
+
+        // Then
+        #expect(sut.isChatResolved == true)
+        #expect(receivedChatID == chatID)
     }
 
     // MARK: - Test Helpers


### PR DESCRIPTION
Closes WOOMOB-3056
Also closes WOOMOB-3061

## Description
Persists support chat resolved state and session ID in chat history. Resumed chats now restore the resolved state, and fetch chat requests include the persisted session ID so unauthenticated chats can be fetched again.

This adds `sessionID` and `isResolved` to the stored support chat summary, updates the Yosemite support chat actions/store, passes the stored state into `SupportChatViewModel`, and sends the optional session ID through the networking fetch path.

## Test Steps
1. Log in to the app using site credentials.
2. Start a support chat, receive a successful response, and verify the chat appears in history.
3. Mark the chat as resolved, reopen it from chat history, and verify it remains in the resolved state.
4. Resume a chat from history and verify the fetch request includes the stored `session_id`.

## Screenshots


https://github.com/user-attachments/assets/f128acd1-8bec-4088-af15-c80a985e42f2



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.