### PR TITLE
[RSM-2726] Add network layer for push notification preferences

### DIFF
--- a/Modules/Sources/Networking/Model/PushNotificationPreferences.swift
+++ b/Modules/Sources/Networking/Model/PushNotificationPreferences.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Per-user push notification preferences served by the WooCommerce plugin under
+/// `wc-push-notifications/preferences`.
+///
+/// The same type is used for the full GET response and for partial POST bodies:
+/// every field is `Optional` and the custom `encode(to:)` implementation drops
+/// `nil` keys via `encodeIfPresent`. Callers building a partial update set only
+/// the sub-fields they want to change; the server deep-merges and returns the
+/// fully populated, sanitized result.
+///
+public struct PushNotificationPreferences: Codable, Equatable, Sendable {
+
+    public let storeOrder: StoreOrder?
+    public let storeReview: StoreReview?
+    public let storeStock: StoreStock?
+
+    public init(storeOrder: StoreOrder? = nil,
+                storeReview: StoreReview? = nil,
+                storeStock: StoreStock? = nil) {
+        self.storeOrder = storeOrder
+        self.storeReview = storeReview
+        self.storeStock = storeStock
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.storeOrder = try container.decodeIfPresent(StoreOrder.self, forKey: .storeOrder)
+        self.storeReview = try container.decodeIfPresent(StoreReview.self, forKey: .storeReview)
+        self.storeStock = try container.decodeIfPresent(StoreStock.self, forKey: .storeStock)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(storeOrder, forKey: .storeOrder)
+        try container.encodeIfPresent(storeReview, forKey: .storeReview)
+        try container.encodeIfPresent(storeStock, forKey: .storeStock)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case storeOrder = "store_order"
+        case storeReview = "store_review"
+        case storeStock = "store_stock"
+    }
+}
+
+public extension PushNotificationPreferences {
+
+    /// Preferences for new-order notifications.
+    ///
+    struct StoreOrder: Codable, Equatable, Sendable {
+
+        /// Master toggle for new-order notifications.
+        public let enabled: Bool?
+
+        /// Order-total threshold below which notifications are suppressed.
+        /// `nil` means no threshold; the server stores any value `<= 0` as `nil`.
+        public let minAmount: Decimal?
+
+        public init(enabled: Bool? = nil, minAmount: Decimal? = nil) {
+            self.enabled = enabled
+            self.minAmount = minAmount
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
+            self.minAmount = try container.decodeIfPresent(Decimal.self, forKey: .minAmount)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(enabled, forKey: .enabled)
+            try container.encodeIfPresent(minAmount, forKey: .minAmount)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case enabled
+            case minAmount = "min_amount"
+        }
+    }
+
+    /// Preferences for product-review notifications.
+    ///
+    struct StoreReview: Codable, Equatable, Sendable {
+
+        /// Master toggle for review notifications.
+        public let enabled: Bool?
+
+        /// Maximum star rating that triggers a notification. Server clamps to `1...5`.
+        public let maxRating: Int?
+
+        public init(enabled: Bool? = nil, maxRating: Int? = nil) {
+            self.enabled = enabled
+            self.maxRating = maxRating
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
+            self.maxRating = try container.decodeIfPresent(Int.self, forKey: .maxRating)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(enabled, forKey: .enabled)
+            try container.encodeIfPresent(maxRating, forKey: .maxRating)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case enabled
+            case maxRating = "max_rating"
+        }
+    }
+
+    /// Preferences for stock-event notifications.
+    ///
+    struct StoreStock: Codable, Equatable, Sendable {
+
+        /// Master toggle for stock notifications.
+        public let enabled: Bool?
+
+        /// Notify when stock crosses the site-level low-stock threshold.
+        public let lowStock: Bool?
+
+        /// Notify when stock reaches the site-level no-stock amount.
+        public let outOfStock: Bool?
+
+        /// Notify when an order causes a backordered purchase (off by default).
+        public let onBackorder: Bool?
+
+        public init(enabled: Bool? = nil,
+                    lowStock: Bool? = nil,
+                    outOfStock: Bool? = nil,
+                    onBackorder: Bool? = nil) {
+            self.enabled = enabled
+            self.lowStock = lowStock
+            self.outOfStock = outOfStock
+            self.onBackorder = onBackorder
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
+            self.lowStock = try container.decodeIfPresent(Bool.self, forKey: .lowStock)
+            self.outOfStock = try container.decodeIfPresent(Bool.self, forKey: .outOfStock)
+            self.onBackorder = try container.decodeIfPresent(Bool.self, forKey: .onBackorder)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(enabled, forKey: .enabled)
+            try container.encodeIfPresent(lowStock, forKey: .lowStock)
+            try container.encodeIfPresent(outOfStock, forKey: .outOfStock)
+            try container.encodeIfPresent(onBackorder, forKey: .onBackorder)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case enabled
+            case lowStock = "low_stock"
+            case outOfStock = "out_of_stock"
+            case onBackorder = "on_backorder"
+        }
+    }
+}

--- a/Modules/Sources/Networking/Model/PushNotificationPreferences.swift
+++ b/Modules/Sources/Networking/Model/PushNotificationPreferences.swift
@@ -48,30 +48,40 @@ public extension PushNotificationPreferences {
 
     /// Preferences for new-order notifications.
     ///
+    /// Callers always send a complete `StoreOrder` when updating — the client
+    /// never produces a partial `store_order` body. Two valid client-controlled
+    /// states:
+    /// - `enabled: false, minAmount: nil` — off, threshold cleared.
+    /// - `enabled: true, minAmount: <positive>` — on with a specific threshold.
+    ///
+    /// The server's default for fresh users (`enabled: true, minAmount: nil`)
+    /// is still decoded correctly on reads.
+    ///
     struct StoreOrder: Codable, Equatable, Sendable {
 
         /// Master toggle for new-order notifications.
-        public let enabled: Bool?
+        public let enabled: Bool
 
         /// Order-total threshold below which notifications are suppressed.
-        /// `nil` means no threshold; the server stores any value `<= 0` as `nil`.
+        /// `nil` is sent on the wire as JSON `null`, which the server interprets
+        /// as "no threshold" (notify on every order when `enabled` is true).
         public let minAmount: Decimal?
 
-        public init(enabled: Bool? = nil, minAmount: Decimal? = nil) {
+        public init(enabled: Bool, minAmount: Decimal? = nil) {
             self.enabled = enabled
             self.minAmount = minAmount
         }
 
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled)
-            self.minAmount = try container.decodeIfPresent(Decimal.self, forKey: .minAmount)
-        }
-
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encodeIfPresent(enabled, forKey: .enabled)
-            try container.encodeIfPresent(minAmount, forKey: .minAmount)
+            try container.encode(enabled, forKey: .enabled)
+            // Use `encode` (not `encodeIfPresent`) so `nil` is written as JSON `null`
+            // — the server interprets explicit null as "clear the threshold".
+            if let minAmount {
+                try container.encode(minAmount, forKey: .minAmount)
+            } else {
+                try container.encodeNil(forKey: .minAmount)
+            }
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Modules/Sources/Networking/Remote/PushNotificationPreferencesRemote.swift
+++ b/Modules/Sources/Networking/Remote/PushNotificationPreferencesRemote.swift
@@ -24,8 +24,8 @@ public protocol PushNotificationPreferencesRemoteProtocol {
 }
 
 /// Remote for the WooCommerce push notification preferences endpoint
-/// (`wc-push-notifications/preferences`). Calls are Jetpack-tunneled to the
-/// merchant's site using the same pattern as `DevicesRemote`'s push-tokens calls.
+/// (`wc-push-notifications/preferences`). Requests prefer the REST fallback when an
+/// application password is available and fall back to the Jetpack tunnel otherwise.
 ///
 public final class PushNotificationPreferencesRemote: Remote, PushNotificationPreferencesRemoteProtocol {
 
@@ -34,7 +34,7 @@ public final class PushNotificationPreferencesRemote: Remote, PushNotificationPr
                                      method: .get,
                                      siteID: siteID,
                                      path: Paths.preferences,
-                                     availableAsRESTRequest: false)
+                                     availableAsRESTRequest: true)
         return try await enqueue(request)
     }
 
@@ -46,7 +46,7 @@ public final class PushNotificationPreferencesRemote: Remote, PushNotificationPr
                                      siteID: siteID,
                                      path: Paths.preferences,
                                      parameters: parameters,
-                                     availableAsRESTRequest: false)
+                                     availableAsRESTRequest: true)
         return try await enqueue(request)
     }
 }

--- a/Modules/Sources/Networking/Remote/PushNotificationPreferencesRemote.swift
+++ b/Modules/Sources/Networking/Remote/PushNotificationPreferencesRemote.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Protocol for `PushNotificationPreferencesRemote` — mockable for tests.
+///
+public protocol PushNotificationPreferencesRemoteProtocol {
+    /// Loads the current user's push notification preferences for a site.
+    ///
+    /// - Parameter siteID: The Jetpack-connected site to query.
+    /// - Returns: The full, server-merged preferences object.
+    func loadPreferences(siteID: Int64) async throws -> PushNotificationPreferences
+
+    /// Sends a partial update to the current user's push notification preferences.
+    ///
+    /// Only the sub-fields set on `changes` are sent over the wire; the server
+    /// deep-merges them with the stored preferences and returns the full result.
+    ///
+    /// - Parameters:
+    ///   - siteID: The Jetpack-connected site to update.
+    ///   - changes: A `PushNotificationPreferences` instance with only the fields
+    ///     the caller wants to change set; everything else should be `nil`.
+    /// - Returns: The full, server-merged preferences object after the update.
+    func updatePreferences(siteID: Int64,
+                           changes: PushNotificationPreferences) async throws -> PushNotificationPreferences
+}
+
+/// Remote for the WooCommerce push notification preferences endpoint
+/// (`wc-push-notifications/preferences`). Calls are Jetpack-tunneled to the
+/// merchant's site using the same pattern as `DevicesRemote`'s push-tokens calls.
+///
+public final class PushNotificationPreferencesRemote: Remote, PushNotificationPreferencesRemoteProtocol {
+
+    public func loadPreferences(siteID: Int64) async throws -> PushNotificationPreferences {
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Paths.preferences,
+                                     availableAsRESTRequest: false)
+        return try await enqueue(request)
+    }
+
+    public func updatePreferences(siteID: Int64,
+                                  changes: PushNotificationPreferences) async throws -> PushNotificationPreferences {
+        let parameters = try changes.toDictionary()
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: Paths.preferences,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: false)
+        return try await enqueue(request)
+    }
+}
+
+// MARK: - Constants
+//
+private extension PushNotificationPreferencesRemote {
+    enum Paths {
+        static let preferences = "wc-push-notifications/preferences"
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import Networking
+@testable import NetworkingCore
+
+struct PushNotificationPreferencesRemoteTests {
+    private let network = MockNetwork()
+    private let sampleSiteID: Int64 = 1234
+
+    // MARK: - Request shape
+
+    @Test func loadPreferences_then_sends_GET_to_wc_push_notifications_preferences() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+
+        // When
+        _ = try? await remote.loadPreferences(siteID: sampleSiteID)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.path == "wc-push-notifications/preferences")
+        #expect(request.method == .get)
+        #expect(request.siteID == sampleSiteID)
+    }
+
+    @Test func updatePreferences_then_sends_POST_to_wc_push_notifications_preferences() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        let changes = PushNotificationPreferences(storeOrder: .init(enabled: false))
+
+        // When
+        _ = try? await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.path == "wc-push-notifications/preferences")
+        #expect(request.method == .post)
+        #expect(request.siteID == sampleSiteID)
+    }
+
+    @Test func updatePreferences_when_only_one_subfield_set_then_serializes_only_that_subfield() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        let changes = PushNotificationPreferences(storeStock: .init(onBackorder: false))
+
+        // When
+        _ = try? await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then — the wire body should be exactly { "store_stock": { "on_backorder": false } }.
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters.count == 1)
+        let storeStock = try #require(parameters["store_stock"] as? [String: Any])
+        #expect(storeStock.count == 1)
+        #expect(storeStock["on_backorder"] as? Bool == false)
+        #expect(parameters["store_order"] == nil)
+        #expect(parameters["store_review"] == nil)
+    }
+
+    @Test func updatePreferences_when_multiple_subfields_set_then_serializes_only_those() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        let changes = PushNotificationPreferences(
+            storeOrder: .init(enabled: true, minAmount: 100),
+            storeReview: .init(maxRating: 3)
+        )
+
+        // When
+        _ = try? await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then
+        let parameters = try #require(network.queryParametersDictionary)
+        #expect(parameters["store_stock"] == nil)
+
+        let storeOrder = try #require(parameters["store_order"] as? [String: Any])
+        #expect(storeOrder["enabled"] as? Bool == true)
+        #expect(storeOrder["min_amount"] != nil)
+
+        let storeReview = try #require(parameters["store_review"] as? [String: Any])
+        #expect(storeReview.count == 1)
+        #expect(storeReview["max_rating"] as? Int == 3)
+        #expect(storeReview["enabled"] == nil)
+    }
+
+    // MARK: - Response decoding
+
+    @Test func loadPreferences_then_decodes_full_response() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences")
+
+        // When
+        let preferences = try await remote.loadPreferences(siteID: sampleSiteID)
+
+        // Then
+        #expect(preferences.storeOrder?.enabled == true)
+        #expect(preferences.storeOrder?.minAmount == nil)
+
+        #expect(preferences.storeReview?.enabled == true)
+        #expect(preferences.storeReview?.maxRating == 5)
+
+        #expect(preferences.storeStock?.enabled == true)
+        #expect(preferences.storeStock?.lowStock == true)
+        #expect(preferences.storeStock?.outOfStock == true)
+        #expect(preferences.storeStock?.onBackorder == false)
+    }
+
+    @Test func loadPreferences_when_unknown_top_level_key_present_then_known_fields_still_decode() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences-forward-compat")
+
+        // When
+        let preferences = try await remote.loadPreferences(siteID: sampleSiteID)
+
+        // Then — unknown `future_type` is ignored; known types decode normally.
+        #expect(preferences.storeOrder?.enabled == true)
+        #expect(preferences.storeOrder?.minAmount == Decimal(string: "25.5"))
+    }
+
+    @Test func loadPreferences_when_subfield_missing_then_decodes_as_nil() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences-forward-compat")
+
+        // When
+        let preferences = try await remote.loadPreferences(siteID: sampleSiteID)
+
+        // Then — store_review has only `enabled` populated in the fixture.
+        #expect(preferences.storeReview?.enabled == true)
+        #expect(preferences.storeReview?.maxRating == nil)
+        // store_stock is entirely absent from the fixture.
+        #expect(preferences.storeStock == nil)
+    }
+
+    @Test func loadPreferences_when_network_error_then_throws() async {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+
+        // When / Then — no simulated response triggers `NetworkError.notFound`.
+        await #expect(throws: (any Error).self) {
+            _ = try await remote.loadPreferences(siteID: self.sampleSiteID)
+        }
+    }
+
+    @Test func updatePreferences_then_returns_decoded_merged_response() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences")
+        let changes = PushNotificationPreferences(storeStock: .init(onBackorder: false))
+
+        // When
+        let preferences = try await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then — server returns the full merged shape regardless of how thin the request was.
+        #expect(preferences.storeOrder?.enabled == true)
+        #expect(preferences.storeReview?.maxRating == 5)
+        #expect(preferences.storeStock?.onBackorder == false)
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
@@ -72,13 +72,30 @@ struct PushNotificationPreferencesRemoteTests {
         #expect(parameters["store_stock"] == nil)
 
         let storeOrder = try #require(parameters["store_order"] as? [String: Any])
+        #expect(storeOrder.count == 2)
         #expect(storeOrder["enabled"] as? Bool == true)
-        #expect(storeOrder["min_amount"] != nil)
+        #expect(storeOrder["min_amount"] as? Int == 100)
 
         let storeReview = try #require(parameters["store_review"] as? [String: Any])
         #expect(storeReview.count == 1)
         #expect(storeReview["max_rating"] as? Int == 3)
         #expect(storeReview["enabled"] == nil)
+    }
+
+    @Test func updatePreferences_when_storeOrder_minAmount_is_nil_then_sends_explicit_null() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        let changes = PushNotificationPreferences(storeOrder: .init(enabled: false, minAmount: nil))
+
+        // When
+        _ = try? await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then — the wire body must include `min_amount` as JSON null so the server clears the threshold.
+        let parameters = try #require(network.queryParametersDictionary)
+        let storeOrder = try #require(parameters["store_order"] as? [String: Any])
+        #expect(storeOrder.count == 2)
+        #expect(storeOrder["enabled"] as? Bool == false)
+        #expect(storeOrder["min_amount"] is NSNull)
     }
 
     // MARK: - Response decoding

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/push-notification-preferences-forward-compat.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/push-notification-preferences-forward-compat.json
@@ -1,0 +1,13 @@
+{
+  "store_order": {
+    "enabled": true,
+    "min_amount": 25.5
+  },
+  "store_review": {
+    "enabled": true
+  },
+  "future_type": {
+    "enabled": true,
+    "some_new_field": 42
+  }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/push-notification-preferences.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/push-notification-preferences.json
@@ -1,0 +1,16 @@
+{
+  "store_order": {
+    "enabled": true,
+    "min_amount": null
+  },
+  "store_review": {
+    "enabled": true,
+    "max_rating": 5
+  },
+  "store_stock": {
+    "enabled": true,
+    "low_stock": true,
+    "out_of_stock": true,
+    "on_backorder": false
+  }
+}


### PR DESCRIPTION
## Description

Adds the iOS network layer for fetching and partially updating per-user push notification preferences against the WooCommerce plugin's new `wc-push-notifications/preferences` REST endpoint. 

Scope is **Networking module only**. Yosemite `Action`/`Store` wiring, UI to toggle preferences, and error mapping for 401/403/400 to user-facing states are explicit follow-ups in subsequent PRs.

Design highlights:
- A single `PushNotificationPreferences` Codable struct serves both the full GET response and partial POST bodies. All fields and nested types are `Optional`. Custom `encode(to:)` uses `encodeIfPresent` so nil keys are omitted from the wire, which the server-side deep-merge requires.
- Custom `init(from:)` uses `decodeIfPresent` everywhere, so unknown top-level keys and missing sub-fields don't crash — forward-compatible with future notification types/sub-fields.
- The Remote exposes async `loadPreferences(siteID:)` and `updatePreferences(siteID:changes:)` plus a `PushNotificationPreferencesRemoteProtocol` for mocking.

Related: RSM-2726.

## Test Steps

There is no user-facing surface yet, so this is verified via the new unit test class. Code review and green CI should be enough. 

## Screenshots

N/A — network-layer-only change, no UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

  No release note: there is no user-facing behavior yet. A note will accompany the UI PR that consumes this layer.