### PR TITLE
Fix duplicate action summary on bulk confirmation cards

### DIFF
--- a/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
@@ -100,7 +100,7 @@ struct ConfirmationCard: View {
                     DiffFieldRow(field: field, isBulk: preview.isBulk)
                 }
             }
-        } else {
+        } else if preview.showsSummaryInBody {
             Text(preview.summary.flattened())
                 .font(.assistantBody)
                 .foregroundStyle(Color.primary)

--- a/Modules/Sources/WooAIAssistant/Safety/ConfirmationPreview.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ConfirmationPreview.swift
@@ -18,6 +18,11 @@ public struct ConfirmationPreview: Equatable, Sendable {
         self.isBulk = isBulk
         self.bulkEntries = bulkEntries
     }
+
+    /// The summary already shows as the card title; the body repeats it only when there are no detail rows.
+    public var showsSummaryInBody: Bool {
+        fields.isEmpty && bulkEntries.isEmpty
+    }
 }
 
 public struct ConfirmationPreviewField: Equatable, Sendable {

--- a/Modules/Tests/WooAIAssistantTests/Safety/ConfirmationPreviewTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/ConfirmationPreviewTests.swift
@@ -44,4 +44,46 @@ struct ConfirmationPreviewTests {
         #expect(preview.isBulk == false)
         #expect(preview.fields.isEmpty)
     }
+
+    @Test
+    func test_showsSummaryInBody_when_bulk_entries_present_then_false() {
+        // Given
+        let preview = ConfirmationPreview(
+            summary: .raw("Update 2 variations of product #820"),
+            isBulk: true,
+            bulkEntries: [
+                ConfirmationBulkEntry(id: 827, displayName: "L Navy Blue"),
+                ConfirmationBulkEntry(id: 832, displayName: "S Forest Green")
+            ]
+        )
+
+        // When / Then
+        #expect(preview.showsSummaryInBody == false)
+    }
+
+    @Test
+    func test_showsSummaryInBody_when_fields_present_then_false() {
+        // Given
+        let preview = ConfirmationPreview(
+            summary: .raw("Update order #3479"),
+            fields: [
+                ConfirmationPreviewField(name: "status",
+                                         label: .raw("Status"),
+                                         value: .raw("completed"),
+                                         priorValue: .raw("processing"))
+            ]
+        )
+
+        // When / Then
+        #expect(preview.showsSummaryInBody == false)
+    }
+
+    @Test
+    func test_showsSummaryInBody_when_only_summary_then_true() {
+        // Given
+        let preview = ConfirmationPreview(summary: .raw("Update order #42"))
+
+        // When / Then
+        #expect(preview.showsSummaryInBody == true)
+    }
 }


### PR DESCRIPTION
## Description
The AI Assistant confirmation card showed the action summary twice on bulk update confirmations. The summary (e.g. "Update 2 variations of product #820") rendered once as the bold card title and again as a footer line below the per-variation rows.

The card title always renders the preview summary. The card body also has a fallback that renders the summary whenever there are no field diffs to show. Bulk previews populate per-entity rows (`bulkEntries`) and leave `fields` empty, so that fallback fired and repeated the title. Single-entity updates carry field diffs, so they never reached the fallback and were unaffected.

The fix guards the body fallback so it renders the summary only when the preview has neither field diffs nor bulk entity rows. When bulk entries are present, the title plus the entity rows already convey the change. The decision is exposed as `ConfirmationPreview.showsSummaryInBody` so it can be unit-tested directly, without SwiftUI view introspection.

## Test Steps
1. Enable the AI Assistant (feature-flagged).
2. Ask the assistant to perform a bulk update (e.g. "set 2 variations of a product to draft") and reach the confirmation card.
3. Confirm the summary appears only once, as the card title, with the affected entity rows listed below it and no duplicated summary footer.
4. Verify single-entity updates still show their field diffs (before -> after) as before.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.