### PR TITLE
Enable SwiftLint rule: return_value_from_void_function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -87,6 +87,9 @@ only_rules:
   # Type annotations are redundant when the type can be inferred.
   - redundant_type_annotation
 
+  # Returning values from Void functions should be avoided.
+  - return_value_from_void_function
+
   # Prefer the shorthand `if let foo` form over `if let foo = foo`.
   - shorthand_optional_binding
 

--- a/Modules/Sources/Networking/Remote/AccountRemote.swift
+++ b/Modules/Sources/Networking/Remote/AccountRemote.swift
@@ -160,7 +160,8 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
         let path = Path.notificationSettings
         let parameters = try settings.toDictionary()
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path, parameters: parameters, encoding: JSONEncoding.default)
-        return try await enqueue(request)
+        try await enqueue(request)
+        return
     }
 
     public func createAccount(email: String,
@@ -199,7 +200,8 @@ public class AccountRemote: Remote, AccountRemoteProtocol {
     public func closeAccount() async throws {
         let path = Path.closeAccount
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
-        return try await enqueue(request)
+        try await enqueue(request)
+        return
     }
 }
 

--- a/Modules/Sources/Networking/Remote/IPLocationRemote.swift
+++ b/Modules/Sources/Networking/Remote/IPLocationRemote.swift
@@ -9,7 +9,8 @@ public final class IPLocationRemote: Remote {
     public func getIPCountryCode(onCompletion: @escaping (Result<String, Error>) -> Void) {
         let path = "geo/" // Needs the trailing slash otherwise the request will fail.
         guard let url = URL(string: Settings.wordpressApiBaseURL + path) else {
-            return onCompletion(.failure(IPLocationError.malformedURL)) // Should not happen.
+            onCompletion(.failure(IPLocationError.malformedURL)) // Should not happen.
+            return // Should not happen.
         }
 
         let request = UnauthenticatedRequest(request: .init(url: url)).asURLRequest()

--- a/Modules/Sources/Networking/Remote/JetpackSettingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/JetpackSettingsRemote.swift
@@ -25,7 +25,8 @@ public final class JetpackSettingsRemote: Remote, JetpackSettingsRemoteProtocol 
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
 
-        return try await enqueue(request)
+        try await enqueue(request)
+        return
     }
 }
 

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -95,7 +95,8 @@ private extension CookieNonceAuthenticator {
 
     func handleSiteCredentialLogin(session: Session) async throws {
         let request = authenticatedRequest()
-        try await withCheckedThrowingContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return try await withCheckedThrowingContinuation { continuation in
             session.request(request)
                 .validate()
                 .response { response in
@@ -106,7 +107,6 @@ private extension CookieNonceAuthenticator {
                     }
                 }
         }
-        return
     }
 
     func handleNonceRetrieval(request: URLRequest, session: Session) async throws -> String {

--- a/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
+++ b/Modules/Sources/NetworkingCore/CookieNonce/CookieNonceAuthenticator.swift
@@ -25,7 +25,8 @@ final class CookieNonceAuthenticator: RequestInterceptor {
     // MARK: Request Adapter
     func adapt(_ urlRequest: URLRequest, for session: Alamofire.Session, completion: @escaping (Result<URLRequest, Swift.Error>) -> Void) {
         guard let nonce = state.nonce else {
-            return completion(.success(urlRequest))
+            completion(.success(urlRequest))
+            return
         }
         var adaptedRequest = urlRequest
         adaptedRequest.addValue(nonce, forHTTPHeaderField: "X-WP-Nonce")
@@ -43,7 +44,8 @@ final class CookieNonceAuthenticator: RequestInterceptor {
             // Only retry because of failed authorization
             case .responseValidationFailed(reason: .unacceptableStatusCode(code: 401)) = error as? AFError
         else {
-            return completion(.doNotRetry)
+            completion(.doNotRetry)
+            return
         }
 
         let shouldStartAuthentication = state.enqueueRetry(completion)
@@ -67,7 +69,8 @@ private extension CookieNonceAuthenticator {
         DDLogInfo("Starting Cookie+Nonce login sequence for \(loginURL)")
         guard let nonceRetrievalURL = buildNonceRequestURL(base: adminURL),
               let nonceRequest = try? URLRequest(url: nonceRetrievalURL, method: .get) else {
-            return invalidateLoginSequence(error: .invalidNewPostURL)
+            invalidateLoginSequence(error: .invalidNewPostURL)
+            return
         }
         Task(priority: .medium) {
             do {
@@ -92,7 +95,7 @@ private extension CookieNonceAuthenticator {
 
     func handleSiteCredentialLogin(session: Session) async throws {
         let request = authenticatedRequest()
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             session.request(request)
                 .validate()
                 .response { response in
@@ -103,6 +106,7 @@ private extension CookieNonceAuthenticator {
                     }
                 }
         }
+        return
     }
 
     func handleNonceRetrieval(request: URLRequest, session: Session) async throws -> String {

--- a/Modules/Sources/NetworkingCore/Remote/SiteRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/SiteRemote.swift
@@ -101,13 +101,15 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
     public func launchSite(siteID: Int64) async throws {
         let path = Path.siteLaunch(siteID: siteID)
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path)
-        return try await enqueue(request)
+        try await enqueue(request)
+        return
     }
 
     public func enableFreeTrial(siteID: Int64) async throws {
         let path = Path.enableFreeTrial(siteID: siteID)
         let request = DotcomRequest(wordpressApiVersion: .mark1_1, method: .post, path: path)
-        return try await enqueue(request)
+        try await enqueue(request)
+        return
     }
 
     public func uploadStoreProfilerAnswers(siteID: Int64, answers: StoreProfilerAnswers) async throws {
@@ -138,7 +140,8 @@ public class SiteRemote: Remote, SiteRemoteProtocol {
                                      path: Path.uploadStoreProfilerAnswers,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        return try await enqueue(request)
+        try await enqueue(request)
+        return
     }
 
     public func loadSite(siteID: Int64) async throws -> Site {

--- a/Modules/Sources/UITestsFoundation/Screens/ExternalAppScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/ExternalAppScreen.swift
@@ -31,7 +31,8 @@ public final class ExternalAppScreen {
         safari.buttons["Go"].tap()
 
         guard safari.links[universalLink].waitForIsHittable(timeout: 10) else {
-            return XCTFail("\(universalLink) is not displayed!")
+            XCTFail("\(universalLink) is not displayed!")
+            return
         }
         safari.links[universalLink].tap()
     }

--- a/Modules/Sources/Yosemite/Base/Dispatcher.swift
+++ b/Modules/Sources/Yosemite/Base/Dispatcher.swift
@@ -71,7 +71,8 @@ public class Dispatcher {
 
         // Avoid silent failure when a store is not retained
         guard let processor = processors[action.identifier] else {
-            return DDLogWarn("⚠️ No processor found for \(action.identifier)!")
+            DDLogWarn("⚠️ No processor found for \(action.identifier)!")
+            return
         }
         processor.onAction(action)
     }

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponService.swift
@@ -75,7 +75,8 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func enableCoupons() async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return try await withCheckedThrowingContinuation { continuation in
             settingsStoreMethods.enableCouponSetting(siteID: siteID) { result in
                 switch result {
                 case .success:
@@ -85,7 +86,6 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                 }
             }
         }
-        return
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Coupons/PointOfSaleCouponService.swift
@@ -75,7 +75,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
 
     @MainActor
     public func enableCoupons() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             settingsStoreMethods.enableCouponSetting(siteID: siteID) { result in
                 switch result {
                 case .success:
@@ -85,6 +85,7 @@ public final class PointOfSaleCouponService: PointOfSaleCouponServiceProtocol {
                 }
             }
         }
+        return
     }
 }
 

--- a/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
+++ b/Modules/Sources/Yosemite/Stores/AppSettingsStore.swift
@@ -353,7 +353,8 @@ private extension AppSettingsStore {
         do {
             if let installationDate = generalAppSettings.value(for: \.installationDate),
                date > installationDate {
-                return onCompletion(.success(false))
+                onCompletion(.success(false))
+                return
             }
 
             try generalAppSettings.setValue(date, for: \.installationDate)
@@ -409,7 +410,8 @@ private extension AppSettingsStore {
     ///
     func loadEligibilityErrorInfo(onCompletion: (Result<EligibilityErrorInfo, Error>) -> Void) {
         guard let errorInfo = generalAppSettings.value(for: \.lastEligibilityErrorInfo) else {
-            return onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
+            onCompletion(.failure(AppSettingsStoreErrors.noEligibilityErrorInfo))
+            return
         }
 
         onCompletion(.success(errorInfo))
@@ -438,11 +440,13 @@ private extension AppSettingsStore {
     func loadJetpackBenefitsBannerVisibility(currentTime: Date, calendar: Calendar, onCompletion: (Bool) -> Void) {
         guard let lastDismissedTime = generalAppSettings.value(for: \.lastJetpackBenefitsBannerDismissedTime) else {
             // If the banner has not been dismissed before, the banner is default to be visible.
-            return onCompletion(true)
+            onCompletion(true)
+            return
         }
 
         guard let numberOfDaysSinceLastDismissal = calendar.dateComponents([.day], from: lastDismissedTime, to: currentTime).day else {
-            return onCompletion(true)
+            onCompletion(true)
+            return
         }
         onCompletion(numberOfDaysSinceLastDismissal >= 5)
     }
@@ -474,7 +478,8 @@ private extension AppSettingsStore {
     func rememberCardReader(cardReaderID: String, onCompletion: (Result<Void, Error>) -> Void) {
         do {
             guard !generalAppSettings.value(for: \.knownCardReaders).contains(cardReaderID) else {
-                return onCompletion(.success(()))
+                onCompletion(.success(()))
+                return
             }
 
             /// NOTE: We now only persist one card reader maximum, although for backwards compatibility
@@ -1143,7 +1148,8 @@ extension AppSettingsStore {
 
     func getFeatureAnnouncementVisibility(campaign: FeatureAnnouncementCampaign, onCompletion: (Result<Bool, Error>) -> ()) {
         guard let campaignSettings = generalAppSettings.value(for: \.featureAnnouncementCampaignSettings)[campaign] else {
-            return onCompletion(.success(true))
+            onCompletion(.success(true))
+            return
         }
 
         if let remindAfter = campaignSettings.remindAfter {

--- a/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
+++ b/Modules/Sources/Yosemite/Stores/CardPresentPaymentStore.swift
@@ -199,7 +199,8 @@ private extension CardPresentPaymentStore {
         do {
             try cardReaderService.start(commonReaderConfigProvider, discoveryMethod: discoveryMethod)
         } catch {
-            return onError(error)
+            onError(error)
+            return
         }
 
         // Over simplification. This is the point where we would receive

--- a/Modules/Sources/Yosemite/Stores/OrderCardPresentPaymentEligibilityStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderCardPresentPaymentEligibilityStore.swift
@@ -36,7 +36,8 @@ private extension OrderCardPresentPaymentEligibilityStore {
         let storage = storageManager.viewStorage
 
         guard let order = storage.loadOrder(siteID: siteID, orderID: orderID)?.toReadOnly() else {
-            return onCompletion(.failure(OrderIsEligibleForCardPresentPaymentError.orderNotFoundInStorage))
+            onCompletion(.failure(OrderIsEligibleForCardPresentPaymentError.orderNotFoundInStorage))
+            return
         }
 
         let orderProductsIDs = order.items.map(\.productID)

--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -226,7 +226,8 @@ private extension OrderStore {
         let storage = storageManager.viewStorage
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
         if storage.firstObject(ofType: StorageOrder.self, matching: predicate) != nil {
-            return onCompletion(.success(true))
+            onCompletion(.success(true))
+            return
         }
 
         // If there are no locally stored orders, then check remote.
@@ -246,7 +247,8 @@ private extension OrderStore {
         // Check first if the order exists in storage. If it doesn't, fetch it from remote.
         let storage = storageManager.viewStorage
         guard let storedOrder = storage.loadOrder(siteID: siteID, orderID: orderID)?.toReadOnly() else {
-            return loadOrderFromRemote(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
+            loadOrderFromRemote(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
+            return
         }
 
         Task {
@@ -651,11 +653,13 @@ private extension OrderStore {
             case .success(let order):
                 // Auto-draft orders are temporary and should not be stored
                 guard order.status != .autoDraft else {
-                    return onCompletion(result)
+                    onCompletion(result)
+                    return
                 }
 
                 if let giftCard, order.appliedGiftCards.contains(where: { $0.code == giftCard }) == false {
-                    return onCompletion(.failure(GiftCardError.notApplied))
+                    onCompletion(.failure(GiftCardError.notApplied))
+                    return
                 }
 
                 upsertStoredOrdersInBackground(readOnlyOrders: [order], onCompletion: {
@@ -666,11 +670,14 @@ private extension OrderStore {
                    case let .unknown(code, message, _) = dotcomError {
                     switch code {
                         case "woocommerce_rest_gift_card_cannot_apply":
-                            return onCompletion(.failure(GiftCardError.cannotApply(reason: message)))
+                            onCompletion(.failure(GiftCardError.cannotApply(reason: message)))
+                            return
                         case "woocommerce_rest_gift_card_cannot_parse_data":
-                            return onCompletion(.failure(GiftCardError.invalid(reason: message)))
+                            onCompletion(.failure(GiftCardError.invalid(reason: message)))
+                            return
                         default:
-                            return onCompletion(result)
+                            onCompletion(result)
+                            return
                     }
                 }
                 onCompletion(result)

--- a/Modules/Sources/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductReview/RetrieveProductReviewFromNoteUseCase.swift
@@ -108,7 +108,8 @@ final class RetrieveProductReviewFromNoteUseCase {
                            abort: @escaping AbortBlock,
                            next: @escaping (Note) -> Void) {
         if let noteInStorage = storageManager?.viewStorage.loadNotification(noteID: noteID) {
-            return next(noteInStorage.toReadOnly())
+            next(noteInStorage.toReadOnly())
+            return
         }
 
         notificationsRemote.loadNotes(noteIDs: [noteID], pageSize: nil) { result in
@@ -133,7 +134,8 @@ final class RetrieveProductReviewFromNoteUseCase {
                                     next: @escaping (ProductReview) -> Void) {
 
         if let productReviewInStorage = storageManager?.viewStorage.loadProductReview(siteID: siteID, reviewID: reviewID) {
-            return next(productReviewInStorage.toReadOnly())
+            next(productReviewInStorage.toReadOnly())
+            return
         }
 
         productReviewsRemote.loadProductReview(for: Int64(siteID), reviewID: Int64(reviewID)) { result in
@@ -152,7 +154,8 @@ final class RetrieveProductReviewFromNoteUseCase {
                                    abort: @escaping AbortBlock,
                                    next: @escaping () -> Void) {
         guard let storageManager else {
-            return abort(ProductReviewFromNoteRetrieveError.storageNoLongerAvailable)
+            abort(ProductReviewFromNoteRetrieveError.storageNoLongerAvailable)
+            return
         }
         storageManager.performAndSave({ storage in
             let storageReview = storage.loadProductReview(siteID: review.siteID, reviewID: review.reviewID)
@@ -168,7 +171,8 @@ final class RetrieveProductReviewFromNoteUseCase {
                               abort: @escaping AbortBlock,
                               next: @escaping (Product) -> Void) {
         if let productInStorage = storageManager?.viewStorage.loadProduct(siteID: siteID, productID: productID) {
-            return next(productInStorage.toReadOnly())
+            next(productInStorage.toReadOnly())
+            return
         }
 
         productsRemote.loadProduct(for: siteID, productID: productID) { result in

--- a/Modules/Sources/Yosemite/Stores/ProductStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductStore.swift
@@ -418,7 +418,8 @@ private extension ProductStore {
                                                                                           ItemIdentifierSearchResultSource), Error>) -> Void) {
 
         guard !identifier.isEmpty else {
-            return onCompletion(.failure(ProductLoadError.emptyIdentifier))
+            onCompletion(.failure(ProductLoadError.emptyIdentifier))
+            return
         }
 
         Task {
@@ -576,7 +577,8 @@ private extension ProductStore {
         // Check for locally stored products first.
         let storage = storageManager.viewStorage
         if storage.hasProducts(siteID: siteID, status: status?.rawValue, type: productType?.rawValue) {
-            return onCompletion(.success(true))
+            onCompletion(.success(true))
+            return
         }
 
         // If there are no locally stored products, then check remote.

--- a/Modules/Sources/Yosemite/Stores/ProductTagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ProductTagStore.swift
@@ -89,7 +89,8 @@ private extension ProductTagStore {
     ///
     func addProductTags(siteID: Int64, tags: [String], onCompletion: @escaping (Result<[ProductTag], Error>) -> Void) {
         guard tags.isEmpty == false else {
-            return onCompletion(.success([]))
+            onCompletion(.success([]))
+            return
         }
         remote.createProductTags(for: siteID, names: tags) { [weak self] (result) in
             switch result {

--- a/Modules/Sources/Yosemite/Stores/ShippingLabelStore.swift
+++ b/Modules/Sources/Yosemite/Stores/ShippingLabelStore.swift
@@ -287,7 +287,8 @@ private extension ShippingLabelStore {
                                                      settings: ShippingLabelSettings,
                                                      onCompletion: @escaping () -> Void) {
         guard shippingLabels.isEmpty == false else {
-            return onCompletion()
+            onCompletion()
+            return
         }
 
         storageManager.performAndSave ({ [weak self] storage in

--- a/Modules/Tests/NetworkingTests/Encoder/ProductImageStatusCodableTests.swift
+++ b/Modules/Tests/NetworkingTests/Encoder/ProductImageStatusCodableTests.swift
@@ -19,7 +19,8 @@ final class ProductImageStatusCodableTests: XCTestCase {
 
         // Then
         guard case let .uploading(.uiImage(decodedImage, decodedFilename, decodedAltText), siteID, productID) = decodedStatus else {
-            return XCTFail("Decoded status should be .uploading with .uiImage asset")
+            XCTFail("Decoded status should be .uploading with .uiImage asset")
+            return
         }
 
         XCTAssertNotNil(decodedImage.pngData(), "Decoded image data should not be nil")
@@ -74,7 +75,8 @@ final class ProductImageStatusCodableTests: XCTestCase {
 
         // Then
         guard case let .remote(image, siteID, productID) = decodedStatus else {
-            return XCTFail("Decoded status should be .remote")
+            XCTFail("Decoded status should be .remote")
+            return
         }
 
         XCTAssertEqual(image.imageID, 111)
@@ -101,7 +103,8 @@ final class ProductImageStatusCodableTests: XCTestCase {
 
         // Then
         guard case let .uploadFailure(.uiImage(_, decodedFilename, decodedAltText), decodedError as NSError, siteID, productID) = decodedStatus else {
-            return XCTFail("Decoded status should be .uploadFailure with .uiImage asset")
+            XCTFail("Decoded status should be .uploadFailure with .uiImage asset")
+            return
         }
 
         XCTAssertEqual(decodedFilename, "failure.png")

--- a/Modules/Tests/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
@@ -22,13 +22,15 @@ private extension CreateBlazeCampaignMapperTests {
             throw FileNotFoundError()
         }
 
-        return try CreateBlazeCampaignMapper().map(response: response)
+        try CreateBlazeCampaignMapper().map(response: response)
+        return
     }
 
     /// Returns the CreateBlazeCampaignMapper output from `blaze-create-campaign-success.json`
     ///
     func mapLoadCreateBlazeCampaignResponse() throws {
-        return try mapCreateBlazeCampaignResponse(from: "blaze-create-campaign-success")
+        try mapCreateBlazeCampaignResponse(from: "blaze-create-campaign-success")
+        return
     }
 
     struct FileNotFoundError: Error {}

--- a/Modules/Tests/NetworkingTests/Validators/DotcomValidatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Validators/DotcomValidatorTests.swift
@@ -12,7 +12,8 @@ class DotcomValidatorTests: XCTestCase {
     func testGenericErrorIsProperlyExtractedFromData() {
         guard let payloadAsData = Loader.contentsOf("generic_error", extension: "json")
             else {
-            return XCTFail()
+            XCTFail()
+            return
         }
 
         XCTAssertThrowsError(try DotcomValidator().validate(data: payloadAsData)) { error in
@@ -28,7 +29,8 @@ class DotcomValidatorTests: XCTestCase {
     func testRestNoRouteErrorIsProperlyExtractedFromData() {
         guard let payloadAsData = Loader.contentsOf("restnoroute_error", extension: "json")
             else {
-            return XCTFail()
+            XCTFail()
+            return
         }
 
         XCTAssertThrowsError(try DotcomValidator().validate(data: payloadAsData)) { error in
@@ -44,7 +46,8 @@ class DotcomValidatorTests: XCTestCase {
     func testNoStatsPermissionErrorIsProperlyExtractedFromData() {
         guard let payloadAsData = Loader.contentsOf("no_stats_permission_error", extension: "json")
             else {
-            return XCTFail()
+            XCTFail()
+            return
         }
 
         XCTAssertThrowsError(try DotcomValidator().validate(data: payloadAsData)) { error in
@@ -60,7 +63,8 @@ class DotcomValidatorTests: XCTestCase {
     func testStatsModuleDisabledErrorIsProperlyExtractedFromData() {
         guard let payloadAsData = Loader.contentsOf("stats_module_disabled_error", extension: "json")
             else {
-            return XCTFail()
+            XCTFail()
+            return
         }
 
         XCTAssertThrowsError(try DotcomValidator().validate(data: payloadAsData)) { error in

--- a/Modules/Tests/NetworkingTests/Validators/WordPressApiValidatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Validators/WordPressApiValidatorTests.swift
@@ -12,7 +12,8 @@ class WordPressApiValidatorTests: XCTestCase {
     func testForbiddenErrorIsProperlyExtractedFromData() {
         guard let payloadAsData = Loader.contentsOf("error-wp-rest-forbidden", extension: "json")
             else {
-            return XCTFail()
+            XCTFail()
+            return
         }
 
         XCTAssertThrowsError(try WordPressApiValidator().validate(data: payloadAsData)) { error in

--- a/Modules/Tests/PointOfSaleTests/Card Present Payments/CardPresentPaymentRetryApproachTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Card Present Payments/CardPresentPaymentRetryApproachTests.swift
@@ -14,7 +14,8 @@ final class CardPresentPaymentRetryApproachTests: XCTestCase {
 
         // Then
         guard case .tryAgain = sut else {
-            return XCTFail("Unexpected retry approach, expected tryAgain, got \(sut)")
+            XCTFail("Unexpected retry approach, expected tryAgain, got \(sut)")
+            return
         }
     }
 
@@ -27,7 +28,8 @@ final class CardPresentPaymentRetryApproachTests: XCTestCase {
 
         // Then
         guard case .dontRetry = sut else {
-            return XCTFail("Unexpected retry approach, expected dontRetry, got \(sut)")
+            XCTFail("Unexpected retry approach, expected dontRetry, got \(sut)")
+            return
         }
     }
 
@@ -41,7 +43,8 @@ final class CardPresentPaymentRetryApproachTests: XCTestCase {
 
         // Then
         guard case .tryAgain = sut else {
-            return XCTFail("Unexpected retry approach, expected tryAgain, got \(sut)")
+            XCTFail("Unexpected retry approach, expected tryAgain, got \(sut)")
+            return
         }
     }
 
@@ -55,7 +58,8 @@ final class CardPresentPaymentRetryApproachTests: XCTestCase {
 
         // Then
         guard case .tryAgain = sut else {
-            return XCTFail("Unexpected retry approach, expected tryAgain, got \(sut)")
+            XCTFail("Unexpected retry approach, expected tryAgain, got \(sut)")
+            return
         }
     }
 
@@ -69,7 +73,8 @@ final class CardPresentPaymentRetryApproachTests: XCTestCase {
 
         // Then
         guard case .tryAnotherPaymentMethod = sut else {
-            return XCTFail("Unexpected retry approach, expected tryAnotherPaymentMethod, got \(sut)")
+            XCTFail("Unexpected retry approach, expected tryAnotherPaymentMethod, got \(sut)")
+            return
         }
     }
 
@@ -83,7 +88,8 @@ final class CardPresentPaymentRetryApproachTests: XCTestCase {
 
         // Then
         guard case .tryAnotherPaymentMethod = sut else {
-            return XCTFail("Unexpected retry approach, expected tryAnotherPaymentMethod, got \(sut)")
+            XCTFail("Unexpected retry approach, expected tryAnotherPaymentMethod, got \(sut)")
+            return
         }
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift
@@ -47,7 +47,8 @@ final class PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests: X
         )
 
         guard let autoDismissWorkItem = try? XCTUnwrap(testScheduler.scheduledActions.first?.2) else {
-            return XCTFail("The autoDismiss work item wasn't found")
+            XCTFail("The autoDismiss work item wasn't found")
+            return
         }
 
         XCTAssertFalse(autoDismissWorkItem.isCancelled)
@@ -69,7 +70,8 @@ final class PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests: X
         )
 
         guard let autoDismissWorkItem = try? XCTUnwrap(testScheduler.scheduledActions.first?.2) else {
-            return XCTFail("The autoDismiss work item wasn't found")
+            XCTFail("The autoDismiss work item wasn't found")
+            return
         }
 
         XCTAssertFalse(autoDismissWorkItem.isCancelled)

--- a/Modules/Tests/PointOfSaleTests/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -19,7 +19,8 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         // Then
         guard case .message(.paymentError(let viewModel)) = presentationStyle else {
-            return XCTFail("Expected payment error message not found")
+            XCTFail("Expected payment error message not found")
+            return
         }
 
         viewModel.tryAgainButtonViewModel.actionHandler()
@@ -45,7 +46,8 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         // Then
         guard case .message(.paymentError(let viewModel)) = presentationStyle else {
-            return XCTFail("Expected payment error message not found")
+            XCTFail("Expected payment error message not found")
+            return
         }
 
         viewModel.tryAgainButtonViewModel.actionHandler()
@@ -71,7 +73,8 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         // Then
         guard case .message(.paymentErrorNonRetryable(let viewModel)) = presentationStyle else {
-            return XCTFail("Expected payment error message not found")
+            XCTFail("Expected payment error message not found")
+            return
         }
 
         viewModel.tryAnotherPaymentMethodButtonViewModel.actionHandler()
@@ -90,7 +93,8 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         // Then
         guard case .message(.paymentSuccess(let viewModel)) = presentationStyle else {
-            return XCTFail("Expected payment success message not found")
+            XCTFail("Expected payment success message not found")
+            return
         }
 
         XCTAssertEqual(viewModel.message, "A card payment of $200.50 was successfully made.")
@@ -117,7 +121,8 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         // Then
         guard case .message(.paymentCaptureError(let viewModel)) = presentationStyle else {
-            return XCTFail("Expected payment capture error message not found")
+            XCTFail("Expected payment capture error message not found")
+            return
         }
 
         viewModel.tryAgainButtonViewModel.actionHandler()
@@ -143,7 +148,8 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         // Then
         guard case .alert(.scanningForReaders(let viewModel)) = presentationStyle else {
-            return XCTFail("Expected scanning for readers alert not found")
+            XCTFail("Expected scanning for readers alert not found")
+            return
         }
 
         viewModel.buttonViewModel.actionHandler()

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockNotificationsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockNotificationsRemote.swift
@@ -27,7 +27,8 @@ extension MockNotificationsRemote: NotificationsRemoteProtocol {
 
     func loadNotes(noteIDs: [Int64]?, pageSize: Int?, completion: @escaping (Result<[Note], Error>) -> Void) {
         guard let noteIDs else {
-            return XCTFail("Expected noteIDs to not be nil.")
+            XCTFail("Expected noteIDs to not be nil.")
+            return
         }
 
         DispatchQueue.main.async { [weak self] in

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockPaymentRemote.swift
@@ -51,6 +51,7 @@ extension MockPaymentRemote: PaymentRemoteProtocol {
             XCTFail("Could not find result for creating a cart.")
             throw NetworkError.notFound()
         }
-        return try result.get()
+        try result.get()
+        return
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockSiteRemote.swift
@@ -72,7 +72,8 @@ extension MockSiteRemote: SiteRemoteProtocol {
             throw NetworkError.notFound()
         }
 
-        return try result.get()
+        try result.get()
+        return
     }
 
     func enableFreeTrial(siteID: Int64) async throws {
@@ -81,7 +82,8 @@ extension MockSiteRemote: SiteRemoteProtocol {
             throw NetworkError.notFound()
         }
 
-        return try result.get()
+        try result.get()
+        return
     }
 
     func uploadStoreProfilerAnswers(siteID: Int64, answers: Networking.StoreProfilerAnswers) async throws {
@@ -90,7 +92,8 @@ extension MockSiteRemote: SiteRemoteProtocol {
             throw NetworkError.notFound()
         }
 
-        return try result.get()
+        try result.get()
+        return
     }
 
     func loadSite(siteID: Int64) async throws -> Site {
@@ -116,6 +119,7 @@ extension MockSiteRemote: SiteRemoteProtocol {
             XCTFail("Could not find result for updating site title")
             throw NetworkError.notFound()
         }
-        return try result.get()
+        try result.get()
+        return
     }
 }

--- a/Modules/Tests/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/Extensions/PaymentIntent+ReceiptParametersTests.swift
@@ -16,7 +16,8 @@ final class PaymentIntent_ReceiptParametersTests: XCTestCase {
         XCTAssertEqual(receiptParameters?.currency, intent.currency)
 
         guard let cardDetails = intent.charges.first?.paymentMethod?.cardPresentDetails else {
-            return XCTFail()
+            XCTFail()
+            return
         }
 
         XCTAssertEqual(receiptParameters?.cardDetails, cardDetails)

--- a/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -735,7 +735,8 @@ extension AppSettingsStoreTests {
         // Then
         let savedSettings: GeneralAppSettings? = try XCTUnwrap(fileStorage?.data(for: expectedGeneralAppSettingsFileURL))
         guard let savedSettings else {
-            return XCTFail("Expected settings to be saved, but none were found")
+            XCTFail("Expected settings to be saved, but none were found")
+            return
         }
         let dismissedDate: Date = try XCTUnwrap(savedSettings.featureAnnouncementCampaignSettings[.linkedProductsPromo]?.dismissedDate)
         XCTAssert(Calendar.current.isDateInToday(dismissedDate))

--- a/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CardPresentPaymentStoreTests.swift
@@ -863,7 +863,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         // Then
         let error = try XCTUnwrap(result.failure as? ServerSidePaymentCaptureError)
         guard case .paymentGateway = error else {
-            return XCTFail("Unexpected payment gateway error: \(error)")
+            XCTFail("Unexpected payment gateway error: \(error)")
+            return
         }
     }
 
@@ -898,7 +899,8 @@ final class CardPresentPaymentStoreTests: XCTestCase {
         // Then
         let error = try XCTUnwrap(result.failure as? ServerSidePaymentCaptureError)
         guard case .terminalPaymentPreparation = error else {
-            return XCTFail("Unexpected terminal payment preparation error: \(error)")
+            XCTFail("Unexpected terminal payment preparation error: \(error)")
+            return
         }
         XCTAssertFalse(mockCardReaderService.didHitWaitForInsertedCardToBeRemoved)
     }

--- a/Modules/Tests/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/CouponStoreTests.swift
@@ -721,7 +721,8 @@ final class CouponStoreTests: XCTestCase {
 
         // Then
         guard case let .success(isValidated) = result else {
-            return XCTFail("Expected success but it wasn't.")
+            XCTFail("Expected success but it wasn't.")
+            return
         }
 
         XCTAssertTrue(isValidated)
@@ -745,7 +746,8 @@ final class CouponStoreTests: XCTestCase {
 
         // Then
         guard case let .success(isValidated) = result else {
-            return XCTFail("Expected success but it wasn't.")
+            XCTFail("Expected success but it wasn't.")
+            return
         }
 
         XCTAssertFalse(isValidated)

--- a/Modules/Tests/YosemiteTests/Stores/JustInTimeMessageStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/JustInTimeMessageStoreTests.swift
@@ -102,7 +102,8 @@ final class JustInTimeMessageStoreTests: XCTestCase {
         XCTAssert(result.isFailure)
         guard case .failure(let error) = result,
             let error = error as? DotcomError else {
-            return XCTFail("Expected error not recieved")
+            XCTFail("Expected error not recieved")
+            return
         }
         assertEqual(DotcomError.noRestRoute(), error)
     }

--- a/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2309,7 +2309,8 @@ final class ProductStoreTests: XCTestCase {
         let skuSearchResult = try XCTUnwrap(result.get())
 
         guard case let (.product(productMatch), _) = skuSearchResult else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         XCTAssertEqual(productMatch.productID, expectedProductID)
@@ -2341,7 +2342,8 @@ final class ProductStoreTests: XCTestCase {
         let identifierSearchResult = try XCTUnwrap(result.get())
 
         guard case let (.product(productMatch), _) = identifierSearchResult else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         XCTAssertEqual(productMatch.productID, expectedProductID)
@@ -2373,7 +2375,8 @@ final class ProductStoreTests: XCTestCase {
         let skuSearchResult = try XCTUnwrap(result.get())
 
         guard case let (.variation(variationMatch), _) = skuSearchResult else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         XCTAssertEqual(variationMatch.productVariationID, expectedProductID)
@@ -2405,7 +2408,8 @@ final class ProductStoreTests: XCTestCase {
         let skuSearchResult = try XCTUnwrap(result.get())
 
         guard case let (.variation(variationMatch), _) = skuSearchResult else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         XCTAssertEqual(variationMatch.productVariationID, expectedProductID)
@@ -2479,7 +2483,8 @@ final class ProductStoreTests: XCTestCase {
         let skuSearchResult = try XCTUnwrap(result.get())
 
         guard case let (.product(productMatch), _) = skuSearchResult else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         XCTAssertEqual(productMatch.sku, "chocobars")

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -998,7 +998,8 @@ final class SettingStoreTests: XCTestCase {
 
         // Then
         guard case let .failure(error) = result else {
-            return XCTFail("Expected failure")
+            XCTFail("Expected failure")
+            return
         }
         XCTAssertEqual(error as? SettingError, .parseError)
         XCTAssertNil(viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: "woocommerce_date_type"))
@@ -1058,7 +1059,8 @@ final class SettingStoreTests: XCTestCase {
 
         // Then
         guard case let .failure(error) = result else {
-            return XCTFail("Expected failure")
+            XCTFail("Expected failure")
+            return
         }
         XCTAssertEqual(error as? SettingError, .parseError)
         XCTAssertNil(viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: "woocommerce_date_type"))

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -231,7 +231,8 @@ private extension AuthenticatedWebViewController {
 private extension AuthenticatedWebViewController {
     func authenticateWPComAndLoadContent(url: URL) {
         guard let wpcomCredentials, case .wpcom = wpcomCredentials else {
-            return loadContent(url: url)
+            loadContent(url: url)
+            return
         }
         do {
             try webView.authenticateForWPComAndRedirect(to: url, credentials: wpcomCredentials)
@@ -247,7 +248,8 @@ private extension AuthenticatedWebViewController {
 
     func authenticateUsingSiteCredentialsAndLoadContent(url: URL) {
         guard let siteCredentials, let request = try? webView.authenticateForWPOrg(with: siteCredentials) else {
-            return loadContent(url: url)
+            loadContent(url: url)
+            return
         }
         webView.load(request)
     }
@@ -265,7 +267,8 @@ private extension AuthenticatedWebViewController {
         switch url.absoluteString {
         case WooConstants.URLs.wpcomTempRedirectURL.rawValue:
             guard let currentSite, let host = URL(string: currentSite.url)?.host else {
-                return loadContent(url: initialURL)
+                loadContent(url: initialURL)
+                return
             }
             let cookie = HTTPCookie(properties: [
                 .domain: host,
@@ -276,7 +279,8 @@ private extension AuthenticatedWebViewController {
 
             let queryItem = URLQueryItem(name: Constants.actionParam, value: Constants.jetpackSSOAction)
             guard let cookie, let loginURL = URL(string: currentSite.loginURL)?.appending(queryItems: [queryItem]) else {
-                return loadContent(url: initialURL)
+                loadContent(url: initialURL)
+                return
             }
             webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
             loadContent(url: loginURL)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -431,15 +431,17 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
 
         guard let siteURL = credentials.wpcom?.siteURL ?? credentials.wporg?.siteURL else {
             // This should not happen since the resulting credentials should be either `wpcom` or `wporg`
-            return DDLogError("⛔️ No site URL found to present Login Epilogue.")
+            DDLogError("⛔️ No site URL found to present Login Epilogue.")
+            return
         }
 
         /// If the user logged in with site credentials,
         /// check if they can use the app and navigates to the home screen.
         if let siteCredentials = credentials.wporg {
-            return didAuthenticateUser(to: siteURL,
+            didAuthenticateUser(to: siteURL,
                                        with: siteCredentials,
                                        in: navigationController)
+            return
         }
 
         let matcher = ULAccountMatcher(storageManager: storageManager)
@@ -554,7 +556,8 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             ServiceLocator.stores.authenticate(credentials: .wporg(username: wporg.username,
                                                                    password: wporg.password,
                                                                    siteAddress: wporg.siteURL))
-            return onCompletion()
+            onCompletion()
+            return
         }
 
         guard let wpcom = credentials.wpcom else {
@@ -820,7 +823,8 @@ private extension AuthenticationManager {
             password: siteCredentials.password,
             siteAddress: siteCredentials.siteURL
         ) else {
-            return assertionFailure("⛔️ Error creating application password use case")
+            assertionFailure("⛔️ Error creating application password use case")
+            return
         }
         checkSiteCredentialLogin(to: siteURL, with: useCase, in: navigationController, previousViewController: nil)
     }

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -763,7 +763,8 @@ extension StorePickerViewController: UITableViewDelegate {
                 showNoWooError(for: site)
             }
 
-            return tableView.deselectRow(at: indexPath, animated: true)
+            tableView.deselectRow(at: indexPath, animated: true)
+            return
         }
 
         currentlySelectedSite = site

--- a/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/SwitchStoreUseCase.swift
@@ -53,7 +53,8 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
         let siteWasStored = wooCommerceSites.contains(where: { $0.siteID == storeID })
 
         guard siteWasStored else {
-            return onCompletion(false)
+            onCompletion(false)
+            return
         }
 
         switchStore(with: storeID, onCompletion: onCompletion)
@@ -81,7 +82,8 @@ final class SwitchStoreUseCase: SwitchStoreUseCaseProtocol {
     ///
     private func logOutOfCurrentStore(onCompletion: @escaping () -> Void) {
         guard stores.sessionManager.defaultStoreID != nil else {
-            return onCompletion()
+            onCompletion()
+            return
         }
 
         stores.removeDefaultStore()

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/LoginJetpackSetupCoordinator.swift
@@ -67,7 +67,8 @@ private extension LoginJetpackSetupCoordinator {
         })
         guard let contentNavigationController = navigationController.presentedViewController as? UINavigationController else {
             // this is not likely to happen but handling this for safety
-            return navigationController.present(UINavigationController(rootViewController: setupUI), animated: true)
+            navigationController.present(UINavigationController(rootViewController: setupUI), animated: true)
+            return
         }
         contentNavigationController.setViewControllers([setupUI], animated: true)
     }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Site Credential Login/SiteCredentialLoginViewModel.swift
@@ -117,7 +117,8 @@ private extension SiteCredentialLoginViewModel {
             // Error 404 means Jetpack is not installed. Allow this to come through.
             // Error 403 means the lack of permission to manage plugins. Also allow this error
             // since we want to show the error on the next screen.
-            return handleCompletion()
+            handleCompletion()
+            return
         case AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401)):
             errorMessage = Localization.wrongCredentials
         default:

--- a/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Navigation Exceptions/WrongAccountErrorViewModel.swift
@@ -133,9 +133,10 @@ final class WrongAccountErrorViewModel: ULAccountMismatchViewModel {
         }
 
         if isSelfHostedSite {
-            return showSiteCredentialLoginAndJetpackConnection(from: viewController)
+            showSiteCredentialLoginAndJetpackConnection(from: viewController)
+            return
         }
-        return presentConnectToWPComSiteAlert(from: viewController)
+        presentConnectToWPComSiteAlert(from: viewController)
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
+++ b/WooCommerce/Classes/Authentication/PostSiteCredentialLoginChecker.swift
@@ -49,7 +49,8 @@ private extension PostSiteCredentialLoginChecker {
                                   with useCase: ApplicationPasswordUseCase,
                                   in navigationController: UINavigationController, onSuccess: @escaping () -> Void) {
         guard useCase.applicationPassword == nil else {
-            return onSuccess()
+            onSuccess()
+            return
         }
         Task { @MainActor in
             do {

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPCom2FALoginViewModel.swift
@@ -58,7 +58,8 @@ final class WPCom2FALoginViewModel: NSObject, ObservableObject {
     @available(iOS 16, *)
     func loginWithSecurityKey() {
         guard let twoStepNonce = loginFields.nonceInfo?.nonceWebauthn else {
-            return handleError(.webAuthNonceNotFound)
+            handleError(.webAuthNonceNotFound)
+            return
         }
 
         isLoggingIn = true
@@ -78,7 +79,8 @@ final class WPCom2FALoginViewModel: NSObject, ObservableObject {
         if let nonceInfo = loginFields.nonceInfo {
             let (authType, nonce) = nonceInfo.authTypeAndNonce(for: strippedCode)
             guard nonce.isNotEmpty else {
-                return handleError(.bad2FACode)
+                handleError(.bad2FACode)
+                return
             }
             loginFacade.loginToWordPressDotCom(withUser: loginFields.nonceUserID, authType: authType, twoStepCode: strippedCode, twoStepNonce: nonce)
         } else {
@@ -133,12 +135,14 @@ extension WPCom2FALoginViewModel: ASAuthorizationControllerDelegate, ASAuthoriza
               let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
               let challengeInfo = loginFields.webauthnChallengeInfo,
               let clientDataJson = extractClientData(from: credential, challengeInfo: challengeInfo) else {
-            return handleError(.webAuthChallengeRequestFailed)
+            handleError(.webAuthChallengeRequestFailed)
+            return
         }
 
         // Validate that the submitted passkey is allowed.
         guard challengeInfo.allowedCredentialIDs.contains(credential.credentialID.base64URLEncodedString()) else {
-            return handleError(.invalidSecurityKey)
+            handleError(.invalidSecurityKey)
+            return
         }
 
         loginFacade.authenticateWebauthnSignature(userID: loginFields.nonceUserID,

--- a/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
+++ b/WooCommerce/Classes/Blaze/BlazeLocalNotificationScheduler.swift
@@ -110,7 +110,8 @@ final class DefaultBlazeLocalNotificationScheduler: BlazeLocalNotificationSchedu
         guard let notificationTime = Calendar.current.date(byAdding: .hour,
                                                            value: Constants.AbandonedCampaignCreationReminder.hoursDurationForNotification,
                                                            to: Date.now) else {
-            return DDLogDebug("Blaze: Failed calculating notification time for abandoned campaign creation local notification.")
+            DDLogDebug("Blaze: Failed calculating notification time for abandoned campaign creation local notification.")
+            return
         }
 
         let notification = LocalNotification(scenario: LocalNotification.Scenario.blazeAbandonedCampaignCreationReminder,
@@ -189,7 +190,8 @@ private extension DefaultBlazeLocalNotificationScheduler {
             Task { @MainActor in
                 await scheduler.cancel(scenario: .blazeNoCampaignReminder)
             }
-            return DDLogDebug("Blaze: An active evergreen campaign is present. No need to schedule a no campaign local notification.")
+            DDLogDebug("Blaze: An active evergreen campaign is present. No need to schedule a no campaign local notification.")
+            return
         }
 
         let latestEndTime = campaigns
@@ -205,17 +207,20 @@ private extension DefaultBlazeLocalNotificationScheduler {
             .max()
 
         guard let latestEndTime else {
-            return DDLogDebug("Blaze: Failed calculating latest campaign end time.")
+            DDLogDebug("Blaze: Failed calculating latest campaign end time.")
+            return
         }
 
         guard let notificationTime = Calendar.current.date(byAdding: .day,
                                                            value: Constants.NoCampaignReminder.daysDurationForNotification,
                                                            to: latestEndTime) else {
-            return DDLogDebug("Blaze: Failed calculating no campaign notification time from latest campaign end time.")
+            DDLogDebug("Blaze: Failed calculating no campaign notification time from latest campaign end time.")
+            return
         }
 
         guard notificationTime > Date.now else {
-            return DDLogDebug("Blaze: Calculated no campaign notification time already passed.")
+            DDLogDebug("Blaze: Calculated no campaign notification time already passed.")
+            return
         }
 
         Task { @MainActor in

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -80,7 +80,7 @@ struct PushNotificationBackgroundSynchronizer: PushNotificationBackgroundSynchro
     ///
     @MainActor
     private func synchronizeNotifications() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             let action = NotificationAction.synchronizeNotifications { error in
                 DDLogInfo("📱 Finished Synchronizing Notifications!")
                 if let error {
@@ -93,6 +93,7 @@ struct PushNotificationBackgroundSynchronizer: PushNotificationBackgroundSynchro
             DDLogInfo("📱 Synchronizing Notifications...")
             stores.dispatch(action)
         }
+        return
     }
 
     /// Synchronizes an specific order.

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -80,7 +80,8 @@ struct PushNotificationBackgroundSynchronizer: PushNotificationBackgroundSynchro
     ///
     @MainActor
     private func synchronizeNotifications() async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return try await withCheckedThrowingContinuation { continuation in
             let action = NotificationAction.synchronizeNotifications { error in
                 DDLogInfo("📱 Finished Synchronizing Notifications!")
                 if let error {
@@ -93,7 +94,6 @@ struct PushNotificationBackgroundSynchronizer: PushNotificationBackgroundSynchro
             DDLogInfo("📱 Synchronizing Notifications...")
             stores.dispatch(action)
         }
-        return
     }
 
     /// Synchronizes an specific order.

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -1015,7 +1015,8 @@ private extension PushNotificationsManager {
         guard let siteID,
               let tokenID = registrationState.wooPushNotificationToken,
               let tokenIDInt = Int64(tokenID) else {
-            return completion(.success(()))
+            completion(.success(()))
+            return
         }
         stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
             siteID: siteID,

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentInvalidatablePaymentOrchestrator.swift
@@ -26,7 +26,8 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
                         onProcessingCompletion: @escaping (PaymentIntent) -> Void,
                         onCompletion: @escaping (Result<CardPresentCapturedPaymentData, any Error>) -> Void) {
         guard invalidated == false else {
-            return onCompletion(.failure(CardPresentPaymentInvalidatablePaymentOrchestratorError.paymentInvalidated))
+            onCompletion(.failure(CardPresentPaymentInvalidatablePaymentOrchestratorError.paymentInvalidated))
+            return
         }
         paymentOrchestrator.collectPayment(for: order,
                                            orderTotal: orderTotal,
@@ -48,7 +49,8 @@ final class CardPresentPaymentInvalidatablePaymentOrchestrator: PaymentCaptureOr
     func retryPayment(for order: Order,
                       onCompletion: @escaping (Result<CardPresentCapturedPaymentData, any Error>) -> Void) {
         guard invalidated == false else {
-            return onCompletion(.failure(CardPresentPaymentInvalidatablePaymentOrchestratorError.paymentInvalidated))
+            onCompletion(.failure(CardPresentPaymentInvalidatablePaymentOrchestratorError.paymentInvalidated))
+            return
         }
         paymentOrchestrator.retryPayment(for: order,
                                          onCompletion: onCompletion)

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentOnboardingAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentOnboardingAdaptor.swift
@@ -40,7 +40,8 @@ final class CardPresentPaymentsOnboardingPresenterAdaptor: CardPresentPaymentsOn
         readinessUseCase.checkCardPaymentReadiness()
 
         guard case .ready = readinessUseCase.readiness else {
-            return showOnboarding(readyToCollectPayment: completion)
+            showOnboarding(readyToCollectPayment: completion)
+            return
         }
 
         completion()

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
@@ -149,7 +149,7 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
 
         connectionControllerManager.knownReaderProvider.forgetCardReader()
 
-        return await withCheckedContinuation { continuation in
+        await withCheckedContinuation { continuation in
             var nillableContinuation: CheckedContinuation<Void, Never>? = continuation
 
             let action = CardPresentPaymentAction.disconnect { [weak self] _ in
@@ -163,6 +163,7 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
             }
             stores.dispatch(action)
         }
+        return
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/CardPresentPaymentService.swift
@@ -149,7 +149,8 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
 
         connectionControllerManager.knownReaderProvider.forgetCardReader()
 
-        await withCheckedContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return await withCheckedContinuation { continuation in
             var nillableContinuation: CheckedContinuation<Void, Never>? = continuation
 
             let action = CardPresentPaymentAction.disconnect { [weak self] _ in
@@ -163,7 +164,6 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
             }
             stores.dispatch(action)
         }
-        return
     }
 
     @MainActor

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -277,11 +277,13 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         // The product has to exist remotely in order to save its images remotely.
         // In product creation, this save function should be called after a new product is saved remotely for the first time.
         guard key.isLocalID == false else {
-            return onProductSave(.failure(ProductImageUploaderError.noRemoteProductIDFound))
+            onProductSave(.failure(ProductImageUploaderError.noRemoteProductIDFound))
+            return
         }
 
         guard let handler = actionHandlersByProduct[key] else {
-            return onProductSave(.failure(ProductImageUploaderError.noActionHandlerFound))
+            onProductSave(.failure(ProductImageUploaderError.noActionHandlerFound))
+            return
         }
 
         let imagesSaver: ProductImagesSaver

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -167,7 +167,8 @@ extension WatchDependenciesSynchronizer {
         // The user info could contain a track event. Send it if we found one.
         guard let rawEvent = userInfo[WooConstants.watchTracksKey] as? String,
               let analyticEvent = WooAnalyticsStat(rawValue: rawEvent) else {
-            return DDLogError("⛔️ Unsupported watch tracks event: \(userInfo)")
+            DDLogError("⛔️ Unsupported watch tracks event: \(userInfo)")
+            return
         }
         analytics.track(analyticEvent)
     }
@@ -185,7 +186,8 @@ extension WatchDependenciesSynchronizer {
     ///
     func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
         guard message[WooConstants.watchSyncKey] as? Bool == true else {
-            return DDLogError("⛔️ Unsupported sync request message: \(message)")
+            DDLogError("⛔️ Unsupported sync request message: \(message)")
+            return
         }
         syncTrigger.toggle()
     }

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -137,7 +137,8 @@ private extension WooNavigationControllerDelegate {
     func setOfflineBannerWhenNoConnection(for viewController: UIViewController, status: ConnectivityStatus) {
         // We can only show it when we are sure we can't reach the internet
         guard status == .notReachable else {
-            return removeOfflineBanner(for: viewController)
+            removeOfflineBanner(for: viewController)
+            return
         }
 
         // Only add banner view if it's not already added.

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -92,7 +92,7 @@ private struct CurrentOrderListSyncUseCase {
     ///
     @MainActor
     private func syncOrders(filters: FilterOrderListViewModel.Filters) async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
             let action = useCase.actionFor(pageNumber: SyncingCoordinator.Defaults.pageFirstIndex,
                                            pageSize: SyncingCoordinator.Defaults.pageSize,
@@ -107,5 +107,6 @@ private struct CurrentOrderListSyncUseCase {
             })
             stores.dispatch(action)
         }
+        return
     }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -92,7 +92,8 @@ private struct CurrentOrderListSyncUseCase {
     ///
     @MainActor
     private func syncOrders(filters: FilterOrderListViewModel.Filters) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return try await withCheckedThrowingContinuation { continuation in
             let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
             let action = useCase.actionFor(pageNumber: SyncingCoordinator.Defaults.pageFirstIndex,
                                            pageSize: SyncingCoordinator.Defaults.pageSize,
@@ -107,6 +108,5 @@ private struct CurrentOrderListSyncUseCase {
             })
             stores.dispatch(action)
         }
-        return
     }
 }

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -179,7 +179,8 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
         userName = name
         userEmail = email
         saveUserProfile()
-        return try await createZendeskIdentity()
+        try await createZendeskIdentity()
+        return
     }
 
     /// Creates a Zendesk Identity to be able to submit support request tickets.
@@ -274,7 +275,8 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 
     private func uploadSingleAttachment(_ attachment: ZendeskAttachment?, _ completionHandler: @escaping (ZDKUploadResponse?) -> Void) {
         guard let attachment else {
-            return completionHandler(nil)
+            completionHandler(nil)
+            return
         }
 
         let uploadProvider = ZDKUploadProvider()
@@ -326,7 +328,7 @@ private extension ZendeskManager {
 
     @MainActor
     func createZendeskIdentity() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             createZendeskIdentity { [weak self] success in
                 guard let self, success else {
                     DDLogError("⛔️ Creating Zendesk identity failed.")
@@ -337,6 +339,7 @@ private extension ZendeskManager {
                 continuation.resume(returning: ())
             }
         }
+        return
     }
 
     func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping onUserInformationCompletion) {

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -328,7 +328,8 @@ private extension ZendeskManager {
 
     @MainActor
     func createZendeskIdentity() async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return try await withCheckedThrowingContinuation { continuation in
             createZendeskIdentity { [weak self] success in
                 guard let self, success else {
                     DDLogError("⛔️ Creating Zendesk identity failed.")
@@ -339,7 +340,6 @@ private extension ZendeskManager {
                 continuation.resume(returning: ())
             }
         }
-        return
     }
 
     func getUserInformationAndShowPrompt(withName: Bool, from viewController: UIViewController, completion: @escaping onUserInformationCompletion) {

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -70,7 +70,8 @@ struct UniversalLinkRouter {
         guard let matchedRoute = matcher.firstRouteMatching(url),
               matchedRoute.performAction() else {
             analyticsTracker?.trackUniversalLinkFailure(url: url)
-            return bouncingURLOpener.open(url)
+            bouncingURLOpener.open(url)
+            return
         }
 
         analyticsTracker?.trackUniversalLinkOpened(subPath: matchedRoute.subPath)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -50,7 +50,8 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         guard let openWCSettingsAction else {
-            return retrySearchAction()
+            retrySearchAction()
+            return
         }
         openWCSettingsAction()
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -67,7 +67,8 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         guard let viewController else {
-            return onDismiss()
+            onDismiss()
+            return
         }
         viewController.dismiss(animated: true) { [weak self] in
             self?.onDismiss()

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorEmailSent.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorEmailSent.swift
@@ -68,7 +68,8 @@ final class CardPresentModalNonRetryableErrorEmailSent: CardPresentPaymentsModal
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         guard let viewController else {
-            return onDismiss()
+            onDismiss()
+            return
         }
         viewController.dismiss(animated: true) { [weak self] in
             self?.onDismiss()

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableErrorWithoutEmail.swift
@@ -55,7 +55,8 @@ final class CardPresentModalNonRetryableErrorWithoutEmail: CardPresentPaymentsMo
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
         guard let viewController else {
-            return onDismiss()
+            onDismiss()
+            return
         }
         viewController.dismiss(animated: true) { [weak self] in
             self?.onDismiss()

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -146,7 +146,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
     func retryPayment(for order: Order,
                       onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> Void) {
         guard let handlers = handlersForActivePayment else {
-            return onCompletion(.failure(PaymentCaptureOrchestratorError.couldNotRetryPayment))
+            onCompletion(.failure(PaymentCaptureOrchestratorError.couldNotRetryPayment))
+            return
         }
 
         handlers.onPreparingReader()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -413,7 +413,7 @@ extension OrderDetailsViewModel {
     func syncTrackingsWhenShipmentTrackingIsEnabled() async {
         let orderID = order.orderID
         let siteID = order.siteID
-        return await withCheckedContinuation { continuation in
+        await withCheckedContinuation { continuation in
             stores.dispatch(
                 ShipmentAction.synchronizeShipmentTrackingData(siteID: siteID,
                                                                orderID: orderID) { error in
@@ -429,6 +429,7 @@ extension OrderDetailsViewModel {
                                                                }
             )
         }
+        return
     }
 
     /// Syncs order fulfillments from the fulfillments endpoint.
@@ -436,7 +437,7 @@ extension OrderDetailsViewModel {
     func syncOrderFulfillments() async {
         let orderID = order.orderID
         let siteID = order.siteID
-        return await withCheckedContinuation { continuation in
+        await withCheckedContinuation { continuation in
             stores.dispatch(
                 OrderFulfillmentAction.synchronizeOrderFulfillments(
                     siteID: siteID,
@@ -449,6 +450,7 @@ extension OrderDetailsViewModel {
                 }
             )
         }
+        return
     }
 }
 
@@ -753,7 +755,8 @@ extension OrderDetailsViewModel {
             }()
             // Update the order with the newly synced shipping labels
             let updatedOrder = order.copy(shippingLabels: shippingLabels)
-            return update(order: updatedOrder)
+            update(order: updatedOrder)
+            return
         }
 
         guard !orderContainsOnlyVirtualProducts else {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -413,7 +413,8 @@ extension OrderDetailsViewModel {
     func syncTrackingsWhenShipmentTrackingIsEnabled() async {
         let orderID = order.orderID
         let siteID = order.siteID
-        await withCheckedContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return await withCheckedContinuation { continuation in
             stores.dispatch(
                 ShipmentAction.synchronizeShipmentTrackingData(siteID: siteID,
                                                                orderID: orderID) { error in
@@ -429,7 +430,6 @@ extension OrderDetailsViewModel {
                                                                }
             )
         }
-        return
     }
 
     /// Syncs order fulfillments from the fulfillments endpoint.
@@ -437,7 +437,8 @@ extension OrderDetailsViewModel {
     func syncOrderFulfillments() async {
         let orderID = order.orderID
         let siteID = order.siteID
-        await withCheckedContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return await withCheckedContinuation { continuation in
             stores.dispatch(
                 OrderFulfillmentAction.synchronizeOrderFulfillments(
                     siteID: siteID,
@@ -450,7 +451,6 @@ extension OrderDetailsViewModel {
                 }
             )
         }
-        return
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -83,7 +83,8 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
             }
         case .custom:
             guard datePaid != nil else {
-                return onCompletion(false)
+                onCompletion(false)
+                return
             }
             isEligibleForBackendReceipts { isEligibleForReceipt in
                 onCompletion(isEligibleForReceipt)
@@ -98,7 +99,8 @@ final class ReceiptEligibilityUseCase: ReceiptEligibilityUseCaseProtocol {
                 }
             }
         default:
-            return onCompletion(false)
+            onCompletion(false)
+            return
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -325,7 +325,8 @@ private extension AppCoordinator {
         /// If authenticating with site credentials only is incomplete,
         /// show the prologue screen to force the user to log in again.
         guard stores.isAuthenticatedWithoutWPCom == false else {
-            return displayAuthenticatorWithOnboardingIfNeeded()
+            displayAuthenticatorWithOnboardingIfNeeded()
+            return
         }
 
         let matcher = ULAccountMatcher(storageManager: storageManager)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -375,16 +375,19 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
     func didTapConfirmDetails() {
         guard image != nil else {
-            return isShowingMissingImageErrorAlert = true
+            isShowingMissingImageErrorAlert = true
+            return
         }
 
         guard finalDestinationURL.isNotEmpty else {
-            return isShowingMissingDestinationURLAlert = true
+            isShowingMissingDestinationURLAlert = true
+            return
         }
 
         if featureFlagService.isFeatureFlagEnabled(.blazeCampaignObjective),
            campaignObjective == nil {
-            return isShowingMissingObjectiveAlert = true
+            isShowingMissingObjectiveAlert = true
+            return
         }
 
         let taglineMatching = suggestions.map { $0.siteName }.contains { $0 == tagline }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -136,7 +136,8 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
             analyticsTracker.setCandidateReader(connectedReader)
             if connectedReader.discoveryMethod == discoveryMethod,
                paymentGatewayAccount.siteID == siteID {
-                return handleConnectionResult(.success(.connected(connectedReader)), paymentGatewayAccount: paymentGatewayAccount)
+                handleConnectionResult(.success(.connected(connectedReader)), paymentGatewayAccount: paymentGatewayAccount)
+                return
             } else {
                 // Wrong discovery method or different store - disconnect and reconnect
                 do {
@@ -144,8 +145,9 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                     analyticsTracker.automaticallyDisconnectedFromReader()
                     checkOnboarding(connectionAttemptID: connectionAttemptID)
                 } catch {
-                    return handlePreflightFailure(
+                    handlePreflightFailure(
                         error: CardPresentPaymentPreflightError.failedToAutomaticallyDisconnect(reader: connectedReader))
+                    return
                 }
             }
         } else {
@@ -180,7 +182,8 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
         // Once onboarding is complete, a Payment Gateway will have been chosen
         guard let paymentGatewayAccount = await selectedPaymentGateway() else {
             DDLogError("⛔️ Cannot proceed with reader connection, no Payment Gateway found")
-            return handlePreflightFailure(error: CardPresentPaymentPreflightError.paymentGatewayAccountNotFound)
+            handlePreflightFailure(error: CardPresentPaymentPreflightError.paymentGatewayAccountNotFound)
+            return
         }
 
         await startReaderConnection(using: paymentGatewayAccount, connectionAttemptID: connectionAttemptID)
@@ -191,7 +194,8 @@ where TapToPayAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
         guard isCurrentConnectionAttempt(connectionAttemptID) else { return }
         let isReconnecting = tapToPayReconnectionController.isReconnecting
         guard !isReconnecting else {
-            return adoptReconnection(using: paymentGatewayAccount, connectionAttemptID: connectionAttemptID)
+            adoptReconnection(using: paymentGatewayAccount, connectionAttemptID: connectionAttemptID)
+            return
         }
         let tapToPayReaderSupported = await supportDeterminer.deviceSupportsTapToPayReader() && supportDeterminer.siteSupportsTapToPayReader()
         guard isCurrentConnectionAttempt(connectionAttemptID) else { return }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -651,7 +651,8 @@ private extension CardReaderConnectionController {
 
         if case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: _) = error,
            underlyingError.isSoftwareUpdateError {
-            return onUpdateFailed(error: error)
+            onUpdateFailed(error: error)
+            return
         }
         showConnectionFailed(error: error)
     }
@@ -697,10 +698,11 @@ private extension CardReaderConnectionController {
         }
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
-            return alertsPresenter.present(
+            alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailed(error: error,
                                                            retrySearch: continueSearch,
                                                            cancelSearch: cancelSearch))
+            return
         }
 
         switch underlyingError {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/TapToPayCardReaderConnectionController.swift
@@ -523,7 +523,8 @@ private extension TapToPayCardReaderConnectionController {
 
         if case CardReaderServiceError.softwareUpdate(underlyingError: let underlyingError, batteryLevel: _) = error,
            underlyingError.isSoftwareUpdateError {
-            return onUpdateFailed(error: error)
+            onUpdateFailed(error: error)
+            return
         }
         showConnectionFailed(error: error)
     }
@@ -570,10 +571,11 @@ private extension TapToPayCardReaderConnectionController {
         }
 
         guard case CardReaderServiceError.connection(let underlyingError) = error else {
-            return alertsPresenter.present(
+            alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailed(error: error,
                                                            retrySearch: retrySearch,
                                                            cancelSearch: cancelSearch))
+            return
         }
 
         switch underlyingError {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -701,7 +701,8 @@ extension AnalyticsHubViewModel {
         }
 
         guard let storedCards else {
-            return allCardsWithSettings = AnalyticsHubViewModel.defaultCards
+            allCardsWithSettings = AnalyticsHubViewModel.defaultCards
+            return
         }
 
         // Any new cards added to the analytics hub since the stored cards were saved.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -323,7 +323,8 @@ private extension BlazeCampaignDashboardViewModel {
 
     func updateResults() {
         guard isSiteEligibleForBlaze else {
-            return update(state: .empty)
+            update(state: .empty)
+            return
         }
 
         if let campaign = blazeCampaignResultsController.fetchedObjects.first {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/Payments/StoreOnboardingPaymentsSetupCoordinator.swift
@@ -75,7 +75,8 @@ private extension StoreOnboardingPaymentsSetupCoordinator {
         }
 
         guard let url = URL(string: urlString) else {
-            return assertionFailure("Invalid URL for onboarding payments setup: \(urlString)")
+            assertionFailure("Invalid URL for onboarding payments setup: \(urlString)")
+            return
         }
 
         let webViewModel = WooPaymentSetupWebViewModel(title: title, initialURL: url) { [weak self] success in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreDetails/StoreOnboardingStoreDetailsCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreDetails/StoreOnboardingStoreDetailsCoordinator.swift
@@ -30,7 +30,8 @@ private extension StoreOnboardingStoreDetailsCoordinator {
         let urlString = Constants.url(site: site)
 
         guard let url = URL(string: urlString) else {
-            return assertionFailure("Invalid URL for onboarding Store details: \(urlString)")
+            assertionFailure("Invalid URL for onboarding Store details: \(urlString)")
+            return
         }
 
         let webViewModel = WPAdminWebViewModel(title: Localization.title, initialURL: url)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -216,7 +216,7 @@ private extension LastOrdersDashboardCardViewModel {
 
     @MainActor
     func loadOrderStatuses() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
                 switch result {
                 case .success:
@@ -226,6 +226,7 @@ private extension LastOrdersDashboardCardViewModel {
                 }
             })
         }
+        return
     }
 
     func configureStatusResultsController() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -216,7 +216,8 @@ private extension LastOrdersDashboardCardViewModel {
 
     @MainActor
     func loadOrderStatuses() async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        // swiftlint:disable:next return_value_from_void_function
+        return try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(OrderStatusAction.retrieveOrderStatuses(siteID: siteID) { result in
                 switch result {
                 case .success:
@@ -226,7 +227,6 @@ private extension LastOrdersDashboardCardViewModel {
                 }
             })
         }
-        return
     }
 
     func configureStatusResultsController() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm+Presentation.swift
@@ -11,15 +11,18 @@ extension SupportFormHostingController {
 
         // If the controller is a UIViewController, set the modal display for iPad.
         if !controller.isKind(of: UINavigationController.self) && UIDevice.current.userInterfaceIdiom == .pad {
-            return showViewModally(from: controller)
+            showViewModally(from: controller)
+            return
         }
 
         if let navController = controller as? UINavigationController {
-            return navController.pushViewController(self, animated: true)
+            navController.pushViewController(self, animated: true)
+            return
         }
 
         if let navController = controller.navigationController {
-            return navController.pushViewController(self, animated: true)
+            navController.pushViewController(self, animated: true)
+            return
         }
 
         showViewModally(from: controller)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -90,7 +90,8 @@ struct InPersonPaymentsSelectPluginView: View {
         guard let selectedPlugin else {
             // This should not be possible
             assertionFailure()
-            return DDLogError("Attempt to confirm a payment gateway selection with no gateway selected")
+            DDLogError("Attempt to confirm a payment gateway selection with no gateway selected")
+            return
         }
         onPluginSelected(selectedPlugin)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -68,7 +68,8 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
         trackSkipTapped()
 
         guard let siteID else {
-            return completion()
+            completion()
+            return
         }
 
         let action = AppSettingsAction.setSkippedCashOnDeliveryOnboardingStep(siteID: siteID)
@@ -80,7 +81,8 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
         trackEnableTapped()
 
         guard let siteID else {
-            return completion()
+            completion()
+            return
         }
 
         awaitingResponse = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayBadgePromotionChecker.swift
@@ -31,14 +31,16 @@ final class TapToPayBadgePromotionChecker {
     @MainActor
     private func checkTapToPayBadgeVisibility() async {
         guard let siteID = stores.sessionManager.defaultStoreID else {
-            return shouldShowTapToPayBadges = false
+            shouldShowTapToPayBadges = false
+            return
         }
 
         let supportDeterminer = CardReaderSupportDeterminer(siteID: siteID)
         guard supportDeterminer.siteSupportsTapToPayReader(),
               await supportDeterminer.deviceSupportsTapToPayReader(),
               await !supportDeterminer.hasPreviousTapToPayUsage() else {
-            return shouldShowTapToPayBadges = false
+            shouldShowTapToPayBadges = false
+            return
         }
 
         do {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
@@ -113,7 +113,8 @@ where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     func showAlertsForReconnection(from alertsPresenter: AlertPresenter,
                                    onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void) {
         guard isReconnecting else {
-            return onCompletion(.failure(TapToPayReconnectionError.noReconnectionInProgress))
+            onCompletion(.failure(TapToPayReconnectionError.noReconnectionInProgress))
+            return
         }
         adoptedConnectionCompletionHandler = onCompletion
         silencingAlertsPresenter.startPresentingAlerts(from: alertsPresenter)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/UpdateAnalyticsSettingsUseCase.swift
@@ -31,12 +31,14 @@ final class UpdateAnalyticsSettingUseCase {
     @MainActor func update(optOut: Bool) async throws {
         // There is no need to perform any request if the user hasn't changed the current analytic setting.
         guard analytics.userHasOptedIn == optOut else {
-            return updateLocally(optOut: optOut)
+            updateLocally(optOut: optOut)
+            return
         }
 
         // If we can't find an account(non-jp sites), lets commit the change immediately.
         guard let defaultAccount = stores.sessionManager.defaultAccount else {
-            return updateLocally(optOut: optOut)
+            updateLocally(optOut: optOut)
+            return
         }
 
         let userID = defaultAccount.userID

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -388,7 +388,8 @@ private extension SettingsViewController {
     func sitePluginsWasPressed() {
         ServiceLocator.analytics.track(.settingsPluginListTapped)
         guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
-            return DDLogError("⛔️ Cannot find ID for current site to load plugins for!")
+            DDLogError("⛔️ Cannot find ID for current site to load plugins for!")
+            return
         }
         let pluginListViewModel = PluginListViewModel(siteID: siteID)
         let pluginListHostingController = UIHostingController(rootView: PluginListView(siteID: siteID, viewModel: pluginListViewModel, onClose: { [weak self] in
@@ -443,7 +444,8 @@ private extension SettingsViewController {
         ServiceLocator.analytics.track(.settingsPushNotificationsButtonTap)
         DDLogInfo("🔔 Settings: Enable Push Notifications tapped")
         guard let site = stores.sessionManager.defaultSite else {
-            return DDLogError("⛔️ Cannot find ID for current site to enable push notifications!")
+            DDLogError("⛔️ Cannot find ID for current site to enable push notifications!")
+            return
         }
         let viewModel = WPComPushNotificationsBenefitsViewModel(siteID: site.siteID, siteURL: site.url, onDismiss: { [weak self] in
             self?.dismiss(animated: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformerDataViewController.swift
@@ -112,7 +112,8 @@ private extension TopPerformerDataViewController {
             }
         }
         guard let items = topEarnerStats?.items?.sorted(by: >), items.isNotEmpty else {
-            return viewModel.update(state: .loaded(rows: []))
+            viewModel.update(state: .loaded(rows: []))
+            return
         }
         viewModel.update(state: .loaded(rows: items))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -116,7 +116,8 @@ final class TopPerformersDashboardViewModel: ObservableObject {
         // Preemptively show any cached content
         // Stop if data is relatively new
         if !forceRefresh && DashboardTimestampStore.isTimestampFresh(for: .topPerformers, at: timeRange.timestampRange) {
-            return updateUIInLoadedState()
+            updateUIInLoadedState()
+            return
         }
 
         syncingData = true
@@ -320,7 +321,8 @@ private extension TopPerformersDashboardViewModel {
         }
         guard let items = topEarnerStats?.items?.sorted(by: >), items.isNotEmpty else {
             entityListeners = [:]
-            return periodViewModel.update(state: .loaded(rows: []))
+            periodViewModel.update(state: .loaded(rows: []))
+            return
         }
         periodViewModel.update(state: .loaded(rows: items))
         observeProducts(for: items)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/WPComPushNotificationsBenefitsViewModel.swift
@@ -99,7 +99,8 @@ final class WPComPushNotificationsBenefitsViewModel {
 
         /// Skip Jetpack connection check if site is JCP
         guard stores.sessionManager.defaultSite?.isJetpackCPConnected == false else {
-            return await checkWooPluginVersion()
+            await checkWooPluginVersion()
+            return
         }
 
         do {

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -589,7 +589,8 @@ private extension FilterListViewController {
             // Do not allow selection for an unavailable promotable type.
             // Instead, just launch a webview to promote it.
             if let promotable = selected as? PromotableProductType, !promotable.isAvailable {
-                return launchPromoteWebview(for: promotable)
+                launchPromoteWebview(for: promotable)
+                return
             }
 
             onItemSelectedSubject.send(selected)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -82,7 +82,8 @@ final class HubMenuCoordinator {
         }
 
         guard let noteID = notification.noteID else {
-            return attemptRetrieveProductReviewWithoutNoteID(notification: notification)
+            attemptRetrieveProductReviewWithoutNoteID(notification: notification)
+            return
         }
         let action = ProductReviewAction.retrieveProductReviewFromNote(noteID: Int64(noteID)) { [weak self] result in
             self?.handleProductReviewResult(result)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -68,10 +68,12 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     ///
     func showPrivacySettings() {
         guard let navigationController else {
-            return DDLogError("⛔️ Could not find a navigation controller context.")
+            DDLogError("⛔️ Could not find a navigation controller context.")
+            return
         }
         guard let privacy = UIStoryboard.settings.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
-            return DDLogError("⛔️ Could not instantiate PrivacySettingsViewController")
+            DDLogError("⛔️ Could not instantiate PrivacySettingsViewController")
+            return
         }
 
         let settings = SettingsViewController()

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -230,9 +230,10 @@ private extension JetpackSetupCoordinator {
     func startJetpackSetupFlow(authToken: String) {
         /// Dismiss any existing login flow if possible.
         if rootViewController.presentedViewController != nil {
-            return rootViewController.dismiss(animated: true) {
+            rootViewController.dismiss(animated: true) {
                 self.startJetpackSetupFlow(authToken: authToken)
             }
+            return
         }
         let progressView = InProgressViewController(viewProperties: .init(title: Localization.pleaseWait, message: ""))
         rootViewController.topmostPresentedViewController.present(progressView, animated: true)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -1190,7 +1190,8 @@ private extension MainTabBarController {
         if let productsSplitViewWrapperController = productsContainerController.wrappedController as? ProductsSplitViewWrapperController,
            let productForm = productsSplitViewWrapperController.currentProductForm(for: error.productOrVariationID.id) {
             // Ask the product form to display an alert about the error
-            return productForm.handleProductUploadError(error)
+            productForm.handleProductUploadError(error)
+            return
         }
 
         let model: ProductLoaderViewController.Model = {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentReceiptEmailCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentReceiptEmailCoordinator.swift
@@ -42,7 +42,8 @@ final class CardPresentPaymentReceiptEmailCoordinator: NSObject {
                           completion: @escaping () -> Void) {
         guard MFMailComposeViewController.canSendMail() else {
             DDLogError("⛔️ Failed to submit email receipt for order: \(data.order.orderID). Email is not configured.")
-            return completion()
+            completion()
+            return
         }
 
         self.completion = completion

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentsOnboardingPresenter.swift
@@ -36,7 +36,8 @@ final class CardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardin
                                   readyToCollectPayment completion: @escaping () -> Void) {
         readinessUseCase.checkCardPaymentReadiness()
         guard case .ready = readinessUseCase.readiness else {
-            return showOnboarding(from: viewController, readyToCollectPayment: completion)
+            showOnboarding(from: viewController, readyToCollectPayment: completion)
+            return
         }
         completion()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -481,7 +481,8 @@ private extension CollectOrderPaymentUseCase {
     func handlePaymentCancellationFromReader(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>) {
         analyticsTracker.trackPaymentCancelation(cancelationSource: .reader)
         guard let dismissedOnReaderAlert = paymentAlerts.cancelledOnReader() else {
-            return alertsPresenter.dismiss()
+            alertsPresenter.dismiss()
+            return
         }
         alertsPresenter.present(viewModel: dismissedOnReaderAlert)
     }
@@ -495,11 +496,12 @@ private extension CollectOrderPaymentUseCase {
                                                       channel: PaymentChannel,
                                                       onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         guard case ServerSidePaymentCaptureError.paymentGateway = error else {
-            return handlePaymentFailureAndRetryPayment(error,
+            handlePaymentFailureAndRetryPayment(error,
                                                        alertProvider: paymentAlerts,
                                                        paymentGatewayAccount: paymentGatewayAccount,
                                                        channel: channel,
                                                        onCompletion: onCompletion)
+            return
         }
 
         // This is an unknown error during payment capture.
@@ -702,7 +704,8 @@ private extension CollectOrderPaymentUseCase {
     private func completeAfterErrorDismissal(_ error: Error,
                                              onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
         guard shouldCancelPaymentAfterDismissing(error) else {
-            return onCompletion(.failure(error))
+            onCompletion(.failure(error))
+            return
         }
 
         cancelPaymentAndComplete(with: error, onCompletion: onCompletion)
@@ -915,7 +918,8 @@ private extension CollectOrderPaymentUseCase {
 
         // Order only fails when the payment is declined by the payment processor, other types of failure don't produce failure states and receipts.
         guard isErrorEligibleForSendingFailureReceiptAfterPayment else {
-            return completion(.noEmailReceipt)
+            completion(.noEmailReceipt)
+            return
         }
 
         receiptEligibilityUseCase.isEligibleForFailedPaymentEmailReceipts(paymentGatewayID: paymentGatewayID) { [weak self] isEligible in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -85,7 +85,8 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
         guard validateEmail() else {
             notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
-            return onFinish(false)
+            onFinish(false)
+            return
         }
 
         if showDifferentAddressForm {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -613,7 +613,8 @@ final class EditableOrderViewModel: ObservableObject {
         // Creates the product row view model needed for `ProductInOrderViewModel`.
         guard let orderItem = orderSynchronizer.order.items.first(where: { $0.itemID == itemID }),
               let rowViewModel = createProductRowViewModel(for: orderItem, childItems: []) else {
-            return discountViewModel = nil
+            discountViewModel = nil
+            return
         }
 
         discountViewModel = .init(id: itemID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/CouponLineDetailsViewModel.swift
@@ -83,7 +83,8 @@ private extension CouponLineDetailsViewModel {
     func saveData() {
         guard let initialCode,
              initialCode.isNotEmpty else {
-            return didSelectSave(.added(newCode: code))
+            didSelectSave(.added(newCode: code))
+            return
         }
 
         didSelectSave(.edited(oldCode: initialCode, newCode: code))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolver.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/NewOrderInitialStatusResolver.swift
@@ -25,7 +25,8 @@ struct NewOrderInitialStatusResolver {
     @MainActor
     func resolve(onCompletion: @escaping (OrderStatusEnum) -> ()) {
         guard let wooPlugin = pluginsService.loadPluginInStorage(siteID: siteID, plugin: .wooCommerce, isActive: true) else {
-            return onCompletion(.pending)
+            onCompletion(.pending)
+            return
         }
 
         // auto-draft should exists in versions greater than `6.3.0`

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AddressFormViewModel.swift
@@ -386,7 +386,8 @@ private extension AddressFormViewModel {
 
         // Trigger a sync request if there are no countries.
         guard !countriesResultsController.isEmpty else {
-            return syncCountriesTrigger.send()
+            syncCountriesTrigger.send()
+            return
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AreaSelectorCommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/AreaSelectorCommand.swift
@@ -50,7 +50,8 @@ final class AreaSelectorCommand: ObservableListSelectorCommand {
     ///
     func filterAreas(term: String) {
         guard term.isNotEmpty else {
-            return data = areas
+            data = areas
+            return
         }
 
         // Trim the search term to remove newlines or whitespaces (e.g added from the keyboard predictive text) from both ends

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressFormViewModel.swift
@@ -112,7 +112,8 @@ final class EditOrderAddressFormViewModel: AddressFormViewModel, AddressFormView
     func saveAddress(onFinish: @escaping (Bool) -> Void) {
         guard validateEmail() else {
             notice = AddressFormViewModel.NoticeFactory.createInvalidEmailNotice()
-            return onFinish(false)
+            onFinish(false)
+            return
         }
 
         let updatedAddress = fields.toAddress()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -97,7 +97,8 @@ private extension OrderLoaderViewController {
         // If we have an stored order there is no point on re-loading it now and delaying the user interface.
         // In any the OrderDetailViewController will reload the order data.
         if let storedOrder = orderResultsController.fetchedObjects.first {
-            return self.state = .success(order: storedOrder)
+            self.state = .success(order: storedOrder)
+            return
         }
 
         let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { [weak self] (order, error) in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -137,7 +137,8 @@ private extension ManualTrackingViewController {
 
     @objc func dismissButtonTapped() {
         guard !viewModel.hasUnsavedChanges else {
-            return displayDismissConfirmationAlert()
+            displayDismissConfirmationAlert()
+            return
         }
         dismiss()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -277,7 +277,8 @@ final class ShippingLabelFormViewModel {
     func handleCustomsFormsValueChanges(customsForms: [ShippingLabelCustomsForm], isValidated: Bool) {
         self.customsForms = customsForms
         guard isValidated else {
-            return updateRowState(type: .customs, dataState: .pending, displayMode: .editable)
+            updateRowState(type: .customs, dataState: .pending, displayMode: .editable)
+            return
         }
         updateRowState(type: .customs, dataState: .validated, displayMode: .editable)
         // We reset the carrier and rates selected because if the package change
@@ -868,7 +869,8 @@ extension ShippingLabelFormViewModel {
         guard packages.isNotEmpty else {
             let error = PurchaseError.invalidPackageDetails
             DDLogError("⛔️ Error finding matching package: \(error)")
-            return onCompletion(.failure(error))
+            onCompletion(.failure(error))
+            return
         }
 
         let startTime = Date()
@@ -927,7 +929,8 @@ extension ShippingLabelFormViewModel {
 
     private func verifyEUShippingNoticeDismissState(onCompletion: @escaping (Bool) -> Void) {
         guard isEUShippingNotificationEnabled else {
-            return onCompletion(false)
+            onCompletion(false)
+            return
         }
 
         let action = AppSettingsAction.loadEUShippingNoticeDismissState { result in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingServiceViewModel.swift
@@ -141,12 +141,14 @@ final class WooShippingServiceViewModel: ObservableObject {
 
         guard let originAddress, let destinationAddress, hasDestinationAddress else {
             onLoadingCompletion(.failure(Error.missingDestinationAddress))
-            return updateLoadingState(to: .error(Error.missingDestinationAddress))
+            updateLoadingState(to: .error(Error.missingDestinationAddress))
+            return
         }
 
         guard selectedPackage.weight > 0 else {
             onLoadingCompletion(.failure(Error.missingShipmentWeight))
-            return updateLoadingState(to: .error(Error.missingShipmentWeight))
+            updateLoadingState(to: .error(Error.missingShipmentWeight))
+            return
         }
 
         updateLoadingState(to: .loading)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -477,7 +477,8 @@ private extension WooShippingSplitShipmentsViewModel {
             .reduce(0, +)
 
         guard selectedItemsCount > 0 else {
-            return moveToNoticeViewModel = nil
+            moveToNoticeViewModel = nil
+            return
         }
 
         let totalItemCount = currentShipment.contents
@@ -491,10 +492,12 @@ private extension WooShippingSplitShipmentsViewModel {
 
         if shipments.count == 1 && allItemsSelected {
             // do not allow moving all items if there is only one shipment at the moment
-            return moveToNoticeViewModel = nil
+            moveToNoticeViewModel = nil
+            return
         } else if existingShipmentsIndexesToMove.isEmpty && allItemsSelected {
             // prevent moving all items if all other shipments are fulfilled
-            return moveToNoticeViewModel = nil
+            moveToNoticeViewModel = nil
+            return
         }
 
         moveToNoticeViewModel = MoveToShipmentNoticeViewModel(

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -383,7 +383,8 @@ extension OrderListViewController {
 
     private func markOrderAsCompleted(resultID: FetchResultSnapshotObjectID) {
         guard let orderDetailsViewModel = viewModel.detailsViewModel(withID: resultID) else {
-            return DDLogError("⛔️ ViewModel for resultID: \(resultID) not found")
+            DDLogError("⛔️ ViewModel for resultID: \(resultID) not found")
+            return
         }
         /// Actions that performs the mark completed request remotely.
         let fulfillmentProcess = orderDetailsViewModel.markCompleted(flow: .list)
@@ -596,7 +597,8 @@ private extension OrderListViewController {
                 state != .empty else {
             selectedOrderID = nil
             selectedIndexPath = nil
-            return switchDetailsHandler([], 0, false, nil)
+            switchDetailsHandler([], 0, false, nil)
+            return
         }
         switchDetailsHandler([orderDetailsViewModel], 0, false) { [weak self] hasBeenSelected in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -50,7 +50,8 @@ final class OrdersSplitViewWrapperController: UIViewController {
             }
             let loaderViewController = OrderLoaderViewController(orderID: orderID, siteID: Int64(siteID), note: note)
             let loaderNavigationController = WooNavigationController(rootViewController: loaderViewController)
-            return showSecondaryView(loaderNavigationController)
+            showSecondaryView(loaderNavigationController)
+            return
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -219,12 +219,14 @@ final class PaymentMethodsViewModel: ObservableObject {
 
         guard let rootViewController else {
             DDLogError("⛔️ Root ViewController is nil, can't present payment alerts.")
-            return presentNoticeSubject.send(.error(Localization.genericCollectError))
+            presentNoticeSubject.send(.error(Localization.genericCollectError))
+            return
         }
 
         guard let order = ordersResultController.fetchedObjects.first else {
             DDLogError("⛔️ Order not found, can't collect payment.")
-            return presentNoticeSubject.send(.error(Localization.genericCollectError))
+            presentNoticeSubject.send(.error(Localization.genericCollectError))
+            return
         }
         let alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
         let merchantEducationPresenter = TapToPayCardReaderMerchantEducationPresenter(rootViewController: rootViewController)

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -249,7 +249,8 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
 
         // Perform local email validation
         guard email.isEmpty || EmailFormatValidator.validate(string: email) else {
-            return presentNoticeSubject.send(.error(Localization.invalidEmail))
+            presentNoticeSubject.send(.error(Localization.invalidEmail))
+            return
         }
 
         showLoadingIndicator = true

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductDescriptionGenerationViewModel.swift
@@ -70,10 +70,12 @@ final class ProductDescriptionGenerationViewModel: ObservableObject {
     /// Generates product description async.
     func generateDescription() {
         guard name.isNotEmpty else {
-            return missingName = true
+            missingName = true
+            return
         }
         guard features.isNotEmpty else {
-            return missingFeatures = true
+            missingFeatures = true
+            return
         }
         analytics.track(event: .ProductFormAI.productDescriptionAIGenerateButtonTapped(isRetry: suggestedText?.isNotEmpty == true))
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -240,7 +240,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
 
             guard case .success = imageState else {
                 analytics.track(event: .ProductCreationAI.saveAsDraftSuccess())
-                return onProductCreated(remoteProduct)
+                onProductCreated(remoteProduct)
+                return
             }
 
             /// Updates local product with images

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -79,7 +79,8 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
         imageState = .loading
 
         guard let image = await onPickPackagePhoto(source) else {
-            return imageState = previousState
+            imageState = previousState
+            return
         }
 
         await detectTexts(from: image.image)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Tags/ProductTagsViewController.swift
@@ -247,7 +247,8 @@ private extension ProductTagsViewController {
         textView.resignFirstResponder()
 
         guard allTags.isNotEmpty else {
-            return onCompletion([])
+            onCompletion([])
+            return
         }
 
         createNewTagsRemotely()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -507,7 +507,8 @@ extension ProductFormViewModel {
 
         // If the product doesn't have any pending changes, we can safely override the original product
         guard hasUnsavedChanges() else {
-            return resetProduct(newOriginalProduct)
+            resetProduct(newOriginalProduct)
+            return
         }
 
         // If the product has pending changes, we need to override the `originalProduct` first and the `living product` later with a saved copy.

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -206,7 +206,8 @@ extension ProductImagesCollectionViewController {
         case .remote:
             break
         case let .uploadFailure(asset, error, _, _):
-            return onFailedUploadSelected(asset, error)
+            onFailedUploadSelected(asset, error)
+            return
         case .uploading:
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -46,7 +46,8 @@ final class ProductImagesSaver {
 
         let imageStatuses = imageActionHandler.productImageStatuses
         guard imageStatuses.hasPendingUpload else {
-            return saveProductImages(imageStatuses.images, onProductSave: onProductSave)
+            saveProductImages(imageStatuses.images, onProductSave: onProductSave)
+            return
         }
 
         imageStatusesToSave = imageStatuses

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsListViewModel.swift
@@ -212,7 +212,8 @@ final class ProductListViewModel: ProductsListViewModelProtocol {
             completion(false)
         case false:
             guard featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory), isCameraAvailable else {
-                return completion(false)
+                completion(false)
+                return
             }
             // If all conditions are met, scan to update inventory should be visible:
             // 1. No Square plugin

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -167,7 +167,7 @@ private extension ProductsSplitViewCoordinator {
         // This works based on the assumption that there is only one product form in the secondary navigation stack.
         if let lastProductFormViewController = secondaryNavigationController.viewControllers
             .compactMap({ $0 as? ProductFormViewController<ProductFormViewModel> }).last {
-            return lastProductFormViewController.close(completion: {
+            lastProductFormViewController.close(completion: {
                 closure()
             }, onCancel: { [weak self] in
                 guard let self else { return }
@@ -175,6 +175,7 @@ private extension ProductsSplitViewCoordinator {
                 // Otherwise, the most recently tapped row is selected in the table view.
                 contentTypes = contentTypes
             })
+            return
         } else {
             closure()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -59,7 +59,8 @@ private extension ProductsSplitViewWrapperController {
 
     func configureChildViewController() {
         guard let contentView = productsSplitViewController.view else {
-            return assertionFailure("Split view not available")
+            assertionFailure("Split view not available")
+            return
         }
         addChild(productsSplitViewController)
         view.addSubview(contentView)

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/Add Attributes/AddAttributeOptionsViewController.swift
@@ -76,7 +76,8 @@ private extension AddAttributeOptionsViewController {
     func configureRightButtonItem() {
         // The update indicator has precedence over the next button
         if viewModel.showUpdateIndicator {
-            return navigationItem.rightBarButtonItems = [createUpdateIndicatorButton()]
+            navigationItem.rightBarButtonItems = [createUpdateIndicatorButton()]
+            return
         }
 
         // Assemble buttons based view model visibility

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/GenerateAllVariationsPresenter.swift
@@ -88,7 +88,8 @@ private extension GenerateAllVariationsPresenter {
         // There should be already a presented `InProgressViewController`. But we present one in case there isn;t.
         guard let inProgressViewController = baseViewController.presentedViewController as? InProgressViewController else {
             let inProgressViewController = InProgressViewController(viewProperties: newViewProperties)
-            return baseViewController.present(inProgressViewController, animated: true)
+            baseViewController.present(inProgressViewController, animated: true)
+            return
         }
 
         // Update the already presented view controller with the "Creating..." copy.

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -498,7 +498,8 @@ private extension ProductVariationsViewController {
         }
 
         guard let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) else {
-            return show(editAttributeViewController, sender: nil)
+            show(editAttributeViewController, sender: nil)
+            return
         }
 
         let viewControllersUntilSelf = navigationController.viewControllers[0...indexOfSelf]

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -341,7 +341,8 @@ private extension EmptyStateViewController {
 
         guard pullToRefreshHandler != nil else {
             // Remove refresh control if config doesn't have action handler
-            return scrollView.refreshControl = nil
+            scrollView.refreshControl = nil
+            return
         }
 
         // Create refresh control if needed

--- a/WooCommerce/Classes/ViewRelated/Themes/ThemeInstaller.swift
+++ b/WooCommerce/Classes/ViewRelated/Themes/ThemeInstaller.swift
@@ -46,7 +46,8 @@ struct DefaultThemeInstaller: ThemeInstaller {
     /// - Parameter siteID: site ID to install and activate the theme
     func installPendingThemeIfNeeded(siteID: Int64) async throws {
         guard let themeID = userDefaults.pendingThemeID(for: siteID) else {
-            return DDLogInfo("No pending theme installation.")
+            DDLogInfo("No pending theme installation.")
+            return
         }
 
         DDLogInfo("Attempt to perform pending theme installation. Theme ID: \(themeID), Site ID : \(siteID)")

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticationManagerTests.swift
@@ -164,7 +164,8 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         guard case .presentEmailController = result else {
-            return XCTFail("Unexpected result returned for non-Jetpack site")
+            XCTFail("Unexpected result returned for non-Jetpack site")
+            return
         }
     }
 
@@ -187,7 +188,8 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         guard case .presentEmailController = result else {
-            return XCTFail("Unexpected result returned for non-Jetpack site")
+            XCTFail("Unexpected result returned for non-Jetpack site")
+            return
         }
     }
 
@@ -211,7 +213,8 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         guard case .presentEmailController = result else {
-            return XCTFail("Expected presentEmailController for Commerce Garden site")
+            XCTFail("Expected presentEmailController for Commerce Garden site")
+            return
         }
     }
 
@@ -234,7 +237,8 @@ final class AuthenticationManagerTests: XCTestCase {
 
         // Then
         guard case .presentPasswordController = result else {
-            return XCTFail("Unexpected result returned for non-Jetpack site")
+            XCTFail("Unexpected result returned for non-Jetpack site")
+            return
         }
     }
 

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackConnectionServiceTests.swift
@@ -41,7 +41,8 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
         // Then
         guard case .alreadyConnected(let email) = outcome else {
-            return XCTFail("Expected .alreadyConnected, got \(outcome)")
+            XCTFail("Expected .alreadyConnected, got \(outcome)")
+            return
         }
         XCTAssertEqual(email, testEmail)
     }
@@ -79,7 +80,8 @@ final class JetpackConnectionServiceTests: XCTestCase {
 
         // Then
         guard case .webViewRequired = outcome else {
-            return XCTFail("Expected .webViewRequired, got \(outcome)")
+            XCTFail("Expected .webViewRequired, got \(outcome)")
+            return
         }
     }
 
@@ -226,7 +228,8 @@ private extension JetpackConnectionServiceTests {
         let outcome = try await service.evaluateAndConnect(siteURL: testURL, credentials: credentials)
 
         guard case .connected(let email) = outcome else {
-            return XCTFail("Expected .connected, got \(outcome)")
+            XCTFail("Expected .connected, got \(outcome)")
+            return
         }
         XCTAssertEqual(email, testEmail)
         XCTAssertEqual(triggeredRegister, expectsRegister)

--- a/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/WrongAccountErrorViewModelTests.swift
@@ -294,7 +294,8 @@ private final class MockAuthenticator: Authenticator {
     static func fetchSiteInfo(for siteURL: String, onCompletion: @escaping (Result<WordPressComSiteInfo, Error>) -> Void) {
         fetchSiteInfoTriggered = true
         guard let siteInfo else {
-            return onCompletion(.failure(AuthenticatorError.serviceError))
+            onCompletion(.failure(AuthenticatorError.serviceError))
+            return
         }
         onCompletion(.success(siteInfo))
     }

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentsStoresManager.swift
@@ -87,10 +87,12 @@ final class MockCardPresentPaymentsStoresManager: DefaultStoresManager {
                 return
             }
             guard let batteryLevel = reader.batteryLevel, batteryLevel > 0.1 else {
-                return onCompletion(.failure(CardReaderServiceError.connection(underlyingError: .bluetoothConnectionFailedBatteryCriticallyLow)))
+                onCompletion(.failure(CardReaderServiceError.connection(underlyingError: .bluetoothConnectionFailedBatteryCriticallyLow)))
+                return
             }
             guard !failUpdate else {
-                return onCompletion(.failure(CardReaderServiceError.softwareUpdate(underlyingError: .readerSoftwareUpdateFailedBatteryLow, batteryLevel: 0.25)))
+                onCompletion(.failure(CardReaderServiceError.softwareUpdate(underlyingError: .readerSoftwareUpdateFailedBatteryLow, batteryLevel: 0.25)))
+                return
             }
             onCompletion(Result.success(reader))
         case .cancelCardReaderDiscovery(let onCompletion):

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductListViewModel.swift
@@ -14,7 +14,8 @@ final class MockProductListViewModel: ProductsListViewModelProtocol {
     func scanToUpdateInventoryButtonShouldBeVisible(isCameraAvailable: Bool? = true, completion: @escaping (Bool) -> (Void)) {
         guard self.featureFlagService.isFeatureFlagEnabled(.scanToUpdateInventory) else {
             scanToUpdateInventoryShouldBeVisible = false
-            return completion(false)
+            completion(false)
+            return
         }
         scanToUpdateInventoryShouldBeVisible = true
         completion(true)

--- a/WooCommerce/WooCommerceTests/Mocks/MockWordPressComAccountService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockWordPressComAccountService.swift
@@ -12,7 +12,8 @@ final class MockWordPressComAccountService: WordPressComAccountServiceProtocol {
     func isPasswordlessAccount(username: String, success: @escaping (Bool) -> Void, failure: @escaping (Error) -> Void) {
         triggeredIsPasswordlessAccount = true
         guard let passwordlessAccountCheckError else {
-            return success(shouldReturnPasswordlessAccount)
+            success(shouldReturnPasswordlessAccount)
+            return
         }
         failure(passwordlessAccountCheckError)
     }
@@ -24,7 +25,8 @@ final class MockWordPressComAccountService: WordPressComAccountServiceProtocol {
                                    failure: @escaping (Error) -> Void) {
         triggeredRequestAuthenticationLink = true
         guard let authenticationLinkRequestError else {
-            return success()
+            success()
+            return
         }
         failure(authenticationLinkRequestError)
     }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -825,7 +825,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -874,7 +875,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -920,7 +922,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -966,7 +969,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1014,7 +1018,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When — new token arrives, clearing previously registered sites
@@ -1059,7 +1064,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1107,7 +1113,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1150,7 +1157,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1195,7 +1203,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1395,7 +1404,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1436,7 +1446,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1475,7 +1486,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1642,7 +1654,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         manager = makeManager()
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When — first call stores pending token since eligibility is nil
@@ -1709,7 +1722,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1762,7 +1776,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         }
 
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
 
         // When
@@ -1807,7 +1822,8 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         // Provide a device token so the manager has one
         guard let tokenAsData = Sample.deviceToken.data(using: .utf8) else {
-            return XCTFail("Invalid sample token")
+            XCTFail("Invalid sample token")
+            return
         }
         manager.registerDeviceToken(with: tokenAsData)
 

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -163,7 +163,8 @@ class WooAnalyticsTests: XCTestCase {
     func test_events_when_logged_in_include_site_properties() {
         // Given
         guard let testingProvider else {
-            return XCTFail("Testing provider not available")
+            XCTFail("Testing provider not available")
+            return
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
                                                                    defaultSite: Site.fake().copy(
@@ -181,7 +182,8 @@ class WooAnalyticsTests: XCTestCase {
         XCTAssertEqual(testingProvider.receivedEvents.first, WooAnalyticsStat.sitePickerContinueTapped.rawValue)
 
         guard let receivedProperties = testingProvider.receivedProperties.first as? [AnyHashable: AnyHashable] else {
-            return XCTFail("Non-equatable properties found")
+            XCTFail("Non-equatable properties found")
+            return
         }
 
         let expectedProperties: [String: AnyHashable] = [
@@ -205,7 +207,8 @@ class WooAnalyticsTests: XCTestCase {
     func test_events_when_logged_out_do_not_include_site_properties() {
         // Given
         guard let testingProvider else {
-            return XCTFail("Testing provider not available")
+            XCTFail("Testing provider not available")
+            return
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false,
                                                                    defaultSite: Site.fake().copy(
@@ -219,7 +222,8 @@ class WooAnalyticsTests: XCTestCase {
         XCTAssertEqual(testingProvider.receivedEvents.first, WooAnalyticsStat.sitePickerContinueTapped.rawValue)
 
         guard let receivedProperties = testingProvider.receivedProperties.first else {
-            return XCTFail("No properties found")
+            XCTFail("No properties found")
+            return
         }
 
         let expectedToBeAbsentProperties = [
@@ -243,7 +247,8 @@ class WooAnalyticsTests: XCTestCase {
     func test_track_Event_when_authenticated_then_includes_site_properties() {
         // Given
         guard let testingProvider else {
-            return XCTFail("Testing provider not available")
+            XCTFail("Testing provider not available")
+            return
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
                                                                    defaultSite: Site.fake().copy(
@@ -258,7 +263,8 @@ class WooAnalyticsTests: XCTestCase {
         // Then
         XCTAssertEqual(testingProvider.receivedEvents.first, "booking_detail_attendance_status_update")
         guard let receivedProperties = testingProvider.receivedProperties.first else {
-            return XCTFail("No properties found")
+            XCTFail("No properties found")
+            return
         }
         XCTAssertEqual(receivedProperties["booking_status"] as? String, "attended")
         XCTAssertEqual(receivedProperties["blog_id"] as? Int64, sampleSiteID)
@@ -267,7 +273,8 @@ class WooAnalyticsTests: XCTestCase {
     func test_track_Event_when_not_authenticated_then_skips_site_properties() {
         // Given
         guard let testingProvider else {
-            return XCTFail("Testing provider not available")
+            XCTFail("Testing provider not available")
+            return
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         ServiceLocator.setStores(stores)
@@ -279,7 +286,8 @@ class WooAnalyticsTests: XCTestCase {
         // Then
         XCTAssertEqual(testingProvider.receivedEvents.first, "booking_detail_attendance_status_update")
         guard let receivedProperties = testingProvider.receivedProperties.first else {
-            return XCTFail("No properties found")
+            XCTFail("No properties found")
+            return
         }
         XCTAssertEqual(receivedProperties["booking_status"] as? String, "attended")
         XCTAssertNil(receivedProperties["blog_id"])

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/FeatureAnnouncementCardViewModelTests.swift
@@ -108,7 +108,8 @@ final class FeatureAnnouncementCardViewModelTests: XCTestCase {
         expectedCampaign: FeatureAnnouncementCampaign) {
         guard let actualProperties = analyticsProvider.receivedProperties.first(where: { $0.keys.contains("source")
         }) else {
-            return XCTFail("Expected properties were not logged")
+            XCTFail("Expected properties were not logged")
+            return
         }
 
         assertEqual(expectedSource.rawValue, actualProperties["source"] as? String)

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/JustInTimeMessageViewModelTests.swift
@@ -193,7 +193,8 @@ final class JustInTimeMessageViewModelTests: XCTestCase {
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: name),
               let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
         else {
-            return XCTFail("Analytics not logged")
+            XCTFail("Analytics not logged")
+            return
         }
 
         for property in expectedProperties {

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptViewModelTests.swift
@@ -21,7 +21,8 @@ final class ReceiptViewModelTests: XCTestCase {
         let fakeReceipt = Receipt.fake().copy(receiptURL: "https://mywootestingstore.com/transient/12345",
                                               expirationDate: "2024-01-27")
         guard let validURL = URL(string: fakeReceipt.receiptURL) else {
-            return XCTFail("Invalid URL")
+            XCTFail("Invalid URL")
+            return
         }
         let expectedURLRequest = URLRequest(url: validURL)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Bookings/BookingDetailsViewModelTests.swift
@@ -441,7 +441,8 @@ final class BookingDetailsViewModelTests: XCTestCase {
         let task = Task { try await viewModel.cancelBooking() }
         let action = try await waitForFirstBookingAction()
         guard case let .cancelBooking(_, _, onCompletion) = action else {
-            return XCTFail("Expected cancelBooking action")
+            XCTFail("Expected cancelBooking action")
+            return
         }
         onCompletion(nil)
         try await task.value

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderConnectionControllerTests.swift
@@ -81,7 +81,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.searchingForReader, source)
     }
@@ -124,7 +125,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .connected(let reader) = connectionResult else {
-            return XCTFail("Expected reader to be connected")
+            XCTFail("Expected reader to be connected")
+            return
         }
         assertEqual(MockCardReader.bbposChipper2XBT(), reader)
 
@@ -171,7 +173,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .connected(let reader) = connectionResult else {
-            return XCTFail("Expected reader to be connected")
+            XCTFail("Expected reader to be connected")
+            return
         }
         assertEqual(MockCardReader.bbposChipper2XBT(), reader)
     }
@@ -256,7 +259,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.foundSeveralReaders, source)
     }
@@ -303,7 +307,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.connectionError, source)
 
@@ -351,7 +356,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.connectionError, source)
     }
@@ -396,7 +402,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .connected(let reader) = connectionResult else {
-            return XCTFail("Expected reader to be connected")
+            XCTFail("Expected reader to be connected")
+            return
         }
         assertEqual(MockCardReader.bbposChipper2XBT(), reader)
     }
@@ -443,7 +450,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.searchingForReader, source)
     }
@@ -490,7 +498,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.searchingForReader, source)
     }
@@ -533,7 +542,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.foundReader, source)
     }
@@ -582,7 +592,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .connected(let reader) = connectionResult else {
-            return XCTFail("Expected reader to be connected")
+            XCTFail("Expected reader to be connected")
+            return
         }
         assertEqual(MockCardReader.bbposChipper2XBT(), reader)
     }
@@ -635,7 +646,8 @@ final class CardReaderConnectionControllerTests: XCTestCase {
 
         // Then
         guard case .canceled(let source) = connectionResult else {
-            return XCTFail("Expected connection to be canceled")
+            XCTFail("Expected connection to be canceled")
+            return
         }
         assertEqual(.locationPermissionDenied, source)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -185,7 +185,8 @@ final class DashboardViewModelTests: XCTestCase {
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "jitm_fetch_success"),
               let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
         else {
-            return XCTFail("Expected event was not logged")
+            XCTFail("Expected event was not logged")
+            return
         }
 
         assertEqual("my_store", properties["source"] as? String)
@@ -233,7 +234,8 @@ final class DashboardViewModelTests: XCTestCase {
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "jitm_fetch_failure"),
               let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
         else {
-            return XCTFail("Expected event was not logged")
+            XCTFail("Expected event was not logged")
+            return
         }
 
         assertEqual("my_store", properties["source"] as? String)
@@ -318,7 +320,8 @@ final class DashboardViewModelTests: XCTestCase {
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"),
               let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
         else {
-            return XCTFail("Expected event was not logged")
+            XCTFail("Expected event was not logged")
+            return
         }
 
         assertEqual("-1", properties["local_timezone"] as? String)
@@ -342,7 +345,8 @@ final class DashboardViewModelTests: XCTestCase {
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(of: "dashboard_store_timezone_differ_from_device"),
               let properties = analyticsProvider.receivedProperties[eventIndex] as? [String: AnyHashable]
         else {
-            return XCTFail("Expected event was not logged")
+            XCTFail("Expected event was not logged")
+            return
         }
 
         assertEqual("-1.5", properties["local_timezone"] as? String)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsOverviewViewModelTests.swift
@@ -28,7 +28,8 @@ final class WooPaymentsPayoutsOverviewViewModelTests: XCTestCase {
               let properties = analyticsProvider.receivedProperties[safe: index],
               let trackedCurrencyProperty = properties[WooAnalyticsEvent.PayoutSummary.Keys.currency] as? String
         else {
-            return XCTFail("Expected properties not found")
+            XCTFail("Expected properties not found")
+            return
         }
 
         assertEqual("GBP", trackedCurrencyProperty)
@@ -53,7 +54,8 @@ final class WooPaymentsPayoutsOverviewViewModelTests: XCTestCase {
               let properties = analyticsProvider.receivedProperties[safe: index],
               let trackedNumberOfCurrenciesProperty = properties[WooAnalyticsEvent.PayoutSummary.Keys.numberOfCurrencies] as? Int
         else {
-            return XCTFail("Expected properties not found")
+            XCTFail("Expected properties not found")
+            return
         }
 
         assertEqual(trackedNumberOfCurrenciesProperty, 2)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/WPComPushNotificationsBenefitsViewModelTests.swift
@@ -119,7 +119,8 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
 
         // Then
         guard case .generic = viewModel.error else {
-            return XCTFail("Expected generic error, got \(String(describing: viewModel.error))")
+            XCTFail("Expected generic error, got \(String(describing: viewModel.error))")
+            return
         }
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
@@ -372,7 +373,8 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
 
         // Then
         guard case .noPermission = viewModel.error else {
-            return XCTFail("Expected noPermission error, got \(String(describing: viewModel.error))")
+            XCTFail("Expected noPermission error, got \(String(describing: viewModel.error))")
+            return
         }
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }
@@ -388,7 +390,8 @@ final class WPComPushNotificationsBenefitsViewModelTests: XCTestCase {
 
         // Then
         guard case .generic = viewModel.error else {
-            return XCTFail("Expected generic error, got \(String(describing: viewModel.error))")
+            XCTFail("Expected generic error, got \(String(describing: viewModel.error))")
+            return
         }
         XCTAssertFalse(viewModel.isCheckingPlugin)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuCoordinatorTests.swift
@@ -104,7 +104,8 @@ final class HubMenuCoordinatorTests: XCTestCase {
         // Simulate that the network call returns a parcel
         let receivedAction = try XCTUnwrap(storesManager.receivedActions.first as? ProductReviewAction)
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedAction else {
-            return XCTFail("Expected retrieveProductReviewFromNote action.")
+            XCTFail("Expected retrieveProductReviewFromNote action.")
+            return
         }
         completion(.failure(NSError(domain: "domain", code: 0)))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/PluginVersionCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComConnectionSetup/PluginVersionCheckerTests.swift
@@ -35,7 +35,8 @@ final class PluginVersionCheckerTests: XCTestCase {
 
         // Then
         guard case .compatible = result else {
-            return XCTFail("Expected .compatible, got \(result)")
+            XCTFail("Expected .compatible, got \(result)")
+            return
         }
     }
 
@@ -59,7 +60,8 @@ final class PluginVersionCheckerTests: XCTestCase {
 
         // Then
         guard case let .incompatible(currentVersion, requiredVersion) = result else {
-            return XCTFail("Expected .incompatible, got \(result)")
+            XCTFail("Expected .incompatible, got \(result)")
+            return
         }
         XCTAssertEqual(currentVersion, "14.3")
         XCTAssertEqual(requiredVersion, "14.4")

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -132,7 +132,8 @@ final class MainTabBarControllerTests: XCTestCase {
         // Simulate that the network call returns a parcel
         let receivedAction = try XCTUnwrap(storesManager.receivedActions.first(where: { $0 is ProductReviewAction }) as? ProductReviewAction)
         guard case .retrieveProductReviewFromNote(_, let completion) = receivedAction else {
-            return XCTFail("Expected retrieveProductReviewFromNote action.")
+            XCTFail("Expected retrieveProductReviewFromNote action.")
+            return
         }
         completion(.success(ProductReviewFromNoteParcelFactory().parcel(metaSiteID: 606)))
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1196,7 +1196,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(analytics.receivedEvents.contains(where: { $0.description == WooAnalyticsStat.orderProductAdd.rawValue}))
 
         guard let eventIndex = analytics.receivedEvents.firstIndex(where: { $0.description == WooAnalyticsStat.orderProductAdd.rawValue}) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analytics.receivedProperties[eventIndex]
@@ -1283,12 +1284,14 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         guard let eventIndex = analytics.receivedEvents.firstIndex(where: {
             $0.description == WooAnalyticsStat.orderCreationProductSelectorClearSelectionButtonTapped.rawValue }) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analytics.receivedProperties[eventIndex]
         guard let event = eventProperties.first(where: { $0.key as? String == "source"}) else {
-            return XCTFail("No property received")
+            XCTFail("No property received")
+            return
         }
 
         XCTAssertEqual(event.value as? String, "product_selector")
@@ -2335,7 +2338,8 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentOrderItems.count, 1)
 
         guard let item = viewModel.currentOrderItems.first else {
-            return XCTFail("Expected 1 item, but got none")
+            XCTFail("Expected 1 item, but got none")
+            return
         }
         XCTAssertEqual(item.productID, sampleProductID)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -852,12 +852,14 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(where: { $0 == "order_creation_product_selector_confirm_button_tapped"}) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analyticsProvider.receivedProperties[eventIndex]
         guard let property = eventProperties.first(where: { $0.key as? String == "product_count"}) else {
-            return XCTFail("No property received")
+            XCTFail("No property received")
+            return
         }
         XCTAssertEqual(property.value as? Int64, 3)
     }
@@ -886,12 +888,14 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(where: { $0 == "order_creation_product_selector_confirm_button_tapped"}) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analyticsProvider.receivedProperties[eventIndex]
         guard let property = eventProperties.first(where: { $0.key as? String == "is_filter_active"}) else {
-            return XCTFail("No property received")
+            XCTFail("No property received")
+            return
         }
         XCTAssertTrue((property.value as? Bool) ?? false)
     }
@@ -931,13 +935,15 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(where: { $0 == "order_creation_product_selector_confirm_button_tapped"}) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analyticsProvider.receivedProperties[eventIndex]
         guard let property = eventProperties.first(where: { $0.key as? String == "source"}),
         let propertyValue = property.value as? String else {
-            return XCTFail("No property received")
+            XCTFail("No property received")
+            return
         }
 
         XCTAssertTrue(propertyValue.contains("popular"))
@@ -969,13 +975,15 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(where: { $0 == "order_creation_product_selector_confirm_button_tapped"}) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analyticsProvider.receivedProperties[eventIndex]
         guard let property = eventProperties.first(where: { $0.key as? String == "source"}),
         let propertyValue = property.value as? String else {
-            return XCTFail("No property received")
+            XCTFail("No property received")
+            return
         }
 
         XCTAssertEqual(propertyValue, "search")
@@ -1016,13 +1024,15 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         guard let eventIndex = analyticsProvider.receivedEvents.firstIndex(where: { $0 == "order_creation_product_selector_confirm_button_tapped"}) else {
-            return XCTFail("No event received")
+            XCTFail("No event received")
+            return
         }
 
         let eventProperties = analyticsProvider.receivedProperties[eventIndex]
         guard let property = eventProperties.first(where: { $0.key as? String == "source"}),
         let propertyValue = property.value as? String else {
-            return XCTFail("No property received")
+            XCTFail("No property received")
+            return
         }
 
         XCTAssertTrue(propertyValue.contains("popular"))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -56,7 +56,8 @@ final class OrderListCellViewModelTests: XCTestCase {
 
         // Then
         guard let accessoryView = viewModel.accessoryView else {
-            return XCTFail("Cell does not have an accessory view.")
+            XCTFail("Cell does not have an accessory view.")
+            return
         }
         XCTAssertEqual(accessoryView.image, expectedImage)
         XCTAssertEqual(accessoryView.tintColor, .tertiaryLabel)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelTests.swift
@@ -207,7 +207,8 @@ final class FilterProductListViewModelTests: XCTestCase {
 
         // Then
         guard case .staticOptions = viewModel.listSelectorConfig else {
-            return XCTFail("Expected static options for product type filter.")
+            XCTFail("Expected static options for product type filter.")
+            return
         }
         XCTAssertEqual(checker.lastSite, sampleSite)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Scanner/BarcodeScannerProductFinderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Scanner/BarcodeScannerProductFinderTests.swift
@@ -79,7 +79,8 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
         let result = try? await sut.searchByIdentifier(from: scannedBarcode, siteID: 1, source: source)
 
         guard case let .product(retrievedProduct) = result else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         // Then
@@ -106,7 +107,8 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
         let result = try? await sut.searchByIdentifier(from: scannedBarcode, siteID: 1, source: source)
 
         guard case let .product(retrievedProduct) = result else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
         // Then
@@ -146,7 +148,8 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
         let result = try? await sut.searchByIdentifier(from: scannedBarcode, siteID: 1, source: .orderCreation)
 
         guard case let .product(retrievedProduct) = result else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
 
@@ -177,7 +180,8 @@ final class BarcodeScannerItemFinderTests: XCTestCase {
         let result = try? await sut.searchByIdentifier(from: scannedBarcode, siteID: 1, source: .orderCreation)
 
         guard case let .product(retrievedProduct) = result else {
-            return XCTFail("It didn't provide a product as expected")
+            XCTFail("It didn't provide a product as expected")
+            return
         }
 
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -178,7 +178,8 @@ final class SettingsViewModelTests: XCTestCase {
             storageManager: storageManager)
         guard let currentVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
         else {
-            return XCTFail("Could not get the current app version")
+            XCTFail("Could not get the current app version")
+            return
         }
 
         waitFor { [weak self] promise in

--- a/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/TrackEventRequestNotificationHandlerTests.swift
@@ -42,7 +42,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
 
         guard let actualProperties = analyticsProvider.receivedProperties.first(where: { $0.keys.contains("scenario")
         }) else {
-            return XCTFail("Expected properties were not logged")
+            XCTFail("Expected properties were not logged")
+            return
         }
 
         assertEqual("regeneration", actualProperties["scenario"] as? String)
@@ -60,7 +61,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
 
         guard let actualProperties = analyticsProvider.receivedProperties.first(where: { $0.keys.contains("scenario")
         }) else {
-            return XCTFail("Expected properties were not logged")
+            XCTFail("Expected properties were not logged")
+            return
         }
 
         assertEqual("regeneration", actualProperties["scenario"] as? String)
@@ -79,7 +81,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
 
         guard let actualProperties = analyticsProvider.receivedProperties.first(where: { $0.keys.contains("scenario")
         }) else {
-            return XCTFail("Expected properties were not logged")
+            XCTFail("Expected properties were not logged")
+            return
         }
 
         assertEqual("regeneration", actualProperties["scenario"] as? String)
@@ -98,7 +101,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
 
         guard let actualProperties = analyticsProvider.receivedProperties.first(where: { $0.keys.contains("scenario")
         }) else {
-            return XCTFail("Expected properties were not logged")
+            XCTFail("Expected properties were not logged")
+            return
         }
 
         assertEqual("regeneration", actualProperties["scenario"] as? String)
@@ -117,7 +121,8 @@ final class TrackEventRequestNotificationHandlerTests: XCTestCase {
 
         guard let actualProperties = analyticsProvider.receivedProperties.first(where: { $0.keys.contains("scenario")
         }) else {
-            return XCTFail("Expected properties were not logged")
+            XCTFail("Expected properties were not logged")
+            return
         }
 
         assertEqual("regeneration", actualProperties["scenario"] as? String)

--- a/WooCommerce/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/NUX/Button/NUXStackedButtonsViewController.swift
@@ -171,7 +171,8 @@ private extension NUXStackedButtonsViewController {
 
     func configureDivider() {
         guard showDivider else {
-            return dividerStackView.isHidden = true
+            dividerStackView.isHidden = true
+            return
         }
 
         leadingDividerLine.backgroundColor = style.orDividerSeparatorColor

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/2FA/TwoFAViewController.swift
@@ -124,7 +124,8 @@ final class TwoFAViewController: LoginViewController {
         // If the error happened because the security key challenge request started more than 1 minute ago, show a timeout error.
         // This check is needed because the server sends a generic error.
         if let initialChallengeRequestTime, Date().timeIntervalSince(initialChallengeRequestTime) >= 60, err.code == .zero {
-            return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.timeoutError)
+            displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.timeoutError)
+            return
         }
 
         configureViewLoading(false)
@@ -186,12 +187,14 @@ private extension TwoFAViewController {
     ///
     func validateForm() {
         guard let nonceInfo = loginFields.nonceInfo else {
-            return validateFormAndLogin()
+            validateFormAndLogin()
+            return
         }
 
         let (authType, nonce) = nonceInfo.authTypeAndNonce(for: loginFields.multifactorCode)
         if nonce.isEmpty {
-            return validateFormAndLogin()
+            validateFormAndLogin()
+            return
         }
 
         loginWithNonce(nonce, authType: authType, code: loginFields.multifactorCode)
@@ -214,7 +217,8 @@ private extension TwoFAViewController {
     func loginWithSecurityKeys() {
 
         guard let twoStepNonce = loginFields.nonceInfo?.nonceWebauthn else {
-            return displaySecurityKeyErrorMessageAndExitFlow()
+            displaySecurityKeyErrorMessageAndExitFlow()
+            return
         }
 
         configureViewLoading(true)
@@ -296,12 +300,14 @@ extension TwoFAViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
               let credential = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion,
               let challengeInfo = loginFields.webauthnChallengeInfo,
               let clientDataJson = extractClientData(from: credential, challengeInfo: challengeInfo) else {
-            return displaySecurityKeyErrorMessageAndExitFlow()
+            displaySecurityKeyErrorMessageAndExitFlow()
+            return
         }
 
         // Validate that the submitted passkey is allowed.
         guard challengeInfo.allowedCredentialIDs.contains(credential.credentialID.base64URLEncodedString()) else {
-            return displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.invalidKey)
+            displaySecurityKeyErrorMessageAndExitFlow(message: LocalizedText.invalidKey)
+            return
         }
 
         loginFacade.authenticateWebauthnSignature(userID: loginFields.nonceUserID,

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Get Started/GetStartedViewController.swift
@@ -307,7 +307,8 @@ private extension GetStartedViewController {
     ///
     func configureDivider() {
         guard showsContinueButtonAtTheBottom == false else {
-            return dividerStackView.isHidden = true
+            dividerStackView.isHidden = true
+            return
         }
         let color = WordPressAuthenticator.shared.unifiedStyle?.borderColor ?? WordPressAuthenticator.shared.style.primaryNormalBorderColor
         leadingDividerLine.backgroundColor = color

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequestedViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Login/MagicLinkRequestedViewController.swift
@@ -66,7 +66,8 @@ final class MagicLinkRequestedViewController: LoginViewController {
     ///
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
-            return super.styleBackground()
+            super.styleBackground()
+            return
         }
         view.backgroundColor = unifiedBackgroundColor
     }

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordCoordinator.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Password/PasswordCoordinator.swift
@@ -57,7 +57,8 @@ private extension PasswordCoordinator {
     /// Navigates the user to enter WP.com password.
     func showPassword() {
         guard let vc = PasswordViewController.instantiate(from: .password) else {
-            return WPAuthenticatorLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
+            WPAuthenticatorLogError("Failed to navigate to PasswordViewController from GetStartedViewController")
+            return
         }
 
         vc.source = source

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -445,7 +445,8 @@ private extension SiteAddressViewController {
 
         guard let url = URL(string: loginFields.siteAddress) else {
             configureViewLoading(false)
-            return displayError(message: Localization.invalidURL, moveVoiceOverFocus: true)
+            displayError(message: Localization.invalidURL, moveVoiceOverFocus: true)
+            return
         }
 
         // Checks that the site exists

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/VerifyEmail/VerifyEmailViewController.swift
@@ -51,7 +51,8 @@ final class VerifyEmailViewController: LoginViewController {
     ///
     override func styleBackground() {
         guard let unifiedBackgroundColor = WordPressAuthenticator.shared.unifiedStyle?.viewControllerBackgroundColor else {
-            return super.styleBackground()
+            super.styleBackground()
+            return
         }
 
         view.backgroundColor = unifiedBackgroundColor

--- a/WooCommerce/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/GoogleSignIn/NewGoogleAuthenticatorTests.swift
@@ -27,7 +27,8 @@ class NewGoogleAuthenticatorTests: XCTestCase {
         } catch {
             let error = try XCTUnwrap(error as? OAuthError)
             guard case .urlDidNotContainCodeParameter(let urlFromError) = error else {
-                return XCTFail("Received unexpected error \(error)")
+                XCTFail("Received unexpected error \(error)")
+                return
             }
             XCTAssertEqual(urlFromError, url)
         }
@@ -76,7 +77,8 @@ class NewGoogleAuthenticatorTests: XCTestCase {
         } catch {
             let error = try XCTUnwrap(error as? OAuthError)
             guard case .tokenResponseDidNotIncludeIdToken = error else {
-                return XCTFail("Received unexpected error \(error)")
+                XCTFail("Received unexpected error \(error)")
+                return
             }
         }
     }

--- a/WooCommerce/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/GoogleSignIn/URL+GoogleSignInTests.swift
@@ -47,21 +47,23 @@ func assert(
     line: UInt = #line
 ) {
     guard var components = URLComponents(url: actual, resolvingAgainstBaseURL: false) else {
-        return XCTFail(
+        XCTFail(
             "Could not created `URLComponents` from given `URL` \(actual).",
             file: file,
             line: line
         )
+        return
     }
 
     components.query = .none
 
     guard let baseURL = components.url else {
-        return XCTFail(
+        XCTFail(
             "Could not extract `URL` from `URLComponents` created from \(actual).",
             file: file,
             line: line
         )
+        return
     }
 
     XCTAssertEqual(baseURL.absoluteString, baseURLString, file: file, line: line)
@@ -75,11 +77,12 @@ func assertQueryItems(
     line: UInt = #line
 ) {
     guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-        return XCTFail(
+        XCTFail(
             "Could not created `URLComponents` from given `URL` \(url).",
             file: file,
             line: line
         )
+        return
     }
 
     guard let queryItems = components.queryItems else {

--- a/WooCommerce/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/SingIn/AppleAuthenticatorTests.swift
@@ -35,7 +35,8 @@ class AppleAuthenticatorTests: XCTestCase {
 
         let service = try XCTUnwrap(delegateSpy.socialUser?.service)
         guard case .apple = service else {
-            return XCTFail("Expected Apple social service, got \(service) instead")
+            XCTFail("Expected Apple social service, got \(service) instead")
+            return
         }
     }
 

--- a/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/SingIn/LoginViewControllerTests.swift
@@ -27,7 +27,8 @@ class LoginViewControllerTests: XCTestCase {
 
         let service = try XCTUnwrap(delegateSpy.socialUser?.service)
         guard case .google = service else {
-            return XCTFail("Expected Google social service, got \(service) instead")
+            XCTFail("Expected Google social service, got \(service) instead")
+            return
         }
     }
 }

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/RemoteTestCase.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/WordPressKitTests/Tests/RemoteTestCase.swift
@@ -58,7 +58,8 @@ extension RemoteTestCase {
         // The pattern here should be to XCTUnwrap and throw.
         // In the interest of moving along with the work, let's fail the tests at this level if the file is not found.
         guard let stubPath = OHPathForFile(filename, type(of: self)) else {
-            return XCTFail("Could not find file at path '\(filename)'.")
+            XCTFail("Could not find file at path '\(filename)'.")
+            return
         }
 
         stub(condition: condition) { _ in
@@ -84,7 +85,8 @@ extension RemoteTestCase {
         // The pattern here should be to XCTUnwrap and throw.
         // In the interest of moving along with the work, let's fail the tests at this level if the file is not found.
         guard let stubPath = OHPathForFile(filename, type(of: self)) else {
-            return XCTFail("Could not find file at path '\(filename)'.")
+            XCTFail("Could not find file at path '\(filename)'.")
+            return
         }
 
         stub(condition: { request in


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> @woocommerce/ios-developers personally, I don't mind `return somethingThatReturnsVoid()` from a `-> Void` function. In WordPress iOS, we decided to ignore this rule. However, one case could be made that adopting it makes for consistent code (e.g. no inconsistency between tests with `return XCTFail(...)` and `XCTFail(...) \n return`. Up to you...

## Rationale

Part of the progressive SwiftLint rules rollout. This PR enables `return_value_from_void_function`, which flags `return X` where the function returns `Void` — the `return` keyword is misleading because there's no value to return.

## What this changes

- 329 auto-fixed violations + 1 manual fix = 330 violations resolved.
- Autofix applied via `rake lint:autocorrect` (SwiftLint 0.63.2).
- Rule added to `only_rules` in `.swiftlint.yml`.

## How to test

Local lint should be clean after `rake lint`. CI will verify build and tests.

## Note

Local build verification was not feasible: my local Xcode is 26.3 but \`.xcode-version\` pins \`~> 26.2\`, causing an unrelated \`StoreWidgetTheme.swift\` compile failure (\`Color(.accent)\` in WatchWidgetsExtension) that does not reproduce with the pinned toolchain on Buildkite. The autofix is confined to \`Modules/Sources/...\` and \`Modules/Tests/...\` — none of which touch \`StoreWidgets/\` — and trunk Buildkite is green on the base commit. Relying on CI to verify.