### PR TITLE
Handle EFTPOS card brands in refunds

### DIFF
--- a/Modules/Sources/Networking/Model/WCPayCardBrand.swift
+++ b/Modules/Sources/Networking/Model/WCPayCardBrand.swift
@@ -9,12 +9,25 @@ import Codegen
 ///
 public enum WCPayCardBrand: String, Codable, GeneratedCopiable, GeneratedFakeable, Equatable {
     case amex
+    case cartesBancaires = "cartes_bancaires"
     case diners
     case discover
+    case eftposAu = "eftpos_au"
     case interac
     case jcb
     case mastercard
     case unionpay
     case visa
     case unknown
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = WCPayCardBrand(rawValue: rawValue) ?? .unknown
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
 }

--- a/Modules/Tests/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
@@ -94,6 +94,78 @@ class WCPayChargeMapperTests: XCTestCase {
         assertEqual(wcpayCharge, expectedWcpayCharge)
     }
 
+    /// Verifies that the fields are all parsed correctly for an eftpos card present payment.
+    ///
+    func test_WCPayCharge_map_parses_all_fields_in_result_for_eftpos_card_present() throws {
+        let response = Data("""
+        {
+            "data": {
+                "id": "ch_3TUljCR5cNsnNRn20NfCY3Ht",
+                "amount": 1800,
+                "amount_captured": 1800,
+                "amount_refunded": 0,
+                "authorization_code": "123456",
+                "captured": true,
+                "created": 1778598369,
+                "currency": "aud",
+                "paid": true,
+                "payment_intent": "pi_3TUljCR5cNsnNRn20NfCY3Ht",
+                "payment_method": "pm_1TUPSvR5cNsnNRn2dWCTE6oL",
+                "payment_method_details": {
+                    "card_present": {
+                        "brand": "eftpos_au",
+                        "funding": "debit",
+                        "last4": "0978",
+                        "network": "eftpos_au",
+                        "receipt": {
+                            "account_type": "checking",
+                            "application_preferred_name": "eftpos SAV",
+                            "dedicated_file_name": "A00000038410"
+                        }
+                    },
+                    "type": "card_present"
+                },
+                "refunded": false,
+                "status": "succeeded"
+            }
+        }
+        """.utf8)
+        let wcpayCharge = try WCPayChargeMapper(siteID: dummySiteID).map(response: response)
+
+        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1778598369)
+
+        let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.cardPresent(
+            details: .init(brand: .eftposAu,
+                           last4: "0978",
+                           funding: .debit,
+                           receipt: .init(accountType: .checking,
+                                          applicationPreferredName: "eftpos SAV",
+                                          dedicatedFileName: "A00000038410")))
+
+        let expectedWcpayCharge = WCPayCharge(siteID: dummySiteID,
+                                              id: "ch_3TUljCR5cNsnNRn20NfCY3Ht",
+                                              amount: 1800,
+                                              amountCaptured: 1800,
+                                              amountRefunded: 0,
+                                              authorizationCode: "123456",
+                                              captured: true,
+                                              created: expectedCreatedDate,
+                                              currency: "aud",
+                                              paid: true,
+                                              paymentIntentID: "pi_3TUljCR5cNsnNRn20NfCY3Ht",
+                                              paymentMethodID: "pm_1TUPSvR5cNsnNRn2dWCTE6oL",
+                                              paymentMethodDetails: expectedPaymentMethodDetails,
+                                              refunded: false,
+                                              status: .succeeded)
+        XCTAssertEqual(wcpayCharge, expectedWcpayCharge)
+    }
+
+    func test_WCPayCardBrand_decodes_unknown_raw_value_as_unknown() throws {
+        let brand = try JSONDecoder().decode(WCPayCardBrand.self, from: Data(#""future_stripe_brand""#.utf8))
+
+        XCTAssertEqual(brand, .unknown)
+    }
+
     /// Verifies that the fields are all parsed correctly for a card present payment
     ///
     func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present_with_nulls() throws {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -347,6 +347,8 @@ private extension WCPayCardBrand {
             return "•••• %1$@ (Diners Club)"
         case .discover:
             return "•••• %1$@ (Discover)"
+        case .eftposAu:
+            return "•••• %1$@ (eftpos)"
         case .interac:
             return "•••• %1$@ (Interac)"
         case .jcb:
@@ -357,6 +359,8 @@ private extension WCPayCardBrand {
             return "•••• %1$@ (UnionPay)"
         case .visa:
             return "•••• %1$@ (Visa)"
+        case .cartesBancaires:
+            return "•••• %1$@ (Cartes Bancaires)"
         case .unknown:
             return "•••• %1$@"
         }
@@ -370,6 +374,8 @@ private extension WCPayCardBrand {
             return "Diners Club"
         case .discover:
             return "Discover"
+        case .eftposAu:
+            return "eftpos"
         case .interac:
             return "Interac"
         case .jcb:
@@ -380,6 +386,8 @@ private extension WCPayCardBrand {
             return "UnionPay"
         case .visa:
             return "Visa"
+        case .cartesBancaires:
+            return "Cartes Bancaires"
         case .unknown:
             return ""
         }


### PR DESCRIPTION
Part of: RSM-642

## Description
This is PR 4 of 6 in the WooPayments AU card-present stack, based on `rsm-642-ios-terminal-prep-capture-flow`.

This PR teaches the app about WCPay `eftpos_au` card brands where we need brand-specific behavior, especially the refund charge-details path. EFTPOS payments are refundable via the API, so they should not fall into the card-present refund-details failure state.

## Test Steps

It's easiest to test this on PR6, so just unit tests for now.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
