### PR TITLE
Add ExPlat and remote feature flag gating for AR parcel fitting

### DIFF
--- a/Modules/Sources/Experiments/ABTest.swift
+++ b/Modules/Sources/Experiments/ABTest.swift
@@ -6,6 +6,9 @@ public enum ABTest: String, Codable, CaseIterable {
     /// Mocks for unit testing
     case mockLoggedIn, mockLoggedOut
 
+    /// AR parcel fitting experiment
+    case arParcelFitting = "woocommerceios_shipping_ar_parcel_fitting"
+
     /// Returns a variation for the given experiment
     ///
     public var variation: Variation? {
@@ -22,6 +25,8 @@ public enum ABTest: String, Codable, CaseIterable {
             return .loggedIn
         case .mockLoggedOut:
             return .loggedOut
+        case .arParcelFitting:
+            return .loggedIn
         }
     }
 

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -124,7 +124,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .wooAIAssistant:
             return true
         case .arParcelFitting:
-            return !buildConfig.isProduction
+            return true
         case .smarterNotifications:
             return !buildConfig.isProduction
         default:

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -124,7 +124,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .wooAIAssistant:
             return true
         case .arParcelFitting:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .smarterNotifications:
             return !buildConfig.isProduction
         default:

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -124,7 +124,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .wooAIAssistant:
             return true
         case .arParcelFitting:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return !buildConfig.isProduction
         case .smarterNotifications:
             return !buildConfig.isProduction
         default:

--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -39,6 +39,7 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case pointOfSaleScanToPay
     case pointOfSaleMarkOrderAsPaid
     case wooAIAssistant
+    case arParcelFitting
 
     init?(rawValue: String) {
         switch rawValue {
@@ -66,6 +67,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .pointOfSaleMarkOrderAsPaid
         case "woo_mobile_ai_assistant":
             self = .wooAIAssistant
+        case "woo_ar_parcel_fitting":
+            self = .arParcelFitting
         default:
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/ARParcelFittingEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/ARParcelFittingEligibilityChecker.swift
@@ -1,0 +1,53 @@
+import ARKit
+import Experiments
+import Foundation
+import Yosemite
+
+protocol ARParcelFittingEligibilityChecking {
+    @MainActor
+    func isEligible() async -> Bool
+}
+
+struct ARParcelFittingEligibilityChecker: ARParcelFittingEligibilityChecking {
+    private let featureFlagService: FeatureFlagService
+    private let abTestVariationProvider: ABTestVariationProvider
+    private let stores: StoresManager
+    private let isARWorldTrackingSupported: Bool
+
+    init(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider(),
+         stores: StoresManager = ServiceLocator.stores,
+         isARWorldTrackingSupported: Bool = ARWorldTrackingConfiguration.isSupported) {
+        self.featureFlagService = featureFlagService
+        self.abTestVariationProvider = abTestVariationProvider
+        self.stores = stores
+        self.isARWorldTrackingSupported = isARWorldTrackingSupported
+    }
+
+    /// Resolves AR parcel fitting availability:
+    /// ARSupported AND localFF AND (remoteFF OR ExPlat).
+    @MainActor
+    func isEligible() async -> Bool {
+        guard isARWorldTrackingSupported else {
+            return false
+        }
+        guard featureFlagService.isFeatureFlagEnabled(.arParcelFitting) else {
+            return false
+        }
+        if abTestVariationProvider.variation(for: .arParcelFitting) == .treatment {
+            return true
+        }
+        return await isRemoteFeatureFlagEnabled()
+    }
+
+    @MainActor
+    private func isRemoteFeatureFlagEnabled() async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.arParcelFitting,
+                                                                      defaultValue: false) { isEnabled in
+                continuation.resume(returning: isEnabled)
+            }
+            stores.dispatch(action)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -15,6 +15,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
     private let abTestVariationProvider: ABTestVariationProvider
+    private let isRemoteARParcelFittingEnabled: Bool
     private let shippingSettingsService: ShippingSettingsService
 
     private let starAnimation: Animation = .spring(duration: 0.2)
@@ -39,6 +40,12 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.abTestVariationProvider = abTestVariationProvider
         self.shippingSettingsService = shippingSettingsService
+
+        var remoteFFEnabled = false
+        stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(.arParcelFitting, defaultValue: false) { isEnabled in
+            remoteFFEnabled = isEnabled
+        })
+        self.isRemoteARParcelFittingEnabled = remoteFFEnabled
         self.starToggleService = PackageStarToggleService(siteID: siteID, stores: stores, analytics: analytics)
 
         selectedPackageType = .custom
@@ -141,17 +148,6 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         return isRemoteARParcelFittingEnabled
             || abTestVariationProvider.variation(for: .arParcelFitting) == .treatment
             || featureFlagService.isFeatureFlagEnabled(.arParcelFitting)
-    }
-
-    /// Reads the remote FF value from cache via synchronous dispatch.
-    /// Returns `false` if cache is cold (the completion fires asynchronously in that case).
-    private var isRemoteARParcelFittingEnabled: Bool {
-        var result = false
-        let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.arParcelFitting, defaultValue: false) { isEnabled in
-            result = isEnabled
-        }
-        stores.dispatch(action)
-        return result
     }
 
     var arDimensionUnit: UnitLength {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -1,4 +1,3 @@
-import ARKit
 import Combine
 import Experiments
 import Foundation
@@ -14,9 +13,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     private let storage: StorageManagerType
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
-    private let abTestVariationProvider: ABTestVariationProvider
-    private let isRemoteARParcelFittingEnabled: Bool
-    private let isARWorldTrackingSupported: Bool
+    private let arParcelFittingEligibilityChecker: ARParcelFittingEligibilityChecking
     private let shippingSettingsService: ShippingSettingsService
 
     private let starAnimation: Animation = .spring(duration: 0.2)
@@ -32,23 +29,15 @@ final class WooShippingAddPackageViewModel: ObservableObject {
          storage: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider(),
-         isARWorldTrackingSupported: Bool = ARWorldTrackingConfiguration.isSupported,
+         arParcelFittingEligibilityChecker: ARParcelFittingEligibilityChecking = ARParcelFittingEligibilityChecker(),
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService) {
         self.siteID = siteID
         self.stores = stores
         self.storage = storage
         self.analytics = analytics
         self.featureFlagService = featureFlagService
-        self.abTestVariationProvider = abTestVariationProvider
-        self.isARWorldTrackingSupported = isARWorldTrackingSupported
+        self.arParcelFittingEligibilityChecker = arParcelFittingEligibilityChecker
         self.shippingSettingsService = shippingSettingsService
-
-        var remoteFFEnabled = false
-        stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(.arParcelFitting, defaultValue: false) { isEnabled in
-            remoteFFEnabled = isEnabled
-        })
-        self.isRemoteARParcelFittingEnabled = remoteFFEnabled
         self.starToggleService = PackageStarToggleService(siteID: siteID, stores: stores, analytics: analytics)
 
         selectedPackageType = .custom
@@ -67,6 +56,14 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         configureResultsController()
         analytics.track(event: .WooShipping.packageSelectionStep(state: .started))
         starToggleSubscription = starToggleService.$notice.assign(to: \.notice, on: self)
+        refreshARParcelFittingEligibility()
+    }
+
+    private func refreshARParcelFittingEligibility() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isARParcelFittingAvailable = await self.arParcelFittingEligibilityChecker.isEligible()
+        }
     }
 
     @Published private(set) var isLoadingPackages: Bool = false
@@ -141,17 +138,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
     // MARK: - AR Parcel Fitting
 
-    /// Resolves AR parcel fitting availability:
-    /// localFF AND (remoteFF OR ExPlat).
-    /// Local FF gates client capability. Remote FF and ExPlat control enablement.
-    var isARParcelFittingAvailable: Bool {
-        guard isARWorldTrackingSupported else {
-            return false
-        }
-        return featureFlagService.isFeatureFlagEnabled(.arParcelFitting)
-            && (isRemoteARParcelFittingEnabled
-                || abTestVariationProvider.variation(for: .arParcelFitting) == .treatment)
-    }
+    @Published private(set) var isARParcelFittingAvailable: Bool = false
 
     var arDimensionUnit: UnitLength {
         .fromStoreUnit(shippingSettingsService.dimensionUnit ?? "in")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -16,6 +16,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     private let featureFlagService: FeatureFlagService
     private let abTestVariationProvider: ABTestVariationProvider
     private let isRemoteARParcelFittingEnabled: Bool
+    private let isARWorldTrackingSupported: Bool
     private let shippingSettingsService: ShippingSettingsService
 
     private let starAnimation: Animation = .spring(duration: 0.2)
@@ -32,6 +33,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider(),
+         isARWorldTrackingSupported: Bool = ARWorldTrackingConfiguration.isSupported,
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService) {
         self.siteID = siteID
         self.stores = stores
@@ -39,6 +41,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
         self.analytics = analytics
         self.featureFlagService = featureFlagService
         self.abTestVariationProvider = abTestVariationProvider
+        self.isARWorldTrackingSupported = isARWorldTrackingSupported
         self.shippingSettingsService = shippingSettingsService
 
         var remoteFFEnabled = false
@@ -142,7 +145,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     /// remote FF (includes override store) → ExPlat → local FF.
     /// The first gate returning `true` enables the feature.
     var isARParcelFittingAvailable: Bool {
-        guard ARWorldTrackingConfiguration.isSupported else {
+        guard isARWorldTrackingSupported else {
             return false
         }
         return isRemoteARParcelFittingEnabled

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -141,16 +141,16 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
     // MARK: - AR Parcel Fitting
 
-    /// Resolves AR parcel fitting availability using a cascade:
-    /// remote FF (includes override store) → ExPlat → local FF.
-    /// The first gate returning `true` enables the feature.
+    /// Resolves AR parcel fitting availability:
+    /// localFF AND (remoteFF OR ExPlat).
+    /// Local FF gates client capability. Remote FF and ExPlat control enablement.
     var isARParcelFittingAvailable: Bool {
         guard isARWorldTrackingSupported else {
             return false
         }
-        return isRemoteARParcelFittingEnabled
-            || abTestVariationProvider.variation(for: .arParcelFitting) == .treatment
-            || featureFlagService.isFeatureFlagEnabled(.arParcelFitting)
+        return featureFlagService.isFeatureFlagEnabled(.arParcelFitting)
+            && (isRemoteARParcelFittingEnabled
+                || abTestVariationProvider.variation(for: .arParcelFitting) == .treatment)
     }
 
     var arDimensionUnit: UnitLength {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -14,6 +14,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     private let storage: StorageManagerType
     private let analytics: Analytics
     private let featureFlagService: FeatureFlagService
+    private let abTestVariationProvider: ABTestVariationProvider
     private let shippingSettingsService: ShippingSettingsService
 
     private let starAnimation: Animation = .spring(duration: 0.2)
@@ -29,12 +30,14 @@ final class WooShippingAddPackageViewModel: ObservableObject {
          storage: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         abTestVariationProvider: ABTestVariationProvider = DefaultABTestVariationProvider(),
          shippingSettingsService: ShippingSettingsService = ServiceLocator.shippingSettingsService) {
         self.siteID = siteID
         self.stores = stores
         self.storage = storage
         self.analytics = analytics
         self.featureFlagService = featureFlagService
+        self.abTestVariationProvider = abTestVariationProvider
         self.shippingSettingsService = shippingSettingsService
         self.starToggleService = PackageStarToggleService(siteID: siteID, stores: stores, analytics: analytics)
 
@@ -128,9 +131,27 @@ final class WooShippingAddPackageViewModel: ObservableObject {
 
     // MARK: - AR Parcel Fitting
 
+    /// Resolves AR parcel fitting availability using a cascade:
+    /// remote FF (includes override store) → ExPlat → local FF.
+    /// The first gate returning `true` enables the feature.
     var isARParcelFittingAvailable: Bool {
-        featureFlagService.isFeatureFlagEnabled(.arParcelFitting)
-        && ARWorldTrackingConfiguration.isSupported
+        guard ARWorldTrackingConfiguration.isSupported else {
+            return false
+        }
+        return isRemoteARParcelFittingEnabled
+            || abTestVariationProvider.variation(for: .arParcelFitting) == .treatment
+            || featureFlagService.isFeatureFlagEnabled(.arParcelFitting)
+    }
+
+    /// Reads the remote FF value from cache via synchronous dispatch.
+    /// Returns `false` if cache is cold (the completion fires asynchronously in that case).
+    private var isRemoteARParcelFittingEnabled: Bool {
+        var result = false
+        let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.arParcelFitting, defaultValue: false) { isEnabled in
+            result = isEnabled
+        }
+        stores.dispatch(action)
+        return result
     }
 
     var arDimensionUnit: UnitLength {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/ARParcelFittingEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/ARParcelFittingEligibilityCheckerTests.swift
@@ -1,0 +1,184 @@
+import Experiments
+import Testing
+import Yosemite
+import enum AutomatticTracks.Variation
+@testable import WooCommerce
+
+@MainActor
+struct ARParcelFittingEligibilityCheckerTests {
+
+    // localFF AND (remoteFF OR explatTreatment)
+    // (remoteFF, explatTreatment, localFF, expected)
+    @Test
+    func test_isEligible_for_all_flag_permutations() async {
+        let cases: [(Bool, Bool, Bool, Bool)] = [
+            (false, false, false, false),
+            (false, false, true, false),
+            (false, true, false, false),
+            (false, true, true, true),
+            (true, false, false, false),
+            (true, false, true, true),
+            (true, true, false, false),
+            (true, true, true, true),
+        ]
+
+        for (remoteFF, explatTreatment, localFF, expected) in cases {
+            // Given
+            let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+            stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+                switch action {
+                case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
+                    completion(remoteFF)
+                }
+            }
+            let featureFlagService = MockFeatureFlagService()
+            featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = localFF
+            let abTestProvider = MockABTestVariationProvider()
+            abTestProvider.mockVariationValue = explatTreatment ? .treatment : .control
+
+            let sut = ARParcelFittingEligibilityChecker(featureFlagService: featureFlagService,
+                                                        abTestVariationProvider: abTestProvider,
+                                                        stores: stores,
+                                                        isARWorldTrackingSupported: true)
+
+            // When
+            let result = await sut.isEligible()
+
+            // Then
+            #expect(result == expected,
+                    "remoteFF=\(remoteFF), explat=\(explatTreatment), localFF=\(localFF)")
+        }
+    }
+
+    @Test
+    func test_isEligible_when_AR_not_supported_then_returns_false() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
+                completion(true)
+            }
+        }
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = true
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .treatment
+
+        let sut = ARParcelFittingEligibilityChecker(featureFlagService: featureFlagService,
+                                                    abTestVariationProvider: abTestProvider,
+                                                    stores: stores,
+                                                    isARWorldTrackingSupported: false)
+
+        // When
+        let result = await sut.isEligible()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test
+    func test_isEligible_when_localFF_off_then_does_not_dispatch_remote_check() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = false
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .control
+
+        let sut = ARParcelFittingEligibilityChecker(featureFlagService: featureFlagService,
+                                                    abTestVariationProvider: abTestProvider,
+                                                    stores: stores,
+                                                    isARWorldTrackingSupported: true)
+
+        // When
+        let result = await sut.isEligible()
+
+        // Then
+        #expect(result == false)
+        #expect(stores.receivedActions.isEmpty)
+    }
+
+    @Test
+    func test_isEligible_when_explat_treatment_then_does_not_dispatch_remote_check() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = true
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .treatment
+
+        let sut = ARParcelFittingEligibilityChecker(featureFlagService: featureFlagService,
+                                                    abTestVariationProvider: abTestProvider,
+                                                    stores: stores,
+                                                    isARWorldTrackingSupported: true)
+
+        // When
+        let result = await sut.isEligible()
+
+        // Then
+        #expect(result == true)
+        #expect(stores.receivedActions.isEmpty)
+    }
+
+    @Test
+    func test_isEligible_dispatches_remote_check_with_defaultValue_false() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
+                completion(false)
+            }
+        }
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = true
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .control
+
+        let sut = ARParcelFittingEligibilityChecker(featureFlagService: featureFlagService,
+                                                    abTestVariationProvider: abTestProvider,
+                                                    stores: stores,
+                                                    isARWorldTrackingSupported: true)
+
+        // When
+        _ = await sut.isEligible()
+
+        // Then
+        let dispatched = stores.receivedActions.compactMap { $0 as? FeatureFlagAction }
+        #expect(dispatched.count == 1)
+        if case let .isRemoteFeatureFlagEnabled(flag, defaultValue, _, _) = dispatched.first {
+            #expect(flag == .arParcelFitting)
+            #expect(defaultValue == false)
+        } else {
+            Issue.record("Expected isRemoteFeatureFlagEnabled action")
+        }
+    }
+
+    @Test
+    func test_isEligible_when_remote_flag_completes_asynchronously_then_returns_correct_value() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
+                Task { completion(true) }
+            }
+        }
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = true
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .control
+
+        let sut = ARParcelFittingEligibilityChecker(featureFlagService: featureFlagService,
+                                                    abTestVariationProvider: abTestProvider,
+                                                    stores: stores,
+                                                    isARWorldTrackingSupported: true)
+
+        // When
+        let result = await sut.isEligible()
+
+        // Then
+        #expect(result == true)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -555,13 +555,13 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
     func test_isARParcelFittingAvailable_for_all_flag_permutations() {
         let cases: [(Bool, Bool, Bool, Bool)] = [
             (false, false, false, false),
-            (false, false, true,  false),
-            (false, true,  false, false),
-            (false, true,  true,  true),
-            (true,  false, false, false),
-            (true,  false, true,  true),
-            (true,  true,  false, false),
-            (true,  true,  true,  true),
+            (false, false, true, false),
+            (false, true, false, false),
+            (false, true, true, true),
+            (true, false, false, false),
+            (true, false, true, true),
+            (true, true, false, false),
+            (true, true, true, true),
         ]
 
         for (remoteFF, explatTreatment, localFF, expected) in cases {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -3,7 +3,6 @@ import TestKit
 import YosemiteTestHelpers
 @testable import WooCommerce
 import Yosemite
-import enum AutomatticTracks.Variation
 import enum Networking.WooShippingPackageType
 
 final class WooShippingAddPackageViewModelTests: XCTestCase {
@@ -172,9 +171,8 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         await viewModel.loadPackages()
 
         // Then
-        XCTAssertEqual(mockStores.receivedActions.count, 2)
-        assertThat(mockStores.receivedActions.first, isAnInstanceOf: FeatureFlagAction.self)
-        assertThat(mockStores.receivedActions.last, isAnInstanceOf: WooShippingAction.self)
+        XCTAssertEqual(mockStores.receivedActions.count, 1)
+        assertThat(mockStores.receivedActions.first, isAnInstanceOf: WooShippingAction.self)
     }
 
     @MainActor
@@ -545,49 +543,6 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
             for (index, package) in sortedCustomSavedPackages.enumerated() {
                 XCTAssertEqual(package.id, viewModel.customSavedPackages[index].id)
             }
-        }
-    }
-
-    // MARK: - AR Parcel Fitting Gating
-
-    // localFF AND (remoteFF OR explatTreatment)
-    // (remoteFF, explatTreatment, localFF, expected)
-    func test_isARParcelFittingAvailable_for_all_flag_permutations() {
-        let cases: [(Bool, Bool, Bool, Bool)] = [
-            (false, false, false, false),
-            (false, false, true, false),
-            (false, true, false, false),
-            (false, true, true, true),
-            (true, false, false, false),
-            (true, false, true, true),
-            (true, true, false, false),
-            (true, true, true, true),
-        ]
-
-        for (remoteFF, explatTreatment, localFF, expected) in cases {
-            // Given
-            let mockStores = MockStoresManager(sessionManager: .testingInstance)
-            mockStores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
-                switch action {
-                case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
-                    completion(remoteFF)
-                }
-            }
-            let featureFlagService = MockFeatureFlagService()
-            featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = localFF
-            let abTestProvider = MockABTestVariationProvider()
-            abTestProvider.mockVariationValue = explatTreatment ? .treatment : .control
-
-            // When
-            let viewModel = WooShippingAddPackageViewModel(siteID: 1,
-                                                           stores: mockStores,
-                                                           featureFlagService: featureFlagService,
-                                                           abTestVariationProvider: abTestProvider,
-                                                           isARWorldTrackingSupported: true)
-
-            // Then
-            XCTAssertEqual(viewModel.isARParcelFittingAvailable, expected,
-                           "remoteFF=\(remoteFF), explat=\(explatTreatment), localFF=\(localFF)")
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -3,6 +3,7 @@ import TestKit
 import YosemiteTestHelpers
 @testable import WooCommerce
 import Yosemite
+import enum AutomatticTracks.Variation
 import enum Networking.WooShippingPackageType
 
 final class WooShippingAddPackageViewModelTests: XCTestCase {
@@ -544,6 +545,47 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
                 XCTAssertEqual(package.id, viewModel.customSavedPackages[index].id)
             }
         }
+    }
+    // MARK: - AR Parcel Fitting Gating
+
+    // Note: ARWorldTrackingConfiguration.isSupported returns false on simulators,
+    // so isARParcelFittingAvailable is always false in CI. These tests verify
+    // the feature flag / ExPlat gating logic is wired correctly.
+
+    func test_isARParcelFittingAvailable_when_both_feature_flag_and_explat_disabled_then_returns_false() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let featureFlagService = MockFeatureFlagService()
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .control
+
+        // When
+        let viewModel = WooShippingAddPackageViewModel(siteID: 1,
+                                                       stores: mockStores,
+                                                       featureFlagService: featureFlagService,
+                                                       abTestVariationProvider: abTestProvider)
+
+        // Then
+        XCTAssertFalse(viewModel.isARParcelFittingAvailable)
+    }
+
+    func test_isARParcelFittingAvailable_when_explat_returns_treatment_then_still_false_on_simulator() {
+        // Given
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        let featureFlagService = MockFeatureFlagService()
+        let abTestProvider = MockABTestVariationProvider()
+        abTestProvider.mockVariationValue = .treatment
+
+        // When
+        let viewModel = WooShippingAddPackageViewModel(siteID: 1,
+                                                       stores: mockStores,
+                                                       featureFlagService: featureFlagService,
+                                                       abTestVariationProvider: abTestProvider)
+
+        // Then
+        // On a physical device with AR support this would return true.
+        // On simulators ARWorldTrackingConfiguration.isSupported is false.
+        XCTAssertFalse(viewModel.isARParcelFittingAvailable)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -549,44 +549,44 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
 
     // MARK: - AR Parcel Fitting Gating
 
-    // Note: ARWorldTrackingConfiguration.isSupported returns false on simulators,
-    // so isARParcelFittingAvailable is always false in CI. These tests verify
-    // the feature flag / ExPlat gating logic is wired correctly.
+    // (remoteFF, explatTreatment, localFF, expected)
+    func test_isARParcelFittingAvailable_for_all_flag_permutations() {
+        let cases: [(Bool, Bool, Bool, Bool)] = [
+            (false, false, false, false),
+            (false, false, true,  true),
+            (false, true,  false, true),
+            (false, true,  true,  true),
+            (true,  false, false, true),
+            (true,  false, true,  true),
+            (true,  true,  false, true),
+            (true,  true,  true,  true),
+        ]
 
-    func test_isARParcelFittingAvailable_when_both_feature_flag_and_explat_disabled_then_returns_false() {
-        // Given
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let featureFlagService = MockFeatureFlagService()
-        let abTestProvider = MockABTestVariationProvider()
-        abTestProvider.mockVariationValue = .control
+        for (remoteFF, explatTreatment, localFF, expected) in cases {
+            // Given
+            let mockStores = MockStoresManager(sessionManager: .testingInstance)
+            mockStores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+                switch action {
+                case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
+                    completion(remoteFF)
+                }
+            }
+            let featureFlagService = MockFeatureFlagService()
+            featureFlagService.isFeatureFlagEnabledReturnValue[.arParcelFitting] = localFF
+            let abTestProvider = MockABTestVariationProvider()
+            abTestProvider.mockVariationValue = explatTreatment ? .treatment : .control
 
-        // When
-        let viewModel = WooShippingAddPackageViewModel(siteID: 1,
-                                                       stores: mockStores,
-                                                       featureFlagService: featureFlagService,
-                                                       abTestVariationProvider: abTestProvider)
+            // When
+            let viewModel = WooShippingAddPackageViewModel(siteID: 1,
+                                                           stores: mockStores,
+                                                           featureFlagService: featureFlagService,
+                                                           abTestVariationProvider: abTestProvider,
+                                                           isARWorldTrackingSupported: true)
 
-        // Then
-        XCTAssertFalse(viewModel.isARParcelFittingAvailable)
-    }
-
-    func test_isARParcelFittingAvailable_when_explat_returns_treatment_then_still_false_on_simulator() {
-        // Given
-        let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let featureFlagService = MockFeatureFlagService()
-        let abTestProvider = MockABTestVariationProvider()
-        abTestProvider.mockVariationValue = .treatment
-
-        // When
-        let viewModel = WooShippingAddPackageViewModel(siteID: 1,
-                                                       stores: mockStores,
-                                                       featureFlagService: featureFlagService,
-                                                       abTestVariationProvider: abTestProvider)
-
-        // Then
-        // On a physical device with AR support this would return true.
-        // On simulators ARWorldTrackingConfiguration.isSupported is false.
-        XCTAssertFalse(viewModel.isARParcelFittingAvailable)
+            // Then
+            XCTAssertEqual(viewModel.isARParcelFittingAvailable, expected,
+                           "remoteFF=\(remoteFF), explat=\(explatTreatment), localFF=\(localFF)")
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -172,8 +172,9 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         await viewModel.loadPackages()
 
         // Then
-        XCTAssertEqual(mockStores.receivedActions.count, 1)
-        assertThat(mockStores.receivedActions.first, isAnInstanceOf: WooShippingAction.self)
+        XCTAssertEqual(mockStores.receivedActions.count, 2)
+        assertThat(mockStores.receivedActions.first, isAnInstanceOf: FeatureFlagAction.self)
+        assertThat(mockStores.receivedActions.last, isAnInstanceOf: WooShippingAction.self)
     }
 
     @MainActor
@@ -549,16 +550,17 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
 
     // MARK: - AR Parcel Fitting Gating
 
+    // localFF AND (remoteFF OR explatTreatment)
     // (remoteFF, explatTreatment, localFF, expected)
     func test_isARParcelFittingAvailable_for_all_flag_permutations() {
         let cases: [(Bool, Bool, Bool, Bool)] = [
             (false, false, false, false),
-            (false, false, true,  true),
-            (false, true,  false, true),
+            (false, false, true,  false),
+            (false, true,  false, false),
             (false, true,  true,  true),
-            (true,  false, false, true),
+            (true,  false, false, false),
             (true,  false, true,  true),
-            (true,  true,  false, true),
+            (true,  true,  false, false),
             (true,  true,  true,  true),
         ]
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -546,6 +546,7 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
             }
         }
     }
+
     // MARK: - AR Parcel Fitting Gating
 
     // Note: ARWorldTrackingConfiguration.isSupported returns false on simulators,


### PR DESCRIPTION
## Description

Gates the AR parcel fitting feature behind `localFF AND (remoteFF OR ExPlat)`. Local FF acts as a client capability gate, while remote FF and ExPlat control enablement.

Remote and ExPlat changes will be done later, this just prepares the client to handle those values.

## Test Steps

1. Log in with these [credentials](https://mc.a8c.com/secret-store/?secret_id=14371)
2. Reset the feature flags state in the DebugPanel
3. Navigate Orders -> Scroll to bottom -> Open order `#45 Adam Borbas`
4. Wait for the "Create Shipping Label" CTA to load
5. Tap CTA
6. Tap "Select a Package"
7. Tap the camera icon in the toolbar
8. Now enable the remote  FF `arParcelFitting`
9. Navigate to the same order and note that now the camera icon appears

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.