### PR TITLE
Remove "Starting a new store?" button from login prologue

### DIFF
--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -41,7 +41,7 @@ extension WordPressAuthenticator {
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
                                                                 enableSiteAddressLoginOnlyInPrologue: true,
-                                                                enableSiteCreationGuide: true,
+                                                                enableSiteCreationGuide: false,
                                                                 enableSiteCredentialsLoginForWPCOMSuspendedSites: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)


### PR DESCRIPTION
## Description
Hides the "Starting a new store?" CTA button on the login prologue screen by setting `enableSiteCreationGuide` to `false` in the authenticator configuration.

## Test Steps
1. Log out of the app (or launch fresh)
2. Verify the login prologue screen shows only the "Log In" button
3. Verify the "Starting a new store?" link is no longer displayed

## Screenshots
| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/88e071d9-4cb5-4ab3-ac55-5e20f149cda8" /> | <img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/c21541e4-7651-49ab-a42a-05632088c5e5" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.