### PR TITLE
Restrict AI Assistant Markdown links to http(s) schemes

### DIFF
--- a/Modules/Sources/WooAIAssistant/Presentation/AssistantChatView.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/AssistantChatView.swift
@@ -1,3 +1,4 @@
+import CocoaLumberjackSwift
 import SwiftUI
 
 public struct AssistantChatView: View {
@@ -58,6 +59,13 @@ public struct AssistantChatView: View {
                     }
                 }
             }
+            .environment(\.openURL, OpenURLAction { url in
+                guard AssistantURLPolicy.allows(url) else {
+                    DDLogWarn("AI Assistant blocked link with disallowed scheme: \(url.scheme ?? "nil")")
+                    return .discarded
+                }
+                return .systemAction
+            })
             .environment(\.assistantConfirmationHandler,
                           AssistantConfirmationHandler(
                             onConfirm: { id in controller.confirmProposal(id) },

--- a/Modules/Sources/WooAIAssistant/Presentation/AssistantURLPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/AssistantURLPolicy.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Allowlist applied to URLs the AI Assistant tries to open.
+///
+/// Tool result strings can be attacker-controlled (guest order names,
+/// customer notes, reviews). Markdown rendering turns those into tappable
+/// links, so we filter at the renderer layer rather than trusting the
+/// system prompt to keep URLs safe.
+enum AssistantURLPolicy {
+    static let allowedSchemes: Set<String> = ["http", "https"]
+
+    static func allows(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return allowedSchemes.contains(scheme)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Presentation/AssistantURLPolicyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Presentation/AssistantURLPolicyTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct AssistantURLPolicyTests {
+
+    @Test(arguments: [
+        "https://example.com",
+        "http://example.com",
+        "HTTPS://example.com"
+    ])
+    func test_allows_when_scheme_is_http_or_https_then_returns_true(_ string: String) throws {
+        // Given
+        let url = try #require(URL(string: string))
+
+        // When
+        let allowed = AssistantURLPolicy.allows(url)
+
+        // Then
+        #expect(allowed)
+    }
+
+    @Test(arguments: [
+        "sms:+19001234567?body=YES",
+        "tel:+1900",
+        "mailto:foo@bar.com",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "whatsapp://send?phone=1",
+        "itms-apps://itunes.apple.com/app/idXXX"
+    ])
+    func test_allows_when_scheme_is_disallowed_then_returns_false(_ string: String) throws {
+        // Given
+        let url = try #require(URL(string: string))
+
+        // When
+        let allowed = AssistantURLPolicy.allows(url)
+
+        // Then
+        #expect(allowed == false)
+    }
+
+    @Test
+    func test_allows_when_url_has_no_scheme_then_returns_false() throws {
+        // Given
+        let url = try #require(URL(string: "no-scheme", relativeTo: nil))
+
+        // When
+        let allowed = AssistantURLPolicy.allows(url)
+
+        // Then
+        #expect(allowed == false)
+    }
+}


### PR DESCRIPTION
## Description

The AI Assistant chat bubble renders the model's replies as inline Markdown via `AttributedString(markdown:)`, so `[text](url)` syntax becomes a tappable link. SwiftUI's default `OpenURLAction` then opens whatever URL is provided through `UIApplication.shared.open(...)`, with no scheme filter.

The model frequently echoes tool-output strings verbatim, and many of those fields are attacker-controlled with zero authentication: customer first/last name, billing address, order `customer_note`, product review content, etc. An attacker can plant `[click](sms:+1900?body=YES)` (or a deep link into another installed app, a `tel:` to a premium-rate number, a `javascript:` URI, a phishing `https://`) into any of these fields via guest checkout. The next time the merchant asks the assistant something like "who are my new customers" or "any notes on recent orders", the model returns the malicious string and SwiftUI renders it as a live link.

This PR adds an allowlist at the chat view's `OpenURLAction`, accepting only `http` and `https`. Disallowed schemes are logged and discarded.

### Non-obvious decisions
- The allowlist is the v1 minimum. Phishing via `https://` is still possible since allowed URLs open directly in Safari. A confirmation prompt or in-app `SFSafariViewController` containment is deferred.
- `MessageBubble.renderedText` is left unchanged: disallowed-scheme links still appear underlined/coloured but the tap is a no-op. Stripping the link styling for blocked schemes is a UX follow-up.
- `mailto:` is explicitly NOT in the allowlist for v1. Easy to add if a real use case emerges.

## Test Steps

- Confirm that Woo documentation link continues to work
- Model generally refuses to present those malicious notes so it was difficult to reproduce directly

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.