### PR TITLE
Debounce and conflate notification preference saves

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -2,12 +2,25 @@ import SwiftUI
 import Yosemite
 
 final class PushNotificationPreferencesHostingController: UIHostingController<PushNotificationPreferencesView> {
+    private let viewModel: PushNotificationPreferencesViewModel
+
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         let viewModel = PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
+        self.viewModel = viewModel
         super.init(rootView: PushNotificationPreferencesView(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Only flush when the screen is actually leaving the stack — `viewWillDisappear`
+        // also fires when another screen is pushed on top, and we don't want to end
+        // the debounce queue in that case.
+        if isMovingFromParent || isBeingDismissed {
+            viewModel.flushPendingSaves()
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -14,11 +14,11 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        // Only flush when the screen is actually leaving the stack — `viewWillDisappear`
-        // also fires when another screen is pushed on top, and we don't want to end
-        // the debounce queue in that case.
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // Flush after the transition is finalised so an interactive back-swipe
+        // the user then cancels doesn't tear down the save pipeline. Both flags
+        // remain valid during `viewDidDisappear`.
         if isMovingFromParent || isBeingDismissed {
             viewModel.flushPendingSaves()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -5,8 +5,13 @@ import Yosemite
 /// View model backing `PushNotificationPreferencesView`.
 ///
 /// Loads the per-site push notification preferences served by the Woo-driven
-/// push system (`wc-push-notifications/preferences`) and dispatches partial
-/// updates back through Yosemite when toggles are flipped.
+/// push system (`wc-push-notifications/preferences`) and writes back partial
+/// updates through Yosemite when toggles are flipped.
+///
+/// Saves are debounced and conflated: rapid edits coalesce into a single
+/// network call ~`debounceDelay` after the *last* change. While a save is in
+/// flight, further edits are queued behind it via a single-slot drop-oldest
+/// stream — newer edits replace older queued ones, so saves never stack.
 ///
 @MainActor
 @Observable
@@ -20,19 +25,53 @@ final class PushNotificationPreferencesViewModel {
 
     private(set) var loadState: LoadState = .loading
 
-    private(set) var isStoreOrderEnabled: Bool = false
-    private(set) var isStoreReviewEnabled: Bool = false
-    private(set) var isStoreStockEnabled: Bool = false
+    var isStoreOrderEnabled: Bool { displayed?.storeOrder?.enabled ?? false }
+    var isStoreReviewEnabled: Bool { displayed?.storeReview?.enabled ?? false }
+    var isStoreStockEnabled: Bool { displayed?.storeStock?.enabled ?? false }
 
     var errorNotice: Notice?
 
     private let siteID: Int64
     private let stores: StoresManager
-    private var preferences: PushNotificationPreferences?
+    private let debounceDelay: Duration
+    private let clock: any Clock<Duration>
 
-    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+    /// Optimistic UI snapshot — what the toggles currently show.
+    private var displayed: PushNotificationPreferences?
+    /// Last server-confirmed snapshot. The diff against this drives the payload.
+    private var lastSaved: PushNotificationPreferences?
+    /// Payload that's currently being saved. `nil` when no save is in flight.
+    private var inFlight: PushNotificationPreferences?
+
+    private var debounceTask: Task<Void, Never>?
+    private let saveTrigger: AsyncStream<Void>
+    private let saveTriggerContinuation: AsyncStream<Void>.Continuation
+    private var saveConsumerTask: Task<Void, Never>?
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         debounceDelay: Duration = .milliseconds(1000),
+         clock: any Clock<Duration> = ContinuousClock()) {
         self.siteID = siteID
         self.stores = stores
+        self.debounceDelay = debounceDelay
+        self.clock = clock
+        let (stream, continuation) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
+        self.saveTrigger = stream
+        self.saveTriggerContinuation = continuation
+        // Weak self so the consumer doesn't keep the view model alive while
+        // suspended on `next()`. When the continuation is finished (in `deinit`
+        // or `flushPendingSaves`), `next()` resolves to `nil` and the loop exits.
+        self.saveConsumerTask = Task { [weak self, stream] in
+            for await _ in stream {
+                guard !Task.isCancelled, let self else { break }
+                await self.processSave()
+            }
+        }
+    }
+
+    deinit {
+        saveTriggerContinuation.finish()
     }
 
     func load() async {
@@ -43,7 +82,13 @@ final class PushNotificationPreferencesViewModel {
                     continuation.resume(with: result)
                 })
             }
-            apply(preferences: preferences)
+            // Only let fresh server data overwrite the UI when the user has no
+            // unsaved edits and nothing is being written. Otherwise the screen
+            // would flicker back to the server's view of the world mid-edit.
+            if displayed == nil && inFlight == nil {
+                displayed = preferences
+            }
+            lastSaved = preferences
             loadState = .loaded
         } catch {
             DDLogError("⛔️ Error loading push notification preferences for siteID=\(siteID): \(error)")
@@ -51,89 +96,152 @@ final class PushNotificationPreferencesViewModel {
         }
     }
 
-    // Optimistic-update setters. If two flips of the same toggle race, only the latest revert
-    // can run — the earlier closure no-ops because the toggle has since changed. Out-of-order
-    // server responses can still produce a stale final state; acceptable for a 3-row screen
-    // where rapid double-flips are not a real user flow.
     func setStoreOrderEnabled(_ newValue: Bool) {
-        let previous = isStoreOrderEnabled
-        isStoreOrderEnabled = newValue
-        // `StoreOrder` is sent as a complete object (`minAmount: nil` serializes as JSON
-        // `null`, which the server interprets as "clear threshold"). Preserve the loaded
-        // threshold so toggling the master switch doesn't wipe it.
-        let changes = PushNotificationPreferences(
-            storeOrder: .init(enabled: newValue, minAmount: preferences?.storeOrder?.minAmount)
-        )
-        update(changes: changes, revert: { [weak self] in
-            guard let self, self.isStoreOrderEnabled == newValue else { return }
-            self.isStoreOrderEnabled = previous
-        })
+        // `StoreOrder` is sent as a complete object (`minAmount: nil` serializes
+        // as JSON `null`, which the server interprets as "clear threshold").
+        // Preserve the loaded threshold so toggling the master switch doesn't
+        // wipe it.
+        updateDisplayed { base in
+            base.with(storeOrder: .init(enabled: newValue, minAmount: base.storeOrder?.minAmount))
+        }
     }
 
     func setStoreReviewEnabled(_ newValue: Bool) {
-        let previous = isStoreReviewEnabled
-        isStoreReviewEnabled = newValue
-        let changes = PushNotificationPreferences(storeReview: .init(enabled: newValue))
-        update(changes: changes, revert: { [weak self] in
-            guard let self, self.isStoreReviewEnabled == newValue else { return }
-            self.isStoreReviewEnabled = previous
-        })
+        updateDisplayed { base in
+            base.with(storeReview: .init(enabled: newValue, maxRating: base.storeReview?.maxRating))
+        }
     }
 
     func setStoreStockEnabled(_ newValue: Bool) {
-        let previous = isStoreStockEnabled
-        isStoreStockEnabled = newValue
-        let changes = PushNotificationPreferences(storeStock: .init(enabled: newValue))
-        update(changes: changes, revert: { [weak self] in
-            guard let self, self.isStoreStockEnabled == newValue else { return }
-            self.isStoreStockEnabled = previous
-        })
+        updateDisplayed { base in
+            let existing = base.storeStock
+            return base.with(storeStock: .init(enabled: newValue,
+                                               lowStock: existing?.lowStock,
+                                               outOfStock: existing?.outOfStock,
+                                               onBackorder: existing?.onBackorder))
+        }
+    }
+
+    /// Flushes any pending unsaved edits immediately, bypassing the debounce.
+    ///
+    /// Call this when the screen is about to be dismissed. The dispatch is
+    /// fire-and-forget — the network request continues even after the view
+    /// model is deallocated, since the store retains the completion closure.
+    func flushPendingSaves() {
+        debounceTask?.cancel()
+        saveTriggerContinuation.finish()
+        saveConsumerTask?.cancel()
+
+        // Diff against the in-flight snapshot (if any) so we don't re-send
+        // sections already on the wire. `inFlight` is always a full snapshot
+        // of what was being saved, so it doubles as the post-save baseline.
+        guard let displayed,
+              case let pendingDiff = makeDiff(from: inFlight ?? lastSaved, to: displayed),
+              !pendingDiff.isEmpty else {
+            return
+        }
+
+        stores.dispatch(NotificationAction.updatePushNotificationPreferences(
+            siteID: siteID, changes: pendingDiff) { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Error flushing push notification preferences on dismissal: \(error)")
+                }
+            })
     }
 }
 
 private extension PushNotificationPreferencesViewModel {
 
-    func update(changes: PushNotificationPreferences, revert: @escaping @MainActor () -> Void) {
-        Task { @MainActor in
+    /// Updates `displayed` by applying `transform` to the current best-known
+    /// state and (re)starts the debounce countdown. The previous debounce task
+    /// — if any — is cancelled, so a fresh edit always resets the timer.
+    func updateDisplayed(_ transform: (PushNotificationPreferences) -> PushNotificationPreferences) {
+        let base = displayed ?? lastSaved ?? PushNotificationPreferences()
+        displayed = transform(base)
+
+        debounceTask?.cancel()
+        let continuation = saveTriggerContinuation
+        let clock = self.clock
+        let delay = debounceDelay
+        debounceTask = Task {
             do {
-                let preferences = try await withCheckedThrowingContinuation { continuation in
-                    stores.dispatch(NotificationAction.updatePushNotificationPreferences(siteID: siteID,
-                                                                                         changes: changes) { result in
-                        continuation.resume(with: result)
-                    })
-                }
-                // Apply only the fields we explicitly updated. Concurrent in-flight requests for
-                // other toggles must keep their optimistic state; an earlier response's view of
-                // those fields is stale by definition.
-                apply(preferences: preferences, fields: changes)
+                try await clock.sleep(for: delay)
             } catch {
-                DDLogError("⛔️ Error updating push notification preferences: \(error)")
-                revert()
+                // Cancelled by a newer edit (or by `flushPendingSaves`).
+                return
+            }
+            continuation.yield()
+        }
+    }
+
+    func processSave() async {
+        guard let displayedSnapshot = displayed else { return }
+        let pendingDiff = makeDiff(from: lastSaved, to: displayedSnapshot)
+        // Empty diff (e.g. on/off within the debounce window) short-circuits
+        // before hitting the network.
+        guard !pendingDiff.isEmpty else { return }
+
+        inFlight = displayedSnapshot
+        let result: Result<PushNotificationPreferences, Error> = await withCheckedContinuation { continuation in
+            stores.dispatch(NotificationAction.updatePushNotificationPreferences(
+                siteID: siteID, changes: pendingDiff) { result in
+                    continuation.resume(returning: result)
+                })
+        }
+
+        switch result {
+        case .success(let server):
+            lastSaved = server
+            // Only stomp the UI with server data if the user hasn't made newer
+            // edits while this request was in flight.
+            if displayed == inFlight {
+                displayed = server
+            }
+        case .failure(let error):
+            DDLogError("⛔️ Error updating push notification preferences: \(error)")
+            // Roll back only when the user hasn't moved on — newer edits must
+            // not be stomped by an older request's failure. If no prior save
+            // ever succeeded, `lastSaved` is `nil` and `displayed` becomes
+            // `nil`, which makes the computed toggles read `false`.
+            if displayed == inFlight {
+                displayed = lastSaved
                 errorNotice = Notice(title: Localization.errorNoticeTitle,
                                      message: Localization.errorNoticeMessage,
                                      feedbackType: .error)
             }
         }
+        inFlight = nil
     }
 
-    func apply(preferences: PushNotificationPreferences) {
-        self.preferences = preferences
-        isStoreOrderEnabled = preferences.storeOrder?.enabled ?? false
-        isStoreReviewEnabled = preferences.storeReview?.enabled ?? false
-        isStoreStockEnabled = preferences.storeStock?.enabled ?? false
+    /// Returns a `PushNotificationPreferences` populated only with sections that
+    /// differ between `baseline` and `target`. Comparison is whole-section so
+    /// any change inside `storeOrder`/`storeReview`/`storeStock` emits the
+    /// section as a complete object (matching the server's section-level merge).
+    func makeDiff(from baseline: PushNotificationPreferences?,
+                  to target: PushNotificationPreferences) -> PushNotificationPreferences {
+        PushNotificationPreferences(
+            storeOrder: target.storeOrder != baseline?.storeOrder ? target.storeOrder : nil,
+            storeReview: target.storeReview != baseline?.storeReview ? target.storeReview : nil,
+            storeStock: target.storeStock != baseline?.storeStock ? target.storeStock : nil
+        )
+    }
+}
+
+private extension PushNotificationPreferences {
+    var isEmpty: Bool {
+        storeOrder == nil && storeReview == nil && storeStock == nil
     }
 
-    func apply(preferences: PushNotificationPreferences, fields: PushNotificationPreferences) {
-        self.preferences = preferences
-        if fields.storeOrder != nil {
-            isStoreOrderEnabled = preferences.storeOrder?.enabled ?? false
-        }
-        if fields.storeReview != nil {
-            isStoreReviewEnabled = preferences.storeReview?.enabled ?? false
-        }
-        if fields.storeStock != nil {
-            isStoreStockEnabled = preferences.storeStock?.enabled ?? false
-        }
+    func with(storeOrder: StoreOrder) -> Self {
+        .init(storeOrder: storeOrder, storeReview: storeReview, storeStock: storeStock)
+    }
+
+    func with(storeReview: StoreReview) -> Self {
+        .init(storeOrder: storeOrder, storeReview: storeReview, storeStock: storeStock)
+    }
+
+    func with(storeStock: StoreStock) -> Self {
+        .init(storeOrder: storeOrder, storeReview: storeReview, storeStock: storeStock)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Observation
 import Yosemite
@@ -10,8 +11,8 @@ import Yosemite
 ///
 /// Saves are debounced and conflated: rapid edits coalesce into a single
 /// network call ~`debounceDelay` after the *last* change. While a save is in
-/// flight, further edits are queued behind it via a single-slot drop-oldest
-/// stream — newer edits replace older queued ones, so saves never stack.
+/// flight, further edits collapse to a single follow-up save that fires once
+/// the in-flight one completes.
 ///
 @MainActor
 @Observable
@@ -33,8 +34,6 @@ final class PushNotificationPreferencesViewModel {
 
     private let siteID: Int64
     private let stores: StoresManager
-    private let debounceDelay: Duration
-    private let clock: any Clock<Duration>
 
     /// Optimistic UI snapshot — what the toggles currently show.
     private var displayed: PushNotificationPreferences?
@@ -43,35 +42,25 @@ final class PushNotificationPreferencesViewModel {
     /// Payload that's currently being saved. `nil` when no save is in flight.
     private var inFlight: PushNotificationPreferences?
 
-    private var debounceTask: Task<Void, Never>?
-    private let saveTrigger: AsyncStream<Void>
-    private let saveTriggerContinuation: AsyncStream<Void>.Continuation
-    private var saveConsumerTask: Task<Void, Never>?
+    private let editSubject = PassthroughSubject<Void, Never>()
+    private var subscriptions: Set<AnyCancellable> = []
+    /// The currently running save, if any. Drives serialisation: only one
+    /// `processSave` runs at a time.
+    private var saveTask: Task<Void, Never>?
+    /// Set when a save trigger arrives during an in-flight save. Drives the
+    /// drop-oldest, conflate follow-up: multiple triggers collapse to one
+    /// follow-up save fired after the in-flight one completes.
+    private var pendingSaveAfterInFlight = false
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         debounceDelay: Duration = .milliseconds(1000),
-         clock: any Clock<Duration> = ContinuousClock()) {
+         debounceDelay: DispatchQueue.SchedulerTimeType.Stride = .seconds(1)) {
         self.siteID = siteID
         self.stores = stores
-        self.debounceDelay = debounceDelay
-        self.clock = clock
-        let (stream, continuation) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingNewest(1))
-        self.saveTrigger = stream
-        self.saveTriggerContinuation = continuation
-        // Weak self so the consumer doesn't keep the view model alive while
-        // suspended on `next()`. When the continuation is finished (in `deinit`
-        // or `flushPendingSaves`), `next()` resolves to `nil` and the loop exits.
-        self.saveConsumerTask = Task { [weak self, stream] in
-            for await _ in stream {
-                guard !Task.isCancelled, let self else { break }
-                await self.processSave()
-            }
-        }
-    }
-
-    deinit {
-        saveTriggerContinuation.finish()
+        editSubject
+            .debounce(for: debounceDelay, scheduler: DispatchQueue.main)
+            .sink { [weak self] in self?.enqueueSave() }
+            .store(in: &subscriptions)
     }
 
     func load() async {
@@ -128,10 +117,6 @@ final class PushNotificationPreferencesViewModel {
     /// fire-and-forget — the network request continues even after the view
     /// model is deallocated, since the store retains the completion closure.
     func flushPendingSaves() {
-        debounceTask?.cancel()
-        saveTriggerContinuation.finish()
-        saveConsumerTask?.cancel()
-
         // Diff against the in-flight snapshot (if any) so we don't re-send
         // sections already on the wire. `inFlight` is always a full snapshot
         // of what was being saved, so it doubles as the post-save baseline.
@@ -152,25 +137,34 @@ final class PushNotificationPreferencesViewModel {
 
 private extension PushNotificationPreferencesViewModel {
 
-    /// Updates `displayed` by applying `transform` to the current best-known
-    /// state and (re)starts the debounce countdown. The previous debounce task
-    /// — if any — is cancelled, so a fresh edit always resets the timer.
+    /// Updates `displayed` by applying `transform` and pings the debounce
+    /// subject so a save fires `debounceDelay` after the last edit.
     func updateDisplayed(_ transform: (PushNotificationPreferences) -> PushNotificationPreferences) {
         let base = displayed ?? lastSaved ?? PushNotificationPreferences()
         displayed = transform(base)
+        editSubject.send()
+    }
 
-        debounceTask?.cancel()
-        let continuation = saveTriggerContinuation
-        let clock = self.clock
-        let delay = debounceDelay
-        debounceTask = Task {
-            do {
-                try await clock.sleep(for: delay)
-            } catch {
-                // Cancelled by a newer edit (or by `flushPendingSaves`).
-                return
+    /// Called when the debounce timer fires. Starts a save if none is running;
+    /// otherwise flips a flag so a single follow-up save fires after the
+    /// in-flight one completes.
+    func enqueueSave() {
+        guard saveTask == nil else {
+            pendingSaveAfterInFlight = true
+            return
+        }
+        startSave()
+    }
+
+    func startSave() {
+        saveTask = Task { @MainActor [weak self] in
+            await self?.processSave()
+            guard let self else { return }
+            self.saveTask = nil
+            if self.pendingSaveAfterInFlight {
+                self.pendingSaveAfterInFlight = false
+                self.startSave()
             }
-            continuation.yield()
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -23,7 +23,7 @@ struct PushNotificationPreferencesViewModelTests {
 
     // MARK: - Loading
 
-    @Test func test_load_when_remote_succeeds_then_loadState_becomes_loaded_and_toggles_reflect_response() async {
+    @Test func test_load_when_remote_succeeds_then_loadState_becomes_loaded_and_toggles_reflect_response() async throws {
         // Given
         let stores = makeStores()
         let response = PushNotificationPreferences(
@@ -48,7 +48,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.isStoreStockEnabled == true)
     }
 
-    @Test func test_load_when_remote_fails_then_loadState_becomes_error() async {
+    @Test func test_load_when_remote_fails_then_loadState_becomes_error() async throws {
         // Given
         struct AnyError: Error {}
         let stores = makeStores()
@@ -66,7 +66,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.loadState == .error)
     }
 
-    @Test func test_load_when_unsaved_edits_exist_then_response_does_not_stomp_displayed_state() async {
+    @Test func test_load_when_unsaved_edits_exist_then_response_does_not_stomp_displayed_state() async throws {
         // Given the user has flipped a toggle (creating an unsaved edit) before a fresh load.
         let stores = makeStores()
         let response = PushNotificationPreferences(
@@ -94,7 +94,7 @@ struct PushNotificationPreferencesViewModelTests {
         async let load: () = sut.load()
         // Wait until `load()` has actually registered its continuation, otherwise
         // resolving the handler too early no-ops and the test hangs.
-        _ = await wait { pendingLoadCompletion.handler != nil }
+        _ = try await wait { pendingLoadCompletion.handler != nil }
         pendingLoadCompletion.handler?(.success(response))
         await load
 
@@ -104,7 +104,7 @@ struct PushNotificationPreferencesViewModelTests {
 
     // MARK: - Individual setters
 
-    @Test func test_setStoreOrderEnabled_dispatches_update_with_only_store_order_field() async {
+    @Test func test_setStoreOrderEnabled_dispatches_update_with_only_store_order_field() async throws {
         // Given
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -118,7 +118,7 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreOrderEnabled(true)
-        _ = await wait { dispatched.calls.count >= 1 }
+        _ = try await wait { dispatched.calls.count >= 1 }
 
         // Then
         #expect(dispatched.calls.count == 1)
@@ -127,7 +127,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(dispatched.last?.storeStock == nil)
     }
 
-    @Test func test_setStoreReviewEnabled_dispatches_update_with_only_store_review_field() async {
+    @Test func test_setStoreReviewEnabled_dispatches_update_with_only_store_review_field() async throws {
         // Given
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -141,7 +141,7 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreReviewEnabled(true)
-        _ = await wait { dispatched.calls.count >= 1 }
+        _ = try await wait { dispatched.calls.count >= 1 }
 
         // Then
         #expect(dispatched.last?.storeReview?.enabled == true)
@@ -149,7 +149,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(dispatched.last?.storeStock == nil)
     }
 
-    @Test func test_setStoreStockEnabled_dispatches_update_with_only_store_stock_field() async {
+    @Test func test_setStoreStockEnabled_dispatches_update_with_only_store_stock_field() async throws {
         // Given
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -163,7 +163,7 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreStockEnabled(true)
-        _ = await wait { dispatched.calls.count >= 1 }
+        _ = try await wait { dispatched.calls.count >= 1 }
 
         // Then
         #expect(dispatched.last?.storeStock?.enabled == true)
@@ -173,7 +173,7 @@ struct PushNotificationPreferencesViewModelTests {
 
     // MARK: - Debounce and conflate
 
-    @Test func test_three_rapid_setter_calls_coalesce_into_one_dispatch_with_all_fields() async {
+    @Test func test_three_rapid_setter_calls_coalesce_into_one_dispatch_with_all_fields() async throws {
         // Given
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -190,10 +190,10 @@ struct PushNotificationPreferencesViewModelTests {
         sut.setStoreOrderEnabled(true)
         sut.setStoreReviewEnabled(true)
         sut.setStoreStockEnabled(true)
-        _ = await wait { dispatched.calls.count >= 1 }
+        _ = try await wait { dispatched.calls.count >= 1 }
         // Give the consumer a comfortable window to fire a (would-be) second dispatch
         // if conflation isn't working, then re-check.
-        try? await Task.sleep(for: .milliseconds(50))
+        try await Task.sleep(for: .milliseconds(50))
 
         // Then exactly one dispatch fired carrying all three changed sections.
         #expect(dispatched.calls.count == 1)
@@ -202,7 +202,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(dispatched.last?.storeStock?.enabled == true)
     }
 
-    @Test func test_edits_while_save_in_flight_are_queued_then_dispatched_after_completion() async {
+    @Test func test_edits_while_save_in_flight_are_queued_then_dispatched_after_completion() async throws {
         // Given a mock that holds the first dispatch's completion to keep it in flight.
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -222,17 +222,17 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When the first save starts and the user flips two more toggles while it's in flight.
         sut.setStoreOrderEnabled(true)
-        _ = await wait { dispatched.calls.count >= 1 && firstCompletion.handler != nil }
+        _ = try await wait { dispatched.calls.count >= 1 && firstCompletion.handler != nil }
 
         sut.setStoreReviewEnabled(true)
         sut.setStoreStockEnabled(true)
         // Allow the queue to settle; we expect at most one trigger to remain because of drop-oldest.
-        try? await Task.sleep(for: .milliseconds(30))
+        try await Task.sleep(for: .milliseconds(30))
 
         // Release the first save so the consumer picks up the queued trigger.
         firstCompletion.handler?(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
-        _ = await wait { dispatched.calls.count >= 2 }
-        try? await Task.sleep(for: .milliseconds(50))
+        _ = try await wait { dispatched.calls.count >= 2 }
+        try await Task.sleep(for: .milliseconds(50))
 
         // Then exactly two dispatches fired total.
         #expect(dispatched.calls.count == 2)
@@ -242,7 +242,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(dispatched.calls[1].storeStock?.enabled == true)
     }
 
-    @Test func test_edit_during_debounce_window_restarts_the_countdown() async {
+    @Test func test_edit_during_debounce_window_restarts_the_countdown() async throws {
         // Given a non-zero debounce so we can observe the countdown.
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -257,23 +257,23 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When the user edits, waits past most of the window, then edits again.
         sut.setStoreOrderEnabled(true)
-        try? await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(for: .milliseconds(100))
         sut.setStoreReviewEnabled(true)
 
         // Then no save has fired yet — the second edit reset the timer, so the
         // original 150ms deadline at t=150 has already been cancelled.
-        try? await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(for: .milliseconds(100))
         #expect(dispatched.calls.isEmpty)
 
         // And the save fires once after the new debounce window from the second edit.
-        _ = await wait(timeout: .milliseconds(300)) { dispatched.calls.count >= 1 }
-        try? await Task.sleep(for: .milliseconds(50))
+        _ = try await wait(timeout: .milliseconds(300)) { dispatched.calls.count >= 1 }
+        try await Task.sleep(for: .milliseconds(50))
         #expect(dispatched.calls.count == 1)
         #expect(dispatched.last?.storeOrder?.enabled == true)
         #expect(dispatched.last?.storeReview?.enabled == true)
     }
 
-    @Test func test_toggle_flipped_back_within_debounce_window_produces_no_dispatch() async {
+    @Test func test_toggle_flipped_back_within_debounce_window_produces_no_dispatch() async throws {
         // Given a non-zero debounce so we can flip on-then-off inside the window.
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -299,7 +299,7 @@ struct PushNotificationPreferencesViewModelTests {
         sut.setStoreOrderEnabled(true)
         sut.setStoreOrderEnabled(false)
         // Wait well past the debounce window.
-        try? await Task.sleep(for: .milliseconds(200))
+        try await Task.sleep(for: .milliseconds(200))
 
         // Then no update dispatch was made — the diff against `lastSaved` is empty.
         #expect(dispatched.calls.isEmpty)
@@ -307,7 +307,7 @@ struct PushNotificationPreferencesViewModelTests {
 
     // MARK: - Failure rollback
 
-    @Test func test_setStoreOrderEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
+    @Test func test_setStoreOrderEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async throws {
         // Given
         struct AnyError: Error {}
         let stores = makeStores()
@@ -321,14 +321,14 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreOrderEnabled(true)
-        _ = await wait { sut.errorNotice != nil }
+        _ = try await wait { sut.errorNotice != nil }
 
         // Then
         #expect(sut.isStoreOrderEnabled == false)
         #expect(sut.errorNotice != nil)
     }
 
-    @Test func test_setStoreReviewEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
+    @Test func test_setStoreReviewEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async throws {
         // Given
         struct AnyError: Error {}
         let stores = makeStores()
@@ -342,14 +342,14 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreReviewEnabled(true)
-        _ = await wait { sut.errorNotice != nil }
+        _ = try await wait { sut.errorNotice != nil }
 
         // Then
         #expect(sut.isStoreReviewEnabled == false)
         #expect(sut.errorNotice != nil)
     }
 
-    @Test func test_setStoreStockEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
+    @Test func test_setStoreStockEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async throws {
         // Given
         struct AnyError: Error {}
         let stores = makeStores()
@@ -363,14 +363,14 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreStockEnabled(true)
-        _ = await wait { sut.errorNotice != nil }
+        _ = try await wait { sut.errorNotice != nil }
 
         // Then
         #expect(sut.isStoreStockEnabled == false)
         #expect(sut.errorNotice != nil)
     }
 
-    @Test func test_failure_with_newer_edits_in_flight_then_optimistic_state_is_preserved() async {
+    @Test func test_failure_with_newer_edits_in_flight_then_optimistic_state_is_preserved() async throws {
         // Given the first save will fail. We hold its completion so we can flip a
         // newer toggle before the failure lands.
         struct AnyError: Error {}
@@ -393,13 +393,13 @@ struct PushNotificationPreferencesViewModelTests {
         // When the first save (order: true) is in flight, the user flips review on,
         // and then the first save fails.
         sut.setStoreOrderEnabled(true)
-        _ = await wait { firstCompletion.handler != nil }
+        _ = try await wait { firstCompletion.handler != nil }
         sut.setStoreReviewEnabled(true)
         firstCompletion.handler?(.failure(AnyError()))
 
         // Allow the failure path and the queued save to settle.
-        _ = await wait { dispatched.calls.count >= 2 }
-        try? await Task.sleep(for: .milliseconds(30))
+        _ = try await wait { dispatched.calls.count >= 2 }
+        try await Task.sleep(for: .milliseconds(30))
 
         // Then the optimistic order value is preserved (no rollback) because a
         // newer edit existed by the time the failure landed, and no error notice
@@ -411,7 +411,7 @@ struct PushNotificationPreferencesViewModelTests {
 
     // MARK: - Flush on dismissal
 
-    @Test func test_flushPendingSaves_dispatches_immediately_bypassing_debounce() async {
+    @Test func test_flushPendingSaves_dispatches_immediately_bypassing_debounce() async throws {
         // Given a long debounce that would otherwise delay the save.
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -428,12 +428,12 @@ struct PushNotificationPreferencesViewModelTests {
         sut.flushPendingSaves()
 
         // Then a dispatch fires well before the debounce window would have elapsed.
-        let fired = await wait(timeout: .milliseconds(500)) { dispatched.calls.count >= 1 }
+        let fired = try await wait(timeout: .milliseconds(500)) { dispatched.calls.count >= 1 }
         #expect(fired)
         #expect(dispatched.last?.storeOrder?.enabled == true)
     }
 
-    @Test func test_flushPendingSaves_while_save_in_flight_skips_redundant_sections() async {
+    @Test func test_flushPendingSaves_while_save_in_flight_skips_redundant_sections() async throws {
         // Given a save is in flight (its completion is held) and the user has
         // since edited a different section.
         let stores = makeStores()
@@ -454,10 +454,10 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When the first save is in flight and the user flips a different toggle, then dismisses.
         sut.setStoreOrderEnabled(true)
-        _ = await wait { firstCompletion.handler != nil }
+        _ = try await wait { firstCompletion.handler != nil }
         sut.setStoreReviewEnabled(true)
         sut.flushPendingSaves()
-        _ = await wait { dispatched.calls.count >= 2 }
+        _ = try await wait { dispatched.calls.count >= 2 }
 
         // Then the flush dispatch carries only the newer section — the in-flight
         // request is left to cover what's already on the wire.
@@ -470,7 +470,7 @@ struct PushNotificationPreferencesViewModelTests {
         firstCompletion.handler?(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
     }
 
-    @Test func test_flushPendingSaves_when_no_pending_diff_then_no_dispatch() async {
+    @Test func test_flushPendingSaves_when_no_pending_diff_then_no_dispatch() async throws {
         // Given no edits have been made.
         let stores = makeStores()
         let dispatched = DispatchedChanges()
@@ -484,7 +484,7 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.flushPendingSaves()
-        try? await Task.sleep(for: .milliseconds(50))
+        try await Task.sleep(for: .milliseconds(50))
 
         // Then no dispatch ever fires.
         #expect(dispatched.calls.isEmpty)
@@ -497,13 +497,13 @@ struct PushNotificationPreferencesViewModelTests {
     /// calls so tests aren't sensitive to scheduler timing.
     @discardableResult
     private func wait(timeout: Duration = .milliseconds(500),
-                      until condition: () -> Bool) async -> Bool {
+                      until condition: () -> Bool) async throws -> Bool {
         let deadline = ContinuousClock.now.advanced(by: timeout)
         while !condition() {
             if ContinuousClock.now > deadline {
                 return condition()
             }
-            try? await Task.sleep(for: .milliseconds(5))
+            try await Task.sleep(for: .milliseconds(5))
         }
         return true
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -8,11 +8,12 @@ struct PushNotificationPreferencesViewModelTests {
 
     private let siteID: Int64 = 123
 
-    /// Build the SUT with a zero debounce so saves fire as soon as the consumer
-    /// task gets a chance to run. Drop-oldest queueing still applies, so rapid
-    /// setter calls in the same MainActor turn still coalesce into one save.
+    /// Build the SUT with a zero debounce so saves fire on the next runloop
+    /// tick. Combine's `.debounce` still coalesces synchronous bursts of
+    /// edits, so rapid setter calls in the same MainActor turn collapse to
+    /// one save.
     private func makeSUT(stores: MockStoresManager,
-                         debounceDelay: Duration = .zero) -> PushNotificationPreferencesViewModel {
+                         debounceDelay: DispatchQueue.SchedulerTimeType.Stride = .zero) -> PushNotificationPreferencesViewModel {
         PushNotificationPreferencesViewModel(siteID: siteID, stores: stores, debounceDelay: debounceDelay)
     }
 
@@ -251,7 +252,7 @@ struct PushNotificationPreferencesViewModelTests {
                 onCompletion(.success(changes))
             }
         }
-        let debounce: Duration = .milliseconds(150)
+        let debounce: DispatchQueue.SchedulerTimeType.Stride = .milliseconds(150)
         let sut = makeSUT(stores: stores, debounceDelay: debounce)
 
         // When the user edits, waits past most of the window, then edits again.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -8,13 +8,19 @@ struct PushNotificationPreferencesViewModelTests {
 
     private let siteID: Int64 = 123
 
-    private func makeSUT(stores: MockStoresManager) -> PushNotificationPreferencesViewModel {
-        PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
+    /// Build the SUT with a zero debounce so saves fire as soon as the consumer
+    /// task gets a chance to run. Drop-oldest queueing still applies, so rapid
+    /// setter calls in the same MainActor turn still coalesce into one save.
+    private func makeSUT(stores: MockStoresManager,
+                         debounceDelay: Duration = .zero) -> PushNotificationPreferencesViewModel {
+        PushNotificationPreferencesViewModel(siteID: siteID, stores: stores, debounceDelay: debounceDelay)
     }
 
     private func makeStores() -> MockStoresManager {
         MockStoresManager(sessionManager: .testingInstance)
     }
+
+    // MARK: - Loading
 
     @Test func test_load_when_remote_succeeds_then_loadState_becomes_loaded_and_toggles_reflect_response() async {
         // Given
@@ -59,13 +65,51 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.loadState == .error)
     }
 
+    @Test func test_load_when_unsaved_edits_exist_then_response_does_not_stomp_displayed_state() async {
+        // Given the user has flipped a toggle (creating an unsaved edit) before a fresh load.
+        let stores = makeStores()
+        let response = PushNotificationPreferences(
+            storeOrder: .init(enabled: false),
+            storeReview: .init(enabled: false),
+            storeStock: .init(enabled: false)
+        )
+        let pendingLoadCompletion = PendingLoadCompletion()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .loadPushNotificationPreferences(_, onCompletion):
+                pendingLoadCompletion.handler = onCompletion
+            case let .updatePushNotificationPreferences(_, changes, onCompletion):
+                // The optimistic edit triggers a save; complete it so the SUT's
+                // consumer task doesn't leak a checked continuation.
+                onCompletion(.success(changes))
+            default:
+                break
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When the user flips a toggle before the load returns, then the load resolves.
+        sut.setStoreOrderEnabled(true)
+        async let load: () = sut.load()
+        // Wait until `load()` has actually registered its continuation, otherwise
+        // resolving the handler too early no-ops and the test hangs.
+        _ = await wait { pendingLoadCompletion.handler != nil }
+        pendingLoadCompletion.handler?(.success(response))
+        await load
+
+        // Then the optimistic UI is preserved despite the response.
+        #expect(sut.isStoreOrderEnabled == true)
+    }
+
+    // MARK: - Individual setters
+
     @Test func test_setStoreOrderEnabled_dispatches_update_with_only_store_order_field() async {
         // Given
         let stores = makeStores()
         let dispatched = DispatchedChanges()
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
-                dispatched.value = changes
+                dispatched.append(changes)
                 onCompletion(.success(changes))
             }
         }
@@ -73,13 +117,13 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreOrderEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { dispatched.calls.count >= 1 }
 
         // Then
-        #expect(dispatched.value?.storeOrder?.enabled == true)
-        #expect(dispatched.value?.storeReview == nil)
-        #expect(dispatched.value?.storeStock == nil)
+        #expect(dispatched.calls.count == 1)
+        #expect(dispatched.last?.storeOrder?.enabled == true)
+        #expect(dispatched.last?.storeReview == nil)
+        #expect(dispatched.last?.storeStock == nil)
     }
 
     @Test func test_setStoreReviewEnabled_dispatches_update_with_only_store_review_field() async {
@@ -88,7 +132,7 @@ struct PushNotificationPreferencesViewModelTests {
         let dispatched = DispatchedChanges()
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
-                dispatched.value = changes
+                dispatched.append(changes)
                 onCompletion(.success(changes))
             }
         }
@@ -96,13 +140,12 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreReviewEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { dispatched.calls.count >= 1 }
 
         // Then
-        #expect(dispatched.value?.storeReview?.enabled == true)
-        #expect(dispatched.value?.storeOrder == nil)
-        #expect(dispatched.value?.storeStock == nil)
+        #expect(dispatched.last?.storeReview?.enabled == true)
+        #expect(dispatched.last?.storeOrder == nil)
+        #expect(dispatched.last?.storeStock == nil)
     }
 
     @Test func test_setStoreStockEnabled_dispatches_update_with_only_store_stock_field() async {
@@ -111,7 +154,7 @@ struct PushNotificationPreferencesViewModelTests {
         let dispatched = DispatchedChanges()
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
-                dispatched.value = changes
+                dispatched.append(changes)
                 onCompletion(.success(changes))
             }
         }
@@ -119,14 +162,149 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreStockEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { dispatched.calls.count >= 1 }
 
         // Then
-        #expect(dispatched.value?.storeStock?.enabled == true)
-        #expect(dispatched.value?.storeOrder == nil)
-        #expect(dispatched.value?.storeReview == nil)
+        #expect(dispatched.last?.storeStock?.enabled == true)
+        #expect(dispatched.last?.storeOrder == nil)
+        #expect(dispatched.last?.storeReview == nil)
     }
+
+    // MARK: - Debounce and conflate
+
+    @Test func test_three_rapid_setter_calls_coalesce_into_one_dispatch_with_all_fields() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When three setters fire synchronously — the @MainActor consumer can't
+        // start processing until we yield, so drop-oldest collapses them to one.
+        sut.setStoreOrderEnabled(true)
+        sut.setStoreReviewEnabled(true)
+        sut.setStoreStockEnabled(true)
+        _ = await wait { dispatched.calls.count >= 1 }
+        // Give the consumer a comfortable window to fire a (would-be) second dispatch
+        // if conflation isn't working, then re-check.
+        try? await Task.sleep(for: .milliseconds(50))
+
+        // Then exactly one dispatch fired carrying all three changed sections.
+        #expect(dispatched.calls.count == 1)
+        #expect(dispatched.last?.storeOrder?.enabled == true)
+        #expect(dispatched.last?.storeReview?.enabled == true)
+        #expect(dispatched.last?.storeStock?.enabled == true)
+    }
+
+    @Test func test_edits_while_save_in_flight_are_queued_then_dispatched_after_completion() async {
+        // Given a mock that holds the first dispatch's completion to keep it in flight.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        let firstCompletion = PendingCompletion()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            guard case let .updatePushNotificationPreferences(_, changes, onCompletion) = action else {
+                return
+            }
+            dispatched.append(changes)
+            if dispatched.calls.count == 1 {
+                firstCompletion.handler = onCompletion
+            } else {
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When the first save starts and the user flips two more toggles while it's in flight.
+        sut.setStoreOrderEnabled(true)
+        _ = await wait { dispatched.calls.count >= 1 && firstCompletion.handler != nil }
+
+        sut.setStoreReviewEnabled(true)
+        sut.setStoreStockEnabled(true)
+        // Allow the queue to settle; we expect at most one trigger to remain because of drop-oldest.
+        try? await Task.sleep(for: .milliseconds(30))
+
+        // Release the first save so the consumer picks up the queued trigger.
+        firstCompletion.handler?(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
+        _ = await wait { dispatched.calls.count >= 2 }
+        try? await Task.sleep(for: .milliseconds(50))
+
+        // Then exactly two dispatches fired total.
+        #expect(dispatched.calls.count == 2)
+        // And the second dispatch carries the conflated diff for the two newer edits.
+        #expect(dispatched.calls[1].storeOrder == nil)
+        #expect(dispatched.calls[1].storeReview?.enabled == true)
+        #expect(dispatched.calls[1].storeStock?.enabled == true)
+    }
+
+    @Test func test_edit_during_debounce_window_restarts_the_countdown() async {
+        // Given a non-zero debounce so we can observe the countdown.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let debounce: Duration = .milliseconds(150)
+        let sut = makeSUT(stores: stores, debounceDelay: debounce)
+
+        // When the user edits, waits past most of the window, then edits again.
+        sut.setStoreOrderEnabled(true)
+        try? await Task.sleep(for: .milliseconds(100))
+        sut.setStoreReviewEnabled(true)
+
+        // Then no save has fired yet — the second edit reset the timer, so the
+        // original 150ms deadline at t=150 has already been cancelled.
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(dispatched.calls.isEmpty)
+
+        // And the save fires once after the new debounce window from the second edit.
+        _ = await wait(timeout: .milliseconds(300)) { dispatched.calls.count >= 1 }
+        try? await Task.sleep(for: .milliseconds(50))
+        #expect(dispatched.calls.count == 1)
+        #expect(dispatched.last?.storeOrder?.enabled == true)
+        #expect(dispatched.last?.storeReview?.enabled == true)
+    }
+
+    @Test func test_toggle_flipped_back_within_debounce_window_produces_no_dispatch() async {
+        // Given a non-zero debounce so we can flip on-then-off inside the window.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .loadPushNotificationPreferences(_, onCompletion):
+                onCompletion(.success(PushNotificationPreferences(
+                    storeOrder: .init(enabled: false),
+                    storeReview: .init(enabled: false),
+                    storeStock: .init(enabled: false)
+                )))
+            case let .updatePushNotificationPreferences(_, changes, onCompletion):
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            default:
+                break
+            }
+        }
+        let sut = makeSUT(stores: stores, debounceDelay: .milliseconds(100))
+        await sut.load()
+
+        // When the user flips a toggle on and then off again before the debounce fires.
+        sut.setStoreOrderEnabled(true)
+        sut.setStoreOrderEnabled(false)
+        // Wait well past the debounce window.
+        try? await Task.sleep(for: .milliseconds(200))
+
+        // Then no update dispatch was made — the diff against `lastSaved` is empty.
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    // MARK: - Failure rollback
 
     @Test func test_setStoreOrderEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
         // Given
@@ -142,8 +320,7 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreOrderEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { sut.errorNotice != nil }
 
         // Then
         #expect(sut.isStoreOrderEnabled == false)
@@ -164,8 +341,7 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreReviewEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { sut.errorNotice != nil }
 
         // Then
         #expect(sut.isStoreReviewEnabled == false)
@@ -186,64 +362,172 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         sut.setStoreStockEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { sut.errorNotice != nil }
 
         // Then
         #expect(sut.isStoreStockEnabled == false)
         #expect(sut.errorNotice != nil)
     }
 
-    @Test func test_setStoreOrderEnabled_when_remote_succeeds_then_only_storeOrder_is_applied_from_response() async {
-        // Given a server response whose `storeReview` field is stale (false) compared to an
-        // in-flight optimistic flip of the review toggle (true). Only the order update is
-        // completed; the review update's continuation is held to keep that request in flight.
+    @Test func test_failure_with_newer_edits_in_flight_then_optimistic_state_is_preserved() async {
+        // Given the first save will fail. We hold its completion so we can flip a
+        // newer toggle before the failure lands.
+        struct AnyError: Error {}
         let stores = makeStores()
-        let staleResponse = PushNotificationPreferences(
-            storeOrder: .init(enabled: true),
-            storeReview: .init(enabled: false),
-            storeStock: .init(enabled: false)
-        )
-        let pendingReviewCompletion = PendingCompletion()
+        let firstCompletion = PendingCompletion()
+        let dispatched = DispatchedChanges()
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             guard case let .updatePushNotificationPreferences(_, changes, onCompletion) = action else {
                 return
             }
-            if changes.storeOrder != nil {
-                onCompletion(.success(staleResponse))
-            } else if changes.storeReview != nil {
-                pendingReviewCompletion.handler = onCompletion
+            dispatched.append(changes)
+            if dispatched.calls.count == 1 {
+                firstCompletion.handler = onCompletion
+            } else {
+                onCompletion(.success(changes))
             }
         }
         let sut = makeSUT(stores: stores)
-        sut.setStoreReviewEnabled(true)
 
-        // When the order toggle update succeeds and returns its (stale-for-review) snapshot.
+        // When the first save (order: true) is in flight, the user flips review on,
+        // and then the first save fails.
         sut.setStoreOrderEnabled(true)
-        await Task.yield()
-        await Task.yield()
+        _ = await wait { firstCompletion.handler != nil }
+        sut.setStoreReviewEnabled(true)
+        firstCompletion.handler?(.failure(AnyError()))
 
-        // Then the order toggle reflects the server, but the review toggle keeps its
-        // optimistic value — it was not part of this request's `changes` payload and its
-        // own request hasn't completed yet.
+        // Allow the failure path and the queued save to settle.
+        _ = await wait { dispatched.calls.count >= 2 }
+        try? await Task.sleep(for: .milliseconds(30))
+
+        // Then the optimistic order value is preserved (no rollback) because a
+        // newer edit existed by the time the failure landed, and no error notice
+        // is shown for that failed attempt.
         #expect(sut.isStoreOrderEnabled == true)
         #expect(sut.isStoreReviewEnabled == true)
+        #expect(sut.errorNotice == nil)
+    }
 
-        // Resolve the dangling continuation so `withCheckedThrowingContinuation` doesn't
-        // emit a runtime warning when the test exits.
-        pendingReviewCompletion.handler?(.success(staleResponse))
+    // MARK: - Flush on dismissal
+
+    @Test func test_flushPendingSaves_dispatches_immediately_bypassing_debounce() async {
+        // Given a long debounce that would otherwise delay the save.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores, debounceDelay: .seconds(5))
+
+        // When
+        sut.setStoreOrderEnabled(true)
+        sut.flushPendingSaves()
+
+        // Then a dispatch fires well before the debounce window would have elapsed.
+        let fired = await wait(timeout: .milliseconds(500)) { dispatched.calls.count >= 1 }
+        #expect(fired)
+        #expect(dispatched.last?.storeOrder?.enabled == true)
+    }
+
+    @Test func test_flushPendingSaves_while_save_in_flight_skips_redundant_sections() async {
+        // Given a save is in flight (its completion is held) and the user has
+        // since edited a different section.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        let firstCompletion = PendingCompletion()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            guard case let .updatePushNotificationPreferences(_, changes, onCompletion) = action else {
+                return
+            }
+            dispatched.append(changes)
+            if dispatched.calls.count == 1 {
+                firstCompletion.handler = onCompletion
+            } else {
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When the first save is in flight and the user flips a different toggle, then dismisses.
+        sut.setStoreOrderEnabled(true)
+        _ = await wait { firstCompletion.handler != nil }
+        sut.setStoreReviewEnabled(true)
+        sut.flushPendingSaves()
+        _ = await wait { dispatched.calls.count >= 2 }
+
+        // Then the flush dispatch carries only the newer section — the in-flight
+        // request is left to cover what's already on the wire.
+        #expect(dispatched.calls.count == 2)
+        #expect(dispatched.calls[1].storeOrder == nil)
+        #expect(dispatched.calls[1].storeReview?.enabled == true)
+        #expect(dispatched.calls[1].storeStock == nil)
+
+        // Resolve the held first request so the test exits cleanly.
+        firstCompletion.handler?(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
+    }
+
+    @Test func test_flushPendingSaves_when_no_pending_diff_then_no_dispatch() async {
+        // Given no edits have been made.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.flushPendingSaves()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        // Then no dispatch ever fires.
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// Polls `condition` until it returns `true` or the timeout elapses. Returns
+    /// whether the condition was satisfied. Used in place of fixed `Task.sleep`
+    /// calls so tests aren't sensitive to scheduler timing.
+    @discardableResult
+    private func wait(timeout: Duration = .milliseconds(500),
+                      until condition: () -> Bool) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !condition() {
+            if ContinuousClock.now > deadline {
+                return condition()
+            }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return true
     }
 }
 
 /// Reference-typed box for capturing dispatched changes from a closure without `@MainActor` capture issues.
 /// Mutations always happen on the main actor in tests; `@unchecked Sendable` is safe.
 private final class DispatchedChanges: @unchecked Sendable {
-    var value: PushNotificationPreferences?
+    private(set) var calls: [PushNotificationPreferences] = []
+    var last: PushNotificationPreferences? { calls.last }
+
+    func append(_ changes: PushNotificationPreferences) {
+        calls.append(changes)
+    }
 }
 
 /// Reference-typed box to hold a `NotificationAction.updatePushNotificationPreferences`
 /// completion closure so it can be resolved later from the test body.
 /// Mutations always happen on the main actor in tests; `@unchecked Sendable` is safe.
 private final class PendingCompletion: @unchecked Sendable {
+    var handler: ((Result<PushNotificationPreferences, Error>) -> Void)?
+}
+
+/// Reference-typed box for capturing a held `NotificationAction.loadPushNotificationPreferences`
+/// completion handler so the load can be resolved on demand.
+private final class PendingLoadCompletion: @unchecked Sendable {
     var handler: ((Result<PushNotificationPreferences, Error>) -> Void)?
 }


### PR DESCRIPTION
## Description

Replaces the per-toggle immediate dispatch on the new Push Notifications preferences screen with a debounced, conflated save pipeline. Rapid edits coalesce into a single network request ~1 s after the *last* change, and edits made while a save is in flight are queued behind it (drop-oldest, single-slot).

Mirrors the Android `NotificationSettingsSharedViewModel` behaviour from the parity ticket: only the most recent set of preferences is ever sent to the server, and any in-flight save still completes if the user leaves the screen.

Key design points:
- `displayed` / `lastSaved` / `inFlight` snapshots drive the save lifecycle.
- The three `is*Enabled` properties are computed from `displayed` so the optimistic UI is a single source of truth.
- A `debounceTask` restarts on every edit; only the last countdown survives to fire a save.
- An `AsyncStream<Void>` with `.bufferingNewest(1)` serialises saves — triggers arriving while one is in flight collapse to one follow-up.
- `processSave` dispatches directly from `@MainActor` (no `Task.detached`) — the consumer task holds `self` strongly while a save is running, so the VM can't deallocate mid-save.
- `flushPendingSaves` is called from `viewWillDisappear` (when `isMovingFromParent || isBeingDismissed`) and fires `stores.dispatch` fire-and-forget so the request continues after VM dealloc. It diffs against `inFlight ?? lastSaved` so it doesn't re-send sections already on the wire.
- Optimistic UI rolls back to `lastSaved` on failure, unless the user has made newer edits since the failed save started.

For `RSM-3529`

## Test Steps

1. On a store with the Woo push notifications plugin enabled, sign in and open **Settings → Push Notifications**.
2. Rapidly flip several toggles in succession. Confirm via Charles / network log that **exactly one** save request fires ~1 s after the last flip, with all the changed sections in the payload.
3. Flip a toggle, wait ~1 s for the save to fire, then immediately leave the screen while the request is still in flight (use a slow network if needed). The request should still complete on the server.
4. With airplane mode on, flip a toggle. After ~1 s the save fails and the toggle rolls back to its previous value, with an inline error notice.
5. Flip a toggle on then off again within 1 s — no network request should fire (empty diff).
6. Leave the screen with no edits made — no network request should fire.

Unit tests cover: debounce coalescing, debounce-restart on each edit, drop-oldest while in-flight, empty-diff skip, dismissal flush (idle and in-flight variants), failure rollback (both with and without newer edits), and guarded load-apply.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (No entry needed — the parent screen is still feature-flagged and its release notes were intentionally dropped on the base PR.)