### PR TITLE
[RSM-1630] Add Push Notifications preferences screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 
 24.8
 -----
+- [Internal] Add push notification preferences screen behind the `smarter_notifications` feature flag for sites registered with Woo-driven push notifications.
 - [*] Customer details: fixed bugs in form when adding a customer on iPad [https://github.com/woocommerce/woocommerce-ios/pull/17074]
 - [Internal] Silently discard push notifications whose `type` is not recognized, both in the main app and in the NotificationServiceExtension, so newer server-side push types do not surface broken UI in older clients.
 - [*] Introducing the AI Assistant: a new way to run your store from your pocket. Rolling out to selected stores. [https://github.com/woocommerce/woocommerce-ios/pull/17163]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 
 24.8
 -----
-- [Internal] Add push notification preferences screen behind the `smarter_notifications` feature flag for sites registered with Woo-driven push notifications.
 - [*] Customer details: fixed bugs in form when adding a customer on iPad [https://github.com/woocommerce/woocommerce-ios/pull/17074]
 - [Internal] Silently discard push notifications whose `type` is not recognized, both in the main app and in the NotificationServiceExtension, so newer server-side push types do not surface broken UI in older clients.
 - [*] Introducing the AI Assistant: a new way to run your store from your pocket. Rolling out to selected stores. [https://github.com/woocommerce/woocommerce-ios/pull/17163]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import Yosemite
+
+final class PushNotificationPreferencesHostingController: UIHostingController<PushNotificationPreferencesView> {
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        let viewModel = PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
+        super.init(rootView: PushNotificationPreferencesView(viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Settings screen showing per-site Woo-driven push notification preferences:
+/// new orders, new reviews and stock alerts.
+///
+struct PushNotificationPreferencesView: View {
+
+    @Bindable private var viewModel: PushNotificationPreferencesViewModel
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.loadState {
+            case .loading, .loaded:
+                preferencesList
+                    .disabled(viewModel.loadState == .loading)
+            case .error:
+                EmptyState(title: Localization.errorTitle,
+                           description: Localization.errorMessage,
+                           image: .errorImage,
+                           buttonTitle: Localization.retry,
+                           buttonAction: {
+                    Task { await viewModel.load() }
+                })
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .background(Color(.listBackground))
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if viewModel.loadState == .loading {
+                ToolbarItem(placement: .topBarTrailing) {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                }
+            }
+        }
+        .task {
+            if viewModel.loadState == .loading {
+                await viewModel.load()
+            }
+        }
+        .notice($viewModel.errorNotice)
+    }
+
+    private var preferencesList: some View {
+        List {
+            Section {
+                row(title: Localization.newOrdersTitle,
+                    detail: Localization.newOrdersDetail,
+                    isOn: Binding(get: { viewModel.isStoreOrderEnabled },
+                                  set: { viewModel.setStoreOrderEnabled($0) }))
+                row(title: Localization.newReviewsTitle,
+                    detail: Localization.newReviewsDetail,
+                    isOn: Binding(get: { viewModel.isStoreReviewEnabled },
+                                  set: { viewModel.setStoreReviewEnabled($0) }))
+                row(title: Localization.stockTitle,
+                    detail: Localization.stockDetail,
+                    isOn: Binding(get: { viewModel.isStoreStockEnabled },
+                                  set: { viewModel.setStoreStockEnabled($0) }))
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private func row(title: String, detail: String, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: Layout.contentSpacing) {
+            VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+                Text(title)
+                    .bodyStyle()
+                Text(detail)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .captionStyle()
+            }
+            Spacer()
+            Toggle("", isOn: isOn)
+                .labelsHidden()
+                .accessibilityLabel(title)
+                .accessibilityHint(detail)
+            Image(systemName: "chevron.forward")
+                .foregroundStyle(Color(.tertiaryLabel))
+                .font(.footnote.weight(.semibold))
+                .accessibilityHidden(true)
+        }
+        .contentShape(Rectangle())
+    }
+}
+
+private extension PushNotificationPreferencesView {
+    enum Layout {
+        static let contentSpacing: CGFloat = 8
+        static let titleDetailSpacing: CGFloat = 4
+    }
+}
+
+extension PushNotificationPreferencesView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pushNotificationPreferencesView.title",
+            value: "Push Notifications",
+            comment: "Title of the push notification preferences screen."
+        )
+        static let newOrdersTitle = NSLocalizedString(
+            "pushNotificationPreferencesView.newOrders.title",
+            value: "New orders",
+            comment: "Title of the row that toggles new-order push notifications."
+        )
+        static let newOrdersDetail = NSLocalizedString(
+            "pushNotificationPreferencesView.newOrders.detail",
+            value: "All orders",
+            comment: "Detail text for the row that toggles new-order push notifications."
+        )
+        static let newReviewsTitle = NSLocalizedString(
+            "pushNotificationPreferencesView.newReviews.title",
+            value: "New reviews",
+            comment: "Title of the row that toggles new-review push notifications."
+        )
+        static let newReviewsDetail = NSLocalizedString(
+            "pushNotificationPreferencesView.newReviews.detail",
+            value: "All reviews",
+            comment: "Detail text for the row that toggles new-review push notifications."
+        )
+        static let stockTitle = NSLocalizedString(
+            "pushNotificationPreferencesView.stock.title",
+            value: "Stock",
+            comment: "Title of the row that toggles stock push notifications."
+        )
+        static let stockDetail = NSLocalizedString(
+            "pushNotificationPreferencesView.stock.detail",
+            value: "All stock alerts",
+            comment: "Detail text for the row that toggles stock push notifications."
+        )
+        static let errorTitle = NSLocalizedString(
+            "pushNotificationPreferencesView.error.title",
+            value: "Couldn't load notification preferences",
+            comment: "Title shown when the push notification preferences fail to load."
+        )
+        static let errorMessage = NSLocalizedString(
+            "pushNotificationPreferencesView.error.message",
+            value: "Please check your connection and try again.",
+            comment: "Message shown when the push notification preferences fail to load."
+        )
+        static let retry = NSLocalizedString(
+            "pushNotificationPreferencesView.retry",
+            value: "Retry",
+            comment: "Button on the error state to retry loading push notification preferences."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Observation
+import Yosemite
+
+/// View model backing `PushNotificationPreferencesView`.
+///
+/// Loads the per-site push notification preferences served by the Woo-driven
+/// push system (`wc-push-notifications/preferences`) and dispatches partial
+/// updates back through Yosemite when toggles are flipped.
+///
+@MainActor
+@Observable
+final class PushNotificationPreferencesViewModel {
+
+    enum LoadState: Equatable {
+        case loading
+        case loaded
+        case error
+    }
+
+    private(set) var loadState: LoadState = .loading
+
+    private(set) var isStoreOrderEnabled: Bool = false
+    private(set) var isStoreReviewEnabled: Bool = false
+    private(set) var isStoreStockEnabled: Bool = false
+
+    var errorNotice: Notice?
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private var preferences: PushNotificationPreferences?
+
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+
+    func load() async {
+        loadState = .loading
+        do {
+            let preferences = try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(NotificationAction.loadPushNotificationPreferences(siteID: siteID) { result in
+                    continuation.resume(with: result)
+                })
+            }
+            apply(preferences: preferences)
+            loadState = .loaded
+        } catch {
+            DDLogError("⛔️ Error loading push notification preferences for siteID=\(siteID): \(error)")
+            loadState = .error
+        }
+    }
+
+    // Optimistic-update setters. If two flips of the same toggle race, only the latest revert
+    // can run — the earlier closure no-ops because the toggle has since changed. Out-of-order
+    // server responses can still produce a stale final state; acceptable for a 3-row screen
+    // where rapid double-flips are not a real user flow.
+    func setStoreOrderEnabled(_ newValue: Bool) {
+        let previous = isStoreOrderEnabled
+        isStoreOrderEnabled = newValue
+        // `StoreOrder` is sent as a complete object (`minAmount: nil` serializes as JSON
+        // `null`, which the server interprets as "clear threshold"). Preserve the loaded
+        // threshold so toggling the master switch doesn't wipe it.
+        let changes = PushNotificationPreferences(
+            storeOrder: .init(enabled: newValue, minAmount: preferences?.storeOrder?.minAmount)
+        )
+        update(changes: changes, revert: { [weak self] in
+            guard let self, self.isStoreOrderEnabled == newValue else { return }
+            self.isStoreOrderEnabled = previous
+        })
+    }
+
+    func setStoreReviewEnabled(_ newValue: Bool) {
+        let previous = isStoreReviewEnabled
+        isStoreReviewEnabled = newValue
+        let changes = PushNotificationPreferences(storeReview: .init(enabled: newValue))
+        update(changes: changes, revert: { [weak self] in
+            guard let self, self.isStoreReviewEnabled == newValue else { return }
+            self.isStoreReviewEnabled = previous
+        })
+    }
+
+    func setStoreStockEnabled(_ newValue: Bool) {
+        let previous = isStoreStockEnabled
+        isStoreStockEnabled = newValue
+        let changes = PushNotificationPreferences(storeStock: .init(enabled: newValue))
+        update(changes: changes, revert: { [weak self] in
+            guard let self, self.isStoreStockEnabled == newValue else { return }
+            self.isStoreStockEnabled = previous
+        })
+    }
+}
+
+private extension PushNotificationPreferencesViewModel {
+
+    func update(changes: PushNotificationPreferences, revert: @escaping @MainActor () -> Void) {
+        Task { @MainActor in
+            do {
+                let preferences = try await withCheckedThrowingContinuation { continuation in
+                    stores.dispatch(NotificationAction.updatePushNotificationPreferences(siteID: siteID,
+                                                                                         changes: changes) { result in
+                        continuation.resume(with: result)
+                    })
+                }
+                // Apply only the fields we explicitly updated. Concurrent in-flight requests for
+                // other toggles must keep their optimistic state; an earlier response's view of
+                // those fields is stale by definition.
+                apply(preferences: preferences, fields: changes)
+            } catch {
+                DDLogError("⛔️ Error updating push notification preferences: \(error)")
+                revert()
+                errorNotice = Notice(title: Localization.errorNotice, feedbackType: .error)
+            }
+        }
+    }
+
+    func apply(preferences: PushNotificationPreferences) {
+        self.preferences = preferences
+        isStoreOrderEnabled = preferences.storeOrder?.enabled ?? false
+        isStoreReviewEnabled = preferences.storeReview?.enabled ?? false
+        isStoreStockEnabled = preferences.storeStock?.enabled ?? false
+    }
+
+    func apply(preferences: PushNotificationPreferences, fields: PushNotificationPreferences) {
+        self.preferences = preferences
+        if fields.storeOrder != nil {
+            isStoreOrderEnabled = preferences.storeOrder?.enabled ?? false
+        }
+        if fields.storeReview != nil {
+            isStoreReviewEnabled = preferences.storeReview?.enabled ?? false
+        }
+        if fields.storeStock != nil {
+            isStoreStockEnabled = preferences.storeStock?.enabled ?? false
+        }
+    }
+}
+
+extension PushNotificationPreferencesViewModel {
+    enum Localization {
+        static let errorNotice = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.errorNotice",
+            value: "Couldn't update notification preferences. Please try again.",
+            comment: "Notice shown when updating push notification preferences fails."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -109,7 +109,9 @@ private extension PushNotificationPreferencesViewModel {
             } catch {
                 DDLogError("⛔️ Error updating push notification preferences: \(error)")
                 revert()
-                errorNotice = Notice(title: Localization.errorNotice, feedbackType: .error)
+                errorNotice = Notice(title: Localization.errorNoticeTitle,
+                                     message: Localization.errorNoticeMessage,
+                                     feedbackType: .error)
             }
         }
     }
@@ -137,10 +139,15 @@ private extension PushNotificationPreferencesViewModel {
 
 extension PushNotificationPreferencesViewModel {
     enum Localization {
-        static let errorNotice = NSLocalizedString(
-            "pushNotificationPreferencesViewModel.errorNotice",
-            value: "Couldn't update notification preferences. Please try again.",
-            comment: "Notice shown when updating push notification preferences fails."
+        static let errorNoticeTitle = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.errorNoticeTitle",
+            value: "Couldn't update notification preferences",
+            comment: "Title of the notice shown when updating push notification preferences fails."
+        )
+        static let errorNoticeMessage = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.errorNoticeMessage",
+            value: "Please try again.",
+            comment: "Message of the notice shown when updating push notification preferences fails."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -157,6 +157,8 @@ private extension SettingsViewController {
             configureSendFeedback(cell: cell)
         case let cell as BasicTableViewCell where row == .notifications:
             configureNotificationSettings(cell: cell)
+        case let cell as BasicTableViewCell where row == .pushNotificationPreferences:
+            configurePushNotificationPreferences(cell: cell)
         case let cell as BasicTableViewCell where row == .privacy:
             configurePrivacy(cell: cell)
         case let cell as BasicTableViewCell where row == .about:
@@ -242,6 +244,12 @@ private extension SettingsViewController {
         cell.accessoryType = .disclosureIndicator
         cell.selectionStyle = .default
         cell.textLabel?.text = Localization.notificationSettings
+    }
+
+    func configurePushNotificationPreferences(cell: BasicTableViewCell) {
+        cell.accessoryType = .disclosureIndicator
+        cell.selectionStyle = .default
+        cell.textLabel?.text = Localization.pushNotifications
     }
 
     func configurePrivacy(cell: BasicTableViewCell) {
@@ -506,6 +514,14 @@ private extension SettingsViewController {
         show(controller, sender: self)
     }
 
+    func showPushNotificationPreferences() {
+        guard let siteID = stores.sessionManager.defaultSite?.siteID else {
+            return
+        }
+        let controller = PushNotificationPreferencesHostingController(siteID: siteID, stores: stores)
+        show(controller, sender: self)
+    }
+
     func showConnectivityTool() {
         ServiceLocator.analytics.track(event: .ConnectivityTool.settingsTroubleshootTapped())
         let controller = ConnectivityToolViewController()
@@ -659,6 +675,8 @@ extension SettingsViewController: UITableViewDelegate {
             showThemeSettings()
         case .notifications:
             showNotificationSettings()
+        case .pushNotificationPreferences:
+            showPushNotificationPreferences()
         case .connectivity:
             showConnectivityTool()
         default:
@@ -729,6 +747,7 @@ extension SettingsViewController {
 
         // App Settings
         case notifications
+        case pushNotificationPreferences
         case privacy
 
         // About the App
@@ -773,7 +792,7 @@ extension SettingsViewController {
                 return BasicTableViewCell.self
             case .logout, .accountSettings:
                 return BasicTableViewCell.self
-            case .privacy, .notifications:
+            case .privacy, .notifications, .pushNotificationPreferences:
                 return BasicTableViewCell.self
             case .enablePushNotifications:
                 return BasicTableViewCell.self
@@ -879,6 +898,12 @@ private extension SettingsViewController {
             "settingsViewController.notificationSettings",
             value: "Notification Settings",
             comment: "Navigates to the Notification Settings screen"
+        )
+
+        static let pushNotifications = NSLocalizedString(
+            "settingsViewController.pushNotifications",
+            value: "Push Notifications",
+            comment: "Navigates to the Push Notifications preferences screen"
         )
 
         static let experimentalFeatures = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -322,7 +322,17 @@ private extension SettingsViewModel {
                 return isSelfDrivenPNEligible &&
                 pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID)
             }()
-            if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {
+            let isRegisteredForWooDrivenPushes: Bool = {
+                guard let siteID = stores.sessionManager.defaultSite?.siteID else {
+                    return false
+                }
+                return pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID)
+            }()
+            let showPushNotificationPreferences = isRegisteredForWooDrivenPushes
+                && featureFlagService.isFeatureFlagEnabled(.smarterNotifications)
+            if showPushNotificationPreferences {
+                rows = [.pushNotificationPreferences, .privacy]
+            } else if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {
                 rows = [.notifications, .privacy]
             } else {
                 rows = [.privacy]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -1,0 +1,249 @@
+import Testing
+import Foundation
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+struct PushNotificationPreferencesViewModelTests {
+
+    private let siteID: Int64 = 123
+
+    private func makeSUT(stores: MockStoresManager) -> PushNotificationPreferencesViewModel {
+        PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
+    }
+
+    private func makeStores() -> MockStoresManager {
+        MockStoresManager(sessionManager: .testingInstance)
+    }
+
+    @Test func test_load_when_remote_succeeds_then_loadState_becomes_loaded_and_toggles_reflect_response() async {
+        // Given
+        let stores = makeStores()
+        let response = PushNotificationPreferences(
+            storeOrder: .init(enabled: true),
+            storeReview: .init(enabled: false),
+            storeStock: .init(enabled: true)
+        )
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(response))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.loadState == .loaded)
+        #expect(sut.isStoreOrderEnabled == true)
+        #expect(sut.isStoreReviewEnabled == false)
+        #expect(sut.isStoreStockEnabled == true)
+    }
+
+    @Test func test_load_when_remote_fails_then_loadState_becomes_error() async {
+        // Given
+        struct AnyError: Error {}
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.failure(AnyError()))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.loadState == .error)
+    }
+
+    @Test func test_setStoreOrderEnabled_dispatches_update_with_only_store_order_field() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.value = changes
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.setStoreOrderEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(dispatched.value?.storeOrder?.enabled == true)
+        #expect(dispatched.value?.storeReview == nil)
+        #expect(dispatched.value?.storeStock == nil)
+    }
+
+    @Test func test_setStoreReviewEnabled_dispatches_update_with_only_store_review_field() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.value = changes
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.setStoreReviewEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(dispatched.value?.storeReview?.enabled == true)
+        #expect(dispatched.value?.storeOrder == nil)
+        #expect(dispatched.value?.storeStock == nil)
+    }
+
+    @Test func test_setStoreStockEnabled_dispatches_update_with_only_store_stock_field() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.value = changes
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.setStoreStockEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(dispatched.value?.storeStock?.enabled == true)
+        #expect(dispatched.value?.storeOrder == nil)
+        #expect(dispatched.value?.storeReview == nil)
+    }
+
+    @Test func test_setStoreOrderEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
+        // Given
+        struct AnyError: Error {}
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
+                onCompletion(.failure(AnyError()))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        #expect(sut.isStoreOrderEnabled == false)
+
+        // When
+        sut.setStoreOrderEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreOrderEnabled == false)
+        #expect(sut.errorNotice != nil)
+    }
+
+    @Test func test_setStoreReviewEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
+        // Given
+        struct AnyError: Error {}
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
+                onCompletion(.failure(AnyError()))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        #expect(sut.isStoreReviewEnabled == false)
+
+        // When
+        sut.setStoreReviewEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreReviewEnabled == false)
+        #expect(sut.errorNotice != nil)
+    }
+
+    @Test func test_setStoreStockEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
+        // Given
+        struct AnyError: Error {}
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
+                onCompletion(.failure(AnyError()))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        #expect(sut.isStoreStockEnabled == false)
+
+        // When
+        sut.setStoreStockEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreStockEnabled == false)
+        #expect(sut.errorNotice != nil)
+    }
+
+    @Test func test_setStoreOrderEnabled_when_remote_succeeds_then_only_storeOrder_is_applied_from_response() async {
+        // Given a server response whose `storeReview` field is stale (false) compared to an
+        // in-flight optimistic flip of the review toggle (true). Only the order update is
+        // completed; the review update's continuation is held to keep that request in flight.
+        let stores = makeStores()
+        let staleResponse = PushNotificationPreferences(
+            storeOrder: .init(enabled: true),
+            storeReview: .init(enabled: false),
+            storeStock: .init(enabled: false)
+        )
+        let pendingReviewCompletion = PendingCompletion()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            guard case let .updatePushNotificationPreferences(_, changes, onCompletion) = action else {
+                return
+            }
+            if changes.storeOrder != nil {
+                onCompletion(.success(staleResponse))
+            } else if changes.storeReview != nil {
+                pendingReviewCompletion.handler = onCompletion
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        sut.setStoreReviewEnabled(true)
+
+        // When the order toggle update succeeds and returns its (stale-for-review) snapshot.
+        sut.setStoreOrderEnabled(true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then the order toggle reflects the server, but the review toggle keeps its
+        // optimistic value — it was not part of this request's `changes` payload and its
+        // own request hasn't completed yet.
+        #expect(sut.isStoreOrderEnabled == true)
+        #expect(sut.isStoreReviewEnabled == true)
+
+        // Resolve the dangling continuation so `withCheckedThrowingContinuation` doesn't
+        // emit a runtime warning when the test exits.
+        pendingReviewCompletion.handler?(.success(staleResponse))
+    }
+}
+
+/// Reference-typed box for capturing dispatched changes from a closure without `@MainActor` capture issues.
+/// Mutations always happen on the main actor in tests; `@unchecked Sendable` is safe.
+private final class DispatchedChanges: @unchecked Sendable {
+    var value: PushNotificationPreferences?
+}
+
+/// Reference-typed box to hold a `NotificationAction.updatePushNotificationPreferences`
+/// completion closure so it can be resolved later from the test body.
+/// Mutations always happen on the main actor in tests; `@unchecked Sendable` is safe.
+private final class PendingCompletion: @unchecked Sendable {
+    var handler: ((Result<PushNotificationPreferences, Error>) -> Void)?
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -295,6 +295,67 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_sections_contains_pushNotificationPreferences_row_when_site_is_registered_and_flag_is_on() async {
+        // Given
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123], hasStoredSiteIDsRegisteredForWooPNs: true)
+        let featureFlagService = MockFeatureFlagService(smarterNotifications: true)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults,
+                                          pushNotesManager: pushNotesManager)
+
+        // When
+        viewModel.onViewDidLoad()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.pushNotificationPreferences) })
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.notifications) })
+    }
+
+    @MainActor
+    func test_sections_does_not_contain_pushNotificationPreferences_row_when_flag_is_off() async {
+        // Given
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123], hasStoredSiteIDsRegisteredForWooPNs: true)
+        let featureFlagService = MockFeatureFlagService(smarterNotifications: false)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults,
+                                          pushNotesManager: pushNotesManager)
+
+        // When
+        viewModel.onViewDidLoad()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.pushNotificationPreferences) })
+    }
+
+    @MainActor
+    func test_sections_does_not_contain_pushNotificationPreferences_row_when_site_is_not_registered() async {
+        // Given
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [], hasStoredSiteIDsRegisteredForWooPNs: false)
+        let featureFlagService = MockFeatureFlagService(smarterNotifications: true)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults,
+                                          pushNotesManager: pushNotesManager)
+
+        // When
+        viewModel.onViewDidLoad()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.pushNotificationPreferences) })
+    }
+
+    @MainActor
     func test_sections_contains_enable_push_notifications_row_for_app_password_users_when_eligible() async {
         // Given
         let eligibilityChecker = MockWooPushNotificationEligibilityChecker()


### PR DESCRIPTION
## Description

Adds the iOS Push Notifications preferences screen (RSM-1630) on top of the network + Yosemite layers shipped in RSM-3342. The screen is reachable from **Menu → Settings → Push Notifications** behind two gates:

- `smarter_notifications` local feature flag is ON
- The current site is registered with the Woo-driven push system (`pushNotesManager.siteIDsRegisteredForWooPNs`)

When both gates pass, the new row replaces the legacy `.notifications` row in the App Settings section.

The screen itself is a SwiftUI `List` with three toggle rows — **New orders**, **New reviews**, **Stock** — backed by `NotificationAction.loadPushNotificationPreferences` and `NotificationAction.updatePushNotificationPreferences`. Toggles update optimistically; only the field whose sub-struct was sent in the request is updated from the server response, so concurrent in-flight requests on different toggles don't stomp each other's optimistic state. On failure, the toggle reverts (guarded against being undone if the user has flipped it again) and surfaces a non-blocking `Notice`.

Loading state keeps the list visible with disabled controls and a small toolbar progress indicator. Initial-load failures show a full-screen `EmptyState` with a Retry button.

Detail (chevron) navigation is intentionally out of scope here — it'll be picked up in RSM-1631.

## Test Steps

Ping me for access to a site with the dev version of the Woo Core plugin. 

1. Run on simulator/device signed into a site registered for Woo-driven push notifications, on a build where `smarterNotifications` is ON (non-production builds enable it by default).
2. Open **Menu → Settings**. Confirm a new **Push Notifications** row appears in the *App Settings* section in place of the legacy *Notification Settings* row.
3. Tap the row. Three toggle rows render: *New orders*, *New reviews*, *Stock*. While loading, toggles are disabled and a small spinner shows in the nav bar.
4. Once loaded, flip any toggle. Proxyman shows one `POST` to `wc-push-notifications/preferences` with only the relevant sub-struct populated. The toggle stays where you put it on success.
5. Force a failure (toggle airplane mode, or block the host): the toggle reverts and an error notice appears at the bottom.
6. Force an *initial load* failure: the full-screen error state with a Retry button replaces the list. Tap Retry — the list re-loads on success.
7. With the gate conditions **not** met (smarter_notifications off, or site not Woo-PN-registered), confirm the legacy *Notification Settings* row is shown as before.
8. Run the new unit tests: `xcodebuild ... test -only-testing:\"WooCommerceTests/PushNotificationPreferencesViewModelTests\"`.

## Screenshots

| Success | Error |
|---|---|
|  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-18 at 14 42 22" src="https://github.com/user-attachments/assets/e0f269c4-2a4f-4762-9fef-3817c521a565" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-18 at 14 56 36" src="https://github.com/user-attachments/assets/b9143f8e-529b-4285-89dc-4f5abd1713cd" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.