### PR TITLE
[POS] Cherry-pick $0 product checkout crash fix to 24.7

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderPriceChangeDetector.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderPriceChangeDetector.swift
@@ -47,14 +47,25 @@ private extension POSOrderPriceChangeDetector {
         default:
             priceString = nil
         }
-        guard let priceString else { return nil }
-        return NSDecimalNumber(string: priceString)
+        // `Decimal(string:)` returns nil for empty/invalid input. `NSDecimalNumber(string:)`
+        // returns `.notANumber`, which raises on subsequent arithmetic — the source of
+        // the production overflow crash this helper has hit.
+        guard let priceString,
+              let decimal = Decimal(string: priceString) else { return nil }
+        return NSDecimalNumber(decimal: decimal)
     }
 
     func priceMatches(_ cartUnitPrice: NSDecimalNumber, orderItem: OrderItem) -> Bool {
         let expectedLineTotal = cartUnitPrice.multiplying(by: NSDecimalNumber(decimal: orderItem.quantity))
-        let exTaxSubtotal = NSDecimalNumber(string: orderItem.subtotal)
-        let taxInclusiveSubtotal = exTaxSubtotal.adding(NSDecimalNumber(string: orderItem.subtotalTax))
+        // If the order's subtotal can't be parsed there's nothing to compare against —
+        // trust the server and don't flag a price change so we don't block checkout.
+        guard let subtotalDecimal = Decimal(string: orderItem.subtotal) else { return true }
+        let exTaxSubtotal = NSDecimalNumber(decimal: subtotalDecimal)
+        // `subtotalTax` is empty for tax-exempt items, fees, or zero-tax jurisdictions.
+        // Treat unparseable / empty as zero rather than letting `.notANumber` propagate
+        // and raise on the `.adding(...)` below.
+        let taxDecimal = Decimal(string: orderItem.subtotalTax) ?? 0
+        let taxInclusiveSubtotal = exTaxSubtotal.adding(NSDecimalNumber(decimal: taxDecimal))
 
         return approximatelyEqual(expectedLineTotal, exTaxSubtotal)
             || approximatelyEqual(expectedLineTotal, taxInclusiveSubtotal)


### PR DESCRIPTION
## Description

Cherry-picks the fix for the POS `NSDecimalNumber` overflow crash from trunk (`f053b318`) onto `release/24.7`.

Tapping "Check out" in POS crashes the app when the cart includes any product with a `$0` price (with or without other non-zero priced products). Root cause: `NSDecimalNumber(string:)` returns `.notANumber` for empty/unparseable input, and subsequent arithmetic on `.notANumber` raises an overflow exception. `subtotalTax` is empty for tax-exempt items, fees, or zero-tax jurisdictions, which triggered the crash via `priceMatches` in `POSOrderPriceChangeDetector`.

The fix switches to `Decimal(string:)` (returns `nil` on bad input), treats empty `subtotalTax` as `0`, and short-circuits unparseable `subtotal` to "matches" so we trust the server rather than block checkout.

Issue: WOOMOB-3097
Sentry: https://a8c.sentry.io/issues/7481440127/?project=1458804&referrer=project-issue-stream
Original PR / commit: https://github.com/woocommerce/woocommerce-ios/commit/f053b318f5b070c3114108f37013c79f5fdc32f2

## Test Steps

1. Log in to a store eligible for POS with at least one POS-eligible product priced at `$0`.
2. Enter POS.
3. Add the `$0` product to the cart (optionally with other non-zero priced products).
4. Tap to continue checkout.
5. Verify the checkout flow proceeds without crashing. (vs. crash is reproducible in TestFlight 24.7.0.3)
6. Repeat for a cart with only non-zero priced items to verify no regression in the happy path.

## Screenshots


https://github.com/user-attachments/assets/a02a58ad-54bc-443f-a150-12eda31de6b3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.