### PR TITLE
Update Store Stats widget error copy

### DIFF
--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoHomescreenWidget.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoHomescreenWidget.swift
@@ -86,9 +86,9 @@ private extension NotLoggedInView {
 private extension UnableToFetchView {
     enum Localization {
         static let unableToFetch = AppLocalizedString(
-            "storeWidgets.unableToFetchView.unableToFetch",
-            value: "Unable to fetch today's stats",
-            comment: "Title label when the widget can't fetch data."
+            "storeWidgets.unableToFetchView.unableToFetchStats",
+            value: "Unable to fetch stats",
+            comment: "Title label when the home-screen stats widget can't fetch data."
         )
     }
 

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -68,7 +68,7 @@ final class StoreInfoProvider {
             return Timeline<StoreInfoEntry>(entries: [entry], policy: .after(reloadDate))
         } catch {
             // WooFoundation does not expose `DDLOG` types. Should we include them?
-            print("⛔️ Error fetching today's widget stats: \(error)")
+            print("⛔️ Error fetching widget stats: \(error)")
             return Timeline<StoreInfoEntry>(entries: [.error], policy: .after(reloadDate))
         }
     }


### PR DESCRIPTION
## Description
Updates the home-screen Store Stats widget failed-load copy to be range-agnostic. The widget can now be configured for Today, Weekly, Monthly, or Yearly, so the error state should not say it failed to fetch today's stats.

Also updates the related debug log message to avoid the same range-specific wording.

## Test Steps
- Preview or trigger the home-screen Store Stats widget error state and confirm it shows `Unable to fetch stats`.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.