### PR TITLE
Add terminal payment preparation foundation

### DIFF
--- a/Modules/Sources/Fakes/Hardware.generated.swift
+++ b/Modules/Sources/Fakes/Hardware.generated.swift
@@ -81,7 +81,8 @@ extension Hardware.PaymentIntent {
             amount: .fake(),
             currency: .fake(),
             metadata: .fake(),
-            charges: .fake()
+            charges: .fake(),
+            collectedPaymentMethod: nil
         )
     }
 }

--- a/Modules/Sources/Hardware/CardReader/CardPresentTransactionDetails.swift
+++ b/Modules/Sources/Hardware/CardReader/CardPresentTransactionDetails.swift
@@ -19,6 +19,9 @@ public struct CardPresentTransactionDetails: Codable, Equatable, GeneratedFakeab
     /// The issuing brand of the card.
     public let brand: CardBrand
 
+    /// Card networks available to process the payment, when the reader provides them after collection.
+    public let availableNetworks: [CardBrand]?
+
     /// ID of a card PaymentMethod that may be attached to a Customer for future transactions.
     /// Only present if it was possible to generate a card PaymentMethod.
     public let generatedCard: String?
@@ -42,6 +45,7 @@ public struct CardPresentTransactionDetails: Codable, Equatable, GeneratedFakeab
                 expYear: Int,
                 cardholderName: String?,
                 brand: CardBrand,
+                availableNetworks: [CardBrand]? = nil,
                 generatedCard: String?,
                 receipt: ReceiptDetails?,
                 emvAuthData: String?,
@@ -52,6 +56,7 @@ public struct CardPresentTransactionDetails: Codable, Equatable, GeneratedFakeab
         self.expYear = expYear
         self.cardholderName = cardholderName
         self.brand = brand
+        self.availableNetworks = availableNetworks
         self.generatedCard = generatedCard
         self.receipt = receipt
         self.emvAuthData = emvAuthData
@@ -74,6 +79,7 @@ extension CardPresentTransactionDetails {
         case expYear = "exp_year"
         case cardholderName = "cardholder_name"
         case brand = "brand"
+        case availableNetworks = "available_networks"
         case generatedCard = "generated_card"
         case receipt = "receipt"
         case emvAuthData = "emv_auth_data"

--- a/Modules/Sources/Hardware/CardReader/CardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/CardReaderService.swift
@@ -53,23 +53,15 @@ public protocol CardReaderService {
     /// We need to call this method when switching accounts or stores
     func clear()
 
-    /// Captures a payment after collecting a payment method succeeds.
-    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
-    func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error>
-
-    /// Captures a payment, running a hook after payment method collection succeeds and before payment confirmation.
+    /// Captures a payment after collecting a payment method, running any required work before payment confirmation.
     /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     func capturePayment(_ parameters: PaymentIntentParameters,
                         beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error>
 
-    /// Retries the most recent payment intent attempted.
+    /// Retries the most recent payment intent attempted, running any required work before payment confirmation.
     /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     /// This action continues at the appropriate place in the `capturePayment` flow, but parameters cannot be changed.
     /// If the payment cannot be retried, an appropriate error will immediately return.
-    func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error>
-
-    /// Retries the most recent payment intent attempted, running a hook before payment confirmation.
-    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error>
 
     /// Cancels a PaymentIntent
@@ -90,15 +82,4 @@ public protocol CardReaderService {
     /// Use this when the user wants to manually connect a different reader
     /// or cancel the automatic reconnection process.
     func cancelReconnection() -> Future<Void, Error>
-}
-
-public extension CardReaderService {
-    func capturePayment(_ parameters: PaymentIntentParameters,
-                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
-        capturePayment(parameters)
-    }
-
-    func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
-        retryActivePaymentIntent()
-    }
 }

--- a/Modules/Sources/Hardware/CardReader/CardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/CardReaderService.swift
@@ -57,11 +57,20 @@ public protocol CardReaderService {
     /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error>
 
+    /// Captures a payment, running a hook after payment method collection succeeds and before payment confirmation.
+    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
+    func capturePayment(_ parameters: PaymentIntentParameters,
+                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error>
+
     /// Retries the most recent payment intent attempted.
     /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
     /// This action continues at the appropriate place in the `capturePayment` flow, but parameters cannot be changed.
     /// If the payment cannot be retried, an appropriate error will immediately return.
     func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error>
+
+    /// Retries the most recent payment intent attempted, running a hook before payment confirmation.
+    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
+    func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error>
 
     /// Cancels a PaymentIntent
     func cancelPaymentIntent() -> Future<Void, Error>
@@ -81,4 +90,15 @@ public protocol CardReaderService {
     /// Use this when the user wants to manually connect a different reader
     /// or cancel the automatic reconnection process.
     func cancelReconnection() -> Future<Void, Error>
+}
+
+public extension CardReaderService {
+    func capturePayment(_ parameters: PaymentIntentParameters,
+                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
+        capturePayment(parameters)
+    }
+
+    func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
+        retryActivePaymentIntent()
+    }
 }

--- a/Modules/Sources/Hardware/CardReader/PaymentIntent.swift
+++ b/Modules/Sources/Hardware/CardReader/PaymentIntent.swift
@@ -27,13 +27,17 @@ public struct PaymentIntent: Identifiable, GeneratedCopiable, GeneratedFakeable 
     // Charges that were created by this PaymentIntent, if any.
     public let charges: [Charge]
 
+    /// Payment method collected for this PaymentIntent before confirmation, if available.
+    public let collectedPaymentMethod: PaymentMethod?
+
     public init(id: String,
                 status: PaymentIntentStatus,
                 created: Date,
                 amount: UInt,
                 currency: String,
                 metadata: [String: String]?,
-                charges: [Charge]) {
+                charges: [Charge],
+                collectedPaymentMethod: PaymentMethod? = nil) {
         self.id = id
         self.status = status
         self.created = created
@@ -41,6 +45,7 @@ public struct PaymentIntent: Identifiable, GeneratedCopiable, GeneratedFakeable 
         self.currency = currency
         self.metadata = metadata
         self.charges = charges
+        self.collectedPaymentMethod = collectedPaymentMethod
     }
 }
 
@@ -133,11 +138,9 @@ public extension PaymentIntent {
 }
 
 public extension PaymentIntent {
-    /// Returns the payment method from a PaymentIntent if available, typically after the payment is processed.
-    /// Before the payment is processed, `nil` is returned.
-    /// - Returns: an optional payment method that is set after the payment is processed.
+    /// Returns the payment method from a PaymentIntent if available, preferring the collected payment method before charges exist.
     func paymentMethod() -> PaymentMethod? {
-        charges.first?.paymentMethod
+        collectedPaymentMethod ?? charges.first?.paymentMethod
     }
 }
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/CardPresentDetails+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/CardPresentDetails+Stripe.swift
@@ -11,6 +11,9 @@ extension CardPresentTransactionDetails {
                   expYear: details.expYear,
                   cardholderName: details.cardholderName,
                   brand: CardBrand(brand: details.brand),
+                  availableNetworks: details.networks?.available?.compactMap {
+                      StripeTerminal.CardBrand(rawValue: $0.intValue).map(CardBrand.init(brand:))
+                  },
                   generatedCard: details.generatedCard,
                   receipt: Hardware.ReceiptDetails(receiptDetails: details.receipt),
                   emvAuthData: details.emvAuthData,
@@ -35,6 +38,7 @@ protocol StripeCardPresentDetails {
     var receipt: StripeTerminal.ReceiptDetails? { get }
     var emvAuthData: String? { get }
     var wallet: StripeTerminal.SCPWallet? { get }
+    var networks: StripeTerminal.SCPNetworks? { get }
     var network: NSNumber? { get }
 }
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
@@ -75,9 +75,10 @@ public struct NoOpCardReaderService: CardReaderService {
         // no-op
     }
 
-    /// Captures a payment after collecting a payment method succeeds.
-    /// The returned publisher will behave as a Future, eventually producing a single value and finishing, or failing.
-    public func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
+    public func capturePayment(
+        _ parameters: PaymentIntentParameters,
+        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
+    ) -> AnyPublisher<PaymentIntent, Error> {
         return Future() { promise in
             promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()
@@ -102,7 +103,9 @@ public struct NoOpCardReaderService: CardReaderService {
         }.eraseToAnyPublisher()
     }
 
-    public func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error> {
+    public func retryActivePaymentIntent(
+        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
+    ) -> AnyPublisher<PaymentIntent, Error> {
         return Future() { promise in
             promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntent+Stripe.swift
@@ -19,6 +19,7 @@ extension PaymentIntent {
         self.currency = intent.currency
         self.metadata = intent.metadata
         self.charges = intent.charges.map { .init(charge: $0) }
+        self.collectedPaymentMethod = PaymentMethod(method: intent.paymentMethod)
     }
 }
 
@@ -35,6 +36,7 @@ protocol StripePaymentIntent {
     var currency: String { get }
     var metadata: [String: String]? { get }
     var charges: [StripeTerminal.Charge] { get }
+    var paymentMethod: StripeTerminal.PaymentMethod? { get }
 }
 
 /// StripePaymentIntent Conformance

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentMethod+Stripe.swift
@@ -3,6 +3,35 @@ import StripeTerminal
 
 extension PaymentMethod {
     /// Failable initializer.
+    /// Maps a SCPPaymentMethod to PaymentMethod
+    init?(method: StripeTerminal.PaymentMethod?) {
+        guard let method else {
+            return nil
+        }
+
+        switch method.type {
+        case .card:
+            self = .card
+        case .cardPresent:
+            guard let details = method.cardPresent else {
+                self = .unknown
+                return
+            }
+            self = .cardPresent(details: CardPresentTransactionDetails(details: details))
+        case .interacPresent:
+            guard let details = method.interacPresent else {
+                self = .unknown
+                return
+            }
+            self = .interacPresent(details: CardPresentTransactionDetails(details: details))
+        case .affirm, .wechatPay, .paynow, .paypay, .unknown:
+            self = .unknown
+        @unknown default:
+            self = .unknown
+        }
+    }
+
+    /// Failable initializer.
     /// Maps a SCPPaymentMethodDetails to PaymentMethod
     init?(method: StripeTerminal.PaymentMethodDetails?) {
         guard let method else {

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -342,14 +342,6 @@ extension StripeCardReaderService: CardReaderService {
         }
     }
 
-    public func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
-        capturePayment(parameters) { _ in
-            Just(())
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
-        }
-    }
-
     public func capturePayment(_ parameters: PaymentIntentParameters,
                                beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
         // The documentation for this protocol method promises that this will produce either
@@ -369,15 +361,7 @@ extension StripeCardReaderService: CardReaderService {
                 self.processPayment(intent: intent)
             }
             .map(PaymentIntent.init(intent:))
-                .eraseToAnyPublisher()
-    }
-
-    public func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error> {
-        retryActivePaymentIntent { _ in
-            Just(())
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
-        }
+            .eraseToAnyPublisher()
     }
 
     public func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -343,6 +343,15 @@ extension StripeCardReaderService: CardReaderService {
     }
 
     public func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
+        capturePayment(parameters) { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    }
+
+    public func capturePayment(_ parameters: PaymentIntentParameters,
+                               beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
         // The documentation for this protocol method promises that this will produce either
         // a single value or it will fail.
         // This isn't enforced by the type system, but it is guaranteed as long as all the
@@ -355,13 +364,23 @@ extension StripeCardReaderService: CardReaderService {
             }.flatMap { intent in
                 self.collectPaymentMethod(intent: intent)
             }.flatMap { intent in
+                self.prepareForPaymentConfirmation(intent: intent, beforePaymentConfirmation: beforePaymentConfirmation)
+            }.flatMap { intent in
                 self.processPayment(intent: intent)
             }
             .map(PaymentIntent.init(intent:))
-            .eraseToAnyPublisher()
+                .eraseToAnyPublisher()
     }
 
     public func retryActivePaymentIntent() -> AnyPublisher<PaymentIntent, Error> {
+        retryActivePaymentIntent { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+    }
+
+    public func retryActivePaymentIntent(beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
         guard let activePaymentIntent else {
             return Fail(error: CardReaderServiceError.retryNotPossibleNoActivePayment)
                 .eraseToAnyPublisher()
@@ -369,6 +388,9 @@ extension StripeCardReaderService: CardReaderService {
         switch activePaymentIntent.status {
         case .requiresPaymentMethod:
             return collectPaymentMethod(intent: activePaymentIntent)
+                .flatMap { intent in
+                    self.prepareForPaymentConfirmation(intent: intent, beforePaymentConfirmation: beforePaymentConfirmation)
+                }
                 .flatMap { intent in
                     self.processPayment(intent: intent)
                 }
@@ -386,7 +408,10 @@ extension StripeCardReaderService: CardReaderService {
                 }
                 .eraseToAnyPublisher()
         case .requiresConfirmation:
-            return processPayment(intent: activePaymentIntent)
+            return prepareForPaymentConfirmation(intent: activePaymentIntent, beforePaymentConfirmation: beforePaymentConfirmation)
+                .flatMap { intent in
+                    self.processPayment(intent: intent)
+                }
                 .map(PaymentIntent.init(intent:))
                 .eraseToAnyPublisher()
         case .requiresCapture:
@@ -727,10 +752,14 @@ private extension StripeCardReaderService {
 
     func collectPaymentMethod(intent: StripeTerminal.PaymentIntent) -> AnyPublisher<StripeTerminal.PaymentIntent, Error> {
         let collectPaymentMethodFuture = Future<StripeTerminal.PaymentIntent, Error>() { [weak self] promise in
+            guard let collectConfiguration = self?.collectPaymentIntentConfiguration() else {
+                return promise(.failure(CardReaderServiceError.paymentMethodCollection(underlyingError: .internalServiceError)))
+            }
+
             /// Collect Payment method returns a cancellable
             /// Because we are chaining promises, we need to retain a reference
             /// to this cancellable if we want to cancel
-            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent) { (intent, error) in
+            self?.paymentCancellable = Terminal.shared.collectPaymentMethod(intent, collectConfig: collectConfiguration) { (intent, error) in
                 if let error {
                     var underlyingError = Self.logAndDecodeError(error)
                     /// the completion block for collectPaymentMethod will be called
@@ -754,6 +783,7 @@ private extension StripeCardReaderService {
 
                 if let intent {
                     self?.paymentCancellable = nil
+                    self?.activePaymentIntent = intent
                     self?.sendReaderEvent(.cardDetailsCollected)
                     promise(.success(intent))
                 }
@@ -773,8 +803,28 @@ private extension StripeCardReaderService {
                     return CardReaderServiceError.paymentMethodCollection(
                         underlyingError: .paymentMethodCollectionTimedOut)
                 })
-                .eraseToAnyPublisher()
+            .eraseToAnyPublisher()
         }
+    }
+
+    func collectPaymentIntentConfiguration() -> StripeTerminal.CollectPaymentIntentConfiguration? {
+        do {
+            let builder = StripeTerminal.CollectPaymentIntentConfigurationBuilder()
+            builder.setUpdatePaymentIntent(true)
+            return try builder.build()
+        } catch {
+            DDLogError("Failed to build CollectPaymentIntentConfiguration. Error:\(error)")
+            return nil
+        }
+    }
+
+    func prepareForPaymentConfirmation(
+        intent: StripeTerminal.PaymentIntent,
+        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
+    ) -> AnyPublisher<StripeTerminal.PaymentIntent, Error> {
+        beforePaymentConfirmation(PaymentIntent(intent: intent))
+            .map { intent }
+            .eraseToAnyPublisher()
     }
 
     func processPayment(intent: StripeTerminal.PaymentIntent) -> Future<StripeTerminal.PaymentIntent, Error> {

--- a/Modules/Sources/Hardware/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Hardware/Model/Copiable/Models+Copiable.generated.swift
@@ -74,7 +74,8 @@ extension Hardware.PaymentIntent {
         amount: CopiableProp<UInt> = .copy,
         currency: CopiableProp<String> = .copy,
         metadata: NullableCopiableProp<[String: String]> = .copy,
-        charges: CopiableProp<[Charge]> = .copy
+        charges: CopiableProp<[Charge]> = .copy,
+        collectedPaymentMethod: NullableCopiableProp<PaymentMethod> = .copy
     ) -> Hardware.PaymentIntent {
         let id = id ?? self.id
         let status = status ?? self.status
@@ -83,6 +84,7 @@ extension Hardware.PaymentIntent {
         let currency = currency ?? self.currency
         let metadata = metadata ?? self.metadata
         let charges = charges ?? self.charges
+        let collectedPaymentMethod = collectedPaymentMethod ?? self.collectedPaymentMethod
 
         return Hardware.PaymentIntent(
             id: id,
@@ -91,7 +93,8 @@ extension Hardware.PaymentIntent {
             amount: amount,
             currency: currency,
             metadata: metadata,
-            charges: charges
+            charges: charges,
+            collectedPaymentMethod: collectedPaymentMethod
         )
     }
 }

--- a/Modules/Sources/Networking/Model/SiteAPI.swift
+++ b/Modules/Sources/Networking/Model/SiteAPI.swift
@@ -17,6 +17,10 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
     ///
     public let applicationPasswordAvailable: Bool
 
+    /// Available REST API routes.
+    ///
+    public let routes: [String]
+
     /// Highest Woo API version installed on the site
     ///
     public var highestWooVersion: WooAPIVersion {
@@ -59,15 +63,18 @@ public struct SiteAPI: Decodable, Equatable, GeneratedFakeable {
         let authentication = try? siteAPIContainer.decode(Authentication.self, forKey: .authentication)
         let applicationPasswordAvailable = authentication?.applicationPasswords?.endpoints?.authorization != nil
 
-        self.init(siteID: siteID, namespaces: namespaces, applicationPasswordAvailable: applicationPasswordAvailable)
+        let routes = (try? siteAPIContainer.decodeIfPresent([String: AnyDecodable].self, forKey: .routes))?.keys.sorted() ?? []
+
+        self.init(siteID: siteID, namespaces: namespaces, applicationPasswordAvailable: applicationPasswordAvailable, routes: routes)
     }
 
     /// Designated Initializer.
     ///
-    public init(siteID: Int64, namespaces: [String], applicationPasswordAvailable: Bool) {
+    public init(siteID: Int64, namespaces: [String], applicationPasswordAvailable: Bool, routes: [String] = []) {
         self.siteID = siteID
         self.namespaces = namespaces
         self.applicationPasswordAvailable = applicationPasswordAvailable
+        self.routes = routes
     }
 }
 
@@ -78,6 +85,7 @@ private extension SiteAPI {
 
     enum SiteAPIKeys: String, CodingKey {
         case namespaces
+        case routes
         case authentication
     }
 

--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -35,6 +35,7 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case selfDrivenPushNotificationsM1
     case inPersonPaymentsCountryExpansion
     case inPersonPaymentsCountryExpansionEUExtended
+    case inPersonPaymentsAustraliaWooPayments
     case pointOfSaleScanToPay
     case pointOfSaleMarkOrderAsPaid
     case wooAIAssistant
@@ -57,6 +58,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .inPersonPaymentsCountryExpansion
         case "woo_ipp_country_expansion_eu_extended":
             self = .inPersonPaymentsCountryExpansionEUExtended
+        case "woo_ipp_australia_woopayments":
+            self = .inPersonPaymentsAustraliaWooPayments
         case "woo_pos_scan_to_pay":
             self = .pointOfSaleScanToPay
         case "woo_pos_mark_order_as_paid":

--- a/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
@@ -37,6 +37,6 @@ private extension SiteAPIRemote {
     }
 
     enum ParameterValues {
-        static let fieldValues: String = "authentication,namespaces"
+        static let fieldValues: String = "authentication,namespaces,routes"
     }
 }

--- a/Modules/Sources/Networking/Remote/WCPayRemote.swift
+++ b/Modules/Sources/Networking/Remote/WCPayRemote.swift
@@ -35,8 +35,35 @@ public class WCPayRemote: Remote {
         let path = "\(Path.orders)/\(orderID)/\(Path.captureTerminalPayment)"
 
         let parameters = [
-            CaptureOrderPaymentKeys.fields: CaptureOrderPaymentValues.fieldValues,
-            CaptureOrderPaymentKeys.paymentIntentID: paymentIntentID
+            TerminalPaymentIntentParameterKeys.fields: TerminalPaymentIntentParameterValues.fieldValues,
+            TerminalPaymentIntentParameterKeys.paymentIntentID: paymentIntentID
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+
+        let mapper = RemotePaymentIntentMapper()
+
+        return enqueue(request, mapper: mapper)
+    }
+
+    /// Prepares a terminal payment before the payment intent is confirmed.
+    /// - Parameters:
+    ///   - siteID: Site for which we'll prepare the payment intent.
+    ///   - orderID: Order for which we are preparing the payment.
+    ///   - paymentIntentID: Stripe Payment Intent ID created using the Terminal SDK.
+    public func prepareTerminalPayment(for siteID: Int64,
+                                       orderID: Int64,
+                                       paymentIntentID: String) -> AnyPublisher<Result<RemotePaymentIntent, Error>, Never> {
+        let path = "\(Path.orders)/\(orderID)/\(Path.prepareTerminalPayment)"
+
+        let parameters = [
+            TerminalPaymentIntentParameterKeys.fields: TerminalPaymentIntentParameterValues.fieldValues,
+            TerminalPaymentIntentParameterKeys.paymentIntentID: paymentIntentID
         ]
 
         let request = JetpackRequest(wooApiVersion: .mark3,
@@ -140,6 +167,7 @@ private extension WCPayRemote {
         static let accounts = "payments/accounts"
         static let orders = "payments/orders"
         static let captureTerminalPayment = "capture_terminal_payment"
+        static let prepareTerminalPayment = "prepare_terminal_payment"
         static let createCustomer = "create_customer"
         static let locations = "payments/terminal/locations/store"
         static let charges = "payments/charges"
@@ -157,12 +185,12 @@ private extension WCPayRemote {
             """
     }
 
-    enum CaptureOrderPaymentKeys {
+    enum TerminalPaymentIntentParameterKeys {
         static let fields: String = "_fields"
         static let paymentIntentID: String = "payment_intent_id"
     }
 
-    enum CaptureOrderPaymentValues {
+    enum TerminalPaymentIntentParameterValues {
         static let fieldValues: String = "id,status"
     }
 }

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -278,7 +278,11 @@ private extension CardPresentPaymentStore {
             onCardReaderMessage(event)
         }
 
-        paymentCancellable = handlePaymentEvents(from: cardReaderService.capturePayment(parameters),
+        paymentCancellable = handlePaymentEvents(from: cardReaderService.capturePayment(parameters) { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        },
                                                  readerEventsSubscription: readerEventsSubscription,
                                                  siteID: siteID,
                                                  orderID: orderID,
@@ -334,7 +338,11 @@ private extension CardPresentPaymentStore {
             onCardReaderMessage(event)
         }
 
-        paymentCancellable = handlePaymentEvents(from: cardReaderService.retryActivePaymentIntent(),
+        paymentCancellable = handlePaymentEvents(from: cardReaderService.retryActivePaymentIntent { _ in
+            Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        },
                                                  readerEventsSubscription: readerEventsSubscription,
                                                  siteID: siteID,
                                                  orderID: orderID,

--- a/Modules/Tests/HardwareTests/Mocks/MockStripeCardPresentDetails.swift
+++ b/Modules/Tests/HardwareTests/Mocks/MockStripeCardPresentDetails.swift
@@ -13,6 +13,7 @@ struct MockStripeCardPresentDetails {
     public let receipt: StripeTerminal.ReceiptDetails?
     public let emvAuthData: String?
     public let wallet: StripeTerminal.SCPWallet?
+    public let networks: StripeTerminal.SCPNetworks?
     public let network: NSNumber?
 }
 
@@ -27,6 +28,7 @@ extension MockStripeCardPresentDetails {
                                      receipt: nil,
                                      emvAuthData: "authdata",
                                      wallet: nil,
+                                     networks: nil,
                                      network: NSNumber(integerLiteral: 1))
     }
 }

--- a/Modules/Tests/HardwareTests/Mocks/MockStripePaymentIntent.swift
+++ b/Modules/Tests/HardwareTests/Mocks/MockStripePaymentIntent.swift
@@ -11,6 +11,7 @@ struct MockStripePaymentIntent {
     let currency: String
     let metadata: [String: String]?
     let charges: [StripeTerminal.Charge]
+    let paymentMethod: StripeTerminal.PaymentMethod?
 }
 
 extension MockStripePaymentIntent: StripePaymentIntent {
@@ -29,6 +30,7 @@ extension MockStripePaymentIntent {
                                 amount: 100,
                                 currency: "USD",
                                 metadata: nil,
-                                charges: [])
+                                charges: [],
+                                paymentMethod: nil)
     }
 }

--- a/Modules/Tests/HardwareTests/PaymentIntentTests.swift
+++ b/Modules/Tests/HardwareTests/PaymentIntentTests.swift
@@ -87,4 +87,42 @@ final class PaymentIntentTests: XCTestCase {
         // Then
         XCTAssertEqual(intent.paymentMethod(), .card)
     }
+
+    func test_paymentMethod_prefers_collected_payment_method_before_charges() {
+        let collectedPaymentMethod = PaymentMethod.interacPresent(details: cardPresentDetails(brand: .interac))
+
+        // When
+        let intent = PaymentIntent(id: "",
+                                   status: .processing,
+                                   created: .init(),
+                                   amount: 1201,
+                                   currency: "cad",
+                                   metadata: nil,
+                                   charges: [.init(id: "",
+                                                   amount: 201,
+                                                   currency: "cad",
+                                                   status: .failed,
+                                                   description: nil,
+                                                   metadata: nil,
+                                                   paymentMethod: .card)],
+                                   collectedPaymentMethod: collectedPaymentMethod)
+
+        // Then
+        XCTAssertEqual(intent.paymentMethod(), collectedPaymentMethod)
+    }
+}
+
+private extension PaymentIntentTests {
+    func cardPresentDetails(brand: CardBrand) -> CardPresentTransactionDetails {
+        CardPresentTransactionDetails(last4: "1234",
+                                      expMonth: 12,
+                                      expYear: 2030,
+                                      cardholderName: nil,
+                                      brand: brand,
+                                      generatedCard: nil,
+                                      receipt: nil,
+                                      emvAuthData: nil,
+                                      wallet: nil,
+                                      network: nil)
+    }
 }

--- a/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
@@ -73,6 +73,17 @@ final class FeatureFlagRemoteTests: XCTestCase {
         XCTAssertEqual(flag, .wooAIAssistant)
     }
 
+    func test_rawValue_when_woo_ipp_australia_woopayments_then_maps_to_inPersonPaymentsAustraliaWooPayments_case() {
+        // Given
+        let key = "woo_ipp_australia_woopayments"
+
+        // When
+        let flag = RemoteFeatureFlag(rawValue: key)
+
+        // Then
+        XCTAssertEqual(flag, .inPersonPaymentsAustraliaWooPayments)
+    }
+
     func test_rawValue_when_unknown_key_then_returns_nil() {
         // Given
         let key = "definitely_not_a_known_flag"

--- a/Modules/Tests/NetworkingTests/Remote/SiteAPIRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SiteAPIRemoteTests.swift
@@ -40,6 +40,10 @@ class SiteAPIRemoteTests: XCTestCase {
         let siteAPI = try result.get()
         XCTAssertEqual(siteAPI.siteID, sampleSiteID)
         XCTAssertEqual(siteAPI.highestWooVersion, WooAPIVersion.mark3)
+        XCTAssertEqual(siteAPI.routes, ["/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"])
+
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? JetpackRequest)
+        XCTAssertEqual(request.parameters["_fields"] as? String, "authentication,namespaces,routes")
     }
 
     /// Verifies that loadAPIInformation properly relays Networking Layer errors.

--- a/Modules/Tests/NetworkingTests/Remote/WCPayRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/WCPayRemoteTests.swift
@@ -615,6 +615,32 @@ final class WCPayRemoteTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
     }
 
+    func test_prepareTerminalPayment_sends_request_and_parses_response() throws {
+        let remote = WCPayRemote(network: network)
+
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "wcpay-payment-intent-requires-confirmation")
+
+        let result: Result<RemotePaymentIntent, Error> = waitFor { promise in
+            remote.prepareTerminalPayment(for: self.sampleSiteID,
+                                          orderID: self.sampleOrderID,
+                                          paymentIntentID: self.samplePaymentIntentID).sink { result in
+                promise(result)
+            }.store(in: &self.subscriptions)
+        }
+
+        XCTAssertTrue(result.isSuccess)
+        let paymentIntent = try result.get()
+        XCTAssertEqual(paymentIntent.status, .requiresConfirmation)
+        XCTAssertEqual(paymentIntent.id, self.samplePaymentIntentID)
+
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.path, "payments/orders/\(sampleOrderID)/prepare_terminal_payment")
+        XCTAssertEqual(request.parameters["_fields"] as? String, "id,status")
+        XCTAssertEqual(request.parameters["payment_intent_id"] as? String, samplePaymentIntentID)
+    }
+
     func test_loadDefaultReaderLocation_properly_returns_location() throws {
         let remote = WCPayRemote(network: network)
         let expectedLocationID = "tml_0123456789abcd"

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/site-api.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/site-api.json
@@ -12,6 +12,14 @@
             "wp\/v2"
         ],
         "authentication": [],
+        "routes": {
+            "\/wc\/v3\/payments\/orders\/(?P<order_id>\\w+)\/prepare_terminal_payment": {
+                "namespace": "wc\/v3",
+                "methods": [
+                    "POST"
+                ]
+            }
+        },
         "_links": {
             "help": [
                 {

--- a/Modules/Tests/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -148,16 +148,14 @@ final class MockCardReaderService: CardReaderService {
 
     func clear() { }
 
-    func capturePayment(_ parameters: PaymentIntentParameters) -> AnyPublisher<PaymentIntent, Error> {
-        capturePaymentPublisher ??
-        Just(.fake())
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
-    }
-
     func capturePayment(_ parameters: PaymentIntentParameters,
                         beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
-        capturePayment(parameters)
+        let paymentPublisher = capturePaymentPublisher ??
+            Just(.fake())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+
+        return paymentPublisher
             .flatMap { intent in
                 beforePaymentConfirmation(intent)
                     .map { intent }
@@ -166,16 +164,11 @@ final class MockCardReaderService: CardReaderService {
             .eraseToAnyPublisher()
     }
 
-    func retryActivePaymentIntent() -> AnyPublisher<Hardware.PaymentIntent, Error> {
-        Just(.fake())
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
-    }
-
     func retryActivePaymentIntent(
         beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
     ) -> AnyPublisher<Hardware.PaymentIntent, Error> {
-        retryActivePaymentIntent()
+        Just(.fake())
+            .setFailureType(to: Error.self)
             .flatMap { intent in
                 beforePaymentConfirmation(intent)
                     .map { intent }

--- a/Modules/Tests/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/CardPresentPayments/MockCardReaderService.swift
@@ -155,9 +155,32 @@ final class MockCardReaderService: CardReaderService {
             .eraseToAnyPublisher()
     }
 
+    func capturePayment(_ parameters: PaymentIntentParameters,
+                        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>) -> AnyPublisher<PaymentIntent, Error> {
+        capturePayment(parameters)
+            .flatMap { intent in
+                beforePaymentConfirmation(intent)
+                    .map { intent }
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+
     func retryActivePaymentIntent() -> AnyPublisher<Hardware.PaymentIntent, Error> {
         Just(.fake())
             .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    func retryActivePaymentIntent(
+        beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
+    ) -> AnyPublisher<Hardware.PaymentIntent, Error> {
+        retryActivePaymentIntent()
+            .flatMap { intent in
+                beforePaymentConfirmation(intent)
+                    .map { intent }
+                    .eraseToAnyPublisher()
+            }
             .eraseToAnyPublisher()
     }
 

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -1170,7 +1170,8 @@ private extension SettingStoreTests {
     func sampleSiteAPIWithWoo() -> Networking.SiteAPI {
         return SiteAPI(siteID: sampleSiteID,
                        namespaces: ["oembed/1.0", "akismet/v1", "jetpack/v4", "wpcom/v2", "wc/v1", "wc/v2", "wc/v3", "wc-pb/v3", "wp/v2"],
-                       applicationPasswordAvailable: false)
+                       applicationPasswordAvailable: false,
+                       routes: ["/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"])
     }
 
     func sampleSiteAPINoWoo() -> Networking.SiteAPI {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -128,7 +128,8 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: country, currency: currency)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
-                                               stores: stores)
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService)
 
         // When
         let result = await checker.checkEligibility()


### PR DESCRIPTION
Part of: RSM-642

## Description
This is PR 1 of 6 in the WooPayments AU card-present stack.

Stack:
1. `rsm-642-ios-terminal-prep-foundation`
2. `rsm-642-ios-terminal-prep-store`
3. `rsm-642-ios-terminal-prep-capture-flow`
4. `rsm-642-ios-terminal-brand-correctness`
5. `rsm-642-ios-terminal-brand-icons`
6. `rsm-642-ios-au-card-present-launch`

This PR adds the lower-level data needed by the capture flow:

* exposes collected terminal payment method details from Stripe Terminal - we use these to determine whether to call `prepare_terminal_payment` on the server;
* adds the WCPay `prepare_terminal_payment` remote endpoint;
* adds Site API route parsing so older WCPay installs can fall back safely - this is for CA stores;
* adds the AU WooPayments remote feature flag key.

## Test Steps
Practical testing seems a bit pointless at this step, better off testing the whole stack on PR6.

Unit tests alone should suffice.

## Screenshots
N/A - foundation/networking changes only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
