### PR TITLE
Add terminal payment preparation store flow

### DIFF
--- a/Modules/Sources/Yosemite/Actions/CardPresentPaymentAction.swift
+++ b/Modules/Sources/Yosemite/Actions/CardPresentPaymentAction.swift
@@ -3,6 +3,7 @@
 
 import Combine
 import Foundation
+import enum WooFoundation.CountryCode
 
 public enum CardPresentPaymentAction: Action {
     /// Sets the store to use a given payment gateway
@@ -60,6 +61,8 @@ public enum CardPresentPaymentAction: Action {
     case collectPayment(siteID: Int64,
                         orderID: Int64,
                         parameters: PaymentParameters,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         onCardReaderMessage: (CardReaderEvent) -> Void,
                         onProcessingCompletion: (PaymentIntent) -> Void,
                         onCompletion: (Result<PaymentIntent, Error>) -> Void)
@@ -69,6 +72,8 @@ public enum CardPresentPaymentAction: Action {
 
     case retryPayment(siteID: Int64,
                       orderID: Int64,
+                      countryCode: CountryCode,
+                      terminalPaymentPreparationEnabled: Bool,
                       onCardReaderMessage: (CardReaderEvent) -> Void,
                       onProcessingCompletion: (PaymentIntent) -> Void,
                       onCompletion: (Result<PaymentIntent, Error>) -> Void)

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockCardPresentPaymentActionHandler.swift
@@ -23,7 +23,7 @@ struct MockCardPresentPaymentActionHandler: MockActionHandler {
             observeConnectedReaders(onCompletion: onCompletion)
         case .observeCardReaderUpdateState(let onCompletion):
             observeCardReaderUpdateState(onCompletion: onCompletion)
-        case .collectPayment(_, _, _, let onCardReaderMessage, _, _):
+        case .collectPayment(_, _, _, _, _, let onCardReaderMessage, _, _):
             // This immediately brings up the `CardPresentModalTapCard` screen, which is used by
             // `WooCommerceScreenshots` to display it for screenshotting purpose.
             onCardReaderMessage(.waitingForInput([.tap, .swipe, .insert]))

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -3,6 +3,7 @@ import Storage
 import Hardware
 import Networking
 import Combine
+import enum WooFoundation.CountryCode
 
 // MARK: CardPresentPaymentStore
 ///
@@ -108,16 +109,33 @@ public final class CardPresentPaymentStore: Store {
             disconnect(onCompletion: completion)
         case .observeConnectedReaders(let completion):
             observeConnectedReaders(onCompletion: completion)
-        case .collectPayment(let siteID, let orderID, let parameters, let event, let processPaymentCompletion, let completion):
+        case .collectPayment(let siteID,
+                             let orderID,
+                             let parameters,
+                             let countryCode,
+                             let terminalPaymentPreparationEnabled,
+                             let event,
+                             let processPaymentCompletion,
+                             let completion):
             collectPayment(siteID: siteID,
                            orderID: orderID,
                            parameters: parameters,
+                           countryCode: countryCode,
+                           terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
                            onCardReaderMessage: event,
                            onProcessingCompletion: processPaymentCompletion,
                            onCompletion: completion)
-        case .retryPayment(let siteID, let orderID, let event, let processPaymentCompletion, let completion):
+        case .retryPayment(let siteID,
+                           let orderID,
+                           let countryCode,
+                           let terminalPaymentPreparationEnabled,
+                           let event,
+                           let processPaymentCompletion,
+                           let completion):
             retryActivePayment(siteID: siteID,
                                orderID: orderID,
+                               countryCode: countryCode,
+                               terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
                                onCardReaderMessage: event,
                                onProcessingCompletion: processPaymentCompletion,
                                onCompletion: completion)
@@ -270,6 +288,8 @@ private extension CardPresentPaymentStore {
     func collectPayment(siteID: Int64,
                         orderID: Int64,
                         parameters: PaymentParameters,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
@@ -278,10 +298,12 @@ private extension CardPresentPaymentStore {
             onCardReaderMessage(event)
         }
 
-        paymentCancellable = handlePaymentEvents(from: cardReaderService.capturePayment(parameters) { _ in
-            Just(())
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
+        paymentCancellable = handlePaymentEvents(from: cardReaderService.capturePayment(parameters) { intent in
+            self.prepareTerminalPayment(siteID: siteID,
+                                        orderID: orderID,
+                                        paymentIntent: intent,
+                                        countryCode: countryCode,
+                                        terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
         },
                                                  readerEventsSubscription: readerEventsSubscription,
                                                  siteID: siteID,
@@ -331,6 +353,8 @@ private extension CardPresentPaymentStore {
 
     func retryActivePayment(siteID: Int64,
                             orderID: Int64,
+                            countryCode: CountryCode,
+                            terminalPaymentPreparationEnabled: Bool,
                             onCardReaderMessage: @escaping (CardReaderEvent) -> Void,
                             onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                             onCompletion: @escaping (Result<PaymentIntent, Error>) -> Void) {
@@ -338,10 +362,12 @@ private extension CardPresentPaymentStore {
             onCardReaderMessage(event)
         }
 
-        paymentCancellable = handlePaymentEvents(from: cardReaderService.retryActivePaymentIntent { _ in
-            Just(())
-                .setFailureType(to: Error.self)
-                .eraseToAnyPublisher()
+        paymentCancellable = handlePaymentEvents(from: cardReaderService.retryActivePaymentIntent { intent in
+            self.prepareTerminalPayment(siteID: siteID,
+                                        orderID: orderID,
+                                        paymentIntent: intent,
+                                        countryCode: countryCode,
+                                        terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
         },
                                                  readerEventsSubscription: readerEventsSubscription,
                                                  siteID: siteID,
@@ -594,6 +620,33 @@ private extension CardPresentPaymentStore {
             .eraseToAnyPublisher()
     }
 
+    /// Prepares a WCPay terminal payment before the Terminal SDK confirms a collected payment intent.
+    func prepareTerminalPayment(siteID: Int64,
+                                orderID: Int64,
+                                paymentIntent: PaymentIntent,
+                                countryCode: CountryCode,
+                                terminalPaymentPreparationEnabled: Bool) -> AnyPublisher<Void, Error> {
+        guard usingBackend == .wcPay,
+              terminalPaymentPreparationEnabled,
+              paymentIntent.requiresTerminalPaymentPreparation(countryCode: countryCode) else {
+            return Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+
+        return remote.prepareTerminalPayment(for: siteID, orderID: orderID, paymentIntentID: paymentIntent.id)
+            .tryMap { result in
+                switch result {
+                case .success:
+                    return ()
+                case .failure(let error):
+                    let error = PaymentsError(underlyingError: error)
+                    throw ServerSidePaymentCaptureError.terminalPaymentPreparation(error: error)
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+
     func fetchCharge(siteID: Int64, chargeID: String, completion: @escaping (Result<WCPayCharge, Error>) -> Void) {
         switch usingBackend {
         case .wcPay:
@@ -616,6 +669,38 @@ private extension CardPresentPaymentStore {
         case .stripe:
             break /// not implemented
         }
+    }
+}
+
+private extension PaymentIntent {
+    func requiresTerminalPaymentPreparation(countryCode: CountryCode) -> Bool {
+        switch paymentMethod() {
+        case .interacPresent:
+            return true
+        case .cardPresent(let details):
+            return countryCode == .AU && details.canProcessAsEftposAu
+        default:
+            return false
+        }
+    }
+}
+
+private extension Data {
+    var restErrorCode: String? {
+        guard let response = try? JSONDecoder().decode(RESTErrorResponse.self, from: self) else {
+            return nil
+        }
+        return response.code
+    }
+}
+
+private struct RESTErrorResponse: Decodable {
+    let code: String
+}
+
+private extension CardPresentTransactionDetails {
+    var canProcessAsEftposAu: Bool {
+        brand == .eftposAu || availableNetworks?.contains(.eftposAu) == true
     }
 }
 
@@ -710,12 +795,15 @@ private extension CardPresentPaymentStore {
 public enum ServerSidePaymentCaptureError: Error, LocalizedError {
     case paymentIntentNotSuccessful
     case paymentGateway(error: PaymentsError)
+    case terminalPaymentPreparation(error: PaymentsError)
 
     public var errorDescription: String? {
         switch self {
         case .paymentIntentNotSuccessful:
             return "Payment intent not successful"
         case .paymentGateway(error: let error):
+            return error.localizedDescription
+        case .terminalPaymentPreparation(error: let error):
             return error.localizedDescription
         }
     }

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -685,19 +685,6 @@ private extension PaymentIntent {
     }
 }
 
-private extension Data {
-    var restErrorCode: String? {
-        guard let response = try? JSONDecoder().decode(RESTErrorResponse.self, from: self) else {
-            return nil
-        }
-        return response.code
-    }
-}
-
-private struct RESTErrorResponse: Decodable {
-    let code: String
-}
-
 private extension CardPresentTransactionDetails {
     var canProcessAsEftposAu: Bool {
         brand == .eftposAu || availableNetworks?.contains(.eftposAu) == true

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -4,6 +4,7 @@ import Fakes
 import YosemiteTestHelpers
 @testable import Yosemite
 @testable import Networking
+@testable import NetworkingCore
 @testable import Storage
 @testable import Hardware
 
@@ -601,7 +602,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     func test_collectPayment_calls_onProcessingCompletion_but_not_onCompletion_after_card_reader_capturePayment_success() {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher())
@@ -614,7 +615,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .US,
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
 
                 } onProcessingCompletion: { intent in
                     promise(intent)
@@ -634,7 +637,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     func test_collectPayment_calls_onCompletion_after_card_reader_capturePayment_success_and_card_removal_and_site_capturePayment() throws {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher())
@@ -649,7 +652,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .US,
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                 } onCompletion: { result in
                     promise(result)
@@ -661,6 +666,167 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         let finalIntent = try XCTUnwrap(result.get())
         XCTAssertEqual(finalIntent.id, intent.id)
         XCTAssertEqual(finalIntent.status, intent.status)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_prepares_au_eftpos_payment_before_site_capturePayment() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .eftposAu)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "wcpay-payment-intent-requires-confirmation")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .AU,
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_prepares_au_card_payment_with_eftpos_available_before_site_capturePayment() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa,
+                                                                                                    availableNetworks: [.visa, .eftposAu])))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "wcpay-payment-intent-requires-confirmation")
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .AU,
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_skips_preparing_au_card_payment_when_eftpos_is_not_available() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa,
+                                                                                                    availableNetworks: [.visa])))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "AUD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .AU,
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
+    }
+
+    func test_collectPayment_skips_preparing_interac_payment_when_terminal_payment_preparation_is_disabled() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .interacPresent(details: cardPresentDetails(brand: .interac)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/capture_terminal_payment",
+                                 filename: "wcpay-payment-intent-succeeded")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "CAD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .CA,
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let finalIntent = try XCTUnwrap(result.get())
+        XCTAssertEqual(finalIntent.id, intent.id)
+
+        let requestedPaths = network.requestsForResponseData.compactMap { ($0 as? JetpackRequest)?.path }
+        XCTAssertEqual(requestedPaths, [
+            "payments/orders/\(sampleOrderID)/capture_terminal_payment"
+        ])
     }
 
     /// Verifies that `onCompletion` is called with an error after card reader finishes capturing payment, the card is removed successfully
@@ -668,7 +834,7 @@ final class CardPresentPaymentStoreTests: XCTestCase {
     ///
     func test_collectPayment_calls_onCompletion_with_failure_after_card_reader_capturePayment_success_but_site_capturePayment_failure() throws {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         // Success on client-side processing.
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
@@ -685,7 +851,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .US,
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                 } onCompletion: { result in
                     promise(result)
@@ -700,12 +868,48 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         }
     }
 
+    func test_collectPayment_calls_onCompletion_with_failure_when_prepare_terminal_payment_fails_before_processing_completion() throws {
+        // Given
+        let intent = paymentIntent(collectedPaymentMethod: .interacPresent(details: cardPresentDetails(brand: .interac)))
+        mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher())
+        mockCardReaderService.whenWaitForInsertedCardToBeRemoved(thenReturn: Future<Void, Never> { promise in
+            promise(.success(()))
+        })
+        network.simulateResponse(requestUrlSuffix: "payments/orders/\(sampleOrderID)/prepare_terminal_payment",
+                                 filename: "generic_error")
+
+        // When
+        let result: Result<PaymentIntent, Error> = waitFor { [self] promise in
+            let action = CardPresentPaymentAction
+                .collectPayment(siteID: sampleSiteID,
+                                orderID: sampleOrderID,
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .CA,
+                                terminalPaymentPreparationEnabled: true) { cardReaderEvent in
+                } onProcessingCompletion: { intent in
+                    XCTFail("`onProcessingCompletion` should only be called after the payment intent is prepared and confirmed.")
+                } onCompletion: { result in
+                    promise(result)
+                }
+            cardPresentStore.onAction(action)
+        }
+
+        // Then
+        let error = try XCTUnwrap(result.failure as? ServerSidePaymentCaptureError)
+        guard case .terminalPaymentPreparation = error else {
+            return XCTFail("Unexpected terminal payment preparation error: \(error)")
+        }
+        XCTAssertFalse(mockCardReaderService.didHitWaitForInsertedCardToBeRemoved)
+    }
+
     /// Verifies that `CardReaderEvent.cardRemovedAfterPaymentCapture` is sent after card reader finishes capturing payment, the card is removed successfully
     /// and before the site captures payment.
     ///
     func test_collectPayment_sends_cardRemovedAfterPaymentCapture_event_after_card_removal_and_before_site_capturePayment_completion() {
         // Given
-        let intent = PaymentIntent.fake()
+        let intent = paymentIntent(collectedPaymentMethod: .cardPresent(details: cardPresentDetails(brand: .visa)))
         // Success on client-side processing.
         mockCardReaderService.whenCapturingPayment(thenReturn: Just(intent)
             .setFailureType(to: Error.self)
@@ -722,7 +926,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: self.sampleSiteID,
                                 orderID: self.sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .US,
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                     cardReaderEvents.append(cardReaderEvent)
                     if cardReaderEvent == .cardRemovedAfterClientSidePaymentCapture {
                         promise(())
@@ -756,7 +962,9 @@ final class CardPresentPaymentStoreTests: XCTestCase {
             let action = CardPresentPaymentAction
                 .collectPayment(siteID: sampleSiteID,
                                 orderID: sampleOrderID,
-                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100)) { cardReaderEvent in
+                                parameters: .init(amount: 2.5, currency: "USD", stripeSmallestCurrencyUnitMultiplier: 100),
+                                countryCode: .US,
+                                terminalPaymentPreparationEnabled: false) { cardReaderEvent in
                 } onProcessingCompletion: { intent in
                     XCTFail("`onProcessingCompletion` should only be called when payment capture succeeds.")
                 } onCompletion: { result in
@@ -965,5 +1173,26 @@ final class CardPresentPaymentStoreTests: XCTestCase {
 
         // Then
         XCTAssertNil(mockCardReaderConfigProvider.currentSiteID)
+    }
+
+}
+
+private extension CardPresentPaymentStoreTests {
+    func paymentIntent(collectedPaymentMethod: PaymentMethod?) -> PaymentIntent {
+        PaymentIntent.fake().copy(collectedPaymentMethod: collectedPaymentMethod)
+    }
+
+    func cardPresentDetails(brand: CardBrand, availableNetworks: [CardBrand]? = nil) -> CardPresentTransactionDetails {
+        CardPresentTransactionDetails(last4: "1234",
+                                      expMonth: 12,
+                                      expYear: 2030,
+                                      cardholderName: nil,
+                                      brand: brand,
+                                      availableNetworks: availableNetworks,
+                                      generatedCard: nil,
+                                      receipt: nil,
+                                      emvAuthData: nil,
+                                      wallet: nil,
+                                      network: nil)
     }
 }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import WooFoundation
 
 final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOrchestrating {
     private var invalidated: Bool = false
@@ -14,6 +15,8 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: @escaping () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -30,6 +33,8 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
                                            paymentGatewayAccount: paymentGatewayAccount,
                                            paymentMethodTypes: paymentMethodTypes,
                                            stripeSmallestCurrencyUnitMultiplier: stripeSmallestCurrencyUnitMultiplier,
+                                           countryCode: countryCode,
+                                           terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
                                            channel: channel,
                                            onPreparingReader: onPreparingReader,
                                            onWaitingForInput: onWaitingForInput,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -17,6 +17,8 @@ protocol PaymentCaptureOrchestrating {
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: @escaping () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -72,6 +74,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: @escaping () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -85,7 +89,9 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                                                    onCardInserted: onCardInserted,
                                                    onProcessingMessage: onProcessingMessage,
                                                    onDisplayMessage: onDisplayMessage,
-                                                   onProcessingCompletion: onProcessingCompletion)
+                                                   onProcessingCompletion: onProcessingCompletion,
+                                                   countryCode: countryCode,
+                                                   terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled)
         onPreparingReader()
 
         let parameters = paymentParameters(order: order,
@@ -105,6 +111,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
             siteID: order.siteID,
             orderID: order.orderID,
             parameters: parameters,
+            countryCode: countryCode,
+            terminalPaymentPreparationEnabled: terminalPaymentPreparationEnabled,
             onCardReaderMessage: { event in
                 switch event {
                 case .waitingForInput(let inputMethods):
@@ -146,6 +154,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         let retryPaymentAction = CardPresentPaymentAction.retryPayment(
             siteID: order.siteID,
             orderID: order.orderID,
+            countryCode: handlers.countryCode,
+            terminalPaymentPreparationEnabled: handlers.terminalPaymentPreparationEnabled,
             onCardReaderMessage: { event in
                 switch event {
                 case .waitingForInput(let inputMethods):
@@ -391,5 +401,7 @@ private extension PaymentCaptureOrchestrator {
         let onProcessingMessage: () -> Void
         let onDisplayMessage: (String) -> Void
         let onProcessingCompletion: (PaymentIntent) -> Void
+        let countryCode: CountryCode
+        let terminalPaymentPreparationEnabled: Bool
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -332,6 +332,8 @@ private extension CollectOrderPaymentUseCase {
                     paymentGatewayAccount: paymentGatewayAccount,
                     paymentMethodTypes: self.configuration.paymentMethods,
                     stripeSmallestCurrencyUnitMultiplier: self.configuration.stripeSmallestCurrencyUnitMultiplier,
+                    countryCode: self.configuration.countryCode,
+                    terminalPaymentPreparationEnabled: false,
                     channel: channel,
                     onPreparingReader: { [weak self] in
                         self?.alertsPresenter.present(viewModel: paymentAlerts.preparingReader(onCancel: {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import WooCommerce
 import Yosemite
+import WooFoundation
 
 final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     var mockCollectPaymentHandler: ((_ onPreparingReader: () -> Void,
@@ -16,12 +17,16 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     var spyCollectPaymentGatewayAccount: PaymentGatewayAccount? = nil
     var spyCollectPaymentMethodTypes: [PaymentMethodType]? = nil
     var spyCollectPaymentStripeSmallestCurrencyUnitMultiplier: Decimal? = nil
+    var spyCollectPaymentCountryCode: CountryCode? = nil
+    var spyTerminalPaymentPreparationEnabled: Bool?
     var spyChannel: PaymentChannel? = nil
     func collectPayment(for order: Order,
                         orderTotal: NSDecimalNumber,
                         paymentGatewayAccount: PaymentGatewayAccount,
                         paymentMethodTypes: [PaymentMethodType],
                         stripeSmallestCurrencyUnitMultiplier: Decimal,
+                        countryCode: CountryCode,
+                        terminalPaymentPreparationEnabled: Bool,
                         channel: PaymentChannel,
                         onPreparingReader: () -> Void,
                         onWaitingForInput: @escaping (CardReaderInput) -> Void,
@@ -35,6 +40,8 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         spyCollectPaymentGatewayAccount = paymentGatewayAccount
         spyCollectPaymentMethodTypes = paymentMethodTypes
         spyCollectPaymentStripeSmallestCurrencyUnitMultiplier = stripeSmallestCurrencyUnitMultiplier
+        spyCollectPaymentCountryCode = countryCode
+        spyTerminalPaymentPreparationEnabled = terminalPaymentPreparationEnabled
         spyChannel = channel
 
         mockCollectPaymentHandler?(onPreparingReader,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/PaymentCaptureOrchestratorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Yosemite
+import WooFoundation
 @testable import WooCommerce
 
 final class PaymentCaptureOrchestratorTests: XCTestCase {
@@ -34,7 +35,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let paymentSiteID = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(siteID, _, _, _, _, _) = action {
+                if case let .collectPayment(siteID, _, _, _, _, _, _, _) = action {
                     promise(siteID)
                 }
             }
@@ -45,6 +46,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: PaymentGatewayAccount.fake(),
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -67,7 +70,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let paymentOrderID = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, orderID, _, _, _, _) = action {
+                if case let .collectPayment(_, orderID, _, _, _, _, _, _) = action {
                     promise(orderID)
                 }
             }
@@ -78,6 +81,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: PaymentGatewayAccount.fake(),
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -90,6 +95,76 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
 
         // Then
         assertEqual(9283, paymentOrderID)
+    }
+
+    func test_collect_payment_passes_configured_country_to_payment_action() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let countryCode = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, _, countryCode, _, _, _, _) = action {
+                    promise(countryCode)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: false,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        assertEqual(.AU, countryCode)
+    }
+
+    func test_collect_payment_passes_terminal_payment_preparation_setting_to_payment_action() {
+        // Given
+        let order = Order.fake()
+        let orderTotal: NSDecimalNumber = 150
+
+        // When
+        let terminalPaymentPreparationEnabled = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
+                if case let .collectPayment(_, _, _, _, terminalPaymentPreparationEnabled, _, _, _) = action {
+                    promise(terminalPaymentPreparationEnabled)
+                }
+            }
+
+            self.sut.collectPayment(
+                for: order,
+                orderTotal: orderTotal,
+                paymentGatewayAccount: PaymentGatewayAccount.fake(),
+                paymentMethodTypes: [.cardPresent],
+                stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .AU,
+                terminalPaymentPreparationEnabled: true,
+                channel: .storeManagement,
+                onPreparingReader: {},
+                onWaitingForInput: { _ in },
+                onCardInserted: {},
+                onProcessingMessage: {},
+                onDisplayMessage: { _ in },
+                onProcessingCompletion: { _ in },
+                onCompletion: { _ in })
+        }
+
+        // Then
+        XCTAssertTrue(terminalPaymentPreparationEnabled)
     }
 
     func test_collect_payment_starts_payment_with_valid_parameters() {
@@ -108,7 +183,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let paymentParameters = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
                     promise(parameters)
                 }
             }
@@ -119,6 +194,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: PaymentGatewayAccount.fake(),
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -163,7 +240,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let parameters: PaymentParameters = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
                     promise(parameters)
                 }
             }
@@ -174,6 +251,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: account,
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .US,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },
@@ -201,7 +280,7 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
         // When
         let parameters: PaymentParameters = waitFor { promise in
             self.stores.whenReceivingAction(ofType: CardPresentPaymentAction.self) { action in
-                if case let .collectPayment(_, _, parameters, _, _, _) = action {
+                if case let .collectPayment(_, _, parameters, _, _, _, _, _) = action {
                     promise(parameters)
                 }
             }
@@ -212,6 +291,8 @@ final class PaymentCaptureOrchestratorTests: XCTestCase {
                 paymentGatewayAccount: account,
                 paymentMethodTypes: [.cardPresent],
                 stripeSmallestCurrencyUnitMultiplier: 100,
+                countryCode: .CA,
+                terminalPaymentPreparationEnabled: false,
                 channel: .storeManagement,
                 onPreparingReader: {},
                 onWaitingForInput: { _ in },


### PR DESCRIPTION
Part of: RSM-642

## Description
This is PR 2 of 6 in the WooPayments AU card-present stack, based on `rsm-642-ios-terminal-prep-foundation`.

This PR adds the logic for preparing a terminal payment after collection and before confirmation. It also adds the cancellation path used when preparation fails, so the reader/payment session can recover cleanly.

We do this `prepare` step so that the server gets a chance to update the intent before it's captured, for single-step confirmation payment methods (such as eftpos/interac)

## Test Steps

Unit tests should be enough here, save the practical testing for PR6.

## Screenshots
N/A - store/orchestration changes only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
