### PR TITLE
Enable SwiftLint rule: period_spacing

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,6 +81,9 @@ only_rules:
 
   - overridden_super_call
 
+  # No whitespace should follow a period.
+  - period_spacing
+
   # Prefer `0` over explicit type initializers like `CGFloat(0)`.
   - prefer_zero_over_explicit_init
 

--- a/Modules/Sources/Networking/Model/TaxRate.swift
+++ b/Modules/Sources/Networking/Model/TaxRate.swift
@@ -24,7 +24,7 @@ public struct TaxRate: Decodable, Equatable, GeneratedFakeable, GeneratedCopiabl
     ///
     public let state: String
 
-    /// Tax rate postcode.  Deprecated in WooCommerce 5.3 (use postcodes)
+    /// Tax rate postcode. Deprecated in WooCommerce 5.3 (use postcodes)
     ///
     public let postcode: String
 

--- a/Modules/Sources/Networking/Remote/ProductAttributesRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductAttributesRemote.swift
@@ -76,7 +76,7 @@ public final class ProductAttributesRemote: Remote {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Delete a `ProductAttribute`.  This also will delete all terms from the selected attribute.
+    /// Delete a `ProductAttribute`. This also will delete all terms from the selected attribute.
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll delete the product attribute.

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -21,7 +21,7 @@ public class OrdersRemote: Remote, OrdersRemoteProtocol {
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch remote orders.
     ///     - statuses: Filters the Orders by the specified Status, if any.
-    ///     - after: If given, limit response to orders published after a given compliant date.  Passing a local date is fine. This
+    ///     - after: If given, limit response to orders published after a given compliant date. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - before: If given, limit response to resources published before a given compliant date.. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -23,7 +23,7 @@ public class OrdersRemote: Remote, OrdersRemoteProtocol {
     ///     - statuses: Filters the Orders by the specified Status, if any.
     ///     - after: If given, limit response to orders published after a given compliant date. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
-    ///     - before: If given, limit response to resources published before a given compliant date.. Passing a local date is fine. This
+    ///     - before: If given, limit response to resources published before a given compliant date. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - modifiedAfter: If given, limit response to resources modified after a given compliant date. Passing a local date is fine.
     ///     This method will convert it to UTC ISO 8601 before calling the REST API.

--- a/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSFontStyle.swift
@@ -127,7 +127,7 @@ extension POSFontStyle {
     }
 
     /// Returns the effective font size (post-scaling, post-floor) for a given layout scale and
-    /// Dynamic Type content size category.  Exposed as `internal` so PointOfSaleTests can assert
+    /// Dynamic Type content size category. Exposed as `internal` so PointOfSaleTests can assert
     /// on the numeric result without having to inspect a `Font` value.
     func effectiveFontSize(for scale: POSLayoutScale, contentSizeCategory: UIContentSizeCategory) -> CGFloat {
         let base = baseSize(for: scale)

--- a/Modules/Sources/Storage/CoreData/CoreDataIterativeMigrator.swift
+++ b/Modules/Sources/Storage/CoreData/CoreDataIterativeMigrator.swift
@@ -45,7 +45,7 @@ final class CoreDataIterativeMigrator {
             return (true, ["No store exists at URL \(sourceStoreURL).  Skipping migration."])
         }
 
-        // Get the persistent store's metadata.  The metadata is used to
+        // Get the persistent store's metadata. The metadata is used to
         // get information about the store's managed object model.
         let sourceMetadata =
             try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: sourceStoreURL, options: nil)

--- a/Modules/Sources/WooFoundation/Utilities/TypedPredicates.swift
+++ b/Modules/Sources/WooFoundation/Utilities/TypedPredicates.swift
@@ -43,7 +43,7 @@ public func || (p1: TypedPredicate, p2: TypedPredicate) -> CompoundPredicate {
 
 // MARK: - Comparison Operators Overloads
 
-/// Overloads for comparison  operators.  Each operator takes a `KeyPath` and a `Value`
+/// Overloads for comparison  operators. Each operator takes a `KeyPath` and a `Value`
 /// That will be mapped to `NSExpressions` instances  for then constructing a `ComparisonPredicate` with the correct comparison rule.
 /// These overloads make use of `Generics` because need to know at compile time that the `KeyPath.ResultingType` has the same type as the `Value`.
 /// As well as making sure that those values are `Equatable`.

--- a/Modules/Sources/WordPressShared/Utility/EmailFormatValidator.swift
+++ b/Modules/Sources/WordPressShared/Utility/EmailFormatValidator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Test a string to see if it resembles an email address.  The checks in this
+/// Test a string to see if it resembles an email address. The checks in this
 /// class are based on those in wp-includes/formatting.php `is_email`.
 ///
 open class EmailFormatValidator {

--- a/Modules/Sources/WordPressShared/Utility/NSString+Summary.swift
+++ b/Modules/Sources/WordPressShared/Utility/NSString+Summary.swift
@@ -23,7 +23,7 @@ extension NSString {
     }
 
     /// Converts HTML content into plain text by stripping HTML tags and decodinig XML chars.
-    /// Transforms the specified string to plain text.  HTML markup is removed and HTML entities are decoded.
+    /// Transforms the specified string to plain text. HTML markup is removed and HTML entities are decoded.
     ///
     /// - Returns: The transformed string.
     ///

--- a/Modules/Sources/WordPressShared/Utility/String+URLValidation.swift
+++ b/Modules/Sources/WordPressShared/Utility/String+URLValidation.swift
@@ -4,7 +4,7 @@ extension String {
 
     /// This method can be used to check if the string contains a valid URL.
     ///
-    /// - Returns: `true` if the string contains a valid string.  `false` otherwise.
+    /// - Returns: `true` if the string contains a valid string. `false` otherwise.
     ///
     public func isValidURL() -> Bool {
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)

--- a/Modules/Sources/WordPressShared/Utility/String+URLValidation.swift
+++ b/Modules/Sources/WordPressShared/Utility/String+URLValidation.swift
@@ -4,7 +4,7 @@ extension String {
 
     /// This method can be used to check if the string contains a valid URL.
     ///
-    /// - Returns: `true` if the string contains a valid string. `false` otherwise.
+    /// - Returns: `true` if the string contains a valid URL. `false` otherwise.
     ///
     public func isValidURL() -> Bool {
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)

--- a/Modules/Sources/WordPressShared/Utility/WPImageURLHelper.swift
+++ b/Modules/Sources/WordPressShared/Utility/WPImageURLHelper.swift
@@ -5,7 +5,7 @@ open class WPImageURLHelper: NSObject {
     /**
      Adds to the provided url width and height parameters to allow the image to be resized on the server
 
-     - parameter size: the required pixel size for the image.  If height is set to zero the
+     - parameter size: the required pixel size for the image. If height is set to zero the
      returned image will have a height proportional to the requested width and vice versa.
      - parameter url:  the original url for the image
 

--- a/Modules/Sources/WordPressShared/Views/WPStyleGuide+DynamicType.swift
+++ b/Modules/Sources/WordPressShared/Views/WPStyleGuide+DynamicType.swift
@@ -116,7 +116,7 @@ extension WPStyleGuide {
     ///
     @objc public class func fontForTextStyle(_ style: UIFont.TextStyle, fontWeight weight: UIFont.Weight) -> UIFont {
         /// WORKAROUND: Some font weights scale up well initially but they don't scale up well if dynamic type
-        ///     is changed in real time.  Creating a scaled font offers an alternative solution that works well
+        ///     is changed in real time. Creating a scaled font offers an alternative solution that works well
         ///     even in real time.
         let weightsThatNeedScaledFont: [UIFont.Weight] = [.black, .bold, .heavy, .semibold]
 
@@ -164,18 +164,18 @@ extension WPStyleGuide {
         return UIFont.systemFont(ofSize: fontSize, weight: weight)
     }
 
-    /// Created a scaled UIFont for the specified style and weight.  A scaled font will be resized Automatically
+    /// Created a scaled UIFont for the specified style and weight. A scaled font will be resized Automatically
     /// by iOS to respond to dynamic type changes.
     ///
     /// - Important: The size of a scaled font built with this method may not match exactly the size for the built
     /// in fonts at the same dynamic type configuration, but this is currently a limitation with iOS rather than
-    /// a limitation with this method.  For more info check:
+    /// a limitation with this method. For more info check:
     ///     https://stackoverflow.com/questions/51243804/uifontmetrics-scaled-font-size-calculation
     ///
     /// - Parameters:
     ///     - style: the style for the font.
     ///     - weight: the weight for the font.
-    ///     - design: the design for the font.  The default value is `.default`.
+    ///     - design: the design for the font. The default value is `.default`.
     ///
     /// - Returns: the requested scaled font.
     ///

--- a/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
+++ b/Modules/Sources/Yosemite/Actions/AppSettingsAction.swift
@@ -158,7 +158,7 @@ public enum AppSettingsAction: Action {
     case forgetCardReader(onCompletion: (Result<Void, Error>) -> Void)
 
     /// Loads the most recently membered reader, if any (i.e. a reader that should be reconnected to automatically)
-    /// E.g.  "CHB204909005931"
+    /// E.g. "CHB204909005931"
     ///
     case loadCardReader(onCompletion: (Result<String?, Error>) -> Void)
 

--- a/Modules/Sources/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
+++ b/Modules/Sources/Yosemite/SnapshotsProvider/FetchResultSnapshotsProvider.swift
@@ -378,9 +378,9 @@ private extension FetchResultSnapshotsProvider {
     /// we would get a crash like this when something changes in the database:
     ///
     /// ```
-    /// [error] error: Serious application error.  Exception was caught during Core Data change
-    /// processing.  This is usually a bug within an observer of
-    /// NSManagedObjectContextObjectsDidChangeNotification.  Object's persistent store is not
+    /// [error] error: Serious application error. Exception was caught during Core Data change
+    /// processing. This is usually a bug within an observer of
+    /// NSManagedObjectContextObjectsDidChangeNotification. Object's persistent store is not
     /// reachable from this NSManagedObjectContext's coordinator with userInfo (null)
     /// ```
     ///

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -503,7 +503,7 @@ private extension AppSettingsStore {
 
     /// Loads the most recently remembered card reader, if any (i.e. to reconnect to automatically)
     /// NOTE: We now only persist one card reader maximum.
-    /// E.g.  "CHB204909005931"
+    /// E.g. "CHB204909005931"
     ///
     func loadCardReader(onCompletion: (Result<String?, Error>) -> Void) {
         /// NOTE: We now only persist one card reader maximum, although for backwards compatibility

--- a/Modules/Sources/Yosemite/Tools/AsyncPaginationTracker.swift
+++ b/Modules/Sources/Yosemite/Tools/AsyncPaginationTracker.swift
@@ -41,9 +41,9 @@ public final class AsyncPaginationTracker {
 
     /// Should be called whenever a scroll position is approaching the end of the list for infinite scroll support.
     /// This method will:
-    ///     1.  Proceed only if there is next page to sync.
-    ///     2.  Verify if the next page isn't currently being synced.
-    ///     3.  Proceed syncing the next page.
+    ///     1. Proceed only if there is next page to sync.
+    ///     2. Verify if the next page isn't currently being synced.
+    ///     3. Proceed syncing the next page.
     public func ensureNextPageIsSynced(syncFunction: @escaping SyncFunction) async throws -> NextPageSyncState {
         guard hasNextPage else {
             return .noNextPage

--- a/WooCommerce/Classes/Extensions/FancyAnimatedButton+Woo.swift
+++ b/WooCommerce/Classes/Extensions/FancyAnimatedButton+Woo.swift
@@ -36,7 +36,7 @@ class FancyAnimatedButton: FancyButton {
         addSubview(activityIndicator)
     }
 
-    /// Toggles the visibility of the activity indicator.  When visible the button
+    /// Toggles the visibility of the activity indicator. When visible the button
     /// title is hidden.
     ///
     /// - Parameter show: True to show the spinner. False hides it.

--- a/WooCommerce/Classes/Tools/AppRatings/AppRatingManager.swift
+++ b/WooCommerce/Classes/Tools/AppRatings/AppRatingManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This class will help track whether or not a user should be prompted for an
-/// app review.  This class is loosely based on
+/// app review. This class is loosely based on
 /// [Appirater](https://github.com/arashpayan/appirater)
 ///
 public class AppRatingManager {

--- a/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
@@ -59,9 +59,9 @@ final class PaginationTracker {
 
     /// Should be called whenever a scroll position is approaching the end of the list for infinite scroll support.
     /// This method will:
-    ///     1.  Proceed only if a given element is the last one in it's page
-    ///     2.  Verify if the nextpage isn't currently being synced
-    ///     3.  Proceed syncing the next page, if possible / needed
+    ///     1. Proceed only if a given element is the last one in it's page
+    ///     2. Verify if the nextpage isn't currently being synced
+    ///     3. Proceed syncing the next page, if possible / needed
     func ensureNextPageIsSynced() {
         guard hasNextPage else {
             return

--- a/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
+++ b/WooCommerce/Classes/Tools/InfiniteScroll/PaginationTracker.swift
@@ -59,7 +59,7 @@ final class PaginationTracker {
 
     /// Should be called whenever a scroll position is approaching the end of the list for infinite scroll support.
     /// This method will:
-    ///     1. Proceed only if a given element is the last one in it's page
+    ///     1. Proceed only if a given element is the last one in its page
     ///     2. Verify if the nextpage isn't currently being synced
     ///     3. Proceed syncing the next page, if possible / needed
     func ensureNextPageIsSynced() {

--- a/WooCommerce/Classes/Tools/SyncCoordinator.swift
+++ b/WooCommerce/Classes/Tools/SyncCoordinator.swift
@@ -85,9 +85,9 @@ class SyncingCoordinator: SyncingCoordinatorProtocol {
 
     /// Should be called whenever a given Entity becomes visible. This method will:
     ///
-    ///     1.  Proceed only if a given Element is the last one in it's page
-    ///     2.  Verify if the (NEXT) page isn't being sync'ed (OR) if its cache has expired
-    ///     3.  Proceed sync'ing the next page, if possible / needed
+    ///     1. Proceed only if a given Element is the last one in it's page
+    ///     2. Verify if the (NEXT) page isn't being sync'ed (OR) if its cache has expired
+    ///     3. Proceed sync'ing the next page, if possible / needed
     ///
     func ensureNextPageIsSynchronized(lastVisibleIndex: Int) {
         guard isLastElementInPage(elementIndex: lastVisibleIndex) else {

--- a/WooCommerce/Classes/Tools/SyncCoordinator.swift
+++ b/WooCommerce/Classes/Tools/SyncCoordinator.swift
@@ -85,7 +85,7 @@ class SyncingCoordinator: SyncingCoordinatorProtocol {
 
     /// Should be called whenever a given Entity becomes visible. This method will:
     ///
-    ///     1. Proceed only if a given Element is the last one in it's page
+    ///     1. Proceed only if a given Element is the last one in its page
     ///     2. Verify if the (NEXT) page isn't being sync'ed (OR) if its cache has expired
     ///     3. Proceed sync'ing the next page, if possible / needed
     ///

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -452,7 +452,7 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
 
 // MARK: - Stored Order Settings (eg. filters)
 private extension OrdersRootViewController {
-    /// Fetch local Orders Settings (eg.  status or date range filters stored in Orders settings)
+    /// Fetch local Orders Settings (eg. status or date range filters stored in Orders settings)
     ///
     func syncLocalOrdersSettings(onCompletion: @escaping (Result<StoredOrderSettings.Setting, Error>) -> Void) {
         let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { [weak self] (result) in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1480,7 +1480,7 @@ extension ProductsViewController: PaginationTrackerDelegate {
         ServiceLocator.stores.dispatch(action)
     }
 
-    /// Fetch local Products Settings (eg.  sort order or filters stored in Products settings)
+    /// Fetch local Products Settings (eg. sort order or filters stored in Products settings)
     ///
     private func syncLocalProductsSettings(onCompletion: @escaping (Result<StoredProductSettings.Setting, Error>) -> Void) {
         let action = AppSettingsAction.loadProductsSettings(siteID: siteID) { [weak self] (result) in

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
@@ -5,7 +5,7 @@ class ValueOneTableViewCell: UITableViewCell {
     /// The style options for the `ValueOneTableViewCell`
     ///
     enum Style {
-        /// Uses BodyStyle for the Text  and Subheadline for the DetailText.  This is the default.
+        /// Uses BodyStyle for the Text  and Subheadline for the DetailText. This is the default.
         case primary
         /// The same as `primary` except that for the DetailText uses a Tertiary text color.
         case secondary

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/ValueOneTableViewCell.swift
@@ -5,7 +5,7 @@ class ValueOneTableViewCell: UITableViewCell {
     /// The style options for the `ValueOneTableViewCell`
     ///
     enum Style {
-        /// Uses BodyStyle for the Text  and Subheadline for the DetailText. This is the default.
+        /// Uses BodyStyle for the Text and Subheadline for the DetailText. This is the default.
         case primary
         /// The same as `primary` except that for the DetailText uses a Tertiary text color.
         case secondary

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -465,7 +465,7 @@ private extension DefaultStoresManager {
     }
 
     /// Replaces the temporary UUID username in default credentials with the
-    /// actual username from the passed account.  This *shouldn't* be necessary
+    /// actual username from the passed account. This *shouldn't* be necessary
     /// under normal conditions but is a safety net in case there is an error
     /// preventing the temp username from being updated during login.
     ///

--- a/WooCommerce/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WooCommerce/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -9,7 +9,7 @@ public class AuthenticatorAnalyticsTracker {
     private static let defaultFlow: Flow = .prologue
     private static let defaultStep: Step = .prologue
 
-    /// The method used for analytics tracking.  Useful for overriding in automated tests.
+    /// The method used for analytics tracking. Useful for overriding in automated tests.
     ///
     typealias TrackerMethod = (_ event: AnalyticsEvent) -> Void
 
@@ -303,12 +303,12 @@ public class AuthenticatorAnalyticsTracker {
     ///
     public let state = State()
 
-    /// The backing analytics tracking method.  Can be overridden for testing purposes.
+    /// The backing analytics tracking method. Can be overridden for testing purposes.
     ///
     let track: TrackerMethod
 
-    /// Whether tracking is enabled or not.  This is just a convenience configuration to enable this tracker to be turned on and off
-    /// using a feature flag.  It should go away once we remove the legacy tracking.
+    /// Whether tracking is enabled or not. This is just a convenience configuration to enable this tracker to be turned on and off
+    /// using a feature flag. It should go away once we remove the legacy tracking.
     ///
     let enabled: Bool
 
@@ -319,7 +319,7 @@ public class AuthenticatorAnalyticsTracker {
         self.track = track
     }
 
-    /// Resets the flow and step to the defaults.  The source is left untouched, and should only be set explicitely.
+    /// Resets the flow and step to the defaults. The source is left untouched, and should only be set explicitely.
     ///
     func resetState() {
         set(flow: Self.defaultFlow)
@@ -339,7 +339,7 @@ public class AuthenticatorAnalyticsTracker {
     }
 
     /// This is a convenience method, that's useful for cases where we simply want to check if the legacy tracking should be
-    /// enabled.  It can be particularly useful in cases where we don't have a matching tracking call in the new flow.
+    /// enabled. It can be particularly useful in cases where we don't have a matching tracking call in the new flow.
     ///
     ///  - Returns: `true` if we must use legacy tracking, `false` otherwise.
     ///
@@ -425,7 +425,7 @@ public class AuthenticatorAnalyticsTracker {
 
     // MARK: - Event Construction & Context Updating
 
-    /// Creates an event for a step.  Updates the state machine.
+    /// Creates an event for a step. Updates the state machine.
     ///
     /// - Parameters:
     ///     - step: the step we're tracking.
@@ -443,7 +443,7 @@ public class AuthenticatorAnalyticsTracker {
         return event
     }
 
-    /// Creates an event for a failure.  Loads the properties from the state machine.
+    /// Creates an event for a failure. Loads the properties from the state machine.
     ///
     /// - Parameters:
     ///     - failure: the error message we want to track.
@@ -459,7 +459,7 @@ public class AuthenticatorAnalyticsTracker {
             properties: properties)
     }
 
-    /// Creates an event for a click interaction.  Loads the properties from the state machine.
+    /// Creates an event for a click interaction. Loads the properties from the state machine.
     ///
     /// - Parameters:
     ///     - click: the target of the click interaction.

--- a/WooCommerce/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WooCommerce/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -319,7 +319,7 @@ public class AuthenticatorAnalyticsTracker {
         self.track = track
     }
 
-    /// Resets the flow and step to the defaults. The source is left untouched, and should only be set explicitely.
+    /// Resets the flow and step to the defaults. The source is left untouched, and should only be set explicitly.
     ///
     func resetState() {
         set(flow: Self.defaultFlow)

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -324,8 +324,8 @@ import WordPressUI
     ///
     /// - Parameters:
     ///     - url: The authentication URL
-    ///     - rootViewController: The view controller to act as the presenter for the signin view controller.  By convention this is the app's root vc.
-    ///     - automatedTesting: for calling this method for automated testing.  It won't sync the account or load any other VCs.
+    ///     - rootViewController: The view controller to act as the presenter for the signin view controller. By convention this is the app's root vc.
+    ///     - automatedTesting: for calling this method for automated testing. It won't sync the account or load any other VCs.
     ///
     @objc public class func openAuthenticationURL(
         _ url: URL,
@@ -354,7 +354,7 @@ import WordPressUI
         }
 
         // We could just use the flow, but since `MagicLinkFlow` is an ObjC enum, it always
-        // allows a `default` value.  By mapping the ObjC enum to a Swift enum we can avoid that afterwards.
+        // allows a `default` value. By mapping the ObjC enum to a Swift enum we can avoid that afterwards.
         let flow: NUXLinkAuthViewController.Flow
 
         switch MagicLinkFlow(rawValue: flowRawValue) {

--- a/WooCommerce/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -262,7 +262,7 @@ extension WPStyleGuide {
         button.setTitleColor(WordPressAuthenticator.shared.style.subheadlineColor, for: .normal)
 
         // These constraints work around some issues with multiline buttons and
-        // vertical layout.  Without them the button's height may not account
+        // vertical layout. Without them the button's height may not account
         // for the titleLabel's height.
 
         let verticalLabelSpacing = forUnified ? 0 : Constants.verticalLabelSpacing

--- a/WooCommerce/WordPressAuthenticator/Model/LoginFields.swift
+++ b/WooCommerce/WordPressAuthenticator/Model/LoginFields.swift
@@ -34,7 +34,7 @@ public class LoginFields: NSObject {
     public var webauthnChallengeInfo: WebauthnChallengeInfo?
 
     /// Used by the SignupViewController. Signup currently asks for both a
-    /// username and an email address.  This can be factored away when we revamp
+    /// username and an email address. This can be factored away when we revamp
     /// the signup flow.
     @objc public var emailAddress = ""
 

--- a/WooCommerce/WordPressAuthenticator/Model/LoginFieldsMeta.swift
+++ b/WooCommerce/WordPressAuthenticator/Model/LoginFieldsMeta.swift
@@ -8,7 +8,7 @@ class LoginFieldsMeta {
     ///
     var jetpackLogin: Bool
 
-    /// Indicates whether a user is logging in via the wpcom flow or a self-hosted flow.  Used by the
+    /// Indicates whether a user is logging in via the wpcom flow or a self-hosted flow. Used by the
     /// the LoginFacade in its branching logic.
     /// This is a good candidate to refactor out and call the proper login method directly.
     ///
@@ -19,7 +19,7 @@ class LoginFieldsMeta {
     ///
     var passwordless: Bool
 
-    /// Should point to the site's xmlrpc.php for a self-hosted log in.  Should be the value returned via XML-RPC discovery.
+    /// Should point to the site's xmlrpc.php for a self-hosted log in. Should be the value returned via XML-RPC discovery.
     ///
     var xmlrpcURL: NSURL?
 

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXButton.swift
@@ -93,7 +93,7 @@ public struct NUXButtonStyle {
 
     // MARK: - Instance Methods
 
-    /// Toggles the visibility of the activity indicator.  When visible the button
+    /// Toggles the visibility of the activity indicator. When visible the button
     /// title is hidden.
     ///
     /// - Parameter show: True to show the spinner. False hides it.

--- a/WooCommerce/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -32,7 +32,7 @@ class NUXLinkAuthViewController: LoginViewController {
 
             switch flow {
             case .signup:
-                // This stat is part of a funnel that provides critical information.  Before
+                // This stat is part of a funnel that provides critical information. Before
                 // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                 WordPressAuthenticator.track(.createdAccount, properties: ["source": "email"])
                 WordPressAuthenticator.track(.signupMagicLinkSucceeded)

--- a/WooCommerce/WordPressAuthenticator/Signin/AppleAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/AppleAuthenticator.swift
@@ -89,7 +89,7 @@ private extension AppleAuthenticator {
     }
 
     func signupSuccessful(with credentials: AuthenticatorCredentials) {
-        // This stat is part of a funnel that provides critical information.  Before
+        // This stat is part of a funnel that provides critical information. Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         track(.createdAccount)
 
@@ -101,7 +101,7 @@ private extension AppleAuthenticator {
     }
 
     func loginSuccessful(with credentials: AuthenticatorCredentials) {
-        // This stat is part of a funnel that provides critical information.  Please
+        // This stat is part of a funnel that provides critical information. Please
         // consult with your lead before removing this event.
         track(.signedIn)
 

--- a/WooCommerce/WordPressAuthenticator/Signin/Login2FAViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/Login2FAViewController.swift
@@ -162,7 +162,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         let credentials = AuthenticatorCredentials(wpcom: wpcom)
         syncWPComAndPresentEpilogue(credentials: credentials)
 
-        // This stat is part of a funnel that provides critical information.  Please
+        // This stat is part of a funnel that provides critical information. Please
         // consult with your lead before removing this event.
         WordPressAuthenticator.track(.signedIn)
 

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -325,7 +325,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     /// - Parameters:
     ///     - immediately: True if the newly loaded controller should immedately attempt
-    ///                        to authenticate the user with the available credentails.  Default is `false`.
+    ///                        to authenticate the user with the available credentails. Default is `false`.
     ///
     func loginWithUsernamePassword(immediately: Bool = false) {
         if immediately {
@@ -397,7 +397,7 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
                                             strongSelf.displayError(message: msg)
                                         } else if errorCode == "email_login_not_allowed" {
                                                 // If we get this error, we know we have a WordPress.com user but their
-                                                // email address is flagged as suspicious.  They need to login via their
+                                                // email address is flagged as suspicious. They need to login via their
                                                 // username instead.
                                                 strongSelf.showSelfHostedUsernamePasswordAndError(error)
                                         } else {

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -325,7 +325,12 @@ open class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     /// - Parameters:
     ///     - immediately: True if the newly loaded controller should immedately attempt
-    ///                        to authenticate the user with the available credentails. Default is `false`.
+/// Displays the wpcom sign in form, optionally telling it to immediately make
+/// the call to authenticate with the available credentials.
+///
+/// - Parameters:
+///     - immediately: True if the newly loaded controller should immediately attempt
+    ///                        to authenticate the user with the available credentials. Default is `false`.
     ///
     func loginWithUsernamePassword(immediately: Bool = false) {
         if immediately {

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginLinkRequestViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import WordPressShared
 
 /// Step one in the auth link flow. This VC displays a form to request a "magic"
-/// authentication link be emailed to the user.  Allows the user to signin via
+/// authentication link be emailed to the user. Allows the user to signin via
 /// email instead of their password.
 ///
 class LoginLinkRequestViewController: LoginViewController {

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -31,7 +31,7 @@ class LoginPrologueViewController: LoginViewController {
     })
 
     /// We can't rely on `isMovingToParent` to know if we need to track the `.prologue` step
-    /// because for the root view in an App, it's always `false`.  We're relying this variiable
+    /// because for the root view in an App, it's always `false`. We're relying this variiable
     /// instead, since the `.prologue` step only needs to be tracked once.
     ///
     private var prologueFlowTracked = false
@@ -86,7 +86,7 @@ class LoginPrologueViewController: LoginViewController {
         super.viewDidAppear(animated)
 
         // We've found some instances where the iCloud Keychain login flow was being started
-        // when the device was idle and the app was logged out and in the background.  I couldn't
+        // when the device was idle and the app was logged out and in the background. I couldn't
         // find precise reproduction steps for this issue but my guess is that some background
         // operation is triggering a call to this method while the app is in the background.
         // The proposed solution is based off this StackOverflow reply:

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -31,7 +31,7 @@ class LoginPrologueViewController: LoginViewController {
     })
 
     /// We can't rely on `isMovingToParent` to know if we need to track the `.prologue` step
-    /// because for the root view in an App, it's always `false`. We're relying this variiable
+    /// because for the root view in an App, it's always `false`. We're relying on this variable
     /// instead, since the `.prologue` step only needs to be tracked once.
     ///
     private var prologueFlowTracked = false

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -291,7 +291,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     /// Does a local / quick Site Address validation and refreshes the UI with an error
     /// if necessary.
     ///
-    /// - Returns: `true` if the Site Address contains a valid URL.  `false` otherwise.
+    /// - Returns: `true` if the Site Address contains a valid URL. `false` otherwise.
     ///
     private func refreshSiteAddressError(immediate: Bool) {
         let showError = !loginFields.siteAddress.isEmpty && !loginFields.validateSiteForSignin()

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -291,7 +291,7 @@ extension LoginViewController {
             ]
         }
 
-        // This stat is part of a funnel that provides critical information.  Please
+        // This stat is part of a funnel that provides critical information. Please
         // consult with your lead before removing this event.
         WordPressAuthenticator.track(.signedIn, properties: properties)
         tracker.track(step: .success)
@@ -322,7 +322,7 @@ extension LoginViewController {
                         serviceToken: serviceToken,
                         connectParameters: appleConnectParameters,
                         success: {
-                            // This stat is part of a funnel that provides critical information.  Please
+                            // This stat is part of a funnel that provides critical information. Please
                             // consult with your lead before removing this event.
                             let source = appleConnectParameters != nil ? "apple" : "google"
                             WordPressAuthenticator.track(.signedIn, properties: ["source": source])
@@ -336,7 +336,7 @@ extension LoginViewController {
             WordPressAuthenticator.track(.loginSocialConnectFailure, error: error)
             // We're opting to let this call fail silently.
             // Our user has already successfully authenticated and can use the app --
-            // connecting the social service isn't critical.  There's little to
+            // connecting the social service isn't critical. There's little to
             // be gained by displaying an error that can not currently be resolved
             // in the app and doing so might tarnish an otherwise satisfying login
             // experience.

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginWPComViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginWPComViewController.swift
@@ -61,7 +61,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
 
         if isMovingFromParent {
             // There was a bug that was causing iOS's update password prompt to come up
-            // when this VC was being dismissed pressing the "< Back" button.  The following
+            // when this VC was being dismissed pressing the "< Back" button. The following
             // line ensures that such prompt doesn't come up anymore.
             //
             // More information can be found in the PR where this workaround is introduced:

--- a/WooCommerce/WordPressAuthenticator/UI/SearchTableViewCell.swift
+++ b/WooCommerce/WordPressAuthenticator/UI/SearchTableViewCell.swift
@@ -29,7 +29,7 @@ open class SearchTableViewCell: UITableViewCell {
     ///
     open var liveSearch: Bool = false
 
-    /// If `true` then the user can type in spaces regularly.  If `false` the whitespaces will be
+    /// If `true` then the user can type in spaces regularly. If `false` the whitespaces will be
     /// stripped before they're entered into the field.
     ///
     open var allowSpaces: Bool = true

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/GoogleAuthenticator.swift
@@ -283,7 +283,7 @@ extension GoogleAuthenticator: LoginFacadeDelegate {
     func finishedLogin(withGoogleIDToken googleIDToken: String, authToken: String) {
         SVProgressHUD.dismiss()
 
-        // This stat is part of a funnel that provides critical information.  Please
+        // This stat is part of a funnel that provides critical information. Please
         // consult with your lead before removing this event.
         track(.signedIn)
 
@@ -397,11 +397,11 @@ private extension GoogleAuthenticator {
     }
 
     func accountCreated(credentials: AuthenticatorCredentials) {
-        // This stat is part of a funnel that provides critical information.  Before
+        // This stat is part of a funnel that provides critical information. Before
         // making ANY modification to this stat please refer to: p4qSXL-35X-p2
         track(.createdAccount)
 
-        // This stat is part of a funnel that provides critical information.  Please
+        // This stat is part of a funnel that provides critical information. Please
         // consult with your lead before removing this event.
         track(.signedIn)
 
@@ -416,7 +416,7 @@ private extension GoogleAuthenticator {
     func logInInstead(credentials: AuthenticatorCredentials) {
         tracker.set(flow: .loginWithGoogle)
 
-        // This stat is part of a funnel that provides critical information.  Please
+        // This stat is part of a funnel that provides critical information. Please
         // consult with your lead before removing this event.
         track(.signedIn)
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/StoredCredentialsAuthenticator.swift
@@ -3,8 +3,8 @@ import AuthenticationServices
 import SVProgressHUD
 
 /// The authorization flow handled by this class starts by showing Apple's `ASAuthorizationController`
-/// through our class `StoredCredentialsPicker`.  This controller lets the user pick the credentials they
-/// want to login with.  This class handles both showing that controller and executing the remaining flow to
+/// through our class `StoredCredentialsPicker`. This controller lets the user pick the credentials they
+/// want to login with. This class handles both showing that controller and executing the remaining flow to
 /// complete the login process.
 ///
 class StoredCredentialsAuthenticator: NSObject {
@@ -85,7 +85,7 @@ class StoredCredentialsAuthenticator: NSObject {
         }
     }
 
-    /// The selection of credentials and subsequent authorization by the OS succeeded.  This method processes the credentials
+    /// The selection of credentials and subsequent authorization by the OS succeeded. This method processes the credentials
     /// and proceeds with the login operation.
     ///
     /// - Parameters:
@@ -112,7 +112,7 @@ class StoredCredentialsAuthenticator: NSObject {
         }
     }
 
-    /// The selection of credentials or the subsequent authorization by the OS failed.  This method processes the failure.
+    /// The selection of credentials or the subsequent authorization by the OS failed. This method processes the failure.
     ///
     /// - Parameters:
     ///         - error: The error detailing what failed.
@@ -125,9 +125,9 @@ class StoredCredentialsAuthenticator: NSObject {
             // The user cancelling the flow is not really an error, so we're not reporting or tracking
             // this as an error.
             //
-            // We're not tracking this either, since the Android App doesn't for SmartLock.  The reason is
+            // We're not tracking this either, since the Android App doesn't for SmartLock. The reason is
             // that it's not trivial to know when the credentials picker UI is shown to the user, so knowing
-            // it's being dismissed is also not trivial.  This was decided during the Unified Login & Signup
+            // it's being dismissed is also not trivial. This was decided during the Unified Login & Signup
             // project in a conversation between myself (Diego Rey Mendez) and Renan Ferrari.
             break
         default:
@@ -192,7 +192,7 @@ extension StoredCredentialsAuthenticator {
                                                     onDismiss: {})
     }
 
-    /// Presents the login email screen, displaying the specified error.  This is useful
+    /// Presents the login email screen, displaying the specified error. This is useful
     /// for example for iCloud Keychain in the case where there's an error logging the user
     /// in with the stored credentials for whatever reason.
     ///
@@ -210,7 +210,7 @@ extension StoredCredentialsAuthenticator {
         navigationController?.pushViewController(toVC, animated: true)
     }
 
-    /// Presents the get started screen, displaying the specified error.  This is useful
+    /// Presents the get started screen, displaying the specified error. This is useful
     /// for example for iCloud Keychain in the case where there's an error logging the user
     /// in with the stored credentials for whatever reason.
     ///

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordViewController.swift
@@ -162,7 +162,7 @@ class PasswordViewController: LoginViewController {
 
     override func displayError(message: String, moveVoiceOverFocus: Bool = false) {
         // The reason why this check is necessary is that we're calling this method
-        // with an empty error message when setting up the VC.  We don't want to track
+        // with an empty error message when setting up the VC. We don't want to track
         // an empty error when that happens.
         if !message.isEmpty {
             tracker.track(failure: message)

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/Utility/NSCharacterSet+URLEncode.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/Utility/NSCharacterSet+URLEncode.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc
 public extension NSCharacterSet {
-    /// The base character set `urlPathAllowed` allows single apostrophes.  This encoding is a bit more
+    /// The base character set `urlPathAllowed` allows single apostrophes. This encoding is a bit more
     /// restrictive and disallows some extra characters as per RFC 3986.
     ///
     @objc(URLPathRFC3986AllowedCharacterSet)


### PR DESCRIPTION
Enables the auto-fixable [`period_spacing`](https://realm.github.io/SwiftLint/period_spacing.html) SwiftLint rule, which forbids whitespace immediately after a period.

`rake lint:autocorrect` did all the cleanup; the rest of the diff is mechanical.

### Test plan

- CI lint job stays green.