### PR TITLE
Add AR coaching overlay UI for package sizing

### DIFF
--- a/Modules/Sources/ParcelFittingCheck/Models/ParcelDimensions.swift
+++ b/Modules/Sources/ParcelFittingCheck/Models/ParcelDimensions.swift
@@ -71,7 +71,7 @@ public struct ParcelDimensions: Hashable {
         Float(Measurement(value: 1.0, unit: unit).converted(to: .meters).value)
     }
 
-    private enum Localization {
+    enum Localization {
         static let lengthLabel = NSLocalizedString(
             "parcelFitting.dimensions.lengthLabel",
             value: "L",

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARCoachCard.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARCoachCard.swift
@@ -3,18 +3,22 @@ import SwiftUI
 struct ARCoachCard: View {
     let onDismiss: () -> Void
 
+    private let hints: [Hint] = [
+        Hint(iconName: "hand.draw", label: Localization.drag),
+        Hint(iconName: "arrow.trianglehead.counterclockwise.rotate.90", label: Localization.twist),
+        Hint(iconName: "hand.pinch", label: Localization.pinch),
+    ]
+
     var body: some View {
         ARGlassCard {
             VStack(alignment: .leading, spacing: 0) {
                 header
-                ARHintRow(iconName: "hand.draw", label: Localization.drag)
-                    .padding(.vertical, 8)
-                separator
-                ARHintRow(iconName: "arrow.trianglehead.counterclockwise.rotate.90", label: Localization.twist)
-                    .padding(.vertical, 8)
-                separator
-                ARHintRow(iconName: "hand.pinch", label: Localization.pinch)
-                    .padding(.vertical, 8)
+                ForEach(Array(hints.enumerated()), id: \.element.iconName) { index, hint in
+                    if index > 0 {
+                        separator
+                    }
+                    hintRow(hint)
+                }
             }
         }
     }
@@ -22,27 +26,45 @@ struct ARCoachCard: View {
     private var header: some View {
         HStack {
             Text(Localization.title)
-                .font(.system(size: 13, weight: .semibold))
+                .font(.footnote.weight(.semibold))
                 .foregroundStyle(.white)
             Spacer()
             Button(action: onDismiss) {
                 Image(systemName: "xmark")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.55))
-                    .padding(5)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.white.opacity(Constants.dismissButtonOpacity))
+                    .padding(Constants.dismissButtonPadding)
                     .contentShape(Rectangle())
             }
             .accessibilityLabel(Localization.dismiss)
         }
-        .padding(.bottom, 4)
+        .padding(.bottom, Constants.headerBottomPadding)
+    }
+
+    private func hintRow(_ hint: Hint) -> some View {
+        ARHintRow(iconName: hint.iconName, label: hint.label)
+            .padding(.vertical, Constants.rowVerticalPadding)
     }
 
     private var separator: some View {
-        Divider().overlay(Color.white.opacity(0.06))
+        Divider().overlay(Color.white.opacity(Constants.separatorOpacity))
     }
 }
 
 private extension ARCoachCard {
+    struct Hint {
+        let iconName: String
+        let label: String
+    }
+
+    enum Constants {
+        static let dismissButtonOpacity: Double = 0.55
+        static let dismissButtonPadding: CGFloat = 5
+        static let headerBottomPadding: CGFloat = 4
+        static let rowVerticalPadding: CGFloat = 8
+        static let separatorOpacity: Double = 0.06
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "parcelFitting.coaching.title",

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARCoachCard.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARCoachCard.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct ARCoachCard: View {
+    let onDismiss: () -> Void
+
+    var body: some View {
+        ARGlassCard {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                gestureRow(icon: "hand.draw", bold: Localization.drag, regular: Localization.dragDescription)
+                hairline
+                gestureRow(icon: "arrow.trianglehead.counterclockwise.rotate.90", bold: Localization.twist, regular: Localization.twistDescription)
+                hairline
+                gestureRow(icon: "hand.pinch", bold: Localization.pinch, regular: Localization.pinchDescription)
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text(Localization.title)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.white)
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.55))
+                    .frame(width: 22, height: 22)
+            }
+            .accessibilityLabel(Localization.dismiss)
+        }
+        .padding(.bottom, 4)
+    }
+
+    private func gestureRow(icon: String, bold: String, regular: String) -> some View {
+        ARHintRow(iconName: icon, boldText: bold, regularText: regular)
+            .padding(.vertical, 8)
+    }
+
+    private var hairline: some View {
+        Divider().overlay(Color.white.opacity(0.06))
+    }
+}
+
+private extension ARCoachCard {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "parcelFitting.coaching.title",
+            value: "Fit the box around your package",
+            comment: "Title for the AR coaching card that teaches gesture controls")
+        static let drag = NSLocalizedString(
+            "parcelFitting.coaching.drag",
+            value: "Drag",
+            comment: "Bold verb for the drag gesture hint in AR coaching")
+        static let dragDescription = NSLocalizedString(
+            "parcelFitting.coaching.drag.description",
+            value: "to move the box",
+            comment: "Description following 'Drag' in AR coaching gesture hint")
+        static let twist = NSLocalizedString(
+            "parcelFitting.coaching.twist",
+            value: "Twist",
+            comment: "Bold verb for the twist/rotate gesture hint in AR coaching")
+        static let twistDescription = NSLocalizedString(
+            "parcelFitting.coaching.twist.description",
+            value: "with two fingers to rotate",
+            comment: "Description following 'Twist' in AR coaching gesture hint")
+        static let pinch = NSLocalizedString(
+            "parcelFitting.coaching.pinch",
+            value: "Pinch",
+            comment: "Bold verb for the pinch/resize gesture hint in AR coaching")
+        static let pinchDescription = NSLocalizedString(
+            "parcelFitting.coaching.pinch.description",
+            value: "an axis to resize that side",
+            comment: "Description following 'Pinch' in AR coaching gesture hint")
+        static let dismiss = NSLocalizedString(
+            "parcelFitting.coaching.dismiss.accessibilityLabel",
+            value: "Dismiss",
+            comment: "Accessibility label for the dismiss button on the AR coaching card")
+    }
+}

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARCoachCard.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARCoachCard.swift
@@ -7,11 +7,14 @@ struct ARCoachCard: View {
         ARGlassCard {
             VStack(alignment: .leading, spacing: 0) {
                 header
-                gestureRow(icon: "hand.draw", bold: Localization.drag, regular: Localization.dragDescription)
-                hairline
-                gestureRow(icon: "arrow.trianglehead.counterclockwise.rotate.90", bold: Localization.twist, regular: Localization.twistDescription)
-                hairline
-                gestureRow(icon: "hand.pinch", bold: Localization.pinch, regular: Localization.pinchDescription)
+                ARHintRow(iconName: "hand.draw", label: Localization.drag)
+                    .padding(.vertical, 8)
+                separator
+                ARHintRow(iconName: "arrow.trianglehead.counterclockwise.rotate.90", label: Localization.twist)
+                    .padding(.vertical, 8)
+                separator
+                ARHintRow(iconName: "hand.pinch", label: Localization.pinch)
+                    .padding(.vertical, 8)
             }
         }
     }
@@ -26,19 +29,15 @@ struct ARCoachCard: View {
                 Image(systemName: "xmark")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.white.opacity(0.55))
-                    .frame(width: 22, height: 22)
+                    .padding(5)
+                    .contentShape(Rectangle())
             }
             .accessibilityLabel(Localization.dismiss)
         }
         .padding(.bottom, 4)
     }
 
-    private func gestureRow(icon: String, bold: String, regular: String) -> some View {
-        ARHintRow(iconName: icon, boldText: bold, regularText: regular)
-            .padding(.vertical, 8)
-    }
-
-    private var hairline: some View {
+    private var separator: some View {
         Divider().overlay(Color.white.opacity(0.06))
     }
 }
@@ -50,29 +49,17 @@ private extension ARCoachCard {
             value: "Fit the box around your package",
             comment: "Title for the AR coaching card that teaches gesture controls")
         static let drag = NSLocalizedString(
-            "parcelFitting.coaching.drag",
-            value: "Drag",
-            comment: "Bold verb for the drag gesture hint in AR coaching")
-        static let dragDescription = NSLocalizedString(
-            "parcelFitting.coaching.drag.description",
-            value: "to move the box",
-            comment: "Description following 'Drag' in AR coaching gesture hint")
+            "parcelFitting.coaching.drag.hint",
+            value: "Drag to move the box",
+            comment: "Hint explaining the drag gesture to move the AR fitting box")
         static let twist = NSLocalizedString(
-            "parcelFitting.coaching.twist",
-            value: "Twist",
-            comment: "Bold verb for the twist/rotate gesture hint in AR coaching")
-        static let twistDescription = NSLocalizedString(
-            "parcelFitting.coaching.twist.description",
-            value: "with two fingers to rotate",
-            comment: "Description following 'Twist' in AR coaching gesture hint")
+            "parcelFitting.coaching.twist.hint",
+            value: "Twist with two fingers to rotate",
+            comment: "Hint explaining the two-finger twist gesture to rotate the AR fitting box")
         static let pinch = NSLocalizedString(
-            "parcelFitting.coaching.pinch",
-            value: "Pinch",
-            comment: "Bold verb for the pinch/resize gesture hint in AR coaching")
-        static let pinchDescription = NSLocalizedString(
-            "parcelFitting.coaching.pinch.description",
-            value: "an axis to resize that side",
-            comment: "Description following 'Pinch' in AR coaching gesture hint")
+            "parcelFitting.coaching.pinch.hint",
+            value: "Pinch an axis to resize that side",
+            comment: "Hint explaining the pinch gesture to resize one side of the AR fitting box")
         static let dismiss = NSLocalizedString(
             "parcelFitting.coaching.dismiss.accessibilityLabel",
             value: "Dismiss",

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARDimensionTile.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARDimensionTile.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ARDimensionTile: View {
+    let label: String
+    let value: String
+    let unit: String
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.system(size: 9.5, weight: .bold))
+                .tracking(1)
+                .foregroundStyle(.white.opacity(0.55))
+
+            Text(value)
+                .font(.system(size: 22, weight: .semibold).monospacedDigit())
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            Text(unit)
+                .font(.system(size: 10))
+                .foregroundStyle(.white)
+        }
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+    }
+}

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARDimensionTile.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARDimensionTile.swift
@@ -6,24 +6,36 @@ struct ARDimensionTile: View {
     let unit: String
 
     var body: some View {
-        VStack(spacing: 2) {
+        VStack(spacing: Constants.innerSpacing) {
             Text(label)
-                .font(.system(size: 9.5, weight: .bold))
-                .tracking(1)
-                .foregroundStyle(.white.opacity(0.55))
+                .font(.caption2.bold())
+                .tracking(Constants.labelTracking)
+                .foregroundStyle(.white.opacity(Constants.secondaryOpacity))
 
             Text(value)
-                .font(.system(size: 22, weight: .semibold).monospacedDigit())
+                .font(.title2.monospacedDigit().weight(.semibold))
                 .foregroundStyle(.white)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(Constants.minimumScaleFactor)
 
             Text(unit)
-                .font(.system(size: 10))
+                .font(.caption2)
                 .foregroundStyle(.white)
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, Constants.verticalPadding)
         .frame(maxWidth: .infinity)
-        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+        .background(Color.white.opacity(Constants.backgroundOpacity), in: RoundedRectangle(cornerRadius: Constants.cornerRadius))
+    }
+}
+
+private extension ARDimensionTile {
+    enum Constants {
+        static let innerSpacing: CGFloat = 2
+        static let verticalPadding: CGFloat = 8
+        static let cornerRadius: CGFloat = 10
+        static let labelTracking: CGFloat = 1
+        static let backgroundOpacity: Double = 0.08
+        static let secondaryOpacity: Double = 0.55
+        static let minimumScaleFactor: CGFloat = 0.7
     }
 }

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARGlassCard.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARGlassCard.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ARGlassCard<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    private static var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: ARGlassCardConstants.cornerRadius)
+    }
+
+    var body: some View {
+        content()
+            .padding(ARGlassCardConstants.padding)
+            .background(ARGlassCardConstants.backgroundColor, in: Self.shape)
+            .overlay(Self.shape.stroke(ARGlassCardConstants.borderColor, lineWidth: 1))
+            .shadow(color: ARGlassCardConstants.shadowColor, radius: 30, y: 12)
+    }
+}
+
+private enum ARGlassCardConstants {
+    static let cornerRadius: CGFloat = 18
+    static let padding: CGFloat = 14
+    static let backgroundColor = Color(red: 28 / 255, green: 28 / 255, blue: 30 / 255).opacity(0.85)
+    static let borderColor = Color.white.opacity(0.09)
+    static let shadowColor = Color.black.opacity(0.35)
+}

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARHintRow.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARHintRow.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ARHintRow: View {
     let iconName: String
-    let label: Text
+    let label: String
 
     var body: some View {
         HStack(spacing: 10) {
@@ -12,17 +12,10 @@ struct ARHintRow: View {
                 .frame(width: 28, height: 28)
                 .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
 
-            label
+            Text(label)
                 .font(.system(size: 13.5))
                 .lineSpacing(13.5 * 0.35)
-                .foregroundStyle(.white)
+                .foregroundStyle(.white.opacity(0.62))
         }
-    }
-}
-
-extension ARHintRow {
-    init(iconName: String, boldText: String, regularText: String) {
-        self.iconName = iconName
-        self.label = Text(boldText).bold() + Text(" ") + Text(regularText).foregroundColor(.white.opacity(0.62))
     }
 }

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARHintRow.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARHintRow.swift
@@ -5,17 +5,27 @@ struct ARHintRow: View {
     let label: String
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: Constants.spacing) {
             Image(systemName: iconName)
-                .font(.system(size: 16))
+                .font(.system(size: Constants.iconFontSize))
                 .foregroundStyle(.white)
-                .frame(width: 28, height: 28)
-                .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+                .frame(width: Constants.iconTileSize, height: Constants.iconTileSize)
+                .background(Color.white.opacity(Constants.iconTileBackgroundOpacity), in: RoundedRectangle(cornerRadius: Constants.iconTileCornerRadius))
 
             Text(label)
-                .font(.system(size: 13.5))
-                .lineSpacing(13.5 * 0.35)
-                .foregroundStyle(.white.opacity(0.62))
+                .font(.footnote)
+                .foregroundStyle(.white.opacity(Constants.labelOpacity))
         }
+    }
+}
+
+private extension ARHintRow {
+    enum Constants {
+        static let spacing: CGFloat = 10
+        static let iconFontSize: CGFloat = 16
+        static let iconTileSize: CGFloat = 28
+        static let iconTileCornerRadius: CGFloat = 8
+        static let iconTileBackgroundOpacity: Double = 0.08
+        static let labelOpacity: Double = 0.62
     }
 }

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARHintRow.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARHintRow.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct ARHintRow: View {
+    let iconName: String
+    let label: Text
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: iconName)
+                .font(.system(size: 16))
+                .foregroundStyle(.white)
+                .frame(width: 28, height: 28)
+                .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+
+            label
+                .font(.system(size: 13.5))
+                .lineSpacing(13.5 * 0.35)
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+extension ARHintRow {
+    init(iconName: String, boldText: String, regularText: String) {
+        self.iconName = iconName
+        self.label = Text(boldText).bold() + Text(" ") + Text(regularText).foregroundColor(.white.opacity(0.62))
+    }
+}

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingView.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingView.swift
@@ -23,6 +23,12 @@ struct ARParcelSizingView: View {
         self.onConfirm = onConfirm
     }
 
+    private var phase: ARPhase {
+        if isPlaced { return .placed(hintsVisible: viewModel.hintsVisible) }
+        if isARReady { return .awaitingTap }
+        return .detecting
+    }
+
     var body: some View {
         ZStack {
             ARParcelSceneView(
@@ -39,25 +45,29 @@ struct ARParcelSizingView: View {
             VStack {
                 topToolbar
 
-                if let message = headerMessage {
-                    Text(message)
-                        .font(.callout.monospacedDigit())
-                        .foregroundStyle(.white)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(.black.opacity(0.55), in: Capsule())
-                        .padding(.horizontal)
-                        .padding(.top, 8)
-                }
+                coachingContent
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
 
                 Spacer()
 
                 if isPlaced {
-                    confirmButton
+                    ARSizingFooterHUD(
+                        dimensions: viewModel.dimensions,
+                        unit: viewModel.unit,
+                        hintsVisible: viewModel.hintsVisible,
+                        onShowHints: { viewModel.showHints() },
+                        onConfirm: {
+                            viewModel.trackSizingCompleted()
+                            onConfirm(viewModel.dimensions)
+                        }
+                    )
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 16)
+                    .transition(Self.cardTransition)
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: isPlaced)
+            .animation(.easeOut(duration: 0.22), value: phase)
         }
         .background(Color.black)
         .onChange(of: scenePhase) { _, newPhase in
@@ -73,9 +83,32 @@ struct ARParcelSizingView: View {
             if ready { viewModel.recordARReady() }
         }
         .onChange(of: isPlaced) { _, placed in
-            if placed { viewModel.trackBoxPlaced() }
+            if placed {
+                viewModel.trackBoxPlaced()
+                viewModel.onBoxPlaced()
+            }
         }
     }
+
+    @ViewBuilder
+    private var coachingContent: some View {
+        switch phase {
+        case .detecting:
+            EmptyView()
+        case .awaitingTap:
+            ARTapHintCard()
+                .transition(Self.cardTransition)
+        case .placed(hintsVisible: true):
+            ARCoachCard(onDismiss: { viewModel.dismissHints() })
+                .transition(Self.cardTransition)
+        case .placed(hintsVisible: false):
+            EmptyView()
+        }
+    }
+
+    private static let cardTransition: AnyTransition = .opacity
+        .combined(with: .scale(scale: 0.97, anchor: .top))
+        .combined(with: .offset(y: -6))
 
     private func userReset() {
         resetTrigger += 1
@@ -88,16 +121,6 @@ struct ARParcelSizingView: View {
         viewModel.resetToDefaults()
     }
 
-    private var headerMessage: String? {
-        if isPlaced {
-            return viewModel.dimensionsLabel
-        }
-        if isARReady {
-            return Localization.placementHint
-        }
-        return nil
-    }
-
     private var topToolbar: some View {
         ARCuboidSceneToolbar(
             onCancel: {
@@ -106,34 +129,5 @@ struct ARParcelSizingView: View {
             },
             onReset: isPlaced ? { userReset() } : nil
         )
-    }
-
-    private var confirmButton: some View {
-        Button {
-            viewModel.trackSizingCompleted()
-            onConfirm(viewModel.confirmedDimensions)
-        } label: {
-            Text(Localization.useTheseDimensions)
-                .font(.headline)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(Color.accentColor, in: Capsule())
-                .foregroundStyle(.white)
-        }
-        .padding(.horizontal, 16)
-        .padding(.bottom, 16)
-    }
-}
-
-private extension ARParcelSizingView {
-    enum Localization {
-        static let placementHint = NSLocalizedString(
-            "parcelFitting.sizing.placementHint",
-            value: "Tap on the surface to place the fitting box",
-            comment: "Hint text shown when the AR surface is ready for cuboid placement")
-        static let useTheseDimensions = NSLocalizedString(
-            "parcelFitting.sizing.useTheseDimensions",
-            value: "Use these dimensions",
-            comment: "Button to confirm the measured dimensions in the AR sizing view")
     }
 }

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingView.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingView.swift
@@ -68,6 +68,7 @@ struct ARParcelSizingView: View {
                 }
             }
             .animation(.easeOut(duration: 0.22), value: phase)
+            .animation(.easeOut(duration: 0.22), value: viewModel.hintsVisible)
         }
         .background(Color.black)
         .onChange(of: scenePhase) { _, newPhase in

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingView.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingView.swift
@@ -46,8 +46,8 @@ struct ARParcelSizingView: View {
                 topToolbar
 
                 coachingContent
-                    .padding(.horizontal, 16)
-                    .padding(.top, 8)
+                    .padding(.horizontal, Constants.horizontalPadding)
+                    .padding(.top, Constants.coachingTopPadding)
 
                 Spacer()
 
@@ -62,13 +62,13 @@ struct ARParcelSizingView: View {
                             onConfirm(viewModel.dimensions)
                         }
                     )
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 16)
+                    .padding(.horizontal, Constants.horizontalPadding)
+                    .padding(.bottom, Constants.bottomPadding)
                     .transition(Self.cardTransition)
                 }
             }
-            .animation(.easeOut(duration: 0.22), value: phase)
-            .animation(.easeOut(duration: 0.22), value: viewModel.hintsVisible)
+            .animation(.easeOut(duration: Constants.animationDuration), value: phase)
+            .animation(.easeOut(duration: Constants.animationDuration), value: viewModel.hintsVisible)
         }
         .background(Color.black)
         .onChange(of: scenePhase) { _, newPhase in
@@ -108,8 +108,8 @@ struct ARParcelSizingView: View {
     }
 
     private static let cardTransition: AnyTransition = .opacity
-        .combined(with: .scale(scale: 0.97, anchor: .top))
-        .combined(with: .offset(y: -6))
+        .combined(with: .scale(scale: Constants.transitionScale, anchor: .top))
+        .combined(with: .offset(y: Constants.transitionOffsetY))
 
     private func userReset() {
         resetTrigger += 1
@@ -120,6 +120,15 @@ struct ARParcelSizingView: View {
     private func resetWithoutTracking() {
         resetTrigger += 1
         viewModel.resetToDefaults()
+    }
+
+    private enum Constants {
+        static let horizontalPadding: CGFloat = 16
+        static let coachingTopPadding: CGFloat = 8
+        static let bottomPadding: CGFloat = 16
+        static let animationDuration: Double = 0.22
+        static let transitionScale: CGFloat = 0.97
+        static let transitionOffsetY: CGFloat = -6
     }
 
     private var topToolbar: some View {

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingViewModel.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingViewModel.swift
@@ -99,12 +99,14 @@ final class ARParcelSizingViewModel {
 
     func onBoxPlaced() {
         hintsVisible = !hasSeenHints
+        if !hasSeenHints {
+            hasSeenHints = true
+            defaults.set(true, forKey: Constants.hintsSeenKey)
+        }
     }
 
     func dismissHints() {
         hintsVisible = false
-        hasSeenHints = true
-        defaults.set(true, forKey: Constants.hintsSeenKey)
     }
 
     func showHints() {

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingViewModel.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARParcelSizingViewModel.swift
@@ -1,6 +1,12 @@
 import Foundation
 import EventHorizonSDK
 
+enum ARPhase: Equatable {
+    case detecting
+    case awaitingTap
+    case placed(hintsVisible: Bool)
+}
+
 @Observable
 final class ARParcelSizingViewModel {
     let unit: UnitLength
@@ -11,13 +17,21 @@ final class ARParcelSizingViewModel {
     private(set) var resetCount: Int = 0
     private(set) var arReadyTime: Date?
     private(set) var hasTrackedPlacement: Bool = false
+    private(set) var hintsVisible: Bool = false
 
+    private var hasSeenHints: Bool
+    private let defaults: UserDefaults
     private let analytics: ParcelFittingAnalyticsTracking
 
-    init(unit: UnitLength, initial: ParcelDimensions? = nil, analytics: ParcelFittingAnalyticsTracking) {
+    init(unit: UnitLength,
+         initial: ParcelDimensions? = nil,
+         analytics: ParcelFittingAnalyticsTracking,
+         defaults: UserDefaults = .standard) {
         self.unit = unit
         self.dimensions = initial ?? .defaultDimensions(for: unit)
         self.analytics = analytics
+        self.defaults = defaults
+        self.hasSeenHints = defaults.bool(forKey: Constants.hintsSeenKey)
     }
 
     func recordGestureCompleted(mode: TwoFingerTracker.Mode) {
@@ -71,8 +85,6 @@ final class ARParcelSizingViewModel {
         dimensions.toMeters(unit: unit)
     }
 
-    var confirmedDimensions: ParcelDimensions { dimensions }
-
     var dimensionsLabel: String {
         dimensions.formattedWithLabels(unit: unit)
     }
@@ -83,5 +95,23 @@ final class ARParcelSizingViewModel {
 
     func resetToDefaults() {
         dimensions = .defaultDimensions(for: unit)
+    }
+
+    func onBoxPlaced() {
+        hintsVisible = !hasSeenHints
+    }
+
+    func dismissHints() {
+        hintsVisible = false
+        hasSeenHints = true
+        defaults.set(true, forKey: Constants.hintsSeenKey)
+    }
+
+    func showHints() {
+        hintsVisible = true
+    }
+
+    enum Constants {
+        static let hintsSeenKey = "parcelFitting.coachingHintsDismissed"
     }
 }

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct ARSizingFooterHUD: View {
+    let dimensions: ParcelDimensions
+    let unit: UnitLength
+    let hintsVisible: Bool
+    let onShowHints: () -> Void
+    let onConfirm: () -> Void
+
+    var body: some View {
+        ARGlassCard {
+            VStack(spacing: 12) {
+                measuredRow
+                dimensionTiles
+                confirmButton
+            }
+        }
+    }
+
+    private var measuredRow: some View {
+        HStack {
+            Text(Localization.measured)
+                .font(.system(size: 10.5, weight: .semibold))
+                .tracking(1.2)
+                .foregroundStyle(.white.opacity(0.55))
+
+            Spacer()
+
+            if !hintsVisible {
+                Button(action: onShowHints) {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.white)
+                        .frame(width: 22, height: 22)
+                        .background(Color.white.opacity(0.10), in: Circle())
+                }
+                .accessibilityLabel(Localization.showHints)
+                .transition(.scale(scale: 0.7).combined(with: .opacity))
+            }
+        }
+        .animation(.easeOut(duration: 0.18), value: hintsVisible)
+    }
+
+    private var dimensionTiles: some View {
+        HStack(spacing: 8) {
+            DimensionTile(label: ParcelDimensions.Localization.lengthLabel,
+                          value: ParcelDimensions.formatValue(dimensions.length),
+                          unit: unit.symbol)
+            DimensionTile(label: ParcelDimensions.Localization.widthLabel,
+                          value: ParcelDimensions.formatValue(dimensions.width),
+                          unit: unit.symbol)
+            DimensionTile(label: ParcelDimensions.Localization.heightLabel,
+                          value: ParcelDimensions.formatValue(dimensions.height),
+                          unit: unit.symbol)
+        }
+    }
+
+    private var confirmButton: some View {
+        Button(action: onConfirm) {
+            Text(Localization.useTheseDimensions)
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.accentColor, in: Capsule())
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+private struct DimensionTile: View {
+    let label: String
+    let value: String
+    let unit: String
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.system(size: 9.5, weight: .bold))
+                .tracking(1)
+                .foregroundStyle(.white.opacity(0.55))
+
+            Text(value)
+                .font(.system(size: 22, weight: .semibold).monospacedDigit())
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            Text(unit)
+                .font(.system(size: 10))
+                .foregroundStyle(.white)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private extension ARSizingFooterHUD {
+    enum Localization {
+        static let measured = NSLocalizedString(
+            "parcelFitting.sizing.measured",
+            value: "MEASURED",
+            comment: "Label above the dimension tiles in the AR sizing footer")
+        static let useTheseDimensions = NSLocalizedString(
+            "parcelFitting.sizing.useTheseDimensions",
+            value: "Use these dimensions",
+            comment: "Button to confirm the measured dimensions in the AR sizing view")
+        static let showHints = NSLocalizedString(
+            "parcelFitting.sizing.showHints.accessibilityLabel",
+            value: "Show tips",
+            comment: "Accessibility label for the info button that reopens the AR coaching hints")
+    }
+}

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
@@ -88,7 +88,9 @@ private struct DimensionTile: View {
                 .font(.system(size: 10))
                 .foregroundStyle(.white)
         }
+        .padding(.vertical, 8)
         .frame(maxWidth: .infinity)
+        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
     }
 }
 

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
@@ -26,17 +26,16 @@ struct ARSizingFooterHUD: View {
 
             Spacer()
 
-            if !hintsVisible {
-                Button(action: onShowHints) {
-                    Image(systemName: "info.circle")
-                        .font(.system(size: 14))
-                        .foregroundStyle(.white)
-                        .frame(width: 22, height: 22)
-                        .background(Color.white.opacity(0.10), in: Circle())
-                }
-                .accessibilityLabel(Localization.showHints)
-                .transition(.scale(scale: 0.7).combined(with: .opacity))
+            Button(action: onShowHints) {
+                Image(systemName: "info.circle")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.white)
+                    .frame(width: 22, height: 22)
+                    .background(Color.white.opacity(0.10), in: Circle())
             }
+            .accessibilityLabel(Localization.showHints)
+            .opacity(hintsVisible ? 0 : 1)
+            .allowsHitTesting(!hintsVisible)
         }
         .animation(.easeOut(duration: 0.18), value: hintsVisible)
     }

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
@@ -42,15 +42,15 @@ struct ARSizingFooterHUD: View {
 
     private var dimensionTiles: some View {
         HStack(spacing: 8) {
-            DimensionTile(label: ParcelDimensions.Localization.lengthLabel,
-                          value: ParcelDimensions.formatValue(dimensions.length),
-                          unit: unit.symbol)
-            DimensionTile(label: ParcelDimensions.Localization.widthLabel,
-                          value: ParcelDimensions.formatValue(dimensions.width),
-                          unit: unit.symbol)
-            DimensionTile(label: ParcelDimensions.Localization.heightLabel,
-                          value: ParcelDimensions.formatValue(dimensions.height),
-                          unit: unit.symbol)
+            ARDimensionTile(label: ParcelDimensions.Localization.lengthLabel,
+                            value: ParcelDimensions.formatValue(dimensions.length),
+                            unit: unit.symbol)
+            ARDimensionTile(label: ParcelDimensions.Localization.widthLabel,
+                            value: ParcelDimensions.formatValue(dimensions.width),
+                            unit: unit.symbol)
+            ARDimensionTile(label: ParcelDimensions.Localization.heightLabel,
+                            value: ParcelDimensions.formatValue(dimensions.height),
+                            unit: unit.symbol)
         }
     }
 
@@ -63,34 +63,6 @@ struct ARSizingFooterHUD: View {
                 .background(Color.accentColor, in: Capsule())
                 .foregroundStyle(.white)
         }
-    }
-}
-
-private struct DimensionTile: View {
-    let label: String
-    let value: String
-    let unit: String
-
-    var body: some View {
-        VStack(spacing: 2) {
-            Text(label)
-                .font(.system(size: 9.5, weight: .bold))
-                .tracking(1)
-                .foregroundStyle(.white.opacity(0.55))
-
-            Text(value)
-                .font(.system(size: 22, weight: .semibold).monospacedDigit())
-                .foregroundStyle(.white)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-
-            Text(unit)
-                .font(.system(size: 10))
-                .foregroundStyle(.white)
-        }
-        .padding(.vertical, 8)
-        .frame(maxWidth: .infinity)
-        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
     }
 }
 

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARSizingFooterHUD.swift
@@ -9,7 +9,7 @@ struct ARSizingFooterHUD: View {
 
     var body: some View {
         ARGlassCard {
-            VStack(spacing: 12) {
+            VStack(spacing: Constants.contentSpacing) {
                 measuredRow
                 dimensionTiles
                 confirmButton
@@ -20,28 +20,28 @@ struct ARSizingFooterHUD: View {
     private var measuredRow: some View {
         HStack {
             Text(Localization.measured)
-                .font(.system(size: 10.5, weight: .semibold))
-                .tracking(1.2)
-                .foregroundStyle(.white.opacity(0.55))
+                .font(.caption2.weight(.semibold))
+                .tracking(Constants.measuredTracking)
+                .foregroundStyle(.white.opacity(Constants.secondaryOpacity))
 
             Spacer()
 
             Button(action: onShowHints) {
                 Image(systemName: "info.circle")
-                    .font(.system(size: 14))
+                    .font(.footnote)
                     .foregroundStyle(.white)
-                    .frame(width: 22, height: 22)
-                    .background(Color.white.opacity(0.10), in: Circle())
+                    .frame(width: Constants.infoButtonSize, height: Constants.infoButtonSize)
+                    .background(Color.white.opacity(Constants.infoButtonBackgroundOpacity), in: Circle())
             }
             .accessibilityLabel(Localization.showHints)
             .opacity(hintsVisible ? 0 : 1)
             .allowsHitTesting(!hintsVisible)
         }
-        .animation(.easeOut(duration: 0.18), value: hintsVisible)
+        .animation(.easeOut(duration: Constants.infoButtonAnimationDuration), value: hintsVisible)
     }
 
     private var dimensionTiles: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Constants.tileSpacing) {
             ARDimensionTile(label: ParcelDimensions.Localization.lengthLabel,
                             value: ParcelDimensions.formatValue(dimensions.length),
                             unit: unit.symbol)
@@ -59,7 +59,7 @@ struct ARSizingFooterHUD: View {
             Text(Localization.useTheseDimensions)
                 .font(.headline)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
+                .padding(.vertical, Constants.confirmButtonVerticalPadding)
                 .background(Color.accentColor, in: Capsule())
                 .foregroundStyle(.white)
         }
@@ -67,6 +67,17 @@ struct ARSizingFooterHUD: View {
 }
 
 private extension ARSizingFooterHUD {
+    enum Constants {
+        static let contentSpacing: CGFloat = 12
+        static let measuredTracking: CGFloat = 1.2
+        static let secondaryOpacity: Double = 0.55
+        static let infoButtonSize: CGFloat = 22
+        static let infoButtonBackgroundOpacity: Double = 0.10
+        static let infoButtonAnimationDuration: Double = 0.18
+        static let tileSpacing: CGFloat = 8
+        static let confirmButtonVerticalPadding: CGFloat = 12
+    }
+
     enum Localization {
         static let measured = NSLocalizedString(
             "parcelFitting.sizing.measured",

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARTapHintCard.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARTapHintCard.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct ARTapHintCard: View {
+    var body: some View {
+        ARGlassCard {
+            ARHintRow(
+                iconName: "hand.tap",
+                label: Text(Localization.action).fontWeight(.semibold) +
+                       Text(" ") +
+                       Text(Localization.description).foregroundColor(.white.opacity(0.62))
+            )
+        }
+    }
+}
+
+private extension ARTapHintCard {
+    enum Localization {
+        static let action = NSLocalizedString(
+            "parcelFitting.coaching.tapHint.action",
+            value: "Tap on the surface",
+            comment: "Bold part of the hint telling the user to tap a surface to place the fitting box")
+        static let description = NSLocalizedString(
+            "parcelFitting.coaching.tapHint.description",
+            value: "to place the fitting box",
+            comment: "Regular part of the hint following the bold 'Tap on the surface' text")
+    }
+}

--- a/Modules/Sources/ParcelFittingCheck/Sizing/ARTapHintCard.swift
+++ b/Modules/Sources/ParcelFittingCheck/Sizing/ARTapHintCard.swift
@@ -5,9 +5,7 @@ struct ARTapHintCard: View {
         ARGlassCard {
             ARHintRow(
                 iconName: "hand.tap",
-                label: Text(Localization.action).fontWeight(.semibold) +
-                       Text(" ") +
-                       Text(Localization.description).foregroundColor(.white.opacity(0.62))
+                label: Localization.hint
             )
         }
     }
@@ -15,13 +13,9 @@ struct ARTapHintCard: View {
 
 private extension ARTapHintCard {
     enum Localization {
-        static let action = NSLocalizedString(
-            "parcelFitting.coaching.tapHint.action",
-            value: "Tap on the surface",
-            comment: "Bold part of the hint telling the user to tap a surface to place the fitting box")
-        static let description = NSLocalizedString(
-            "parcelFitting.coaching.tapHint.description",
-            value: "to place the fitting box",
-            comment: "Regular part of the hint following the bold 'Tap on the surface' text")
+        static let hint = NSLocalizedString(
+            "parcelFitting.coaching.tapHint",
+            value: "Tap on the surface to place the fitting box",
+            comment: "Hint telling the user to tap a detected surface to place the fitting box in AR")
     }
 }

--- a/Modules/Tests/ParcelFittingCheckTests/ARParcelFittingResultsViewModelTests.swift
+++ b/Modules/Tests/ParcelFittingCheckTests/ARParcelFittingResultsViewModelTests.swift
@@ -173,7 +173,6 @@ struct ARParcelFittingResultsViewModelTests {
         let event = try #require(analytics.lastEvent)
         #expect(event.name == "arfitting_browse_all_packages_tapped")
     }
-
 }
 
 // MARK: - Helpers

--- a/Modules/Tests/ParcelFittingCheckTests/ARParcelSizingViewModelTests.swift
+++ b/Modules/Tests/ParcelFittingCheckTests/ARParcelSizingViewModelTests.swift
@@ -174,7 +174,7 @@ struct ARParcelSizingViewModelTests {
 
     struct HintVisibility {
 
-        @Test func test_onBoxPlaced_when_first_launch_then_hintsVisible_is_true() {
+        @Test func test_onBoxPlaced_when_first_placement_then_hintsVisible_is_true() {
             // Given
             let sut = makeSUT()
 
@@ -185,7 +185,19 @@ struct ARParcelSizingViewModelTests {
             #expect(sut.hintsVisible == true)
         }
 
-        @Test func test_onBoxPlaced_when_previously_dismissed_then_hintsVisible_is_false() {
+        @Test func test_onBoxPlaced_when_second_placement_then_hintsVisible_is_false() {
+            // Given
+            let sut = makeSUT()
+            sut.onBoxPlaced()
+
+            // When
+            sut.onBoxPlaced()
+
+            // Then
+            #expect(sut.hintsVisible == false)
+        }
+
+        @Test func test_onBoxPlaced_when_previously_seen_then_hintsVisible_is_false() {
             // Given
             let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
             defaults.set(true, forKey: ARParcelSizingViewModel.Constants.hintsSeenKey)
@@ -210,12 +222,11 @@ struct ARParcelSizingViewModelTests {
             #expect(sut.hintsVisible == false)
         }
 
-        @Test func test_dismissHints_then_new_instance_remembers_dismissal() {
+        @Test func test_onBoxPlaced_persists_then_new_instance_starts_collapsed() {
             // Given
             let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
             let first = makeSUT(defaults: defaults)
             first.onBoxPlaced()
-            first.dismissHints()
 
             // When
             let second = makeSUT(defaults: defaults)
@@ -228,28 +239,14 @@ struct ARParcelSizingViewModelTests {
         @Test func test_showHints_then_sets_hintsVisible_true() {
             // Given
             let sut = makeSUT()
+            sut.onBoxPlaced()
             sut.dismissHints()
-            #expect(sut.hintsVisible == false)
 
             // When
             sut.showHints()
 
             // Then
             #expect(sut.hintsVisible == true)
-        }
-
-        @Test func test_dismissHints_then_onBoxPlaced_then_hintsVisible_stays_false() {
-            // Given
-            let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
-            let sut = makeSUT(defaults: defaults)
-            sut.onBoxPlaced()
-            sut.dismissHints()
-
-            // When
-            sut.onBoxPlaced()
-
-            // Then
-            #expect(sut.hintsVisible == false)
         }
     }
 }

--- a/Modules/Tests/ParcelFittingCheckTests/ARParcelSizingViewModelTests.swift
+++ b/Modules/Tests/ParcelFittingCheckTests/ARParcelSizingViewModelTests.swift
@@ -171,9 +171,92 @@ struct ARParcelSizingViewModelTests {
             #expect(event.hasProperty("reset_count", value: "0"))
         }
     }
+
+    struct HintVisibility {
+
+        @Test func test_onBoxPlaced_when_first_launch_then_hintsVisible_is_true() {
+            // Given
+            let sut = makeSUT()
+
+            // When
+            sut.onBoxPlaced()
+
+            // Then
+            #expect(sut.hintsVisible == true)
+        }
+
+        @Test func test_onBoxPlaced_when_previously_dismissed_then_hintsVisible_is_false() {
+            // Given
+            let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+            defaults.set(true, forKey: ARParcelSizingViewModel.Constants.hintsSeenKey)
+            let sut = makeSUT(defaults: defaults)
+
+            // When
+            sut.onBoxPlaced()
+
+            // Then
+            #expect(sut.hintsVisible == false)
+        }
+
+        @Test func test_dismissHints_then_sets_hintsVisible_false() {
+            // Given
+            let sut = makeSUT()
+            sut.onBoxPlaced()
+
+            // When
+            sut.dismissHints()
+
+            // Then
+            #expect(sut.hintsVisible == false)
+        }
+
+        @Test func test_dismissHints_then_new_instance_remembers_dismissal() {
+            // Given
+            let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+            let first = makeSUT(defaults: defaults)
+            first.onBoxPlaced()
+            first.dismissHints()
+
+            // When
+            let second = makeSUT(defaults: defaults)
+            second.onBoxPlaced()
+
+            // Then
+            #expect(second.hintsVisible == false)
+        }
+
+        @Test func test_showHints_then_sets_hintsVisible_true() {
+            // Given
+            let sut = makeSUT()
+            sut.dismissHints()
+            #expect(sut.hintsVisible == false)
+
+            // When
+            sut.showHints()
+
+            // Then
+            #expect(sut.hintsVisible == true)
+        }
+
+        @Test func test_dismissHints_then_onBoxPlaced_then_hintsVisible_stays_false() {
+            // Given
+            let defaults = UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+            let sut = makeSUT(defaults: defaults)
+            sut.onBoxPlaced()
+            sut.dismissHints()
+
+            // When
+            sut.onBoxPlaced()
+
+            // Then
+            #expect(sut.hintsVisible == false)
+        }
+    }
 }
 
 private func makeSUT(unit: UnitLength = .centimeters,
-                     analytics: ParcelFittingAnalyticsTracking = MockParcelFittingAnalytics()) -> ARParcelSizingViewModel {
-    ARParcelSizingViewModel(unit: unit, analytics: analytics)
+                     analytics: ParcelFittingAnalyticsTracking = MockParcelFittingAnalytics(),
+                     defaults: UserDefaults? = nil) -> ARParcelSizingViewModel {
+    let store = defaults ?? UserDefaults(suiteName: "test-\(UUID().uuidString)")!
+    return ARParcelSizingViewModel(unit: unit, analytics: analytics, defaults: store)
 }


### PR DESCRIPTION
## Description

Adds coaching UI cards to the AR package sizing flow to guide users through surface-tap and box-manipulation gestures. Replaces the previous capsule header + standalone CTA with a richer set of glass-surface cards:

- **ARGlassCard** — reusable dark glass card container (used by all coaching views and footer)
- **ARHintRow** — shared icon tile + label row component
- **ARTapHintCard** — pre-placement "Tap on the surface" hint
- **ARCoachCard** — post-placement coaching (Drag/Twist/Pinch gestures) with dismiss
- **ARSizingFooterHUD** — bottom HUD with MEASURED label, L/W/H dimension tiles, info button, and CTA
- **ARDimensionTile** — individual dimension display with label, value, and unit

The coaching card shows expanded on the first box placement ever (persisted via UserDefaults), then defaults to collapsed on subsequent placements. Users can always reopen via the (i) button in the footer.

## Test Steps

1. Log in with these [credentials](https://mc.a8c.com/secret-store/?secret_id=14371)
2. Enable the arParcelFitting FF
3. Navigate Orders -> Scroll to bottom -> Open order `#45 Adam Borbas`
1. Open the AR parcel sizing
4. Place a box on a surface
5. Verify the coaching card appears expanded with Drag/Twist/Pinch hints
6. Dismiss the coaching card
7. Verify it collapses and the footer shows the info button
8. Leave and re-enter the AR screen, place again
9.  Verify the coaching card stays collapsed
10. Tap the info button
11. Verify the coaching card reappears
12. Verify the footer HUD shows MEASURED, L/W/H tiles, and CTA button
13. Verify the CTA confirms dimensions correctly

## Screenshots

| Hint | Tutorial expanded | Tutorial collapsed |
| --- | --- | --- |
| <img width="1170" height="2532" alt="IMG_0156" src="https://github.com/user-attachments/assets/1ea8fdb2-f1fa-4207-9f67-56e20a5ae377" /> | <img width="1170" height="2532" alt="IMG_0157" src="https://github.com/user-attachments/assets/fb67a10e-f4b8-4e3c-89df-ec7c81aa688d" /> | <img width="1170" height="2532" alt="IMG_0158" src="https://github.com/user-attachments/assets/07de27a9-3549-449d-b320-fd5632c5de3c" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.