### PR TITLE
Drop toggles from Push Notification preferences list view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -51,23 +51,17 @@ struct PushNotificationPreferencesView: View {
         List {
             Section {
                 row(title: Localization.newOrdersTitle,
-                    detail: Localization.newOrdersDetail,
-                    isOn: Binding(get: { viewModel.isStoreOrderEnabled },
-                                  set: { viewModel.setStoreOrderEnabled($0) }))
+                    detail: viewModel.isStoreOrderEnabled ? Localization.newOrdersDetail : Localization.off)
                 row(title: Localization.newReviewsTitle,
-                    detail: Localization.newReviewsDetail,
-                    isOn: Binding(get: { viewModel.isStoreReviewEnabled },
-                                  set: { viewModel.setStoreReviewEnabled($0) }))
+                    detail: viewModel.isStoreReviewEnabled ? Localization.newReviewsDetail : Localization.off)
                 row(title: Localization.stockTitle,
-                    detail: Localization.stockDetail,
-                    isOn: Binding(get: { viewModel.isStoreStockEnabled },
-                                  set: { viewModel.setStoreStockEnabled($0) }))
+                    detail: viewModel.isStoreStockEnabled ? Localization.stockDetail : Localization.off)
             }
         }
         .listStyle(.insetGrouped)
     }
 
-    private func row(title: String, detail: String, isOn: Binding<Bool>) -> some View {
+    private func row(title: String, detail: String) -> some View {
         HStack(spacing: Layout.contentSpacing) {
             VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
                 Text(title)
@@ -77,16 +71,14 @@ struct PushNotificationPreferencesView: View {
                     .captionStyle()
             }
             Spacer()
-            Toggle("", isOn: isOn)
-                .labelsHidden()
-                .accessibilityLabel(title)
-                .accessibilityHint(detail)
             Image(systemName: "chevron.forward")
                 .foregroundStyle(Color(.tertiaryLabel))
                 .font(.footnote.weight(.semibold))
                 .accessibilityHidden(true)
         }
         .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
     }
 }
 
@@ -133,6 +125,11 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.stock.detail",
             value: "All stock alerts",
             comment: "Detail text for the row that toggles stock push notifications."
+        )
+        static let off = NSLocalizedString(
+            "pushNotificationPreferencesView.off",
+            value: "Off",
+            comment: "Detail text shown on a notification row when notifications are disabled."
         )
         static let errorTitle = NSLocalizedString(
             "pushNotificationPreferencesView.error.title",


### PR DESCRIPTION
## Description

Each row of the Push Notifications preferences list currently shows both an inline `Toggle` and a disclosure chevron. A reviewer on a prior PR flagged that combination as non-idiomatic on iOS — the chevron implies navigation, the toggle implies in-place editing, and having both is confusing.

This drops the `Toggle` from each row. The existing subtitle takes over as the state indicator: it keeps its current copy ("All orders" / "All reviews" / "All stock alerts") when the underlying preference is enabled, and reads "Off" when disabled. The master switch for each notification type lives on the detail screens (covered by `RSM-1631` / `RSM-1632` / `RSM-1633`).


For `RSM-3624`.

## Test Steps

1. On a store with the Woo push-notifications plugin enabled, sign in.
2. With the `smarter_notifications` feature flag ON, open **Settings → Push Notifications**.
3. Confirm each row shows title on top, subtitle below in secondary colour, and a chevron on the right — **no inline toggle**.
4. With a row's master preference enabled, the subtitle reads its current selection ("All orders" / "All reviews" / "All stock alerts").
5. Flip a master preference off (via the detail screen once it lands, or by editing the response in a debugger / proxy). The subtitle should now read "Off".

## Screenshots

| Before | After |
|---|---|
|  <img width="1206" height="2622" alt="594119042-e0f269c4-2a4f-4762-9fef-3817c521a565" src="https://github.com/user-attachments/assets/036de726-f737-4098-9ede-cc091e09e2cd" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-20 at 20 16 39" src="https://github.com/user-attachments/assets/9523a2e4-c69f-431c-b0c0-d539db2928ae" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (No release note: the screen is behind the `smarter_notifications` feature flag and the parent ticket `RSM-1630` intentionally dropped its release-notes entry.)