### PR TITLE
Harden the AI Assistant agentic loop against double-writes and stale reads

### DIFF
--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -288,8 +288,8 @@ public actor AgenticLoopOrchestrator {
                     messages.append(.init(role: .tool, content: payload, toolCallID: call.id))
                 }
 
-                // Outcome-unknown write must not invite a retry: terminate the turn here.
-                if dispatch.writeOutcomeUnknown != nil {
+                // A write we can't confirm must not be retried: that risks applying it twice.
+                if dispatch.hasUncertainWrite {
                     continuation.yield(.textChunk(Localization.outcomeUnknownTerminal))
                     continuation.yield(.completed(routeConfidence: nil))
                     setOutcome(.completed)
@@ -349,6 +349,22 @@ public actor AgenticLoopOrchestrator {
         return .toolCalls(pendingCalls)
     }
 
+    // MARK: - Tool dispatch
+
+    /// Unknown tool names default to unsafe so an unrecognized name never skips the write ordering.
+    private func isUnsafe(_ call: OpenAIChat.ToolCall, toolsByName: [String: AITool]) -> Bool {
+        (toolsByName[call.function.name]?.safetyLevel ?? .unsafe) == .unsafe
+    }
+
+    /// Writes run before reads in the same batch so a read paired with a write renders post-write state.
+    private func dispatchBatchesInSafetyOrder(_ approvedIndices: [Int],
+                                              calls: [OpenAIChat.ToolCall],
+                                              toolsByName: [String: AITool]) -> [[Int]] {
+        let writes = approvedIndices.filter { isUnsafe(calls[$0], toolsByName: toolsByName) }
+        let reads = approvedIndices.filter { !isUnsafe(calls[$0], toolsByName: toolsByName) }
+        return [writes, reads].filter { !$0.isEmpty }
+    }
+
     /// Dispatch every call in `calls` under the safety policy and return the per-call payloads in input
     /// order. Identical calls (across the turn or within this batch) replay the cached payload via a
     /// success-shaped `cached_result_reused` envelope rather than an error shape, because models treat
@@ -380,7 +396,7 @@ public actor AgenticLoopOrchestrator {
                 }
             }
             let payloads = calls.map { _ in #"{"error":"No tool registry is configured for this client."}"# }
-            return DispatchResult(payloads: payloads, writeOutcomeUnknown: nil)
+            return DispatchResult(payloads: payloads, hasUncertainWrite: false)
         }
 
         var approvedIndices: [Int] = []
@@ -388,8 +404,7 @@ public actor AgenticLoopOrchestrator {
         var liveSignatures = priorCallSignatures
         let liveResults = priorResultsBySignature
         var liveTurnTallies = priorPerToolTallies
-        // Keep only the earliest-in-batch unsafe outcome-unknown so the terminal message names one tool.
-        var writeOutcomeUnknown: Int?
+        var hasUncertainWrite = false
 
         // Without intra-batch dedupe the task group fires the registry once per duplicate in parallel.
         var firstPrimaryByIntraSignature: [String: Int] = [:]
@@ -513,41 +528,47 @@ public actor AgenticLoopOrchestrator {
                                                     argumentsJSON: call.function.arguments))
                 startTimesByIndex[index] = clock.nowMs()
             }
-            // withTaskGroup (not throwing) so a single tool failure no longer
-            // tears down sibling tasks. Errors from the registry get folded
-            // into a per-tool failed result and surface as toolCallCompleted
-            // events for every call - no orphan running pills.
-            await withTaskGroup(of: (Int, ToolResult).self) { group in
-                for index in approvedIndices {
-                    let call = calls[index]
-                    group.addTask {
-                        let result = await registry.execute(name: call.function.name,
-                                                            arguments: call.function.arguments,
-                                                            toolCallID: call.id)
-                        return (index, result)
+            // Non-throwing task group: a single tool's failure becomes a per-tool failed result
+            // instead of tearing down its siblings and leaving orphan running pills.
+            func runGroup(for indices: [Int]) async {
+                guard !indices.isEmpty else { return }
+                await withTaskGroup(of: (Int, ToolResult).self) { group in
+                    for index in indices {
+                        let call = calls[index]
+                        group.addTask {
+                            let result = await registry.execute(name: call.function.name,
+                                                                arguments: call.function.arguments,
+                                                                toolCallID: call.id)
+                            return (index, result)
+                        }
+                    }
+                    for await (index, result) in group {
+                        let call = calls[index]
+                        let payload = self.handleToolResult(result,
+                                                            for: call,
+                                                            continuation: continuation)
+                        resolvedResults[index] = payload
+                        if case .failed(let failed) = result,
+                           failed.kind == .outcomeUnknown,
+                           isUnsafe(call, toolsByName: toolsByName) {
+                            hasUncertainWrite = true
+                        }
+                        if let telemetryContext, let startMs = startTimesByIndex[index] {
+                            let duration = max(0, clock.nowMs() - startMs)
+                            await emitToolDecisionTelemetry(result: result,
+                                                            call: call,
+                                                            durationMs: duration,
+                                                            telemetryContext: telemetryContext,
+                                                            toolsByName: toolsByName)
+                        }
                     }
                 }
-                for await (index, result) in group {
-                    let call = calls[index]
-                    let payload = self.handleToolResult(result,
-                                                        for: call,
-                                                        continuation: continuation)
-                    resolvedResults[index] = payload
-                    if case .failed(let failed) = result,
-                       failed.kind == .outcomeUnknown,
-                       toolsByName[call.function.name]?.safetyLevel == .unsafe,
-                       (writeOutcomeUnknown ?? .max) > index {
-                        writeOutcomeUnknown = index
-                    }
-                    if let telemetryContext, let startMs = startTimesByIndex[index] {
-                        let duration = max(0, clock.nowMs() - startMs)
-                        await emitToolDecisionTelemetry(result: result,
-                                                        call: call,
-                                                        durationMs: duration,
-                                                        telemetryContext: telemetryContext,
-                                                        toolsByName: toolsByName)
-                    }
-                }
+            }
+
+            for batch in dispatchBatchesInSafetyOrder(approvedIndices,
+                                                      calls: calls,
+                                                      toolsByName: toolsByName) {
+                await runGroup(for: batch)
             }
         }
 
@@ -590,7 +611,7 @@ public actor AgenticLoopOrchestrator {
             }
             return payload
         }
-        return DispatchResult(payloads: payloads, writeOutcomeUnknown: writeOutcomeUnknown)
+        return DispatchResult(payloads: payloads, hasUncertainWrite: hasUncertainWrite)
     }
 
     private func handleToolResult(_ result: ToolResult,
@@ -655,6 +676,8 @@ public actor AgenticLoopOrchestrator {
             return payload
         }
     }
+
+    // MARK: - Turn message assembly
 
     /// Inject a one-shot system nudge when this turn's transcript shows the model misbehaving (an
     /// empty-list retry loop or the same tool called 3+ times). Each guard key fires at most once.
@@ -1008,7 +1031,7 @@ private enum TurnOutcome {
 
 struct DispatchResult {
     let payloads: [String]
-    let writeOutcomeUnknown: Int?
+    let hasUncertainWrite: Bool
 }
 
 /// Tests/read-only prototypes that don't need a real safety check.

--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -277,15 +277,23 @@ public actor AgenticLoopOrchestrator {
                 let priorResults = Self.computePriorResultsBySignature(in: messages)
                 let priorTurnTallies = Self.computePerToolPriorTallies(in: messages)
 
-                let payloads = try await dispatchTools(calls,
+                let dispatch = try await dispatchTools(calls,
                                                        toolsByName: toolsByName,
                                                        priorCallSignatures: priorSignatures,
                                                        priorResultsBySignature: priorResults,
                                                        priorPerToolTallies: priorTurnTallies,
                                                        telemetryContext: telemetryContext,
                                                        continuation: continuation)
-                for (call, payload) in zip(calls, payloads) {
+                for (call, payload) in zip(calls, dispatch.payloads) {
                     messages.append(.init(role: .tool, content: payload, toolCallID: call.id))
+                }
+
+                // Outcome-unknown write must not invite a retry: terminate the turn here.
+                if dispatch.writeOutcomeUnknown != nil {
+                    continuation.yield(.textChunk(Localization.outcomeUnknownTerminal))
+                    continuation.yield(.completed(routeConfidence: nil))
+                    setOutcome(.completed)
+                    return
                 }
                 continue
             }
@@ -352,7 +360,7 @@ public actor AgenticLoopOrchestrator {
                                priorPerToolTallies: [String: Int],
                                telemetryContext: AssistantTelemetryContext?,
                                continuation: AsyncThrowingStream<AssistantEvent, Error>.Continuation)
-    async throws -> [String] {
+    async throws -> DispatchResult {
         guard let registry = toolRegistry else {
             for call in calls {
                 continuation.yield(.toolCallStarted(id: call.id,
@@ -371,7 +379,8 @@ public actor AgenticLoopOrchestrator {
                                                            durationMs: nil))
                 }
             }
-            return calls.map { _ in #"{"error":"No tool registry is configured for this client."}"# }
+            let payloads = calls.map { _ in #"{"error":"No tool registry is configured for this client."}"# }
+            return DispatchResult(payloads: payloads, writeOutcomeUnknown: nil)
         }
 
         var approvedIndices: [Int] = []
@@ -379,6 +388,8 @@ public actor AgenticLoopOrchestrator {
         var liveSignatures = priorCallSignatures
         let liveResults = priorResultsBySignature
         var liveTurnTallies = priorPerToolTallies
+        // Keep only the earliest-in-batch unsafe outcome-unknown so the terminal message names one tool.
+        var writeOutcomeUnknown: Int?
 
         // Without intra-batch dedupe the task group fires the registry once per duplicate in parallel.
         var firstPrimaryByIntraSignature: [String: Int] = [:]
@@ -522,6 +533,12 @@ public actor AgenticLoopOrchestrator {
                                                         for: call,
                                                         continuation: continuation)
                     resolvedResults[index] = payload
+                    if case .failed(let failed) = result,
+                       failed.kind == .outcomeUnknown,
+                       toolsByName[call.function.name]?.safetyLevel == .unsafe,
+                       (writeOutcomeUnknown ?? .max) > index {
+                        writeOutcomeUnknown = index
+                    }
                     if let telemetryContext, let startMs = startTimesByIndex[index] {
                         let duration = max(0, clock.nowMs() - startMs)
                         await emitToolDecisionTelemetry(result: result,
@@ -566,13 +583,14 @@ public actor AgenticLoopOrchestrator {
             }
         }
 
-        return resolvedResults.map { payload -> String in
+        let payloads = resolvedResults.map { payload -> String in
             guard let payload else {
                 assertionFailure("dispatchTools left a nil result slot - safety-branch coverage gap")
                 return #"{"error":"missing tool result"}"#
             }
             return payload
         }
+        return DispatchResult(payloads: payloads, writeOutcomeUnknown: writeOutcomeUnknown)
     }
 
     private func handleToolResult(_ result: ToolResult,
@@ -605,7 +623,7 @@ public actor AgenticLoopOrchestrator {
         case .failed(let failed) where failed.kind == .outcomeUnknown:
             // Per-call event, not a terminal failure: the model still gets a tool message so it can
             // react, and the UI gets a typed failed event so it can render the distinct unknown state.
-            let payload = Self.outcomeUnknownJSON(toolName: call.function.name)
+            let payload = Self.outcomeUnknownJSON(toolName: call.function.name, reason: failed.reason)
             continuation.yield(.toolCallCompleted(id: call.id,
                                                    name: call.function.name,
                                                    resultJSON: payload))
@@ -767,14 +785,19 @@ public actor AgenticLoopOrchestrator {
         #"{"status":"user_cancelled","reason":"User declined this action in the iOS confirmation prompt."}"#
     }
 
-    private static func outcomeUnknownJSON(toolName: String) -> String {
-        let body: [String: Any] = [
-            "outcome": "unknown",
-            "tool": toolName,
-            "advice": "Ask the merchant to verify the operation by viewing the order in the native UI."
-        ]
+    private struct OutcomeUnknownPayload: Encodable {
+        let outcome = "unknown"
+        let tool: String
+        let detail: String?
+    }
+
+    private static func outcomeUnknownJSON(toolName: String, reason: String) -> String {
+        let payload = OutcomeUnknownPayload(tool: toolName,
+                                            detail: reason.isEmpty ? nil : reason)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
         do {
-            let data = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+            let data = try encoder.encode(payload)
             if let json = String(data: data, encoding: .utf8) { return json }
         } catch {
             DDLogError("AgenticLoopOrchestrator outcomeUnknownJSON encode failed: \(error)")
@@ -968,6 +991,11 @@ public actor AgenticLoopOrchestrator {
             value: "The chat service ended the stream without finishing cleanly. Try again.",
             comment: "Failure surfaced when the chat service's stream ends without emitting a finish event, indicating an upstream truncation."
         )
+        static let outcomeUnknownTerminal = NSLocalizedString(
+            "ai.assistant.loop.outcome_unknown_terminal",
+            value: "I couldn't confirm whether the previous change applied. Please check your store and try again if it didn't take effect.",
+            comment: "Synthesized terminal assistant message when a write tool's outcome could not be confirmed."
+        )
     }
 }
 
@@ -976,6 +1004,11 @@ public actor AgenticLoopOrchestrator {
 private enum TurnOutcome {
     case completed
     case toolCalls([OpenAIChat.ToolCall])
+}
+
+struct DispatchResult {
+    let payloads: [String]
+    let writeOutcomeUnknown: Int?
 }
 
 /// Tests/read-only prototypes that don't need a real safety check.

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopDispatchOrderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopDispatchOrderTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct LoopDispatchOrderTests {
+
+    @Test
+    func test_dispatch_when_batch_mixes_write_and_read_then_write_runs_before_read() async throws {
+        // Given
+        let writeTool = AITool(name: "orders_update",
+                               description: "Update an order",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let readTool = AITool(name: "orders_get",
+                              description: "Fetch an order",
+                              parametersSchema: .object([:]),
+                              safetyLevel: .safe)
+        let writeCall = OpenAIChat.ToolCall(
+            id: "call_write",
+            function: .init(name: "orders_update", arguments: #"{"id":42,"status":"processing"}"#)
+        )
+        let readCall = OpenAIChat.ToolCall(
+            id: "call_read",
+            function: .init(name: "orders_get", arguments: #"{"id":42}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(writeCall), .toolCall(readCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = OrderRecordingToolRegistry(availableTools: [writeTool, readTool])
+        let safetyPolicy = AutoApprovingSafetyPolicy()
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   safetyPolicy: safetyPolicy)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update and re-fetch order 42") {}
+
+        // Then
+        let order = await registry.executionOrder
+        #expect(order == ["orders_update", "orders_get"])
+        let readSawWriteDone = await registry.writeDoneObservedAtReadStart
+        #expect(readSawWriteDone == true)
+    }
+}
+
+/// Records every execute() invocation in arrival order so tests can pin write-before-read
+/// dispatch. Also exposes a flag the write flips on completion so reads can assert they
+/// observed the post-write state.
+private actor OrderRecordingToolRegistry: ToolRegistry {
+
+    private(set) var executionOrder: [String] = []
+    private(set) var writeDoneObservedAtReadStart: Bool?
+    private var writeDone = false
+    private let tools: [AITool]
+
+    init(availableTools: [AITool]) {
+        self.tools = availableTools
+    }
+
+    func availableTools() async throws -> [AITool] {
+        tools
+    }
+
+    func execute(name: String, arguments: String, toolCallID: String) async -> ToolResult {
+        executionOrder.append(name)
+        if name == "orders_get" && writeDoneObservedAtReadStart == nil {
+            writeDoneObservedAtReadStart = writeDone
+        }
+        let result = ToolResult.success(.init(toolName: name,
+                                              structured: .object(["id": .int(42)])))
+        if name == "orders_update" {
+            writeDone = true
+        }
+        return result.stamping(toolCallID: toolCallID)
+    }
+}
+
+/// Approves every confirmation so tests can focus on dispatch ordering rather than the
+/// confirmation handshake.
+private struct AutoApprovingSafetyPolicy: SafetyPolicy {
+    func decision(for name: String,
+                  arguments: String,
+                  tool: AITool) async -> SafetyDecision {
+        .execute
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopOutcomeUnknownTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopOutcomeUnknownTests.swift
@@ -6,20 +6,24 @@ import Testing
 struct LoopOutcomeUnknownTests {
 
     @Test
-    func test_outcomeUnknown_when_write_tool_returns_outcomeUnknown_then_emits_failed_event_with_outcomeUnknown_kind() async throws {
+    func test_loop_when_write_tool_returns_outcome_unknown_then_turn_terminates_without_further_tool_calls() async throws {
         // Given
         let writeTool = AITool(name: "orders_update",
                                description: "Update an order",
                                parametersSchema: .object([:]),
-                               safetyLevel: .safe)
-        let toolCall = OpenAIChat.ToolCall(
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
             id: "call_1",
             function: .init(name: "orders_update", arguments: #"{"id":42,"status":"processing"}"#)
         )
+        let retryCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "orders_update", arguments: #"{"id":42,"status":"completed"}"#)
+        )
         let chat = MockAIChatService()
         await chat.setScriptedTurns([
-            [.toolCall(toolCall), .completed(.toolCalls)],
-            [.textDelta("I couldn't confirm the change. Check the order."), .completed(.stop)]
+            [.toolCall(firstCall), .completed(.toolCalls)],
+            [.toolCall(retryCall), .completed(.toolCalls)]
         ])
         let registry = MockToolRegistry()
         await registry.setAvailableTools([writeTool])
@@ -36,28 +40,159 @@ struct LoopOutcomeUnknownTests {
         }
 
         // Then
-        let unknownFailure: AssistantError? = events.compactMap { event in
-            if case .failed(let error) = event, error.kind == .outcomeUnknown {
-                return error
-            }
-            return nil
-        }.first
-        let error = try #require(unknownFailure)
-        #expect(error.message == "Network dropped after request was sent.")
+        let invocations = await registry.invocationCount(for: "orders_update")
+        #expect(invocations == 1)
 
-        // The loop continued (model produced text after) so the
-        // terminal outcome is still .completed, not .failed.
         let outcome = await orchestrator.lastOutcome
         #expect(outcome == .completed)
 
-        // The model should have seen the outcome_unknown advice
-        // tool message in its follow-up request.
         let capturedRequests = await chat.capturedRequests
-        #expect(capturedRequests.count >= 2)
-        let secondRequest = capturedRequests[1]
-        let toolMessage = secondRequest.messages.last { $0.role == .tool && $0.toolCallID == "call_1" }
-        let content = try #require(toolMessage?.content)
-        #expect(content.contains("\"outcome\":\"unknown\""))
-        #expect(content.contains("verify"))
+        #expect(capturedRequests.count == 1)
+
+        let textChunks: [String] = events.compactMap { event in
+            if case .textChunk(let text) = event { return text }
+            return nil
+        }
+        #expect(textChunks.contains { $0.contains("check your store") })
+
+        let failureKinds: [AssistantErrorKind] = events.compactMap { event in
+            if case .failed(let error) = event { return error.kind }
+            return nil
+        }
+        #expect(failureKinds.contains(.outcomeUnknown))
+    }
+
+    @Test
+    func test_loop_when_read_tool_returns_outcome_unknown_then_loop_continues() async throws {
+        // Given
+        let readTool = AITool(name: "orders_list",
+                              description: "List orders",
+                              parametersSchema: .object([:]),
+                              safetyLevel: .safe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "orders_list", arguments: #"{"status":"processing"}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .completed(.toolCalls)],
+            [.textDelta("I'll let you know once the list comes back."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([readTool])
+        await registry.setResult(for: "orders_list",
+                                 result: .failed(.init(toolName: "orders_list",
+                                                       kind: .outcomeUnknown,
+                                                       reason: "Read timed out.")))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        var events: [AssistantEvent] = []
+        for try await event in orchestrator.run(prompt: "Show processing orders") {
+            events.append(event)
+        }
+
+        // Then
+        let invocations = await registry.invocationCount(for: "orders_list")
+        #expect(invocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        #expect(capturedRequests.count == 2)
+
+        let textChunks: [String] = events.compactMap { event in
+            if case .textChunk(let text) = event { return text }
+            return nil
+        }
+        #expect(!textChunks.contains { $0.contains("check your store") })
+        #expect(textChunks.contains { $0.contains("let you know") })
+
+        let outcome = await orchestrator.lastOutcome
+        #expect(outcome == .completed)
+    }
+
+    @Test
+    func test_loop_when_write_outcome_unknown_then_partial_success_reason_passes_through_to_failure_event() async throws {
+        // Given
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let call = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"id":42},{"id":43}]}"#)
+        )
+        let receiptJSON = #"{"results":[{"id":42,"status":"success"},{"id":43,"status":"outcome_unknown"}]}"#
+        let reason = "One or more product updates did not get a confirmed response. \(receiptJSON)"
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(call), .completed(.toolCalls)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .failed(.init(toolName: "products_update",
+                                                       kind: .outcomeUnknown,
+                                                       reason: reason)))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        var events: [AssistantEvent] = []
+        for try await event in orchestrator.run(prompt: "Bump prices on 42 and 43") {
+            events.append(event)
+        }
+
+        // Then
+        let failureMessages: [String] = events.compactMap { event in
+            if case .failed(let error) = event { return error.message }
+            return nil
+        }
+        let receiptFailure = try #require(failureMessages.first { $0.contains("id\":42") })
+        #expect(receiptFailure.contains("success"))
+        #expect(receiptFailure.contains("outcome_unknown"))
+    }
+
+    @Test
+    func test_outcome_unknown_transcript_payload_has_minimal_shape_with_reason_in_detail() async throws {
+        // Given
+        let writeTool = AITool(name: "orders_update",
+                               description: "Update an order",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let call = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "orders_update", arguments: #"{"id":42}"#)
+        )
+        let reason = "Network dropped after request was sent."
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(call), .completed(.toolCalls)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "orders_update",
+                                 result: .failed(.init(toolName: "orders_update",
+                                                       kind: .outcomeUnknown,
+                                                       reason: reason)))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        var events: [AssistantEvent] = []
+        for try await event in orchestrator.run(prompt: "Mark order 42 processing") {
+            events.append(event)
+        }
+
+        // Then
+        let toolCompletedPayloads: [String] = events.compactMap { event -> String? in
+            guard case .toolCallCompleted(_, _, let payload) = event else { return nil }
+            return payload
+        }
+        let payload = try #require(toolCompletedPayloads.first { $0.contains("\"outcome\":\"unknown\"") })
+        let data = try #require(payload.data(using: .utf8))
+        let parsed = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(parsed["outcome"] as? String == "unknown")
+        #expect(parsed["tool"] as? String == "orders_update")
+        #expect(parsed["detail"] as? String == reason)
+        #expect(parsed["advice"] == nil)
+        #expect(parsed["receipt"] == nil)
     }
 }


### PR DESCRIPTION
## Why

Two timing-dependent failure modes in the agentic loop can leave a merchant looking at wrong state after a write. Both are hard to trigger on purpose - the read usually loses the timing window, so neither showed up in normal use. The stale-read case only became reproducible internally once product tools were consolidated, at which point the model started pairing a write with a `show_cards` in the same tool-call batch and the race surfaced.

1. When a write tool's outcome is uncertain (transport drop / 408 on a request that may or may not have applied), the loop continued and the model could retry the same write - risking a second application of a change that already went through.
2. When the model emits a write and a read in the same tool-call batch (e.g. "set the order to processing and show me the order"), both dispatch in parallel. The read can resolve before the write commits and render pre-write state.

When they do hit, they produce a double-write or a stale card immediately after the merchant confirmed a change. This makes the ordering deterministic so neither can occur.

## Key non-obvious decisions

- **Outcome-unknown terminates the turn** rather than surfacing a retryable error. A retryable shape invites the model to fire the write again; ending the turn with a "couldn't confirm, check your store" message is the only safe response when we genuinely don't know if the write applied. Reads that return outcome-unknown still continue the loop - they're safe to retry.
- **Writes dispatch before reads within a batch, unconditionally.** This is safe without dependency analysis because tool calls in one assistant message are independent by construction: the model emits them all before seeing any result, so a write can never consume a read's output from the same batch. A read that needs a prior result is a cross-turn sequence, which is a separate batch and unaffected. The only behavioral change is that a read targeting a just-written entity deterministically sees post-write state, which matches the merchant's intent for "update X and show me".
- **Unknown tool names default to unsafe** so an unrecognized name never skips the write-before-read ordering.

## Tests

Sanity check only - the original races are timing-dependent and hard to reproduce on demand (the read usually loses the window); this change makes the ordering deterministic rather than fixing a step-by-step repro.

1. Open the AI Assistant.
2. Type: "set the last order to processing and show it after that".
3. Expect a confirmation card proposing to set the order's status to Processing.
4. Confirm the change.
5. Expect the order card rendered afterward to show status = Processing (the post-write state).

Before this change the read could race ahead of the write and render the previous status.

## Screenshots

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f60d7a35-331b-4e32-bb11-73165bf87164" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.