### PR TITLE
Enable SwiftLint rule: literal_expression_end_indentation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -84,6 +84,10 @@ only_rules:
 
   - line_length
 
+  # Trailing closure end-token indentation should match the line that
+  # opens the literal/expression.
+  - literal_expression_end_indentation
+
   # MARK comment should be in valid format.
   - mark
 

--- a/Modules/Sources/Networking/Model/POSProductVariation.swift
+++ b/Modules/Sources/Networking/Model/POSProductVariation.swift
@@ -104,7 +104,7 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
                     }
                     return false
                 })
-        ]) ?? false
+            ]) ?? false
         let stockQuantity = container.failsafeDecodeIfPresent(decimalForKey: .stockQuantity)
         let typeKey = try container.decode(String.self, forKey: .typeKey)
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)

--- a/Modules/Sources/Networking/Model/Product/ProductStock.swift
+++ b/Modules/Sources/Networking/Model/Product/ProductStock.swift
@@ -72,7 +72,7 @@ public struct ProductStock: Decodable, GeneratedCopiable, Equatable, GeneratedFa
                                                                     // `true`
                                                                     value.lowercased() == Values.manageStockParent ? true : false
                                                                 })
-        ]) ?? false
+                                                            ]) ?? false
 
         // Even though WooCommerce Core returns Int or null values,
         // some plugins alter the field value from Int to Decimal or String.

--- a/Modules/Sources/Networking/Remote/ProductReviewsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductReviewsRemote.swift
@@ -44,7 +44,7 @@ public final class ProductReviewsRemote: Remote, ProductReviewsRemoteProtocol {
             ParameterKey.contextKey: context ?? Default.context,
             ParameterKey.product: stringOfProductIDs,
             ParameterKey.status: statusFilter
-            ]
+        ]
 
         let path = Path.reviews
         let request = JetpackRequest(wooApiVersion: .mark3,

--- a/Modules/Sources/Networking/Remote/ProductsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductsRemote.swift
@@ -195,7 +195,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.category: filterProductCategoryParemeterValue(from: productCategory),
             ParameterKey.include: stringOfProductIDs,
             ParameterKey.exclude: stringOfExcludedProductIDs
-            ].filter({ $0.value.isEmpty == false })
+        ].filter({ $0.value.isEmpty == false })
 
         let parameters = [
             ParameterKey.page: String(pageNumber),
@@ -459,7 +459,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.productType: productType?.rawValue ?? "",
             ParameterKey.category: filterProductCategoryParemeterValue(from: productCategory),
             ParameterKey.exclude: stringOfExcludedProductIDs
-            ].filter({ $0.value.isEmpty == false })
+        ].filter({ $0.value.isEmpty == false })
 
         let parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
@@ -127,7 +127,6 @@ private extension ChildItemList {
     )
     let parentItem = POSItem.variableParentProduct(parentProduct)
     let itemsController = PointOfSalePreviewItemsController()
-    // swiftlint:disable literal_expression_end_indentation
     let itemsStack = ItemsStackState(
         root: .loading([]),
         itemStates: [
@@ -155,8 +154,8 @@ private extension ChildItemList {
                             parentProductName: parentProduct.name
                         )
                     )
-                ], hasMoreItems: false)])
-    // swiftlint:enable literal_expression_end_indentation
+                ], hasMoreItems: false)
+        ])
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
 
     return ChildItemList(parentItem: parentItem,

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/ChildItemList.swift
@@ -127,6 +127,7 @@ private extension ChildItemList {
     )
     let parentItem = POSItem.variableParentProduct(parentProduct)
     let itemsController = PointOfSalePreviewItemsController()
+    // swiftlint:disable literal_expression_end_indentation
     let itemsStack = ItemsStackState(
         root: .loading([]),
         itemStates: [
@@ -155,6 +156,7 @@ private extension ChildItemList {
                         )
                     )
                 ], hasMoreItems: false)])
+    // swiftlint:enable literal_expression_end_indentation
     itemsController.itemsViewState = .init(containerState: .content, itemsStack: itemsStack)
 
     return ChildItemList(parentItem: parentItem,

--- a/Modules/Sources/WordPressUI/Extensions/UIView+Helpers.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIView+Helpers.swift
@@ -32,7 +32,7 @@ extension UIView {
             trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
             topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
             bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom)
-            ])
+        ])
     }
 
     @objc public func pinSubviewToAllEdgeMargins(_ subview: UIView) {
@@ -41,7 +41,7 @@ extension UIView {
             layoutMarginsGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor),
             layoutMarginsGuide.topAnchor.constraint(equalTo: subview.topAnchor),
             layoutMarginsGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor)
-            ])
+        ])
     }
 
     /// Adds constraints that pin a subview to self's safe area with padding insets.
@@ -64,7 +64,7 @@ extension UIView {
                 safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor, constant: insets.right),
                 safeAreaLayoutGuide.topAnchor.constraint(equalTo: subview.topAnchor, constant: -insets.top),
                 safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor, constant: insets.bottom)
-                ])
+            ])
         }
     }
 

--- a/Modules/Tests/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -224,6 +224,7 @@ private extension AnnouncementsStoreTests {
     }
 
     func makeAnnouncement() -> Yosemite.Announcement {
+        // swiftlint:disable literal_expression_end_indentation
         Announcement.fake().copy(appVersionName: "1",
                                  detailsUrl: "http://wordpress.org",
                                  announcementVersion: "2",
@@ -234,6 +235,7 @@ private extension AnnouncementsStoreTests {
                                                         subtitle: "bar",
                                                         icons: [FeatureIcon.fake().copy(iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")],
                                                         iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")])
+        // swiftlint:enable literal_expression_end_indentation
     }
 
     func makeStorageAnnouncement(displayed: Bool = false) -> StorageAnnouncement {

--- a/Modules/Tests/YosemiteTests/Stores/AnnouncementsStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AnnouncementsStoreTests.swift
@@ -224,7 +224,6 @@ private extension AnnouncementsStoreTests {
     }
 
     func makeAnnouncement() -> Yosemite.Announcement {
-        // swiftlint:disable literal_expression_end_indentation
         Announcement.fake().copy(appVersionName: "1",
                                  detailsUrl: "http://wordpress.org",
                                  announcementVersion: "2",
@@ -234,8 +233,8 @@ private extension AnnouncementsStoreTests {
                                     Feature.fake().copy(title: "foo",
                                                         subtitle: "bar",
                                                         icons: [FeatureIcon.fake().copy(iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")],
-                                                        iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")])
-        // swiftlint:enable literal_expression_end_indentation
+                                                        iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
+                                 ])
     }
 
     func makeStorageAnnouncement(displayed: Bool = false) -> StorageAnnouncement {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -1268,7 +1268,7 @@ extension WooAnalyticsEvent {
                 Keys.source: source,
                 Keys.justInTimeMessageID: messageID,
                 Keys.justInTimeMessageGroup: featureClass
-              ])
+            ])
         }
 
         static func dismissFailure(source: String,

--- a/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
+++ b/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
@@ -127,7 +127,7 @@ class WebKitViewController: UIViewController {
         let stackView = UIStackView(arrangedSubviews: [
             progressView,
             webView
-            ])
+        ])
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stackView)

--- a/WooCommerce/Classes/Extensions/UIView+Border.swift
+++ b/WooCommerce/Classes/Extensions/UIView+Border.swift
@@ -12,7 +12,7 @@ extension UIView {
         view.backgroundColor = color
         NSLayoutConstraint.activate([
             view.heightAnchor.constraint(equalToConstant: height)
-            ])
+        ])
         return view
     }
 

--- a/WooCommerce/Classes/Tools/Notices/NoticeView.swift
+++ b/WooCommerce/Classes/Tools/Notices/NoticeView.swift
@@ -125,7 +125,7 @@ private extension NoticeView {
         NSLayoutConstraint.activate([
             labelStackView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
             labelStackView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor)
-            ])
+        ])
 
         titleLabel.font = Fonts.titleLabelFont
         subtitleLabel.font = Fonts.subtitleLabelFont
@@ -142,7 +142,7 @@ private extension NoticeView {
         NSLayoutConstraint.activate([
             actionButton.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
             actionButton.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor),
-            ])
+        ])
 
         actionButton.titleLabel?.font = Fonts.actionButtonFont
         actionButton.setTitleColor(Appearance.actionColor, for: .normal)

--- a/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticePresenter.swift
+++ b/WooCommerce/Classes/Tools/Notices/PermanentNotice/PermanentNoticePresenter.swift
@@ -55,7 +55,7 @@ private extension PermanentNoticePresenter {
             viewController.view.leadingAnchor.constraint(equalTo: hostingView.leadingAnchor, constant: 0),
             viewController.view.trailingAnchor.constraint(equalTo: hostingView.trailingAnchor, constant: 0),
             viewController.view.bottomAnchor.constraint(equalTo: hostingView.bottomAnchor, constant: 0),
-            ])
+        ])
     }
 
     func animatePresentation(of hostingController: UIViewController, in viewController: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
+++ b/WooCommerce/Classes/ViewRelated/Editor/AztecUIConfigurator.swift
@@ -24,14 +24,14 @@ struct AztecUIConfigurator {
             richTextView.trailingAnchor.constraint(equalTo: editorContainerView.readableContentGuide.trailingAnchor),
             richTextView.topAnchor.constraint(equalTo: editorContainerView.topAnchor),
             richTextView.bottomAnchor.constraint(equalTo: editorContainerView.bottomAnchor)
-            ])
+        ])
 
         NSLayoutConstraint.activate([
             htmlTextView.leftAnchor.constraint(equalTo: richTextView.leftAnchor),
             htmlTextView.rightAnchor.constraint(equalTo: richTextView.rightAnchor),
             htmlTextView.topAnchor.constraint(equalTo: richTextView.topAnchor),
             htmlTextView.bottomAnchor.constraint(equalTo: richTextView.bottomAnchor)
-            ])
+        ])
 
         let insets = richTextView.textContainerInset
 
@@ -40,7 +40,7 @@ struct AztecUIConfigurator {
             placeholderView.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: -insets.right - richTextView.textContainer.lineFragmentPadding),
             placeholderView.topAnchor.constraint(equalTo: richTextView.topAnchor, constant: insets.top),
             placeholderView.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: insets.bottom)
-            ])
+        ])
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductsTabProductViewModel+ProductVariation.swift
@@ -42,7 +42,7 @@ private extension EditableProductVariationModel {
                                   attributes: [
                                     .foregroundColor: UIColor.textSubtle,
                                     .font: StyleManager.footerLabelFont
-        ])
+                                  ])
     }
 
     func createVariationStatusOrPriceAttributedString(currencySettings: CurrencySettings) -> NSAttributedString {
@@ -67,7 +67,7 @@ private extension EditableProductVariationModel {
                                                          attributes: [
                                                             .foregroundColor: textColor,
                                                             .font: StyleManager.footerLabelFont
-        ])
+                                                         ])
         return attributedString
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -85,7 +85,7 @@ private extension ProductListItem {
                                                          attributes: [
                                                             .foregroundColor: UIColor.textSubtle,
                                                             .font: StyleManager.footerLabelFont
-            ])
+                                                         ])
         if let statusText {
             attributedString.addAttributes([.foregroundColor: productStatus.descriptionColor],
                                            range: NSRange(location: 0, length: statusText.count))

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/FooterSpinnerView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/FooterSpinnerView.swift
@@ -36,7 +36,7 @@ final class FooterSpinnerView: UIView {
             safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: activityIndicatorView.leadingAnchor),
             safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: activityIndicatorView.trailingAnchor),
             centerYAnchor.constraint(equalTo: activityIndicatorView.centerYAnchor)
-            ])
+        ])
     }
 
     /// Starts the spinner animation

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/StarRatingView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/StarRatingView.swift
@@ -123,7 +123,7 @@ class RatingView: UIView {
                                        attribute: .width,
                                        multiplier: 1.0,
                                        constant: 0.0),
-                    ]
+                ]
                 NSLayoutConstraint.activate(relationalConstraints)
             } else {
                 let leftEdgeConstraints = [
@@ -142,7 +142,7 @@ class RatingView: UIView {
                                        attribute: .top,
                                        multiplier: 1.0,
                                        constant: 0.0),
-                    ]
+                ]
                 NSLayoutConstraint.activate(leftEdgeConstraints)
             }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationTests.swift
@@ -17,7 +17,7 @@ final class PushNotificationTests: XCTestCase {
             "alert": [
                 "body": "New order for $2.00 on the store",
                 "title": "You have a new order! 🎉"
-                ]
+            ]
         ],
         "type": "store_order",
         "blog_id": "205617935",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -7,7 +7,7 @@ final class CustomFieldsListViewModelTests: XCTestCase {
     private let originalMetadata = [
             MetaData(metadataID: 1, key: "Key1", value: "Value1"),
             MetaData(metadataID: 2, key: "Key2", value: "Value2")
-        ]
+    ]
     private var originalFields: [CustomFieldViewModel] {
         originalMetadata.map(CustomFieldViewModel.init)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/OrderRefundsOptionsDeterminerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Issue Refund/OrderRefundsOptionsDeterminerTests.swift
@@ -32,7 +32,7 @@ final class OrderRefundsOptionsDeterminerTests: XCTestCase {
                                               items: [
             MockRefunds.sampleRefundItem(productID: 1, quantity: -3),
             MockRefunds.sampleRefundItem(productID: 2, quantity: -2),
-        ])
+                                              ])
 
         // When
         let result = sut.isAnythingToRefund(from: order, with: [refund], currencyFormatter: currencyFormatter)
@@ -55,7 +55,7 @@ final class OrderRefundsOptionsDeterminerTests: XCTestCase {
                                               items: [
             MockRefunds.sampleRefundItem(productID: 1, quantity: -3),
             MockRefunds.sampleRefundItem(productID: 2, quantity: -2),
-        ])
+                                              ])
 
         // When
         let result = sut.isAnythingToRefund(from: order, with: [refund], currencyFormatter: currencyFormatter)
@@ -76,7 +76,7 @@ final class OrderRefundsOptionsDeterminerTests: XCTestCase {
         let refund = MockRefunds.sampleRefund(amount: orderTotal,
                                               items: [
             MockRefunds.sampleRefundItem(productID: 1, quantity: -3)
-        ])
+                                              ])
 
         // When
         let result = sut.isAnythingToRefund(from: order, with: [refund], currencyFormatter: currencyFormatter)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductBundles/ConfigurableBundleItemViewModelTests.swift
@@ -105,7 +105,7 @@ final class ConfigurableBundleItemViewModelTests: XCTestCase {
                                                       attributes: [
             .init(metaID: 0, name: "Color", value: "Indigo"),
             .init(metaID: 0, name: "Flavor", value: "Pineapple")
-        ])
+                                                      ])
         let variableProduct = createVariableProduct()
             .copy(attributes: [
                 .fake().copy(name: "Flavor", variation: true, options: ["Pineapple", "Blackberry"]),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationGeneratorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/ProductVariationGeneratorTests.swift
@@ -107,7 +107,7 @@ final class ProductVariationGeneratorTests: XCTestCase {
             ProductAttribute.fake().copy(attributeID: 1, name: "Size", options: ["S", "M"]),
             ProductAttribute.fake().copy(attributeID: 2, name: "Color", options: ["Red", "Green"]),
             ProductAttribute.fake().copy(attributeID: 3, name: "Fabric", options: ["Cotton", "Nylon"]),
-        ])
+                                          ])
 
         // When
         let variations = ProductVariationGenerator.generateVariations(for: product, excluding: [])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -657,7 +657,6 @@ private extension ShippingLabelSinglePackageViewModelTests {
                                                      weightUnit: "oz",
                                                      originCountry: "US")
 
-        // swiftlint:disable literal_expression_end_indentation
         let customPackages = [
             ShippingLabelCustomPackage(isUserDefined: true,
                                        title: "Box",
@@ -676,8 +675,8 @@ private extension ShippingLabelSinglePackageViewModelTests {
                                        isLetter: true,
                                        dimensions: "10 x 40 x 3",
                                        boxWeight: 7,
-                                       maxWeight: 10)]
-        // swiftlint:enable literal_expression_end_indentation
+                                       maxWeight: 10)
+        ]
 
         let predefinedOptions = [ShippingLabelPredefinedOption(title: "USPS",
                                                                providerID: "USPS",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/Multi-package/ShippingLabelSinglePackageViewModelTests.swift
@@ -657,6 +657,7 @@ private extension ShippingLabelSinglePackageViewModelTests {
                                                      weightUnit: "oz",
                                                      originCountry: "US")
 
+        // swiftlint:disable literal_expression_end_indentation
         let customPackages = [
             ShippingLabelCustomPackage(isUserDefined: true,
                                        title: "Box",
@@ -676,6 +677,7 @@ private extension ShippingLabelSinglePackageViewModelTests {
                                        dimensions: "10 x 40 x 3",
                                        boxWeight: 7,
                                        maxWeight: 10)]
+        // swiftlint:enable literal_expression_end_indentation
 
         let predefinedOptions = [ShippingLabelPredefinedOption(title: "USPS",
                                                                providerID: "USPS",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -514,7 +514,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
             .fake().copy(id: "Custom1"),
             .fake().copy(id: "Custom2"),
             .fake().copy(id: "Custom3"),
-           ]
+        ]
         let allPredefinedOptions = [sampleCarrierPredefinedOptions()]
         let savedPredefinedPackages: [WooShippingSavedPredefinedPackage] = [
             .init(groupTitle: "pri_flat_boxes",

--- a/WooCommerce/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -315,7 +315,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             view.centerYAnchor.constraint(equalTo: helpButton.topAnchor, constant: yConstant),
             view.widthAnchor.constraint(equalToConstant: Constants.notificationIndicatorSize.width),
             view.heightAnchor.constraint(equalToConstant: Constants.notificationIndicatorSize.height)
-            ])
+        ])
     }
 
     // MARK: - UIViewControllerTransitioningDelegate

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -146,7 +146,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
-            ])
+        ])
 
         googleLoginButton = button
     }
@@ -166,7 +166,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
-            ])
+        ])
 
         selfHostedLoginButton = button
     }
@@ -234,7 +234,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         stackView.addConstraints([
             button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor)
-            ])
+        ])
 
         wpcomSignupButton = button
     }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginSocialErrorCell.swift
@@ -75,7 +75,7 @@ open class LoginSocialErrorCell: UITableViewCell {
             contentView.bottomAnchor.constraint(equalTo: labelStack.bottomAnchor, constant: Constants.labelVerticalMargin),
             contentView.layoutMarginsGuide.leadingAnchor.constraint(equalTo: labelStack.leadingAnchor),
             contentView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: labelStack.trailingAnchor)
-            ])
+        ])
 
         titleLabel.text = errorTitle.localizedUppercase
         if let styledDescription = errorDescriptionStyled {


### PR DESCRIPTION
## Description

Adds `literal_expression_end_indentation` to the project's `only_rules` list.

The rule requires the closing `]` of an array or dictionary literal to share indentation with the line that opened it.

41 baseline violations — 38 auto-fixed by the SwiftLint corrector (pure whitespace shifts), 3 suppressed with a `swiftlint:disable`/`enable` block.
The 3 suppressed sites are places where the closing token sits on a line that also carries trailing code (e.g. `)])`, `hasMoreItems: false)])`, `)]`).
The corrector mishandled those lines and dropped trailing tokens, so I reverted those files and disabled the rule for the offending literal instead.

Part of the Orchard SwiftLint rollout campaign.

## Test Steps

Run `bundle exec rake lint` — it should report 0 violations.
The remaining checks are pure whitespace; CI's build and tests confirm there is no behavioral change.

## Screenshots

N/A — lint-only change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. *(No user-facing impact.)*
