### PR TITLE
Extract release-notes AI helper and run Fastlane helper tests in CI

### DIFF
--- a/.buildkite/commands/run-ruby-automation-tests.sh
+++ b/.buildkite/commands/run-ruby-automation-tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -eu
+
+# Runs pure-Ruby Minitest files for our Fastlane helpers
+# (fastlane/helpers/*_test.rb). The tests have no Fastlane runtime
+# dependency, so they're cheap to run (<1s total) on the linter queue.
+#
+# Skip behavior:
+# - On PR builds: skip when no `fastlane/**` files have changed.
+# - On non-PR builds (trunk, release branches): always run, so the latest
+#   merged state is validated.
+
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" =~ ^[0-9]+$ ]]; then
+  if ! pr_changed_files --any-match 'fastlane/*'; then
+    echo "--- :fast_forward: Skipping — no fastlane/ changes in this PR"
+    exit 0
+  fi
+fi
+
+test_files=(fastlane/helpers/*_test.rb)
+if [[ ${#test_files[@]} -eq 0 ]] || [[ ! -f "${test_files[0]}" ]]; then
+  echo "No fastlane/helpers/*_test.rb files found — nothing to run."
+  exit 0
+fi
+
+status=0
+for f in "${test_files[@]}"; do
+  echo "--- :ruby: $f"
+  if ! ruby "$f"; then
+    status=1
+  fi
+done
+
+exit "$status"

--- a/.buildkite/commands/run-ruby-automation-tests.sh
+++ b/.buildkite/commands/run-ruby-automation-tests.sh
@@ -10,7 +10,7 @@
 #   merged state is validated.
 
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" =~ ^[0-9]+$ ]]; then
-  if ! pr_changed_files --any-match 'fastlane/*'; then
+  if ! pr_changed_files --any-match 'fastlane/**'; then
     echo "--- :fast_forward: Skipping — no fastlane/ changes in this PR"
     exit 0
   fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,8 +75,6 @@ steps:
   - label: ":ruby: Ruby Automation Tests"
     command: .buildkite/commands/run-ruby-automation-tests.sh
     plugins: [$CI_TOOLKIT]
-    agents:
-      queue: default
     notify:
       - github_commit_status:
           context: Ruby Automation Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
     command: .buildkite/commands/run-ruby-automation-tests.sh
     plugins: [$CI_TOOLKIT]
     agents:
-      queue: linter
+      queue: default
     notify:
       - github_commit_status:
           context: Ruby Automation Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,6 +70,18 @@ steps:
           context: WordPressAuthenticator Unit Tests
 
   #################
+  # Ruby Automation Tests (Fastlane helpers)
+  #################
+  - label: ":ruby: Ruby Automation Tests"
+    command: .buildkite/commands/run-ruby-automation-tests.sh
+    plugins: [$CI_TOOLKIT]
+    agents:
+      queue: linter
+    notify:
+      - github_commit_status:
+          context: Ruby Automation Tests
+
+  #################
   # Linters
   #################
   - group: Linters

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,7 @@ fastlane_require 'git'
 fastlane_require 'octokit'
 
 require_relative 'helpers/release_notes_pr_helper'
+require_relative 'helpers/release_notes_ai_helper'
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
@@ -1715,39 +1716,22 @@ def fail_lane!(context:, message:)
   UI.user_error!(message)
 end
 
-# Calls OpenAI via release-toolkit's `openai_ask` action using a tool-use loop:
-# the model submits drafts through the `validate_release_notes_length` tool and the
-# handler validates length externally, replying with `ok:`/`length:`/`cut_at_least:`
-# until an accepted draft is captured.
-#
-# The accepted text is captured directly from the validated tool argument
-# rather than read off the assistant's final plain-text turn. That avoids
-# subtle drift if the model adds a leading "Here it is:" or similar — the
-# returned value is exactly what passed length validation.
+# Drives the `openai_ask` tool-use loop that enforces the release-notes length
+# limit. Delegates the tool definition, validator, and orchestration to
+# `ReleaseNotesAIHelper` (which is independently unit-tested); this wrapper
+# supplies the Fastlane-side concerns: the prompt, the API key, and how to
+# surface failures.
 def generate_ai_release_notes(version:, items_text:)
   question = ReleaseNotesPRHelper.build_ai_release_notes_prompt(version: version, items_text: items_text)
   max_length = ReleaseNotesPRHelper::PREFERRED_RELEASE_NOTES_MAX_LENGTH
-  handler, captured = build_release_notes_length_validator(max_length: max_length)
 
-  openai_ask(
-    prompt: :release_notes,
-    question: question,
-    api_token: get_required_env('OPENAI_API_KEY'),
-    tools: [release_notes_length_validation_tool],
-    tool_handlers: { 'validate_release_notes_length' => handler }
-  )
-
-  captured_text = captured[:text]
-  # Distinct from the empty-string case below: nil means the model finished
-  # without ever invoking `validate_release_notes_length`. The handler rejects
-  # empty drafts and keeps the loop going, so a nil capture indicates the model
-  # bypassed the tool entirely (tool calling not supported/enabled, or the
-  # toolkit pin lacks tool-use support) — not that it produced empty text.
-  if captured_text.nil?
-    fail_lane!(
-      context: 'release-notes-pr-error',
-      message: 'openai_ask returned without invoking validate_release_notes_length — ' \
-               'check that the model supports tool calling.'
+  captured_text = ReleaseNotesAIHelper.generate(max_length: max_length) do |tools:, tool_handlers:|
+    openai_ask(
+      prompt: :release_notes,
+      question: question,
+      api_token: get_required_env('OPENAI_API_KEY'),
+      tools: tools,
+      tool_handlers: tool_handlers
     )
   end
 
@@ -1757,61 +1741,8 @@ def generate_ai_release_notes(version:, items_text:)
 
   UI.success("Generated release notes are #{captured_text.length} characters.")
   captured_text
-end
-
-# Builds the `validate_release_notes_length` tool handler. Returns `[handler, captured]`:
-# the lambda the toolkit invokes, and a 1-key Hash whose `:text` field is set to the
-# accepted draft when the model produces one. The Hash is used as a writable capture
-# slot — closing over a plain local would force the caller to share its scope with the
-# lambda, which is fine but forces the whole flow into one method.
-#
-# Validation rules:
-# - strip leading/trailing whitespace so it never lands in `release_notes.txt` or
-#   `CHANGELOG.md` and doesn't inflate the character count
-# - reject empty drafts as a length-style failure so the model stays in the loop
-#   instead of terminating early and being caught later as "empty release notes"
-# - on success, capture the validated text and tell the model `ok: true, length:`
-# - on overshoot, tell the model how many characters to cut via `cut_at_least`
-# - on empty, tell the model via `reason` (no `cut_at_least` since the action is to add
-#   content, not trim) — both rejection shapes share the `ok: false, length:, max:` keys
-def build_release_notes_length_validator(max_length:)
-  captured = { text: nil }
-  handler = lambda do |args|
-    text = args['text'].to_s.strip
-    length = text.length
-    if length.zero?
-      { ok: false, length: 0, max: max_length, reason: 'empty draft — submit a non-empty paragraph' }
-    elsif length <= max_length
-      captured[:text] = text
-      { ok: true, length: length }
-    else
-      { ok: false, length: length, max: max_length, cut_at_least: length - max_length }
-    end
-  end
-  [handler, captured]
-end
-
-# OpenAI tool definition for `validate_release_notes_length`.
-def release_notes_length_validation_tool
-  {
-    type: 'function',
-    function: {
-      name: 'validate_release_notes_length',
-      description: 'Checks the length of the proposed release notes paragraph against the character limit. ' \
-                   'Returns `{ ok: true, length: }` if the text fits, or `{ ok: false, length:, max:, cut_at_least?, reason? }` ' \
-                   'otherwise — `cut_at_least` is included when the draft is too long; `reason` is included for other rejections ' \
-                   '(e.g. an empty draft). Call this repeatedly with revised drafts until it returns `ok: true`. ' \
-                   'When shortening, restructure or remove phrases or items — do not drop letters from words, ' \
-                   'omit articles, or invent abbreviations to hit the limit. Grammar and spelling must remain correct.',
-      parameters: {
-        type: 'object',
-        properties: {
-          text: { type: 'string', description: 'The proposed release notes paragraph.' }
-        },
-        required: ['text']
-      }
-    }
-  }
+rescue ReleaseNotesAIHelper::ToolCallNotInvokedError => e
+  fail_lane!(context: 'release-notes-pr-error', message: e.message)
 end
 
 # Returns the `html_url` of an open PR for `head -> base` in the WCiOS

--- a/fastlane/helpers/release_notes_ai_helper.rb
+++ b/fastlane/helpers/release_notes_ai_helper.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Pure-Ruby helpers for the AI release-notes generation loop used by
+# `create_release_notes_pr`.
+#
+# Encapsulates the `openai_ask` tool-use logic: the length-validation tool
+# definition, the handler that backs it, and the orchestration that drives a
+# Fastlane-side `openai_ask` call until the model produces a valid draft.
+#
+# Deliberately free of Fastlane / network / openai_ask dependencies so the
+# logic can be exercised by unit tests without touching the network or the
+# Fastlane runtime: the caller injects the actual ask via a block.
+module ReleaseNotesAIHelper
+  # Raised when the model finished its turn without invoking the
+  # `validate_release_notes_length` tool — meaning we never captured an
+  # accepted draft. Distinct from a draft that was rejected for being empty
+  # (the handler keeps the loop going in that case).
+  class ToolCallNotInvokedError < StandardError; end
+
+  # Name of the OpenAI tool the model uses to submit drafts for length
+  # validation. Exposed so callers can build the `tool_handlers` map without
+  # duplicating the string.
+  LENGTH_VALIDATION_TOOL_NAME = 'validate_release_notes_length'
+
+  module_function
+
+  # Drives an `openai_ask` tool-use loop that enforces the release-notes
+  # length limit. The caller is expected to invoke `openai_ask` (or another
+  # equivalent) inside the block, threading `tools:` and `tool_handlers:`
+  # through verbatim. The accepted draft is returned by reading the captured
+  # value the handler stashes — not the model's final plain-text turn — so
+  # the returned text is exactly what passed length validation.
+  #
+  # @param max_length [Integer] max allowed length for the validated draft
+  # @yieldparam tools [Array<Hash>] OpenAI tool definitions
+  # @yieldparam tool_handlers [Hash{String=>#call}] handler keyed by tool name
+  # @return [String] the accepted release-notes text
+  # @raise [ToolCallNotInvokedError] if the model never called the tool
+  def generate(max_length:)
+    raise ArgumentError, 'a block is required' unless block_given?
+
+    handler, captured = build_length_validator(max_length: max_length)
+    yield(tools: [length_validation_tool], tool_handlers: { LENGTH_VALIDATION_TOOL_NAME => handler })
+
+    captured_text = captured[:text]
+    if captured_text.nil?
+      raise ToolCallNotInvokedError,
+            "openai_ask returned without invoking #{LENGTH_VALIDATION_TOOL_NAME} — " \
+            'check that the model supports tool calling.'
+    end
+
+    captured_text
+  end
+
+  # Builds the `validate_release_notes_length` tool handler. Returns
+  # `[handler, captured]`: the lambda the toolkit invokes, and a 1-key Hash
+  # whose `:text` field is set to the accepted draft when the model produces
+  # one. The Hash is used as a writable capture slot — closing over a plain
+  # local would force the caller to share its scope with the lambda, which
+  # is fine but forces the whole flow into one method.
+  #
+  # Validation rules:
+  # - strip leading/trailing whitespace so it never lands in `release_notes.txt`
+  #   or `CHANGELOG.md` and doesn't inflate the character count
+  # - reject empty drafts as a length-style failure so the model stays in the
+  #   loop instead of terminating early and being caught later as "empty
+  #   release notes"
+  # - on success, capture the validated text and tell the model `ok: true, length:`
+  # - on overshoot, tell the model how many characters to cut via `cut_at_least`
+  # - on empty, tell the model via `reason` (no `cut_at_least` since the action
+  #   is to add content, not trim) — both rejection shapes share the
+  #   `ok: false, length:, max:` keys
+  #
+  # @param max_length [Integer]
+  # @return [Array(Proc, Hash)] [handler, captured]
+  def build_length_validator(max_length:)
+    captured = { text: nil }
+    handler = lambda do |args|
+      text = args['text'].to_s.strip
+      length = text.length
+      if length.zero?
+        { ok: false, length: 0, max: max_length, reason: 'empty draft — submit a non-empty paragraph' }
+      elsif length <= max_length
+        captured[:text] = text
+        { ok: true, length: length }
+      else
+        { ok: false, length: length, max: max_length, cut_at_least: length - max_length }
+      end
+    end
+    [handler, captured]
+  end
+
+  # OpenAI tool definition for `validate_release_notes_length`.
+  def length_validation_tool
+    {
+      type: 'function',
+      function: {
+        name: LENGTH_VALIDATION_TOOL_NAME,
+        description: 'Checks the length of the proposed release notes paragraph against the character limit. ' \
+                     'Returns `{ ok: true, length: }` if the text fits, or `{ ok: false, length:, max:, cut_at_least?, reason? }` ' \
+                     'otherwise — `cut_at_least` is included when the draft is too long; `reason` is included for other rejections ' \
+                     '(e.g. an empty draft). Call this repeatedly with revised drafts until it returns `ok: true`. ' \
+                     'When shortening, restructure or remove phrases or items — do not drop letters from words, ' \
+                     'omit articles, or invent abbreviations to hit the limit. Grammar and spelling must remain correct.',
+        parameters: {
+          type: 'object',
+          properties: {
+            text: { type: 'string', description: 'The proposed release notes paragraph.' }
+          },
+          required: ['text']
+        }
+      }
+    }
+  end
+end

--- a/fastlane/helpers/release_notes_ai_helper_test.rb
+++ b/fastlane/helpers/release_notes_ai_helper_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Pure-Ruby unit tests for ReleaseNotesAIHelper. Uses Ruby's stdlib Minitest so
+# no extra gems are required.
+#
+# Run:
+#   ruby fastlane/helpers/release_notes_ai_helper_test.rb
+
+require 'minitest/autorun'
+require_relative 'release_notes_ai_helper'
+
+# Unit tests for ReleaseNotesAIHelper.
+class ReleaseNotesAIHelperTest < Minitest::Test # rubocop:disable Metrics/ClassLength
+  Helper = ReleaseNotesAIHelper
+
+  # --- length_validation_tool ------------------------------------------------
+
+  def test_length_validation_tool_has_expected_shape
+    tool = Helper.length_validation_tool
+    function = tool[:function]
+    parameters = function[:parameters]
+
+    assert_equal 'function', tool[:type]
+    assert_equal Helper::LENGTH_VALIDATION_TOOL_NAME, function[:name]
+    assert_equal 'object', parameters[:type]
+    assert_equal %w[text], parameters[:required]
+    assert_equal 'string', parameters[:properties][:text][:type]
+  end
+
+  def test_length_validation_tool_description_mentions_protocol_keys
+    description = Helper.length_validation_tool[:function][:description]
+    assert_includes description, '{ ok: true, length: }'
+    assert_includes description, '{ ok: false, length:, max:, cut_at_least?, reason? }'
+  end
+
+  # --- build_length_validator: accepted drafts -------------------------------
+
+  def test_build_length_validator_accepts_text_within_limit
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    result = handler.call({ 'text' => 'Short copy.' })
+
+    assert_equal({ ok: true, length: 'Short copy.'.length }, result)
+    assert_equal 'Short copy.', captured[:text]
+  end
+
+  def test_build_length_validator_accepts_text_at_exact_limit
+    text = 'a' * 350
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    result = handler.call({ 'text' => text })
+
+    assert_equal({ ok: true, length: 350 }, result)
+    assert_equal text, captured[:text]
+  end
+
+  def test_build_length_validator_strips_surrounding_whitespace
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    result = handler.call({ 'text' => "  Short copy.  \n" })
+
+    assert_equal({ ok: true, length: 'Short copy.'.length }, result)
+    assert_equal 'Short copy.', captured[:text]
+  end
+
+  # --- build_length_validator: rejected drafts -------------------------------
+
+  def test_build_length_validator_rejects_text_over_limit_with_cut_at_least
+    handler, captured = Helper.build_length_validator(max_length: 10)
+
+    result = handler.call({ 'text' => 'x' * 15 })
+
+    assert_equal({ ok: false, length: 15, max: 10, cut_at_least: 5 }, result)
+    assert_nil captured[:text]
+  end
+
+  def test_build_length_validator_rejects_empty_text_with_reason
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    result = handler.call({ 'text' => '' })
+
+    assert_equal false, result[:ok]
+    assert_equal 0, result[:length]
+    assert_equal 350, result[:max]
+    refute_nil result[:reason]
+    refute result.key?(:cut_at_least)
+    assert_nil captured[:text]
+  end
+
+  def test_build_length_validator_treats_whitespace_only_text_as_empty
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    result = handler.call({ 'text' => "   \n  " })
+
+    assert_equal false, result[:ok]
+    assert_equal 0, result[:length]
+    assert_equal 350, result[:max]
+    refute_nil result[:reason]
+    assert_nil captured[:text]
+  end
+
+  def test_build_length_validator_treats_nil_text_as_empty
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    result = handler.call({ 'text' => nil })
+
+    assert_equal false, result[:ok]
+    assert_equal 0, result[:length]
+    assert_nil captured[:text]
+  end
+
+  def test_build_length_validator_keeps_last_accepted_draft
+    handler, captured = Helper.build_length_validator(max_length: 350)
+
+    handler.call({ 'text' => 'First draft.' })
+    handler.call({ 'text' => 'x' * 400 })
+    handler.call({ 'text' => 'Second draft.' })
+
+    # Capture reflects the most recent accepted draft; over-limit calls don't overwrite.
+    assert_equal 'Second draft.', captured[:text]
+  end
+
+  # --- generate orchestration ------------------------------------------------
+
+  def test_generate_yields_tools_and_handlers_and_returns_captured_text
+    yielded = nil
+    result = Helper.generate(max_length: 350) do |tools:, tool_handlers:|
+      yielded = { tools: tools, tool_handlers: tool_handlers }
+      # Simulate the model invoking the validation tool with an acceptable draft.
+      tool_handlers[Helper::LENGTH_VALIDATION_TOOL_NAME].call({ 'text' => 'Accepted draft copy.' })
+    end
+
+    assert_equal 'Accepted draft copy.', result
+    assert_equal 1, yielded[:tools].size
+    assert_equal Helper::LENGTH_VALIDATION_TOOL_NAME, yielded[:tools].first[:function][:name]
+    assert_includes yielded[:tool_handlers].keys, Helper::LENGTH_VALIDATION_TOOL_NAME
+  end
+
+  def test_generate_raises_when_tool_is_never_invoked
+    error = assert_raises(Helper::ToolCallNotInvokedError) do
+      Helper.generate(max_length: 350) do |tools:, tool_handlers:|
+        # Simulate the model returning without invoking the tool.
+        _ = [tools, tool_handlers]
+      end
+    end
+    assert_includes error.message, Helper::LENGTH_VALIDATION_TOOL_NAME
+  end
+
+  def test_generate_returns_text_from_final_accepted_draft_after_retries
+    result = Helper.generate(max_length: 20) do |tools:, tool_handlers:|
+      handler = tool_handlers[Helper::LENGTH_VALIDATION_TOOL_NAME]
+      # Simulate over-limit attempt first, then a corrected one.
+      handler.call({ 'text' => 'x' * 25 })
+      handler.call({ 'text' => 'Fits.' })
+      _ = tools
+    end
+
+    assert_equal 'Fits.', result
+  end
+
+  def test_generate_raises_argument_error_without_block
+    assert_raises(ArgumentError) do
+      Helper.generate(max_length: 350)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Follow-up to `WOOMOB-3063`, addressing two items raised in the review of #17119:

1. **Extract AI loop into a dedicated helper.** The `validate_release_notes_length` tool, capture-based length validator, and `openai_ask` orchestrator move out of `fastlane/Fastfile` into a new `ReleaseNotesAIHelper` module. The Fastfile's `generate_ai_release_notes` shrinks to a thin wrapper that supplies the actual `openai_ask` call via a block, while the helper stays product-agnostic and unit-testable in isolation (14 tests / 42 assertions).
2. **Run Fastlane helper unit tests in CI.** New standalone "Ruby Automation Tests" Buildkite step that runs every `fastlane/helpers/*_test.rb` (44 tests / 189 assertions total today). Uses a dedicated script (`.buildkite/commands/run-ruby-automation-tests.sh`) with a changed-files guard: on PR builds it skips when no `fastlane/**` files have changed; non-PR builds (trunk, release branches) always run so latest state is validated.

The `Fastfile` lane behavior is unchanged — only its internals were moved.

## Test Steps

1. **Local helper tests:**
   - `ruby fastlane/helpers/release_notes_ai_helper_test.rb` → 14 runs, 42 assertions, 0 failures
   - `ruby fastlane/helpers/release_notes_pr_helper_test.rb` → 30 runs, 147 assertions, 0 failures
2. **Local CI script:**
   - `BUILDKITE_PULL_REQUEST=false bash .buildkite/commands/run-ruby-automation-tests.sh` — both test files run and report all green.
3. **CI verification (this PR):**
   - "Ruby Automation Tests" step appears in the Buildkite build for this PR and runs (this PR touches `fastlane/`).
   - The step's logs show both `release_notes_ai_helper_test.rb` and `release_notes_pr_helper_test.rb` executing.
4. **Changed-files guard verification (optional):**
   - On a separate PR that doesn't touch `fastlane/`, the step should log `Skipping — no fastlane/ changes in this PR` and exit 0. (Could not be verified in this PR since it _does_ touch `fastlane/`.)
5. **End-to-end smoke for the lane (requires `OPENAI_API_KEY`):**
   - `OPENAI_API_KEY=sk-... bundle exec fastlane create_release_notes_pr version:24.x dry_run:true` produces the same dry-run preview annotation as before this refactor.
   - Or trigger via Buildkite as documented in https://github.com/woocommerce/woocommerce-ios/pull/17119#issuecomment-4428357336: _New build_ with options like:

```
PIPELINE=release-pipelines/create-release-notes-pr.yml
RELEASE_VERSION=x.y
DRY_RUN=true
```

6. **Pipeline YAML sanity:** `ruby -r yaml -e "YAML.load_file('.buildkite/pipeline.yml')"\` exits 0.

## Screenshots

N/A — Fastlane/CI tooling change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. (No entry needed — internal tooling.)