### PR TITLE
[AI assistant] Update newest customers assistant prompt

### DIFF
--- a/Modules/Sources/WooAIAssistant/Presentation/EmptyStateView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/EmptyStateView.swift
@@ -100,9 +100,9 @@ struct EmptyStateView: View {
             comment: "Suggested prompt chip asking the assistant to list recent orders"
         )
         static let suggestionNewCustomers = NSLocalizedString(
-            "assistantChat.empty.suggestion.newCustomers.v2",
-            value: "Who's new this week?",
-            comment: "Suggested prompt chip asking the assistant to list the most recently registered customers"
+            "assistantChat.empty.suggestion.newestCustomers.v1",
+            value: "Who are my newest customers?",
+            comment: "Suggested prompt chip asking the assistant to list the newest customers"
         )
         static let promptRevenueWeek = NSLocalizedString(
             "assistantChat.empty.prompt.revenueWeek",
@@ -120,9 +120,9 @@ struct EmptyStateView: View {
             comment: "Full prompt sent to the assistant when the recent-orders suggestion chip is tapped"
         )
         static let promptNewCustomers = NSLocalizedString(
-            "assistantChat.empty.prompt.newCustomers",
-            value: "Who's new this week? List the customers who registered or placed their first order recently.",
-            comment: "Full prompt sent to the assistant when the new-customers suggestion chip is tapped"
+            "assistantChat.empty.prompt.newestCustomers.v1",
+            value: "Show my newest customers. List up to 10 customers sorted by registration date, newest first.",
+            comment: "Full prompt sent to the assistant when the newest-customers suggestion chip is tapped"
         )
     }
 }

--- a/Modules/Tests/WooAIAssistantTests/Presentation/EmptyStateSuggestionsTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/EmptyStateSuggestionsTests.swift
@@ -19,4 +19,17 @@ struct EmptyStateSuggestionsTests {
         #expect(prompts.allSatisfy { !$0.isEmpty })
         #expect(suggestions.allSatisfy { $0.prompt != $0.title })
     }
+
+    @Test
+    func test_defaultSuggestions_when_inspected_then_includes_newest_customers_prompt() throws {
+        // Given
+        let suggestions = EmptyStateView.defaultSuggestions
+
+        // When
+        let newCustomersSuggestion = try #require(suggestions.last)
+
+        // Then
+        #expect(newCustomersSuggestion.title == "Who are my newest customers?")
+        #expect(newCustomersSuggestion.prompt == "Show my newest customers. List up to 10 customers sorted by registration date, newest first.")
+    }
 }


### PR DESCRIPTION
## Description
Updates the AI Assistant empty-state suggestion previously labeled "Who's new this week?" to "Who are my newest customers?".

The previous week-based wording was problematic because the current `customers_list` tool does not support an `after` argument for filtering customers by registration date. Because of that, the implied `last week` request could not be mapped reliably to the available tool arguments and failed most of the time.

The expanded prompt now asks the assistant to show up to 10 newest customers sorted by registration date, newest first. This avoids the unsupported date filter while still answering the merchant's intent, and adds focused test coverage for the default suggestion copy.

## Test Steps
1. Run `xcodebuild -workspace WooCommerce.xcworkspace -scheme WooAIAssistant -destination 'platform=iOS Simulator,id=D7699BF8-2C81-4882-8F13-E090DA2CF87C' -sdk iphonesimulator test -only-testing:"WooAIAssistantTests/EmptyStateSuggestionsTests"`
2. Open the AI Assistant empty state.
3. Verify the customer suggestion label reads "Who are my newest customers?".
4. Tap the suggestion and verify it sends: "Show my newest customers. List up to 10 customers sorted by registration date, newest first."

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.