### PR TITLE
[RSM] Phone POS - Tap to Pay on iPhone UX polish + one-shot Bluetooth

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -226,26 +226,34 @@ extension POSPaymentModel {
     /// — but threaded through with the explicit method so the eventual collect
     /// targets the reader that's actually coming up.
     func startPaymentWithMethod(_ method: CardReaderConnectionMethod) async {
-        DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus)")
+        DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus), currentPaymentMethod: \(String(describing: currentPaymentMethod))")
 
-        // Defensive re-entry guard: only kick a fresh flow off the idle state.
-        // If a payment is already mid-flight (preparing, accepting, processing,
-        // success, error), a second call from a stray closure / restored
-        // subscription / SwiftUI re-render could clobber generation tracking
-        // and confuse the Stripe Terminal state machine. The hero / sheet
-        // buttons in `TotalsView` already double-tap-protect via the
-        // `isStartingPayment` gate; this is the model-side belt to that.
-        guard paymentState.card == .idle else {
-            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — card state is \(paymentState.card)")
+        // Same-method re-entry guard. Two different shapes:
+        // - BT: card state moves out of `.idle` during collection, so the
+        //   currentPaymentMethod check catches re-entry too.
+        // - TTP: we suppress intermediate card states so `paymentState.card`
+        //   stays `.idle` for the whole session — `currentPaymentMethod` is
+        //   the canonical "in flight" check.
+        if currentPaymentMethod == method {
+            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — \(method) session already active")
             return
         }
-        // On TTP we suppress the intermediate card states so `paymentState.card`
-        // stays `.idle` for the entire collection session — the guard above
-        // therefore can't catch re-entry there. `currentPaymentMethod` is the
-        // canonical "in flight" check for TTP.
-        if currentPaymentMethod == .tapToPay {
-            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — TTP session already active")
+        // Block re-entry while non-idle if there's no active method to switch
+        // *from* (stray closure / SwiftUI re-render after a terminal state).
+        if paymentState.card != .idle, currentPaymentMethod == nil {
+            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod ignored — non-idle card state with no active method")
             return
+        }
+
+        // Method-switch path: the merchant is switching from one active
+        // method to another (e.g. picking Tap to Pay from the Other Payment
+        // Methods sheet while a BT reader is mid-collection). Cancel the
+        // in-flight collection on the SDK before we tear down the reader —
+        // otherwise the new collect would race with a still-pending one and
+        // Stripe Terminal would reject it.
+        if let active = currentPaymentMethod, active != method {
+            DDLogInfo("🃏 [CardPayment] startPaymentWithMethod switching \(active) -> \(method) — cancelling current payment first")
+            try? await cardPresentPaymentService.cancelPayment()
         }
 
         if method == .tapToPay {
@@ -259,18 +267,16 @@ extension POSPaymentModel {
         currentPaymentMethod = method
         isAwaitingExplicitPaymentStart = false
 
-        // If a reader is connected via the *other* method, drop it before
-        // connecting via the chosen one. Stripe Terminal can only have one
-        // active reader; without the disconnect the new connect would be
-        // rejected. iPad never hits this branch (preferred is always
-        // bluetooth there), so the disconnect is scoped to the phone-with-TTP
-        // method-switch case.
-        if case .connected = cardReaderConnectionStatus {
-            if method == .bluetooth, preferredConnectionMethod == .tapToPay {
-                await cardPresentPaymentService.disconnectReader()
-            } else if method == .tapToPay, preferredConnectionMethod == .bluetooth {
-                await cardPresentPaymentService.disconnectReader()
-            }
+        // If a reader is connected via a *different* method than the one the
+        // merchant just picked, disconnect it first. Stripe Terminal can only
+        // hold one active reader, so the subsequent connect would be rejected
+        // otherwise. `lastConnectedMethod` is the canonical "what method is
+        // currently connected" signal — distinct from `preferredConnectionMethod`
+        // which is the POS-level default and doesn't track what's actually
+        // attached right now. (The previous check used `preferredConnectionMethod`
+        // and missed phone-POS-with-BT-currently-attached cases.)
+        if case .connected = cardReaderConnectionStatus, lastConnectedMethod != method {
+            await cardPresentPaymentService.disconnectReader()
         }
 
         if case .disconnected = cardReaderConnectionStatus {

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -258,12 +258,30 @@ extension POSPaymentModel {
         }
 
         if case .disconnected = cardReaderConnectionStatus {
-            Task { @MainActor [weak self] in
-                do {
-                    _ = try await self?.cardPresentPaymentService.connectReader(using: method)
-                    self?.lastConnectedMethod = method
-                } catch {
-                    DDLogWarn("🃏 [CardPayment] explicit connect via \(method) failed: \(error)")
+            // Skip the explicit connect if the silent TTP pre-connect is
+            // already running — status stays `.disconnected` for the entire
+            // duration of a Stripe Terminal `connectReader` call (there is no
+            // intermediate `.connecting` case), so the only way to know
+            // "connect already in flight" is the `tapToPayConnectTask` guard.
+            // Without this, tapping the hero CTA before pre-connect has
+            // finished fires a *second* concurrent `connectReader(.tapToPay)`,
+            // which the SDK can't reconcile — the connect errors out, status
+            // never reaches `.connected`, and the `startPaymentFlow`
+            // one-shot subscription that's about to be set up never fires.
+            // The merchant sees the CTA spin forever and the TTP modal never
+            // appears. We let the existing pre-connect Task drive the connect;
+            // `startPaymentFlow` will subscribe to `.connected` and collect as
+            // soon as the pre-connect Task completes.
+            if method == .tapToPay, tapToPayConnectTask != nil {
+                DDLogInfo("🃏 [CardPayment] tap during pre-connect — letting existing pre-connect drive the connect")
+            } else {
+                Task { @MainActor [weak self] in
+                    do {
+                        _ = try await self?.cardPresentPaymentService.connectReader(using: method)
+                        self?.lastConnectedMethod = method
+                    } catch {
+                        DDLogWarn("🃏 [CardPayment] explicit connect via \(method) failed: \(error)")
+                    }
                 }
             }
         }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -34,7 +34,7 @@ final class POSPaymentModel {
         return false
     }
 
-/// The connection method of the currently active payment session, or nil
+    /// The connection method of the currently active payment session, or nil
     /// between sessions. Distinct from `preferredConnectionMethod` (the POS
     /// session's default): the merchant can pick BT via the "Other payment
     /// methods" sheet on a TTP-default device, in which case the active
@@ -1157,7 +1157,11 @@ private extension POSPaymentModel {
                 self.paymentState.card = .idle
                 self.cardPresentPaymentInlineMessage = nil
                 Task { @MainActor [weak self] in
-                    try? await self?.cardPresentPaymentService.cancelPayment()
+                    do {
+                        try await self?.cardPresentPaymentService.cancelPayment()
+                    } catch {
+                        DDLogError("🃏 [CardPayment] cancelPayment on cancelledOnReader failed: \(error)")
+                    }
                 }
             }
             .store(in: &paymentSessionCancellables)

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -186,16 +186,21 @@ extension POSPaymentModel {
         subscribeToPaymentSessionEvents()
 
         if preferredConnectionMethod == .tapToPay {
-            // Phone POS with TTP available: TTP-only product scope (initial
-            // prototype release). BT is removed from the merchant-reachable
-            // UI on this path, so the BT auto-resume branch that used to live
-            // here is no longer needed — there's no way for the merchant to
-            // have committed to BT in the first place. The BT auto-resume code
-            // (and related state-machine paths) stays dormant in this file
-            // for a future re-introduction once the state-machine refactor
-            // lands; the gate at the UI level is the source of truth for
-            // "BT is not available on phone POS for now."
-            //
+            // One-shot Bluetooth cleanup. Each new order on phone POS
+            // returns to the TTP hero — we do **not** auto-resume Bluetooth
+            // across orders, even if the BT reader is still attached from
+            // the previous transaction. If a merchant wants BT for the next
+            // order, they re-pick "Card reader" from the Other payment
+            // methods sheet. This deliberately keeps the state machine
+            // simple: every checkout entry begins from a clean TTP-pre-
+            // connect baseline, eliminating the mid-flow auto-resume and
+            // method-switch surface that produced the foundReader race +
+            // state-drift issues in earlier iterations.
+            if lastConnectedMethod == .bluetooth,
+               case .connected = cardReaderConnectionStatus {
+                DDLogInfo("🃏 [CardPayment] Phone POS one-shot BT: dropping BT reader before TTP pre-connect")
+                await cardPresentPaymentService.disconnectReader()
+            }
             // Awaiting an explicit method tap from the hero / sheet — leave the
             // gate true so transient Stripe events during pre-connect can't
             // advance the state machine. No `currentPaymentMethod` yet — the
@@ -248,6 +253,20 @@ extension POSPaymentModel {
         if let active = currentPaymentMethod, active != method {
             DDLogInfo("🃏 [CardPayment] startPaymentWithMethod switching \(active) -> \(method) — cancelling current payment first")
             try? await cardPresentPaymentService.cancelPayment()
+        }
+
+        // When switching to Bluetooth from a TTP-pre-connect-in-flight state
+        // (merchant tapped Card reader before the silent pre-connect had
+        // settled), **wait** for the pre-connect Task to finish before
+        // starting the BT scan. Crucially this is a wait, not a cancel —
+        // letting the SDK complete its in-flight `connectReader(.tapToPay)`
+        // cleanly avoids the foundReader race where a still-tearing-down
+        // TTP reader briefly appears in the subsequent BT discovery results
+        // (the "Found [hex]" flash we kept hitting). Cost: ~1-2s of perceived
+        // latency if the merchant taps Card reader very early on entry.
+        if method == .bluetooth, let task = tapToPayConnectTask {
+            DDLogInfo("🃏 [CardPayment] BT pick waiting for in-flight TTP pre-connect to finish")
+            _ = await task.value
         }
 
         if method == .tapToPay {

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -931,14 +931,15 @@ extension POSPaymentModel {
 extension POSPaymentModel {
     func observeReaderReconnection() {
         cardReaderDisconnection = cardPresentPaymentService.readerConnectionStatusPublisher
-            // `removeDuplicates` BEFORE the filter — Stripe Terminal can emit
-            // multiple identical status values in succession (e.g., during
-            // teardown / re-init), and without dedup the sink fires for each
-            // one. The downstream `startPayment` call kicks off another
-            // pre-connect Task each time, racing every previous one. (The
-            // `tapToPayConnectTask` coalesce on the pre-connect side already
-            // catches most of this, but de-duping here also avoids the
-            // wasted `startPayment` work.)
+            // Dedup before the switch — Stripe Terminal can emit multiple
+            // identical status values in succession (e.g., during teardown /
+            // re-init). Without this, a duplicate `.connected` re-kicks
+            // `startPayment` (BT auto-resume branch), and a duplicate
+            // `.disconnected` re-kicks the silent TTP pre-connect. Either
+            // races the previous run. The `tapToPayConnectTask` coalesce on
+            // the pre-connect side catches most of the pre-connect waste, but
+            // de-duping here also short-circuits the redundant `startPayment`
+            // hop entirely.
             .removeDuplicates()
             .sink { [weak self] status in
                 Task { @MainActor [weak self] in

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -34,22 +34,7 @@ final class POSPaymentModel {
         return false
     }
 
-    /// True while the silent Tap to Pay pre-connect is still in flight: the
-    /// merchant is on the TTP path and the reader hasn't moved out of
-    /// `.disconnected` yet. Drives the hero's "Preparing Tap to Pay…"
-    /// affordance so the merchant gets feedback during the (usually short)
-    /// pre-connect window.
-    var isPreparingTapToPay: Bool {
-        guard preferredConnectionMethod == .tapToPay else { return false }
-        // If a non-TTP session is in flight (BT picked via the sheet),
-        // we deliberately disconnected TTP — showing "Preparing Tap to Pay…"
-        // would mislead. The BT path drives its own UI from here.
-        if let currentPaymentMethod, currentPaymentMethod != .tapToPay { return false }
-        if case .disconnected = cardReaderConnectionStatus { return true }
-        return false
-    }
-
-    /// The connection method of the currently active payment session, or nil
+/// The connection method of the currently active payment session, or nil
     /// between sessions. Distinct from `preferredConnectionMethod` (the POS
     /// session's default): the merchant can pick BT via the "Other payment
     /// methods" sheet on a TTP-default device, in which case the active

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -895,7 +895,7 @@ extension POSPaymentModel {
     func observeReaderReconnection() {
         cardReaderDisconnection = cardPresentPaymentService.readerConnectionStatusPublisher
             // `removeDuplicates` BEFORE the filter — Stripe Terminal can emit
-            // multiple `.disconnected` values in succession (e.g., during
+            // multiple identical status values in succession (e.g., during
             // teardown / re-init), and without dedup the sink fires for each
             // one. The downstream `startPayment` call kicks off another
             // pre-connect Task each time, racing every previous one. (The
@@ -903,19 +903,39 @@ extension POSPaymentModel {
             // catches most of this, but de-duping here also avoids the
             // wasted `startPayment` work.)
             .removeDuplicates()
-            .filter({ $0 == .disconnected })
-            .sink { [weak self] _ in
+            .sink { [weak self] status in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    // The auto-reconnect is for "reader fell off the device"
-                    // scenarios when no payment is in flight. If a session is
-                    // active (e.g. a BT-via-sheet pick on a TTP-default
-                    // device deliberately disconnected TTP first), the
-                    // session manages its own reconnect and we should stay
-                    // out of the way — otherwise we race the session's
-                    // chosen method and confuse the SDK.
+                    // Both branches below are scoped to "no active session" —
+                    // if a session is in flight (e.g. a BT-via-sheet pick on
+                    // a TTP-default device deliberately disconnected TTP
+                    // first), the session manages its own reconnect and we
+                    // should stay out of the way — otherwise we race the
+                    // session's chosen method and confuse the SDK.
                     guard self.currentPaymentMethod == nil else { return }
-                    await self.startPayment()
+                    switch status {
+                    case .disconnected:
+                        // "Reader fell off the device" — re-enter the
+                        // checkout default (silent TTP pre-connect on phone
+                        // POS, BT auto-collect on iPad).
+                        await self.startPayment()
+                    case .connected:
+                        // The reader came back up after a transient drop
+                        // (`.reconnecting -> .connected` or
+                        // `.disconnected -> .connected` via Settings). When
+                        // the merchant had previously committed to BT, kick
+                        // `startPayment` so the auto-resume path can re-run
+                        // collect — otherwise the totals view lands in the
+                        // dead state where `useTapToPayHeroLayout` is
+                        // suppressed (BT connected) but no `PaymentViewContent`
+                        // / bottom strip surfaces either, leaving the
+                        // merchant with no actionable UI.
+                        if self.lastConnectedMethod == .bluetooth {
+                            await self.startPayment()
+                        }
+                    case .cancellingConnection, .disconnecting, .reconnecting:
+                        break
+                    }
                 }
             }
     }

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -186,22 +186,16 @@ extension POSPaymentModel {
         subscribeToPaymentSessionEvents()
 
         if preferredConnectionMethod == .tapToPay {
-            // If a BT reader is already attached from a previous session, the
-            // merchant explicitly chose BT — auto-resume the BT collect flow
-            // just like iPad's BT-preferred path. Without this, the TTP hero
-            // would re-appear on the next idle checkout even though the BT
-            // reader is still connected and ready to go. The reader-status
-            // check guards against the (rare) case where `lastConnectedMethod`
-            // says BT but the SDK has since disconnected — we don't want to
-            // collect on a non-existent reader.
-            if lastConnectedMethod == .bluetooth,
-               case .connected = cardReaderConnectionStatus {
-                DDLogInfo("🃏 [CardPayment] BT reader still attached — auto-resuming BT collect instead of TTP pre-connect")
-                currentPaymentMethod = .bluetooth
-                isAwaitingExplicitPaymentStart = false
-                await startPaymentFlow(using: .bluetooth)
-                return
-            }
+            // Phone POS with TTP available: TTP-only product scope (initial
+            // prototype release). BT is removed from the merchant-reachable
+            // UI on this path, so the BT auto-resume branch that used to live
+            // here is no longer needed — there's no way for the merchant to
+            // have committed to BT in the first place. The BT auto-resume code
+            // (and related state-machine paths) stays dormant in this file
+            // for a future re-introduction once the state-machine refactor
+            // lands; the gate at the UI level is the source of truth for
+            // "BT is not available on phone POS for now."
+            //
             // Awaiting an explicit method tap from the hero / sheet — leave the
             // gate true so transient Stripe events during pre-connect can't
             // advance the state machine. No `currentPaymentMethod` yet — the

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -252,7 +252,11 @@ extension POSPaymentModel {
         // Stripe Terminal would reject it.
         if let active = currentPaymentMethod, active != method {
             DDLogInfo("🃏 [CardPayment] startPaymentWithMethod switching \(active) -> \(method) — cancelling current payment first")
-            try? await cardPresentPaymentService.cancelPayment()
+            do {
+                try await cardPresentPaymentService.cancelPayment()
+            } catch {
+                DDLogError("🃏 [CardPayment] cancelPayment on method switch failed: \(error)")
+            }
         }
 
         // When switching to Bluetooth from a TTP-pre-connect-in-flight state
@@ -410,7 +414,11 @@ extension POSPaymentModel {
     /// The generation check after the cancel guards against a newer
     /// `startPayment()` call that may have started during the await.
     private func cancelThenCollectCardPayment(generation: Int, using method: CardReaderConnectionMethod) async {
-        try? await cardPresentPaymentService.cancelPayment()
+        do {
+            try await cardPresentPaymentService.cancelPayment()
+        } catch {
+            DDLogError("🃏 [CardPayment] cancelPayment before collect failed: \(error)")
+        }
         DDLogInfo("🃏 [CardPayment] startPayment cancel completed — card state: \(paymentState.card), cash state: \(paymentState.cash)")
 
         guard startPaymentGeneration == generation else {
@@ -451,7 +459,11 @@ extension POSPaymentModel {
             await cardPresentPaymentService.cancelReconnection()
         }
 
-        try? await cardPresentPaymentService.cancelPayment()
+        do {
+            try await cardPresentPaymentService.cancelPayment()
+        } catch {
+            DDLogError("🃏 [CardPayment] cancelPayment before retry-collect failed: \(error)")
+        }
 
         guard case .connected = cardReaderConnectionStatus else {
             return

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -497,8 +497,16 @@ extension POSPaymentModel {
             // can stay at `.reconnecting` and the "Reconnecting reader…"
             // screen never transitions away. Explicit disconnect forces the
             // status to `.disconnected` so the UI can fall back to the TTP
-            // hero (or the iPad disconnect message). Disconnect on an
-            // already-disconnected reader is a no-op at the SDK level.
+            // hero (or the iPad disconnect message).
+            //
+            // Re-check the status after the cancel `await` — if the reconnect
+            // actually completed during the cancel (a real race on the BT
+            // path, especially on iPad where BT is primary), bail without
+            // disconnecting. Tearing down a connection the merchant didn't
+            // ask to drop would surface as "I tapped Cancel reconnection and
+            // it disconnected my reader" — exactly the iPad regression
+            // samiuelson flagged.
+            guard case .reconnecting = self?.cardReaderConnectionStatus else { return }
             await self?.cardPresentPaymentService.disconnectReader()
         }
     }
@@ -969,6 +977,16 @@ extension POSPaymentModel {
                         // / bottom strip surfaces either, leaving the
                         // merchant with no actionable UI.
                         if self.lastConnectedMethod == .bluetooth {
+                            // Diagnostic: `startPayment` re-subscribes via
+                            // `subscribeToPaymentSessionEvents`'s
+                            // `paymentSessionCancellables.isEmpty` guard. If a
+                            // prior `deactivate()` cleared them and we somehow
+                            // miss the re-subscribe, the resumed collection
+                            // runs blind to events. Log the cancellables count
+                            // here so a "no events firing after reconnect"
+                            // bug is one Bartleby search away from the cause.
+                            DDLogDebug("🃏 [CardPayment] BT auto-resume re-kick — "
+                                       + "paymentSessionCancellables.count: \(self.paymentSessionCancellables.count)")
                             await self.startPayment()
                         }
                     case .cancellingConnection, .disconnecting, .reconnecting:

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -186,6 +186,22 @@ extension POSPaymentModel {
         subscribeToPaymentSessionEvents()
 
         if preferredConnectionMethod == .tapToPay {
+            // If a BT reader is already attached from a previous session, the
+            // merchant explicitly chose BT — auto-resume the BT collect flow
+            // just like iPad's BT-preferred path. Without this, the TTP hero
+            // would re-appear on the next idle checkout even though the BT
+            // reader is still connected and ready to go. The reader-status
+            // check guards against the (rare) case where `lastConnectedMethod`
+            // says BT but the SDK has since disconnected — we don't want to
+            // collect on a non-existent reader.
+            if lastConnectedMethod == .bluetooth,
+               case .connected = cardReaderConnectionStatus {
+                DDLogInfo("🃏 [CardPayment] BT reader still attached — auto-resuming BT collect instead of TTP pre-connect")
+                currentPaymentMethod = .bluetooth
+                isAwaitingExplicitPaymentStart = false
+                await startPaymentFlow(using: .bluetooth)
+                return
+            }
             // Awaiting an explicit method tap from the hero / sheet — leave the
             // gate true so transient Stripe events during pre-connect can't
             // advance the state machine. No `currentPaymentMethod` yet — the

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -225,7 +225,8 @@ extension POSPaymentModel {
     /// — but threaded through with the explicit method so the eventual collect
     /// targets the reader that's actually coming up.
     func startPaymentWithMethod(_ method: CardReaderConnectionMethod) async {
-        DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus), currentPaymentMethod: \(String(describing: currentPaymentMethod))")
+        DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus), "
+                  + "currentPaymentMethod: \(String(describing: currentPaymentMethod))")
 
         // Same-method re-entry guard. Two different shapes:
         // - BT: card state moves out of `.idle` during collection, so the

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -463,6 +463,17 @@ extension POSPaymentModel {
     func cancelReconnection() {
         Task { @MainActor [weak self] in
             await self?.cardPresentPaymentService.cancelReconnection()
+            // Belt-and-suspenders: the SDK's `cancelReconnection` has an
+            // early-return path when its internal `reconnectionCancelable` is
+            // already nil or completed. In that path the Hardware layer sends
+            // `.idle` to the reconnection-state subject but does *not* clear
+            // the connected-readers subject, so `cardReaderConnectionStatus`
+            // can stay at `.reconnecting` and the "Reconnecting reader…"
+            // screen never transitions away. Explicit disconnect forces the
+            // status to `.disconnected` so the UI can fall back to the TTP
+            // hero (or the iPad disconnect message). Disconnect on an
+            // already-disconnected reader is a no-op at the SDK level.
+            await self?.cardPresentPaymentService.disconnectReader()
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Barcode Scanner Setup/POSBarcodeScannerSetup.swift
@@ -51,7 +51,10 @@ struct POSBarcodeScannerSetup: View {
             flowManager.onDisappear()
         }
         .maximumScreenBrightness()
-        .posModalFullScreen(isCompactWidth)
+        // `.posModalFullScreen(isCompactWidth)` is intentionally not called here —
+        // `POSRootModalViewModifier` auto-detects compact width and OR's it into
+        // its `isFullScreen` check, so the explicit call would be a duplicated
+        // mechanism for the same outcome. See #17067 review feedback.
     }
 
     // MARK: - Computed Properties

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundDetailView.swift
@@ -30,7 +30,8 @@ struct POSRefundDetailView: View {
         }
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
-        .posModalFullScreen(horizontalSizeClass == .compact)
+        // `.posModalFullScreen(horizontalSizeClass == .compact)` removed —
+        // `POSRootModalViewModifier` auto-detects compact width. See #17067 review.
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -88,7 +88,8 @@ struct POSRefundModalContentView: View {
 
     var body: some View {
         content
-            .posModalFullScreen(horizontalSizeClass == .compact)
+            // `.posModalFullScreen(horizontalSizeClass == .compact)` removed —
+            // `POSRootModalViewModifier` auto-detects compact width. See #17067 review.
             .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
                 POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
                     try await orderListModel.sendReceipt(order: order, email: email)

--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -8,30 +8,20 @@ import SwiftUI
 ///   this lists Card reader, Scan to Pay, and Mark order as paid.
 /// - On the TTP-available + BT-reader-connected screen, this lists only Scan to Pay
 ///   and Mark order as paid. The Card reader row is hidden because a reader is
-///   already connected; Tap to Pay is hidden too because the iOS phone POS uses a
-///   one-shot Bluetooth model — the BT session must finish (success / cancel /
-///   abandonment) before the merchant returns to the TTP hero, where Tap to Pay
-///   is the primary CTA again.
+///   already connected.
 ///
-/// Mirrors the Android phone POS overflow dialog that pairs with the TTP hero
-/// (samiuelson #15842 / #15825). The iOS layout deliberately diverges in one
-/// respect: Android offers Tap to Pay as a sheet row during a BT session (lets
-/// the merchant switch mid-flow); iOS does not (see commentary on the
-/// `isTapToPayRowAvailableInOtherMethodsSheet` gate in `TotalsView`).
+/// The iOS phone POS uses a one-shot Bluetooth model: the BT session must finish
+/// (success / cancel / abandonment) before the merchant returns to the TTP hero
+/// where Tap to Pay is the primary CTA again. Tap to Pay is therefore never
+/// surfaced as a sheet row — deliberately diverging from Android (samiuelson
+/// #15842 / #15825), which offers Tap to Pay as a sheet row during a BT session
+/// to let the merchant switch mid-flow.
 struct POSOtherPaymentMethodsSheet: View {
     /// True when the Card reader row should appear. Pass false when a reader is
     /// already connected — the "Connect a Bluetooth reader…" subtitle would
     /// mislead the merchant in that case.
     var isCardReaderAvailable: Bool = true
     let onCardReader: () -> Void
-    /// True when the Tap to Pay row should appear. In the current one-shot
-    /// Bluetooth model every caller passes `false`: on the TTP hero screen
-    /// Tap to Pay is already the primary CTA above the sheet, and during a
-    /// Bluetooth collection the iOS phone POS doesn't let the merchant
-    /// switch methods mid-flow. Parameter kept on the API for symmetry with
-    /// the other rows and to leave room if that policy ever changes.
-    var isTapToPayAvailable: Bool = false
-    var onTapToPay: (() -> Void)?
     var isScanToPayAvailable: Bool = false
     var onScanToPay: (() -> Void)?
     var isMarkOrderAsPaidAvailable: Bool = false
@@ -47,16 +37,6 @@ struct POSOtherPaymentMethodsSheet: View {
                 .padding(.horizontal, POSPadding.medium)
                 .padding(.top, POSPadding.large)
                 .padding(.bottom, POSPadding.medium)
-
-            if isTapToPayAvailable, let onTapToPay {
-                row(systemImage: "wave.3.right.circle",
-                    title: Localization.tapToPayTitle,
-                    subtitle: Localization.tapToPaySubtitle,
-                    accessibilityIdentifier: "pos-other-payments-tap-to-pay") {
-                    dismiss()
-                    onTapToPay()
-                }
-            }
 
             if isCardReaderAvailable {
                 row(systemImage: "creditcard",
@@ -142,17 +122,6 @@ private extension POSOtherPaymentMethodsSheet {
             "pos.otherPaymentMethods.sheet.title",
             value: "Other payment methods",
             comment: "Title of the bottom sheet listing non-Tap-to-Pay payment methods on phone POS checkout."
-        )
-        static let tapToPayTitle = NSLocalizedString(
-            "pos.otherPaymentMethods.tapToPay.title",
-            value: "Tap to Pay on iPhone",
-            comment: "Row title in the Other Payment Methods sheet for switching to Tap to Pay on iPhone. " +
-                "\"Tap to Pay on iPhone\" is Apple's product name and must be capitalised exactly as shown."
-        )
-        static let tapToPaySubtitle = NSLocalizedString(
-            "pos.otherPaymentMethods.tapToPay.subtitle",
-            value: "Use this device to accept contactless card payments.",
-            comment: "Row subtitle in the Other Payment Methods sheet for switching to Tap to Pay on iPhone."
         )
         static let cardReaderTitle = NSLocalizedString(
             "pos.otherPaymentMethods.cardReader.title",

--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -6,22 +6,30 @@ import SwiftUI
 ///
 /// - On the TTP-available + no-reader-connected screen (paired with the TTP hero),
 ///   this lists Card reader, Scan to Pay, and Mark order as paid.
-/// - On the TTP-available + BT-reader-connected screen, this lists Tap to Pay on
-///   iPhone, Scan to Pay, and Mark order as paid — the Card reader row is hidden
-///   because a reader is already connected and offering to "connect a Bluetooth
-///   reader" would contradict that state.
+/// - On the TTP-available + BT-reader-connected screen, this lists only Scan to Pay
+///   and Mark order as paid. The Card reader row is hidden because a reader is
+///   already connected; Tap to Pay is hidden too because the iOS phone POS uses a
+///   one-shot Bluetooth model — the BT session must finish (success / cancel /
+///   abandonment) before the merchant returns to the TTP hero, where Tap to Pay
+///   is the primary CTA again.
 ///
 /// Mirrors the Android phone POS overflow dialog that pairs with the TTP hero
-/// (samiuelson #15842 / #15825).
+/// (samiuelson #15842 / #15825). The iOS layout deliberately diverges in one
+/// respect: Android offers Tap to Pay as a sheet row during a BT session (lets
+/// the merchant switch mid-flow); iOS does not (see commentary on the
+/// `isTapToPayRowAvailableInOtherMethodsSheet` gate in `TotalsView`).
 struct POSOtherPaymentMethodsSheet: View {
     /// True when the Card reader row should appear. Pass false when a reader is
     /// already connected — the "Connect a Bluetooth reader…" subtitle would
     /// mislead the merchant in that case.
     var isCardReaderAvailable: Bool = true
     let onCardReader: () -> Void
-    /// True when the Tap to Pay row should appear. Pass false when the sheet is
-    /// hosted by the TTP hero screen (TTP is already the primary CTA on that
-    /// screen so it shouldn't show up again here) or when TTP isn't available.
+    /// True when the Tap to Pay row should appear. In the current one-shot
+    /// Bluetooth model every caller passes `false`: on the TTP hero screen
+    /// Tap to Pay is already the primary CTA above the sheet, and during a
+    /// Bluetooth collection the iOS phone POS doesn't let the merchant
+    /// switch methods mid-flow. Parameter kept on the API for symmetry with
+    /// the other rows and to leave room if that policy ever changes.
     var isTapToPayAvailable: Bool = false
     var onTapToPay: (() -> Void)?
     var isScanToPayAvailable: Bool = false

--- a/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSOtherPaymentMethodsSheet.swift
@@ -1,14 +1,29 @@
 import SwiftUI
 
 /// Bottom sheet shown when the merchant taps "Other payment methods" on the phone
-/// POS checkout (TTP-available layout). Lists the non-TTP payment methods available
-/// to the merchant: Card reader, Scan to Pay (when enabled), and Mark order as paid
-/// (when enabled).
+/// POS checkout. Lists the non-primary payment methods available to the merchant
+/// for the current screen state:
+///
+/// - On the TTP-available + no-reader-connected screen (paired with the TTP hero),
+///   this lists Card reader, Scan to Pay, and Mark order as paid.
+/// - On the TTP-available + BT-reader-connected screen, this lists Tap to Pay on
+///   iPhone, Scan to Pay, and Mark order as paid — the Card reader row is hidden
+///   because a reader is already connected and offering to "connect a Bluetooth
+///   reader" would contradict that state.
 ///
 /// Mirrors the Android phone POS overflow dialog that pairs with the TTP hero
 /// (samiuelson #15842 / #15825).
 struct POSOtherPaymentMethodsSheet: View {
+    /// True when the Card reader row should appear. Pass false when a reader is
+    /// already connected — the "Connect a Bluetooth reader…" subtitle would
+    /// mislead the merchant in that case.
+    var isCardReaderAvailable: Bool = true
     let onCardReader: () -> Void
+    /// True when the Tap to Pay row should appear. Pass false when the sheet is
+    /// hosted by the TTP hero screen (TTP is already the primary CTA on that
+    /// screen so it shouldn't show up again here) or when TTP isn't available.
+    var isTapToPayAvailable: Bool = false
+    var onTapToPay: (() -> Void)?
     var isScanToPayAvailable: Bool = false
     var onScanToPay: (() -> Void)?
     var isMarkOrderAsPaidAvailable: Bool = false
@@ -25,12 +40,24 @@ struct POSOtherPaymentMethodsSheet: View {
                 .padding(.top, POSPadding.large)
                 .padding(.bottom, POSPadding.medium)
 
-            row(systemImage: "creditcard",
-                title: Localization.cardReaderTitle,
-                subtitle: Localization.cardReaderSubtitle,
-                accessibilityIdentifier: "pos-other-payments-card-reader") {
-                dismiss()
-                onCardReader()
+            if isTapToPayAvailable, let onTapToPay {
+                row(systemImage: "wave.3.right.circle",
+                    title: Localization.tapToPayTitle,
+                    subtitle: Localization.tapToPaySubtitle,
+                    accessibilityIdentifier: "pos-other-payments-tap-to-pay") {
+                    dismiss()
+                    onTapToPay()
+                }
+            }
+
+            if isCardReaderAvailable {
+                row(systemImage: "creditcard",
+                    title: Localization.cardReaderTitle,
+                    subtitle: Localization.cardReaderSubtitle,
+                    accessibilityIdentifier: "pos-other-payments-card-reader") {
+                    dismiss()
+                    onCardReader()
+                }
             }
 
             if isScanToPayAvailable, let onScanToPay {
@@ -107,6 +134,17 @@ private extension POSOtherPaymentMethodsSheet {
             "pos.otherPaymentMethods.sheet.title",
             value: "Other payment methods",
             comment: "Title of the bottom sheet listing non-Tap-to-Pay payment methods on phone POS checkout."
+        )
+        static let tapToPayTitle = NSLocalizedString(
+            "pos.otherPaymentMethods.tapToPay.title",
+            value: "Tap to Pay on iPhone",
+            comment: "Row title in the Other Payment Methods sheet for switching to Tap to Pay on iPhone. " +
+                "\"Tap to Pay on iPhone\" is Apple's product name and must be capitalised exactly as shown."
+        )
+        static let tapToPaySubtitle = NSLocalizedString(
+            "pos.otherPaymentMethods.tapToPay.subtitle",
+            value: "Use this device to accept contactless card payments.",
+            comment: "Row subtitle in the Other Payment Methods sheet for switching to Tap to Pay on iPhone."
         )
         static let cardReaderTitle = NSLocalizedString(
             "pos.otherPaymentMethods.cardReader.title",

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -5,39 +5,21 @@ import SwiftUI
 /// merchant's primary path is the big "Pay with Tap to pay" CTA; cash and the rest
 /// of the methods live in a smaller two-button strip at the bottom of the totals
 /// view (rendered separately by `TotalsView`).
-///
-/// Idle-state visual only for now. Preparing / collecting / success / error states
-/// are still handled by the existing `POSCardPaymentContentView` modal flow until
-/// they're folded into a richer hero in a follow-up commit.
 struct POSTapToPayHeroView: View {
     let onPayTapped: () -> Void
+    /// True between the merchant tapping the CTA and the payment state machine
+    /// reacting. The button stays tappable on entry (silent pre-connect runs in
+    /// the background — no visible indicator until the merchant taps), so this
+    /// is purely double-tap protection. While true the illustration swaps to a
+    /// spinner so the merchant gets immediate feedback that their tap landed,
+    /// even when the pre-connect or PaymentIntent creation is still in flight.
     var isPayDisabled: Bool = false
-    /// Drives the inline "Preparing Tap to Pay…" indicator. Set true while the
-    /// silent pre-connect is still in flight (`POSPaymentModel.isPreparingTapToPay`).
-    /// The CTA stays tappable — `startPaymentFlow` already handles a tap that
-    /// arrives before the reader connects by waiting for the connection event.
-    var isPreparing: Bool = false
 
-    /// Delays the indicator's first appearance so the common fast-pre-connect
-    /// case (sub-second) doesn't flash a spinner.
-    private static let appearanceDelay: Duration = .milliseconds(700)
-    /// If the pre-connect hasn't finished after this, give up showing the
-    /// indicator. Stops it sitting forever when pre-connect silently fails
-    /// (entitlement / Apple ToS / location-services edge cases the
-    /// `.connectingFailed*` suppression on `POSPaymentModel` swallows).
-    private static let timeout: Duration = .seconds(12)
-
-    @State private var isIndicatorVisible: Bool = false
+    private static let illustrationSize: CGFloat = 96
 
     var body: some View {
         VStack(spacing: POSSpacing.large) {
-            // Placeholder illustration — the Android design uses a layered cards
-            // graphic; the matching iOS asset will swap in here once design provides
-            // it. Using an SF Symbol keeps the layout shaped correctly in the meantime.
-            Image(systemName: "wave.3.right.circle.fill")
-                .font(.system(size: 96, weight: .regular))
-                .foregroundStyle(Color.posPrimary)
-                .accessibilityHidden(true)
+            illustration
 
             VStack(spacing: POSSpacing.small) {
                 Text(Localization.title)
@@ -56,59 +38,31 @@ struct POSTapToPayHeroView: View {
                 Text(Localization.payButton)
                     .font(POSFontStyle.posBodyLargeBold)
             }
-            // `isLoading` is gated on `isPayDisabled` rather than the broader
-            // `isPayDisabled || isIndicatorVisible` below, so the in-button
-            // spinner only shows during the "merchant just tapped, waiting for
-            // Apple's TTP modal to open" gap. While the silent pre-connect
-            // indicator is up the button is disabled (greyed) but the spinner
-            // doesn't show — the inline "Preparing Tap to Pay…" text already
-            // explains the wait there.
-            .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isPayDisabled))
+            .buttonStyle(POSFilledButtonStyle(size: .normal))
             .padding(.horizontal, POSPadding.medium)
-            // Disabled while preparing only once the indicator becomes visible
-            // (after the 700ms grace). Fast pre-connects therefore never flicker
-            // the button into a disabled state, and slow pre-connects show the
-            // disabled button alongside the "Preparing…" indicator that
-            // explains why it's not tappable.
-            .disabled(isPayDisabled || isIndicatorVisible)
+            .disabled(isPayDisabled)
             .accessibilityIdentifier("pos-tap-to-pay-hero-pay-button")
-
-            preparingIndicator
-        }
-        .task(id: isPreparing) {
-            await updateIndicatorVisibility()
         }
     }
 
+    /// Static SF Symbol normally, swapped to a `ProgressView` once the merchant
+    /// taps the CTA. The placeholder illustration will get replaced with a real
+    /// designer asset later; the spinner-on-tap behaviour stays the same once
+    /// that lands.
     @ViewBuilder
-    private var preparingIndicator: some View {
-        HStack(spacing: POSSpacing.small) {
+    private var illustration: some View {
+        if isPayDisabled {
             ProgressView()
-                .controlSize(.small)
-            Text(Localization.preparing)
-                .font(.posBodyMediumRegular())
-                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                .controlSize(.extraLarge)
+                .tint(Color.posPrimary)
+                .frame(width: Self.illustrationSize, height: Self.illustrationSize)
+                .accessibilityHidden(true)
+        } else {
+            Image(systemName: "wave.3.right.circle.fill")
+                .font(.system(size: Self.illustrationSize, weight: .regular))
+                .foregroundStyle(Color.posPrimary)
+                .accessibilityHidden(true)
         }
-        .accessibilityElement(children: .combine)
-        .opacity(isIndicatorVisible ? 1 : 0)
-        .animation(.default, value: isIndicatorVisible)
-        .accessibilityHidden(!isIndicatorVisible)
-    }
-
-    private func updateIndicatorVisibility() async {
-        guard isPreparing else {
-            isIndicatorVisible = false
-            return
-        }
-        // Hold for the appearance delay; bail if pre-connect finished first.
-        try? await Task.sleep(for: Self.appearanceDelay)
-        guard !Task.isCancelled, isPreparing else { return }
-        isIndicatorVisible = true
-        // Auto-hide after the timeout so a silently failed pre-connect doesn't
-        // leave the indicator sitting indefinitely.
-        try? await Task.sleep(for: Self.timeout)
-        guard !Task.isCancelled else { return }
-        isIndicatorVisible = false
     }
 }
 
@@ -129,11 +83,6 @@ private extension POSTapToPayHeroView {
             value: "Pay with Tap to pay",
             comment: "Primary CTA shown in the Tap to Pay hero on the POS checkout."
         )
-        static let preparing = NSLocalizedString(
-            "pos.tapToPay.hero.preparing",
-            value: "Preparing Tap to Pay…",
-            comment: "Inline indicator shown under the Tap to Pay CTA while the silent reader pre-connect is in flight."
-        )
     }
 }
 
@@ -143,8 +92,8 @@ private extension POSTapToPayHeroView {
         .padding()
 }
 
-#Preview("Preparing") {
-    POSTapToPayHeroView(onPayTapped: {}, isPreparing: true)
+#Preview("Tapped (loading)") {
+    POSTapToPayHeroView(onPayTapped: {}, isPayDisabled: true)
         .padding()
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -10,16 +10,20 @@ struct POSTapToPayHeroView: View {
     /// True between the merchant tapping the CTA and the payment state machine
     /// reacting. The button stays tappable on entry (silent pre-connect runs in
     /// the background — no visible indicator until the merchant taps), so this
-    /// is purely double-tap protection. While true the illustration swaps to a
-    /// spinner so the merchant gets immediate feedback that their tap landed,
-    /// even when the pre-connect or PaymentIntent creation is still in flight.
+    /// is purely double-tap protection. While true the button renders its
+    /// built-in `isLoading` spinner so the merchant gets immediate feedback
+    /// that their tap landed, even when the pre-connect or PaymentIntent
+    /// creation is still in flight.
     var isPayDisabled: Bool = false
 
     private static let illustrationSize: CGFloat = 96
 
     var body: some View {
         VStack(spacing: POSSpacing.large) {
-            illustration
+            Image(systemName: "wave.3.right.circle.fill")
+                .font(.system(size: Self.illustrationSize, weight: .regular))
+                .foregroundStyle(Color.posPrimary)
+                .accessibilityHidden(true)
 
             VStack(spacing: POSSpacing.small) {
                 Text(Localization.title)
@@ -38,30 +42,10 @@ struct POSTapToPayHeroView: View {
                 Text(Localization.payButton)
                     .font(POSFontStyle.posBodyLargeBold)
             }
-            .buttonStyle(POSFilledButtonStyle(size: .normal))
+            .buttonStyle(POSFilledButtonStyle(size: .normal, isLoading: isPayDisabled))
             .padding(.horizontal, POSPadding.medium)
             .disabled(isPayDisabled)
             .accessibilityIdentifier("pos-tap-to-pay-hero-pay-button")
-        }
-    }
-
-    /// Static SF Symbol normally, swapped to a `ProgressView` once the merchant
-    /// taps the CTA. The placeholder illustration will get replaced with a real
-    /// designer asset later; the spinner-on-tap behaviour stays the same once
-    /// that lands.
-    @ViewBuilder
-    private var illustration: some View {
-        if isPayDisabled {
-            ProgressView()
-                .controlSize(.extraLarge)
-                .tint(Color.posPrimary)
-                .frame(width: Self.illustrationSize, height: Self.illustrationSize)
-                .accessibilityHidden(true)
-        } else {
-            Image(systemName: "wave.3.right.circle.fill")
-                .font(.system(size: Self.illustrationSize, weight: .regular))
-                .foregroundStyle(Color.posPrimary)
-                .accessibilityHidden(true)
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSTapToPayHeroView.swift
@@ -53,19 +53,23 @@ struct POSTapToPayHeroView: View {
 private extension POSTapToPayHeroView {
     enum Localization {
         static let title = NSLocalizedString(
-            "pos.tapToPay.hero.title",
-            value: "Tap to pay",
-            comment: "Title shown in the Tap to Pay hero on the POS checkout."
+            "pos.tapToPay.hero.title.v2",
+            value: "Tap to Pay on iPhone",
+            comment: "Title shown in the Tap to Pay on iPhone hero on the POS checkout. " +
+                "\"Tap to Pay on iPhone\" is Apple's product name and must be capitalised exactly as shown."
         )
         static let subtitle = NSLocalizedString(
             "pos.tapToPay.hero.subtitle",
             value: "Use this device to accept contactless card payments.",
-            comment: "Subtitle shown in the Tap to Pay hero on the POS checkout."
+            comment: "Subtitle shown in the Tap to Pay on iPhone hero on the POS checkout."
         )
         static let payButton = NSLocalizedString(
-            "pos.tapToPay.hero.payButton",
-            value: "Pay with Tap to pay",
-            comment: "Primary CTA shown in the Tap to Pay hero on the POS checkout."
+            "pos.tapToPay.hero.payButton.v2",
+            value: "Pay with Tap to Pay",
+            comment: "Primary CTA shown in the Tap to Pay on iPhone hero on the POS checkout. " +
+                "The full product name \"Tap to Pay on iPhone\" appears in the hero title above, " +
+                "so the CTA uses the shortened form \"Tap to Pay\" — Apple's branding guidelines " +
+                "permit this once the full name has been shown on the same screen."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -126,12 +126,25 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
                                 Button(action: {
                                     items[index].action?()
                                 }) {
-                                    Text(items[index].title)
-                                        .font(.posHeadingBold)
-                                        .lineLimit(1)
-                                        .fixedSize(horizontal: true, vertical: false)
-                                        .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
-                                        .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
+                                    Group {
+                                        // Phone: items live inside a horizontal ScrollView, so
+                                        // `.fixedSize` lets long titles take their natural width
+                                        // and swipe rather than squeeze. iPad: items render
+                                        // inline (no ScrollView), so we keep the pre-#17092
+                                        // `.minimumScaleFactor(0.5)` shrinking behaviour to
+                                        // avoid overflowing in narrow split-view.
+                                        if layoutScale == .phone {
+                                            Text(items[index].title)
+                                                .fixedSize(horizontal: true, vertical: false)
+                                        } else {
+                                            Text(items[index].title)
+                                                .minimumScaleFactor(0.5)
+                                        }
+                                    }
+                                    .font(.posHeadingBold)
+                                    .lineLimit(1)
+                                    .dynamicTypeSize(...POSHeaderLayoutConstants.maximumDynamicTypeSize)
+                                    .foregroundColor(items[index].isSelected ? .posOnSurface : .posOnSurfaceVariantLowest)
                                 }
                                 .disabled(items[index].isSelected)
                                 .accessibilityElement()

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSSuccessIcon.swift
@@ -8,10 +8,23 @@ struct POSSuccessIcon: View {
             Circle()
                 .frame(width: iconSize, height: iconSize)
                 .foregroundColor(.posSuccess)
-            Image(systemName: "checkmark")
-                .font(.system(size: checkmarkSize, weight: .bold))
-                .foregroundColor(.posOnSuccess)
-                .accessibilityHidden(true)
+
+            // Phone uses the SF Symbol checkmark to match the rest of the
+            // phone-prototype iconography. iPad keeps the brand asset (its
+            // glyph weight + proportions are what the design ships) — gating
+            // the swap on `.phone` so this PR stays scoped to phone polish.
+            if layoutScale == .phone {
+                Image(systemName: "checkmark")
+                    .font(.system(size: checkmarkSize, weight: .bold))
+                    .foregroundColor(.posOnSuccess)
+                    .accessibilityHidden(true)
+            } else {
+                PointOfSaleAssets.successCheck.image
+                    .renderingMode(.template)
+                    .foregroundColor(.posOnSuccess)
+                    .frame(width: checkmarkSize)
+                    .accessibilityHidden(true)
+            }
         }
     }
 
@@ -20,6 +33,8 @@ struct POSSuccessIcon: View {
     }
 
     private var checkmarkSize: CGFloat {
+        // Phone keeps the SF-Symbol-sized 28pt; iPad restores the design's
+        // 52pt brand-asset width that #17092's drift had bumped to 64pt.
         layoutScale == .phone ? Constants.phoneCheckmarkSize : Constants.tabletCheckmarkSize
     }
 }
@@ -27,7 +42,7 @@ struct POSSuccessIcon: View {
 private extension POSSuccessIcon {
     enum Constants {
         static let tabletIconSize: CGFloat = 165
-        static let tabletCheckmarkSize: CGFloat = 64
+        static let tabletCheckmarkSize: CGFloat = 52
         static let phoneIconSize: CGFloat = 72
         static let phoneCheckmarkSize: CGFloat = 28
     }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -146,6 +146,17 @@ struct TotalsView: View {
         .onChange(of: paymentModel.paymentState.cash) {
             isStartingPayment = false
         }
+        .onChange(of: paymentModel.paymentState.scanToPay) {
+            // Scan to Pay transitions out of `.idle` when the QR flow starts —
+            // release the gate so the merchant can interact with the next state.
+            isStartingPayment = false
+        }
+        .onChange(of: paymentModel.paymentState.markAsPaid) {
+            // Mark as Paid transitions out of `.idle` when the confirmation push
+            // happens — release the gate so the merchant can interact with the
+            // next state.
+            isStartingPayment = false
+        }
         .onChange(of: paymentModel.isPaymentSessionActive) { _, isActive in
             // The card-state onChange above doesn't always fire when a flow
             // wraps up — TTP filters intermediate states (idle → idle on
@@ -193,12 +204,23 @@ struct TotalsView: View {
                 },
                 isScanToPayAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
                 onScanToPay: {
+                    // Same double-tap guard the other sheet callbacks use. Without
+                    // this, a quick double-tap in the brief window between the merchant
+                    // tapping Scan to Pay and `paymentState.scanToPay` transitioning
+                    // out of `.idle` could fire `startScanToPayPayment()` twice.
+                    guard !isStartingPayment else { return }
+                    isStartingPayment = true
                     Task { @MainActor in
                         await paymentModel.startScanToPayPayment()
                     }
                 },
                 isMarkOrderAsPaidAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid),
                 onMarkOrderAsPaid: {
+                    // Same double-tap guard as the other sheet callbacks. Mark as Paid
+                    // dispatches into a push that the merchant could otherwise re-trigger
+                    // by tapping the row a second time during the same render frame.
+                    guard !isStartingPayment else { return }
+                    isStartingPayment = true
                     paymentModel.startMarkAsPaidPayment()
                 }
             )

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -787,23 +787,27 @@ private extension TotalsView {
     }
 
     /// True when the Card reader row should appear inside the Other Payment
-    /// Methods sheet. False once a reader is already connected — its
-    /// "Connect a Bluetooth reader…" subtitle would mislead in that state.
+    /// Methods sheet. Shown only on the TTP-hero screen — that's the only
+    /// state where the merchant hasn't yet committed to a method and might
+    /// want to opt out to BT. On the BT-reader-connected screen Card reader
+    /// would be a no-op contradiction; on the (rare) catch-all row screen the
+    /// sheet doesn't surface anyway.
+    ///
+    /// Critically: we can't gate this on `cardReaderConnectionStatus` alone
+    /// because the silent TTP pre-connect also reports the reader as
+    /// `.connected`. The hero layout is the canonical signal for "no
+    /// merchant-chosen reader."
     var isCardReaderRowAvailableInOtherMethodsSheet: Bool {
-        let viewHelper = POSPaymentViewHelper()
-        return viewHelper.shouldShowDisconnectedMessage(
-            readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
-            paymentState: displayPaymentState
-        )
+        useTapToPayHeroLayout
     }
 
     /// True when the Tap to Pay on iPhone row should appear inside the Other
     /// Payment Methods sheet. We surface it only when the merchant has already
-    /// picked BT (reader connected) — on the TTP-hero screen TTP is the
-    /// primary CTA already and listing it inside the sheet would duplicate it.
+    /// picked BT (off the hero) — on the TTP-hero screen TTP is the primary
+    /// CTA already and listing it inside the sheet would duplicate it.
     var isTapToPayRowAvailableInOtherMethodsSheet: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        return !isCardReaderRowAvailableInOtherMethodsSheet
+        return !useTapToPayHeroLayout
     }
 
     func handleTapToPayTapped() {

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -653,7 +653,11 @@ private extension TotalsView {
         if isTapToPayAvailable {
             methods.append(.tapToPay)
         }
-        if isReaderDisconnected {
+        // On phone POS with TTP available we drop Bluetooth from the
+        // prototype's initial scope (see `isCardReaderRowAvailableInOtherMethodsSheet`
+        // for the rationale). Keep `.cardReader` only on iPad and on TTP-
+        // ineligible phones where BT is the lone card path.
+        if isReaderDisconnected && paymentModel.preferredConnectionMethod != .tapToPay {
             methods.append(.cardReader)
         }
         methods.append(.cashPayment)
@@ -712,24 +716,24 @@ private extension TotalsView {
         guard displayPaymentState.scanToPay == .idle && displayPaymentState.markAsPaid == .idle else { return false }
         guard case .loaded(let totals) = posModel.orderState else { return false }
         guard !totals.orderTotalDecimal.isZero else { return false }
-        // Suppress the TTP hero only when **BT is currently `.connected`**.
-        // That covers the BT-ready / BT-auto-resume scenarios where the
-        // merchant has committed to a reader that's actually attached. In
-        // every other reader state — `.disconnected`, `.reconnecting`,
-        // `.disconnecting`, `.cancellingConnection` — BT is unreachable
-        // and the merchant should see the TTP hero so they can take payment
-        // via TTP without waiting on BT recovery. If BT later reconnects,
-        // the auto-resume path kicks back in and the BT-ready screen
-        // returns naturally.
-        //
-        // The check is `currentPaymentMethod == .bluetooth || lastConnectedMethod == .bluetooth`
-        // so both flavours of "BT is the active path" are caught (active
-        // session vs. between-sessions auto-resume), but only when the reader
-        // is actually `.connected`. We deliberately don't suppress on those
-        // properties alone — once the reader drops, `currentPaymentMethod`
-        // stays stale and `lastConnectedMethod` is just a memory; relying on
-        // them in isolation would strand the merchant on a "Reader not
-        // connected" screen with no path back to TTP.
+        // On phone POS with TTP available (`preferredConnectionMethod == .tapToPay`)
+        // we've dropped Bluetooth from the prototype's initial scope, so any
+        // residual BT state in `currentPaymentMethod` / `lastConnectedMethod`
+        // — e.g. from prior testing / dogfood builds before the drop —
+        // shouldn't suppress the hero. TTP is the only reachable card path
+        // and the hero should always surface on idle.
+        guard paymentModel.preferredConnectionMethod != .tapToPay else {
+            return true
+        }
+        // iPad / TTP-ineligible phones: suppress the TTP hero only when
+        // **BT is currently `.connected`**. That covers the BT-ready / BT-
+        // auto-resume scenarios where the merchant has committed to a reader
+        // that's actually attached. In every other reader state — `.disconnected`,
+        // `.reconnecting`, `.disconnecting`, `.cancellingConnection` — BT is
+        // unreachable and the merchant should see the TTP hero (where TTP is
+        // even available — note this whole method already returned false at
+        // the top when TTP isn't available, so on iPad we never reach this
+        // path anyway).
         if case .connected = paymentModel.cardReaderConnectionStatus,
            paymentModel.currentPaymentMethod == .bluetooth || paymentModel.lastConnectedMethod == .bluetooth {
             return false
@@ -807,7 +811,14 @@ private extension TotalsView {
     /// `.connected` — only `currentPaymentMethod` distinguishes
     /// "merchant committed to BT" from "TTP reader is warm."
     var isCardReaderRowAvailableInOtherMethodsSheet: Bool {
-        paymentModel.currentPaymentMethod != .bluetooth
+        // On phone POS with Tap to Pay on iPhone available
+        // (`preferredConnectionMethod == .tapToPay`) we drop Bluetooth from
+        // the prototype's initial scope. TTP + Cash + Scan to Pay + Mark as
+        // Paid is the complete set; merchants who need BT use iPad. The BT
+        // code paths in `POSPaymentModel` stay in place (dormant) for a
+        // future re-introduction once the state-machine refactor lands.
+        if paymentModel.preferredConnectionMethod == .tapToPay { return false }
+        return paymentModel.currentPaymentMethod != .bluetooth
     }
 
     /// True when the Tap to Pay on iPhone row should appear inside the Other

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -705,6 +705,22 @@ private extension TotalsView {
     /// processing / success / error).
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
+        // BT reconnecting + idle card state: on phone POS the merchant has
+        // TTP as an immediate alternative, so we skip the iPad-style
+        // "Reconnecting reader…" wait and surface the TTP hero so they can
+        // take payment right now. If BT later reconnects on its own, the
+        // auto-resume path kicks back in and the BT-ready screen returns.
+        // We gate on idle card state to avoid swapping the screen away from
+        // a payment that's actually mid-collection.
+        if case .reconnecting = paymentModel.cardReaderConnectionStatus,
+           displayPaymentState.card == .idle,
+           displayPaymentState.cash == .idle,
+           displayPaymentState.scanToPay == .idle,
+           displayPaymentState.markAsPaid == .idle,
+           case .loaded(let totals) = posModel.orderState,
+           !totals.orderTotalDecimal.isZero {
+            return true
+        }
         // Suppress only when BT is *currently* the active path — either we're
         // in a BT session (`currentPaymentMethod == .bluetooth`) or a BT
         // reader is still attached from a previous session

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -796,27 +796,27 @@ private extension TotalsView {
     }
 
     /// True when the Card reader row should appear inside the Other Payment
-    /// Methods sheet. Shown only on the TTP-hero screen — that's the only
-    /// state where the merchant hasn't yet committed to a method and might
-    /// want to opt out to BT. On the BT-reader-connected screen Card reader
-    /// would be a no-op contradiction; on the (rare) catch-all row screen the
-    /// sheet doesn't surface anyway.
+    /// Methods sheet. Hidden only when the merchant is currently using BT —
+    /// re-listing it there would be a no-op contradiction. Visible everywhere
+    /// else, including during a TTP collection (lets the merchant switch back
+    /// to a BT reader mid-flow).
     ///
-    /// Critically: we can't gate this on `cardReaderConnectionStatus` alone
+    /// Uses `currentPaymentMethod` instead of `cardReaderConnectionStatus`
     /// because the silent TTP pre-connect also reports the reader as
-    /// `.connected`. The hero layout is the canonical signal for "no
-    /// merchant-chosen reader."
+    /// `.connected` — only `currentPaymentMethod` distinguishes
+    /// "merchant committed to BT" from "TTP reader is warm."
     var isCardReaderRowAvailableInOtherMethodsSheet: Bool {
-        useTapToPayHeroLayout
+        paymentModel.currentPaymentMethod != .bluetooth
     }
 
     /// True when the Tap to Pay on iPhone row should appear inside the Other
-    /// Payment Methods sheet. We surface it only when the merchant has already
-    /// picked BT (off the hero) — on the TTP-hero screen TTP is the primary
-    /// CTA already and listing it inside the sheet would duplicate it.
+    /// Payment Methods sheet. Hidden on the TTP hero (it's already the
+    /// primary CTA up top) and during an active TTP session (already on it).
+    /// Visible during BT flows so the merchant can switch over.
     var isTapToPayRowAvailableInOtherMethodsSheet: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        return !useTapToPayHeroLayout
+        if useTapToPayHeroLayout { return false }
+        return paymentModel.currentPaymentMethod != .tapToPay
     }
 
     func handleTapToPayTapped() {

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -705,15 +705,24 @@ private extension TotalsView {
     /// processing / success / error).
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        // If a BT reader is connected (the merchant committed to BT in a
-        // previous session and it's still attached), `startPayment` auto-
-        // resumes the BT collect flow on the next idle checkout. Showing the
-        // TTP hero in the brief window before the card state transitions
-        // would flash misleadingly. `lastConnectedMethod` is the canonical
-        // "merchant committed to BT" signal — distinct from
-        // `cardReaderConnectionStatus.connected` which is also true for the
-        // silent TTP pre-connect.
-        if paymentModel.lastConnectedMethod == .bluetooth { return false }
+        // Suppress only when BT is *currently* the active path — either we're
+        // in a BT session (`currentPaymentMethod == .bluetooth`) or a BT
+        // reader is still attached from a previous session
+        // (`lastConnectedMethod == .bluetooth` + reader status `.connected`).
+        // The second clause matters because `startPayment` auto-resumes BT
+        // collect when the reader is still there, and the TTP hero shouldn't
+        // flash in that brief window before the card state transitions.
+        //
+        // Critically we do NOT suppress on `lastConnectedMethod == .bluetooth`
+        // alone — that's a memory of the last successful connect, not a
+        // live signal. Once the BT reader drops, we should fall back to
+        // the TTP hero instead of leaving the merchant on a "Reader not
+        // connected" screen with no way back to TTP.
+        if paymentModel.currentPaymentMethod == .bluetooth { return false }
+        if paymentModel.lastConnectedMethod == .bluetooth,
+           case .connected = paymentModel.cardReaderConnectionStatus {
+            return false
+        }
         guard displayPaymentState.card == .idle && displayPaymentState.cash == .idle else { return false }
         // Also gate on scanToPay / markAsPaid being idle. After a successful
         // payment via either of those the totals view renders their success

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -194,10 +194,11 @@ struct TotalsView: View {
                         await paymentModel.startPaymentWithMethod(.bluetooth)
                     }
                 },
-                // Surface Tap to Pay in the sheet only when the merchant has
-                // *already* committed to BT (reader connected). On the TTP-hero
-                // screen TTP is the primary CTA already, so re-listing it in
-                // the sheet would be redundant.
+                // One-shot Bluetooth model: Tap to Pay is never offered from the
+                // sheet. On the TTP hero, TTP is already the primary CTA above;
+                // during a BT session, switching to TTP mid-flow is out of scope.
+                // The gate property is always false today — see its docstring
+                // for the policy rationale.
                 isTapToPayAvailable: isTapToPayRowAvailableInOtherMethodsSheet,
                 onTapToPay: {
                     handleTapToPayTapped()
@@ -792,8 +793,11 @@ private extension TotalsView {
     /// True whenever the bottom of the totals view should render the
     /// `cashAndOtherMethodsBottomStrip` instead of `POSCheckoutPaymentButtonsRow`.
     /// Covers both the TTP-hero case (no reader connected) and the
-    /// TTP-available + BT-reader-connected case where TTP lives in the sheet
-    /// rather than as a primary CTA contradicting the reader-ready screen.
+    /// TTP-available + BT-reader-connected case. In the BT-connected case the
+    /// strip renders Cash + Other payment methods (with Scan to Pay and
+    /// Mark as Paid inside the sheet); the row's TTP-as-primary CTA would
+    /// contradict the reader-ready screen, so it's collapsed into the strip
+    /// shape used by the hero.
     var useCashAndOtherMethodsBottomStrip: Bool {
         if useTapToPayHeroLayout { return true }
         // Reader-connected case: only fold into the strip when TTP would

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -705,59 +705,35 @@ private extension TotalsView {
     /// processing / success / error).
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        // BT reconnecting + idle card state: on phone POS the merchant has
-        // TTP as an immediate alternative, so we skip the iPad-style
-        // "Reconnecting reader…" wait and surface the TTP hero so they can
-        // take payment right now. If BT later reconnects on its own, the
-        // auto-resume path kicks back in and the BT-ready screen returns.
-        // We gate on idle card state to avoid swapping the screen away from
-        // a payment that's actually mid-collection.
-        if case .reconnecting = paymentModel.cardReaderConnectionStatus,
-           displayPaymentState.card == .idle,
-           displayPaymentState.cash == .idle,
-           displayPaymentState.scanToPay == .idle,
-           displayPaymentState.markAsPaid == .idle,
-           case .loaded(let totals) = posModel.orderState,
-           !totals.orderTotalDecimal.isZero {
-            return true
-        }
-        // Suppress only when BT is *currently* the active path — either we're
-        // in a BT session (`currentPaymentMethod == .bluetooth`) or a BT
-        // reader is still attached from a previous session
-        // (`lastConnectedMethod == .bluetooth` + reader status `.connected`).
-        // The second clause matters because `startPayment` auto-resumes BT
-        // collect when the reader is still there, and the TTP hero shouldn't
-        // flash in that brief window before the card state transitions.
-        //
-        // Critically we do NOT suppress on `lastConnectedMethod == .bluetooth`
-        // alone — that's a memory of the last successful connect, not a
-        // live signal. Once the BT reader drops, we should fall back to
-        // the TTP hero instead of leaving the merchant on a "Reader not
-        // connected" screen with no way back to TTP.
-        if paymentModel.currentPaymentMethod == .bluetooth { return false }
-        if paymentModel.lastConnectedMethod == .bluetooth,
-           case .connected = paymentModel.cardReaderConnectionStatus {
-            return false
-        }
+        // Idle-state gates — same as before. After a successful payment via
+        // any non-card method the totals view renders that method's success
+        // UI via `PaymentViewContent`; the hero must not show on top of it.
         guard displayPaymentState.card == .idle && displayPaymentState.cash == .idle else { return false }
-        // Also gate on scanToPay / markAsPaid being idle. After a successful
-        // payment via either of those the totals view renders their success
-        // UI via `PaymentViewContent` — we don't want the hero showing on
-        // top of (or instead of) that. Critically, without this the merchant
-        // could tap "Pay with Tap to pay" while `paymentState.markAsPaid`
-        // is still `.paymentSuccess`, and the card-state subscription's
-        // `markAsPaid != .idle` guard would silently swallow every Stripe
-        // event — the button disables but nothing happens.
         guard displayPaymentState.scanToPay == .idle && displayPaymentState.markAsPaid == .idle else { return false }
-        // Empty-cart / syncing / reconnecting guards computed directly. We
-        // can't reuse `shouldShowCollectCashPaymentButton` here — that helper
-        // also requires the reader to be disconnected when card state is idle
-        // (an iPad pay-row assumption). On TTP the device is silently
-        // pre-connected, so reusing it would collapse the hero whenever the
-        // pre-connect succeeds.
         guard case .loaded(let totals) = posModel.orderState else { return false }
         guard !totals.orderTotalDecimal.isZero else { return false }
-        if case .reconnecting = paymentModel.cardReaderConnectionStatus { return false }
+        // Suppress the TTP hero only when **BT is currently `.connected`**.
+        // That covers the BT-ready / BT-auto-resume scenarios where the
+        // merchant has committed to a reader that's actually attached. In
+        // every other reader state — `.disconnected`, `.reconnecting`,
+        // `.disconnecting`, `.cancellingConnection` — BT is unreachable
+        // and the merchant should see the TTP hero so they can take payment
+        // via TTP without waiting on BT recovery. If BT later reconnects,
+        // the auto-resume path kicks back in and the BT-ready screen
+        // returns naturally.
+        //
+        // The check is `currentPaymentMethod == .bluetooth || lastConnectedMethod == .bluetooth`
+        // so both flavours of "BT is the active path" are caught (active
+        // session vs. between-sessions auto-resume), but only when the reader
+        // is actually `.connected`. We deliberately don't suppress on those
+        // properties alone — once the reader drops, `currentPaymentMethod`
+        // stays stale and `lastConnectedMethod` is just a memory; relying on
+        // them in isolation would strand the merchant on a "Reader not
+        // connected" screen with no path back to TTP.
+        if case .connected = paymentModel.cardReaderConnectionStatus,
+           paymentModel.currentPaymentMethod == .bluetooth || paymentModel.lastConnectedMethod == .bluetooth {
+            return false
+        }
         return true
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -103,8 +103,8 @@ struct TotalsView: View {
 
                     Spacer()
 
-                    if useTapToPayHeroLayout {
-                        tapToPayBottomStrip
+                    if useCashAndOtherMethodsBottomStrip {
+                        cashAndOtherMethodsBottomStrip
                     } else if !checkoutPaymentMethods.isEmpty {
                         POSCheckoutPaymentButtonsRow(
                             methods: checkoutPaymentMethods,
@@ -115,6 +115,7 @@ struct TotalsView: View {
                 .scrollVerticallyIfNeeded()
                 .animation(.default, value: isShowingPaymentView)
                 .animation(.default, value: useTapToPayHeroLayout)
+                .animation(.default, value: useCashAndOtherMethodsBottomStrip)
             case .error(.other(let message), let handler):
                 PointOfSaleOrderSyncErrorMessageView(message: message, retryHandler: handler)
                     .transition(.opacity)
@@ -170,12 +171,25 @@ struct TotalsView: View {
         }
         .posSheet(isPresented: $isShowingOtherPaymentMethodsSheet) {
             POSOtherPaymentMethodsSheet(
+                // Hide the Card reader row when a reader is already connected — its
+                // "Connect a Bluetooth reader…" subtitle would contradict the BT
+                // reader status the merchant is already looking at. In the
+                // TTP-hero scenario (no reader connected) the row remains visible.
+                isCardReaderAvailable: isCardReaderRowAvailableInOtherMethodsSheet,
                 onCardReader: {
                     guard !isStartingPayment else { return }
                     isStartingPayment = true
                     Task { @MainActor in
                         await paymentModel.startPaymentWithMethod(.bluetooth)
                     }
+                },
+                // Surface Tap to Pay in the sheet only when the merchant has
+                // *already* committed to BT (reader connected). On the TTP-hero
+                // screen TTP is the primary CTA already, so re-listing it in
+                // the sheet would be redundant.
+                isTapToPayAvailable: isTapToPayRowAvailableInOtherMethodsSheet,
+                onTapToPay: {
+                    handleTapToPayTapped()
                 },
                 isScanToPayAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
                 onScanToPay: {
@@ -714,10 +728,18 @@ private extension TotalsView {
     }
 
     /// Cash + Other payment methods stacked outlined buttons rendered below the
-    /// totals when the Tap to Pay hero is showing. Mirrors the Android phone POS
-    /// "Cash + Other payment methods" row from samiuelson #15825.
+    /// totals. Used in two scenarios:
+    ///
+    /// - **TTP hero layout**: TTP is the primary CTA at the top, the strip
+    ///   carries Cash and the "Other payment methods" sheet (Card reader,
+    ///   Scan to Pay, Mark as Paid). Mirrors samiuelson #15825.
+    /// - **TTP-available + BT reader connected**: the BT reader is the active
+    ///   path showing "Ready for payment" up top, and the strip lets the
+    ///   merchant either take cash or step out via the sheet (which now
+    ///   includes Tap to Pay on iPhone since reader-is-connected means the
+    ///   sheet's Card reader row is hidden).
     @ViewBuilder
-    var tapToPayBottomStrip: some View {
+    var cashAndOtherMethodsBottomStrip: some View {
         VStack(spacing: POSSpacing.medium) {
             Button(action: handleCashPaymentTapped) {
                 Text(Localization.cashPaymentButtonTitle)
@@ -737,6 +759,51 @@ private extension TotalsView {
         }
         .padding(.horizontal, POSPadding.medium)
         .padding(.bottom, POSPadding.xxLarge)
+    }
+
+    /// True whenever the bottom of the totals view should render the
+    /// `cashAndOtherMethodsBottomStrip` instead of `POSCheckoutPaymentButtonsRow`.
+    /// Covers both the TTP-hero case (no reader connected) and the
+    /// TTP-available + BT-reader-connected case where TTP lives in the sheet
+    /// rather than as a primary CTA contradicting the reader-ready screen.
+    var useCashAndOtherMethodsBottomStrip: Bool {
+        if useTapToPayHeroLayout { return true }
+        // Reader-connected case: only fold into the strip when TTP would
+        // otherwise have crowded the row as a redundant primary CTA. If TTP
+        // isn't available we don't need the sheet at all — the row already
+        // does the right thing (just Cash).
+        guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
+        let viewHelper = POSPaymentViewHelper()
+        let isReaderDisconnected = viewHelper.shouldShowDisconnectedMessage(
+            readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
+            paymentState: displayPaymentState
+        )
+        guard !isReaderDisconnected else { return false }
+        return totalsViewHelper.shouldShowCollectCashPaymentButton(
+            orderState: posModel.orderState,
+            paymentState: displayPaymentState,
+            cardReaderConnectionStatus: paymentModel.cardReaderConnectionStatus
+        )
+    }
+
+    /// True when the Card reader row should appear inside the Other Payment
+    /// Methods sheet. False once a reader is already connected — its
+    /// "Connect a Bluetooth reader…" subtitle would mislead in that state.
+    var isCardReaderRowAvailableInOtherMethodsSheet: Bool {
+        let viewHelper = POSPaymentViewHelper()
+        return viewHelper.shouldShowDisconnectedMessage(
+            readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
+            paymentState: displayPaymentState
+        )
+    }
+
+    /// True when the Tap to Pay on iPhone row should appear inside the Other
+    /// Payment Methods sheet. We surface it only when the merchant has already
+    /// picked BT (reader connected) — on the TTP-hero screen TTP is the
+    /// primary CTA already and listing it inside the sheet would duplicate it.
+    var isTapToPayRowAvailableInOtherMethodsSheet: Bool {
+        guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
+        return !isCardReaderRowAvailableInOtherMethodsSheet
     }
 
     func handleTapToPayTapped() {

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -796,7 +796,6 @@ private extension TotalsView {
         // isn't available we don't need the sheet at all — the row already
         // does the right thing (just Cash).
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        let viewHelper = POSPaymentViewHelper()
         let isReaderDisconnected = viewHelper.shouldShowDisconnectedMessage(
             readerConnectionStatus: paymentModel.cardReaderConnectionStatus,
             paymentState: displayPaymentState

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -194,15 +194,6 @@ struct TotalsView: View {
                         await paymentModel.startPaymentWithMethod(.bluetooth)
                     }
                 },
-                // One-shot Bluetooth model: Tap to Pay is never offered from the
-                // sheet. On the TTP hero, TTP is already the primary CTA above;
-                // during a BT session, switching to TTP mid-flow is out of scope.
-                // The gate property is always false today — see its docstring
-                // for the policy rationale.
-                isTapToPayAvailable: isTapToPayRowAvailableInOtherMethodsSheet,
-                onTapToPay: {
-                    handleTapToPayTapped()
-                },
                 isScanToPayAvailable: featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay),
                 onScanToPay: {
                     // Same double-tap guard the other sheet callbacks use. Without
@@ -841,15 +832,6 @@ private extension TotalsView {
         // reader option reappears there for the next order if they want
         // Bluetooth again.
         paymentModel.currentPaymentMethod != .bluetooth
-    }
-
-    /// One-shot Bluetooth model: TTP is never offered from the Other Payment
-    /// Methods sheet. On the TTP hero, TTP is already the primary CTA at the
-    /// top. During a Bluetooth collection, switching to TTP mid-flow is
-    /// explicitly out of scope — the BT session must finish (or be
-    /// abandoned) before the merchant returns to the TTP hero. Always false.
-    var isTapToPayRowAvailableInOtherMethodsSheet: Bool {
-        false
     }
 
     func handleTapToPayTapped() {

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -705,6 +705,15 @@ private extension TotalsView {
     /// processing / success / error).
     var useTapToPayHeroLayout: Bool {
         guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
+        // If a BT reader is connected (the merchant committed to BT in a
+        // previous session and it's still attached), `startPayment` auto-
+        // resumes the BT collect flow on the next idle checkout. Showing the
+        // TTP hero in the brief window before the card state transitions
+        // would flash misleadingly. `lastConnectedMethod` is the canonical
+        // "merchant committed to BT" signal — distinct from
+        // `cardReaderConnectionStatus.connected` which is also true for the
+        // silent TTP pre-connect.
+        if paymentModel.lastConnectedMethod == .bluetooth { return false }
         guard displayPaymentState.card == .idle && displayPaymentState.cash == .idle else { return false }
         // Also gate on scanToPay / markAsPaid being idle. After a successful
         // payment via either of those the totals view renders their success

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -653,11 +653,7 @@ private extension TotalsView {
         if isTapToPayAvailable {
             methods.append(.tapToPay)
         }
-        // On phone POS with TTP available we drop Bluetooth from the
-        // prototype's initial scope (see `isCardReaderRowAvailableInOtherMethodsSheet`
-        // for the rationale). Keep `.cardReader` only on iPad and on TTP-
-        // ineligible phones where BT is the lone card path.
-        if isReaderDisconnected && paymentModel.preferredConnectionMethod != .tapToPay {
+        if isReaderDisconnected {
             methods.append(.cardReader)
         }
         methods.append(.cashPayment)
@@ -716,24 +712,20 @@ private extension TotalsView {
         guard displayPaymentState.scanToPay == .idle && displayPaymentState.markAsPaid == .idle else { return false }
         guard case .loaded(let totals) = posModel.orderState else { return false }
         guard !totals.orderTotalDecimal.isZero else { return false }
-        // On phone POS with TTP available (`preferredConnectionMethod == .tapToPay`)
-        // we've dropped Bluetooth from the prototype's initial scope, so any
-        // residual BT state in `currentPaymentMethod` / `lastConnectedMethod`
-        // — e.g. from prior testing / dogfood builds before the drop —
-        // shouldn't suppress the hero. TTP is the only reachable card path
-        // and the hero should always surface on idle.
-        guard paymentModel.preferredConnectionMethod != .tapToPay else {
-            return true
-        }
-        // iPad / TTP-ineligible phones: suppress the TTP hero only when
-        // **BT is currently `.connected`**. That covers the BT-ready / BT-
-        // auto-resume scenarios where the merchant has committed to a reader
-        // that's actually attached. In every other reader state — `.disconnected`,
-        // `.reconnecting`, `.disconnecting`, `.cancellingConnection` — BT is
-        // unreachable and the merchant should see the TTP hero (where TTP is
-        // even available — note this whole method already returned false at
-        // the top when TTP isn't available, so on iPad we never reach this
-        // path anyway).
+        // Suppress the TTP hero only when **BT is currently `.connected`**.
+        // That covers the BT-ready / BT-collecting scenarios where the
+        // merchant has explicitly picked Card reader from the sheet and we
+        // want the BT screen (`PaymentViewContent`) on top, not the TTP
+        // hero. In every other reader state — `.disconnected`, `.reconnecting`,
+        // `.disconnecting`, `.cancellingConnection` — BT is unreachable and
+        // the merchant should see the TTP hero.
+        //
+        // The one-shot BT model relies on this: a BT drop mid-flow (status
+        // → `.reconnecting` or `.disconnected`) naturally exposes the TTP
+        // hero as the alternative path. When the merchant taps Done after a
+        // BT success, the next `startPayment()` invocation disconnects the
+        // BT reader and pre-connects TTP, returning the merchant to the TTP
+        // hero for the next order.
         if case .connected = paymentModel.cardReaderConnectionStatus,
            paymentModel.currentPaymentMethod == .bluetooth || paymentModel.lastConnectedMethod == .bluetooth {
             return false
@@ -811,24 +803,27 @@ private extension TotalsView {
     /// `.connected` — only `currentPaymentMethod` distinguishes
     /// "merchant committed to BT" from "TTP reader is warm."
     var isCardReaderRowAvailableInOtherMethodsSheet: Bool {
-        // On phone POS with Tap to Pay on iPhone available
-        // (`preferredConnectionMethod == .tapToPay`) we drop Bluetooth from
-        // the prototype's initial scope. TTP + Cash + Scan to Pay + Mark as
-        // Paid is the complete set; merchants who need BT use iPad. The BT
-        // code paths in `POSPaymentModel` stay in place (dormant) for a
-        // future re-introduction once the state-machine refactor lands.
-        if paymentModel.preferredConnectionMethod == .tapToPay { return false }
-        return paymentModel.currentPaymentMethod != .bluetooth
+        // One-shot Bluetooth re-introduction model:
+        //   - From the TTP hero (no active session): Card reader is offered as
+        //     an explicit opt-in.
+        //   - During a Bluetooth collection (`currentPaymentMethod == .bluetooth`):
+        //     Card reader is hidden (no re-pick mid-flow, no method-switch
+        //     state-machine complexity).
+        // After a Bluetooth session ends (success or abandonment), the next
+        // `startPayment()` invocation disconnects the BT reader and pre-
+        // connects TTP, returning the merchant to the TTP hero. The Card
+        // reader option reappears there for the next order if they want
+        // Bluetooth again.
+        paymentModel.currentPaymentMethod != .bluetooth
     }
 
-    /// True when the Tap to Pay on iPhone row should appear inside the Other
-    /// Payment Methods sheet. Hidden on the TTP hero (it's already the
-    /// primary CTA up top) and during an active TTP session (already on it).
-    /// Visible during BT flows so the merchant can switch over.
+    /// One-shot Bluetooth model: TTP is never offered from the Other Payment
+    /// Methods sheet. On the TTP hero, TTP is already the primary CTA at the
+    /// top. During a Bluetooth collection, switching to TTP mid-flow is
+    /// explicitly out of scope — the BT session must finish (or be
+    /// abandoned) before the merchant returns to the TTP hero. Always false.
     var isTapToPayRowAvailableInOtherMethodsSheet: Bool {
-        guard posModel.tapToPayAvailabilityController?.state.isAvailable == true else { return false }
-        if useTapToPayHeroLayout { return false }
-        return paymentModel.currentPaymentMethod != .tapToPay
+        false
     }
 
     func handleTapToPayTapped() {

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -72,8 +72,7 @@ struct TotalsView: View {
                         )
                     } else if useTapToPayHeroLayout {
                         POSTapToPayHeroView(onPayTapped: handleTapToPayTapped,
-                                            isPayDisabled: isStartingPayment,
-                                            isPreparing: paymentModel.isPreparingTapToPay)
+                                            isPayDisabled: isStartingPayment)
                     } else if isShowingPaymentView {
                         PaymentViewContent(
                             paymentState: displayPaymentState,

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -2070,6 +2070,114 @@ struct POSPaymentModelTests {
 
         // Then: verifier was called at least once after activate
         #expect(verifier.checkPaymentStatusCallCount >= 1)
+    // MARK: - Phone POS TTP optimizations
+
+    @Test("startPayment on the TTP path does not auto-collect when no BT reader was previously attached")
+    @MainActor
+    func test_startPayment_when_TTP_preferred_and_no_prior_BT_then_does_not_auto_collect() async {
+        // Given — phone POS path (preferred = .tapToPay), no reader attached.
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .tapToPay)
+
+        // When — `startPayment` fires the silent TTP pre-connect inside a Task,
+        // so wait for the SDK-level `connectReader` to be called before
+        // asserting. Without this the Task hasn't been scheduled yet by the
+        // time the test continues.
+        await withCheckedContinuation { continuation in
+            service.onConnectReaderCalled = { continuation.resume() }
+            Task { @MainActor in await sut.startPayment() }
+        }
+
+        // Then — silent TTP pre-connect kicked off, no collect started, no
+        // active session is set on the model. Collection is gated behind an
+        // explicit method tap from the hero / sheet.
+        #expect(sut.currentPaymentMethod == nil)
+        #expect(service.collectPaymentWasCalled == false)
+        #expect(service.connectReaderCallCount == 1)
+    }
+
+    @Test("startPaymentWithMethod ignores re-entry of the same method during an active session")
+    @MainActor
+    func test_startPaymentWithMethod_when_called_again_with_same_method_then_ignored() async {
+        // Given — an active BT session (set up via the iPad-style auto-collect
+        // path so the mock doesn't have to simulate the SDK's disconnect /
+        // reconnect status propagation that the TTP-preferred path requires).
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+        service.connectedReader = .init(name: "BT Reader", batteryLevel: 0.85)
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .bluetooth)
+        await withCheckedContinuation { continuation in
+            service.onCollectPaymentCalled = { continuation.resume() }
+            Task { @MainActor in await sut.startPayment() }
+        }
+        let connectCountAfterFirst = service.connectReaderCallCount
+        service.collectPaymentWasCalled = false
+
+        // When — re-entering with the same method (e.g. stray closure / SwiftUI
+        // re-render after the session is established).
+        await sut.startPaymentWithMethod(.bluetooth)
+
+        // Then — second call is a no-op: no new connect, no new collect, the
+        // active method is unchanged.
+        #expect(service.connectReaderCallCount == connectCountAfterFirst)
+        #expect(service.collectPaymentWasCalled == false)
+        #expect(sut.currentPaymentMethod == .bluetooth)
+    }
+
+    @Test("startPaymentWithMethod cancels the current payment when switching to a different method")
+    @MainActor
+    func test_startPaymentWithMethod_when_switching_methods_then_cancels_current_payment() async {
+        // Given — an active BT session.
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+        service.connectedReader = .init(name: "BT Reader", batteryLevel: 0.85)
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .bluetooth)
+        await withCheckedContinuation { continuation in
+            service.onCollectPaymentCalled = { continuation.resume() }
+            Task { @MainActor in await sut.startPayment() }
+        }
+        service.cancelPaymentCalled = false
+
+        // When — merchant picks Tap to Pay from the Other payment methods sheet
+        // while BT is mid-collection. Wait until the SUT has finished the
+        // cancel + active-method-flip portion of `startPaymentWithMethod` by
+        // observing `currentPaymentMethod` flipping to `.tapToPay` (which
+        // happens *after* `cancelPayment` has been awaited). The TTP connect
+        // that follows isn't observable through the mock (it doesn't
+        // propagate connect results into the connection-status publisher),
+        // so we stop here and assert on the switch step alone.
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.currentPaymentMethod
+            } onChange: {
+                Task { @MainActor in
+                    if sut.currentPaymentMethod == .tapToPay {
+                        continuation.resume()
+                    }
+                }
+            }
+            Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
+        }
+
+        // Then — the BT collect was cancelled and the active method flipped.
+        #expect(service.cancelPaymentCalled == true)
+        #expect(sut.currentPaymentMethod == .tapToPay)
     }
 }
 
@@ -2089,6 +2197,7 @@ private func makePaymentController(
     analytics: POSAnalyticsProviding = MockPOSAnalytics(),
     collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
     celebration: PaymentCaptureCelebrationProtocol = MockPaymentCaptureCelebration(),
+    preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
     scanToPayPollInterval: TimeInterval = 3,
     preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
     paymentState: PointOfSalePaymentState = .idle
@@ -2106,6 +2215,7 @@ private func makePaymentController(
         analytics: analytics,
         collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
         celebration: celebration,
+        preferredConnectionMethod: preferredConnectionMethod,
         scanToPayPollInterval: scanToPayPollInterval,
         preferredConnectionMethod: preferredConnectionMethod,
         paymentState: paymentState)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -1469,7 +1469,12 @@ struct POSPaymentModelTests {
         // status publisher and the mock's `connectReader` doesn't drive it.
         // The gate side-effects we want — `currentPaymentMethod` set,
         // `isAwaitingExplicitPaymentStart` cleared — happen synchronously
-        // before the first `await` inside the function.)
+        // before the first `await` inside the function, so a single
+        // `Task.yield()` is enough to let the spawned Task run that prefix.
+        // If `startPaymentWithMethod` ever grows an `await` before the
+        // `currentPaymentMethod = method` assignment, this assertion would
+        // start asserting the pre-change value and pass incorrectly — replace
+        // the yield with a `withObservationTracking` wait at that point.
         Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
         await Task.yield()
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -2114,6 +2114,57 @@ struct POSPaymentModelTests {
         #expect(service.connectReaderCallCount == 1)
     }
 
+    @Test("startPayment on the TTP path disconnects a previously-attached BT reader before pre-connecting TTP")
+    @MainActor
+    func test_startPayment_when_TTP_preferred_and_prior_BT_attached_then_disconnects_before_TTP_preconnect() async {
+        // Given — phone POS path (preferred = .tapToPay) with a BT reader
+        // attached from a prior session (`lastConnectedMethod == .bluetooth`).
+        // We can't poke `lastConnectedMethod` directly (it's `private(set)`),
+        // so drive it through the model's own machinery: call
+        // `connectCardReader()` which sets `lastConnectedMethod = .bluetooth`
+        // after a successful BT connect.
+        let service = MockCardPresentPaymentService()
+        service.connectedReader = .init(name: "BT Reader", batteryLevel: 0.85)
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider,
+            preferredConnectionMethod: .tapToPay)
+
+        // Establish `lastConnectedMethod == .bluetooth`. `connectCardReader`
+        // spawns its own Task; wait for the SDK-level `connectReader` to
+        // be called so the post-connect `lastConnectedMethod` assignment
+        // has landed before we proceed.
+        await withCheckedContinuation { continuation in
+            service.onConnectReaderCalled = { continuation.resume() }
+            sut.connectCardReader()
+        }
+        #expect(sut.lastConnectedMethod == .bluetooth)
+        let connectCountAfterBT = service.connectReaderCallCount
+
+        // When — the merchant returns to the TTP hero for a new order.
+        // `startPayment` sees the BT cleanup conditions (TTP preferred +
+        // `lastConnectedMethod == .bluetooth` + reader still connected) and
+        // disconnects before kicking the silent TTP pre-connect.
+        await withCheckedContinuation { continuation in
+            service.onConnectReaderCalled = { continuation.resume() }
+            Task { @MainActor in await sut.startPayment() }
+        }
+
+        // Then — the stale BT reader was dropped and the silent TTP
+        // pre-connect ran. The disconnect on the BT side is the headline
+        // one-shot-Bluetooth cleanup; the second `connectReader` call is
+        // `connectTapToPayReader` doing its pre-connect.
+        #expect(service.disconnectReaderCallCount >= 1)
+        #expect(service.connectReaderCallCount > connectCountAfterBT)
+        // No collect on either side — TTP is gated behind an explicit hero
+        // tap, BT was just torn down without being re-collected.
+        #expect(service.collectPaymentWasCalled == false)
+        #expect(sut.currentPaymentMethod == nil)
+    }
+
     @Test("startPaymentWithMethod ignores re-entry of the same method during an active session")
     @MainActor
     func test_startPaymentWithMethod_when_called_again_with_same_method_then_ignored() async {
@@ -2135,15 +2186,19 @@ struct POSPaymentModelTests {
         }
         let connectCountAfterFirst = service.connectReaderCallCount
         service.collectPaymentWasCalled = false
+        service.cancelPaymentCalled = false
 
         // When — re-entering with the same method (e.g. stray closure / SwiftUI
         // re-render after the session is established).
         await sut.startPaymentWithMethod(.bluetooth)
 
-        // Then — second call is a no-op: no new connect, no new collect, the
-        // active method is unchanged.
+        // Then — second call is a no-op: no new connect, no new collect, no
+        // cancel (the early-return path at `POSPaymentModel.startPaymentWithMethod`
+        // bails before the method-switch cancel runs), and the active method
+        // is unchanged.
         #expect(service.connectReaderCallCount == connectCountAfterFirst)
         #expect(service.collectPaymentWasCalled == false)
+        #expect(service.cancelPaymentCalled == false)
         #expect(sut.currentPaymentMethod == .bluetooth)
     }
 
@@ -2167,25 +2222,17 @@ struct POSPaymentModelTests {
         service.cancelPaymentCalled = false
 
         // When — merchant picks Tap to Pay from the Other payment methods sheet
-        // while BT is mid-collection. Wait until the SUT has finished the
-        // cancel + active-method-flip portion of `startPaymentWithMethod` by
-        // observing `currentPaymentMethod` flipping to `.tapToPay` (which
-        // happens *after* `cancelPayment` has been awaited). The TTP connect
-        // that follows isn't observable through the mock (it doesn't
-        // propagate connect results into the connection-status publisher),
-        // so we stop here and assert on the switch step alone.
-        await withCheckedContinuation { continuation in
-            withObservationTracking {
-                _ = sut.currentPaymentMethod
-            } onChange: {
-                Task { @MainActor in
-                    if sut.currentPaymentMethod == .tapToPay {
-                        continuation.resume()
-                    }
-                }
-            }
-            Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
-        }
+        // while BT is mid-collection. `await task.value` is the most robust
+        // wait we have here — `startPaymentWithMethod` returns deterministically
+        // in the test environment (cancel → disconnect-then-reconnect → kick
+        // a fire-and-forget connectReader Task → set up the
+        // startPaymentOnCardReaderConnection one-shot subscription → return).
+        // Better than `withObservationTracking { _ = sut.currentPaymentMethod }`,
+        // which would hang to the test-suite timeout if a future change ever
+        // emitted an intermediate `currentPaymentMethod` value before
+        // `.tapToPay` and the observation missed the final flip.
+        let task = Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
+        await task.value
 
         // Then — the BT collect was cancelled and the active method flipped.
         #expect(service.cancelPaymentCalled == true)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -1449,7 +1449,6 @@ struct POSPaymentModelTests {
     func startPaymentWithMethod_TTP_when_event_arrives_after_explicit_start_then_card_state_updates() async {
         // Given
         let service = MockCardPresentPaymentService()
-        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         let orderProvider = MockPOSPaymentOrderProvider()
         orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
         orderProvider.totalDecimalToReturn = 10
@@ -1465,16 +1464,24 @@ struct POSPaymentModelTests {
         service.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
         #expect(sut.paymentState.card == .idle)
 
-        // When: merchant explicitly taps "Tap to Pay" — opens the gate
-        await sut.startPaymentWithMethod(.tapToPay)
+        // When: merchant explicitly taps "Tap to Pay" — opens the gate.
+        // (Don't await — `startPaymentWithMethod` blocks on the reader connection
+        // status publisher and the mock's `connectReader` doesn't drive it.
+        // The gate side-effects we want — `currentPaymentMethod` set,
+        // `isAwaitingExplicitPaymentStart` cleared — happen synchronously
+        // before the first `await` inside the function.)
+        Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
+        await Task.yield()
 
-        // Then: events propagate through the now-open gate. The mock's
-        // `collectPayment` auto-fires a `paymentSuccess` event — a terminal
-        // state that reaches `paymentState.card` because the TTP path only
-        // suppresses *intermediate* states (`.acceptingCard`, `.preparingReader`,
-        // etc.) so the merchant's UI doesn't flicker behind Apple's modal.
-        // The `.idle → .cardPaymentSuccessful` transition is unreachable
-        // without an open gate, so observing it here proves propagation.
+        // Then: gate is open — `currentPaymentMethod` reflects the explicit pick.
+        #expect(sut.currentPaymentMethod == .tapToPay)
+
+        // And a terminal payment-success event now propagates through the
+        // open gate to `paymentState.card`. (Intermediate states like
+        // `.acceptingCard` would be suppressed by the TTP filter — see
+        // `subscribeToPaymentSessionEvents`. Only terminal states reach
+        // `paymentState.card` on the TTP path.)
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
         #expect(sut.paymentState.card == .cardPaymentSuccessful)
 
         // And the TTP intermediate-state filter is active: a subsequent
@@ -1490,7 +1497,6 @@ struct POSPaymentModelTests {
     func cancelledOnReader_TTP_when_event_arrives_then_card_state_resets_and_gate_re_arms() async {
         // Given
         let service = MockCardPresentPaymentService()
-        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         let orderProvider = MockPOSPaymentOrderProvider()
         orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
         orderProvider.totalDecimalToReturn = 10
@@ -1502,10 +1508,12 @@ struct POSPaymentModelTests {
 
         await sut.startPayment()
 
-        // Open the gate: merchant taps Tap to Pay. The mock's `collectPayment`
-        // auto-fires a terminal `paymentSuccess` event (intermediate states are
-        // filtered on TTP — see `subscribeToPaymentSessionEvents`).
-        await sut.startPaymentWithMethod(.tapToPay)
+        // Open the gate: merchant taps Tap to Pay. (Don't await — see the
+        // sibling test above for why.) Drive state to a terminal value by
+        // sending a `paymentSuccess` directly through the now-open gate.
+        Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
+        await Task.yield()
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
         #expect(sut.paymentState.card == .cardPaymentSuccessful)
 
         // When: merchant cancels on reader
@@ -1565,7 +1573,6 @@ struct POSPaymentModelTests {
 
         // Given
         let service = MockCardPresentPaymentService()
-        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         let orderProvider = MockPOSPaymentOrderProvider()
         orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
         orderProvider.totalDecimalToReturn = 10
@@ -1577,10 +1584,15 @@ struct POSPaymentModelTests {
 
         await sut.startPayment()
 
-        // Round 1: open gate, reach a terminal state, then cancel on reader.
-        // (Intermediates like `.acceptingCard` are filtered on TTP; the mock's
-        // auto-fired `paymentSuccess` is the terminal state that lands.)
-        await sut.startPaymentWithMethod(.tapToPay)
+        // Round 1: open gate, drive to terminal state via a direct paymentSuccess
+        // event, then cancel on reader. (Don't await `startPaymentWithMethod` —
+        // the BT-as-one-shot architecture's disconnect-then-reconnect path
+        // blocks on connection status the mock doesn't drive. Gate side-effects
+        // happen before the first await; sending the success event after
+        // yielding once proves the gate is open.)
+        Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
+        await Task.yield()
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
         #expect(sut.paymentState.card == .cardPaymentSuccessful)
 
         // When: merchant cancels on reader — gate must close and state must reset
@@ -1589,25 +1601,18 @@ struct POSPaymentModelTests {
         // Then: state is idle immediately
         #expect(sut.paymentState.card == .idle)
 
-        // Re-attach the mock reader for Round 2. `connectTapToPayReader` (kicked off
-        // by Round 1's `startPayment`) disconnected the mock — the mock's
-        // `connectReader` returns a `.connected` result but doesn't update
-        // `connectedReader`, so the publisher stays at `.disconnected`. Without this
-        // reset, `startPaymentFlow`'s `guard case .connected` would short-circuit and
-        // collectPayment wouldn't fire in Round 2, masking the invariant we're testing.
-        service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
-
-        // Round 2: a subsequent startPaymentWithMethod must succeed (gate re-opens
-        // and the mock auto-fires `paymentSuccess` again).
-        await sut.startPaymentWithMethod(.tapToPay)
-
+        // Round 2: subsequent startPaymentWithMethod must re-open the gate cleanly.
         // If subscriber ordering were inverted — card-state sink before
         // cancelledOnReader sink — `cancelledOnReader` would have advanced
-        // `paymentState.card` past `.idle` (terminal states bypass the filter),
-        // and `startPaymentWithMethod`'s `guard paymentState.card == .idle` would
-        // have short-circuited Round 2, leaving us stuck at the prior terminal
-        // state without the second auto-fired `paymentSuccess` ever running.
-        // Reaching `.cardPaymentSuccessful` again proves Round 2 actually proceeded.
+        // `paymentState.card` past `.idle` before the gate closed, and the
+        // `paymentState.card != .idle` guard in `startPaymentWithMethod` would
+        // have short-circuited Round 2, leaving `currentPaymentMethod` unset.
+        Task { @MainActor in await sut.startPaymentWithMethod(.tapToPay) }
+        await Task.yield()
+        #expect(sut.currentPaymentMethod == .tapToPay)
+
+        // And a second paymentSuccess event propagates through the re-opened gate.
+        service.paymentEvent = .show(eventDetails: .paymentSuccess(done: {}))
         #expect(sut.paymentState.card == .cardPaymentSuccessful)
     }
 
@@ -2070,6 +2075,8 @@ struct POSPaymentModelTests {
 
         // Then: verifier was called at least once after activate
         #expect(verifier.checkPaymentStatusCallCount >= 1)
+    }
+
     // MARK: - Phone POS TTP optimizations
 
     @Test("startPayment on the TTP path does not auto-collect when no BT reader was previously attached")
@@ -2197,7 +2204,6 @@ private func makePaymentController(
     analytics: POSAnalyticsProviding = MockPOSAnalytics(),
     collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking = MockPOSCollectOrderPaymentAnalyticsTracker(),
     celebration: PaymentCaptureCelebrationProtocol = MockPaymentCaptureCelebration(),
-    preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
     scanToPayPollInterval: TimeInterval = 3,
     preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
     paymentState: PointOfSalePaymentState = .idle
@@ -2215,7 +2221,6 @@ private func makePaymentController(
         analytics: analytics,
         collectOrderPaymentAnalyticsTracker: collectOrderPaymentAnalyticsTracker,
         celebration: celebration,
-        preferredConnectionMethod: preferredConnectionMethod,
         scanToPayPollInterval: scanToPayPollInterval,
         preferredConnectionMethod: preferredConnectionMethod,
         paymentState: paymentState)

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockCardPresentPaymentService.swift
@@ -52,7 +52,11 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
         return connectReaderResult
     }
 
+    var disconnectReaderCallCount = 0
+    var onDisconnectReaderCalled: (() -> Void)?
     func disconnectReader() async {
+        disconnectReaderCallCount += 1
+        onDisconnectReaderCalled?()
         connectedReader = nil
     }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-ios/pull/17218]
+- [Internal] Phone POS Tap to Pay on iPhone: hero CTA stays tappable during silent pre-connect, Apple-compliant "Tap to Pay on iPhone" wording, Bluetooth as a one-shot opt-in from the Other payment methods sheet. Feature-flagged. [https://github.com/woocommerce/woocommerce-ios/pull/17152]
 
 
 24.8


### PR DESCRIPTION
> Rebased onto trunk after the full upstream cascade landed (#17066 → #17098, #17111, #17112, #17114). Dropped ~21 commits that became redundant via independent paths on trunk. Kept 19 commits covering the two genuinely net-new threads: the BT-as-one-shot architecture and the TTP UX optimizations.

## Description

The final PR in the phone POS Tap to Pay stack. Two interleaved threads:

**Bluetooth-as-one-shot architecture** — the defining product decision of the phone POS surface, and the source of the Android divergences flagged in #17096's review. iPad keeps Bluetooth as a first-class peer to TTP; phone POS demotes Bluetooth to a one-shot opt-in from the Other payment methods sheet, with TTP as the primary card path always. Concretely:

- `a36cefefa8` Drop Bluetooth from phone POS scope (initial cut — TTP-only)
- `3d0587b7ae` Re-introduce Bluetooth as a one-shot opt-in from the TTP hero
- `f93377eece` Unify TTP-hero suppression on a single live "BT actually connected" gate
- `306466c949` Move TTP into Other payment methods sheet on the BT-reader-connected screen
- `adfb8c29ef` Fix sheet content gates: silent TTP pre-connect was masquerading as BT-connected
- `237fadcb19` Auto-resume BT collect when a BT reader is still attached
- `66faef5fc3` Allow method switching from Other payment methods sheet
- `6865455a3d` Fall back to TTP hero when a previously-attached BT reader drops
- `9d042c4fb1` Re-kick startPayment when a BT reader reconnects
- `596e589128` Show TTP hero immediately when BT reader is reconnecting (phone POS only)
- `74ea78e38f` Fix Cancel reconnection button leaving the UI stuck on "Reconnecting reader…"
- `9be3ced7c0` Add unit tests for the new state-machine logic

**TTP UX optimizations**:

- `e16da3b287` Keep hero CTA tappable during silent pre-connect — tap queues an explicit start; no waiting on a sequential pre-connect-then-collect chain.
- `3aa291ae09` Use `POSFilledButtonStyle.isLoading` for the hero CTA spinner — fixes a tap-during-pre-connect deadlock.
- `d0f0c91a7d` Apple-compliant "Tap to Pay on iPhone" wording in the hero (exact capitalization per Apple's TTP branding guidelines).

**Review feedback rollups** (applied from upstream PRs that landed in the cascade):

- `c806075457` Apply review feedback from #17067 (modal redundancy) and #17092 (iPad drift — restores `tabletCheckmarkSize: 52` to its design value)
- `8ee774e839` Apply review feedback from #17097 (try? violations → DDLogError) and #17112 (double-tap protection)

**Lint + test repair**:

- `4e57165d3d` Fix SwiftLint line_length violation in `startPaymentWithMethod` log
- `12f36e96fb` Fix TTP gate tests for the new BT-as-one-shot state machine — three pre-existing tests stopped passing after the architecture change because they depended on the mock's auto-collectPayment behaviour. Rewritten to verify the gate directly via terminal events.

## Dropped commits (verified redundant on current trunk)

| Dropped | Where it landed |
|---|---|
| All 9 Mark as Paid layout iteration commits | squashed into #17114's `200c4f5c51` Mark as Paid layout commit |
| `d700618aec` Update modifier for note-aware confirmMarkAsPaidPayment | redundant — trunk has NavigationStack push, not modifier |
| `28ac2d1bd0` + `6c4ec814db` TTP pre-connect coalescing | squashed into #17114's `9efe46c9db` |
| 10 TTP polish commits (post-cancel flicker, gate, hero loading, etc.) | individually landed on trunk via #17097 + #17098 |
| `7c6a6463e1` Wire ScanToPay + MarkAsPaid into sheet | landed via #17112 |
| `45c253023f` Fix screen brightness | trunk has equivalent (`2230db6a8a`) |
| 4 cherry-picks of trunk-merged features | already on trunk via independent PRs |
| 4 merge commits | merge noise |
| `a6121ff082` + `1d025fe0c6` apply nits + revert | cancel out |
| `fab937b7c1` Diagnostic log | meant to be temporary |
| `e93f64c876` Drop parens (SwiftLint) | the parens were squashed away in #17114 |
| `580ef01ec1` Doc comment cleanup | only relevant in a now-superseded intermediate state |
| Various small fixes already on trunk via #17111/#17112/#17114 | see audit |

## Test Steps

**Setup.** iPhone XS or later, iOS 16.4+, localDeveloper build, `pointOfSaleTapToPay` flag on. Eligible WooCommerce site + region-eligible Apple ID. iPad available as a control for the unchanged-iPad regression.

### 1. TTP hero rendering and Apple-compliant wording

Open POS on a TTP-eligible iPhone. Hero renders with **"Tap to Pay on iPhone"** title (note exact capitalisation), subtitle, and a filled **"Pay with Tap to Pay"** CTA.

### 2. Hero CTA tappable during silent pre-connect

Enter checkout, then immediately tap "Pay with Tap to Pay" before the pre-connect settles. CTA shows the loading spinner via the button's built-in `isLoading` style. When pre-connect completes, the Apple modal opens automatically — no deadlock, no double-press needed.

### 3. One-shot Bluetooth opt-in

Open the Other payment methods sheet, tap **Card reader**. Sheet dismisses; standard BT scan / connect / collect runs. After payment (or merchant cancel), the screen returns to the TTP hero. Re-entering checkout does **not** auto-collect on the previously-paired BT reader — TTP is the default path again.

### 4. Method switching from the sheet

With a BT reader actively connected (mid-session), open the Other payment methods sheet — the **Tap to Pay** row is visible, **Card reader** row is hidden. Tap Tap to Pay → BT collect is cancelled, TTP modal opens.

### 5. Sheet content gates

With no reader connected (and silent TTP pre-connect in flight): sheet shows Card reader, Scan to Pay, Mark order as paid — **Tap to Pay row is hidden** (Tap to Pay is already the hero CTA, would be redundant).

### 6. TTP-hero suppression on "BT actually connected"

With a BT reader actively connected and collecting, the TTP hero is suppressed (the merchant is mid-BT-payment; showing the TTP hero would be confusing). When the BT session ends (success/cancel/disconnect), the hero returns.

### 7. BT reconnection edge cases

- **Cancel reconnection button** no longer leaves UI stuck on "Reconnecting reader…" (`74ea78e38f`).
- **BT reader drops mid-checkout** → falls back to TTP hero immediately (`6865455a3d`).
- **BT reader reconnects mid-checkout** → re-kicks `startPayment` to resume (`9d042c4fb1`).
- **Reconnecting state** → TTP hero shows immediately so the merchant can switch to TTP if they want (`596e589128`).

### 8. Regression

- iPad: every existing path renders unchanged.
- Non-TTP phones: fallback to the multi-method row from #17095 (no hero, no Other payment methods sheet).
- Bluetooth-only iPad sites: legacy Cash + Connect reader UX intact.

### 9. Tests

`xcodebuild test -scheme PointOfSale` — all `POSPaymentModelTests` pass, including the new state-machine tests (`9be3ced7c0`) and the repaired TTP gate tests (`12f36e96fb`).

## Screenshots
N/A — visual changes covered by the test steps; UX is verified live.

---
- [x] No release notes — feature flagged off (`pointOfSaleTapToPay = .localDeveloper`).