### PR TITLE
Add Yosemite layer for push notification preferences

### DIFF
--- a/Modules/Sources/Yosemite/Actions/NotificationAction.swift
+++ b/Modules/Sources/Yosemite/Actions/NotificationAction.swift
@@ -72,4 +72,24 @@ public enum NotificationAction: Action {
                                                    tokenID: Int64,
                                                    availableAsRESTRequest: Bool,
                                                    onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Loads the current user's push notification preferences for a site.
+    ///
+    /// - Parameter siteID: The site to query.
+    ///
+    case loadPushNotificationPreferences(siteID: Int64,
+                                         onCompletion: (Result<PushNotificationPreferences, Error>) -> Void)
+
+    /// Sends a partial update to the current user's push notification preferences and returns the
+    /// full, server-merged result. Only the fields set on `changes` are sent over the wire; the
+    /// server deep-merges them with the stored preferences.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site to update.
+    ///   - changes: A `PushNotificationPreferences` value with only the fields the caller wants to
+    ///     change set; everything else should be `nil`.
+    ///
+    case updatePushNotificationPreferences(siteID: Int64,
+                                           changes: PushNotificationPreferences,
+                                           onCompletion: (Result<PushNotificationPreferences, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -98,6 +98,7 @@ public typealias OrderSalesChannel = Networking.SalesChannel
 public typealias PaymentGateway = Networking.PaymentGateway
 public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product
+public typealias PushNotificationPreferences = Networking.PushNotificationPreferences
 public typealias POSProduct = Networking.POSProduct
 public typealias POSProductVariation = Networking.POSProductVariation
 public typealias ProductAddOn = Networking.ProductAddOn

--- a/Modules/Sources/Yosemite/Stores/NotificationStore.swift
+++ b/Modules/Sources/Yosemite/Stores/NotificationStore.swift
@@ -8,6 +8,7 @@ import Storage
 public class NotificationStore: Store {
     private let remote: NotificationsRemote
     private let devicesRemote: DevicesRemote
+    private let pushNotificationPreferencesRemote: PushNotificationPreferencesRemoteProtocol
 
     /// Shared private StorageType for use during then entire notification sync process
     ///
@@ -16,6 +17,7 @@ public class NotificationStore: Store {
     public override init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network) {
         self.remote = NotificationsRemote(network: network)
         self.devicesRemote = DevicesRemote(network: network)
+        self.pushNotificationPreferencesRemote = PushNotificationPreferencesRemote(network: network)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -71,6 +73,10 @@ public class NotificationStore: Store {
                                                       tokenID: tokenID,
                                                       availableAsRESTRequest: availableAsRESTRequest,
                                                       onCompletion: onCompletion)
+        case let .loadPushNotificationPreferences(siteID, onCompletion):
+            loadPushNotificationPreferences(siteID: siteID, onCompletion: onCompletion)
+        case let .updatePushNotificationPreferences(siteID, changes, onCompletion):
+            updatePushNotificationPreferences(siteID: siteID, changes: changes, onCompletion: onCompletion)
         }
     }
 }
@@ -138,6 +144,37 @@ private extension NotificationStore {
                     availableAsRESTRequest: availableAsRESTRequest
                 )
                 onCompletion(.success(()))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Loads the current user's push notification preferences for a site.
+    ///
+    func loadPushNotificationPreferences(siteID: Int64,
+                                         onCompletion: @escaping (Result<PushNotificationPreferences, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let preferences = try await pushNotificationPreferencesRemote.loadPreferences(siteID: siteID)
+                onCompletion(.success(preferences))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Sends a partial update to the current user's push notification preferences and returns the
+    /// full, server-merged result.
+    ///
+    func updatePushNotificationPreferences(siteID: Int64,
+                                           changes: PushNotificationPreferences,
+                                           onCompletion: @escaping (Result<PushNotificationPreferences, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let preferences = try await pushNotificationPreferencesRemote.updatePreferences(siteID: siteID,
+                                                                                                changes: changes)
+                onCompletion(.success(preferences))
             } catch {
                 onCompletion(.failure(error))
             }

--- a/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/NotificationStoreTests.swift
@@ -569,6 +569,120 @@ final class NotificationStoreTests: XCTestCase {
     }
 
 
+    // MARK: - NotificationAction.loadPushNotificationPreferences
+
+    /// Verifies that `loadPushNotificationPreferences` returns the decoded preferences on success.
+    ///
+    func test_loadPushNotificationPreferences_handles_successful_response() {
+        // Given
+        let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences")
+
+        // When
+        let result: Result<PushNotificationPreferences, Error> = waitFor { promise in
+            let action = NotificationAction.loadPushNotificationPreferences(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            noteStore.onAction(action)
+        }
+
+        // Then
+        switch result {
+        case .success(let preferences):
+            XCTAssertEqual(preferences.storeOrder?.enabled, true)
+            XCTAssertEqual(preferences.storeReview?.enabled, true)
+            XCTAssertEqual(preferences.storeReview?.maxRating, 5)
+            XCTAssertEqual(preferences.storeStock?.enabled, true)
+            XCTAssertEqual(preferences.storeStock?.onBackorder, false)
+        case .failure(let error):
+            XCTFail("Expected success but got error: \(error)")
+        }
+    }
+
+    /// Verifies that `loadPushNotificationPreferences` surfaces an error when the backend returns an error.
+    ///
+    func test_loadPushNotificationPreferences_handles_failure_response() {
+        // Given
+        let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences", filename: "generic_error")
+
+        // When
+        let result: Result<PushNotificationPreferences, Error> = waitFor { promise in
+            let action = NotificationAction.loadPushNotificationPreferences(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            noteStore.onAction(action)
+        }
+
+        // Then
+        switch result {
+        case .success:
+            XCTFail("Expected failure but got success")
+        case .failure(let error):
+            XCTAssertNotNil(error)
+        }
+    }
+
+
+    // MARK: - NotificationAction.updatePushNotificationPreferences
+
+    /// Verifies that `updatePushNotificationPreferences` returns the server-merged preferences on success.
+    ///
+    func test_updatePushNotificationPreferences_handles_successful_response() {
+        // Given
+        let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences")
+        let changes = PushNotificationPreferences(storeStock: .init(onBackorder: false))
+
+        // When
+        let result: Result<PushNotificationPreferences, Error> = waitFor { promise in
+            let action = NotificationAction.updatePushNotificationPreferences(siteID: self.sampleSiteID,
+                                                                              changes: changes) { result in
+                promise(result)
+            }
+            noteStore.onAction(action)
+        }
+
+        // Then
+        switch result {
+        case .success(let preferences):
+            XCTAssertEqual(preferences.storeOrder?.enabled, true)
+            XCTAssertEqual(preferences.storeReview?.maxRating, 5)
+            XCTAssertEqual(preferences.storeStock?.onBackorder, false)
+        case .failure(let error):
+            XCTFail("Expected success but got error: \(error)")
+        }
+    }
+
+    /// Verifies that `updatePushNotificationPreferences` surfaces an error when the backend returns an error.
+    ///
+    func test_updatePushNotificationPreferences_handles_failure_response() {
+        // Given
+        let noteStore = NotificationStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences", filename: "generic_error")
+        let changes = PushNotificationPreferences(storeOrder: .init(enabled: false))
+
+        // When
+        let result: Result<PushNotificationPreferences, Error> = waitFor { promise in
+            let action = NotificationAction.updatePushNotificationPreferences(siteID: self.sampleSiteID,
+                                                                              changes: changes) { result in
+                promise(result)
+            }
+            noteStore.onAction(action)
+        }
+
+        // Then
+        switch result {
+        case .success:
+            XCTFail("Expected failure but got success")
+        case .failure(let error):
+            XCTAssertNotNil(error)
+        }
+    }
+
+
     // MARK: - NotificationAction.updateLocalDeletedStatus
 
     /// Verifies that `markLocalNoteAsDeleted` works as expected.


### PR DESCRIPTION
## Description

Adds the Yosemite (business-logic) layer that bridges the `PushNotificationPreferencesRemote` introduced in RSM-2726 (#17165) to the upcoming Notification Settings UI in RSM-1630.

**Scope:**
- Re-export `Networking.PushNotificationPreferences` from Yosemite.
- Add two cases to `NotificationAction`:
  - `loadPushNotificationPreferences(siteID:onCompletion:)`
  - `updatePushNotificationPreferences(siteID:changes:onCompletion:)`
- Wire both cases in `NotificationStore` using the same `async throws` → completion-`Result` bridge already used for self-driven push registration.
- Add 4 `NotificationStoreTests` cases (load/update × success/failure) using `MockNetwork` and the shared `push-notification-preferences` JSON fixtures from RSM-2726.

No user-visible behavior change.

Linear: RSM-3342


## Test Steps

This PR is internal-only (no UI). Verify via unit tests:

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. _(Internal-only — no release note needed.)_