### PR TITLE
Fix non-exhaustive switch in phone POS navigation

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -134,3 +134,23 @@ struct POSNavigationDestinationEmailReceiptView: View {
         .toolbar(.hidden, for: .navigationBar)
     }
 }
+
+extension View {
+    /// Routes every `POSNavigationDestination` case to its wrapper view.
+    /// Kept in one place so the phone and iPad `NavigationStack`s can't drift
+    /// out of sync when a new destination is added.
+    func posNavigationDestinations() -> some View {
+        navigationDestination(for: POSNavigationDestination.self) { destination in
+            switch destination {
+            case .cashPayment(let orderTotal):
+                POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
+            case .scanToPay(let orderTotal):
+                POSNavigationDestinationScanToPayView(orderTotal: orderTotal)
+            case .markAsPaid(let orderTotal):
+                POSNavigationDestinationMarkAsPaidView(orderTotal: orderTotal)
+            case .emailReceipt:
+                POSNavigationDestinationEmailReceiptView()
+            }
+        }
+    }
+}

--- a/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSNavigationRouter.swift
@@ -137,8 +137,6 @@ struct POSNavigationDestinationEmailReceiptView: View {
 
 extension View {
     /// Routes every `POSNavigationDestination` case to its wrapper view.
-    /// Kept in one place so the phone and iPad `NavigationStack`s can't drift
-    /// out of sync when a new destination is added.
     func posNavigationDestinations() -> some View {
         navigationDestination(for: POSNavigationDestination.self) { destination in
             switch destination {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -227,18 +227,7 @@ struct PointOfSaleDashboardView: View {
                                 .disabled(!canExitFinalizingOnPhone)
                             }
                         }
-                        .navigationDestination(for: POSNavigationDestination.self) { destination in
-                            switch destination {
-                            case .cashPayment(let orderTotal):
-                                POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
-                            case .scanToPay(let orderTotal):
-                                POSNavigationDestinationScanToPayView(orderTotal: orderTotal)
-                            case .markAsPaid(let orderTotal):
-                                POSNavigationDestinationMarkAsPaidView(orderTotal: orderTotal)
-                            case .emailReceipt:
-                                POSNavigationDestinationEmailReceiptView()
-                            }
-                        }
+                        .posNavigationDestinations()
                 }
                 .environment(\.posNavigationRouter, navigationRouter)
             }
@@ -332,18 +321,7 @@ struct PointOfSaleDashboardView: View {
                             .accessibilitySortPriority(posModel.orderStage == .finalizing ? 2 : 0)
                             .allowsHitTesting(posModel.orderStage == .finalizing)
                     }
-                    .navigationDestination(for: POSNavigationDestination.self) { destination in
-                        switch destination {
-                        case .cashPayment(let orderTotal):
-                            POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
-                        case .scanToPay(let orderTotal):
-                            POSNavigationDestinationScanToPayView(orderTotal: orderTotal)
-                        case .markAsPaid(let orderTotal):
-                            POSNavigationDestinationMarkAsPaidView(orderTotal: orderTotal)
-                        case .emailReceipt:
-                            POSNavigationDestinationEmailReceiptView()
-                        }
-                    }
+                    .posNavigationDestinations()
                 }
                 .scrollContentBackground(.hidden)
                 .background(Color.posSurface)

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -231,6 +231,10 @@ struct PointOfSaleDashboardView: View {
                             switch destination {
                             case .cashPayment(let orderTotal):
                                 POSNavigationDestinationCashPaymentView(orderTotal: orderTotal)
+                            case .scanToPay(let orderTotal):
+                                POSNavigationDestinationScanToPayView(orderTotal: orderTotal)
+                            case .markAsPaid(let orderTotal):
+                                POSNavigationDestinationMarkAsPaidView(orderTotal: orderTotal)
                             case .emailReceipt:
                                 POSNavigationDestinationEmailReceiptView()
                             }


### PR DESCRIPTION
## Description

A recent PR of mine, #17153, failed in CI, the reason was an unrelated change:

```
Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift:231:29: switch must be exhaustive
```

This was one of those rare cases when not requiring PRs to be in sync with the main branch before merging backfired. Two PRs landed back-to-back without one updating the other:

- The `scanToPay` and `markAsPaid` cases were added to `POSNavigationDestination`, and the iPad `NavigationStack`'s `navigationDestination` switch was updated to handle them.
- The phone navigation skeleton (#17064) introduced a second `navigationDestination` switch that only knew about the two cases that existed when the branch was written. Once it merged on top of the enum change, the switch became non-exhaustive — a semantic merge conflict Git could not detect.

I decided to address this by DRYing the working iPad implementation.

## Test Steps

- Run the POS module build / tests on a simulator — `xcodebuild ... -scheme PointOfSale ... build-for-testing` passes locally.
- On an iPhone-sized simulator, launch POS, finalize an order, and verify cash / scan-to-pay / mark-as-paid pushes still navigate correctly inside the phone `NavigationStack`.
- On an iPad-sized simulator, repeat the same flows to confirm the iPad navigation path was not regressed by the shared modifier.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (No entry needed: phone POS flows are still feature-flagged and not user-visible; the fix unblocks an internal CI failure.)