### PR TITLE
Enable AU card-present payments for WooPayments

### DIFF
--- a/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
+++ b/Modules/Sources/Storage/Model/GeneralStoreSettings.swift
@@ -107,11 +107,10 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     ///
     public var lastSunsetWarningDismissedDate: Date?
 
-    /// Whether this site is eligible for the In-Person Payments country expansion (RSM-637).
+    /// Whether this site is eligible for In-Person Payments countries gated by remote flags.
     /// `nil` until the eligibility refresher has run for the first time. Cached based on
-    /// the relevant remote feature flag (`inPersonPaymentsCountryExpansion` or
-    /// `inPersonPaymentsCountryExpansionEUExtended`) for the site's country, with US/PR/CA/GB
-    /// short-circuited to `true`.
+    /// the relevant remote feature flag for the site's country, with US/PR/CA/GB
+    /// short-circuited to `true`. Australia uses its own WooPayments-only flag.
     public var isCardPresentPaymentsCountryExpansionEligible: Bool?
 
     public init(storeID: String? = nil,

--- a/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -168,6 +168,22 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 contactlessLimitAmount: 20000,
                 minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
             )
+        case .AU:
+            self.init(
+                countryCode: country,
+                paymentMethods: [.cardPresent],
+                currencies: [.AUD],
+                paymentGateways: [WCPayAccount.gatewayID],
+                supportedReaders: [.wisepad3],
+                supportedPluginVersions: [
+                    .init(plugin: .wcPay, minimumVersion: Constants.minimumWCPayVersionForTerminalPaymentPreparation)
+                ],
+                minimumAllowedChargeAmount: NSDecimalNumber(string: "0.5"),
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                // AUD 200 — Stripe Terminal contactless CVM limit
+                contactlessLimitAmount: 20000,
+                minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
+            )
         default:
             self.init(
                 countryCode: country,
@@ -200,6 +216,7 @@ private enum Constants {
     static let fallbackInPersonPaymentsUrl = URL(string: "https://woocommerce.com/in-person-payments/")!
     static let purchaseReaderForCountryUrlBase = "https://woocommerce.com/products/hardware/"
     static let sharedMinimumIosVersion = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 1)
+    static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0-test-1"
 }
 
 /// The `@retroactive` attribute is used to apply `Equatable` conformance to `OperatingSystemVersion` from the Foundation module.

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
@@ -4,28 +4,31 @@ import enum WooFoundation.CurrencyCode
 
 /// Validator for POS country and currency support.
 ///
-/// Single source of truth for the supported country/currency pairings. The 13 expansion
-/// countries (RSM-637) are accepted only when the supplied
-/// ``CardPresentPaymentsCountryExpansionEligibilityServiceProtocol`` reports the site as
-/// eligible. US/PR/GB are always supported.
+/// Single source of truth for the supported country/currency pairings. Callers
+/// are expected to refresh the per-site gated-country eligibility cache for the
+/// current store country before validating. While the country-expansion flags
+/// are temporary, the cache is a coarse per-site Boolean: the refresher decides
+/// which remote flag controls the current store country, then this validator
+/// applies the cached result to the set of countries that are still gated.
+/// US/PR/GB are always supported.
 public enum POSCountryCurrencyValidator {
     /// Supported countries for POS feature.
-    /// Always includes US, PR, and GB. The 13 expansion countries are added when the supplied
-    /// eligibility service reports the site as eligible.
+    /// Always includes US, PR, and GB. Gated countries are added when the supplied
+    /// eligibility service reports the current site country as eligible.
     public static func supportedCountries(
         siteID: Int64,
         eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
     ) -> [CountryCode] {
         var countries: [CountryCode] = [.US, .PR, .GB]
         if eligibilityService.isEligible(siteID: siteID) {
-            countries.append(contentsOf: expansionCountries)
+            countries.append(contentsOf: remoteFlagGatedCountries)
         }
         return countries
     }
 
     /// Supported currencies per country for POS feature.
-    /// Always includes US/USD, PR/USD, and GB/GBP. Expansion entries are added when the supplied
-    /// eligibility service reports the site as eligible.
+    /// Always includes US/USD, PR/USD, and GB/GBP. Gated entries are added when the supplied
+    /// eligibility service reports the current site country as eligible.
     public static func supportedCurrencies(
         siteID: Int64,
         eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
@@ -41,6 +44,7 @@ public enum POSCountryCurrencyValidator {
             }
             map[.SG] = [.SGD]
             map[.NZ] = [.NZD]
+            map[.AU] = [.AUD]
         }
         return map
     }
@@ -49,8 +53,8 @@ public enum POSCountryCurrencyValidator {
     /// - Parameters:
     ///   - countryCode: The store's country code.
     ///   - currencyCode: The store's currency code.
-    ///   - siteID: The site ID, used to look up per-site expansion eligibility.
-    ///   - eligibilityService: The cached expansion eligibility for this site.
+    ///   - siteID: The site ID, used to look up per-site gated-country eligibility.
+    ///   - eligibilityService: The cached gated-country eligibility for this site.
     /// - Returns: Eligibility state with reason if ineligible.
     public static func validate(
         countryCode: CountryCode,
@@ -77,8 +81,10 @@ public enum POSCountryCurrencyValidator {
         .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES
     ]
 
-    private static var expansionCountries: [CountryCode] {
-        eeaEuroCountries + [.SG, .NZ]
+    /// Countries whose POS eligibility is still controlled by remote rollout
+    /// flags. The specific flag is resolved before this validator is called.
+    private static var remoteFlagGatedCountries: [CountryCode] {
+        eeaEuroCountries + [.SG, .NZ, .AU]
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresher.swift
+++ b/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresher.swift
@@ -1,10 +1,11 @@
 import Foundation
 import enum WooFoundation.CountryCode
 
-/// Refreshes the cached In-Person Payments country expansion eligibility for a site
-/// (RSM-637). Maps the site's country to the relevant remote feature flag, fetches
+/// Refreshes the cached In-Person Payments country eligibility for countries gated by
+/// remote flags. Maps the site's country to the relevant remote feature flag, fetches
 /// the latest value via the supplied provider, and writes it back through
 /// ``CardPresentPaymentsCountryExpansionEligibilityServiceProtocol``.
+/// Australia uses a separate WooPayments-only remote flag.
 ///
 /// US/PR/CA/GB short-circuit to `true` without any flag dispatch.
 public final class CardPresentPaymentsCountryExpansionEligibilityRefresher: @unchecked Sendable {
@@ -21,7 +22,7 @@ public final class CardPresentPaymentsCountryExpansionEligibilityRefresher: @unc
 
     /// Refreshes the cached eligibility for `siteID` based on `countryCode`.
     /// Existing IPP countries (US/PR/CA/GB) short-circuit to `true`.
-    /// Expansion countries dispatch the relevant remote feature flag and persist the result.
+    /// Gated countries dispatch the relevant remote feature flag and persist the result.
     public func refresh(siteID: Int64, countryCode: CountryCode) async {
         guard let flag = Self.flag(for: countryCode) else {
             // Either an existing supported country or one we don't know about — short-circuit.
@@ -45,6 +46,8 @@ public final class CardPresentPaymentsCountryExpansionEligibilityRefresher: @unc
             return .inPersonPaymentsCountryExpansion
         case .AT, .BE, .FI, .IT, .LU, .PT, .ES:
             return .inPersonPaymentsCountryExpansionEUExtended
+        case .AU:
+            return .inPersonPaymentsAustraliaWooPayments
         default:
             return nil
         }
@@ -55,13 +58,16 @@ public final class CardPresentPaymentsCountryExpansionEligibilityRefresher: @unc
 
 public extension CardPresentPaymentsCountryExpansionEligibilityRefresher {
     /// Builds a `(RemoteFeatureFlag) async -> Bool` provider that dispatches a
-    /// `FeatureFlagAction` against the supplied stores. Defaults to `false` when the
-    /// network or remote flag is unavailable.
+    /// `FeatureFlagAction` against the supplied stores. Gated countries default
+    /// to enabled, with remote flags available as off switches.
     static func makeRemoteFeatureFlagProvider(stores: StoresManager) -> @Sendable (RemoteFeatureFlag) async -> Bool {
         return { flag in
             await withCheckedContinuation { continuation in
                 Task { @MainActor in
-                    let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(flag, defaultValue: false) { isEnabled in
+                    let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(
+                        flag,
+                        defaultValue: true
+                    ) { isEnabled in
                         continuation.resume(returning: isEnabled)
                     }
                     stores.dispatch(action)

--- a/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -100,12 +100,18 @@ class CardPresentConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.contactlessLimitAmount, 20000)
     }
 
-    // Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643).
-    func test_configuration_for_Australia_is_unsupported() {
+    func test_configuration_for_Australia() {
         let configuration = CardPresentPaymentsConfiguration(country: .AU)
-        XCTAssertFalse(configuration.isSupportedCountry)
-        XCTAssertEqual(configuration.paymentMethods, [])
-        XCTAssertEqual(configuration.currencies, [])
+        XCTAssertTrue(configuration.isSupportedCountry)
+        XCTAssertEqual(configuration.currencies, [.AUD])
+        XCTAssertEqual(configuration.paymentMethods, [.cardPresent])
+        XCTAssertEqual(configuration.paymentGateways, [Constants.PaymentGateway.wcpay])
+        XCTAssertEqual(configuration.supportedReaders, [.wisepad3])
+        XCTAssertEqual(configuration.supportedPluginVersions, [
+            .init(plugin: .wcPay, minimumVersion: Constants.minimumWCPayVersionForTerminalPaymentPreparation)
+        ])
+        XCTAssertEqual(configuration.minimumAllowedChargeAmount, NSDecimalNumber(string: "0.5"))
+        XCTAssertEqual(configuration.contactlessLimitAmount, 20000)
     }
 
     private enum Constants {
@@ -122,5 +128,7 @@ class CardPresentConfigurationTests: XCTestCase {
             static let ca = "https://woocommerce.com/products/hardware/CA?utm_medium=woo_ios"
             static let gb = "https://woocommerce.com/products/hardware/GB?utm_medium=woo_ios"
         }
+
+        static let minimumWCPayVersionForTerminalPaymentPreparation = "10.8.0-test-1"
     }
 }

--- a/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
@@ -30,8 +30,8 @@ struct POSCountryCurrencyValidatorTests {
         #expect(result == .eligible)
     }
 
-    @Test("PR with USD is eligible without expansion eligibility")
-    func test_PR_with_USD_is_eligible_without_expansion_eligibility() {
+    @Test("PR with USD is eligible without cached country eligibility")
+    func test_PR_with_USD_is_eligible_without_cached_country_eligibility() {
         let result = POSCountryCurrencyValidator.validate(countryCode: .PR,
                                                           currencyCode: .USD,
                                                           siteID: siteID,
@@ -39,9 +39,9 @@ struct POSCountryCurrencyValidatorTests {
         #expect(result == .eligible)
     }
 
-    // MARK: - Unsupported Countries (eligibility off)
+    // MARK: - Unsupported Countries (cached country eligibility off)
 
-    @Test("CA with USD is ineligible due to unsupported country when expansion eligibility off")
+    @Test("CA with USD is ineligible due to unsupported country when cached country eligibility is off")
     func testCAWithUSDIsIneligible() {
         let result = POSCountryCurrencyValidator.validate(countryCode: .CA,
                                                           currencyCode: .USD,
@@ -61,12 +61,12 @@ struct POSCountryCurrencyValidatorTests {
         #expect(!supportedCountries.contains(.CA))
     }
 
-    @Test("AU with AUD is ineligible due to unsupported country")
-    func testAUWithAUDIsIneligible() {
+    @Test("AU with AUD is ineligible due to unsupported country when cached country eligibility is off")
+    func testAUWithAUDIsIneligibleWhenCachedCountryEligibilityOff() {
         let result = POSCountryCurrencyValidator.validate(countryCode: .AU,
                                                           currencyCode: .AUD,
                                                           siteID: siteID,
-                                                          eligibilityService: eligibleService)
+                                                          eligibilityService: ineligibleService)
 
         guard case .ineligible(let reason) = result else {
             Issue.record("Expected ineligible result")
@@ -76,6 +76,16 @@ struct POSCountryCurrencyValidatorTests {
             Issue.record("Expected unsupportedCountry reason")
             return
         }
+    }
+
+    @Test("AU with AUD is eligible when current-site country eligibility is cached")
+    func testAUWithAUDIsEligibleWhenCurrentSiteCountryEligibilityIsCached() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .AU,
+                                                          currencyCode: .AUD,
+                                                          siteID: siteID,
+                                                          eligibilityService: eligibleService)
+
+        #expect(result == .eligible)
     }
 
     // MARK: - Unsupported Currencies for Supported Countries
@@ -158,7 +168,7 @@ struct POSCountryCurrencyValidatorTests {
 
     // MARK: - Supported Countries List
 
-    @Test("Supported countries list contains only US, PR, and GB when expansion eligibility off")
+    @Test("Supported countries list contains only US, PR, and GB when cached country eligibility is off")
     func testSupportedCountriesList() {
         let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: ineligibleService)
         #expect(supportedCountries.count == 3)
@@ -167,23 +177,21 @@ struct POSCountryCurrencyValidatorTests {
         #expect(supportedCountries.contains(.GB))
     }
 
-    @Test("Supported countries list contains all 16 countries when expansion eligibility on")
-    func testSupportedCountriesIncludeExpansionCountriesWhenEligibilityOn() {
+    @Test("Supported countries list includes the validator's gated-country set when the current site country is eligible")
+    func testSupportedCountriesIncludeValidatorGatedCountrySetWhenCurrentSiteCountryEligible() {
         let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: eligibleService)
 
         #expect(supportedCountries.contains(.US))
         #expect(supportedCountries.contains(.PR))
         #expect(supportedCountries.contains(.GB))
-        for country in expansionCountries {
-            #expect(supportedCountries.contains(country), "Expected \(country) to be supported when eligibility is on")
+        for country in validatorGatedCountrySet {
+            #expect(supportedCountries.contains(country), "Expected \(country) to be present in the validator's gated-country set")
         }
-        // Australia is intentionally excluded pending EFTPOS support (RSM-642/643)
-        #expect(!supportedCountries.contains(.AU))
     }
 
     // MARK: - Supported Currencies Map
 
-    @Test("Supported currencies map only contains US, PR, and GB entries when expansion eligibility off")
+    @Test("Supported currencies map only contains US, PR, and GB entries when cached country eligibility is off")
     func testSupportedCurrenciesMap() {
         let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies(siteID: siteID, eligibilityService: ineligibleService)
 
@@ -196,19 +204,19 @@ struct POSCountryCurrencyValidatorTests {
         #expect(supportedCurrencies[.NZ] == nil)
     }
 
-    @Test("Supported currencies map includes EUR/SGD/NZD entries when expansion eligibility on")
-    func testSupportedCurrenciesMapIncludesExpansionEntriesWhenEligibilityOn() {
+    @Test("Supported currencies map includes the validator's gated-country entries when the current site country is eligible")
+    func testSupportedCurrenciesMapIncludesValidatorGatedEntriesWhenCurrentSiteCountryEligible() {
         let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies(siteID: siteID, eligibilityService: eligibleService)
 
         for country in eeaEuroCountries {
-            #expect(supportedCurrencies[country] == [.EUR], "Expected \(country) to map to EUR when eligibility is on")
+            #expect(supportedCurrencies[country] == [.EUR], "Expected \(country) to map to EUR in the validator's gated-country set")
         }
         #expect(supportedCurrencies[.SG] == [.SGD])
         #expect(supportedCurrencies[.NZ] == [.NZD])
-        #expect(supportedCurrencies[.AU] == nil)
+        #expect(supportedCurrencies[.AU] == [.AUD])
     }
 
-    // MARK: - Country Expansion (eligibility on)
+    // MARK: - Validator gated-country behavior
 
     @Test(arguments: [
         (country: CountryCode.AT, currency: CurrencyCode.EUR),
@@ -223,9 +231,10 @@ struct POSCountryCurrencyValidatorTests {
         (country: CountryCode.PT, currency: CurrencyCode.EUR),
         (country: CountryCode.ES, currency: CurrencyCode.EUR),
         (country: CountryCode.SG, currency: CurrencyCode.SGD),
-        (country: CountryCode.NZ, currency: CurrencyCode.NZD)
+        (country: CountryCode.NZ, currency: CurrencyCode.NZD),
+        (country: CountryCode.AU, currency: CurrencyCode.AUD)
     ])
-    func expansion_country_with_local_currency_is_eligible_when_eligibility_on(country: CountryCode, currency: CurrencyCode) {
+    func gated_country_with_local_currency_is_eligible_when_current_site_country_is_eligible(country: CountryCode, currency: CurrencyCode) {
         let result = POSCountryCurrencyValidator.validate(countryCode: country,
                                                           currencyCode: currency,
                                                           siteID: siteID,
@@ -233,8 +242,8 @@ struct POSCountryCurrencyValidatorTests {
         #expect(result == .eligible)
     }
 
-    @Test("Expansion country with mismatched currency is ineligible when eligibility on")
-    func test_expansion_country_with_mismatched_currency_is_ineligible() {
+    @Test("Gated country with mismatched currency is ineligible when the current site country is eligible")
+    func test_gated_country_with_mismatched_currency_is_ineligible() {
         let result = POSCountryCurrencyValidator.validate(countryCode: .DE,
                                                           currencyCode: .USD,
                                                           siteID: siteID,
@@ -242,8 +251,8 @@ struct POSCountryCurrencyValidatorTests {
         #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .DE, supportedCurrencies: [.EUR])))
     }
 
-    @Test("Expansion country is unsupported when eligibility off")
-    func test_expansion_country_is_unsupported_when_eligibility_off() {
+    @Test("Gated country is unsupported when eligibility off")
+    func test_gated_country_is_unsupported_when_eligibility_off() {
         let result = POSCountryCurrencyValidator.validate(countryCode: .DE,
                                                           currencyCode: .EUR,
                                                           siteID: siteID,
@@ -258,8 +267,11 @@ struct POSCountryCurrencyValidatorTests {
         .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES
     ]
 
-    private var expansionCountries: [CountryCode] {
-        eeaEuroCountries + [.SG, .NZ]
+    // Mirrors the validator's temporary coarse gated-country set. The specific
+    // rollout flag is resolved by the refresher before the validator reads the
+    // cached eligibility value.
+    private var validatorGatedCountrySet: [CountryCode] {
+        eeaEuroCountries + [.SG, .NZ, .AU]
     }
 }
 

--- a/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresherTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresherTests.swift
@@ -35,9 +35,9 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         }
     }
 
-    @Test("flag(for:) returns nil for AU (intentionally excluded — RSM-642/643)")
-    func test_flag_for_excluded_australia() {
-        #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: .AU) == nil)
+    @Test("flag(for:) returns inPersonPaymentsAustraliaWooPayments for AU")
+    func test_flag_for_australia() {
+        #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: .AU) == .inPersonPaymentsAustraliaWooPayments)
     }
 
     // MARK: - Refresh behaviour
@@ -46,11 +46,11 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
     func test_refresh_short_circuits_for_existing_country() async {
         // Given
         let service = SpyEligibilityService()
-        var providerInvocations: [RemoteFeatureFlag] = []
+        let providerInvocations = FlagRecorder()
         let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
             eligibilityService: service,
             remoteFeatureFlagProvider: { flag in
-                providerInvocations.append(flag)
+                await providerInvocations.append(flag)
                 return false
             }
         )
@@ -59,7 +59,7 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         await refresher.refresh(siteID: siteID, countryCode: .US)
 
         // Then
-        #expect(providerInvocations.isEmpty, "Existing supported country must not dispatch a flag check")
+        #expect(await providerInvocations.values.isEmpty, "Existing supported country must not dispatch a flag check")
         #expect(service.cachedValues == [siteID: true])
     }
 
@@ -102,11 +102,11 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
     func test_refresh_dispatches_eu_extended_flag() async {
         // Given
         let service = SpyEligibilityService()
-        var dispatchedFlag: RemoteFeatureFlag?
+        let dispatchedFlags = FlagRecorder()
         let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
             eligibilityService: service,
             remoteFeatureFlagProvider: { flag in
-                dispatchedFlag = flag
+                await dispatchedFlags.append(flag)
                 return true
             }
         )
@@ -115,7 +115,28 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         await refresher.refresh(siteID: siteID, countryCode: .ES)
 
         // Then
-        #expect(dispatchedFlag == .inPersonPaymentsCountryExpansionEUExtended)
+        #expect(await dispatchedFlags.values == [.inPersonPaymentsCountryExpansionEUExtended])
+        #expect(service.cachedValues == [siteID: true])
+    }
+
+    @Test("refresh dispatches inPersonPaymentsAustraliaWooPayments for AU")
+    func test_refresh_dispatches_australia_flag() async {
+        // Given
+        let service = SpyEligibilityService()
+        let dispatchedFlags = FlagRecorder()
+        let refresher = CardPresentPaymentsCountryExpansionEligibilityRefresher(
+            eligibilityService: service,
+            remoteFeatureFlagProvider: { flag in
+                await dispatchedFlags.append(flag)
+                return true
+            }
+        )
+
+        // When
+        await refresher.refresh(siteID: siteID, countryCode: .AU)
+
+        // Then
+        #expect(await dispatchedFlags.values == [.inPersonPaymentsAustraliaWooPayments])
         #expect(service.cachedValues == [siteID: true])
     }
 
@@ -149,5 +170,17 @@ private final class SpyEligibilityService: CardPresentPaymentsCountryExpansionEl
 
     func cacheEligibility(siteID: Int64, isEligible: Bool) {
         cachedValues[siteID] = isEligible
+    }
+}
+
+private actor FlagRecorder {
+    private var flags: [RemoteFeatureFlag] = []
+
+    var values: [RemoteFeatureFlag] {
+        flags
+    }
+
+    func append(_ flag: RemoteFeatureFlag) {
+        flags.append(flag)
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -333,11 +333,20 @@ private extension PaymentCaptureOrchestrator {
     }
 
     private func applicationFee(for orderTotal: NSDecimalNumber, countryCode: CountryCode) -> Decimal? {
-        guard countryCode == .CA else {
+        let flatFee: NSDecimalNumber
+        let percentageFee: NSDecimalNumber
+        switch countryCode {
+        case .CA:
+            flatFee = Constants.canadaFlatFee
+            percentageFee = Constants.canadaPercentageFee
+        case .AU:
+            flatFee = Constants.australiaFlatFee
+            percentageFee = Constants.australiaPercentageFee
+        default:
             return nil
         }
 
-        let fee = orderTotal.multiplying(by: Constants.canadaPercentageFee).adding(Constants.canadaFlatFee)
+        let fee = orderTotal.multiplying(by: percentageFee).adding(flatFee)
 
         let numberHandler = NSDecimalNumberHandler(roundingMode: .plain,
                                                    scale: 2,
@@ -376,6 +385,8 @@ private extension PaymentCaptureOrchestrator {
     enum Constants {
         static let canadaFlatFee = NSDecimalNumber(string: "0.15")
         static let canadaPercentageFee = NSDecimalNumber(0)
+        static let australiaFlatFee = NSDecimalNumber(string: "0.10")
+        static let australiaPercentageFee = NSDecimalNumber(string: "0.017")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -16,8 +16,8 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
     ///
     private let sampleSiteID: Int64 = 1234
 
-    private var ineligibleService: StubCardPresentExpansionEligibilityService!
-    private var eligibleService: StubCardPresentExpansionEligibilityService!
+    private var ineligibleService: StubCardPresentCountryEligibilityService!
+    private var eligibleService: StubCardPresentCountryEligibilityService!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -25,8 +25,8 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.sessionManager.setStoreId(sampleSiteID)
         ServiceLocator.setSelectedSiteSettings(SelectedSiteSettings(stores: stores, storageManager: storageManager))
-        ineligibleService = StubCardPresentExpansionEligibilityService(isEligible: false)
-        eligibleService = StubCardPresentExpansionEligibilityService(isEligible: true)
+        ineligibleService = StubCardPresentCountryEligibilityService(isEligible: false)
+        eligibleService = StubCardPresentCountryEligibilityService(isEligible: true)
     }
 
     override func tearDownWithError() throws {
@@ -119,12 +119,24 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertEqual(loader.configuration.currencies, [.NZD])
     }
 
-    func test_configuration_for_Australia_remains_unsupported_when_expansion_eligible() {
-        // Given - Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643)
+    func test_configuration_for_Australia_is_supported_when_country_eligibility_is_cached() {
+        // Given
         setupCountry(country: .au)
 
         // When
         let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
+
+        // Then
+        XCTAssertTrue(loader.configuration.isSupportedCountry)
+        XCTAssertEqual(loader.configuration.currencies, [.AUD])
+    }
+
+    func test_configuration_for_Australia_is_unsupported_when_country_eligibility_is_not_cached() {
+        // Given
+        setupCountry(country: .au)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: ineligibleService)
 
         // Then
         XCTAssertFalse(loader.configuration.isSupportedCountry)
@@ -157,7 +169,7 @@ private extension CardPresentConfigurationLoaderTests {
 
 // MARK: - Test Helper
 
-private final class StubCardPresentExpansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
+private final class StubCardPresentCountryEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol {
     private var isEligibleValue: Bool
 
     init(isEligible: Bool) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -377,6 +377,47 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         let expectedFee = NSDecimalNumber(string: "0.15").decimalValue
         assertEqual(expectedFee, parameters.applicationFee)
     }
+
+    func test_collectPayment_for_a_payment_to_an_AU_gateway_account_includes_applicationFee_in_the_payment_intent() throws {
+        // Given
+        let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
+                                                        defaultCurrency: "AUD",
+                                                        supportedCurrencies: ["AUD"],
+                                                        country: "AU",
+                                                        isCardPresentEligible: true)
+        let order = Order.fake().copy(siteID: sampleSiteID, currency: "AUD")
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let parameters: PaymentParameters = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
+                    promise(parameters)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: account,
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: true,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        let expectedFee = NSDecimalNumber(string: "2.65").decimalValue
+        assertEqual(expectedFee, parameters.applicationFee)
+    }
 }
 
 struct MockReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -129,7 +129,8 @@ struct POSTabEligibilityCheckerTests {
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+                                               systemStatusService: mockSystemStatusService,
+                                               expansionEligibilityService: ineligibleExpansionService)
 
         // When
         let result = await checker.checkEligibility()
@@ -467,7 +468,8 @@ struct POSTabEligibilityCheckerTests {
         (country: Country.es, currency: CurrencyCode.EUR),
         (country: Country.fr, currency: CurrencyCode.EUR),
         (country: Country.sg, currency: CurrencyCode.SGD),
-        (country: Country.nz, currency: CurrencyCode.NZD)
+        (country: Country.nz, currency: CurrencyCode.NZD),
+        (country: Country.au, currency: CurrencyCode.AUD)
     ])
     fileprivate func is_eligible_when_expansion_eligibility_is_enabled(country: Country, currency: CurrencyCode) async throws {
         // Given
@@ -489,11 +491,12 @@ struct POSTabEligibilityCheckerTests {
         Country.de,
         Country.es,
         Country.sg,
-        Country.nz
+        Country.nz,
+        Country.au
     ])
     fileprivate func is_ineligible_when_expansion_eligibility_is_disabled(country: Country) async throws {
         // Given - currencies that would be valid if eligibility were enabled
-        let currency: CurrencyCode = country == .sg ? .SGD : (country == .nz ? .NZD : .EUR)
+        let currency: CurrencyCode = country == .sg ? .SGD : (country == .nz ? .NZD : (country == .au ? .AUD : .EUR))
         setupCountry(country: country, currency: currency)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
@@ -524,21 +527,6 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .DE, supportedCurrencies: [.EUR])))
     }
 
-    @Test func australia_is_ineligible_even_when_expansion_eligibility_is_enabled() async throws {
-        // Given - Australia is intentionally excluded pending EFTPOS support (RSM-642 / RSM-643)
-        setupCountry(country: .au, currency: .AUD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               expansionEligibilityService: eligibleExpansionService)
-
-        // When
-        let result = await checker.checkEligibility()
-
-        // Then
-        #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
-    }
 }
 
 // MARK: - Test Helper

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -52,7 +52,8 @@ struct POSTabVisibilityCheckerTests {
 
     @Test(arguments: [
         (country: Country.ca, currency: CurrencyCode.CAD),
-        (country: Country.es, currency: CurrencyCode.EUR)
+        (country: Country.es, currency: CurrencyCode.EUR),
+        (country: Country.au, currency: CurrencyCode.AUD)
     ])
     fileprivate func is_invisible_when_country_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
@@ -137,6 +138,45 @@ struct POSTabVisibilityCheckerTests {
         // so ES is reported as visible without requiring a prior pre-warm.
         #expect(result == true)
         #expect(expansionEligibilityService.isEligible(siteID: siteID) == true)
+    }
+
+    @Test func is_visible_for_australia_when_au_feature_flag_enabled_even_with_empty_cache() async throws {
+        // Given - AU with an empty country-eligibility cache and the AU remote feature flag enabled.
+        let featureFlagService = MockFeatureFlagService()
+        setupCountry(country: .au, currency: .AUD)
+        accountWhitelistedInBackend(true, australiaWooPaymentsFlagEnabled: true)
+        let expansionEligibilityService = MockCardPresentPaymentsCountryExpansionEligibilityService()
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              expansionEligibilityService: expansionEligibilityService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+        #expect(expansionEligibilityService.isEligible(siteID: siteID) == true)
+    }
+
+    @Test func is_invisible_for_australia_when_au_feature_flag_disabled_even_if_expansion_flags_are_enabled() async throws {
+        // Given - AU must be controlled by its own remote feature flag, not the broader expansion flags.
+        let featureFlagService = MockFeatureFlagService()
+        setupCountry(country: .au, currency: .AUD)
+        accountWhitelistedInBackend(true, expansionFlagsEnabled: true, australiaWooPaymentsFlagEnabled: false)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
     }
 
     @Test func is_invisible_for_expansion_country_when_expansion_flag_disabled() async throws {
@@ -313,9 +353,11 @@ private extension POSTabVisibilityCheckerTests {
 
     /// Configures the mock stores to respond to `FeatureFlagAction.isRemoteFeatureFlagEnabled`.
     /// `isAllowed` controls the `.pointOfSale` flag (whitelisting).
-    /// `expansionFlagsEnabled` controls the IPP country-expansion flags consulted by the
-    /// `CardPresentPaymentsCountryExpansionEligibilityRefresher` injected into the checker.
-    func accountWhitelistedInBackend(_ isAllowed: Bool = false, expansionFlagsEnabled: Bool = false) {
+    /// `expansionFlagsEnabled` controls the existing IPP country-expansion flags.
+    /// `australiaWooPaymentsFlagEnabled` separately controls the AU WooPayments flag.
+    func accountWhitelistedInBackend(_ isAllowed: Bool = false,
+                                     expansionFlagsEnabled: Bool = false,
+                                     australiaWooPaymentsFlagEnabled: Bool = false) {
         stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
             switch action {
             case let .isRemoteFeatureFlagEnabled(flag, _, _, completion):
@@ -324,6 +366,8 @@ private extension POSTabVisibilityCheckerTests {
                     completion(isAllowed)
                 case .inPersonPaymentsCountryExpansion, .inPersonPaymentsCountryExpansionEUExtended:
                     completion(expansionFlagsEnabled)
+                case .inPersonPaymentsAustraliaWooPayments:
+                    completion(australiaWooPaymentsFlagEnabled)
                 default:
                     completion(false)
                 }
@@ -341,6 +385,7 @@ private extension POSTabVisibilityCheckerTests {
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
+        case au = "AU"
 
         var countryCode: CountryCode {
             switch self {
@@ -354,6 +399,8 @@ private extension POSTabVisibilityCheckerTests {
                 return .GB
             case .es:
                 return .ES
+            case .au:
+                return .AU
             }
         }
     }


### PR DESCRIPTION
Closes: RSM-642

## Description
This is PR 6 of 6 in the WooPayments AU card-present stack, based on `rsm-642-ios-terminal-brand-icons`.

This PR enables WooPayments card-present payments for Australia:

* adds AU/AUD WCPay configuration with minimum WCPay `10.8.0-test-1`;
* keeps Stripe gateway disabled for AU;
* enables AU POS country/currency eligibility;
* makes the IPP expansion remote flags default to enabled for all new countries, with remote values still available as off switches. We have set these to `true` on wpcom as we've got release confirmation, and we'll remove them in the next release after we've seen everything working in prod.

The feature flagging is pretty annoyingly complicated... but it will be removed once we've had a release or two live in production.

Feature flags are:
`inPersonPaymentsCountryExpansion` gates FR, DE, IE, NL, SG, NZ in 24.7
`inPersonPaymentsCountryExpansionEUExtended` gates AT, BE, FI, IT, LU, PT, ES in 24.7
`inPersonPaymentsAustraliaWooPayments` gates AU in 24.8

The first two are enabled in WPCom now, and the third is only an off switch anyway.

## Test Steps

* On an AU WCPay store running WooPayments `10.8.0-test-1` or later, confirm card-present payments are available. Note that the release train hasn't quite started yet, so check the WooPayments releases tab but if 10.8 test builds aren't available, I can invite you to a test store as a workaround.
* Confirm card-present payments are not offered for AU stores running Stripe gateway only.
* On iPad, confirm POS is visible for AU/AUD.
* Set the AU remote flag off (Menu > Settings > Debug Panel, then restart the app), and confirm AU IPP/POS entry points are hidden.
* On a WCPay AU store, collect a payment with an eftpos card (simulator has `eftposAuDebit`), and confirm that `prepare_terminal_payment` is called between collect and confirm.
* On an older WCPay CA store without the route, confirm the payment continues through the existing Interac flow.

Refunds: 
* Open an EFTPOS AU order in the iOS app.
* Start a refund.
* Confirm the refund flow can fetch charge details instead of showing `noDetailsPresentForPaymentType`.

Card brands:
* View an EFTPOS AU receipt - you can use the `.eftposAuDebit` simulated card to get this.
* Confirm the EFTPOS logo appears without clipping.

## Screenshots

https://github.com/user-attachments/assets/fd87fee5-89e2-4d51-b00c-feee4765a6e8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
