### PR TITLE
Prepare terminal payments during capture

### DIFF
--- a/Modules/Sources/Hardware/CardReader/CardPresentCaptureMethod.swift
+++ b/Modules/Sources/Hardware/CardReader/CardPresentCaptureMethod.swift
@@ -1,0 +1,7 @@
+/// CardPresentCaptureMethod defines supported card-present capture method preferences.
+/// Mirrors supported types from StripeTerminal.CardPresentCaptureMethod https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPCardPresentCaptureMethod.html
+///
+public enum CardPresentCaptureMethod {
+    case manualPreferred
+    case manual
+}

--- a/Modules/Sources/Hardware/CardReader/PaymentIntentParameters.swift
+++ b/Modules/Sources/Hardware/CardReader/PaymentIntentParameters.swift
@@ -49,6 +49,9 @@ public struct PaymentIntentParameters {
     ///
     public let paymentMethodTypes: [PaymentMethodType]
 
+    /// Capture method preference for card-present payments.
+    public let cardPresentCaptureMethod: CardPresentCaptureMethod?
+
     public init(amount: Decimal,
                 currency: String,
                 stripeSmallestCurrencyUnitMultiplier: Decimal,
@@ -57,6 +60,7 @@ public struct PaymentIntentParameters {
                 statementDescription: String? = nil,
                 receiptEmail: String? = nil,
                 paymentMethodTypes: [PaymentMethodType] = [],
+                cardPresentCaptureMethod: CardPresentCaptureMethod? = nil,
                 metadata: [String: String]? = nil) {
         self.amount = amount
         self.currency = currency
@@ -66,6 +70,7 @@ public struct PaymentIntentParameters {
         self.statementDescription = statementDescription
         self.receiptEmail = receiptEmail
         self.paymentMethodTypes = paymentMethodTypes
+        self.cardPresentCaptureMethod = cardPresentCaptureMethod
         self.metadata = metadata
     }
 }
@@ -80,6 +85,7 @@ extension PaymentIntentParameters: Equatable {
         lhs.statementDescription == rhs.statementDescription &&
         lhs.receiptEmail == rhs.receiptEmail &&
         lhs.metadata == rhs.metadata &&
-        lhs.paymentMethodTypes == rhs.paymentMethodTypes
+        lhs.paymentMethodTypes == rhs.paymentMethodTypes &&
+        lhs.cardPresentCaptureMethod == rhs.cardPresentCaptureMethod
     }
 }

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/PaymentIntentParameters+Stripe.swift
@@ -53,6 +53,10 @@ private extension Hardware.PaymentIntentParameters {
             builder.setApplicationFeeAmount(applicationFeeForStripe)
         }
 
+        if let cardPresentCaptureMethod {
+            _ = builder.setPaymentMethodOptionsParameters(try createCardPresentPaymentMethodOptions(captureMethod: cardPresentCaptureMethod))
+        }
+
         builder.setReceiptEmail(receiptEmail)
 
         let updatedMetadata = prepareMetadataForStripe(with: cardReaderMetadata)
@@ -60,6 +64,15 @@ private extension Hardware.PaymentIntentParameters {
 
         // Return payment intent built configuration:
         return try builder.build()
+    }
+
+    func createCardPresentPaymentMethodOptions(captureMethod: Hardware.CardPresentCaptureMethod) throws -> PaymentMethodOptionsParameters {
+        let cardPresentParameters = try CardPresentParametersBuilder()
+            .setCaptureMethod(captureMethod.stripeTerminalCardPresentCaptureMethod)
+            .build()
+
+        return try PaymentMethodOptionsParametersBuilder(cardPresentParameters: cardPresentParameters)
+            .build()
     }
 
     /// Updates the existing PaymentIntentParameters metadata with our CardReader metadata, if any.
@@ -88,6 +101,17 @@ private extension PaymentMethodType {
             return .cardPresent
         case .interacPresent:
             return .interacPresent
+        }
+    }
+}
+
+private extension Hardware.CardPresentCaptureMethod {
+    var stripeTerminalCardPresentCaptureMethod: StripeTerminal.CardPresentCaptureMethod {
+        switch self {
+        case .manualPreferred:
+            return .manualPreferred
+        case .manual:
+            return .manual
         }
     }
 }

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -247,6 +247,7 @@ public typealias PaymentChannel = Hardware.PaymentChannel
 public typealias PaymentMethod = Hardware.PaymentMethod
 public typealias PaymentParameters = Hardware.PaymentIntentParameters
 public typealias PaymentMethodType = Hardware.PaymentMethodType
+public typealias CardPresentCaptureMethod = Hardware.CardPresentCaptureMethod
 public typealias RefundParameters = Hardware.RefundParameters
 public typealias PaymentIntent = Hardware.PaymentIntent
 public typealias PrintingResult = Hardware.PrintingResult

--- a/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
+++ b/Modules/Tests/HardwareTests/PaymentIntentParametersTests.swift
@@ -1,5 +1,8 @@
 import XCTest
+import StripeTerminal
 @testable import Hardware
+
+private typealias PaymentIntentParameters = Hardware.PaymentIntentParameters
 
 final class PaymentIntentParametersTests: XCTestCase {
     func test_validEmail_is_saved() {
@@ -136,6 +139,19 @@ final class PaymentIntentParametersTests: XCTestCase {
         let stripeParameters = params.toStripe()
 
         XCTAssertNil(stripeParameters?.statementDescriptor)
+    }
+
+    func test_cardPresentCaptureMethod_sets_cardPresent_capture_method_option() throws {
+        let params = PaymentIntentParameters(amount: 100,
+                                             currency: "aud",
+                                             stripeSmallestCurrencyUnitMultiplier: 100,
+                                             paymentMethodTypes: [.cardPresent],
+                                             cardPresentCaptureMethod: .manualPreferred)
+
+        let stripeParameters = try XCTUnwrap(params.toStripe())
+
+        XCTAssertEqual(stripeParameters.paymentMethodOptionsParameters.cardPresentParameters.captureMethod,
+                       NSNumber(value: StripeTerminal.CardPresentCaptureMethod.manualPreferred.rawValue))
     }
 
     func test_cardReaderMetadata_is_passed_to_paymentIntent_when_sent_toStripe_then_stripeParameters_contains_cardReaderMetadata() {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -96,7 +96,7 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
 
         let parameters = paymentParameters(order: order,
                                            orderTotal: orderTotal,
-                                           country: paymentGatewayAccount.country,
+                                           countryCode: countryCode,
                                            statementDescriptor: paymentGatewayAccount.statementDescriptor,
                                            paymentMethodTypes: paymentMethodTypes,
                                            stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
@@ -296,7 +296,7 @@ private extension PaymentCaptureOrchestrator {
 
     func paymentParameters(order: Order,
                            orderTotal: NSDecimalNumber,
-                           country: String,
+                           countryCode: CountryCode,
                            statementDescriptor: String?,
                            paymentMethodTypes: [PaymentMethodType],
                            stripeSmallestCurrencyUnitMultiplier: Decimal,
@@ -314,16 +314,26 @@ private extension PaymentCaptureOrchestrator {
         return PaymentParameters(amount: orderTotal as Decimal,
                                  currency: order.currency,
                                  stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
-                                 applicationFee: applicationFee(for: orderTotal, country: country),
+                                 applicationFee: applicationFee(for: orderTotal, countryCode: countryCode),
                                  receiptDescription: receiptDescription(orderNumber: order.number),
                                  statementDescription: statementDescriptor,
                                  receiptEmail: paymentReceiptEmailParameterDeterminer.receiptEmail(from: order),
                                  paymentMethodTypes: paymentMethodTypes,
+                                 cardPresentCaptureMethod: cardPresentCaptureMethod(for: countryCode),
                                  metadata: metadata)
     }
 
-    private func applicationFee(for orderTotal: NSDecimalNumber, country: String) -> Decimal? {
-        guard country.uppercased() == CountryCode.CA.rawValue else {
+    private func cardPresentCaptureMethod(for countryCode: CountryCode) -> CardPresentCaptureMethod? {
+        switch countryCode {
+        case .AU, .CA:
+            return .manualPreferred
+        default:
+            return nil
+        }
+    }
+
+    private func applicationFee(for orderTotal: NSDecimalNumber, countryCode: CountryCode) -> Decimal? {
+        guard countryCode == .CA else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -4,7 +4,6 @@ import Yosemite
 import MessageUI
 import WordPressUI
 import WooFoundation
-import protocol Storage.StorageManagerType
 //TODO: Move to alertprovider (and ideally, remove from this target or translate through Yosemite)
 import enum Hardware.CardReaderServiceError
 import enum Hardware.UnderlyingError
@@ -320,90 +319,152 @@ private extension CollectOrderPaymentUseCase {
                                                                          channel: channel,
                                                                          onCompletion: onCompletion)
             case .success:
-                guard let orderTotal = self.orderTotal else {
-                    onCompletion(.failure(CollectOrderPaymentUseCaseNotValidAmountError.other))
-                    return
+                self.terminalPaymentPreparationEnabled(paymentGatewayAccount: paymentGatewayAccount) { [weak self] terminalPaymentPreparationEnabled in
+                    guard let self else { return }
+                    self.collectPayment(alertProvider: paymentAlerts,
+                                        paymentGatewayAccount: paymentGatewayAccount,
+                                        terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
+                                        channel: channel,
+                                        onCompletion: onCompletion)
                 }
-
-                // Start collect payment process
-                self.paymentOrchestrator.collectPayment(
-                    for: self.order,
-                    orderTotal: orderTotal,
-                    paymentGatewayAccount: paymentGatewayAccount,
-                    paymentMethodTypes: self.configuration.paymentMethods,
-                    stripeSmallestCurrencyUnitMultiplier: self.configuration.stripeSmallestCurrencyUnitMultiplier,
-                    countryCode: self.configuration.countryCode,
-                    terminalPaymentPreparationEnabled: false,
-                    channel: channel,
-                    onPreparingReader: { [weak self] in
-                        self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
-                            self?.cancelPayment(from: .paymentPreparingReader) {
-                                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                            }
-                        }))
-                    },
-                    onWaitingForInput: { [weak self] inputMethods in
-                        guard let self else { return }
-                        self.alertsPresenter.present(
-                            viewModel: paymentAlerts.tapOrInsertCard(
-                                title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
-                                    username: self.order.billingAddress?.firstName),
-                                amount: self.formattedAmount,
-                                inputMethods: inputMethods,
-                                onCancel: { [weak self] in
-                                    self?.cancelPayment(from: .paymentWaitingForInput) {
-                                        onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                                    }
-                                })
-                        )
-                    }, onCardInserted: { [weak self] in
-                        guard let self else { return }
-                        self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
-                            title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
-                                username: self.order.billingAddress?.firstName),
-                            amount: self.formattedAmount,
-                            onCancel: { [weak self] in
-                                self?.cancelPayment(from: .paymentWaitingForInput) {
-                                    onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
-                                }
-                            })
-                        )
-                    }, onProcessingMessage: { [weak self] in
-                        guard let self else { return }
-                        // Waiting message
-                        self.alertsPresenter.present(
-                            viewModel: paymentAlerts.processingTransaction(
-                                title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
-                                    username: self.order.billingAddress?.firstName)))
-                    }, onDisplayMessage: { [weak self] message in
-                        guard let self else { return }
-                        // Reader messages. EG: Remove Card
-                        self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
-                    }, onProcessingCompletion: { [weak self] intent in
-                        self?.analyticsTracker.trackProcessingCompletion(intent: intent)
-                        self?.markOrderAsPaidIfNeeded(intent: intent)
-                    }, onCompletion: { [weak self] result in
-                        switch result {
-                        case .success(let capturedPaymentData):
-                            self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
-                            onCompletion(.success(capturedPaymentData))
-                        case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
-                            switch cancellationSource {
-                            case .reader:
-                                self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
-                            default:
-                                self?.handlePaymentCancellation(from: .other)
-                            }
-                        case .failure(let error):
-                            self?.checkThenHandlePaymentFailureAndRetryPayment(error,
-                                                                               alertProvider: paymentAlerts,
-                                                                               paymentGatewayAccount: paymentGatewayAccount,
-                                                                               channel: channel,
-                                                                               onCompletion: onCompletion)
-                        }
-                    })
             }
         }
+    }
+
+    func collectPayment(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
+                        paymentGatewayAccount: PaymentGatewayAccount,
+                        terminalPaymentPreparationEnabled: Bool,
+                        channel: PaymentChannel,
+                        onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        guard let orderTotal else {
+            onCompletion(.failure(CollectOrderPaymentUseCaseNotValidAmountError.other))
+            return
+        }
+
+        // Start collect payment process
+        paymentOrchestrator.collectPayment(
+            for: order,
+            orderTotal: orderTotal,
+            paymentGatewayAccount: paymentGatewayAccount,
+            paymentMethodTypes: configuration.paymentMethods,
+            stripeSmallestCurrencyUnitMultiplier: configuration.stripeSmallestCurrencyUnitMultiplier,
+            countryCode: configuration.countryCode,
+            terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
+            channel: channel,
+            onPreparingReader: { [weak self] in
+                self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {
+                    self?.cancelPayment(from: .paymentPreparingReader) {
+                        onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                    }
+                }))
+            },
+            onWaitingForInput: { [weak self] inputMethods in
+                guard let self else { return }
+                self.alertsPresenter.present(
+                    viewModel: paymentAlerts.tapOrInsertCard(
+                        title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
+                            username: self.order.billingAddress?.firstName),
+                        amount: self.formattedAmount,
+                        inputMethods: inputMethods,
+                        onCancel: { [weak self] in
+                            self?.cancelPayment(from: .paymentWaitingForInput) {
+                                onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                            }
+                        })
+                )
+            }, onCardInserted: { [weak self] in
+                guard let self else { return }
+                self.alertsPresenter.present(viewModel: paymentAlerts.cardInserted(
+                    title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
+                        username: self.order.billingAddress?.firstName),
+                    amount: self.formattedAmount,
+                    onCancel: { [weak self] in
+                        self?.cancelPayment(from: .paymentWaitingForInput) {
+                            onCompletion(.failure(CollectOrderPaymentUseCaseError.flowCanceledByUser))
+                        }
+                    })
+                )
+            }, onProcessingMessage: { [weak self] in
+                guard let self else { return }
+                // Waiting message
+                self.alertsPresenter.present(
+                    viewModel: paymentAlerts.processingTransaction(
+                        title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
+                            username: self.order.billingAddress?.firstName)))
+            }, onDisplayMessage: { [weak self] message in
+                guard let self else { return }
+                // Reader messages. EG: Remove Card
+                self.alertsPresenter.present(viewModel: paymentAlerts.displayReaderMessage(message: message))
+            }, onProcessingCompletion: { [weak self] intent in
+                self?.analyticsTracker.trackProcessingCompletion(intent: intent)
+                self?.markOrderAsPaidIfNeeded(intent: intent)
+            }, onCompletion: { [weak self] result in
+                switch result {
+                case .success(let capturedPaymentData):
+                    self?.handleSuccessfulPayment(capturedPaymentData: capturedPaymentData)
+                    onCompletion(.success(capturedPaymentData))
+                case .failure(CardReaderServiceError.paymentMethodCollection(.commandCancelled(let cancellationSource))):
+                    switch cancellationSource {
+                    case .reader:
+                        self?.handlePaymentCancellationFromReader(alertProvider: paymentAlerts)
+                    default:
+                        self?.handlePaymentCancellation(from: .other)
+                    }
+                case .failure(let error):
+                    self?.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                       alertProvider: paymentAlerts,
+                                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                                       channel: channel,
+                                                                       onCompletion: onCompletion)
+                }
+            })
+    }
+
+    func terminalPaymentPreparationEnabled(paymentGatewayAccount: PaymentGatewayAccount,
+                                           completion: @escaping (Bool) -> Void) {
+        guard paymentGatewayAccount.gatewayID == WCPayAccount.gatewayID,
+              terminalPaymentPreparationAvailableForConfiguration else {
+            completion(false)
+            return
+        }
+
+        terminalPaymentPreparationSupportedBySite(completion: completion)
+    }
+
+    var terminalPaymentPreparationAvailableForConfiguration: Bool {
+        switch configuration.countryCode {
+        case .AU, .CA:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func terminalPaymentPreparationSupportedBySite(completion: @escaping (Bool) -> Void) {
+        switch configuration.countryCode {
+        case .AU:
+            completion(true)
+        case .CA:
+            // Canada already supports in-person payments on older WCPay versions, so check for the
+            // terminal preparation endpoint before using it. Once WCPay 10.8 has enough adoption in
+            // Canada, consider raising the minimum WCPay version and removing this compatibility check.
+            checkTerminalPaymentPreparationRoute(completion: completion)
+        default:
+            completion(false)
+        }
+    }
+
+    func checkTerminalPaymentPreparationRoute(completion: @escaping (Bool) -> Void) {
+        let action = SettingAction.retrieveSiteAPI(siteID: siteID) { result in
+            switch result {
+            case .success(let siteAPI):
+                completion(siteAPI.hasTerminalPaymentPreparationRoute)
+            case .failure(let error):
+                DDLogInfo("💳 Skipping terminal payment preparation because the WCPay endpoint could not be verified: \(error)")
+                completion(false)
+            }
+        }
+        stores.dispatch(action)
     }
 
     /// Tracks the successful payments
@@ -540,8 +601,11 @@ private extension CollectOrderPaymentUseCase {
                                                                                                    })
                                                    }
                                                }
-                                           }, dismissCompletion: {
-                                               onCompletion(.failure(error))
+                                           }, dismissCompletion: { [weak self] in
+                                               guard let self else {
+                                                   return onCompletion(.failure(error))
+                                               }
+                                               self.completeAfterErrorDismissal(error, onCompletion: onCompletion)
                                            })
         )
     }
@@ -590,8 +654,11 @@ private extension CollectOrderPaymentUseCase {
                             }
                         }
                     }
-                }, dismissCompletion: {
-                    onCompletion(.failure(error))
+                }, dismissCompletion: { [weak self] in
+                    guard let self else {
+                        return onCompletion(.failure(error))
+                    }
+                    self.completeAfterErrorDismissal(error, onCompletion: onCompletion)
                 })
         )
     }
@@ -600,11 +667,16 @@ private extension CollectOrderPaymentUseCase {
                                           paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                           receiptState: CardReaderTransactionFailureAlertReceiptState,
                                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        let dismissCompletion: () -> Void = { [weak self] in
+            guard let self else {
+                return onCompletion(.failure(error))
+            }
+            self.completeAfterErrorDismissal(error, onCompletion: onCompletion)
+        }
+
         alertsPresenter.present(viewModel: paymentAlerts.nonRetryableError(error: error,
                                                                            receiptState: receiptState,
-                                                                           dismissCompletion: {
-            onCompletion(.failure(error))
-        }))
+                                                                           dismissCompletion: dismissCompletion))
     }
 
     /// Cancels payment and record analytics.
@@ -616,6 +688,34 @@ private extension CollectOrderPaymentUseCase {
             onCompleted()
         }
     }
+
+    private func cancelPaymentAndComplete(with error: Error,
+                                          onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        paymentOrchestrator.cancelPayment { _ in
+            onCompletion(.failure(error))
+        }
+    }
+
+    private func completeAfterErrorDismissal(_ error: Error,
+                                             onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        guard shouldCancelPaymentAfterDismissing(error) else {
+            return onCompletion(.failure(error))
+        }
+
+        cancelPaymentAndComplete(with: error, onCompletion: onCompletion)
+    }
+
+    private func shouldCancelPaymentAfterDismissing(_ error: Error) -> Bool {
+        switch error {
+        case ServerSidePaymentCaptureError.terminalPaymentPreparation:
+            return true
+        case let cardReaderError as CardReaderServiceError:
+            return cardReaderError.shouldCancelPaymentAfterDismissal
+        default:
+            return false
+        }
+    }
+
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     ///
@@ -922,7 +1022,30 @@ protocol CardPaymentErrorProtocol: Error {
     var requiresFallbackPaymentMethod: Bool { get }
 }
 
+private extension SiteAPI {
+    var hasTerminalPaymentPreparationRoute: Bool {
+        routes.contains { route in
+            route.hasPrefix(Constants.prepareTerminalPaymentRoutePrefix) &&
+            route.hasSuffix(Constants.prepareTerminalPaymentRouteSuffix)
+        }
+    }
+
+    enum Constants {
+        static let prepareTerminalPaymentRoutePrefix = "/wc/v3/payments/orders/"
+        static let prepareTerminalPaymentRouteSuffix = "/prepare_terminal_payment"
+    }
+}
+
 extension CardReaderServiceError: CardPaymentErrorProtocol {
+    var shouldCancelPaymentAfterDismissal: Bool {
+        switch self {
+        case .paymentMethodCollection(let underlyingError), .paymentCapture(let underlyingError), .paymentCaptureWithPaymentMethod(let underlyingError, _):
+            return canRetryPayment(underlyingError: underlyingError)
+        default:
+            return false
+        }
+    }
+
     var retryApproach: CardPaymentRetryApproach {
         switch self {
         case .paymentMethodCollection(let underlyingError), .paymentCapture(let underlyingError), .paymentCaptureWithPaymentMethod(let underlyingError, _):
@@ -974,6 +1097,21 @@ extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
             return .restart
         case .couldNotRefreshOrder:
             return .reuseIntent
+        }
+    }
+
+    var requiresFallbackPaymentMethod: Bool {
+        false
+    }
+}
+
+extension ServerSidePaymentCaptureError: CardPaymentErrorProtocol {
+    var retryApproach: CardPaymentRetryApproach {
+        switch self {
+        case .terminalPaymentPreparation:
+            return .reuseIntent
+        case .paymentGateway, .paymentIntentNotSuccessful:
+            return .dontRetry
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -691,7 +691,10 @@ private extension CollectOrderPaymentUseCase {
 
     private func cancelPaymentAndComplete(with error: Error,
                                           onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
-        paymentOrchestrator.cancelPayment { _ in
+        paymentOrchestrator.cancelPayment { result in
+            if case .failure(let cancellationError) = result {
+                DDLogWarn("💳 Failed to cancel payment after payment error dismissal: \(cancellationError)")
+            }
             onCompletion(.failure(error))
         }
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
@@ -60,8 +60,10 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     }
 
     var spyDidCallCancelPayment = false
+    var mockCancelPaymentResult: Result<Void, Error> = .success(())
     func cancelPayment(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         spyDidCallCancelPayment = true
+        onCompletion(mockCancelPaymentResult)
     }
 
     var spyDidCallEmailReceipt = false

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -1,8 +1,10 @@
 import Codegen
 import Combine
+import Networking
 import TestKit
 import XCTest
 import Yosemite
+import WooFoundation
 @testable import WooCommerce
 
 @MainActor
@@ -34,7 +36,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         setUpUseCase(order: order)
     }
 
-    private func setUpUseCase(order: Order) {
+    private func setUpUseCase(order: Order, configuration: CardPresentPaymentsConfiguration = Mocks.configuration) {
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
             case .retrieveOrderRemotely(_, _, let completion):
@@ -48,7 +50,7 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
                                              order: order,
                                              formattedAmount: "1.5",
                                              rootViewController: MockViewControllerPresenting(),
-                                             configuration: Mocks.configuration,
+                                             configuration: configuration,
                                              stores: stores,
                                              paymentOrchestrator: mockPaymentOrchestrator,
                                              alertsPresenter: alertsPresenter,
@@ -96,6 +98,90 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         // Then
         XCTAssert(mockAnalyticsTracker.didCallTrackSuccessfulPayment)
         assertEqual(interacPaymentMethod, mockAnalyticsTracker.spyTrackSuccessfulPaymentCapturedPaymentData?.paymentMethod)
+    }
+
+    func test_collectPayment_enables_terminal_payment_preparation_when_route_is_available_for_Canada() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockTerminalPaymentPreparationRoute(isAvailable: true)
+
+        let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: interacPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, true)
+    }
+
+    func test_collectPayment_disables_terminal_payment_preparation_when_route_is_not_available_for_Canada() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .CA)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockTerminalPaymentPreparationRoute(isAvailable: false)
+
+        let interacPaymentMethod = PaymentMethod.interacPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: interacPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: interacPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, false)
+    }
+
+    func test_collectPayment_enables_terminal_payment_preparation_without_checking_route_for_Australia() throws {
+        // Given
+        let configuration = CardPresentPaymentsConfiguration(country: .AU)
+        let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
+        setUpUseCase(order: order, configuration: configuration)
+        mockUnexpectedTerminalPaymentPreparationRouteCheck()
+
+        let eftposPaymentMethod = PaymentMethod.cardPresent(details: CardPresentTransactionDetails(last4: "0978",
+                                                                                                   expMonth: 12,
+                                                                                                   expYear: 2030,
+                                                                                                   cardholderName: nil,
+                                                                                                   brand: .eftposAu,
+                                                                                                   generatedCard: nil,
+                                                                                                   receipt: nil,
+                                                                                                   emvAuthData: nil,
+                                                                                                   wallet: nil,
+                                                                                                   network: nil))
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: eftposPaymentMethod)])
+        mockSuccessfulCardPresentPaymentActions(intent: intent,
+                                                capturedPaymentData: CardPresentCapturedPaymentData(paymentMethod: eftposPaymentMethod,
+                                                                                                    receiptParameters: .fake()))
+
+        // When
+        waitFor { promise in
+            self.useCase.collectPayment(using: .bluetoothScan, channel: .storeManagement, onFailure: { _ in }, onCancel: {}, onPaymentCompletion: {
+                promise(())
+            }, onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyTerminalPaymentPreparationEnabled, true)
     }
 
     func test_collectPayment_success_with_customer_then_modal_presented_with_email() throws {
@@ -177,6 +263,98 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         XCTAssert(mockAnalyticsTracker.didCallTrackPaymentFailure)
         let receivedError = try XCTUnwrap(mockAnalyticsTracker.spyTrackPaymentFailureError as? CollectOrderPaymentUseCaseNotValidAmountError)
         assertEqual(CollectOrderPaymentUseCaseNotValidAmountError.belowMinimumAmount(amount: "$0.50"), receivedError)
+    }
+
+    func test_dismissing_terminal_payment_preparation_error_cancels_active_payment() throws {
+        // Given
+        let error = ServerSidePaymentCaptureError.terminalPaymentPreparation(
+            error: .orderPaymentCaptureError(message: "Terminal payment preparation failed"))
+        var onFailure: ((Error) -> Void)?
+        let errorAlert = presentErrorAlert(for: error,
+                                           as: CardPresentModalErrorWithoutEmail.self,
+                                           onFailure: { onFailure?($0) })
+
+        // When
+        let _: Error = waitFor { promise in
+            onFailure = { promise($0) }
+            errorAlert.didTapSecondaryButton(in: ImmediateDismissViewController())
+        }
+
+        // Then
+        XCTAssertTrue(mockPaymentOrchestrator.spyDidCallCancelPayment)
+    }
+
+    func test_dismissing_payment_capture_error_cancels_active_payment() throws {
+        // Given
+        let error = CardReaderServiceError.paymentCapture(underlyingError: .internalServiceError)
+        var onFailure: ((Error) -> Void)?
+        let errorAlert = presentErrorAlert(for: error,
+                                           as: CardPresentModalErrorWithoutEmail.self,
+                                           onFailure: { onFailure?($0) })
+
+        // When
+        let _: Error = waitFor { promise in
+            onFailure = { promise($0) }
+            errorAlert.didTapSecondaryButton(in: ImmediateDismissViewController())
+        }
+
+        // Then
+        XCTAssertTrue(mockPaymentOrchestrator.spyDidCallCancelPayment)
+    }
+
+    func test_dismissing_payment_collection_timeout_error_does_not_cancel_active_payment() throws {
+        // Given
+        let error = CardReaderServiceError.paymentMethodCollection(underlyingError: .paymentMethodCollectionTimedOut)
+        var onFailure: ((Error) -> Void)?
+        let errorAlert = presentErrorAlert(for: error,
+                                           as: CardPresentModalNonRetryableErrorWithoutEmail.self,
+                                           onFailure: { onFailure?($0) })
+
+        // When
+        let _: Error = waitFor { promise in
+            onFailure = { promise($0) }
+            errorAlert.didTapPrimaryButton(in: nil)
+        }
+
+        // Then
+        XCTAssertFalse(mockPaymentOrchestrator.spyDidCallCancelPayment)
+    }
+
+    func test_dismissing_processing_in_progress_retry_error_does_not_cancel_active_payment() throws {
+        // Given
+        let error = CardReaderServiceError.retryNotPossibleProcessingInProgress
+        var onFailure: ((Error) -> Void)?
+        let errorAlert = presentErrorAlert(for: error,
+                                           as: CardPresentModalNonRetryableErrorWithoutEmail.self,
+                                           onFailure: { onFailure?($0) })
+
+        // When
+        let _: Error = waitFor { promise in
+            onFailure = { promise($0) }
+            errorAlert.didTapPrimaryButton(in: nil)
+        }
+
+        // Then
+        XCTAssertFalse(mockPaymentOrchestrator.spyDidCallCancelPayment)
+    }
+
+    func test_dismissing_server_capture_error_does_not_cancel_active_payment() throws {
+        // Given
+        let error = ServerSidePaymentCaptureError.paymentGateway(
+            error: .orderPaymentCaptureError(message: "Server-side capture failed"))
+        var onFailure: ((Error) -> Void)?
+        let errorAlert = presentErrorAlert(for: error,
+                                           as: CardPresentModalNonRetryableErrorWithoutEmail.self,
+                                           onFailure: { onFailure?($0) })
+
+        // When
+        let _: Error = waitFor { promise in
+            onFailure = { promise($0) }
+            errorAlert.didTapPrimaryButton(in: nil)
+        }
+
+        // Then
+        XCTAssertFalse(mockPaymentOrchestrator.spyDidCallCancelPayment)
     }
 
     func test_collectPayment_with_interac_dispatches_markOrderAsPaidLocally_after_successful_client_side_capture() throws {
@@ -362,6 +540,20 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         XCTAssertEqual(mockPaymentOrchestrator.spyChannel, .pos)
     }
 
+    func test_collectPayment_configured_country_is_passed_to_payment_capture_orchestrator() throws {
+        // When
+        useCase.collectPayment(using: .bluetoothScan,
+                               channel: .storeManagement,
+                               onFailure: { _ in },
+                               onCancel: {},
+                               onPaymentCompletion: {},
+                               onCompleted: {})
+        mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+
+        // Then
+        XCTAssertEqual(mockPaymentOrchestrator.spyCollectPaymentCountryCode, .US)
+    }
+
     func test_completion_called_after_alert_presentation() throws {
         receiptEligibilityUseCase.isEligibleForBackendReceipts = true
         let paymentMethod = PaymentMethod.cardPresent(details: .fake())
@@ -469,6 +661,60 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 }
 
 private extension CollectOrderPaymentUseCaseTests {
+    func presentErrorAlert<Alert: CardPresentPaymentsModalViewModel>(for error: Error,
+                                                                     as alertType: Alert.Type,
+                                                                     onFailure: @escaping (Error) -> Void) -> Alert {
+        let paymentMethod = PaymentMethod.cardPresent(details: .fake())
+        let intent = PaymentIntent.fake().copy(charges: [.fake().copy(paymentMethod: paymentMethod)])
+        mockFailedCardPresentPaymentActions(intent: intent, error: error)
+
+        return waitFor { promise in
+            self.alertsPresenter.onPresentCalled = { viewModel in
+                guard let errorAlert = viewModel as? Alert else {
+                    return
+                }
+                promise(errorAlert)
+            }
+            self.useCase.collectPayment(using: .bluetoothScan,
+                                        channel: .storeManagement,
+                                        onFailure: onFailure,
+                                        onCancel: {},
+                                        onPaymentCompletion: {},
+                                        onCompleted: {})
+            self.mockPreflightController.completeConnection(reader: MockCardReader.wisePad3(), gatewayID: Mocks.paymentGatewayAccount)
+        }
+    }
+
+    func mockTerminalPaymentPreparationRoute(isAvailable: Bool) {
+        stores.whenReceivingAction(ofType: SettingAction.self) { [defaultSiteID] action in
+            switch action {
+            case let .retrieveSiteAPI(siteID, completion):
+                XCTAssertEqual(siteID, defaultSiteID)
+                completion(.success(SiteAPI(siteID: siteID,
+                                            namespaces: [],
+                                            applicationPasswordAvailable: false,
+                                            routes: isAvailable ? [Mocks.prepareTerminalPaymentRoute] : [])))
+            default:
+                XCTFail("Unexpected setting action: \(action)")
+            }
+        }
+    }
+
+    func mockUnexpectedTerminalPaymentPreparationRouteCheck() {
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveSiteAPI(siteID, completion):
+                XCTFail("AU terminal payment preparation should not depend on the site route list.")
+                completion(.success(SiteAPI(siteID: siteID,
+                                            namespaces: [],
+                                            applicationPasswordAvailable: false,
+                                            routes: [])))
+            default:
+                XCTFail("Unexpected setting action: \(action)")
+            }
+        }
+    }
+
     func mockSuccessfulCardPresentPaymentActions(intent: PaymentIntent, capturedPaymentData: CardPresentCapturedPaymentData) {
         mockPaymentOrchestrator.mockCollectPaymentHandler = { onPreparingReader,
                                                               onWaitingForInput,
@@ -501,5 +747,12 @@ private extension CollectOrderPaymentUseCaseTests {
         static let configuration = CardPresentPaymentsConfiguration(country: .US)
         static let cardReaderModel: String = "WISEPAD_3"
         static let paymentGatewayAccount: String = "woocommerce-payments"
+        static let prepareTerminalPaymentRoute = "/wc/v3/payments/orders/(?P<order_id>\\w+)/prepare_terminal_payment"
+    }
+}
+
+private final class ImmediateDismissViewController: UIViewController {
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        completion?()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -167,6 +167,76 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertTrue(terminalPaymentPreparationEnabled)
     }
 
+    func test_collect_payment_for_AU_sets_manual_preferred_card_present_capture_method() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let paymentParameters = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
+                    promise(parameters)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: false,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        XCTAssertEqual(paymentParameters.cardPresentCaptureMethod, .manualPreferred)
+    }
+
+    func test_collect_payment_for_CA_sets_manual_preferred_card_present_capture_method() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let paymentParameters = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
+                    promise(parameters)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent, .interacPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .CA,
+                terminalPaymentPreparationEnabled: false,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        XCTAssertEqual(paymentParameters.cardPresentCaptureMethod, .manualPreferred)
+    }
+
     func test_collect_payment_starts_payment_with_valid_parameters() {
         // Given
         let order = Order.fake().copy(siteID: sampleSiteID,
@@ -227,7 +297,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         assertEqual(expectedParameters, paymentParameters)
     }
 
-    func test_collectPayment_for_a_payment_to_a_US_gateway_account_does_not_include_applicationFee_in_the_payment_intent() throws {
+    func test_collectPayment_for_US_configuration_does_not_include_applicationFee_in_the_payment_intent() throws {
         // Given
         let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
                                                         defaultCurrency: "USD",
@@ -267,7 +337,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         XCTAssertNil(parameters.applicationFee)
     }
 
-    func test_collectPayment_for_a_payment_to_a_CA_gateway_account_includes_15cents_applicationFee_in_the_payment_intent() throws {
+    func test_collectPayment_for_CA_configuration_includes_15cents_applicationFee_in_the_payment_intent() throws {
         // Given
         let account = PaymentGatewayAccount.fake().copy(siteID: sampleSiteID,
                                                         defaultCurrency: "CAD",


### PR DESCRIPTION
Part of: RSM-642

## Description
This is PR 3 of 6 in the WooPayments AU card-present stack, based on `rsm-642-ios-terminal-prep-store`.

This PR wires terminal payment preparation into the order capture flow:

* sets `manual_preferred` capture method for CA and AU - `manual` is the default and requires/allows server-side capture during `capture_terminal_payment` calls. `manual_preferred` retains this for supported payments but allows automatic capture for eftpos/interac, which require that.
* calls `prepare_terminal_payment` only for WCPay flows that need it;
* allows older CA stores to continue even if they don't have the new route as a fallback on older WCPay installs;
* cancels the in-progress terminal payment when preparation fails before confirmation. This prevents the reader sitting with a live payment intent after the server already failed.

## Test Steps

Check unit tests pass, save manual testing for PR6

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
