### PR TITLE
Rename Store Stats widget display name to "Stats"

### DIFF
--- a/WooCommerce/StoreWidgets/StoreInfoWidget.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoWidget.swift
@@ -64,13 +64,13 @@ private struct StoreInfoWidgetEntryView: View {
 private extension StoreInfoWidget {
     enum Localization {
         static let title = AppLocalizedString(
-            "storeWidgets.displayName",
-            value: "Today",
+            "storeWidgets.stats.displayName",
+            value: "Stats",
             comment: "Widget title, displayed when selecting which widget to add"
         )
         static let description = AppLocalizedString(
-            "storeWidgets.description",
-            value: "WooCommerce Stats Today",
+            "storeWidgets.stats.description",
+            value: "WooCommerce store stats",
             comment: "Widget description, displayed when selecting which widget to add"
         )
     }


### PR DESCRIPTION
## Description
Renames the Store Stats homescreen widget display name from "Today" to "Stats" (and updates the description from "WooCommerce Stats Today" to "WooCommerce store stats") so the widget gallery entry better reflects what it shows. The localization keys were updated alongside the values per our localization rule (`storeWidgets.displayName` → `storeWidgets.stats.displayName`, `storeWidgets.description` → `storeWidgets.stats.description`).

## Test Steps
1. Run the app on a device/simulator.
2. Long-press on the homescreen and tap the "+" to add a widget.
3. Search for "WooCommerce" / find the Store Stats widget.
4. Verify the widget display name shows "Stats" and the description shows "WooCommerce store stats".

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.