### PR TITLE
Add New orders push notification details screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+/// Detail screen for the New orders push notification preferences. Reached by
+/// tapping the New orders row in `PushNotificationPreferencesView`. Navigation
+/// chrome (title, Save bar button, discard confirmation) lives on the wrapping
+/// `NewOrderNotificationPreferencesHostingController`.
+///
+struct NewOrderNotificationPreferencesDetailView: View {
+
+    private typealias Threshold = PushNotificationPreferencesViewModel.StoreOrderThreshold
+
+    @Bindable private var viewModel: PushNotificationPreferencesViewModel
+
+    @State private var thresholdInput: String
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        self.viewModel = viewModel
+        _thresholdInput = State(initialValue: Threshold.formatInput(viewModel.storeOrderMinAmount))
+    }
+
+    var body: some View {
+        List {
+            masterToggleSection
+            customizationSection
+        }
+        .listStyle(.insetGrouped)
+        .background(Color(.listBackground))
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+        // `leftBarButtonItem` set in UIKit doesn't suppress SwiftUI's own back
+        // button, so without this both render side-by-side and only the UIKit
+        // one routes through the discard handler.
+        .navigationBarBackButtonHidden(true)
+        .notice($viewModel.errorNotice)
+        .onChange(of: viewModel.storeOrderMinAmount) { _, newValue in
+            let formatted = Threshold.formatInput(newValue)
+            if formatted != thresholdInput {
+                thresholdInput = formatted
+            }
+        }
+    }
+
+    private var masterToggleSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+                HStack {
+                    Text(Localization.enableTitle)
+                        .bodyStyle()
+                    Spacer()
+                    Toggle("", isOn: Binding(get: { viewModel.isStoreOrderEnabled },
+                                             set: { viewModel.setStoreOrderEnabled($0) }))
+                        .labelsHidden()
+                }
+                Text(Localization.enableSubtitle)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .captionStyle()
+            }
+        }
+    }
+
+    private var customizationSection: some View {
+        Section {
+            radioRow(title: Localization.allOrdersTitle,
+                     subtitle: Localization.allOrdersSubtitle,
+                     isSelected: viewModel.storeOrderMinAmount == nil) {
+                viewModel.setStoreOrderMinAmount(nil)
+            }
+            radioRow(title: Localization.highValueTitle,
+                     subtitle: Localization.highValueSubtitle,
+                     isSelected: viewModel.storeOrderMinAmount != nil) {
+                let restore = viewModel.lastKnownStoreOrderMinAmount
+                    ?? PushNotificationPreferencesViewModel.defaultStoreOrderMinAmount
+                // Seed the input synchronously so the threshold field doesn't render
+                // with empty text for a frame before the VM's `onChange` syncs it.
+                thresholdInput = Threshold.formatInput(restore)
+                viewModel.setStoreOrderMinAmount(restore)
+            }
+            if viewModel.storeOrderMinAmount != nil {
+                thresholdField
+            }
+        } header: {
+            Text(Localization.customizeHeader)
+        }
+        .disabled(!viewModel.isStoreOrderEnabled)
+        .opacity(viewModel.isStoreOrderEnabled ? 1.0 : Layout.disabledOpacity)
+    }
+
+    private func radioRow(title: String,
+                          subtitle: String,
+                          isSelected: Bool,
+                          action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: Layout.contentSpacing) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .foregroundStyle(isSelected ? Color.accentColor : Color(.tertiaryLabel))
+                    .font(.title3)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+                    Text(title)
+                        .bodyStyle()
+                    Text(subtitle)
+                        .foregroundStyle(Color(.secondaryLabel))
+                        .captionStyle()
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+    }
+
+    private var thresholdField: some View {
+        HStack {
+            Text(Localization.thresholdLabel)
+                .bodyStyle()
+            Spacer()
+            TextField(Localization.thresholdPlaceholder, text: $thresholdInput)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}
+
+private extension NewOrderNotificationPreferencesDetailView {
+    enum Layout {
+        static let contentSpacing: CGFloat = 12
+        static let titleDetailSpacing: CGFloat = 4
+        static let disabledOpacity: Double = 0.5
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.title",
+            value: "New orders",
+            comment: "Title of the new-order push notification preferences detail screen."
+        )
+        static let enableTitle = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.enable.title",
+            value: "Enable notifications",
+            comment: "Title of the master toggle for new-order push notifications."
+        )
+        static let enableSubtitle = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.enable.subtitle",
+            value: "Get notified when an order is placed in your store.",
+            comment: "Subtitle of the master toggle for new-order push notifications."
+        )
+        static let customizeHeader = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.notifyMeFor.header",
+            value: "Notify me for",
+            comment: "Section header for new-order notification customization options."
+        )
+        static let allOrdersTitle = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.allOrders.title",
+            value: "All new orders",
+            comment: "Title of the radio row that enables notifications for every new order."
+        )
+        static let allOrdersSubtitle = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.allOrders.subtitle",
+            value: "Ping for every order, regardless of value.",
+            comment: "Subtitle of the radio row that enables notifications for every new order."
+        )
+        static let highValueTitle = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.highValue.title",
+            value: "Only high-value orders",
+            comment: "Title of the radio row that filters notifications to orders above a threshold."
+        )
+        static let highValueSubtitle = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.highValue.subtitle",
+            value: "Filter to orders above your threshold.",
+            comment: "Subtitle of the radio row that filters notifications to orders above a threshold."
+        )
+        static let thresholdLabel = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.threshold.label",
+            value: "Threshold",
+            comment: "Label for the order-total threshold text field."
+        )
+        static let thresholdPlaceholder = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.threshold.placeholder",
+            value: "Amount",
+            comment: "Placeholder for the order-total threshold text field."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -25,6 +25,7 @@ struct NewOrderNotificationPreferencesDetailView: View {
         }
         .listStyle(.insetGrouped)
         .background(Color(.listBackground))
+        .disabled(viewModel.isSaving)
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         // `leftBarButtonItem` set in UIKit doesn't suppress SwiftUI's own back

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -63,7 +63,9 @@ struct NewOrderNotificationPreferencesDetailView: View {
             radioRow(title: Localization.allOrdersTitle,
                      subtitle: Localization.allOrdersSubtitle,
                      isSelected: viewModel.storeOrderMinAmount == nil) {
-                viewModel.setStoreOrderMinAmount(nil)
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    viewModel.setStoreOrderMinAmount(nil)
+                }
             }
             radioRow(title: Localization.highValueTitle,
                      subtitle: Localization.highValueSubtitle,
@@ -73,10 +75,13 @@ struct NewOrderNotificationPreferencesDetailView: View {
                 // Seed the input synchronously so the threshold field doesn't render
                 // with empty text for a frame before the VM's `onChange` syncs it.
                 thresholdInput = Threshold.formatInput(restore)
-                viewModel.setStoreOrderMinAmount(restore)
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    viewModel.setStoreOrderMinAmount(restore)
+                }
             }
             if viewModel.storeOrderMinAmount != nil {
                 thresholdField
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         } header: {
             Text(Localization.customizeHeader)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -68,14 +68,9 @@ struct NewOrderNotificationPreferencesDetailView: View {
     private var masterToggleSection: some View {
         Section {
             VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
-                HStack {
-                    Text(Localization.enableTitle)
-                        .bodyStyle()
-                    Spacer()
-                    Toggle("", isOn: Binding(get: { viewModel.isStoreOrderEnabled },
-                                             set: { viewModel.setStoreOrderEnabled($0) }))
-                        .labelsHidden()
-                }
+                Toggle(Localization.enableTitle,
+                       isOn: Binding(get: { viewModel.isStoreOrderEnabled },
+                                     set: { viewModel.setStoreOrderEnabled($0) }))
                 Text(Localization.enableSubtitle)
                     .foregroundStyle(Color(.secondaryLabel))
                     .captionStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -32,12 +32,37 @@ struct NewOrderNotificationPreferencesDetailView: View {
         // one routes through the discard handler.
         .navigationBarBackButtonHidden(true)
         .notice($viewModel.errorNotice)
+        .onChange(of: thresholdInput) { oldValue, newValue in
+            // Reject any input that isn't a positive integer (no "0", leading
+            // zeros, decimals, or non-digits). Reverting through the binding
+            // forces the TextField to re-sync.
+            let trimmed = newValue.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty && !Threshold.isAllowedInput(trimmed) {
+                thresholdInput = oldValue
+                return
+            }
+            commitThreshold()
+        }
         .onChange(of: viewModel.storeOrderMinAmount) { _, newValue in
+            // Skip the re-sync when the input already represents `newValue` —
+            // otherwise non-Latin digits the user typed (Arabic-Indic,
+            // Devanagari, etc.) get rewritten as ASCII by `formatInput`.
+            if Threshold.parse(thresholdInput) == newValue { return }
             let formatted = Threshold.formatInput(newValue)
             if formatted != thresholdInput {
                 thresholdInput = formatted
             }
         }
+    }
+
+    private func commitThreshold() {
+        // Guard against writing back while the threshold field is hidden
+        // (e.g. "All new orders" selected) — a stale input would re-enable
+        // the high-value mode on the VM.
+        guard viewModel.storeOrderMinAmount != nil,
+              let parsed = Threshold.parse(thresholdInput),
+              parsed > 0 else { return }
+        viewModel.setStoreOrderMinAmount(parsed)
     }
 
     private var masterToggleSection: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -113,7 +113,8 @@ struct NewOrderNotificationPreferencesDetailView: View {
 
     private var thresholdField: some View {
         HStack {
-            Text(Localization.thresholdLabel)
+            Text(String.localizedStringWithFormat(Localization.thresholdLabelFormat,
+                                                  viewModel.storeOrderCurrencySymbol))
                 .bodyStyle()
             Spacer()
             TextField(Localization.thresholdPlaceholder, text: $thresholdInput)
@@ -171,10 +172,10 @@ private extension NewOrderNotificationPreferencesDetailView {
             value: "Filter to orders above your threshold.",
             comment: "Subtitle of the radio row that filters notifications to orders above a threshold."
         )
-        static let thresholdLabel = NSLocalizedString(
-            "newOrderNotificationPreferencesDetailView.threshold.label",
-            value: "Threshold",
-            comment: "Label for the order-total threshold text field."
+        static let thresholdLabelFormat = NSLocalizedString(
+            "newOrderNotificationPreferencesDetailView.threshold.labelFormat",
+            value: "Minimum value (%1$@)",
+            comment: "Label for the order-total threshold text field. %1$@ is the active site's currency symbol, e.g. $."
         )
         static let thresholdPlaceholder = NSLocalizedString(
             "newOrderNotificationPreferencesDetailView.threshold.placeholder",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+import UIKit
+
+/// Hosts `NewOrderNotificationPreferencesDetailView` and owns its navigation
+/// chrome (Save bar button, custom back button, discard-changes flow).
+///
+/// Toolbar items live on `navigationItem` rather than in a SwiftUI `.toolbar`
+/// modifier — when a `UIHostingController`'s root view declares any toolbar
+/// item, SwiftUI takes ownership of the navigation item and routes the back
+/// button through its own gesture stack, bypassing
+/// `UINavigationBarDelegate.navigationBar(_:shouldPop:)` and
+/// `shouldPopOnBackButton`.
+///
+final class NewOrderNotificationPreferencesHostingController: UIHostingController<NewOrderNotificationPreferencesDetailView> {
+
+    private let viewModel: PushNotificationPreferencesViewModel
+
+    private lazy var saveBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(title: Localization.save,
+                                   style: .done,
+                                   target: self,
+                                   action: #selector(handleSaveTapped))
+        item.isEnabled = false
+        return item
+    }()
+
+    private lazy var backBarButtonItem: UIBarButtonItem = {
+        let image = UIImage(systemName: "chevron.backward")
+        let item = UIBarButtonItem(image: image,
+                                   style: .plain,
+                                   target: self,
+                                   action: #selector(handleBackTapped))
+        item.accessibilityLabel = Localization.back
+        return item
+    }()
+
+    private lazy var savingActivityItem: UIBarButtonItem = {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.startAnimating()
+        return UIBarButtonItem(customView: spinner)
+    }()
+
+    private var isSaving = false {
+        didSet { refreshRightBarButtonItem() }
+    }
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        self.viewModel = viewModel
+        super.init(rootView: NewOrderNotificationPreferencesDetailView(viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.leftBarButtonItem = backBarButtonItem
+        refreshRightBarButtonItem()
+        // Routes the edge-swipe gesture through `shouldPopOnSwipeBack`.
+        handleSwipeBackGesture()
+        observeUnsavedChanges()
+    }
+
+    override func shouldPopOnBackButton() -> Bool {
+        if viewModel.hasUnsavedChanges {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+}
+
+private extension NewOrderNotificationPreferencesHostingController {
+    /// `@Observable` tracking fires once and stops, so re-register after each
+    /// change to keep the Save button in sync with `hasUnsavedChanges`.
+    func observeUnsavedChanges() {
+        withObservationTracking {
+            _ = viewModel.hasUnsavedChanges
+        } onChange: { [weak self] in
+            // `onChange` fires from `willSet`; hop to main before touching UIKit.
+            DispatchQueue.main.async {
+                self?.refreshRightBarButtonItem()
+                self?.observeUnsavedChanges()
+            }
+        }
+    }
+
+    func refreshRightBarButtonItem() {
+        if isSaving {
+            navigationItem.rightBarButtonItem = savingActivityItem
+        } else {
+            saveBarButtonItem.isEnabled = viewModel.hasUnsavedChanges
+            navigationItem.rightBarButtonItem = saveBarButtonItem
+        }
+    }
+
+    @objc func handleBackTapped() {
+        if viewModel.hasUnsavedChanges {
+            presentBackNavigationActionSheet()
+        } else {
+            navigationController?.popViewController(animated: true)
+        }
+    }
+
+    @objc func handleSaveTapped() {
+        guard !isSaving else { return }
+        isSaving = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let success = await viewModel.save()
+            isSaving = false
+            if success {
+                navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+
+    func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self,
+                                                           onDiscard: { [weak self] in
+            self?.viewModel.discardStoreOrderEdits()
+            self?.navigationController?.popViewController(animated: true)
+        })
+    }
+}
+
+private extension NewOrderNotificationPreferencesHostingController {
+    enum Localization {
+        static let save = NSLocalizedString(
+            "newOrderNotificationPreferencesHostingController.save",
+            value: "Save",
+            comment: "Title of the Save bar button on the new-order push notification preferences detail screen."
+        )
+        static let back = NSLocalizedString(
+            "newOrderNotificationPreferencesHostingController.back",
+            value: "Back",
+            comment: "VoiceOver label for the back button on the new-order push notification preferences detail screen."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
@@ -40,10 +40,6 @@ final class NewOrderNotificationPreferencesHostingController: UIHostingControlle
         return UIBarButtonItem(customView: spinner)
     }()
 
-    private var isSaving = false {
-        didSet { refreshRightBarButtonItem() }
-    }
-
     init(viewModel: PushNotificationPreferencesViewModel) {
         self.viewModel = viewModel
         super.init(rootView: NewOrderNotificationPreferencesDetailView(viewModel: viewModel))
@@ -77,10 +73,12 @@ final class NewOrderNotificationPreferencesHostingController: UIHostingControlle
 
 private extension NewOrderNotificationPreferencesHostingController {
     /// `@Observable` tracking fires once and stops, so re-register after each
-    /// change to keep the Save button in sync with `hasUnsavedChanges`.
+    /// change to keep the bar item in sync with `hasUnsavedChanges` and
+    /// `isSaving`.
     func observeUnsavedChanges() {
         withObservationTracking {
             _ = viewModel.hasUnsavedChanges
+            _ = viewModel.isSaving
         } onChange: { [weak self] in
             // `onChange` fires from `willSet`; hop to main before touching UIKit.
             DispatchQueue.main.async {
@@ -91,7 +89,7 @@ private extension NewOrderNotificationPreferencesHostingController {
     }
 
     func refreshRightBarButtonItem() {
-        if isSaving {
+        if viewModel.isSaving {
             navigationItem.rightBarButtonItem = savingActivityItem
         } else {
             saveBarButtonItem.isEnabled = viewModel.hasUnsavedChanges
@@ -108,12 +106,10 @@ private extension NewOrderNotificationPreferencesHostingController {
     }
 
     @objc func handleSaveTapped() {
-        guard !isSaving else { return }
-        isSaving = true
+        guard !viewModel.isSaving else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             let success = await viewModel.save()
-            isSaving = false
             if success {
                 navigationController?.popViewController(animated: true)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -8,11 +8,10 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
         let viewModel = PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
         self.viewModel = viewModel
         super.init(rootView: PushNotificationPreferencesView(viewModel: viewModel))
-        // Re-set the root view after `super.init` so the closure can capture `self` weakly.
-        rootView = PushNotificationPreferencesView(viewModel: viewModel,
-                                                   onNewOrderTapped: { [weak self] in
+        // Set after `super.init` so the closure can capture `self` weakly.
+        rootView.onNewOrderTapped = { [weak self] in
             self?.showNewOrderDetail()
-        })
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -2,12 +2,25 @@ import SwiftUI
 import Yosemite
 
 final class PushNotificationPreferencesHostingController: UIHostingController<PushNotificationPreferencesView> {
+    private let viewModel: PushNotificationPreferencesViewModel
+
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         let viewModel = PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
+        self.viewModel = viewModel
         super.init(rootView: PushNotificationPreferencesView(viewModel: viewModel))
+        // Re-set the root view after `super.init` so the closure can capture `self` weakly.
+        rootView = PushNotificationPreferencesView(viewModel: viewModel,
+                                                   onNewOrderTapped: { [weak self] in
+            self?.showNewOrderDetail()
+        })
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func showNewOrderDetail() {
+        let detail = NewOrderNotificationPreferencesHostingController(viewModel: viewModel)
+        navigationController?.pushViewController(detail, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -57,7 +57,7 @@ struct PushNotificationPreferencesView: View {
         List {
             Section {
                 row(title: Localization.newOrdersTitle,
-                    detail: viewModel.isStoreOrderEnabled ? Localization.newOrdersDetail : Localization.off,
+                    detail: viewModel.isStoreOrderEnabled ? viewModel.storeOrderDetailText : Localization.off,
                     accessibilityHint: Localization.newOrdersAccessibilityHint,
                     action: onNewOrderTapped)
                 row(title: Localization.newReviewsTitle,
@@ -130,11 +130,6 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.newOrders.title",
             value: "New orders",
             comment: "Title of the row that toggles new-order push notifications."
-        )
-        static let newOrdersDetail = NSLocalizedString(
-            "pushNotificationPreferencesView.newOrders.detail",
-            value: "All orders",
-            comment: "Detail text for the row that toggles new-order push notifications."
         )
         static let newOrdersAccessibilityHint = NSLocalizedString(
             "pushNotificationPreferencesView.newOrders.accessibilityHint",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -7,8 +7,14 @@ struct PushNotificationPreferencesView: View {
 
     @Bindable private var viewModel: PushNotificationPreferencesViewModel
 
-    init(viewModel: PushNotificationPreferencesViewModel) {
+    /// Invoked when the user taps the New orders row. The hosting controller
+    /// performs the push in UIKit.
+    private let onNewOrderTapped: () -> Void
+
+    init(viewModel: PushNotificationPreferencesViewModel,
+         onNewOrderTapped: @escaping () -> Void = {}) {
         self.viewModel = viewModel
+        self.onNewOrderTapped = onNewOrderTapped
     }
 
     var body: some View {
@@ -51,7 +57,9 @@ struct PushNotificationPreferencesView: View {
         List {
             Section {
                 row(title: Localization.newOrdersTitle,
-                    detail: viewModel.isStoreOrderEnabled ? Localization.newOrdersDetail : Localization.off)
+                    detail: viewModel.isStoreOrderEnabled ? Localization.newOrdersDetail : Localization.off,
+                    accessibilityHint: Localization.newOrdersAccessibilityHint,
+                    action: onNewOrderTapped)
                 row(title: Localization.newReviewsTitle,
                     detail: viewModel.isStoreReviewEnabled ? Localization.newReviewsDetail : Localization.off)
                 row(title: Localization.stockTitle,
@@ -61,7 +69,12 @@ struct PushNotificationPreferencesView: View {
         .listStyle(.insetGrouped)
     }
 
-    private func row(title: String, detail: String) -> some View {
+    /// Title + detail + chevron. Tappable when `action` is non-nil. Uses
+    /// `onTapGesture` rather than `Button` to avoid List's interactive-row tint.
+    private func row(title: String,
+                     detail: String,
+                     accessibilityHint: String? = nil,
+                     action: (() -> Void)? = nil) -> some View {
         HStack(spacing: Layout.contentSpacing) {
             VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
                 Text(title)
@@ -77,8 +90,25 @@ struct PushNotificationPreferencesView: View {
                 .accessibilityHidden(true)
         }
         .contentShape(Rectangle())
+        .onTapGesture { action?() }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isButton)
+        .ifLet(accessibilityHint) { view, hint in
+            view.accessibilityHint(hint)
+        }
+    }
+}
+
+private extension View {
+    /// Applies `transform` only when `value` is non-nil.
+    @ViewBuilder
+    func ifLet<T, Transform: View>(_ value: T?,
+                                   transform: (Self, T) -> Transform) -> some View {
+        if let value {
+            transform(self, value)
+        } else {
+            self
+        }
     }
 }
 
@@ -105,6 +135,11 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.newOrders.detail",
             value: "All orders",
             comment: "Detail text for the row that toggles new-order push notifications."
+        )
+        static let newOrdersAccessibilityHint = NSLocalizedString(
+            "pushNotificationPreferencesView.newOrders.accessibilityHint",
+            value: "Customize new order notifications",
+            comment: "VoiceOver hint announced when focused on the New orders row, describing that it opens a detail screen."
         )
         static let newReviewsTitle = NSLocalizedString(
             "pushNotificationPreferencesView.newReviews.title",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -7,14 +7,12 @@ struct PushNotificationPreferencesView: View {
 
     @Bindable private var viewModel: PushNotificationPreferencesViewModel
 
-    /// Invoked when the user taps the New orders row. The hosting controller
-    /// performs the push in UIKit.
-    private let onNewOrderTapped: () -> Void
+    /// Set by the hosting controller after `super.init`. Default is a no-op so
+    /// previews work without it.
+    var onNewOrderTapped: () -> Void = {}
 
-    init(viewModel: PushNotificationPreferencesViewModel,
-         onNewOrderTapped: @escaping () -> Void = {}) {
+    init(viewModel: PushNotificationPreferencesViewModel) {
         self.viewModel = viewModel
-        self.onNewOrderTapped = onNewOrderTapped
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Observation
 import Yosemite
+import class WooFoundation.CurrencyFormatter
+import class WooFoundation.CurrencySettings
 
 /// View model for `PushNotificationPreferencesView` and the per-section detail
 /// screens. Setters mutate `displayed`; `save()` diffs against `lastSaved` and
@@ -30,20 +32,40 @@ final class PushNotificationPreferencesViewModel {
     /// `nil` means "all orders".
     var storeOrderMinAmount: Decimal? { displayed.storeOrder?.minAmount }
 
+    var storeOrderCurrencySymbol: String {
+        currencySettings.symbol(from: currencySettings.currencyCode)
+    }
+
     /// Last positive threshold seen, used to restore the value when the user
     /// toggles "Only high-value orders" back on after switching to "All new orders".
     private(set) var lastKnownStoreOrderMinAmount: Decimal?
 
     static let defaultStoreOrderMinAmount: Decimal = 100
 
+    var storeOrderDetailText: String {
+        guard let amount = storeOrderMinAmount, amount > 0 else {
+            return Localization.allOrders
+        }
+        let formatted = currencyFormatter.formatAmount(amount,
+                                                       with: currencySettings.currencyCode.rawValue,
+                                                       numberOfDecimals: 0) ?? ""
+        return String.localizedStringWithFormat(Localization.ordersOverFormat, formatted)
+    }
+
     var errorNotice: Notice?
 
     private let siteID: Int64
     private let stores: StoresManager
+    private let currencyFormatter: CurrencyFormatter
+    private let currencySettings: CurrencySettings
 
-    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.siteID = siteID
         self.stores = stores
+        self.currencySettings = currencySettings
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
     }
 
     func load() async {
@@ -217,6 +239,16 @@ extension PushNotificationPreferencesViewModel {
             "pushNotificationPreferencesViewModel.errorNoticeMessage",
             value: "Please try again.",
             comment: "Message of the notice shown when saving push notification preferences fails."
+        )
+        static let allOrders = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeOrder.allOrders",
+            value: "All orders",
+            comment: "Detail text for the New orders row when notifications fire for every order."
+        )
+        static let ordersOverFormat = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeOrder.ordersOverFormat",
+            value: "Orders over %1$@",
+            comment: "Detail text for the New orders row when a threshold is set. %1$@ is the formatted currency amount, e.g. $500."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -25,6 +25,8 @@ final class PushNotificationPreferencesViewModel {
 
     var hasUnsavedChanges: Bool { displayed != lastSaved }
 
+    private(set) var isSaving = false
+
     var isStoreOrderEnabled: Bool { displayed.storeOrder?.enabled ?? false }
     var isStoreReviewEnabled: Bool { displayed.storeReview?.enabled ?? false }
     var isStoreStockEnabled: Bool { displayed.storeStock?.enabled ?? false }
@@ -96,6 +98,9 @@ final class PushNotificationPreferencesViewModel {
     func save() async -> Bool {
         let pendingDiff = makeDiff(from: lastSaved, to: displayed)
         guard !pendingDiff.isEmpty else { return true }
+        guard !isSaving else { return false }
+        isSaving = true
+        defer { isSaving = false }
         do {
             let server = try await withCheckedThrowingContinuation { continuation in
                 stores.dispatch(NotificationAction.updatePushNotificationPreferences(siteID: siteID,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -2,11 +2,9 @@ import Foundation
 import Observation
 import Yosemite
 
-/// View model backing `PushNotificationPreferencesView`.
-///
-/// Loads the per-site push notification preferences served by the Woo-driven
-/// push system (`wc-push-notifications/preferences`) and dispatches partial
-/// updates back through Yosemite when toggles are flipped.
+/// View model for `PushNotificationPreferencesView` and the per-section detail
+/// screens. Setters mutate `displayed`; `save()` diffs against `lastSaved` and
+/// dispatches a single update.
 ///
 @MainActor
 @Observable
@@ -20,15 +18,19 @@ final class PushNotificationPreferencesViewModel {
 
     private(set) var loadState: LoadState = .loading
 
-    private(set) var isStoreOrderEnabled: Bool = false
-    private(set) var isStoreReviewEnabled: Bool = false
-    private(set) var isStoreStockEnabled: Bool = false
+    private(set) var displayed = PushNotificationPreferences()
+    private(set) var lastSaved = PushNotificationPreferences()
+
+    var hasUnsavedChanges: Bool { displayed != lastSaved }
+
+    var isStoreOrderEnabled: Bool { displayed.storeOrder?.enabled ?? false }
+    var isStoreReviewEnabled: Bool { displayed.storeReview?.enabled ?? false }
+    var isStoreStockEnabled: Bool { displayed.storeStock?.enabled ?? false }
 
     var errorNotice: Notice?
 
     private let siteID: Int64
     private let stores: StoresManager
-    private var preferences: PushNotificationPreferences?
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
@@ -43,7 +45,12 @@ final class PushNotificationPreferencesViewModel {
                     continuation.resume(with: result)
                 })
             }
-            apply(preferences: preferences)
+            // Preserve in-progress edits across reloads. `lastSaved` always
+            // advances so the next save still diffs against the latest server.
+            if !hasUnsavedChanges {
+                displayed = preferences
+            }
+            lastSaved = preferences
             loadState = .loaded
         } catch {
             DDLogError("⛔️ Error loading push notification preferences for siteID=\(siteID): \(error)")
@@ -51,89 +58,82 @@ final class PushNotificationPreferencesViewModel {
         }
     }
 
-    // Optimistic-update setters. If two flips of the same toggle race, only the latest revert
-    // can run — the earlier closure no-ops because the toggle has since changed. Out-of-order
-    // server responses can still produce a stale final state; acceptable for a 3-row screen
-    // where rapid double-flips are not a real user flow.
+    /// Persists the diff between `displayed` and `lastSaved`. Returns `true`
+    /// on success; on failure publishes `errorNotice` and keeps `displayed`
+    /// intact so the caller can retry.
+    func save() async -> Bool {
+        let pendingDiff = makeDiff(from: lastSaved, to: displayed)
+        guard !pendingDiff.isEmpty else { return true }
+        do {
+            let server = try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(NotificationAction.updatePushNotificationPreferences(siteID: siteID,
+                                                                                     changes: pendingDiff) { result in
+                    continuation.resume(with: result)
+                })
+            }
+            lastSaved = server
+            // Adopt the server's view so any clamped field (e.g. negative
+            // threshold → nil) shows correctly without re-triggering
+            // `hasUnsavedChanges`.
+            displayed = server
+            return true
+        } catch {
+            DDLogError("⛔️ Error saving push notification preferences: \(error)")
+            errorNotice = Notice(title: Localization.errorNoticeTitle,
+                                 message: Localization.errorNoticeMessage,
+                                 feedbackType: .error)
+            return false
+        }
+    }
+
     func setStoreOrderEnabled(_ newValue: Bool) {
-        let previous = isStoreOrderEnabled
-        isStoreOrderEnabled = newValue
-        // `StoreOrder` is sent as a complete object (`minAmount: nil` serializes as JSON
-        // `null`, which the server interprets as "clear threshold"). Preserve the loaded
-        // threshold so toggling the master switch doesn't wipe it.
-        let changes = PushNotificationPreferences(
-            storeOrder: .init(enabled: newValue, minAmount: preferences?.storeOrder?.minAmount)
-        )
-        update(changes: changes, revert: { [weak self] in
-            guard let self, self.isStoreOrderEnabled == newValue else { return }
-            self.isStoreOrderEnabled = previous
-        })
+        displayed = displayed.with(storeOrder: .init(enabled: newValue,
+                                                     minAmount: displayed.storeOrder?.minAmount))
     }
 
     func setStoreReviewEnabled(_ newValue: Bool) {
-        let previous = isStoreReviewEnabled
-        isStoreReviewEnabled = newValue
-        let changes = PushNotificationPreferences(storeReview: .init(enabled: newValue))
-        update(changes: changes, revert: { [weak self] in
-            guard let self, self.isStoreReviewEnabled == newValue else { return }
-            self.isStoreReviewEnabled = previous
-        })
+        displayed = displayed.with(storeReview: .init(enabled: newValue,
+                                                      maxRating: displayed.storeReview?.maxRating))
     }
 
     func setStoreStockEnabled(_ newValue: Bool) {
-        let previous = isStoreStockEnabled
-        isStoreStockEnabled = newValue
-        let changes = PushNotificationPreferences(storeStock: .init(enabled: newValue))
-        update(changes: changes, revert: { [weak self] in
-            guard let self, self.isStoreStockEnabled == newValue else { return }
-            self.isStoreStockEnabled = previous
-        })
+        let existing = displayed.storeStock
+        displayed = displayed.with(storeStock: .init(enabled: newValue,
+                                                     lowStock: existing?.lowStock,
+                                                     outOfStock: existing?.outOfStock,
+                                                     onBackorder: existing?.onBackorder))
     }
 }
 
 private extension PushNotificationPreferencesViewModel {
+    /// Populates only the sections that differ between `baseline` and `target`.
+    /// Whole-section comparison: any change inside a section emits the section
+    /// as a complete object, matching the server's section-level merge.
+    func makeDiff(from baseline: PushNotificationPreferences,
+                  to target: PushNotificationPreferences) -> PushNotificationPreferences {
+        PushNotificationPreferences(
+            storeOrder: target.storeOrder != baseline.storeOrder ? target.storeOrder : nil,
+            storeReview: target.storeReview != baseline.storeReview ? target.storeReview : nil,
+            storeStock: target.storeStock != baseline.storeStock ? target.storeStock : nil
+        )
+    }
+}
 
-    func update(changes: PushNotificationPreferences, revert: @escaping @MainActor () -> Void) {
-        Task { @MainActor in
-            do {
-                let preferences = try await withCheckedThrowingContinuation { continuation in
-                    stores.dispatch(NotificationAction.updatePushNotificationPreferences(siteID: siteID,
-                                                                                         changes: changes) { result in
-                        continuation.resume(with: result)
-                    })
-                }
-                // Apply only the fields we explicitly updated. Concurrent in-flight requests for
-                // other toggles must keep their optimistic state; an earlier response's view of
-                // those fields is stale by definition.
-                apply(preferences: preferences, fields: changes)
-            } catch {
-                DDLogError("⛔️ Error updating push notification preferences: \(error)")
-                revert()
-                errorNotice = Notice(title: Localization.errorNoticeTitle,
-                                     message: Localization.errorNoticeMessage,
-                                     feedbackType: .error)
-            }
-        }
+private extension PushNotificationPreferences {
+    var isEmpty: Bool {
+        storeOrder == nil && storeReview == nil && storeStock == nil
     }
 
-    func apply(preferences: PushNotificationPreferences) {
-        self.preferences = preferences
-        isStoreOrderEnabled = preferences.storeOrder?.enabled ?? false
-        isStoreReviewEnabled = preferences.storeReview?.enabled ?? false
-        isStoreStockEnabled = preferences.storeStock?.enabled ?? false
+    func with(storeOrder: StoreOrder) -> Self {
+        .init(storeOrder: storeOrder, storeReview: storeReview, storeStock: storeStock)
     }
 
-    func apply(preferences: PushNotificationPreferences, fields: PushNotificationPreferences) {
-        self.preferences = preferences
-        if fields.storeOrder != nil {
-            isStoreOrderEnabled = preferences.storeOrder?.enabled ?? false
-        }
-        if fields.storeReview != nil {
-            isStoreReviewEnabled = preferences.storeReview?.enabled ?? false
-        }
-        if fields.storeStock != nil {
-            isStoreStockEnabled = preferences.storeStock?.enabled ?? false
-        }
+    func with(storeReview: StoreReview) -> Self {
+        .init(storeOrder: storeOrder, storeReview: storeReview, storeStock: storeStock)
+    }
+
+    func with(storeStock: StoreStock) -> Self {
+        .init(storeOrder: storeOrder, storeReview: storeReview, storeStock: storeStock)
     }
 }
 
@@ -142,12 +142,12 @@ extension PushNotificationPreferencesViewModel {
         static let errorNoticeTitle = NSLocalizedString(
             "pushNotificationPreferencesViewModel.errorNoticeTitle",
             value: "Couldn't update notification preferences",
-            comment: "Title of the notice shown when updating push notification preferences fails."
+            comment: "Title of the notice shown when saving push notification preferences fails."
         )
         static let errorNoticeMessage = NSLocalizedString(
             "pushNotificationPreferencesViewModel.errorNoticeMessage",
             value: "Please try again.",
-            comment: "Message of the notice shown when updating push notification preferences fails."
+            comment: "Message of the notice shown when saving push notification preferences fails."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -27,6 +27,15 @@ final class PushNotificationPreferencesViewModel {
     var isStoreReviewEnabled: Bool { displayed.storeReview?.enabled ?? false }
     var isStoreStockEnabled: Bool { displayed.storeStock?.enabled ?? false }
 
+    /// `nil` means "all orders".
+    var storeOrderMinAmount: Decimal? { displayed.storeOrder?.minAmount }
+
+    /// Last positive threshold seen, used to restore the value when the user
+    /// toggles "Only high-value orders" back on after switching to "All new orders".
+    private(set) var lastKnownStoreOrderMinAmount: Decimal?
+
+    static let defaultStoreOrderMinAmount: Decimal = 100
+
     var errorNotice: Notice?
 
     private let siteID: Int64
@@ -51,6 +60,7 @@ final class PushNotificationPreferencesViewModel {
                 displayed = preferences
             }
             lastSaved = preferences
+            rememberLastKnownMinAmount(from: preferences.storeOrder?.minAmount)
             loadState = .loaded
         } catch {
             DDLogError("⛔️ Error loading push notification preferences for siteID=\(siteID): \(error)")
@@ -72,6 +82,7 @@ final class PushNotificationPreferencesViewModel {
                 })
             }
             lastSaved = server
+            rememberLastKnownMinAmount(from: server.storeOrder?.minAmount)
             // Adopt the server's view so any clamped field (e.g. negative
             // threshold → nil) shows correctly without re-triggering
             // `hasUnsavedChanges`.
@@ -89,6 +100,25 @@ final class PushNotificationPreferencesViewModel {
     func setStoreOrderEnabled(_ newValue: Bool) {
         displayed = displayed.with(storeOrder: .init(enabled: newValue,
                                                      minAmount: displayed.storeOrder?.minAmount))
+    }
+
+    /// Reverts only the new-order section of `displayed` to `lastSaved`.
+    /// Other sections are left untouched — their detail screens own their
+    /// own discard paths.
+    func discardStoreOrderEdits() {
+        displayed = PushNotificationPreferences(storeOrder: lastSaved.storeOrder,
+                                                storeReview: displayed.storeReview,
+                                                storeStock: displayed.storeStock)
+    }
+
+    func setStoreOrderMinAmount(_ newValue: Decimal?) {
+        let normalized: Decimal? = {
+            guard let value = newValue, value > 0 else { return nil }
+            return value
+        }()
+        rememberLastKnownMinAmount(from: normalized)
+        displayed = displayed.with(storeOrder: .init(enabled: isStoreOrderEnabled,
+                                                     minAmount: normalized))
     }
 
     func setStoreReviewEnabled(_ newValue: Bool) {
@@ -116,6 +146,45 @@ private extension PushNotificationPreferencesViewModel {
             storeReview: target.storeReview != baseline.storeReview ? target.storeReview : nil,
             storeStock: target.storeStock != baseline.storeStock ? target.storeStock : nil
         )
+    }
+
+    func rememberLastKnownMinAmount(from value: Decimal?) {
+        guard let value, value > 0 else { return }
+        lastKnownStoreOrderMinAmount = value
+    }
+}
+
+extension PushNotificationPreferencesViewModel {
+    /// Threshold text-field input helpers. Accepts digits from any Unicode
+    /// script (ASCII, Arabic-Indic, Devanagari, etc.).
+    enum StoreOrderThreshold {
+        /// `true` if `s` is a positive integer string with no leading zero.
+        static func isAllowedInput(_ s: String) -> Bool {
+            guard !s.isEmpty else { return false }
+            guard let firstDigit = s.first?.wholeNumberValue, firstDigit != 0 else { return false }
+            return s.unicodeScalars.allSatisfy(CharacterSet.decimalDigits.contains)
+        }
+
+        /// Parses `input` as a non-negative integer Decimal, or `nil` for
+        /// empty / invalid input.
+        static func parse(_ input: String) -> Decimal? {
+            let trimmed = input.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            var value: Decimal = 0
+            for char in trimmed {
+                guard let digit = char.wholeNumberValue else { return nil }
+                value = value * 10 + Decimal(digit)
+            }
+            return value
+        }
+
+        /// Formats `amount` for display in the threshold text field as an
+        /// integer string (no decimals, no thousands separator).
+        static func formatInput(_ amount: Decimal?) -> String {
+            guard let amount, amount > 0 else { return "" }
+            let rounded = NSDecimalNumber(decimal: amount).intValue
+            return String(rounded)
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -16,7 +16,9 @@ struct PushNotificationPreferencesViewModelTests {
         MockStoresManager(sessionManager: .testingInstance)
     }
 
-    @Test func test_load_when_remote_succeeds_then_loadState_becomes_loaded_and_toggles_reflect_response() async {
+    // MARK: - Loading
+
+    @Test func test_load_when_remote_succeeds_then_loadState_becomes_loaded_and_displayed_lastSaved_reflect_response() async {
         // Given
         let stores = makeStores()
         let response = PushNotificationPreferences(
@@ -39,6 +41,7 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.isStoreOrderEnabled == true)
         #expect(sut.isStoreReviewEnabled == false)
         #expect(sut.isStoreStockEnabled == true)
+        #expect(sut.hasUnsavedChanges == false)
     }
 
     @Test func test_load_when_remote_fails_then_loadState_becomes_error() async {
@@ -59,191 +62,275 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.loadState == .error)
     }
 
-    @Test func test_setStoreOrderEnabled_dispatches_update_with_only_store_order_field() async {
-        // Given
+    @Test func test_load_when_unsaved_edits_exist_then_response_does_not_stomp_displayed_state() async {
+        // Given the user has flipped a toggle (creating an unsaved edit) before a fresh load.
         let stores = makeStores()
-        let dispatched = DispatchedChanges()
+        let response = PushNotificationPreferences(storeOrder: .init(enabled: false))
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
-                dispatched.value = changes
-                onCompletion(.success(changes))
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(response))
             }
         }
         let sut = makeSUT(stores: stores)
-
-        // When
         sut.setStoreOrderEnabled(true)
-        await Task.yield()
-        await Task.yield()
 
-        // Then
-        #expect(dispatched.value?.storeOrder?.enabled == true)
-        #expect(dispatched.value?.storeReview == nil)
-        #expect(dispatched.value?.storeStock == nil)
-    }
+        // When the load returns with `enabled: false`.
+        await sut.load()
 
-    @Test func test_setStoreReviewEnabled_dispatches_update_with_only_store_review_field() async {
-        // Given
-        let stores = makeStores()
-        let dispatched = DispatchedChanges()
-        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
-                dispatched.value = changes
-                onCompletion(.success(changes))
-            }
-        }
-        let sut = makeSUT(stores: stores)
-
-        // When
-        sut.setStoreReviewEnabled(true)
-        await Task.yield()
-        await Task.yield()
-
-        // Then
-        #expect(dispatched.value?.storeReview?.enabled == true)
-        #expect(dispatched.value?.storeOrder == nil)
-        #expect(dispatched.value?.storeStock == nil)
-    }
-
-    @Test func test_setStoreStockEnabled_dispatches_update_with_only_store_stock_field() async {
-        // Given
-        let stores = makeStores()
-        let dispatched = DispatchedChanges()
-        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
-                dispatched.value = changes
-                onCompletion(.success(changes))
-            }
-        }
-        let sut = makeSUT(stores: stores)
-
-        // When
-        sut.setStoreStockEnabled(true)
-        await Task.yield()
-        await Task.yield()
-
-        // Then
-        #expect(dispatched.value?.storeStock?.enabled == true)
-        #expect(dispatched.value?.storeOrder == nil)
-        #expect(dispatched.value?.storeReview == nil)
-    }
-
-    @Test func test_setStoreOrderEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
-        // Given
-        struct AnyError: Error {}
-        let stores = makeStores()
-        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
-                onCompletion(.failure(AnyError()))
-            }
-        }
-        let sut = makeSUT(stores: stores)
-        #expect(sut.isStoreOrderEnabled == false)
-
-        // When
-        sut.setStoreOrderEnabled(true)
-        await Task.yield()
-        await Task.yield()
-
-        // Then
-        #expect(sut.isStoreOrderEnabled == false)
-        #expect(sut.errorNotice != nil)
-    }
-
-    @Test func test_setStoreReviewEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
-        // Given
-        struct AnyError: Error {}
-        let stores = makeStores()
-        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
-                onCompletion(.failure(AnyError()))
-            }
-        }
-        let sut = makeSUT(stores: stores)
-        #expect(sut.isStoreReviewEnabled == false)
-
-        // When
-        sut.setStoreReviewEnabled(true)
-        await Task.yield()
-        await Task.yield()
-
-        // Then
-        #expect(sut.isStoreReviewEnabled == false)
-        #expect(sut.errorNotice != nil)
-    }
-
-    @Test func test_setStoreStockEnabled_when_remote_fails_then_reverts_optimistic_state_and_surfaces_notice() async {
-        // Given
-        struct AnyError: Error {}
-        let stores = makeStores()
-        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
-                onCompletion(.failure(AnyError()))
-            }
-        }
-        let sut = makeSUT(stores: stores)
-        #expect(sut.isStoreStockEnabled == false)
-
-        // When
-        sut.setStoreStockEnabled(true)
-        await Task.yield()
-        await Task.yield()
-
-        // Then
-        #expect(sut.isStoreStockEnabled == false)
-        #expect(sut.errorNotice != nil)
-    }
-
-    @Test func test_setStoreOrderEnabled_when_remote_succeeds_then_only_storeOrder_is_applied_from_response() async {
-        // Given a server response whose `storeReview` field is stale (false) compared to an
-        // in-flight optimistic flip of the review toggle (true). Only the order update is
-        // completed; the review update's continuation is held to keep that request in flight.
-        let stores = makeStores()
-        let staleResponse = PushNotificationPreferences(
-            storeOrder: .init(enabled: true),
-            storeReview: .init(enabled: false),
-            storeStock: .init(enabled: false)
-        )
-        let pendingReviewCompletion = PendingCompletion()
-        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
-            guard case let .updatePushNotificationPreferences(_, changes, onCompletion) = action else {
-                return
-            }
-            if changes.storeOrder != nil {
-                onCompletion(.success(staleResponse))
-            } else if changes.storeReview != nil {
-                pendingReviewCompletion.handler = onCompletion
-            }
-        }
-        let sut = makeSUT(stores: stores)
-        sut.setStoreReviewEnabled(true)
-
-        // When the order toggle update succeeds and returns its (stale-for-review) snapshot.
-        sut.setStoreOrderEnabled(true)
-        await Task.yield()
-        await Task.yield()
-
-        // Then the order toggle reflects the server, but the review toggle keeps its
-        // optimistic value — it was not part of this request's `changes` payload and its
-        // own request hasn't completed yet.
+        // Then the optimistic edit is preserved on `displayed`, but `lastSaved`
+        // tracks the server snapshot so the next save still diffs correctly.
         #expect(sut.isStoreOrderEnabled == true)
-        #expect(sut.isStoreReviewEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+    }
 
-        // Resolve the dangling continuation so `withCheckedThrowingContinuation` doesn't
-        // emit a runtime warning when the test exits.
-        pendingReviewCompletion.handler?(.success(staleResponse))
+    // MARK: - Setters mutate displayed only
+
+    @Test func test_setStoreOrderEnabled_mutates_displayed_only_and_does_not_dispatch_update() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.setStoreOrderEnabled(true)
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreOrderEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreReviewEnabled_mutates_displayed_only_and_does_not_dispatch_update() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.setStoreReviewEnabled(true)
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreReviewEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreStockEnabled_mutates_displayed_only_and_does_not_dispatch_update() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        sut.setStoreStockEnabled(true)
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreStockEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreOrderEnabled_preserves_existing_minAmount_in_displayed() async {
+        // Given a loaded VM with a positive threshold.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true, minAmount: 100))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When the user flips the master toggle off.
+        sut.setStoreOrderEnabled(false)
+
+        // Then `displayed` retains the threshold so a later save preserves it.
+        #expect(sut.displayed.storeOrder?.enabled == false)
+        #expect(sut.displayed.storeOrder?.minAmount == 100)
+    }
+
+    // MARK: - hasUnsavedChanges
+
+    @Test func test_hasUnsavedChanges_when_displayed_equals_lastSaved_then_false() async {
+        // Given a loaded VM with no edits.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // Then
+        #expect(sut.hasUnsavedChanges == false)
+    }
+
+    @Test func test_hasUnsavedChanges_when_displayed_differs_then_true() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // When
+        sut.setStoreOrderEnabled(true)
+
+        // Then
+        #expect(sut.hasUnsavedChanges == true)
+    }
+
+    @Test func test_hasUnsavedChanges_when_toggle_flipped_back_to_lastSaved_then_false() async {
+        // Given a loaded VM with `enabled: true`.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When the user toggles off then back on.
+        sut.setStoreOrderEnabled(false)
+        sut.setStoreOrderEnabled(true)
+
+        // Then `displayed` equals `lastSaved` again — no diff to save.
+        #expect(sut.hasUnsavedChanges == false)
+    }
+
+    // MARK: - Save
+
+    @Test func test_save_when_remote_succeeds_then_lastSaved_updates_and_returns_true() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        sut.setStoreOrderEnabled(true)
+        #expect(sut.hasUnsavedChanges == true)
+
+        // When
+        let success = await sut.save()
+
+        // Then
+        #expect(success == true)
+        #expect(sut.hasUnsavedChanges == false)
+        #expect(dispatched.last?.storeOrder?.enabled == true)
+        #expect(dispatched.last?.storeReview == nil)
+        #expect(dispatched.last?.storeStock == nil)
+    }
+
+    @Test func test_save_when_remote_fails_then_returns_false_and_surfaces_notice() async {
+        // Given
+        struct AnyError: Error {}
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, _, onCompletion) = action {
+                onCompletion(.failure(AnyError()))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        sut.setStoreOrderEnabled(true)
+
+        // When
+        let success = await sut.save()
+
+        // Then
+        #expect(success == false)
+        #expect(sut.errorNotice != nil)
+        // `displayed` preserved so the user can retry; still unsaved.
+        #expect(sut.isStoreOrderEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+    }
+
+    @Test func test_save_with_no_pending_changes_then_returns_true_without_dispatch() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        let success = await sut.save()
+
+        // Then
+        #expect(success == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_save_dispatches_only_changed_sections() async {
+        // Given a loaded VM with one section edited.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(
+                    storeOrder: .init(enabled: false),
+                    storeReview: .init(enabled: false),
+                    storeStock: .init(enabled: false)
+                )))
+            }
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(PushNotificationPreferences(
+                    storeOrder: .init(enabled: true),
+                    storeReview: .init(enabled: false),
+                    storeStock: .init(enabled: false)
+                )))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When only the order section is edited.
+        sut.setStoreOrderEnabled(true)
+        let success = await sut.save()
+
+        // Then the diff carries only the order section.
+        #expect(success == true)
+        #expect(dispatched.last?.storeOrder?.enabled == true)
+        #expect(dispatched.last?.storeReview == nil)
+        #expect(dispatched.last?.storeStock == nil)
     }
 }
 
-/// Reference-typed box for capturing dispatched changes from a closure without `@MainActor` capture issues.
-/// Mutations always happen on the main actor in tests; `@unchecked Sendable` is safe.
+/// Reference-typed box for capturing dispatched changes from a closure without
+/// `@MainActor` capture issues. Mutations happen on the main actor in tests; the
+/// `@unchecked Sendable` annotation is safe in that context.
 private final class DispatchedChanges: @unchecked Sendable {
-    var value: PushNotificationPreferences?
-}
+    private(set) var calls: [PushNotificationPreferences] = []
+    var last: PushNotificationPreferences? { calls.last }
 
-/// Reference-typed box to hold a `NotificationAction.updatePushNotificationPreferences`
-/// completion closure so it can be resolved later from the test body.
-/// Mutations always happen on the main actor in tests; `@unchecked Sendable` is safe.
-private final class PendingCompletion: @unchecked Sendable {
-    var handler: ((Result<PushNotificationPreferences, Error>) -> Void)?
+    func append(_ changes: PushNotificationPreferences) {
+        calls.append(changes)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import Yosemite
+import class WooFoundation.CurrencySettings
 @testable import WooCommerce
 
 @MainActor
@@ -8,8 +9,19 @@ struct PushNotificationPreferencesViewModelTests {
 
     private let siteID: Int64 = 123
 
-    private func makeSUT(stores: MockStoresManager) -> PushNotificationPreferencesViewModel {
-        PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
+    /// Fixed currency settings for deterministic detail-text formatting in tests.
+    /// USD, left-position `$`, no decimals.
+    private static let testCurrencySettings = CurrencySettings(currencyCode: .USD,
+                                                               currencyPosition: .left,
+                                                               thousandSeparator: ",",
+                                                               decimalSeparator: ".",
+                                                               numberOfDecimals: 0)
+
+    private func makeSUT(stores: MockStoresManager,
+                         currencySettings: CurrencySettings = Self.testCurrencySettings) -> PushNotificationPreferencesViewModel {
+        PushNotificationPreferencesViewModel(siteID: siteID,
+                                             stores: stores,
+                                             currencySettings: currencySettings)
     }
 
     private func makeStores() -> MockStoresManager {
@@ -405,6 +417,33 @@ struct PushNotificationPreferencesViewModelTests {
 
         // Then
         #expect(sut.lastKnownStoreOrderMinAmount == 250)
+    }
+
+    // MARK: - storeOrderDetailText
+
+    @Test func test_storeOrderDetailText_when_minAmount_nil_then_returns_all_orders() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // Then
+        #expect(sut.storeOrderDetailText == "All orders")
+    }
+
+    @Test func test_storeOrderDetailText_when_minAmount_positive_then_returns_formatted_currency_string() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true, minAmount: 500))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.storeOrderDetailText == "Orders over $500")
     }
 
     // MARK: - StoreOrderThreshold helpers

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -280,6 +280,62 @@ struct PushNotificationPreferencesViewModelTests {
 
     // MARK: - Save
 
+    @Test func test_isSaving_is_true_while_save_is_in_flight_and_false_after() async {
+        // Given
+        let stores = makeStores()
+        let saveContinuation = SaveContinuationBox()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                saveContinuation.deliver = { onCompletion(.success(changes)) }
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        sut.setStoreOrderEnabled(true)
+
+        // When
+        async let saveResult = sut.save()
+        // Yield until `save()` reaches its first await so `isSaving` has flipped.
+        await Task.yield()
+
+        // Then
+        #expect(sut.isSaving == true)
+
+        // When
+        saveContinuation.deliver?()
+        _ = await saveResult
+
+        // Then
+        #expect(sut.isSaving == false)
+    }
+
+    @Test func test_save_is_a_noop_while_another_save_is_already_in_flight() async {
+        // Given
+        let stores = makeStores()
+        let saveContinuation = SaveContinuationBox()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                saveContinuation.deliver = { onCompletion(.success(changes)) }
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        sut.setStoreOrderEnabled(true)
+        async let firstSave = sut.save()
+        await Task.yield()
+        #expect(sut.isSaving == true)
+
+        // When
+        let secondSaveResult = await sut.save()
+
+        // Then
+        #expect(secondSaveResult == false)
+        #expect(dispatched.calls.count == 1)
+
+        saveContinuation.deliver?()
+        _ = await firstSave
+    }
+
     @Test func test_save_when_remote_succeeds_then_lastSaved_updates_and_returns_true() async {
         // Given
         let stores = makeStores()
@@ -550,4 +606,10 @@ private final class DispatchedChanges: @unchecked Sendable {
     func append(_ changes: PushNotificationPreferences) {
         calls.append(changes)
     }
+}
+
+/// Stashed by the mock store so tests can keep `viewModel.save()` suspended
+/// while assertions run, then complete it via `deliver?()`.
+private final class SaveContinuationBox: @unchecked Sendable {
+    var deliver: (() -> Void)?
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -170,6 +170,55 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.displayed.storeOrder?.minAmount == 100)
     }
 
+    // MARK: - discardStoreOrderEdits
+
+    @Test func test_discardStoreOrderEdits_reverts_storeOrder_to_lastSaved_and_clears_unsaved_flag() async {
+        // Given a loaded VM with a positive threshold the user then edits.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true, minAmount: 100))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+        sut.setStoreOrderEnabled(false)
+        sut.setStoreOrderMinAmount(500)
+        #expect(sut.hasUnsavedChanges == true)
+
+        // When
+        sut.discardStoreOrderEdits()
+
+        // Then `displayed.storeOrder` matches the server snapshot again.
+        #expect(sut.displayed.storeOrder?.enabled == true)
+        #expect(sut.displayed.storeOrder?.minAmount == 100)
+        #expect(sut.hasUnsavedChanges == false)
+    }
+
+    @Test func test_discardStoreOrderEdits_leaves_other_sections_untouched() async {
+        // Given a loaded VM where the user edits review *and* order.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(
+                    storeOrder: .init(enabled: true),
+                    storeReview: .init(enabled: false)
+                )))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+        sut.setStoreOrderEnabled(false)
+        sut.setStoreReviewEnabled(true)
+
+        // When the user discards the order edits.
+        sut.discardStoreOrderEdits()
+
+        // Then the review edit is preserved — the discard is scoped to the order section.
+        #expect(sut.displayed.storeOrder?.enabled == true)
+        #expect(sut.displayed.storeReview?.enabled == true)
+    }
+
     // MARK: - hasUnsavedChanges
 
     @Test func test_hasUnsavedChanges_when_displayed_equals_lastSaved_then_false() async {
@@ -285,6 +334,135 @@ struct PushNotificationPreferencesViewModelTests {
         // Then
         #expect(success == true)
         #expect(dispatched.calls.isEmpty)
+    }
+
+    // MARK: - setStoreOrderMinAmount
+
+    @Test func test_setStoreOrderMinAmount_mutates_displayed_only_and_preserves_enabled() async {
+        // Given a loaded VM with the master toggle on.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreOrderMinAmount(300)
+
+        // Then
+        #expect(sut.storeOrderMinAmount == 300)
+        #expect(sut.isStoreOrderEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(sut.lastKnownStoreOrderMinAmount == 300)
+    }
+
+    @Test func test_setStoreOrderMinAmount_with_zero_normalizes_to_nil_and_keeps_lastKnown() async {
+        // Given a loaded VM with a positive threshold.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true, minAmount: 200))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreOrderMinAmount(0)
+
+        // Then
+        #expect(sut.storeOrderMinAmount == nil)
+        // `lastKnown` keeps the previous positive value so a later restore works.
+        #expect(sut.lastKnownStoreOrderMinAmount == 200)
+    }
+
+    @Test func test_setStoreOrderMinAmount_with_negative_normalizes_to_nil() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // When
+        sut.setStoreOrderMinAmount(-50)
+
+        // Then
+        #expect(sut.storeOrderMinAmount == nil)
+    }
+
+    @Test func test_load_when_response_has_positive_minAmount_then_lastKnown_is_populated() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: true, minAmount: 250))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.lastKnownStoreOrderMinAmount == 250)
+    }
+
+    // MARK: - StoreOrderThreshold helpers
+
+    @Test func test_storeOrderThreshold_isAllowedInput_accepts_positive_ascii_integer() {
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("5"))
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("12345"))
+    }
+
+    @Test func test_storeOrderThreshold_isAllowedInput_accepts_non_latin_digits() {
+        // Arabic-Indic "500", Eastern Arabic-Indic "500", Devanagari "500".
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("\u{0665}\u{0660}\u{0660}"))
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("\u{06F5}\u{06F0}\u{06F0}"))
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("\u{096B}\u{0966}\u{0966}"))
+    }
+
+    @Test func test_storeOrderThreshold_isAllowedInput_rejects_empty_zero_and_leading_zero() {
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput(""))
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("0"))
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("00"))
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("01"))
+        // Arabic-Indic leading zero (\u{0660} = "٠").
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("\u{0660}\u{0665}"))
+    }
+
+    @Test func test_storeOrderThreshold_isAllowedInput_rejects_non_digit_characters() {
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("abc"))
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("1.5"))
+        #expect(!PushNotificationPreferencesViewModel.StoreOrderThreshold.isAllowedInput("5e3"))
+    }
+
+    @Test func test_storeOrderThreshold_parse_returns_value_for_ascii_and_non_latin_digits() {
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("500") == 500)
+        // Arabic-Indic "500" → 500.
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("\u{0665}\u{0660}\u{0660}") == 500)
+        // Devanagari "500" → 500.
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("\u{096B}\u{0966}\u{0966}") == 500)
+    }
+
+    @Test func test_storeOrderThreshold_parse_returns_nil_for_empty_or_invalid() {
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("") == nil)
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("   ") == nil)
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("abc") == nil)
+    }
+
+    @Test func test_storeOrderThreshold_parse_trims_whitespace() {
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.parse("  500  ") == 500)
+    }
+
+    @Test func test_storeOrderThreshold_formatInput_returns_ascii_integer_for_positive_amount() {
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.formatInput(100) == "100")
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.formatInput(99999) == "99999")
+    }
+
+    @Test func test_storeOrderThreshold_formatInput_returns_empty_for_nil_zero_or_negative() {
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.formatInput(nil).isEmpty)
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.formatInput(0).isEmpty)
+        #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.formatInput(-5).isEmpty)
     }
 
     @Test func test_save_dispatches_only_changed_sections() async {


### PR DESCRIPTION
## Description

Implements [RSM-1631]. Adds the **New orders** detail screen reached by tapping the New orders row in the Push Notifications preferences list. The screen lets the merchant choose between notifications for *all new orders* or *only orders above a custom amount*, with a currency-aware threshold field. The list row's detail text reflects the current threshold immediately ("All orders" ↔ "Orders over $500") while the user edits — changes are committed by an explicit toolbar **Save** button.

Stacked on top of #17206 (RSM-3624 — drops the inline toggles from the list rows), and behind the existing `smarterNotifications` feature flag, gated through `SettingsViewModel`.

### Save / discard pattern

Replaces the original per-toggle immediate-dispatch + optimistic-revert flow (rejected in #17195) with the explicit Save pattern used by `NotificationSettingsView` and `SiteNotificationSettingsView`. Setters mutate an in-progress `displayed` snapshot; `viewModel.save()` diffs against a server-confirmed `lastSaved` and dispatches a single update. The Save button is hidden / disabled until `displayed != lastSaved`; a discard-changes action sheet (the shared `UIAlertController.presentDiscardChangesActionSheet`) fires on back-press or edge-swipe and reverts only the new-order section.


## Test Steps

1. Enable the `smarterNotifications` feature flag.
2. Ensure the site is registered for Woo-driven push notifications.
3. Settings → **Push Notifications** → tap the **New orders** row → detail screen pushes.
4. **Save button**:
   - Initially disabled.
   - Flip the master toggle or change a radio → button becomes enabled.
   - Tap Save → activity indicator appears while in flight → screen pops on success → list row reflects the saved state.
5. **Discard flow** (with unsaved changes):
   - Tap the back chevron → action sheet asks "Are you sure you want to discard these changes?" → tap **Discard changes** → New orders section reverts, screen pops, list row is unchanged.
   - Repeat using the edge-swipe gesture → same sheet appears.
   - Tap back with no unsaved changes → pops immediately (no sheet).
6. **Title and chevron**: navigate to the detail screen — title "New orders" is present and stays (no flicker), and a single `<` chevron is visible (no "< back  <" doubling).
7. **Threshold preservation**: with master ON and threshold `500`, flip master OFF then ON and Save → threshold is preserved (not silently cleared).
8. **Radio + threshold**: tap "Only high-value orders" → threshold field slides in (default 100). Type `500`, Save → list row reads "Orders over $500". Tap "All new orders", Save → field slides out, row reads "All orders". Re-enter detail, tap "Only high-value orders" → threshold field slides back in with `500`.
9. **Disallowed input**: type `0` as the first character — rejected. Type `1`, `0` — field shows `10`. Paste `abc` or `00` — rejected. Clear field and retype — works.
10. **i18n**: switch keyboard to Arabic / Hindi numeral mode, type digits — should be accepted.
11. **Save failure**: enable airplane mode, edit + tap Save → error notice surfaces; `displayed` is preserved so the user can retry; `hasUnsavedChanges` stays true and the Save button stays enabled after the spinner.

## Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-20 at 21 36 55" src="https://github.com/user-attachments/assets/67031018-50d8-4867-bf4c-e1c9bdfc178f" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.