### PR TITLE
Enable SwiftLint rule: untyped_error_in_catch

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -105,6 +105,8 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  - untyped_error_in_catch
+
   - vertical_whitespace
 
   - vertical_whitespace_closing_braces

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/ApplicationLogViewController.swift
@@ -229,7 +229,7 @@ private extension ApplicationLogViewController {
         for logFileInfo in logFiles {
             do {
                 try FileManager.default.removeItem(atPath: logFileInfo.filePath)
-            } catch let error {
+            } catch {
                 DDLogError("⚠️ Error deleting log files \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormRemoteActionUseCase.swift
@@ -318,7 +318,7 @@ private extension ProductFormRemoteActionUseCase {
                     let updatedProduct = EditableProductModel(product: productModel)
                     onCompletion(.success(updatedProduct))
                 }
-            } catch let error {
+            } catch {
                 await MainActor.run {
                     onCompletion(.failure(.unknown(error: AnyError(error))))
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
@@ -392,7 +392,7 @@ private extension CodeScannerViewController {
         var deviceInput: AVCaptureDeviceInput!
         do {
             deviceInput = try AVCaptureDeviceInput(device: validDevice)
-        } catch let error {
+        } catch {
             DDLogError("Error creating device input: \(error)")
             return
         }

--- a/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
+++ b/WooCommerce/WooCommerceScreenshots/Utils/SnapshotHelper.swift
@@ -74,7 +74,7 @@ open class Snapshot: NSObject {
             setLanguage(app)
             setLocale(app)
             setLaunchArguments(app)
-        } catch let error {
+        } catch {
             NSLog(error.localizedDescription)
         }
     }
@@ -188,7 +188,7 @@ open class Snapshot: NSObject {
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif
-            } catch let error {
+            } catch {
                 NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
                 NSLog(error.localizedDescription)
             }


### PR DESCRIPTION
## What

Adds `untyped_error_in_catch` to `.swiftlint.yml`'s `only_rules` list (alphabetical).
[Rule docs](https://realm.github.io/SwiftLint/untyped_error_in_catch.html): catch statements should not declare error variables without specifying the type — prefer the implicit `error` binding.

## Changes

- **Auto-fixed:** 5 violations across 4 files (replaced `} catch let error {` with `} catch {`).
- **Manual fixes:** none.
- **Left for human review:** none.

## Context

Part of the [Orchard](https://github.com/Automattic/orchard) SwiftLint rollout campaign — enabling one rule at a time across mobile repos to keep PRs small and reviewable.