### PR TITLE
Add feature flag for smarter notifications

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -124,7 +124,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .arParcelFitting:
             return false
         case .smarterNotifications:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return !buildConfig.isProduction
         default:
             return true
         }

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -123,6 +123,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return !buildConfig.isProduction
         case .arParcelFitting:
             return false
+        case .smarterNotifications:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -257,4 +257,8 @@ public enum FeatureFlag: Int, CaseIterable {
     /// Enables AR parcel fitting for shipping
     ///
     case arParcelFitting
+
+    /// Enables smarter (AI-powered) push notifications.
+    ///
+    case smarterNotifications
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -25,6 +25,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
     var isCIABBookingsEnabled: Bool
     var isCIABBookingRescheduleEnabled: Bool
     var selfDrivenPushToken: Bool
+    var smarterNotifications: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -46,7 +47,8 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
          isProductImageOptimizedHandlingEnabled: Bool = false,
          isCIABBookingsEnabled: Bool = false,
          isCIABBookingRescheduleEnabled: Bool = false,
-         selfDrivenPushToken: Bool = false) {
+         selfDrivenPushToken: Bool = false,
+         smarterNotifications: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -68,6 +70,7 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
         self.isCIABBookingRescheduleEnabled = isCIABBookingRescheduleEnabled
         self.selfDrivenPushToken = selfDrivenPushToken
+        self.smarterNotifications = smarterNotifications
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -120,6 +123,8 @@ final class MockFeatureFlagService: FeatureFlagService, POSFeatureFlagProviding 
             return isCIABBookingRescheduleEnabled
         case .selfDrivenPushToken:
             return selfDrivenPushToken
+        case .smarterNotifications:
+            return smarterNotifications
         default:
             return false
         }


### PR DESCRIPTION
## Description

Adds a local feature flag, `smarterNotifications`, that will gate an upcoming push-notifications feature on iOS. This change is purely scaffolding — no UI, business logic, analytics, or remote-flag plumbing. Follow-up PRs implementing the feature can gate their code paths behind `featureFlagService.isFeatureFlagEnabled(.smarterNotifications)`.

The flag follows the standard "in-development local flag" pattern used by recent precedents such as `pointOfSaleScanToPay`:
- Returns `true` for `.localDeveloper` and `.alpha` builds.
- Returns `false` for App Store / production builds.

Linear: RSM-1636

## Test Steps

1. Pull this branch and build the WooCommerce scheme on a simulator — it should compile cleanly (the new exhaustive switch case is satisfied).
2. Optional sanity check: add a temporary `DDLogInfo` of `ServiceLocator.featureFlagService.isFeatureFlagEnabled(.smarterNotifications)` in app launch. On a local debug (`.localDeveloper`) build it should log `true`. On a production (App Store) build configuration it should log `false`.
3. Run `WooCommerceTests` to confirm `MockFeatureFlagService` still compiles — no existing tests should be affected (the new init parameter has a `false` default).

## Screenshots
N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (No release note — this is internal scaffolding only.)