### PR TITLE
Deep link stock push notification to product detail

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/MetaContainer.swift
+++ b/Modules/Sources/NetworkingCore/Model/MetaContainer.swift
@@ -56,6 +56,7 @@ extension MetaContainer {
         case order
         case campaignID = "campaign_id"
         case post
+        case product
         case reply  = "reply_comment"
         case site
         case user

--- a/Modules/Sources/NetworkingCore/Model/Note.swift
+++ b/Modules/Sources/NetworkingCore/Model/Note.swift
@@ -229,6 +229,7 @@ extension Note {
         case newPost = "new_post"
         case post
         case storeOrder = "store_order"
+        case storeStock = "store_stock"
         case user
 
         /// Blaze

--- a/WooCommerce/Classes/Notifications/PushNotificationSharedConstants.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationSharedConstants.swift
@@ -21,6 +21,7 @@ enum PushNotificationSharedConstants {
         "new_post",
         "post",
         "store_order",
+        "store_stock",
         "user",
         "blaze_performed_note",
         "blaze_cancelled_note",

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -562,6 +562,8 @@ extension MainTabBarController {
             }
         case .blazeApprovedNote, .blazeRejectedNote, .blazeCancelledNote, .blazePerformedNote:
            navigateToBlazeCampaignDetails(using: notification)
+        case .storeStock:
+            navigateToProductDetails(using: notification)
         default:
             break
         }
@@ -646,6 +648,30 @@ extension MainTabBarController {
                 }
             }
         })
+    }
+
+    static func navigateToProductDetails(using notification: PushNotification) {
+        guard let productID = notification.meta?.identifier(forKey: .product) else {
+            DDLogError("## Notification with [\(String(describing: notification.noteID))] lacks its product ID!")
+            return
+        }
+
+        switchToProductsTab {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.screenTransitionsDelay) {
+                presentProductDetails(productID: Int64(productID), siteID: notification.siteID)
+            }
+        }
+    }
+
+    private static func presentProductDetails(productID: Int64, siteID: Int64) {
+        guard let tabBar = AppDelegate.shared.tabBarController else {
+            return
+        }
+
+        let model: ProductLoaderViewController.Model = .product(productID: productID)
+        let productViewController = ProductLoaderViewController(model: model, siteID: siteID, forceReadOnly: false)
+        let productNavController = WooNavigationController(rootViewController: productViewController)
+        tabBar.rootTabViewController(tab: .products).present(productNavController, animated: true)
     }
 
     static func navigateToBlazeCampaignCreation(for siteID: Int64) {

--- a/WooCommerce/WooCommerceTests/Notifications/NotificationServiceSuppressionTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/NotificationServiceSuppressionTests.swift
@@ -109,6 +109,12 @@ final class NotificationServiceSuppressionTests: XCTestCase {
         XCTAssertTrue(PushNotificationSharedConstants.isKnownNotificationType(in: userInfo))
     }
 
+    func test_isKnownNotificationType_returns_true_for_store_stock() {
+        let userInfo: [AnyHashable: Any] = ["type": "store_stock", "blog": Int64(42)]
+
+        XCTAssertTrue(PushNotificationSharedConstants.isKnownNotificationType(in: userInfo))
+    }
+
     func test_isKnownNotificationType_returns_true_for_badge_reset() {
         let userInfo: [AnyHashable: Any] = ["type": "badge-reset"]
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationTests.swift
@@ -107,6 +107,57 @@ final class PushNotificationTests: XCTestCase {
         XCTAssertEqual(notification.meta?.identifier(forKey: .order), 306)
     }
 
+    // MARK: Store Stock
+    //
+    func test_store_stock_user_info_is_parsed_correctly() throws {
+        // Given — mirrors the real server payload: `note_id` is null for Woo-driven
+        // stock notifications (they are not WPCom-stored notes).
+        let expectedSiteID: Int64 = 205617935
+        let expectedProductID = 42
+        let noteData: [String: Any] = [
+            "notes": [
+                [
+                    "id": NSNull(),
+                    "type": "store_stock",
+                    "meta": [
+                        "ids": [
+                            "site": expectedSiteID,
+                            "product": expectedProductID
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: noteData)
+        let compressedData = try (jsonData as NSData).compressed(using: .zlib)
+        var dataWithHeader = Data([0x78, 0x9C])
+        dataWithHeader.append(compressedData as Data)
+        let base64Encoded = dataWithHeader.base64EncodedString()
+
+        let userInfo: [AnyHashable: Any] = [
+            "blog": expectedSiteID,
+            "note_full_data": base64Encoded,
+            "aps": [
+                "alert": [
+                    "title": "Low stock alert"
+                ]
+            ],
+            "type": "store_stock",
+            "note_id": NSNull()
+        ]
+
+        // When
+        let notification = try XCTUnwrap(PushNotification.from(userInfo: userInfo))
+
+        // Then
+        XCTAssertNil(notification.noteID)
+        XCTAssertEqual(notification.kind, Note.Kind.storeStock)
+        XCTAssertEqual(notification.siteID, expectedSiteID)
+        XCTAssertEqual(notification.meta?.identifier(forKey: .product), expectedProductID)
+        XCTAssertEqual(notification.meta?.identifier(forKey: .site), Int(expectedSiteID))
+    }
+
     // MARK: Blaze
     //
     func test_blaze_rejected_note_user_info_is_parsed_correctly() throws {


### PR DESCRIPTION
## Description
Closes RSM-3555.

Tapping a `store_stock` push notification (the low / out-of-stock alert that WooCommerce sends from the server) now opens the affected product's detail page in the app. Matches the existing Android behaviour.

What this PR does:

- Adds `Note.Kind.storeStock = "store_stock"` so the payload's `type` is recognised by the parser.
- Adds `MetaContainer.Keys.product` so the productID inside `note_full_data` (`meta.ids.product`) can be read.
- Allows `"store_stock"` through the `PushNotificationSharedConstants.knownPushNotificationTypes` suppression gate (the parity test that exists since RSM-3048 enforces this).
- Routes `.storeStock` in `MainTabBarController.presentNotificationDetails(for:)` to a new `navigateToProductDetails(using:)` helper that switches to the Products tab and modally presents `ProductLoaderViewController` with the productID + siteID. Mirrors the `.storeOrder` pattern (trust the outer `switchStoreIfNeededAndPresentNotificationDetails` wrapper to handle the store switch). 



## Test Steps
1. Build & install on a simulator / device signed into a store that has products.
2. Trigger a `store_stock` push for that store (e.g., set a product's stock to a low number via the WC dashboard so the server emits the alert.
3. **App in background**: tap the delivered notification — the app should foreground, switch to the Products tab, and present the product detail modally.
4. **App in foreground**: when the in-app notification banner appears, tap "View" — same result.
5. Verify the Linear-mentioned scenario: tapping a "low stock" PN takes you to that product, not to the Products list or a no-op.

## Screenshots
N/A — text-level routing change.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.