### PR TITLE
[WOOMOB-3093] Tint Store Stats home-screen widget on iOS < 26

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoHomescreenWidget.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoHomescreenWidget.swift
@@ -10,10 +10,13 @@ struct StoreInfoHomescreenWidget: View {
         switch entry {
         case .notConnected:
             NotLoggedInView()
+                .widgetAccentable()
         case .error:
             UnableToFetchView()
+                .widgetAccentable()
         case .data(let data):
             StoreInfoMetricsView(entryData: data)
+                .widgetAccentable()
         }
     }
 }


### PR DESCRIPTION
## Description
On iOS < 26 with a tinted home screen, the Store Stats home-screen widget kept rendering at full color while the surrounding system icons followed the user's tint. Root cause: the widget content was not marked as accentable, so iOS skipped applying the accent / vibrant compositor to it.

Fix: mark the three branches of `StoreInfoHomescreenWidget` (`NotLoggedInView`, `UnableToFetchView`, `StoreInfoMetricsView`) with `.widgetAccentable()`. iOS handles the luminance-based tint from there — no color swaps needed for text, logo, charts, or trend badges. Touches WOOMOB-3093.

## Test Steps
- Add the "Today" widget to the home screen on a device running iOS < 26 (e.g. iOS 18.x).
- Enable tinted home screen mode: long-press the home screen → Edit → Customize → Tinted, pick a tint color.
- Confirm the Store Stats widget content (store name, "As of …", metric values, trend badges, charts, and Woo logo) renders in the system tint alongside the app icons.
- Switch back to Default / Dark mode and confirm the widget still renders with its brand-purple gradient and white foreground (unchanged behavior in `.fullColor`).
- Repeat for `.systemSmall`, `.systemMedium`, `.systemLarge`.
- Verify the not-connected and unable-to-fetch states also tint correctly.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.