### PR TITLE
[RSM-1633] Add New reviews notification settings detail UI

### DIFF
--- a/Modules/Sources/Networking/Model/PushNotificationPreferences.swift
+++ b/Modules/Sources/Networking/Model/PushNotificationPreferences.swift
@@ -98,6 +98,8 @@ public extension PushNotificationPreferences {
         public let enabled: Bool?
 
         /// Maximum star rating that triggers a notification. Server clamps to `1...5`.
+        /// `nil` is sent on the wire as JSON `null`, which the server interprets as
+        /// "notify on every review" (matches the "All new reviews" radio option).
         public let maxRating: Int?
 
         public init(enabled: Bool? = nil, maxRating: Int? = nil) {
@@ -114,7 +116,15 @@ public extension PushNotificationPreferences {
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encodeIfPresent(enabled, forKey: .enabled)
-            try container.encodeIfPresent(maxRating, forKey: .maxRating)
+            // Use `encode`/`encodeNil` (not `encodeIfPresent`) so `nil` is written as
+            // JSON `null` — the server interprets explicit null as "clear the rating".
+            // Without this, omitting the key would mean "no change", and the user
+            // could never switch from "Only low-rated reviews" back to "All new reviews".
+            if let maxRating {
+                try container.encode(maxRating, forKey: .maxRating)
+            } else {
+                try container.encodeNil(forKey: .maxRating)
+            }
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
@@ -98,6 +98,23 @@ struct PushNotificationPreferencesRemoteTests {
         #expect(storeOrder["min_amount"] is NSNull)
     }
 
+    @Test func updatePreferences_when_storeReview_maxRating_is_nil_then_sends_explicit_null() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        let changes = PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: nil))
+
+        // When
+        _ = try? await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then — the wire body must include `max_rating` as JSON null so the server clears
+        // the rating cap (the "All new reviews" selection on the detail screen).
+        let parameters = try #require(network.queryParametersDictionary)
+        let storeReview = try #require(parameters["store_review"] as? [String: Any])
+        #expect(storeReview.count == 2)
+        #expect(storeReview["enabled"] as? Bool == true)
+        #expect(storeReview["max_rating"] is NSNull)
+    }
+
     // MARK: - Response decoding
 
     @Test func loadPreferences_then_decodes_full_response() async throws {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
@@ -1,141 +1,19 @@
 import SwiftUI
-import UIKit
 
-/// Hosts `NewOrderNotificationPreferencesDetailView` and owns its navigation
-/// chrome (Save bar button, custom back button, discard-changes flow).
+/// Hosts `NewOrderNotificationPreferencesDetailView`. Navigation chrome
+/// (Save, back button, discard alert, saving spinner) is inherited from
+/// `NotificationDetailHostingController`.
 ///
-/// Toolbar items live on `navigationItem` rather than in a SwiftUI `.toolbar`
-/// modifier — when a `UIHostingController`'s root view declares any toolbar
-/// item, SwiftUI takes ownership of the navigation item and routes the back
-/// button through its own gesture stack, bypassing
-/// `UINavigationBarDelegate.navigationBar(_:shouldPop:)` and
-/// `shouldPopOnBackButton`.
-///
-final class NewOrderNotificationPreferencesHostingController: UIHostingController<NewOrderNotificationPreferencesDetailView> {
-
-    private let viewModel: PushNotificationPreferencesViewModel
-
-    private lazy var saveBarButtonItem: UIBarButtonItem = {
-        let item = UIBarButtonItem(title: Localization.save,
-                                   style: .done,
-                                   target: self,
-                                   action: #selector(handleSaveTapped))
-        item.isEnabled = false
-        return item
-    }()
-
-    private lazy var backBarButtonItem: UIBarButtonItem = {
-        let image = UIImage(systemName: "chevron.backward")
-        let item = UIBarButtonItem(image: image,
-                                   style: .plain,
-                                   target: self,
-                                   action: #selector(handleBackTapped))
-        item.accessibilityLabel = Localization.back
-        return item
-    }()
-
-    private lazy var savingActivityItem: UIBarButtonItem = {
-        let spinner = UIActivityIndicatorView(style: .medium)
-        spinner.startAnimating()
-        return UIBarButtonItem(customView: spinner)
-    }()
+final class NewOrderNotificationPreferencesHostingController:
+    NotificationDetailHostingController<NewOrderNotificationPreferencesDetailView> {
 
     init(viewModel: PushNotificationPreferencesViewModel) {
-        self.viewModel = viewModel
-        super.init(rootView: NewOrderNotificationPreferencesDetailView(viewModel: viewModel))
+        super.init(viewModel: viewModel,
+                   rootView: NewOrderNotificationPreferencesDetailView(viewModel: viewModel),
+                   onDiscard: { [weak viewModel] in viewModel?.discardStoreOrderEdits() })
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationItem.leftBarButtonItem = backBarButtonItem
-        refreshRightBarButtonItem()
-        // Routes the edge-swipe gesture through `shouldPopOnSwipeBack`.
-        handleSwipeBackGesture()
-        observeUnsavedChanges()
-    }
-
-    override func shouldPopOnBackButton() -> Bool {
-        if viewModel.hasUnsavedChanges {
-            presentBackNavigationActionSheet()
-            return false
-        }
-        return true
-    }
-
-    override func shouldPopOnSwipeBack() -> Bool {
-        return shouldPopOnBackButton()
-    }
-}
-
-private extension NewOrderNotificationPreferencesHostingController {
-    /// `@Observable` tracking fires once and stops, so re-register after each
-    /// change to keep the bar item in sync with `hasUnsavedChanges` and
-    /// `isSaving`.
-    func observeUnsavedChanges() {
-        withObservationTracking {
-            _ = viewModel.hasUnsavedChanges
-            _ = viewModel.isSaving
-        } onChange: { [weak self] in
-            // `onChange` fires from `willSet`; hop to main before touching UIKit.
-            DispatchQueue.main.async {
-                self?.refreshRightBarButtonItem()
-                self?.observeUnsavedChanges()
-            }
-        }
-    }
-
-    func refreshRightBarButtonItem() {
-        if viewModel.isSaving {
-            navigationItem.rightBarButtonItem = savingActivityItem
-        } else {
-            saveBarButtonItem.isEnabled = viewModel.hasUnsavedChanges
-            navigationItem.rightBarButtonItem = saveBarButtonItem
-        }
-    }
-
-    @objc func handleBackTapped() {
-        if viewModel.hasUnsavedChanges {
-            presentBackNavigationActionSheet()
-        } else {
-            navigationController?.popViewController(animated: true)
-        }
-    }
-
-    @objc func handleSaveTapped() {
-        guard !viewModel.isSaving else { return }
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            let success = await viewModel.save()
-            if success {
-                navigationController?.popViewController(animated: true)
-            }
-        }
-    }
-
-    func presentBackNavigationActionSheet() {
-        UIAlertController.presentDiscardChangesActionSheet(viewController: self,
-                                                           onDiscard: { [weak self] in
-            self?.viewModel.discardStoreOrderEdits()
-            self?.navigationController?.popViewController(animated: true)
-        })
-    }
-}
-
-private extension NewOrderNotificationPreferencesHostingController {
-    enum Localization {
-        static let save = NSLocalizedString(
-            "newOrderNotificationPreferencesHostingController.save",
-            value: "Save",
-            comment: "Title of the Save bar button on the new-order push notification preferences detail screen."
-        )
-        static let back = NSLocalizedString(
-            "newOrderNotificationPreferencesHostingController.back",
-            value: "Back",
-            comment: "VoiceOver label for the back button on the new-order push notification preferences detail screen."
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesDetailView.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+/// Detail screen for the New reviews push notification preferences. Reached by
+/// tapping the New reviews row in `PushNotificationPreferencesView`. Navigation
+/// chrome (title, Save bar button, discard confirmation) lives on the wrapping
+/// `NewReviewNotificationPreferencesHostingController`.
+///
+struct NewReviewNotificationPreferencesDetailView: View {
+
+    @Bindable private var viewModel: PushNotificationPreferencesViewModel
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        List {
+            masterToggleSection
+            customizationSection
+        }
+        .listStyle(.insetGrouped)
+        .background(Color(.listBackground))
+        .disabled(viewModel.isSaving)
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+        // `leftBarButtonItem` set in UIKit doesn't suppress SwiftUI's own back
+        // button, so without this both render side-by-side and only the UIKit
+        // one routes through the discard handler.
+        .navigationBarBackButtonHidden(true)
+        .notice($viewModel.errorNotice)
+    }
+
+    private var masterToggleSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+                Toggle(Localization.enableTitle,
+                       isOn: Binding(get: { viewModel.isStoreReviewEnabled },
+                                     set: { viewModel.setStoreReviewEnabled($0) }))
+                Text(Localization.enableSubtitle)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .captionStyle()
+            }
+        }
+    }
+
+    private var customizationSection: some View {
+        Section {
+            radioRow(title: Localization.allReviewsTitle,
+                     subtitle: Localization.allReviewsSubtitle,
+                     isSelected: viewModel.storeReviewMaxRating == nil) {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    viewModel.setStoreReviewMaxRating(nil)
+                }
+            }
+            radioRow(title: Localization.lowRatedTitle,
+                     subtitle: Localization.lowRatedSubtitle,
+                     isSelected: viewModel.storeReviewMaxRating != nil) {
+                let restore = viewModel.lastKnownStoreReviewMaxRating
+                    ?? PushNotificationPreferencesViewModel.defaultStoreReviewMaxRating
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    viewModel.setStoreReviewMaxRating(restore)
+                }
+            }
+            if let currentRating = viewModel.storeReviewMaxRating {
+                starPickerRow(selected: currentRating)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        } header: {
+            Text(Localization.customizeHeader)
+        }
+        .disabled(!viewModel.isStoreReviewEnabled)
+        .opacity(viewModel.isStoreReviewEnabled ? 1.0 : Layout.disabledOpacity)
+    }
+
+    private func radioRow(title: String,
+                          subtitle: String,
+                          isSelected: Bool,
+                          action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: Layout.contentSpacing) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .foregroundStyle(isSelected ? Color.accentColor : Color(.tertiaryLabel))
+                    .font(.title3)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+                    Text(title)
+                        .bodyStyle()
+                    Text(subtitle)
+                        .foregroundStyle(Color(.secondaryLabel))
+                        .captionStyle()
+                }
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+    }
+
+    private func starPickerRow(selected: Int) -> some View {
+        VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+            // Reuses `storeReviewDetailText` so the picker's label and the list row stay in lockstep.
+            // Safe because this view is only rendered when `storeReviewMaxRating != nil`, so the
+            // computed property never returns the "All reviews" branch here.
+            Text(viewModel.storeReviewDetailText)
+                .foregroundStyle(Color.accentColor)
+                .captionStyle()
+            HStack(spacing: Layout.starSpacing) {
+                ForEach(1...5, id: \.self) { star in
+                    Button {
+                        viewModel.setStoreReviewMaxRating(star)
+                    } label: {
+                        Image(systemName: star <= selected ? "star.fill" : "star")
+                            .foregroundStyle(star <= selected ? Color(uiColor: .ratingStarFilled) : Color(uiColor: .ratingStarEmpty))
+                            .font(.title2)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(Self.starAccessibilityLabel(for: star))
+                    .accessibilityAddTraits(star == selected ? [.isSelected, .isButton] : .isButton)
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private static func starAccessibilityLabel(for star: Int) -> String {
+        let format = star == 1 ? Localization.starAccessibilityFormatSingular
+                               : Localization.starAccessibilityFormatPlural
+        let count = NumberFormatter.localizedString(from: NSNumber(value: star), number: .none)
+        return String.localizedStringWithFormat(format, count)
+    }
+}
+
+private extension NewReviewNotificationPreferencesDetailView {
+    enum Layout {
+        static let contentSpacing: CGFloat = 12
+        static let titleDetailSpacing: CGFloat = 4
+        static let disabledOpacity: Double = 0.5
+        static let starSpacing: CGFloat = 16
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.title",
+            value: "New reviews",
+            comment: "Title of the new-review push notification preferences detail screen."
+        )
+        static let enableTitle = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.enable.title",
+            value: "Enable notifications",
+            comment: "Title of the master toggle for new-review push notifications."
+        )
+        static let enableSubtitle = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.enable.subtitle",
+            value: "Get notified when a review is left for your store.",
+            comment: "Subtitle of the master toggle for new-review push notifications."
+        )
+        static let customizeHeader = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.notifyMeFor.header",
+            value: "Notify me for",
+            comment: "Section header for new-review notification customization options."
+        )
+        static let allReviewsTitle = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.allReviews.title",
+            value: "All new reviews",
+            comment: "Title of the radio row that enables notifications for every new review."
+        )
+        static let allReviewsSubtitle = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.allReviews.subtitle",
+            value: "Ping for every review.",
+            comment: "Subtitle of the radio row that enables notifications for every new review."
+        )
+        static let lowRatedTitle = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.lowRated.title",
+            value: "Only low-rated reviews",
+            comment: "Title of the radio row that filters notifications to reviews at or below a chosen rating."
+        )
+        static let lowRatedSubtitle = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.lowRated.subtitle",
+            value: "Filter to reviews at or below your chosen rating.",
+            comment: "Subtitle of the radio row that filters notifications to reviews at or below a chosen rating."
+        )
+        static let starAccessibilityFormatSingular = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.star.accessibilityFormat.singular",
+            value: "%1$@ star",
+            comment: "VoiceOver label for the 1-star button in the maximum-rating picker. %1$@ is the formatted star count."
+        )
+        static let starAccessibilityFormatPlural = NSLocalizedString(
+            "newReviewNotificationPreferencesDetailView.star.accessibilityFormat.plural",
+            value: "%1$@ stars",
+            comment: "VoiceOver label for the 2-5 star buttons in the maximum-rating picker. %1$@ is the formatted star count."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesHostingController.swift
@@ -1,141 +1,19 @@
 import SwiftUI
-import UIKit
 
-/// Hosts `NewReviewNotificationPreferencesDetailView` and owns its navigation
-/// chrome (Save bar button, custom back button, discard-changes flow).
+/// Hosts `NewReviewNotificationPreferencesDetailView`. Navigation chrome
+/// (Save, back button, discard alert, saving spinner) is inherited from
+/// `NotificationDetailHostingController`.
 ///
-/// Toolbar items live on `navigationItem` rather than in a SwiftUI `.toolbar`
-/// modifier — when a `UIHostingController`'s root view declares any toolbar
-/// item, SwiftUI takes ownership of the navigation item and routes the back
-/// button through its own gesture stack, bypassing
-/// `UINavigationBarDelegate.navigationBar(_:shouldPop:)` and
-/// `shouldPopOnBackButton`.
-///
-final class NewReviewNotificationPreferencesHostingController: UIHostingController<NewReviewNotificationPreferencesDetailView> {
-
-    private let viewModel: PushNotificationPreferencesViewModel
-
-    private lazy var saveBarButtonItem: UIBarButtonItem = {
-        let item = UIBarButtonItem(title: Localization.save,
-                                   style: .done,
-                                   target: self,
-                                   action: #selector(handleSaveTapped))
-        item.isEnabled = false
-        return item
-    }()
-
-    private lazy var backBarButtonItem: UIBarButtonItem = {
-        let image = UIImage(systemName: "chevron.backward")
-        let item = UIBarButtonItem(image: image,
-                                   style: .plain,
-                                   target: self,
-                                   action: #selector(handleBackTapped))
-        item.accessibilityLabel = Localization.back
-        return item
-    }()
-
-    private lazy var savingActivityItem: UIBarButtonItem = {
-        let spinner = UIActivityIndicatorView(style: .medium)
-        spinner.startAnimating()
-        return UIBarButtonItem(customView: spinner)
-    }()
+final class NewReviewNotificationPreferencesHostingController:
+    NotificationDetailHostingController<NewReviewNotificationPreferencesDetailView> {
 
     init(viewModel: PushNotificationPreferencesViewModel) {
-        self.viewModel = viewModel
-        super.init(rootView: NewReviewNotificationPreferencesDetailView(viewModel: viewModel))
+        super.init(viewModel: viewModel,
+                   rootView: NewReviewNotificationPreferencesDetailView(viewModel: viewModel),
+                   onDiscard: { [weak viewModel] in viewModel?.discardStoreReviewEdits() })
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        navigationItem.leftBarButtonItem = backBarButtonItem
-        refreshRightBarButtonItem()
-        // Routes the edge-swipe gesture through `shouldPopOnSwipeBack`.
-        handleSwipeBackGesture()
-        observeUnsavedChanges()
-    }
-
-    override func shouldPopOnBackButton() -> Bool {
-        if viewModel.hasUnsavedChanges {
-            presentBackNavigationActionSheet()
-            return false
-        }
-        return true
-    }
-
-    override func shouldPopOnSwipeBack() -> Bool {
-        return shouldPopOnBackButton()
-    }
-}
-
-private extension NewReviewNotificationPreferencesHostingController {
-    /// `@Observable` tracking fires once and stops, so re-register after each
-    /// change to keep the bar item in sync with `hasUnsavedChanges` and
-    /// `isSaving`.
-    func observeUnsavedChanges() {
-        withObservationTracking {
-            _ = viewModel.hasUnsavedChanges
-            _ = viewModel.isSaving
-        } onChange: { [weak self] in
-            // `onChange` fires from `willSet`; hop to main before touching UIKit.
-            DispatchQueue.main.async {
-                self?.refreshRightBarButtonItem()
-                self?.observeUnsavedChanges()
-            }
-        }
-    }
-
-    func refreshRightBarButtonItem() {
-        if viewModel.isSaving {
-            navigationItem.rightBarButtonItem = savingActivityItem
-        } else {
-            saveBarButtonItem.isEnabled = viewModel.hasUnsavedChanges
-            navigationItem.rightBarButtonItem = saveBarButtonItem
-        }
-    }
-
-    @objc func handleBackTapped() {
-        if viewModel.hasUnsavedChanges {
-            presentBackNavigationActionSheet()
-        } else {
-            navigationController?.popViewController(animated: true)
-        }
-    }
-
-    @objc func handleSaveTapped() {
-        guard !viewModel.isSaving else { return }
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            let success = await viewModel.save()
-            if success {
-                navigationController?.popViewController(animated: true)
-            }
-        }
-    }
-
-    func presentBackNavigationActionSheet() {
-        UIAlertController.presentDiscardChangesActionSheet(viewController: self,
-                                                           onDiscard: { [weak self] in
-            self?.viewModel.discardStoreReviewEdits()
-            self?.navigationController?.popViewController(animated: true)
-        })
-    }
-}
-
-private extension NewReviewNotificationPreferencesHostingController {
-    enum Localization {
-        static let save = NSLocalizedString(
-            "newReviewNotificationPreferencesHostingController.save",
-            value: "Save",
-            comment: "Title of the Save bar button on the new-review push notification preferences detail screen."
-        )
-        static let back = NSLocalizedString(
-            "newReviewNotificationPreferencesHostingController.back",
-            value: "Back",
-            comment: "VoiceOver label for the back button on the new-review push notification preferences detail screen."
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesHostingController.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+import UIKit
+
+/// Hosts `NewReviewNotificationPreferencesDetailView` and owns its navigation
+/// chrome (Save bar button, custom back button, discard-changes flow).
+///
+/// Toolbar items live on `navigationItem` rather than in a SwiftUI `.toolbar`
+/// modifier — when a `UIHostingController`'s root view declares any toolbar
+/// item, SwiftUI takes ownership of the navigation item and routes the back
+/// button through its own gesture stack, bypassing
+/// `UINavigationBarDelegate.navigationBar(_:shouldPop:)` and
+/// `shouldPopOnBackButton`.
+///
+final class NewReviewNotificationPreferencesHostingController: UIHostingController<NewReviewNotificationPreferencesDetailView> {
+
+    private let viewModel: PushNotificationPreferencesViewModel
+
+    private lazy var saveBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(title: Localization.save,
+                                   style: .done,
+                                   target: self,
+                                   action: #selector(handleSaveTapped))
+        item.isEnabled = false
+        return item
+    }()
+
+    private lazy var backBarButtonItem: UIBarButtonItem = {
+        let image = UIImage(systemName: "chevron.backward")
+        let item = UIBarButtonItem(image: image,
+                                   style: .plain,
+                                   target: self,
+                                   action: #selector(handleBackTapped))
+        item.accessibilityLabel = Localization.back
+        return item
+    }()
+
+    private lazy var savingActivityItem: UIBarButtonItem = {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.startAnimating()
+        return UIBarButtonItem(customView: spinner)
+    }()
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        self.viewModel = viewModel
+        super.init(rootView: NewReviewNotificationPreferencesDetailView(viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.leftBarButtonItem = backBarButtonItem
+        refreshRightBarButtonItem()
+        // Routes the edge-swipe gesture through `shouldPopOnSwipeBack`.
+        handleSwipeBackGesture()
+        observeUnsavedChanges()
+    }
+
+    override func shouldPopOnBackButton() -> Bool {
+        if viewModel.hasUnsavedChanges {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+}
+
+private extension NewReviewNotificationPreferencesHostingController {
+    /// `@Observable` tracking fires once and stops, so re-register after each
+    /// change to keep the bar item in sync with `hasUnsavedChanges` and
+    /// `isSaving`.
+    func observeUnsavedChanges() {
+        withObservationTracking {
+            _ = viewModel.hasUnsavedChanges
+            _ = viewModel.isSaving
+        } onChange: { [weak self] in
+            // `onChange` fires from `willSet`; hop to main before touching UIKit.
+            DispatchQueue.main.async {
+                self?.refreshRightBarButtonItem()
+                self?.observeUnsavedChanges()
+            }
+        }
+    }
+
+    func refreshRightBarButtonItem() {
+        if viewModel.isSaving {
+            navigationItem.rightBarButtonItem = savingActivityItem
+        } else {
+            saveBarButtonItem.isEnabled = viewModel.hasUnsavedChanges
+            navigationItem.rightBarButtonItem = saveBarButtonItem
+        }
+    }
+
+    @objc func handleBackTapped() {
+        if viewModel.hasUnsavedChanges {
+            presentBackNavigationActionSheet()
+        } else {
+            navigationController?.popViewController(animated: true)
+        }
+    }
+
+    @objc func handleSaveTapped() {
+        guard !viewModel.isSaving else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let success = await viewModel.save()
+            if success {
+                navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+
+    func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self,
+                                                           onDiscard: { [weak self] in
+            self?.viewModel.discardStoreReviewEdits()
+            self?.navigationController?.popViewController(animated: true)
+        })
+    }
+}
+
+private extension NewReviewNotificationPreferencesHostingController {
+    enum Localization {
+        static let save = NSLocalizedString(
+            "newReviewNotificationPreferencesHostingController.save",
+            value: "Save",
+            comment: "Title of the Save bar button on the new-review push notification preferences detail screen."
+        )
+        static let back = NSLocalizedString(
+            "newReviewNotificationPreferencesHostingController.back",
+            value: "Back",
+            comment: "VoiceOver label for the back button on the new-review push notification preferences detail screen."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationDetailHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationDetailHostingController.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import UIKit
+
+/// Generic base for per-section push-notification preference detail screens.
+/// Owns navigation chrome — Save bar button, custom back button, spinner
+/// while saving, discard-changes flow — and observes the shared
+/// `PushNotificationPreferencesViewModel` so each kind's host controller
+/// becomes a thin subclass that just declares its detail view and a scoped
+/// discard handler.
+///
+/// Toolbar items live on `navigationItem` rather than in a SwiftUI `.toolbar`
+/// modifier — when a `UIHostingController`'s root view declares any toolbar
+/// item, SwiftUI takes ownership of the navigation item and routes the back
+/// button through its own gesture stack, bypassing
+/// `UINavigationBarDelegate.navigationBar(_:shouldPop:)` and
+/// `shouldPopOnBackButton`.
+///
+class NotificationDetailHostingController<Content: View>: UIHostingController<Content> {
+
+    let viewModel: PushNotificationPreferencesViewModel
+    private let onDiscard: () -> Void
+
+    private lazy var saveBarButtonItem: UIBarButtonItem = {
+        let item = UIBarButtonItem(title: NotificationDetailHostingControllerStrings.save,
+                                   style: .done,
+                                   target: self,
+                                   action: #selector(handleSaveTapped))
+        item.isEnabled = false
+        return item
+    }()
+
+    private lazy var backBarButtonItem: UIBarButtonItem = {
+        let image = UIImage(systemName: "chevron.backward")
+        let item = UIBarButtonItem(image: image,
+                                   style: .plain,
+                                   target: self,
+                                   action: #selector(handleBackTapped))
+        item.accessibilityLabel = NotificationDetailHostingControllerStrings.back
+        return item
+    }()
+
+    private lazy var savingActivityItem: UIBarButtonItem = {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.startAnimating()
+        return UIBarButtonItem(customView: spinner)
+    }()
+
+    init(viewModel: PushNotificationPreferencesViewModel,
+         rootView: Content,
+         onDiscard: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onDiscard = onDiscard
+        super.init(rootView: rootView)
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.leftBarButtonItem = backBarButtonItem
+        refreshRightBarButtonItem()
+        // Routes the edge-swipe gesture through `shouldPopOnSwipeBack`.
+        handleSwipeBackGesture()
+        observeUnsavedChanges()
+    }
+
+    override func shouldPopOnBackButton() -> Bool {
+        if viewModel.hasUnsavedChanges {
+            presentBackNavigationActionSheet()
+            return false
+        }
+        return true
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+
+    // MARK: - Action handlers
+    //
+    // Lives in the class body (not a private extension) because `@objc`
+    // members aren't permitted in extensions of generic classes.
+
+    @objc private func handleBackTapped() {
+        if viewModel.hasUnsavedChanges {
+            presentBackNavigationActionSheet()
+        } else {
+            navigationController?.popViewController(animated: true)
+        }
+    }
+
+    @objc private func handleSaveTapped() {
+        guard !viewModel.isSaving else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let success = await viewModel.save()
+            if success {
+                navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+
+    /// `@Observable` tracking fires once and stops, so re-register after each
+    /// change to keep the bar item in sync with `hasUnsavedChanges` and
+    /// `isSaving`.
+    private func observeUnsavedChanges() {
+        withObservationTracking {
+            _ = viewModel.hasUnsavedChanges
+            _ = viewModel.isSaving
+        } onChange: { [weak self] in
+            // `onChange` fires from `willSet`; hop to main before touching UIKit.
+            DispatchQueue.main.async {
+                self?.refreshRightBarButtonItem()
+                self?.observeUnsavedChanges()
+            }
+        }
+    }
+
+    private func refreshRightBarButtonItem() {
+        if viewModel.isSaving {
+            navigationItem.rightBarButtonItem = savingActivityItem
+        } else {
+            saveBarButtonItem.isEnabled = viewModel.hasUnsavedChanges
+            navigationItem.rightBarButtonItem = saveBarButtonItem
+        }
+    }
+
+    private func presentBackNavigationActionSheet() {
+        UIAlertController.presentDiscardChangesActionSheet(viewController: self,
+                                                           onDiscard: { [weak self] in
+            self?.onDiscard()
+            self?.navigationController?.popViewController(animated: true)
+        })
+    }
+}
+
+/// Localized strings for `NotificationDetailHostingController`. Lives at file
+/// scope because static stored properties aren't supported inside generic
+/// types.
+private enum NotificationDetailHostingControllerStrings {
+    static let save = NSLocalizedString(
+        "notificationDetailHostingController.save",
+        value: "Save",
+        comment: "Title of the Save bar button on a push notification preferences detail screen."
+    )
+    static let back = NSLocalizedString(
+        "notificationDetailHostingController.back",
+        value: "Back",
+        comment: "VoiceOver label for the back button on a push notification preferences detail screen."
+    )
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -8,9 +8,12 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
         let viewModel = PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
         self.viewModel = viewModel
         super.init(rootView: PushNotificationPreferencesView(viewModel: viewModel))
-        // Set after `super.init` so the closure can capture `self` weakly.
+        // Set after `super.init` so the closures can capture `self` weakly.
         rootView.onNewOrderTapped = { [weak self] in
             self?.showNewOrderDetail()
+        }
+        rootView.onNewReviewTapped = { [weak self] in
+            self?.showNewReviewDetail()
         }
     }
 
@@ -20,6 +23,11 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
 
     private func showNewOrderDetail() {
         let detail = NewOrderNotificationPreferencesHostingController(viewModel: viewModel)
+        navigationController?.pushViewController(detail, animated: true)
+    }
+
+    private func showNewReviewDetail() {
+        let detail = NewReviewNotificationPreferencesHostingController(viewModel: viewModel)
         navigationController?.pushViewController(detail, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -62,7 +62,7 @@ struct PushNotificationPreferencesView: View {
                     accessibilityHint: Localization.newOrdersAccessibilityHint,
                     action: onNewOrderTapped)
                 row(title: Localization.newReviewsTitle,
-                    detail: viewModel.isStoreReviewEnabled ? Localization.newReviewsDetail : Localization.off,
+                    detail: viewModel.isStoreReviewEnabled ? viewModel.storeReviewDetailText : Localization.off,
                     accessibilityHint: Localization.newReviewsAccessibilityHint,
                     action: onNewReviewTapped)
                 row(title: Localization.stockTitle,
@@ -148,11 +148,6 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.newReviews.accessibilityHint",
             value: "Customize new review notifications",
             comment: "VoiceOver hint announced when focused on the New reviews row, describing that it opens a detail screen."
-        )
-        static let newReviewsDetail = NSLocalizedString(
-            "pushNotificationPreferencesView.newReviews.detail",
-            value: "All reviews",
-            comment: "Detail text for the row that toggles new-review push notifications."
         )
         static let stockTitle = NSLocalizedString(
             "pushNotificationPreferencesView.stock.title",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -10,6 +10,9 @@ struct PushNotificationPreferencesView: View {
     /// Set by the hosting controller after `super.init`. Default is a no-op so
     /// previews work without it.
     var onNewOrderTapped: () -> Void = {}
+    /// Set by the hosting controller after `super.init`. Default is a no-op so
+    /// previews work without it.
+    var onNewReviewTapped: () -> Void = {}
 
     init(viewModel: PushNotificationPreferencesViewModel) {
         self.viewModel = viewModel
@@ -59,7 +62,9 @@ struct PushNotificationPreferencesView: View {
                     accessibilityHint: Localization.newOrdersAccessibilityHint,
                     action: onNewOrderTapped)
                 row(title: Localization.newReviewsTitle,
-                    detail: viewModel.isStoreReviewEnabled ? Localization.newReviewsDetail : Localization.off)
+                    detail: viewModel.isStoreReviewEnabled ? Localization.newReviewsDetail : Localization.off,
+                    accessibilityHint: Localization.newReviewsAccessibilityHint,
+                    action: onNewReviewTapped)
                 row(title: Localization.stockTitle,
                     detail: viewModel.isStoreStockEnabled ? Localization.stockDetail : Localization.off)
             }
@@ -138,6 +143,11 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.newReviews.title",
             value: "New reviews",
             comment: "Title of the row that toggles new-review push notifications."
+        )
+        static let newReviewsAccessibilityHint = NSLocalizedString(
+            "pushNotificationPreferencesView.newReviews.accessibilityHint",
+            value: "Customize new review notifications",
+            comment: "VoiceOver hint announced when focused on the New reviews row, describing that it opens a detail screen."
         )
         static let newReviewsDetail = NSLocalizedString(
             "pushNotificationPreferencesView.newReviews.detail",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -54,6 +54,26 @@ final class PushNotificationPreferencesViewModel {
         return String.localizedStringWithFormat(Localization.ordersOverFormat, formatted)
     }
 
+    /// `nil` means "all reviews"; otherwise an in-range value (1...5) is the
+    /// maximum star rating that triggers a notification.
+    var storeReviewMaxRating: Int? { displayed.storeReview?.maxRating }
+
+    /// Last in-range rating seen, used to restore the value when the user
+    /// toggles "Only low-rated reviews" back on after switching to "All new reviews".
+    private(set) var lastKnownStoreReviewMaxRating: Int?
+
+    static let defaultStoreReviewMaxRating: Int = 2
+
+    var storeReviewDetailText: String {
+        guard let maxRating = storeReviewMaxRating, (1...5).contains(maxRating) else {
+            return Localization.allReviews
+        }
+        let format = maxRating == 1 ? Localization.reviewsBelowFormatSingular
+                                    : Localization.reviewsBelowFormatPlural
+        let count = NumberFormatter.localizedString(from: NSNumber(value: maxRating), number: .none)
+        return String.localizedStringWithFormat(format, count)
+    }
+
     var errorNotice: Notice?
 
     private let siteID: Int64
@@ -85,6 +105,7 @@ final class PushNotificationPreferencesViewModel {
             }
             lastSaved = preferences
             rememberLastKnownMinAmount(from: preferences.storeOrder?.minAmount)
+            rememberLastKnownMaxRating(from: preferences.storeReview?.maxRating)
             loadState = .loaded
         } catch {
             DDLogError("⛔️ Error loading push notification preferences for siteID=\(siteID): \(error)")
@@ -110,6 +131,7 @@ final class PushNotificationPreferencesViewModel {
             }
             lastSaved = server
             rememberLastKnownMinAmount(from: server.storeOrder?.minAmount)
+            rememberLastKnownMaxRating(from: server.storeReview?.maxRating)
             // Adopt the server's view so any clamped field (e.g. negative
             // threshold → nil) shows correctly without re-triggering
             // `hasUnsavedChanges`.
@@ -153,6 +175,27 @@ final class PushNotificationPreferencesViewModel {
                                                       maxRating: displayed.storeReview?.maxRating))
     }
 
+    /// Reverts only the new-review section of `displayed` to `lastSaved`.
+    /// Other sections are left untouched — their detail screens own their
+    /// own discard paths.
+    func discardStoreReviewEdits() {
+        displayed = PushNotificationPreferences(storeOrder: displayed.storeOrder,
+                                                storeReview: lastSaved.storeReview,
+                                                storeStock: displayed.storeStock)
+    }
+
+    func setStoreReviewMaxRating(_ newValue: Int?) {
+        // Clamp any non-nil value to the server-supported `1...5` range; nil
+        // stays nil ("all reviews").
+        let normalized: Int? = {
+            guard let value = newValue else { return nil }
+            return min(max(value, 1), 5)
+        }()
+        rememberLastKnownMaxRating(from: normalized)
+        displayed = displayed.with(storeReview: .init(enabled: isStoreReviewEnabled,
+                                                      maxRating: normalized))
+    }
+
     func setStoreStockEnabled(_ newValue: Bool) {
         let existing = displayed.storeStock
         displayed = displayed.with(storeStock: .init(enabled: newValue,
@@ -178,6 +221,11 @@ private extension PushNotificationPreferencesViewModel {
     func rememberLastKnownMinAmount(from value: Decimal?) {
         guard let value, value > 0 else { return }
         lastKnownStoreOrderMinAmount = value
+    }
+
+    func rememberLastKnownMaxRating(from value: Int?) {
+        guard let value, (1...5).contains(value) else { return }
+        lastKnownStoreReviewMaxRating = value
     }
 }
 
@@ -254,6 +302,21 @@ extension PushNotificationPreferencesViewModel {
             "pushNotificationPreferencesViewModel.storeOrder.ordersOverFormat",
             value: "Orders over %1$@",
             comment: "Detail text for the New orders row when a threshold is set. %1$@ is the formatted currency amount, e.g. $500."
+        )
+        static let allReviews = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeReview.allReviews",
+            value: "All reviews",
+            comment: "Detail text for the New reviews row when notifications fire for every review."
+        )
+        static let reviewsBelowFormatSingular = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeReview.reviewsBelowFormat.singular",
+            value: "%1$@ star and below",
+            comment: "Detail text for the New reviews row when the maximum rating is 1. %1$@ is the formatted star count."
+        )
+        static let reviewsBelowFormatPlural = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeReview.reviewsBelowFormat.plural",
+            value: "%1$@ stars and below",
+            comment: "Detail text for the New reviews row when the maximum rating is 2-5. %1$@ is the formatted star count."
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -502,6 +502,206 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.storeOrderDetailText == "Orders over $500")
     }
 
+    // MARK: - setStoreReviewMaxRating
+
+    @Test func test_setStoreReviewMaxRating_mutates_displayed_only_and_preserves_enabled() async {
+        // Given a loaded VM with the master toggle on.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true))))
+            }
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreReviewMaxRating(3)
+
+        // Then `displayed` reflects the edit, no dispatch fires yet.
+        #expect(sut.storeReviewMaxRating == 3)
+        #expect(sut.isStoreReviewEnabled == true)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(sut.lastKnownStoreReviewMaxRating == 3)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreReviewMaxRating_above_5_clamps_to_5() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // When
+        sut.setStoreReviewMaxRating(9)
+
+        // Then
+        #expect(sut.storeReviewMaxRating == 5)
+        #expect(sut.lastKnownStoreReviewMaxRating == 5)
+    }
+
+    @Test func test_setStoreReviewMaxRating_below_1_clamps_to_1() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // When
+        sut.setStoreReviewMaxRating(0)
+
+        // Then
+        #expect(sut.storeReviewMaxRating == 1)
+        #expect(sut.lastKnownStoreReviewMaxRating == 1)
+    }
+
+    @Test func test_setStoreReviewMaxRating_with_nil_clears_rating_and_preserves_lastKnown() async {
+        // Given a loaded VM with an in-range rating.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: 4))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreReviewMaxRating(nil)
+
+        // Then the rating is cleared but lastKnown still holds the previous value.
+        #expect(sut.storeReviewMaxRating == nil)
+        #expect(sut.lastKnownStoreReviewMaxRating == 4)
+    }
+
+    @Test func test_setStoreReviewEnabled_preserves_existing_maxRating_in_displayed() async {
+        // Given a loaded VM with an in-range maxRating.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: 2))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When the user flips the master toggle off.
+        sut.setStoreReviewEnabled(false)
+
+        // Then `displayed` retains the rating so a later save preserves it.
+        #expect(sut.displayed.storeReview?.enabled == false)
+        #expect(sut.displayed.storeReview?.maxRating == 2)
+    }
+
+    // MARK: - discardStoreReviewEdits
+
+    @Test func test_discardStoreReviewEdits_reverts_storeReview_to_lastSaved_and_clears_unsaved_flag() async {
+        // Given a loaded VM with an in-range rating the user then edits.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: 4))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+        sut.setStoreReviewMaxRating(2)
+        #expect(sut.hasUnsavedChanges == true)
+
+        // When
+        sut.discardStoreReviewEdits()
+
+        // Then `displayed.storeReview` matches the server snapshot again.
+        #expect(sut.displayed.storeReview?.enabled == true)
+        #expect(sut.displayed.storeReview?.maxRating == 4)
+        #expect(sut.hasUnsavedChanges == false)
+    }
+
+    @Test func test_discardStoreReviewEdits_leaves_other_sections_untouched() async {
+        // Given a loaded VM where the user edits review *and* order.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(
+                    storeOrder: .init(enabled: false),
+                    storeReview: .init(enabled: true)
+                )))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+        sut.setStoreOrderEnabled(true)
+        sut.setStoreReviewMaxRating(3)
+
+        // When the user discards the review edits.
+        sut.discardStoreReviewEdits()
+
+        // Then the order edit is preserved — the discard is scoped to the review section.
+        #expect(sut.displayed.storeOrder?.enabled == true)
+        #expect(sut.displayed.storeReview?.maxRating == nil)
+    }
+
+    @Test func test_load_when_response_has_in_range_maxRating_then_lastKnown_is_populated() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: 3))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.lastKnownStoreReviewMaxRating == 3)
+    }
+
+    // MARK: - storeReviewDetailText
+
+    @Test func test_storeReviewDetailText_when_maxRating_nil_then_returns_all_reviews() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // Then
+        #expect(sut.storeReviewDetailText == "All reviews")
+    }
+
+    @Test func test_storeReviewDetailText_when_maxRating_is_plural_then_returns_stars_and_below() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: 3))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.storeReviewDetailText == "3 stars and below")
+    }
+
+    @Test func test_storeReviewDetailText_when_maxRating_is_one_then_returns_singular_star_phrasing() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeReview: .init(enabled: true, maxRating: 1))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.storeReviewDetailText == "1 star and below")
+    }
+
     // MARK: - StoreOrderThreshold helpers
 
     @Test func test_storeOrderThreshold_isAllowedInput_accepts_positive_ascii_integer() {


### PR DESCRIPTION
## Description

Implements RSM-1633 — the iOS **New reviews** push-notification detail screen reached from the chevron on the New reviews row in `PushNotificationPreferencesView`. Mirrors the New orders detail pattern: top card with the master `Enable notifications` toggle (labeled), a "Notify me for" radio group with **All new reviews** and **Only low-rated reviews**, and a 5-star picker that animates in when the latter is selected. A caption above the stars (`"1 star and below"` / `"3 stars and below"`) reflects the current selection, and the list row's detail text picks up the same dynamic format.

Extends the shared view model with `storeReviewMaxRating`, `setStoreReviewMaxRating(_:)` (clamps non-nil values to `1...5`, preserves `enabled`), `lastKnownStoreReviewMaxRating` for restoring the user's previous choice when toggling All → Only low-rated, a default of `2` (per RSM-1633), `storeReviewDetailText` for the list/picker captions, and `discardStoreReviewEdits()`.

Also fixes the encoder for `StoreReview.maxRating`: it used `encodeIfPresent`, so passing `nil` dropped the key and the server treated the update as "no change" — the user could never switch from "Only low-rated reviews" back to "All new reviews". Now uses explicit `encodeNil`, matching the existing `StoreOrder.minAmount` pattern. `[Internal]` regression fix, gated behind the same flag.


## Test Steps

Behind the `smarterNotifications` flag (enabled on alpha/dev, disabled in App Store).

1. Settings → Push Notifications. Confirm the New reviews row shows a chevron and the detail text reads **All reviews** (or **Off** if reviews are disabled).
2. Tap the row. The New reviews detail screen pushes, pre-populated with the current state. The Save bar button is **disabled** because there are no edits yet.
3. Toggle the master switch. Save becomes enabled (and toggles back off when state matches `lastSaved`). Tap Save — the row updates accordingly on back-navigation, no network calls fire until Save.
4. Make an edit and tap the custom back chevron (or edge-swipe) without saving. A "Discard Changes?" action sheet appears. Choose **Discard** — the review section reverts to its saved state and the screen pops. Choose **Cancel** — the screen stays.
5. Select **Only low-rated reviews**. The 5-star picker animates in with the default selection (2 stars). The caption above the stars reads "2 stars and below". Tap Save — list row reads "2 stars and below" on back-navigation.
6. Open the detail again, tap each star (1–5). Caption updates immediately; Save stays enabled. Tap Save once — the list row reflects the final selection. Only **one** network request fires regardless of how many stars you tapped first.
7. Select **All new reviews** → Save. Picker animates out; list row reads "All reviews"; verify the wire body sends `"max_rating": null` (proxy / Charles).
8. Re-select **Only low-rated reviews** → Save. The previous rating is restored as the default.
9. Disable the network and tap Save with pending edits. A notice surfaces; the screen stays put with the edits intact so the user can retry. While saving, the form is disabled and the bar item shows a spinner.
10. With master toggle off, the radio rows and picker dim; toggling back on preserves the saved rating (does not silently clear `maxRating`).
11. Make edits on the order *and* review detail screens (without saving each), then discard from the review screen — the order-side edits are preserved (scoped discard).


## Screenshots
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-21 at 09 28 08" src="https://github.com/user-attachments/assets/62d763f5-092b-4543-8a35-0ed8762e7234" />


---
- [x] I have considered if this change warrants user-facing release notes — none added, matching the existing convention for the gated smarter-notifications feature stream (`dd3afb6052 Drop push notification preferences release note`).
