### PR TITLE
Add Theme picker to Store Stats widget

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/Legacy/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/Legacy/StoreInfoView.swift
@@ -177,7 +177,7 @@ private struct NotLoggedInView: View {
                 .statButtonStyle()
         }
         .padding(.vertical, Layout.cardVerticalPadding)
-        .widgetBackground(backgroundView: Color(.brand))
+        .widgetBackground(backgroundView: StoreWidgetHomeScreenBackground())
     }
 }
 
@@ -197,7 +197,7 @@ private struct UnableToFetchView: View {
             Spacer()
         }
         .padding(.vertical, Layout.cardVerticalPadding)
-        .widgetBackground(backgroundView: Color(.brand))
+        .widgetBackground(backgroundView: StoreWidgetHomeScreenBackground())
     }
 }
 

--- a/WooCommerce/StoreWidgets/Homescreen/MetricChartView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricChartView.swift
@@ -5,12 +5,16 @@ import SwiftUI
 /// - `.sparkline` — thin line with a fading area fill (iOS Stocks app style).
 /// - `.bar` — one bar per interval. Reserved for the wider main-metric row.
 ///
-/// Color is driven by `tone` — green for upward trends, red for downward, neutral mint /
-/// periwinkle when the trend is unknown. Edit `Palette` to retune all gradients in one place.
+/// Color is driven by `tone` (up/down/neutral) and the active `\.storeWidgetTheme` from the
+/// environment. The `.default` theme uses the brand-purple-friendly pastels declared in
+/// `Palette`; `.sameAsSystem` falls through to the matching `systemGreen` / `systemRed` /
+/// `systemGray` semantic colors so the chart adapts to light/dark mode.
 ///
 /// Caller sizes via `.frame(...)` and gates on `count > 1`.
 ///
 struct MetricChartView: View {
+    @Environment(\.storeWidgetTheme) private var theme
+
     let data: [MetricChartPoint]
     private let style: Style
     private let tone: Tone
@@ -34,7 +38,7 @@ struct MetricChartView: View {
             // Baseline rule is emitted before the bars so the bars paint on top of it.
             if style == .bar, layout.showsBaseline {
                 RuleMark(y: .value("Baseline", 0))
-                    .foregroundStyle(Color.white.opacity(Constants.baselineOpacity))
+                    .foregroundStyle(theme.chartBaselineColor)
                     .lineStyle(StrokeStyle(
                         lineWidth: Constants.baselineLineWidth,
                         lineCap: .round,
@@ -174,59 +178,46 @@ private extension MetricChartView {
         let showsBaseline: Bool
     }
 
+    /// Active tone palette stops `(high, low, deep)` — switches on the widget theme so the
+    /// chart matches its background. `default` uses the brand-purple-friendly pastels;
+    /// `sameAsSystem` uses semantic system colors that adapt to light/dark mode.
+    var tonePalette: (high: Color, low: Color, deep: Color) {
+        switch (theme, tone) {
+        case (.default, .up):
+            return (Palette.upHigh, Palette.upLow, Palette.upDeep)
+        case (.default, .down):
+            return (Palette.downHigh, Palette.downLow, Palette.downDeep)
+        case (.default, .neutral):
+            return (Palette.neutralHigh, Palette.neutralLow, Palette.neutralDeep)
+        case (.sameAsSystem, .up):
+            return (Color(.systemGreen), Color(.systemGreen).opacity(0.65), Color(.systemGreen).opacity(0.45))
+        case (.sameAsSystem, .down):
+            return (Color(.systemRed), Color(.systemRed).opacity(0.65), Color(.systemRed).opacity(0.45))
+        case (.sameAsSystem, .neutral):
+            return (Color(.systemGray), Color(.systemGray).opacity(0.65), Color(.systemGray).opacity(0.45))
+        }
+    }
+
     /// Solid color for zero-value bars — uses the deepest shade of the tone palette
     /// so the dot reads as darker than the dark end of the regular bar gradient.
     var zeroBarColor: Color {
-        switch tone {
-        case .up: return Palette.upDeep
-        case .down: return Palette.downDeep
-        case .neutral: return Palette.neutralDeep
-        }
+        tonePalette.deep
     }
 
     /// Gradient applied to the bar fill / sparkline stroke. Lighter at the top, darker at
     /// the base — matches the iOS Stocks reading direction (peaks read brighter).
     var lineGradient: LinearGradient {
-        switch tone {
-        case .up:
-            return LinearGradient(
-                colors: [
-                    Palette.upHigh,
-                    Palette.upLow
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        case .down:
-            return LinearGradient(
-                colors: [
-                    Palette.downHigh,
-                    Palette.downLow
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        case .neutral:
-            return LinearGradient(
-                colors: [
-                    Palette.neutralHigh,
-                    Palette.neutralLow
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        }
+        LinearGradient(
+            colors: [tonePalette.high, tonePalette.low],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
     /// Gradient applied to the sparkline `AreaMark`. Solid-ish at the top fading to fully
     /// transparent at the base, so the fill reads as a soft glow under the line.
     var areaGradient: LinearGradient {
-        let top: Color
-        switch tone {
-        case .up: top = Palette.upHigh
-        case .down: top = Palette.downHigh
-        case .neutral: top = Palette.neutralHigh
-        }
+        let top = tonePalette.high
         return LinearGradient(
             colors: [top.opacity(Constants.areaTopOpacity), top.opacity(0.05)],
             startPoint: .top,
@@ -249,7 +240,9 @@ extension MetricChartView {
 }
 
 private extension MetricChartView {
-    /// Single source of truth for chart colors — tweak here to retune both styles.
+    /// Palette stops for the `.default` (brand-purple) theme — tweak here to retune the
+    /// brand-themed gradients applied by both the `.bar` and `.sparkline` styles.
+    /// `.sameAsSystem` doesn't read this palette; it uses semantic system colors instead.
     /// `*Deep` shades are reserved for zero-value bars and sit a step darker than the
     /// dark end of each gradient.
     enum Palette {
@@ -278,7 +271,6 @@ private extension MetricChartView {
         static let barMinHeightRatio = 0.02
         static let sparklineLineWidth = 1.5
         static let baselineLineWidth = 1.0
-        static let baselineOpacity = 0.25
         static let baselineDashPattern: [CGFloat] = [8, 5]
         static let maxBarCornerRadius = 6.0
         static let areaTopOpacity = 0.75

--- a/WooCommerce/StoreWidgets/Homescreen/MetricChartView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricChartView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// - `.bar` — one bar per interval. Reserved for the wider main-metric row.
 ///
 /// Color is driven by `tone` (up/down/neutral) and the active `\.storeWidgetTheme` from the
-/// environment. The `.default` theme uses the brand-purple-friendly pastels declared in
+/// environment. The `.brandPurple` theme uses the brand-purple-friendly pastels declared in
 /// `Palette`; `.sameAsSystem` falls through to the matching `systemGreen` / `systemRed` /
 /// `systemGray` semantic colors so the chart adapts to light/dark mode.
 ///
@@ -179,15 +179,15 @@ private extension MetricChartView {
     }
 
     /// Active tone palette stops `(high, low, deep)` — switches on the widget theme so the
-    /// chart matches its background. `default` uses the brand-purple-friendly pastels;
+    /// chart matches its background. `brandPurple` uses the brand-purple-friendly pastels;
     /// `sameAsSystem` uses semantic system colors that adapt to light/dark mode.
     var tonePalette: (high: Color, low: Color, deep: Color) {
         switch (theme, tone) {
-        case (.default, .up):
+        case (.brandPurple, .up):
             return (Palette.upHigh, Palette.upLow, Palette.upDeep)
-        case (.default, .down):
+        case (.brandPurple, .down):
             return (Palette.downHigh, Palette.downLow, Palette.downDeep)
-        case (.default, .neutral):
+        case (.brandPurple, .neutral):
             return (Palette.neutralHigh, Palette.neutralLow, Palette.neutralDeep)
         case (.sameAsSystem, .up):
             return (Color(.systemGreen), Color(.systemGreen).opacity(0.65), Color(.systemGreen).opacity(0.45))
@@ -240,9 +240,9 @@ extension MetricChartView {
 }
 
 private extension MetricChartView {
-    /// Palette stops for the `.default` (brand-purple) theme — tweak here to retune the
-    /// brand-themed gradients applied by both the `.bar` and `.sparkline` styles.
-    /// `.sameAsSystem` doesn't read this palette; it uses semantic system colors instead.
+    /// Palette stops for the `.brandPurple` theme — tweak here to retune the brand-themed
+    /// gradients applied by both the `.bar` and `.sparkline` styles. `.sameAsSystem` doesn't
+    /// read this palette; it uses semantic system colors instead.
     /// `*Deep` shades are reserved for zero-value bars and sit a step darker than the
     /// dark end of each gradient.
     enum Palette {

--- a/WooCommerce/StoreWidgets/Homescreen/MetricChartView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricChartView.swift
@@ -179,22 +179,28 @@ private extension MetricChartView {
     }
 
     /// Active tone palette stops `(high, low, deep)` — switches on the widget theme so the
-    /// chart matches its background. `brandPurple` uses the brand-purple-friendly pastels;
-    /// `sameAsSystem` uses semantic system colors that adapt to light/dark mode.
+    /// chart matches its background. The brand-purple theme uses the brand-friendly pastels
+    /// from `Palette`; the three system-themed cases (`.light`, `.dark`, `.sameAsSystem`)
+    /// share the same semantic system colors and rely on the forced `\.colorScheme` to
+    /// resolve as light or dark variants.
     var tonePalette: (high: Color, low: Color, deep: Color) {
-        switch (theme, tone) {
-        case (.brandPurple, .up):
+        if theme.usesSystemAppearance {
+            switch tone {
+            case .up:
+                return (Color(.systemGreen), Color(.systemGreen).opacity(0.65), Color(.systemGreen).opacity(0.45))
+            case .down:
+                return (Color(.systemRed), Color(.systemRed).opacity(0.65), Color(.systemRed).opacity(0.45))
+            case .neutral:
+                return (Color(.systemGray), Color(.systemGray).opacity(0.65), Color(.systemGray).opacity(0.45))
+            }
+        }
+        switch tone {
+        case .up:
             return (Palette.upHigh, Palette.upLow, Palette.upDeep)
-        case (.brandPurple, .down):
+        case .down:
             return (Palette.downHigh, Palette.downLow, Palette.downDeep)
-        case (.brandPurple, .neutral):
+        case .neutral:
             return (Palette.neutralHigh, Palette.neutralLow, Palette.neutralDeep)
-        case (.sameAsSystem, .up):
-            return (Color(.systemGreen), Color(.systemGreen).opacity(0.65), Color(.systemGreen).opacity(0.45))
-        case (.sameAsSystem, .down):
-            return (Color(.systemRed), Color(.systemRed).opacity(0.65), Color(.systemRed).opacity(0.45))
-        case (.sameAsSystem, .neutral):
-            return (Color(.systemGray), Color(.systemGray).opacity(0.65), Color(.systemGray).opacity(0.45))
         }
     }
 

--- a/WooCommerce/StoreWidgets/Homescreen/MetricTrendBadgeView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricTrendBadgeView.swift
@@ -72,9 +72,9 @@ private extension MetricTrendBadgeView {
 
     var color: Color {
         switch (theme, trend.direction) {
-        case (.default, .up):
+        case (.brandPurple, .up):
             return Color(red: 0.55, green: 0.88, blue: 0.70)
-        case (.default, .down):
+        case (.brandPurple, .down):
             return Color(red: 0.95, green: 0.65, blue: 0.70)
         case (.sameAsSystem, .up):
             return Color(.systemGreen)

--- a/WooCommerce/StoreWidgets/Homescreen/MetricTrendBadgeView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricTrendBadgeView.swift
@@ -71,17 +71,17 @@ private extension MetricTrendBadgeView {
     }
 
     var color: Color {
-        switch (theme, trend.direction) {
-        case (.brandPurple, .up):
-            return Color(red: 0.55, green: 0.88, blue: 0.70)
-        case (.brandPurple, .down):
-            return Color(red: 0.95, green: 0.65, blue: 0.70)
-        case (.sameAsSystem, .up):
-            return Color(.systemGreen)
-        case (.sameAsSystem, .down):
-            return Color(.systemRed)
-        case (_, .flat):
+        switch trend.direction {
+        case .flat:
             return Color(.systemGray)
+        case .up:
+            return theme.usesSystemAppearance
+                ? Color(.systemGreen)
+                : Color(red: 0.55, green: 0.88, blue: 0.70)
+        case .down:
+            return theme.usesSystemAppearance
+                ? Color(.systemRed)
+                : Color(red: 0.95, green: 0.65, blue: 0.70)
         }
     }
 

--- a/WooCommerce/StoreWidgets/Homescreen/MetricTrendBadgeView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/MetricTrendBadgeView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 /// alongside the title and value.
 ///
 struct MetricTrendBadgeView: View {
+    @Environment(\.storeWidgetTheme) private var theme
+
     let trend: MetricTrendPresentation
     let size: MetricCellTextSize
 
@@ -69,12 +71,16 @@ private extension MetricTrendBadgeView {
     }
 
     var color: Color {
-        switch trend.direction {
-        case .up:
+        switch (theme, trend.direction) {
+        case (.default, .up):
             return Color(red: 0.55, green: 0.88, blue: 0.70)
-        case .down:
+        case (.default, .down):
             return Color(red: 0.95, green: 0.65, blue: 0.70)
-        case .flat:
+        case (.sameAsSystem, .up):
+            return Color(.systemGreen)
+        case (.sameAsSystem, .down):
+            return Color(.systemRed)
+        case (_, .flat):
             return Color(.systemGray)
         }
     }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsLogoHeader.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsLogoHeader.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 /// Logo-led header shared by all metric layouts.
 struct StoreInfoMetricsLogoHeader: View {
+    @Environment(\.storeWidgetTheme) private var theme
+
     let data: StoreInfoData
     private let showsRange: Bool
     private let showsUpdatePrefix: Bool
@@ -17,10 +19,12 @@ struct StoreInfoMetricsLogoHeader: View {
     var body: some View {
         HStack(alignment: .top, spacing: Layout.logoSpacing) {
             Image("woo-mini-logo", bundle: nil)
+                .renderingMode(.template)
                 .resizable()
                 .scaledToFit()
                 .frame(width: Layout.logoWidth, height: Layout.logoHeight)
                 .padding(.top, Layout.logoTopInset)
+                .foregroundStyle(theme.logoTintColor)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: Layout.textSpacing) {

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -36,11 +36,11 @@ struct StoreInfoMetricsView: View {
             }
         }
         // `containerBackground(for: .widget)` (iOS 17+) renders the background view in a
-        // separate environment context, so the theme and color-scheme overrides set on the
-        // foreground hierarchy do not reach it. Push both in explicitly here.
+        // separate environment context, so the theme set on the foreground hierarchy does
+        // not reach it. Re-apply the theme here so the background picks up both the
+        // `\.storeWidgetTheme` value and any forced `\.colorScheme` it implies.
         .widgetBackground(backgroundView: StoreWidgetHomeScreenBackground()
-            .environment(\.storeWidgetTheme, entryData.theme)
-            .storeWidgetForcedColorScheme(entryData.theme.forcedColorScheme))
+            .applyingStoreWidgetTheme(entryData.theme))
         .dynamicTypeSize(.xSmall...StoreInfoDynamicType.maximumSize)
     }
 }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -36,10 +36,11 @@ struct StoreInfoMetricsView: View {
             }
         }
         // `containerBackground(for: .widget)` (iOS 17+) renders the background view in a
-        // separate environment context, so the theme value set on the foreground hierarchy
-        // does not reach it. Push it in explicitly here.
+        // separate environment context, so the theme and color-scheme overrides set on the
+        // foreground hierarchy do not reach it. Push both in explicitly here.
         .widgetBackground(backgroundView: StoreWidgetHomeScreenBackground()
-            .environment(\.storeWidgetTheme, entryData.theme))
+            .environment(\.storeWidgetTheme, entryData.theme)
+            .storeWidgetForcedColorScheme(entryData.theme.forcedColorScheme))
         .dynamicTypeSize(.xSmall...StoreInfoDynamicType.maximumSize)
     }
 }

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoMetricsView.swift
@@ -35,7 +35,11 @@ struct StoreInfoMetricsView: View {
                 EmptyView()
             }
         }
-        .widgetBackground(backgroundView: StoreWidgetHomeScreenBackground())
+        // `containerBackground(for: .widget)` (iOS 17+) renders the background view in a
+        // separate environment context, so the theme value set on the foreground hierarchy
+        // does not reach it. Push it in explicitly here.
+        .widgetBackground(backgroundView: StoreWidgetHomeScreenBackground()
+            .environment(\.storeWidgetTheme, entryData.theme))
         .dynamicTypeSize(.xSmall...StoreInfoDynamicType.maximumSize)
     }
 }

--- a/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
@@ -69,31 +69,52 @@ enum StoreWidgetAppearance {
 
 struct StoreWidgetHomeScreenBackground: View {
     @Environment(\.widgetRenderingMode) private var widgetRenderingMode
+    @Environment(\.storeWidgetTheme) private var theme
 
     var body: some View {
-        if StoreWidgetAppearance.isModernAppearanceEnabled {
-            switch widgetRenderingMode {
-            case .fullColor:
-                ZStack {
-                    LinearGradient(
-                        colors: Layout.backgroundGradientColors,
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                    StoreWidgetAppearance.brandColor.opacity(Layout.brandOverlayOpacity)
-                    LinearGradient(
-                        colors: Layout.highlightGradientColors,
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
+        switch widgetRenderingMode {
+        case .fullColor:
+            switch theme {
+            case .default:
+                brandBackground
+            case .sameAsSystem:
+                systemBackground
+            }
+        case .accented, .vibrant:
+            Color.clear
+        default:
+            Color.clear
+        }
+    }
 
-                    RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
-                        .strokeBorder(Color.white.opacity(Layout.borderOpacity), lineWidth: Layout.borderWidth)
-                }
-            case .accented, .vibrant:
-                Color.clear
-            default:
-                Color.clear
+    @ViewBuilder
+    private var systemBackground: some View {
+        #if os(watchOS)
+        // watchOS widgets don't have a `systemBackground` equivalent; fall back to brand.
+        brandBackground
+        #else
+        Color(.systemBackground)
+        #endif
+    }
+
+    @ViewBuilder
+    private var brandBackground: some View {
+        if StoreWidgetAppearance.isModernAppearanceEnabled {
+            ZStack {
+                LinearGradient(
+                    colors: Layout.backgroundGradientColors,
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                StoreWidgetAppearance.brandColor.opacity(Layout.brandOverlayOpacity)
+                LinearGradient(
+                    colors: Layout.highlightGradientColors,
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+                    .strokeBorder(Color.white.opacity(Layout.borderOpacity), lineWidth: Layout.borderWidth)
             }
         } else {
             StoreWidgetAppearance.brandColor

--- a/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
@@ -74,11 +74,10 @@ struct StoreWidgetHomeScreenBackground: View {
     var body: some View {
         switch widgetRenderingMode {
         case .fullColor:
-            switch theme {
-            case .brandPurple:
-                brandBackground
-            case .sameAsSystem:
+            if theme.usesSystemAppearance {
                 systemBackground
+            } else {
+                brandBackground
             }
         case .accented, .vibrant:
             Color.clear

--- a/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
@@ -75,7 +75,7 @@ struct StoreWidgetHomeScreenBackground: View {
         switch widgetRenderingMode {
         case .fullColor:
             switch theme {
-            case .default:
+            case .brandPurple:
                 brandBackground
             case .sameAsSystem:
                 systemBackground

--- a/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider+AppIntentTimelineProvider.swift
@@ -22,6 +22,7 @@ extension StoreInfoProvider: AppIntentTimelineProvider {
         )
         return await loadTimeline(dateRange: configuration.dateRange,
                                   metrics: metrics,
-                                  selectedStoreID: configuration.store?.id)
+                                  selectedStoreID: configuration.store?.id,
+                                  theme: configuration.theme)
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -87,7 +87,7 @@ struct StoreInfoData {
          metrics: [StoreInfoMetric] = [],
          metricSlots: [StoreInfoMetricSlot]? = nil,
          dateRange: StoreStatsWidgetDateRange? = nil,
-         theme: StoreWidgetTheme = .default) {
+         theme: StoreWidgetTheme = .brandPurple) {
         self.range = range
         self.name = name
         self.revenue = revenue
@@ -190,7 +190,7 @@ final class StoreInfoProvider: TimelineProvider {
         dateRange: StoreStatsWidgetDateRange,
         metrics: [StoreInfoMetricType],
         selectedStoreID: StoreStatsStoreEntity.ID? = nil,
-        theme: StoreWidgetTheme = .default
+        theme: StoreWidgetTheme = .brandPurple
     ) async -> Timeline<StoreInfoEntry> {
         guard let dependencies = Self.fetchDependencies(selectedStoreID: selectedStoreID) else {
             return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
@@ -440,7 +440,7 @@ private extension StoreInfoProvider {
         for dependencies: Dependencies?,
         dateRange: StoreStatsWidgetDateRange = .today,
         metrics: [StoreInfoMetricType] = legacyMetricsPreset,
-        theme: StoreWidgetTheme = .default
+        theme: StoreWidgetTheme = .brandPurple
     ) -> StoreInfoEntry {
         let currencySettings = dependencies?.store.storeCurrencySettings ?? CurrencySettings()
         let sample = StoreInfoDataService.Stats.placeholderSample
@@ -486,7 +486,7 @@ private extension StoreInfoProvider {
                           dateRange: StoreStatsWidgetDateRange,
                           with dependencies: Dependencies,
                           metrics: [StoreInfoMetricType],
-                          theme: StoreWidgetTheme = .default) -> StoreInfoEntry {
+                          theme: StoreWidgetTheme = .brandPurple) -> StoreInfoEntry {
         let currencySettings = dependencies.store.storeCurrencySettings
         let stats = statsPeriod.current
         let previousStats = statsPeriod.previous

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -71,6 +71,11 @@ struct StoreInfoData {
         metricSlots.compactMap(\.concreteMetric)
     }
 
+    /// User-selected color scheme. Drives the background, text colors, logo tint, and
+    /// chart palette via `StoreWidgetTheme`.
+    ///
+    var theme: StoreWidgetTheme
+
     init(range: String,
          name: String,
          revenue: String,
@@ -81,7 +86,8 @@ struct StoreInfoData {
          updatedTime: String,
          metrics: [StoreInfoMetric] = [],
          metricSlots: [StoreInfoMetricSlot]? = nil,
-         dateRange: StoreStatsWidgetDateRange? = nil) {
+         dateRange: StoreStatsWidgetDateRange? = nil,
+         theme: StoreWidgetTheme = .default) {
         self.range = range
         self.name = name
         self.revenue = revenue
@@ -92,6 +98,7 @@ struct StoreInfoData {
         self.updatedTime = updatedTime
         self.metricSlots = metricSlots ?? metrics.map { .metric($0) }
         self.dateRange = dateRange
+        self.theme = theme
     }
 
     /// Used to build per-cell deep-link URLs. `nil` for surfaces without a configured range
@@ -154,7 +161,8 @@ final class StoreInfoProvider: TimelineProvider {
             metrics: Self.resolveMetricSelection(
                 requested: configuration.metrics,
                 family: context.family
-            )
+            ),
+            theme: configuration.theme
         )
     }
 
@@ -181,7 +189,8 @@ final class StoreInfoProvider: TimelineProvider {
     func loadTimeline(
         dateRange: StoreStatsWidgetDateRange,
         metrics: [StoreInfoMetricType],
-        selectedStoreID: StoreStatsStoreEntity.ID? = nil
+        selectedStoreID: StoreStatsStoreEntity.ID? = nil,
+        theme: StoreWidgetTheme = .default
     ) async -> Timeline<StoreInfoEntry> {
         guard let dependencies = Self.fetchDependencies(selectedStoreID: selectedStoreID) else {
             return Timeline<StoreInfoEntry>(entries: [.notConnected], policy: .never)
@@ -198,7 +207,8 @@ final class StoreInfoProvider: TimelineProvider {
                 for: statsPeriod,
                 dateRange: dateRange,
                 with: dependencies,
-                metrics: metrics
+                metrics: metrics,
+                theme: theme
             )
             return Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
         } catch {
@@ -429,7 +439,8 @@ private extension StoreInfoProvider {
     static func placeholderEntry(
         for dependencies: Dependencies?,
         dateRange: StoreStatsWidgetDateRange = .today,
-        metrics: [StoreInfoMetricType] = legacyMetricsPreset
+        metrics: [StoreInfoMetricType] = legacyMetricsPreset,
+        theme: StoreWidgetTheme = .default
     ) -> StoreInfoEntry {
         let currencySettings = dependencies?.store.storeCurrencySettings ?? CurrencySettings()
         let sample = StoreInfoDataService.Stats.placeholderSample
@@ -457,7 +468,8 @@ private extension StoreInfoProvider {
             orders: "\(sample.totalOrders)",
             conversion: conversionString,
             updatedTime: StoreInfoFormatter.currentFormattedTime(),
-            metricSlots: metricSlots
+            metricSlots: metricSlots,
+            theme: theme
         ))
     }
 
@@ -473,7 +485,8 @@ private extension StoreInfoProvider {
     static func dataEntry(for statsPeriod: StoreInfoDataService.StatsPeriod,
                           dateRange: StoreStatsWidgetDateRange,
                           with dependencies: Dependencies,
-                          metrics: [StoreInfoMetricType]) -> StoreInfoEntry {
+                          metrics: [StoreInfoMetricType],
+                          theme: StoreWidgetTheme = .default) -> StoreInfoEntry {
         let currencySettings = dependencies.store.storeCurrencySettings
         let stats = statsPeriod.current
         let previousStats = statsPeriod.previous
@@ -512,7 +525,8 @@ private extension StoreInfoProvider {
             conversion: conversionString,
             updatedTime: StoreInfoFormatter.currentFormattedTime(),
             metricSlots: metricSlots,
-            dateRange: dateRange
+            dateRange: dateRange,
+            theme: theme
         ))
     }
 

--- a/WooCommerce/StoreWidgets/StoreInfoViewModifiers.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoViewModifiers.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // MARK: StoreInfo widget view modifiers.
 //
 // Foreground colors switch on `\.storeWidgetTheme` from the environment so the same
-// modifier renders correctly against either the brand-purple background (default) or
+// modifier renders correctly against either the brand-purple background (brandPurple) or
 // the system widget background (sameAsSystem).
 
 public struct StoreNameStyle: ViewModifier {

--- a/WooCommerce/StoreWidgets/StoreInfoViewModifiers.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoViewModifiers.swift
@@ -2,52 +2,68 @@ import Foundation
 import SwiftUI
 
 // MARK: StoreInfo widget view modifiers.
+//
+// Foreground colors switch on `\.storeWidgetTheme` from the environment so the same
+// modifier renders correctly against either the brand-purple background (default) or
+// the system widget background (sameAsSystem).
 
 public struct StoreNameStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.footnote.weight(.bold))
-            .foregroundColor(Color(.white))
+            .foregroundColor(theme.primaryTextColor)
     }
 }
 
 public struct StatRangeStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.caption)
-            .foregroundColor(Color(.lightText))
+            .foregroundColor(theme.secondaryTextColor)
     }
 }
 
 public struct StatTitleStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.caption.bold())
-            .foregroundColor(Color(.lightText))
+            .foregroundColor(theme.secondaryTextColor)
     }
 }
 
 public struct StatValueStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.title3)
-            .foregroundColor(Color(.white))
+            .foregroundColor(theme.primaryTextColor)
     }
 }
 
 public struct StatTitleLargeStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.subheadline.bold())
-            .foregroundColor(Color(.lightText))
+            .foregroundColor(theme.secondaryTextColor)
     }
 }
 
 public struct StatValueLargeStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.title2)
-            .foregroundColor(Color(.white))
+            .foregroundColor(theme.primaryTextColor)
     }
 }
 
@@ -88,18 +104,22 @@ public struct StatTrendTextLargeStyle: ViewModifier {
 }
 
 public struct StatTextStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.footnote)
-            .foregroundColor(Color(.white))
+            .foregroundColor(theme.primaryTextColor)
     }
 }
 
 public struct StatButtonStyle: ViewModifier {
+    @Environment(\.storeWidgetTheme) private var theme
+
     public func body(content: Content) -> some View {
         content
             .font(.subheadline.weight(.semibold))
-            .foregroundColor(Color(.white))
+            .foregroundColor(theme.primaryTextColor)
     }
 }
 

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -100,11 +100,11 @@ private struct StoreInfoWidgetEntryView: View {
     }
 
     /// Theme to apply to the home-screen widget body. Carried on `StoreInfoData`; error and
-    /// not-connected entries fall back to `.default`.
+    /// not-connected entries fall back to `.brandPurple`.
     private func theme(for entry: StoreInfoEntry) -> StoreWidgetTheme {
         switch entry {
         case .data(let data): return data.theme
-        case .notConnected, .error: return .default
+        case .notConnected, .error: return .brandPurple
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -92,8 +92,10 @@ private struct StoreInfoWidgetEntryView: View {
             // configurable-widgets FF is on, so reaching them implies the metric-driven path.
             // Family-specific layouts are still pending; for now all three render via
             // `StoreInfoHomescreenWidget`'s shared body.
+            let resolvedTheme = theme(for: entry)
             StoreInfoHomescreenWidget(entry: entry)
-                .environment(\.storeWidgetTheme, theme(for: entry))
+                .environment(\.storeWidgetTheme, resolvedTheme)
+                .storeWidgetForcedColorScheme(resolvedTheme.forcedColorScheme)
         default:
             EmptyView()
         }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -92,10 +92,8 @@ private struct StoreInfoWidgetEntryView: View {
             // configurable-widgets FF is on, so reaching them implies the metric-driven path.
             // Family-specific layouts are still pending; for now all three render via
             // `StoreInfoHomescreenWidget`'s shared body.
-            let resolvedTheme = theme(for: entry)
             StoreInfoHomescreenWidget(entry: entry)
-                .environment(\.storeWidgetTheme, resolvedTheme)
-                .storeWidgetForcedColorScheme(resolvedTheme.forcedColorScheme)
+                .applyingStoreWidgetTheme(theme(for: entry))
         default:
             EmptyView()
         }

--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -93,8 +93,18 @@ private struct StoreInfoWidgetEntryView: View {
             // Family-specific layouts are still pending; for now all three render via
             // `StoreInfoHomescreenWidget`'s shared body.
             StoreInfoHomescreenWidget(entry: entry)
+                .environment(\.storeWidgetTheme, theme(for: entry))
         default:
             EmptyView()
+        }
+    }
+
+    /// Theme to apply to the home-screen widget body. Carried on `StoreInfoData`; error and
+    /// not-connected entries fall back to `.default`.
+    private func theme(for entry: StoreInfoEntry) -> StoreWidgetTheme {
+        switch entry {
+        case .data(let data): return data.theme
+        case .notConnected, .error: return .default
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -25,6 +25,9 @@ struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
     @Parameter(title: "Date Range", default: .today)
     var dateRange: StoreStatsWidgetDateRange
 
+    @Parameter(title: "Theme", default: .default)
+    var theme: StoreWidgetTheme
+
     /// User-selected metric set, in display order.
     ///
     /// The `size:` map drives iOS's family-aware fixed-slot rendering — small shows 2 metrics,

--- a/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
+++ b/WooCommerce/StoreWidgets/StoreStatsConfigurationIntent.swift
@@ -25,7 +25,7 @@ struct StoreStatsConfigurationIntent: WidgetConfigurationIntent {
     @Parameter(title: "Date Range", default: .today)
     var dateRange: StoreStatsWidgetDateRange
 
-    @Parameter(title: "Theme", default: .default)
+    @Parameter(title: "Theme", default: .brandPurple)
     var theme: StoreWidgetTheme
 
     /// User-selected metric set, in display order.

--- a/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
+++ b/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
@@ -9,7 +9,7 @@ import AppIntents
 ///
 enum StoreWidgetTheme: String {
     /// Brand-purple background with white text and white logo.
-    case `default`
+    case brandPurple
     /// System widget background (adapts to light/dark) with system text colors and a
     /// brand-purple-tinted logo.
     case sameAsSystem
@@ -29,7 +29,7 @@ extension StoreWidgetTheme: AppEnum {
 
     static var caseDisplayRepresentations: [StoreWidgetTheme: DisplayRepresentation] {
         [
-            .default: DisplayRepresentation(title: "Default"),
+            .brandPurple: DisplayRepresentation(title: "Brand Purple"),
             .sameAsSystem: DisplayRepresentation(title: "Same as system")
         ]
     }
@@ -42,7 +42,7 @@ extension StoreWidgetTheme {
     /// Primary text color — store name, big metric values, body text.
     var primaryTextColor: Color {
         switch self {
-        case .default: return Color(.white)
+        case .brandPurple: return Color(.white)
         case .sameAsSystem: return Color.primary
         }
     }
@@ -50,7 +50,7 @@ extension StoreWidgetTheme {
     /// Secondary text color — date range, "As of …" line, metric titles.
     var secondaryTextColor: Color {
         switch self {
-        case .default:
+        case .brandPurple:
             #if os(watchOS)
             return Color.white.opacity(0.7)
             #else
@@ -67,7 +67,7 @@ extension StoreWidgetTheme {
     /// shade-40 RGB on watchOS where the asset catalog isn't available.
     var logoTintColor: Color {
         switch self {
-        case .default:
+        case .brandPurple:
             return Color(.white)
         case .sameAsSystem:
             #if os(watchOS)
@@ -83,7 +83,7 @@ extension StoreWidgetTheme {
     /// bar group clusters in the middle of a wide chart).
     var chartBaselineColor: Color {
         switch self {
-        case .default: return Color.white.opacity(0.25)
+        case .brandPurple: return Color.white.opacity(0.25)
         case .sameAsSystem: return Color.secondary.opacity(0.35)
         }
     }
@@ -92,7 +92,7 @@ extension StoreWidgetTheme {
 // MARK: - Environment
 
 private struct StoreWidgetThemeEnvironmentKey: EnvironmentKey {
-    static let defaultValue: StoreWidgetTheme = .default
+    static let defaultValue: StoreWidgetTheme = .brandPurple
 }
 
 extension EnvironmentValues {

--- a/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
+++ b/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+#if canImport(AppIntents)
+import AppIntents
+#endif
+
+/// User-selectable color scheme for the home-screen Store Stats widget. Exposed as an
+/// AppIntent parameter via `StoreStatsConfigurationIntent.theme` and propagated to views
+/// through the `\.storeWidgetTheme` SwiftUI environment.
+///
+enum StoreWidgetTheme: String {
+    /// Brand-purple background with white text and white logo.
+    case `default`
+    /// System widget background (adapts to light/dark) with system text colors and a
+    /// brand-purple-tinted logo.
+    case sameAsSystem
+}
+
+// MARK: - AppEnum conformance
+
+// Gated to platforms that ship AppIntents (iOS 16+, watchOS 10+, etc). The
+// `WatchWidgetsExtension` target deploys to watchOS 9, so the conformance is excluded
+// from that build slice — the environment-driven view styling still works there.
+#if canImport(AppIntents)
+@available(iOS 16.0, watchOS 10.0, macOS 13.0, *)
+extension StoreWidgetTheme: AppEnum {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Theme")
+    }
+
+    static var caseDisplayRepresentations: [StoreWidgetTheme: DisplayRepresentation] {
+        [
+            .default: DisplayRepresentation(title: "Default"),
+            .sameAsSystem: DisplayRepresentation(title: "Same as system")
+        ]
+    }
+}
+#endif
+
+// MARK: - Style tokens
+
+extension StoreWidgetTheme {
+    /// Primary text color — store name, big metric values, body text.
+    var primaryTextColor: Color {
+        switch self {
+        case .default: return Color(.white)
+        case .sameAsSystem: return Color.primary
+        }
+    }
+
+    /// Secondary text color — date range, "As of …" line, metric titles.
+    var secondaryTextColor: Color {
+        switch self {
+        case .default:
+            #if os(watchOS)
+            return Color.white.opacity(0.7)
+            #else
+            return Color(.lightText)
+            #endif
+        case .sameAsSystem:
+            return Color.secondary
+        }
+    }
+
+    /// Tint applied to the Woo mini logo in the header. Uses `.accent` — WooCommercePurple
+    /// shade 40 (light mode) / shade 30 (dark mode) — so it reads as a lighter, mode-adaptive
+    /// brand purple instead of the heavy shade-60 `.brand` color. Falls back to a hardcoded
+    /// shade-40 RGB on watchOS where the asset catalog isn't available.
+    var logoTintColor: Color {
+        switch self {
+        case .default:
+            return Color(.white)
+        case .sameAsSystem:
+            #if os(watchOS)
+            // WooCommercePurple shade 40 (rgb 135, 62, 255).
+            return Color(red: 0.529, green: 0.243, blue: 1.000)
+            #else
+            return Color(.accent)
+            #endif
+        }
+    }
+
+    /// Color for the dashed baseline rule in `MetricChartView` (visible only when the
+    /// bar group clusters in the middle of a wide chart).
+    var chartBaselineColor: Color {
+        switch self {
+        case .default: return Color.white.opacity(0.25)
+        case .sameAsSystem: return Color.secondary.opacity(0.35)
+        }
+    }
+}
+
+// MARK: - Environment
+
+private struct StoreWidgetThemeEnvironmentKey: EnvironmentKey {
+    static let defaultValue: StoreWidgetTheme = .default
+}
+
+extension EnvironmentValues {
+    var storeWidgetTheme: StoreWidgetTheme {
+        get { self[StoreWidgetThemeEnvironmentKey.self] }
+        set { self[StoreWidgetThemeEnvironmentKey.self] = newValue }
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
+++ b/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
@@ -7,11 +7,19 @@ import AppIntents
 /// AppIntent parameter via `StoreStatsConfigurationIntent.theme` and propagated to views
 /// through the `\.storeWidgetTheme` SwiftUI environment.
 ///
+/// The three "system" cases (`.light`, `.dark`, `.sameAsSystem`) share the same style
+/// tokens — semantic system colors. The picker between them only changes which
+/// `ColorScheme` the widget body renders against: forced light, forced dark, or whatever
+/// the system is currently set to (see `forcedColorScheme`).
+///
 enum StoreWidgetTheme: String {
     /// Brand-purple background with white text and white logo.
     case brandPurple
-    /// System widget background (adapts to light/dark) with system text colors and a
-    /// brand-purple-tinted logo.
+    /// System widget appearance, forced to light mode regardless of the system setting.
+    case light
+    /// System widget appearance, forced to dark mode regardless of the system setting.
+    case dark
+    /// System widget appearance, following the current system light/dark setting.
     case sameAsSystem
 }
 
@@ -30,61 +38,95 @@ extension StoreWidgetTheme: AppEnum {
     static var caseDisplayRepresentations: [StoreWidgetTheme: DisplayRepresentation] {
         [
             .brandPurple: DisplayRepresentation(title: "Brand Purple"),
+            .light: DisplayRepresentation(title: "Light"),
+            .dark: DisplayRepresentation(title: "Dark"),
             .sameAsSystem: DisplayRepresentation(title: "Same as system")
         ]
     }
 }
 #endif
 
+// MARK: - Behavior
+
+extension StoreWidgetTheme {
+    /// Whether this theme renders against the system widget background (using semantic
+    /// system colors) or the brand-purple background (using brand-tuned colors).
+    var usesSystemAppearance: Bool {
+        switch self {
+        case .brandPurple: return false
+        case .light, .dark, .sameAsSystem: return true
+        }
+    }
+
+    /// Color scheme to force on the widget body, or `nil` to follow the system. Only
+    /// the explicit `.light` and `.dark` themes pin a value; the others let SwiftUI
+    /// resolve `\.colorScheme` from the system trait.
+    var forcedColorScheme: ColorScheme? {
+        switch self {
+        case .light: return .light
+        case .dark: return .dark
+        case .brandPurple, .sameAsSystem: return nil
+        }
+    }
+}
+
 // MARK: - Style tokens
 
 extension StoreWidgetTheme {
     /// Primary text color — store name, big metric values, body text.
     var primaryTextColor: Color {
-        switch self {
-        case .brandPurple: return Color(.white)
-        case .sameAsSystem: return Color.primary
-        }
+        usesSystemAppearance ? Color.primary : Color(.white)
     }
 
     /// Secondary text color — date range, "As of …" line, metric titles.
     var secondaryTextColor: Color {
-        switch self {
-        case .brandPurple:
-            #if os(watchOS)
-            return Color.white.opacity(0.7)
-            #else
-            return Color(.lightText)
-            #endif
-        case .sameAsSystem:
+        if usesSystemAppearance {
             return Color.secondary
         }
+        #if os(watchOS)
+        return Color.white.opacity(0.7)
+        #else
+        return Color(.lightText)
+        #endif
     }
 
-    /// Tint applied to the Woo mini logo in the header. Uses `.accent` — WooCommercePurple
-    /// shade 40 (light mode) / shade 30 (dark mode) — so it reads as a lighter, mode-adaptive
-    /// brand purple instead of the heavy shade-60 `.brand` color. Falls back to a hardcoded
-    /// shade-40 RGB on watchOS where the asset catalog isn't available.
+    /// Tint applied to the Woo mini logo in the header. Uses `.accent` —
+    /// WooCommercePurple shade 40 (light mode) / shade 30 (dark mode) — so the logo
+    /// reads as a lighter, mode-adaptive brand purple instead of the heavy shade-60
+    /// `.brand` color. Falls back to a hardcoded shade-40 RGB on watchOS where the
+    /// asset catalog isn't available.
     var logoTintColor: Color {
-        switch self {
-        case .brandPurple:
+        guard usesSystemAppearance else {
             return Color(.white)
-        case .sameAsSystem:
-            #if os(watchOS)
-            // WooCommercePurple shade 40 (rgb 135, 62, 255).
-            return Color(red: 0.529, green: 0.243, blue: 1.000)
-            #else
-            return Color(.accent)
-            #endif
         }
+        #if os(watchOS)
+        // WooCommercePurple shade 40 (rgb 135, 62, 255).
+        return Color(red: 0.529, green: 0.243, blue: 1.000)
+        #else
+        return Color(.accent)
+        #endif
     }
 
     /// Color for the dashed baseline rule in `MetricChartView` (visible only when the
     /// bar group clusters in the middle of a wide chart).
     var chartBaselineColor: Color {
-        switch self {
-        case .brandPurple: return Color.white.opacity(0.25)
-        case .sameAsSystem: return Color.secondary.opacity(0.35)
+        usesSystemAppearance ? Color.secondary.opacity(0.35) : Color.white.opacity(0.25)
+    }
+}
+
+// MARK: - View helpers
+
+extension View {
+    /// Pins the widget body to a fixed `ColorScheme` when the theme demands it (`.light`
+    /// or `.dark`). For themes that follow the system (`.sameAsSystem`, `.brandPurple`)
+    /// this returns the view unchanged so SwiftUI keeps resolving `\.colorScheme` from
+    /// the system trait.
+    @ViewBuilder
+    func storeWidgetForcedColorScheme(_ scheme: ColorScheme?) -> some View {
+        if let scheme {
+            environment(\.colorScheme, scheme)
+        } else {
+            self
         }
     }
 }

--- a/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
+++ b/WooCommerce/StoreWidgets/StoreWidgetTheme.swift
@@ -117,16 +117,20 @@ extension StoreWidgetTheme {
 // MARK: - View helpers
 
 extension View {
-    /// Pins the widget body to a fixed `ColorScheme` when the theme demands it (`.light`
-    /// or `.dark`). For themes that follow the system (`.sameAsSystem`, `.brandPurple`)
-    /// this returns the view unchanged so SwiftUI keeps resolving `\.colorScheme` from
-    /// the system trait.
+    /// Applies a `StoreWidgetTheme` to the widget body. Sets the `\.storeWidgetTheme`
+    /// environment value (consumed by our text modifiers, chart, badge, etc.) and pins
+    /// `\.colorScheme` when the theme demands it (consumed by SwiftUI's semantic colors
+    /// — `Color.primary`, `Color(.systemBackground)`, `Color(.systemGreen)`, etc.).
+    ///
+    /// Both side effects are bundled here so call sites don't have to know that the
+    /// theme touches two separate environment keys.
     @ViewBuilder
-    func storeWidgetForcedColorScheme(_ scheme: ColorScheme?) -> some View {
-        if let scheme {
-            environment(\.colorScheme, scheme)
+    func applyingStoreWidgetTheme(_ theme: StoreWidgetTheme) -> some View {
+        if let scheme = theme.forcedColorScheme {
+            environment(\.storeWidgetTheme, theme)
+                .environment(\.colorScheme, scheme)
         } else {
-            self
+            environment(\.storeWidgetTheme, theme)
         }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 				StoreInfoMetricType.swift,
 				StoreStatsConfigurationIntent.swift,
 				StoreStatsWidgetDateRange.swift,
+				StoreWidgetTheme.swift,
 				StoreWidgets.intentdefinition,
 				WidgetMetricPresenter.swift,
 				WidgetReportsURL.swift,
@@ -418,6 +419,7 @@
 				Images.xcassets,
 				"Images/UIImage+Widgets.swift",
 				Lockscreen/AppLinkWidget.swift,
+				StoreWidgetTheme.swift,
 			);
 			target = 267A04842C051C5100C91CB4 /* WatchWidgetsExtension */;
 		};


### PR DESCRIPTION
## Description
Adds a Theme configuration parameter to the Store Stats widget with four options — Brand Purple, Light, Dark, and Same as system. The brand-purple look stays the default; the three system-themed cases render against the standard iOS system widget background and adapt text, chart, logo, and trend badge colors accordingly. Light and Dark pin the widget appearance regardless of the device setting; Same as system follows it.

- Add `StoreWidgetTheme` enum (`brandPurple` / `light` / `dark` / `sameAsSystem`) exposed as a widget `@Parameter`
- Plumb the selection through `StoreInfoData` and into a SwiftUI environment value (`\.storeWidgetTheme`)
- Switch the widget background between the brand-purple gradient and `Color(.systemBackground)`
- Make all text style modifiers theme-aware (white / `.lightText` vs `.primary` / `.secondary`)
- Template-render the Woo mini logo and tint it (white in brand; `Color(.accent)` — a mode-adaptive brand purple — in the system themes)
- Swap chart palette and trend badge color from pastel mint/rose to `systemGreen` / `systemRed` in the system themes
- Pin the widget body to a fixed `\.colorScheme` for `.light` and `.dark`; leave it free for `.brandPurple` and `.sameAsSystem`
- Route the not-logged-in and error views through the theme-aware background for consistency

Tech notes:
- `containerBackground(for: .widget)` renders the background view in a separate SwiftUI environment context on iOS 17+, so both `\.storeWidgetTheme` and the forced `\.colorScheme` are explicitly re-applied to the background view at the call site
- `AppEnum` conformance on `StoreWidgetTheme` is gated to platforms that ship AppIntents so the watchOS-9 slice of the widget binary still builds

## Test Steps
- Long-press the widget → Edit Widget → cycle through all four Theme options and confirm each renders correctly (Brand Purple unchanged; Light shows light system appearance; Dark shows dark system appearance; Same as system follows the system mode)
- With Theme = Same as system, toggle the simulator between light and dark mode and confirm text, chart, logo, and trend badge colors all adapt
- With Theme = Light or Dark, toggle the simulator's appearance and confirm the widget keeps its forced mode regardless of the system setting
- Confirm Theme defaults to `Brand Purple` on a freshly added widget tile

## Demo

https://github.com/user-attachments/assets/0572e006-9e2d-4493-8c1f-71a3ed10f146

## Screenshots

<img width="1179" height="2556" alt="Снимок экрана 2026—05—14 в 17 28 17" src="https://github.com/user-attachments/assets/aec6265a-2cc7-422f-a408-36673b316bff" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.