### PR TITLE
Add per-metric Analytics Hub deep-link handling

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1197,7 +1197,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Widgets
     case widgetTapped = "widget_tapped"
-    case widgetDeepLinkTapped = "widget_deep_link_tapped"
+    case storeStatsWidgetMetricTapped = "store_stats_widget_metric_tapped"
 
     // MARK: Application password Events
     case applicationPasswordsNewPasswordCreated = "application_passwords_new_password_created"

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1197,6 +1197,7 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Widgets
     case widgetTapped = "widget_tapped"
+    case widgetDeepLinkTapped = "widget_deep_link_tapped"
 
     // MARK: Application password Events
     case applicationPasswordsNewPasswordCreated = "application_passwords_new_password_created"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -2688,6 +2688,28 @@ extension WooAnalyticsEvent {
             }
             return WooAnalyticsEvent(statName: .widgetTapped, properties: properties)
         }
+
+        /// Event fired when a Store Stats widget metric cell deep link reaches the host app.
+        ///
+        /// `metric` / `range` carry the raw query values straight from the URL — including
+        /// unknown values — so we can observe widget→app contract drift without losing the
+        /// tap event when one side ships a value the other hasn't learned yet.
+        ///
+        static func deepLinkTapped(metric: String?, range: String?) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [:]
+            if let metric {
+                properties[DeepLinkKey.metric.rawValue] = metric
+            }
+            if let range {
+                properties[DeepLinkKey.range.rawValue] = range
+            }
+            return WooAnalyticsEvent(statName: .widgetDeepLinkTapped, properties: properties)
+        }
+
+        enum DeepLinkKey: String {
+            case metric
+            case range
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -2689,24 +2689,25 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .widgetTapped, properties: properties)
         }
 
-        /// Event fired when a Store Stats widget metric cell deep link reaches the host app.
+        /// Event fired when a Store Stats widget metric cell deep link reaches the host app
+        /// and the URL's `source` parameter identifies the Store Stats widget as the producer.
         ///
         /// `metric` / `range` carry the raw query values straight from the URL — including
         /// unknown values — so we can observe widget→app contract drift without losing the
         /// tap event when one side ships a value the other hasn't learned yet.
         ///
-        static func deepLinkTapped(metric: String?, range: String?) -> WooAnalyticsEvent {
+        static func storeStatsWidgetMetricTapped(metric: String?, range: String?) -> WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [:]
             if let metric {
-                properties[DeepLinkKey.metric.rawValue] = metric
+                properties[StoreStatsWidgetKey.metric.rawValue] = metric
             }
             if let range {
-                properties[DeepLinkKey.range.rawValue] = range
+                properties[StoreStatsWidgetKey.range.rawValue] = range
             }
-            return WooAnalyticsEvent(statName: .widgetDeepLinkTapped, properties: properties)
+            return WooAnalyticsEvent(statName: .storeStatsWidgetMetricTapped, properties: properties)
         }
 
-        enum DeepLinkKey: String {
+        enum StoreStatsWidgetKey: String {
             case metric
             case range
         }

--- a/WooCommerce/Classes/Destinations/AnalyticsHubDestination.swift
+++ b/WooCommerce/Classes/Destinations/AnalyticsHubDestination.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Yosemite
+
+/// Destinations the Analytics Hub deep link route can dispatch.
+///
+/// `focusedCard` opens the hub showing a single card at the requested time range — the
+/// shape produced by Store Stats widget metric cells. `defaultHub` opens the hub at its
+/// default state and is used when the deep link arrives without resolvable parameters.
+///
+enum AnalyticsHubDestination: DeepLinkDestinationProtocol {
+    case focusedCard(card: AnalyticsCard.CardType,
+                     range: AnalyticsHubTimeRangeSelection.SelectionType)
+    case defaultHub
+}

--- a/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Yosemite
+import protocol WooFoundation.Analytics
+
+/// Handles `woocommerce.com/mobile/analytics?metric=<rawValue>&range=<rawValue>`, the deep
+/// link emitted by Store Stats widget metric cells. Maps to a focused Analytics Hub card
+/// when both parameters parse, otherwise falls back to opening the hub at its default state.
+///
+struct ReportsRoute: Route {
+    private let deepLinkNavigator: DeepLinkNavigator
+    private let analytics: Analytics
+
+    init(deepLinkNavigator: DeepLinkNavigator,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.deepLinkNavigator = deepLinkNavigator
+        self.analytics = analytics
+    }
+
+    func canHandle(subPath: String) -> Bool {
+        subPath == Constants.analyticsRoot
+    }
+
+    func perform(for subPath: String, with parameters: [String: String]) -> Bool {
+        guard subPath == Constants.analyticsRoot else { return false }
+
+        let metricRaw = parameters[Constants.metricQueryKey]
+        let rangeRaw = parameters[Constants.rangeQueryKey]
+
+        let destination: AnalyticsHubDestination = {
+            guard let card = metricRaw.flatMap(WidgetMetricMapping.cardType(forMetricRawValue:)),
+                  let range = rangeRaw.flatMap(WidgetMetricMapping.selectionType(forRangeRawValue:)) else {
+                return .defaultHub
+            }
+            return .focusedCard(card: card, range: range)
+        }()
+
+        analytics.track(event: .Widgets.deepLinkTapped(metric: metricRaw, range: rangeRaw))
+
+        deepLinkNavigator.navigate(to: destination)
+        return true
+    }
+}
+
+private extension ReportsRoute {
+    enum Constants {
+        static let analyticsRoot = "analytics"
+        static let metricQueryKey = "metric"
+        static let rangeQueryKey = "range"
+    }
+}
+
+/// Maps the widget-side stable raw values (`StoreInfoMetricType`, `StoreStatsWidgetDateRange`)
+/// onto the in-app Analytics Hub types. The widget targets exclude these app types and the
+/// app target excludes the widget enums, so the raw-value strings are the contract that
+/// crosses the boundary and must stay in sync with the widget definitions.
+///
+enum WidgetMetricMapping {
+    /// Mirrors `StoreInfoMetricType` raw values defined in `WooCommerce/StoreWidgets/StoreInfoMetricType.swift`.
+    /// Sub-card granularity (e.g. Total Sales vs. Net Sales within the Revenue card) is not
+    /// modelled — both fall through to `.revenue` and the user reads the right cell visually.
+    ///
+    static func cardType(forMetricRawValue rawValue: String) -> AnalyticsCard.CardType? {
+        switch rawValue {
+        case "revenue", "netSales":
+            return .revenue
+        case "orders", "averageOrderValue":
+            return .orders
+        case "itemsSold":
+            return .products
+        case "visitors", "conversion":
+            return .sessions
+        default:
+            return nil
+        }
+    }
+
+    /// Mirrors `StoreStatsWidgetDateRange` raw values defined in
+    /// `WooCommerce/StoreWidgets/StoreStatsWidgetDateRange.swift`. Cases were chosen 1:1 with
+    /// `AnalyticsHubTimeRangeSelection.SelectionType` so the mapping is mechanical.
+    ///
+    static func selectionType(forRangeRawValue rawValue: String) -> AnalyticsHubTimeRangeSelection.SelectionType? {
+        switch rawValue {
+        case "today": return .today
+        case "yesterday": return .yesterday
+        case "lastWeek": return .lastWeek
+        case "lastMonth": return .lastMonth
+        case "weekToDate": return .weekToDate
+        case "monthToDate": return .monthToDate
+        default: return nil
+        }
+    }
+}

--- a/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
@@ -25,6 +25,7 @@ struct ReportsRoute: Route {
 
         let metricRaw = parameters[Constants.metricQueryKey]
         let rangeRaw = parameters[Constants.rangeQueryKey]
+        let sourceRaw = parameters[Constants.sourceQueryKey]
 
         let destination: AnalyticsHubDestination = {
             guard let card = metricRaw.flatMap(WidgetMetricMapping.cardType(forMetricRawValue:)),
@@ -34,7 +35,9 @@ struct ReportsRoute: Route {
             return .focusedCard(card: card, range: range)
         }()
 
-        analytics.track(event: .Widgets.deepLinkTapped(metric: metricRaw, range: rangeRaw))
+        if sourceRaw == Constants.storeInfoWidgetSource {
+            analytics.track(event: .Widgets.storeStatsWidgetMetricTapped(metric: metricRaw, range: rangeRaw))
+        }
 
         deepLinkNavigator.navigate(to: destination)
         return true
@@ -46,6 +49,10 @@ private extension ReportsRoute {
         static let analyticsRoot = "analytics"
         static let metricQueryKey = "metric"
         static let rangeQueryKey = "range"
+        static let sourceQueryKey = "source"
+        /// Mirrors `WidgetReportsURL.Constants.sourceValue` — the wire-format identifier the
+        /// Store Info widget stamps onto its deep links so the route can attribute the tap.
+        static let storeInfoWidgetSource = "store-info-widget"
     }
 }
 

--- a/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
@@ -44,6 +44,12 @@ struct ReportsRoute: Route {
     }
 }
 
+/// Wire-format contract for the deep link consumed here. Duplicated from
+/// `WidgetReportsURL.Constants` (`WooCommerce/StoreWidgets/WidgetReportsURL.swift`) because
+/// the WooCommerce target and the StoreWidgetsExtension target sync separate source roots
+/// (`Classes/` and `StoreWidgets/` respectively) and share no compilable folder. Any change
+/// here MUST be mirrored in `WidgetReportsURL.Constants` and the corresponding tests on
+/// both sides.
 private extension ReportsRoute {
     enum Constants {
         static let analyticsRoot = "analytics"

--- a/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift
@@ -17,15 +17,15 @@ struct ReportsRoute: Route {
     }
 
     func canHandle(subPath: String) -> Bool {
-        subPath == Constants.analyticsRoot
+        subPath == StoreMetricsReportRoute.subpath
     }
 
     func perform(for subPath: String, with parameters: [String: String]) -> Bool {
-        guard subPath == Constants.analyticsRoot else { return false }
+        guard subPath == StoreMetricsReportRoute.subpath else { return false }
 
-        let metricRaw = parameters[Constants.metricQueryKey]
-        let rangeRaw = parameters[Constants.rangeQueryKey]
-        let sourceRaw = parameters[Constants.sourceQueryKey]
+        let metricRaw = parameters[StoreMetricsReportRoute.QueryKey.metric]
+        let rangeRaw = parameters[StoreMetricsReportRoute.QueryKey.range]
+        let sourceRaw = parameters[StoreMetricsReportRoute.QueryKey.source]
 
         let destination: AnalyticsHubDestination = {
             guard let card = metricRaw.flatMap(WidgetMetricMapping.cardType(forMetricRawValue:)),
@@ -35,30 +35,12 @@ struct ReportsRoute: Route {
             return .focusedCard(card: card, range: range)
         }()
 
-        if sourceRaw == Constants.storeInfoWidgetSource {
+        if sourceRaw == StoreMetricsReportRoute.Source.storeInfoWidget {
             analytics.track(event: .Widgets.storeStatsWidgetMetricTapped(metric: metricRaw, range: rangeRaw))
         }
 
         deepLinkNavigator.navigate(to: destination)
         return true
-    }
-}
-
-/// Wire-format contract for the deep link consumed here. Duplicated from
-/// `WidgetReportsURL.Constants` (`WooCommerce/StoreWidgets/WidgetReportsURL.swift`) because
-/// the WooCommerce target and the StoreWidgetsExtension target sync separate source roots
-/// (`Classes/` and `StoreWidgets/` respectively) and share no compilable folder. Any change
-/// here MUST be mirrored in `WidgetReportsURL.Constants` and the corresponding tests on
-/// both sides.
-private extension ReportsRoute {
-    enum Constants {
-        static let analyticsRoot = "analytics"
-        static let metricQueryKey = "metric"
-        static let rangeQueryKey = "range"
-        static let sourceQueryKey = "source"
-        /// Mirrors `WidgetReportsURL.Constants.sourceValue` — the wire-format identifier the
-        /// Store Info widget stamps onto its deep links so the route can attribute the tap.
-        static let storeInfoWidgetSource = "store-info-widget"
     }
 }
 

--- a/WooCommerce/Classes/Universal Links/Routes/StoreMetricsReportRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/StoreMetricsReportRoute.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Wire-format contract for the Store Stats widget metric deep link. Single source of
+/// truth for the URL the widget emits (`WidgetReportsURL`) and the host app's
+/// `ReportsRoute` consumes.
+///
+/// This file must be a member of both the `WooCommerce` app target (consumer side) and
+/// the `StoreWidgetsExtension` target (producer side). The two targets sync different
+/// source roots and don't share a synced folder, so target membership is set explicitly
+/// in the project file.
+///
+enum StoreMetricsReportRoute {
+    static let scheme = "https"
+    static let host = "woocommerce.com"
+    static let path = "/mobile/analytics"
+    /// Path segment that `UniversalLinkRouter` matches against after stripping the
+    /// `/mobile/` prefix — i.e. the value `Route.canHandle(subPath:)` receives.
+    static let subpath = "analytics"
+
+    enum QueryKey {
+        static let metric = "metric"
+        static let range = "range"
+        static let source = "source"
+    }
+
+    enum Source {
+        /// Stamped by the Store Info widget cells so the route can attribute the tap to
+        /// this widget if another caller ever produces the same URL shape. Mirrors
+        /// `WooConstants.storeInfoWidgetKind` as a URL-friendly slug.
+        static let storeInfoWidget = "store-info-widget"
+    }
+}

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -62,7 +62,8 @@ struct UniversalLinkRouter {
         }
         return routes + [PaymentsRoute(deepLinkNavigator: navigator),
                          OrdersRoute(deepLinkNavigator: navigator),
-                         POSRoute(deepLinkNavigator: navigator)]
+                         POSRoute(deepLinkNavigator: navigator),
+                         ReportsRoute(deepLinkNavigator: navigator)]
     }
 
     func handle(url: URL) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -20,12 +20,34 @@ final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubV
     /// Coordinator to handle Google Ads campaign creation.
     private var googleAdsCampaignCoordinator: GoogleAdsCampaignCoordinator?
 
+    convenience init(siteID: Int64,
+                     timeZone: TimeZone,
+                     timeRange: StatsTimeRangeV4,
+                     systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+                     usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
+        self.init(siteID: siteID,
+                  timeZone: timeZone,
+                  selectionType: AnalyticsHubTimeRangeSelection.SelectionType(timeRange),
+                  focusedCard: nil,
+                  systemNoticePresenter: systemNoticePresenter,
+                  usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+
+    /// Initializes the hub in either default or focused-card mode. The Analytics Hub time-range
+    /// selection is richer than `StatsTimeRangeV4` (it can express e.g. `lastWeek`,
+    /// `weekToDate`), so widget deep links route through this initializer.
+    ///
     init(siteID: Int64,
          timeZone: TimeZone,
-         timeRange: StatsTimeRangeV4,
+         selectionType: AnalyticsHubTimeRangeSelection.SelectionType,
+         focusedCard: AnalyticsCard.CardType? = nil,
          systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
-        self.viewModel = AnalyticsHubViewModel(siteID: siteID, timeZone: timeZone, statsTimeRange: timeRange, usageTracksEventEmitter: usageTracksEventEmitter)
+        self.viewModel = AnalyticsHubViewModel(siteID: siteID,
+                                               timeZone: timeZone,
+                                               selectionType: selectionType,
+                                               focusedCard: focusedCard,
+                                               usageTracksEventEmitter: usageTracksEventEmitter)
         self.systemNoticePresenter = systemNoticePresenter
         super.init(rootView: AnalyticsHubView(viewModel: self.viewModel))
 
@@ -151,11 +173,13 @@ struct AnalyticsHubView: View {
             })
         )
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    viewModel.customizeAnalytics()
-                } label: {
-                    Text(Localization.editButton)
+            if !viewModel.isFocusedCardMode {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewModel.customizeAnalytics()
+                    } label: {
+                        Text(Localization.editButton)
+                    }
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -26,15 +26,38 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     private let userIsAdmin: Bool
 
+    /// When non-nil, the hub renders a single card (e.g. when opened via a widget metric
+    /// deep link). Edit toolbar, customisation persistence, and multi-card fetches are
+    /// suppressed in this mode.
+    ///
+    private let focusedCard: AnalyticsCard.CardType?
+
+    convenience init(siteID: Int64,
+                     timeZone: TimeZone = .siteTimezone,
+                     statsTimeRange: StatsTimeRangeV4,
+                     usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
+                     stores: StoresManager = ServiceLocator.stores,
+                     storage: StorageManagerType = ServiceLocator.storageManager,
+                     analytics: Analytics = ServiceLocator.analytics) {
+        self.init(siteID: siteID,
+                  timeZone: timeZone,
+                  selectionType: AnalyticsHubTimeRangeSelection.SelectionType(statsTimeRange),
+                  focusedCard: nil,
+                  usageTracksEventEmitter: usageTracksEventEmitter,
+                  stores: stores,
+                  storage: storage,
+                  analytics: analytics)
+    }
+
     init(siteID: Int64,
          timeZone: TimeZone = .siteTimezone,
-         statsTimeRange: StatsTimeRangeV4,
+         selectionType: AnalyticsHubTimeRangeSelection.SelectionType,
+         focusedCard: AnalyticsCard.CardType? = nil,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics) {
-        let selectedType = AnalyticsHubTimeRangeSelection.SelectionType(statsTimeRange)
-        let timeRangeSelection = AnalyticsHubTimeRangeSelection(selectionType: selectedType, timezone: timeZone)
+        let timeRangeSelection = AnalyticsHubTimeRangeSelection(selectionType: selectionType, timezone: timeZone)
 
         self.siteID = siteID
         self.timeZone = timeZone
@@ -42,7 +65,8 @@ final class AnalyticsHubViewModel: ObservableObject {
         self.storage = storage
         self.userIsAdmin = stores.sessionManager.defaultRoles.contains(.administrator)
         self.analytics = analytics
-        self.timeRangeSelectionType = selectedType
+        self.focusedCard = focusedCard
+        self.timeRangeSelectionType = selectionType
         self.timeRangeSelection = timeRangeSelection
         self.timeRangeCard = AnalyticsHubViewModel.timeRangeCard(timeRangeSelection: timeRangeSelection,
                                                                  usageTracksEventEmitter: usageTracksEventEmitter,
@@ -50,11 +74,18 @@ final class AnalyticsHubViewModel: ObservableObject {
         self.usageTracksEventEmitter = usageTracksEventEmitter
 
         self.googleCampaignsCard = GoogleAdsCampaignReportCardViewModel(siteID: siteID,
-                                                                        timeRange: selectedType,
+                                                                        timeRange: selectionType,
                                                                         usageTracksEventEmitter: usageTracksEventEmitter)
 
         bindViewModelsWithData()
         bindCardSettingsWithData()
+    }
+
+    /// Whether the hub is rendering a single focused card. Used by the view to gate the
+    /// Edit toolbar item and skip card-settings loading.
+    ///
+    var isFocusedCardMode: Bool {
+        focusedCard != nil
     }
 
     // MARK: View Models
@@ -152,6 +183,9 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// All analytics cards to display in the Analytics Hub.
     ///
     var enabledCards: [AnalyticsCard.CardType] {
+        if let focusedCard {
+            return canDisplayCard(ofType: focusedCard) ? [focusedCard] : []
+        }
         return allCardsWithSettings.compactMap { card in
             guard card.enabled, canDisplayCard(ofType: card.type) else {
                 return nil
@@ -656,6 +690,9 @@ extension AnalyticsHubViewModel {
     ///
     @MainActor
     func loadAnalyticsCardSettings() async {
+        // In focused-card mode we render a single card and don't touch persisted customisation.
+        guard focusedCard == nil else { return }
+
         let storedCards = await withCheckedContinuation { continuation in
             let action = AppSettingsAction.loadAnalyticsHubCards(siteID: siteID) { cards in
                 continuation.resume(returning: cards)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -723,11 +723,37 @@ extension MainTabBarController: DeepLinkNavigator {
             navigateTo(.orders) {
                 Self.ordersTabSplitViewWrapper()?.navigate(to: destination)
             }
+        case let analyticsDestination as AnalyticsHubDestination:
+            navigateTo(.myStore) { [weak self] in
+                self?.presentAnalyticsHub(for: analyticsDestination)
+            }
         case is POSPromotionDestination:
             presentPOSPromotionModal()
         default:
             return
         }
+    }
+
+    private func presentAnalyticsHub(for destination: AnalyticsHubDestination) {
+        let analyticsHubVC: AnalyticsHubHostingViewController
+        switch destination {
+        case .focusedCard(let card, let range):
+            analyticsHubVC = AnalyticsHubHostingViewController(
+                siteID: stores.sessionManager.defaultStoreID ?? 0,
+                timeZone: .siteTimezone,
+                selectionType: range,
+                focusedCard: card,
+                usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()
+            )
+        case .defaultHub:
+            analyticsHubVC = AnalyticsHubHostingViewController(
+                siteID: stores.sessionManager.defaultStoreID ?? 0,
+                timeZone: .siteTimezone,
+                timeRange: .today,
+                usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()
+            )
+        }
+        dashboardNavigationController.pushViewController(analyticsHubVC, animated: true)
     }
 
     private func presentPOSPromotionModal() {

--- a/WooCommerce/StoreWidgets/WidgetReportsURL.swift
+++ b/WooCommerce/StoreWidgets/WidgetReportsURL.swift
@@ -4,6 +4,13 @@ import Foundation
 /// the deep link a widget metric cell opens when tapped. The `source` parameter lets the
 /// host-app route attribute the tap to this widget if another caller ever produces the
 /// same URL shape (e.g. an in-app banner or a marketing link).
+///
+/// The string constants below are the wire-format contract shared with the host app's
+/// `ReportsRoute` (`WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift`). They
+/// are duplicated rather than referenced because the WooCommerce target and the
+/// StoreWidgetsExtension target sync separate source roots (`Classes/` and `StoreWidgets/`
+/// respectively) and share no compilable folder. Any change here MUST be mirrored in
+/// `ReportsRoute.Constants` and the corresponding tests on both sides.
 enum WidgetReportsURL {
     static func url(for metric: StoreInfoMetricType, range: StoreStatsWidgetDateRange) -> URL? {
         var components = URLComponents()
@@ -25,9 +32,8 @@ enum WidgetReportsURL {
         static let metricQueryKey = "metric"
         static let rangeQueryKey = "range"
         static let sourceQueryKey = "source"
-        /// Mirrors `WooConstants.storeInfoWidgetKind` as a URL-friendly slug. Kept in sync
-        /// with the host-app route via the wire-format string contract (the constant lives
-        /// in the main app target, excluded from this widget extension).
+        /// Mirrors `WooConstants.storeInfoWidgetKind` as a URL-friendly slug, and is mirrored
+        /// in `ReportsRoute.Constants.storeInfoWidgetSource` on the host-app side.
         static let sourceValue = "store-info-widget"
     }
 }

--- a/WooCommerce/StoreWidgets/WidgetReportsURL.swift
+++ b/WooCommerce/StoreWidgets/WidgetReportsURL.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-/// Builds `https://woocommerce.com/mobile/analytics?metric=<rawValue>&range=<rawValue>` —
-/// the deep link a widget metric cell opens when tapped.
+/// Builds `https://woocommerce.com/mobile/analytics?metric=<rawValue>&range=<rawValue>&source=store-info-widget` —
+/// the deep link a widget metric cell opens when tapped. The `source` parameter lets the
+/// host-app route attribute the tap to this widget if another caller ever produces the
+/// same URL shape (e.g. an in-app banner or a marketing link).
 enum WidgetReportsURL {
     static func url(for metric: StoreInfoMetricType, range: StoreStatsWidgetDateRange) -> URL? {
         var components = URLComponents()
@@ -10,7 +12,8 @@ enum WidgetReportsURL {
         components.path = Constants.path
         components.queryItems = [
             URLQueryItem(name: Constants.metricQueryKey, value: metric.rawValue),
-            URLQueryItem(name: Constants.rangeQueryKey, value: range.rawValue)
+            URLQueryItem(name: Constants.rangeQueryKey, value: range.rawValue),
+            URLQueryItem(name: Constants.sourceQueryKey, value: Constants.sourceValue)
         ]
         return components.url
     }
@@ -21,5 +24,10 @@ enum WidgetReportsURL {
         static let path = "/mobile/analytics"
         static let metricQueryKey = "metric"
         static let rangeQueryKey = "range"
+        static let sourceQueryKey = "source"
+        /// Mirrors `WooConstants.storeInfoWidgetKind` as a URL-friendly slug. Kept in sync
+        /// with the host-app route via the wire-format string contract (the constant lives
+        /// in the main app target, excluded from this widget extension).
+        static let sourceValue = "store-info-widget"
     }
 }

--- a/WooCommerce/StoreWidgets/WidgetReportsURL.swift
+++ b/WooCommerce/StoreWidgets/WidgetReportsURL.swift
@@ -1,39 +1,20 @@
 import Foundation
 
 /// Builds `https://woocommerce.com/mobile/analytics?metric=<rawValue>&range=<rawValue>&source=store-info-widget` —
-/// the deep link a widget metric cell opens when tapped. The `source` parameter lets the
-/// host-app route attribute the tap to this widget if another caller ever produces the
-/// same URL shape (e.g. an in-app banner or a marketing link).
-///
-/// The string constants below are the wire-format contract shared with the host app's
-/// `ReportsRoute` (`WooCommerce/Classes/Universal Links/Routes/ReportsRoute.swift`). They
-/// are duplicated rather than referenced because the WooCommerce target and the
-/// StoreWidgetsExtension target sync separate source roots (`Classes/` and `StoreWidgets/`
-/// respectively) and share no compilable folder. Any change here MUST be mirrored in
-/// `ReportsRoute.Constants` and the corresponding tests on both sides.
+/// the deep link a widget metric cell opens when tapped. URL shape is owned by
+/// `StoreMetricsReportRoute`, the cross-target contract shared with the host app's
+/// `ReportsRoute`.
 enum WidgetReportsURL {
     static func url(for metric: StoreInfoMetricType, range: StoreStatsWidgetDateRange) -> URL? {
         var components = URLComponents()
-        components.scheme = Constants.scheme
-        components.host = Constants.host
-        components.path = Constants.path
+        components.scheme = StoreMetricsReportRoute.scheme
+        components.host = StoreMetricsReportRoute.host
+        components.path = StoreMetricsReportRoute.path
         components.queryItems = [
-            URLQueryItem(name: Constants.metricQueryKey, value: metric.rawValue),
-            URLQueryItem(name: Constants.rangeQueryKey, value: range.rawValue),
-            URLQueryItem(name: Constants.sourceQueryKey, value: Constants.sourceValue)
+            URLQueryItem(name: StoreMetricsReportRoute.QueryKey.metric, value: metric.rawValue),
+            URLQueryItem(name: StoreMetricsReportRoute.QueryKey.range, value: range.rawValue),
+            URLQueryItem(name: StoreMetricsReportRoute.QueryKey.source, value: StoreMetricsReportRoute.Source.storeInfoWidget)
         ]
         return components.url
-    }
-
-    enum Constants {
-        static let scheme = "https"
-        static let host = "woocommerce.com"
-        static let path = "/mobile/analytics"
-        static let metricQueryKey = "metric"
-        static let rangeQueryKey = "range"
-        static let sourceQueryKey = "source"
-        /// Mirrors `WooConstants.storeInfoWidgetKind` as a URL-friendly slug, and is mirrored
-        /// in `ReportsRoute.Constants.storeInfoWidgetSource` on the host-app side.
-        static let sourceValue = "store-info-widget"
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 				Tools/AppLocalizedString.swift,
 				Tools/StoreWidgets/WidgetSite.swift,
 				Tools/StoreWidgets/WidgetSiteListStore.swift,
+				"Universal Links/Routes/StoreMetricsReportRoute.swift",
 			);
 			target = 3F1FA83F28B60125009E246C /* StoreWidgetsExtension */;
 		};

--- a/WooCommerce/WooCommerceTests/StoreWidgets/WidgetReportsURLTests.swift
+++ b/WooCommerce/WooCommerceTests/StoreWidgets/WidgetReportsURLTests.swift
@@ -35,6 +35,16 @@ struct WidgetReportsURLTests {
         #expect(rangeItem?.value == "monthToDate")
     }
 
+    @Test func url_whenBuilt_thenStampsStoreInfoWidgetAsSource() throws {
+        // Given / When
+        let url = try #require(WidgetReportsURL.url(for: .revenue, range: .today))
+
+        // Then
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let sourceItem = components.queryItems?.first(where: { $0.name == "source" })
+        #expect(sourceItem?.value == "store-info-widget")
+    }
+
     @Test func url_whenAllRangesBuilt_thenAllRoundTripCleanly() throws {
         // Given
         let allRanges: [StoreStatsWidgetDateRange] = [.today, .yesterday, .lastWeek, .lastMonth, .weekToDate, .monthToDate]

--- a/WooCommerce/WooCommerceTests/Universal Links/Routes/ReportsRouteTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/Routes/ReportsRouteTests.swift
@@ -146,7 +146,38 @@ struct ReportsRouteTests {
     }
 
     @Test
-    func test_performAction_tracks_widget_deep_link_tapped_with_raw_query_values() {
+    func test_performAction_when_source_is_store_info_widget_then_tracks_store_stats_widget_metric_tapped() {
+        // Given
+        let analytics = SpyAnalytics()
+        let sut = ReportsRoute(deepLinkNavigator: MockDeepLinkNavigator(), analytics: analytics)
+
+        // When
+        _ = sut.perform(for: "analytics", with: ["metric": "revenue", "range": "today", "source": "store-info-widget"])
+
+        // Then
+        let event = analytics.trackedEvents.first(where: { $0.name == "store_stats_widget_metric_tapped" })
+        #expect(event != nil)
+        #expect(event?.properties?["metric"] as? String == "revenue")
+        #expect(event?.properties?["range"] as? String == "today")
+    }
+
+    @Test
+    func test_performAction_when_source_is_store_info_widget_then_tracks_event_even_with_unknown_metric_and_range() {
+        // Given
+        let analytics = SpyAnalytics()
+        let sut = ReportsRoute(deepLinkNavigator: MockDeepLinkNavigator(), analytics: analytics)
+
+        // When
+        _ = sut.perform(for: "analytics", with: ["metric": "futureMetric", "range": "nextWeek", "source": "store-info-widget"])
+
+        // Then
+        let event = analytics.trackedEvents.first(where: { $0.name == "store_stats_widget_metric_tapped" })
+        #expect(event?.properties?["metric"] as? String == "futureMetric")
+        #expect(event?.properties?["range"] as? String == "nextWeek")
+    }
+
+    @Test
+    func test_performAction_when_source_is_missing_then_does_not_track_widget_event() {
         // Given
         let analytics = SpyAnalytics()
         let sut = ReportsRoute(deepLinkNavigator: MockDeepLinkNavigator(), analytics: analytics)
@@ -155,25 +186,20 @@ struct ReportsRouteTests {
         _ = sut.perform(for: "analytics", with: ["metric": "revenue", "range": "today"])
 
         // Then
-        #expect(analytics.trackedEvents.contains(where: { $0.name == "widget_deep_link_tapped" }))
-        let event = analytics.trackedEvents.first(where: { $0.name == "widget_deep_link_tapped" })
-        #expect(event?.properties?["metric"] as? String == "revenue")
-        #expect(event?.properties?["range"] as? String == "today")
+        #expect(!analytics.trackedEvents.contains(where: { $0.name == "store_stats_widget_metric_tapped" }))
     }
 
     @Test
-    func test_performAction_tracks_widget_deep_link_tapped_even_with_unknown_values() {
+    func test_performAction_when_source_is_unknown_then_does_not_track_widget_event() {
         // Given
         let analytics = SpyAnalytics()
         let sut = ReportsRoute(deepLinkNavigator: MockDeepLinkNavigator(), analytics: analytics)
 
         // When
-        _ = sut.perform(for: "analytics", with: ["metric": "futureMetric", "range": "nextWeek"])
+        _ = sut.perform(for: "analytics", with: ["metric": "revenue", "range": "today", "source": "marketing-email"])
 
         // Then
-        let event = analytics.trackedEvents.first(where: { $0.name == "widget_deep_link_tapped" })
-        #expect(event?.properties?["metric"] as? String == "futureMetric")
-        #expect(event?.properties?["range"] as? String == "nextWeek")
+        #expect(!analytics.trackedEvents.contains(where: { $0.name == "store_stats_widget_metric_tapped" }))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Universal Links/Routes/ReportsRouteTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/Routes/ReportsRouteTests.swift
@@ -1,0 +1,206 @@
+import Testing
+import Foundation
+import protocol WooFoundation.Analytics
+import protocol WooFoundation.AnalyticsProvider
+import Yosemite
+
+@testable import WooCommerce
+
+@Suite(.timeLimit(.minutes(5)))
+struct ReportsRouteTests {
+
+    @Test
+    func test_canHandle_returns_true_for_analytics_subpath() {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When / Then
+        #expect(sut.canHandle(subPath: "analytics"))
+    }
+
+    @Test
+    func test_canHandle_returns_false_for_unrelated_subpath() {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When / Then
+        #expect(!sut.canHandle(subPath: "orders"))
+        #expect(!sut.canHandle(subPath: "analytics/foo"))
+        #expect(!sut.canHandle(subPath: ""))
+    }
+
+    @Test
+    func test_performAction_with_unrecognised_subpath_then_returns_false_and_does_not_navigate() {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When
+        let handled = sut.perform(for: "orders", with: ["metric": "revenue", "range": "today"])
+
+        // Then
+        #expect(handled == false)
+        #expect(navigator.spyDidNavigate == false)
+    }
+
+    @Test(arguments: [
+        ("revenue", AnalyticsCard.CardType.revenue),
+        ("netSales", .revenue),
+        ("orders", .orders),
+        ("averageOrderValue", .orders),
+        ("itemsSold", .products),
+        ("visitors", .sessions),
+        ("conversion", .sessions)
+    ])
+    func test_performAction_with_known_metric_then_navigates_to_matching_focused_card(metric: String,
+                                                                                       expectedCard: AnalyticsCard.CardType) throws {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When
+        let handled = sut.perform(for: "analytics", with: ["metric": metric, "range": "today"])
+
+        // Then
+        #expect(handled)
+        let destination = try #require(navigator.spyNavigatedDestination as? AnalyticsHubDestination)
+        guard case let .focusedCard(card, _) = destination else {
+            Issue.record("Expected focusedCard destination, got \(destination)")
+            return
+        }
+        #expect(card == expectedCard)
+    }
+
+    @Test(arguments: [
+        ("today", AnalyticsHubTimeRangeSelection.SelectionType.today),
+        ("yesterday", .yesterday),
+        ("lastWeek", .lastWeek),
+        ("lastMonth", .lastMonth),
+        ("weekToDate", .weekToDate),
+        ("monthToDate", .monthToDate)
+    ])
+    func test_performAction_with_known_range_then_navigates_with_matching_selection_type(range: String,
+                                                                                         expectedRange: AnalyticsHubTimeRangeSelection.SelectionType) throws {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When
+        let handled = sut.perform(for: "analytics", with: ["metric": "revenue", "range": range])
+
+        // Then
+        #expect(handled)
+        let destination = try #require(navigator.spyNavigatedDestination as? AnalyticsHubDestination)
+        guard case let .focusedCard(_, resolvedRange) = destination else {
+            Issue.record("Expected focusedCard destination, got \(destination)")
+            return
+        }
+        #expect(resolvedRange == expectedRange)
+    }
+
+    @Test
+    func test_performAction_with_no_query_params_then_navigates_to_default_hub() throws {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When
+        let handled = sut.perform(for: "analytics", with: [:])
+
+        // Then
+        #expect(handled)
+        let destination = try #require(navigator.spyNavigatedDestination as? AnalyticsHubDestination)
+        #expect(destination == .defaultHub)
+    }
+
+    @Test
+    func test_performAction_with_unknown_metric_then_navigates_to_default_hub() throws {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When
+        let handled = sut.perform(for: "analytics", with: ["metric": "moonRevenue", "range": "today"])
+
+        // Then
+        #expect(handled)
+        let destination = try #require(navigator.spyNavigatedDestination as? AnalyticsHubDestination)
+        #expect(destination == .defaultHub)
+    }
+
+    @Test
+    func test_performAction_with_unknown_range_then_navigates_to_default_hub() throws {
+        // Given
+        let navigator = MockDeepLinkNavigator()
+        let sut = ReportsRoute(deepLinkNavigator: navigator, analytics: SpyAnalytics())
+
+        // When
+        let handled = sut.perform(for: "analytics", with: ["metric": "revenue", "range": "lastDecade"])
+
+        // Then
+        #expect(handled)
+        let destination = try #require(navigator.spyNavigatedDestination as? AnalyticsHubDestination)
+        #expect(destination == .defaultHub)
+    }
+
+    @Test
+    func test_performAction_tracks_widget_deep_link_tapped_with_raw_query_values() {
+        // Given
+        let analytics = SpyAnalytics()
+        let sut = ReportsRoute(deepLinkNavigator: MockDeepLinkNavigator(), analytics: analytics)
+
+        // When
+        _ = sut.perform(for: "analytics", with: ["metric": "revenue", "range": "today"])
+
+        // Then
+        #expect(analytics.trackedEvents.contains(where: { $0.name == "widget_deep_link_tapped" }))
+        let event = analytics.trackedEvents.first(where: { $0.name == "widget_deep_link_tapped" })
+        #expect(event?.properties?["metric"] as? String == "revenue")
+        #expect(event?.properties?["range"] as? String == "today")
+    }
+
+    @Test
+    func test_performAction_tracks_widget_deep_link_tapped_even_with_unknown_values() {
+        // Given
+        let analytics = SpyAnalytics()
+        let sut = ReportsRoute(deepLinkNavigator: MockDeepLinkNavigator(), analytics: analytics)
+
+        // When
+        _ = sut.perform(for: "analytics", with: ["metric": "futureMetric", "range": "nextWeek"])
+
+        // Then
+        let event = analytics.trackedEvents.first(where: { $0.name == "widget_deep_link_tapped" })
+        #expect(event?.properties?["metric"] as? String == "futureMetric")
+        #expect(event?.properties?["range"] as? String == "nextWeek")
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SpyAnalytics: Analytics {
+    struct TrackedEvent {
+        let name: String
+        let properties: [AnyHashable: Any]?
+    }
+
+    private(set) var trackedEvents: [TrackedEvent] = []
+    var userHasOptedIn: Bool = true
+    let analyticsProvider: AnalyticsProvider = SpyAnalyticsProvider()
+
+    func initialize() {}
+    func track(_ eventName: String, properties: [AnyHashable: Any]?, error: Error?) {
+        trackedEvents.append(TrackedEvent(name: eventName, properties: properties))
+    }
+    func refreshUserData() {}
+    func setUserHasOptedOut(_ optedOut: Bool) { userHasOptedIn = !optedOut }
+}
+
+private final class SpyAnalyticsProvider: AnalyticsProvider {
+    func refreshUserData() {}
+    func track(_ eventName: String) {}
+    func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {}
+    func clearEvents() {}
+    func clearUsers() {}
+}

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -169,13 +169,14 @@ final class UniversalLinkRouterTests: XCTestCase {
         let routes = UniversalLinkRouter.defaultRoutes(navigator: mockNavigator)
 
         // Then
-        assertEqual(5, routes.count)
+        assertEqual(6, routes.count)
 
         XCTAssert(routes.contains { $0 is OrderDetailsRoute })
         XCTAssert(routes.contains { $0 is MyStoreRoute })
         XCTAssert(routes.contains { $0 is PaymentsRoute })
         XCTAssert(routes.contains { $0 is OrdersRoute })
         XCTAssert(routes.contains { $0 is POSRoute })
+        XCTAssert(routes.contains { $0 is ReportsRoute })
     }
 
     func test_canHandle_returns_false_for_magic_link_url() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -567,10 +567,83 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     }
 }
 
+// MARK: - Focused-card mode
+
+extension AnalyticsHubViewModelTests {
+
+    func test_enabledCards_when_focusedCard_is_set_then_returns_only_that_card() {
+        // Given
+        let vm = createFocusedViewModel(focusedCard: .revenue)
+
+        // Then
+        XCTAssertEqual(vm.enabledCards, [.revenue])
+    }
+
+    func test_isFocusedCardMode_when_focusedCard_is_set_then_returns_true() {
+        // Given
+        let vm = createFocusedViewModel(focusedCard: .orders)
+
+        // Then
+        XCTAssertTrue(vm.isFocusedCardMode)
+    }
+
+    func test_isFocusedCardMode_when_focusedCard_is_nil_then_returns_false() {
+        // Given
+        let vm = createViewModel()
+
+        // Then
+        XCTAssertFalse(vm.isFocusedCardMode)
+    }
+
+    func test_enabledCards_when_focusedCard_is_unsupported_on_store_then_returns_empty() {
+        // Given – JCP store cannot display the sessions card
+        let jcpStores = MockStoresManager(sessionManager: .makeForTesting(
+            authenticated: true,
+            defaultSite: .fake().copy(isJetpackThePluginInstalled: false, isJetpackConnected: true)))
+        let vm = createFocusedViewModel(focusedCard: .sessions, stores: jcpStores)
+
+        // Then
+        XCTAssertTrue(vm.enabledCards.isEmpty)
+    }
+
+    @MainActor
+    func test_loadAnalyticsCardSettings_when_focusedCard_is_set_then_does_not_dispatch_load_action() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(adminURL: sampleAdminURL)))
+        var dispatchedLoad = false
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            if case .loadAnalyticsHubCards = action {
+                dispatchedLoad = true
+            }
+        }
+        let vm = createFocusedViewModel(focusedCard: .revenue, stores: stores)
+
+        // When
+        await vm.loadAnalyticsCardSettings()
+
+        // Then
+        XCTAssertFalse(dispatchedLoad)
+        XCTAssertEqual(vm.enabledCards, [.revenue])
+    }
+}
+
 private extension AnalyticsHubViewModelTests {
     func createViewModel(stores: MockStoresManager? = nil, storage: MockStorageManager? = nil) -> AnalyticsHubViewModel {
         AnalyticsHubViewModel(siteID: sampleSiteID,
                               statsTimeRange: .thisMonth,
+                              usageTracksEventEmitter: eventEmitter,
+                              stores: stores ?? self.stores,
+                              storage: storage ?? MockStorageManager(),
+                              analytics: analytics)
+    }
+
+    func createFocusedViewModel(focusedCard: AnalyticsCard.CardType,
+                                selectionType: AnalyticsHubTimeRangeSelection.SelectionType = .today,
+                                stores: MockStoresManager? = nil,
+                                storage: MockStorageManager? = nil) -> AnalyticsHubViewModel {
+        AnalyticsHubViewModel(siteID: sampleSiteID,
+                              selectionType: selectionType,
+                              focusedCard: focusedCard,
                               usageTracksEventEmitter: eventEmitter,
                               stores: stores ?? self.stores,
                               storage: storage ?? MockStorageManager(),


### PR DESCRIPTION
## Description
WOOMOB-2823, WOOMOB-2827

Wires up the host-app side of the widget metric deep links shipped on the parent branch. A widget metric tap now opens the Analytics Hub focused on the corresponding card at the requested time range; the bare `/mobile/analytics` path opens the hub at its default state.

- Focused-card mode on the existing Analytics Hub (single card, no Edit toolbar, no persisted customisation)
- New `AnalyticsHubHostingViewController` / `AnalyticsHubViewModel` init accepting `SelectionType` directly so the richer widget ranges (e.g. `lastWeek`, `weekToDate`) round-trip cleanly
- New `AnalyticsHubDestination` + `ReportsRoute` parsing `metric` and `range` query params and mapping to a focused card, falling back to the default hub on missing/unknown values
- `MainTabBarController.navigate(to:)` switches to My Store and pushes the focused hub onto the dashboard nav stack
- New `store_stats_widget_metric_tapped` event fired only when the URL carries `source=store-info-widget`, so future non-widget callers of the same path can't pollute the metric. The widget URL builder now stamps that source param

## Analytics event example

```
🔵 Tracked store_stats_widget_metric_tapped, properties: [store_id: {}, site_url: https://rsm-woo-widget.mystagingwebsite.com, is_ciab: false, blog_id: -1, is_jetpack_installed: true, cached_woo_core_version: 10.7.0, metric: revenue, range: lastMonth, is_jetpack_connected: true, is_jetpack_cp_connected: false, is_wpcom_store: false]
```

## Demo

https://github.com/user-attachments/assets/161aefb0-ddba-49bd-b19d-40de2499eb95

## Test Steps

- Install the Store Stats widget at small/medium/large.
- Long-press a metric cell with a value and tap it. Confirm the app opens directly to the Analytics Hub on the My Store tab.
- Verify only the card matching the tapped metric is rendered (Revenue → Revenue card, Visitors/Conversion → Sessions card, etc.) and that the Edit toolbar item is hidden.
- Verify the hub's time range matches the widget's configured range (try `today`, `lastWeek`, `weekToDate`, `monthToDate`).
- Verify a `store_stats_widget_metric_tapped` event is fired per deeplink navigation. Check out event payload example above.
- Tap the back button and confirm you return to the dashboard with the previous state intact.
- On a non-Jetpack store, configure a Visitors cell, tap it; verify it isn't tappable in the first place (no app launch).
- Open `https://woocommerce.com/mobile/analytics` directly (no params) and confirm the hub opens at its default state.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.