### PR TITLE
Set AI Assistant prompt and tool catalog version to v1.0.0

### DIFF
--- a/Modules/Sources/WooAIAssistant/Telemetry/AssistantTelemetryConstants.swift
+++ b/Modules/Sources/WooAIAssistant/Telemetry/AssistantTelemetryConstants.swift
@@ -2,6 +2,6 @@ import Foundation
 
 public enum AssistantTelemetryConstants {
     public static let completionStack = "jetpack_ai_query"
-    public static let promptVersion = "v1.1.0"
-    public static let toolCatalogVersion = "v1.1.0"
+    public static let promptVersion = "v1.0.0"
+    public static let toolCatalogVersion = "v1.0.0"
 }


### PR DESCRIPTION
## Description
The AI Assistant telemetry constants reported `v1.1.0` for both the prompt version and the tool catalog version, but the v1 release ships with the locked v1.0.0 system prompt and tool catalog. This corrects both constants so telemetry reflects the version that actually shipped.

The constants are referenced symbolically across the telemetry layer (and the privacy canary tests), so this is a value-only change with no behavioural impact beyond the reported version string.

## Test Steps
1. Trigger an AI Assistant turn.
2. Confirm the telemetry events (`ai_assistant_turn_started`, `ai_assistant_turn_completed`, etc.) report `prompt_version` and `tool_catalog_version` as `v1.0.0`.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.