### PR TITLE
Pin AI Assistant dashboard card to the top of saved layout

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -884,16 +884,15 @@ private extension DashboardViewModel {
                               canShowAIAssistant: Bool) -> [DashboardCard] {
         var cards = [DashboardCard]()
 
+        cards.append(DashboardCard(type: .aiAssistant,
+                                   availability: canShowAIAssistant ? .show : .hide,
+                                   enabled: canShowAIAssistant))
+
         // Onboarding card.
         // When not available, Onboarding card needs to be hidden from Dashboard and Customize
         cards.append(DashboardCard(type: .onboarding,
                                    availability: canShowOnboarding ? .show : .hide,
                                    enabled: canShowOnboarding))
-
-        // AI Assistant lands right after onboarding, at the top of the editable list.
-        cards.append(DashboardCard(type: .aiAssistant,
-                                   availability: canShowAIAssistant ? .show : .hide,
-                                   enabled: canShowAIAssistant))
 
         // Performance and Top Performance cards (also known as Analytics cards).
         // When not available, Analytics cards need to be hidden from Dashboard, but appear on Customize as "Unavailable"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -443,14 +443,8 @@ private extension DashboardViewModel {
         guard !savedCards.contains(where: { $0.type == .aiAssistant }) else { return }
 
         let aiAssistantCard = DashboardCard(type: .aiAssistant, availability: .show, enabled: true)
-        let insertionIndex: Int = {
-            if let onboardingIndex = savedCards.firstIndex(where: { $0.type == .onboarding }) {
-                return savedCards.index(after: onboardingIndex)
-            }
-            return savedCards.startIndex
-        }()
         var updatedSaved = savedCards
-        updatedSaved.insert(aiAssistantCard, at: insertionIndex)
+        updatedSaved.insert(aiAssistantCard, at: savedCards.startIndex)
         saveDashboardCards(cards: updatedSaved)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1252,7 +1252,7 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_aiAssistant_when_eligible_user_has_saved_cards_without_it_then_card_is_auto_inserted() async throws {
+    func test_ensureAIAssistantCardInSavedCards_when_onboarding_present_then_inserts_at_top() async throws {
         // Given
         let savedCards: [DashboardCard] = [
             DashboardCard(type: .onboarding, availability: .show, enabled: true),
@@ -1303,9 +1303,10 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         let updatedCards = try XCTUnwrap(capturedSaves.first)
+        XCTAssertGreaterThanOrEqual(updatedCards.count, 2)
+        XCTAssertEqual(updatedCards.first?.type, .aiAssistant)
+        XCTAssertEqual(updatedCards[1].type, .onboarding)
         let aiIndex = try XCTUnwrap(updatedCards.firstIndex(where: { $0.type == .aiAssistant }))
-        let onboardingIndex = try XCTUnwrap(updatedCards.firstIndex(where: { $0.type == .onboarding }))
-        XCTAssertEqual(aiIndex, onboardingIndex + 1)
         XCTAssertTrue(updatedCards[aiIndex].enabled)
         XCTAssertEqual(updatedCards[aiIndex].availability, .show)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -434,8 +434,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            aiAssistantEligibilityChecker: MockAIAssistantEligibilityChecker(isEligible: false))
         mockReloadingData(storeHasOrders: false)
 
-        let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
-                             DashboardCard(type: .aiAssistant, availability: .hide, enabled: false),
+        let expectedCards = [DashboardCard(type: .aiAssistant, availability: .hide, enabled: false),
+                             DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
                              DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false),
                              DashboardCard(type: .blaze, availability: .hide, enabled: false),
@@ -475,8 +475,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            aiAssistantEligibilityChecker: MockAIAssistantEligibilityChecker(isEligible: false))
         mockReloadingData(storeHasOrders: false)
 
-        let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
-                             DashboardCard(type: .aiAssistant, availability: .hide, enabled: false),
+        let expectedCards = [DashboardCard(type: .aiAssistant, availability: .hide, enabled: false),
+                             DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
                              DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false),
                              DashboardCard(type: .blaze, availability: .hide, enabled: false),


### PR DESCRIPTION
## Why

The AI Assistant card was landing directly below the Setup Your Store card on two paths: the saved-layout insertion path (when onboarding was still pending and a saved layout already existed), and the fresh-install / post-reset path (where the default card array hard-coded `.onboarding` before `.aiAssistant`). The product decision is to keep AI Assistant at the top of the dashboard at all times on both paths, prioritising feature discoverability over the dynamic "Setup first while pending" behaviour the original code provided.

This PR addresses both paths:

- `ensureAIAssistantCardInSavedCards` now inserts the card at the start of the saved layout instead of after onboarding.
- `generateDefaultCards` now appends AI Assistant before onboarding, so fresh installs and post-reset states match the saved-layout fix above (otherwise the saved-layout fix short-circuits on empty saved cards and the user still sees onboarding on top).

## Key non-obvious decisions

- No migration for pre-release testers who already have the card persisted at index 1. The existing `!savedCards.contains(where: { $0.type == .aiAssistant })` guard respects user reordering once the card is in the saved layout, and a forced relocation would break that contract. Pre-release testers can wipe storage to pick up the corrected default; the released audience sees the right order from the first launch.
- The "Setup Your Store appears, then disappears, AI Assistant slides up" pattern the original code produced was a thoughtful side-effect of the `index(after: onboardingIndex)` choice. Replacing it with a hard top pin is a deliberate trade against that dynamic in favour of consistent first-card placement.

## Cross-platform alignment with Android

Matches `DashboardRepository.insertAIAssistantWidgetAtTopIfMissing` in `woocommerce-android` (`WooCommerce/src/main/kotlin/com/woocommerce/android/ui/dashboard/data/DashboardRepository.kt` on trunk), which prepends the AI Assistant widget at index 0 with a single "skip if already present" guard. Android only needs one widget-creation path because its dashboard schema is repository-driven; iOS has two paths (default-card array + saved-layout reconciliation) that both now converge on Android's single insertion behaviour.

| Concern | Android | iOS (this PR) | Status |
|---|---|---|---|
| Insert position when adding | `addWidgets(aiAssistantWidget); addAllWidgets(storedWidgets)` (index 0) | `updatedSaved.insert(aiAssistantCard, at: savedCards.startIndex)` | aligned |
| Skip if already present | `if storedWidgets.any { it.type == AI_ASSISTANT } return` | `guard !savedCards.contains(where: { $0.type == .aiAssistant }) else { return }` | aligned |
| Fresh-install / default order | repository-driven; AI Assistant is prepended via `insertAIAssistantWidgetAtTopIfMissing` after defaults load | `generateDefaultCards` appends AI Assistant before onboarding | aligned |
| Pre-release migration | None | None | aligned |

## Tests

`DashboardViewModelTests` covers the "inserts at index 0 when onboarding is present" case for the saved-layout path. The two `test_generated_default_cards_are_as_expected_*` tests were updated to assert the new default order (AI Assistant before onboarding). App-target tests verified on CI.

1. Install a new version of the app
2. Login to the Dotcom store
3. Confirm AI Assistant card appears on top

## Screenshots

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-15 at 07 53 41" src="https://github.com/user-attachments/assets/d6fbc6a1-7f18-46ba-8ec7-76de8cc8ada1" />
