### PR TITLE
Enable SwiftLint rule: explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,6 +57,9 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `string` to `""`.
   - empty_string
 
+  # Prefer explicit `.init(...)` over implicit initializer calls.
+  - explicit_init
+
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,7 +57,8 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `string` to `""`.
   - empty_string
 
-  # Prefer explicit `.init(...)` over implicit initializer calls.
+  # Prefer implicit initializer calls over explicit `.init(...)` when the
+  # type can be inferred.
   - explicit_init
 
   # Prefer `first(where:)` over `filter { }.first`.

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/NoOpCardReaderService.swift
@@ -44,7 +44,7 @@ public struct NoOpCardReaderService: CardReaderService {
     /// Cancels the discovery process.
     public func cancelDiscovery() -> Future <Void, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }
     }
 
@@ -52,14 +52,14 @@ public struct NoOpCardReaderService: CardReaderService {
     /// - Parameter reader: The card reader we want to connect to.
     public func connect(_ reader: CardReader, options: CardReaderConnectionOptions?) -> AnyPublisher <CardReader, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()
     }
 
     /// Disconnects from the currently connected reader
     public func disconnect() -> Future <Void, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }
     }
 
@@ -80,26 +80,26 @@ public struct NoOpCardReaderService: CardReaderService {
         beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
     ) -> AnyPublisher<PaymentIntent, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()
     }
 
     /// Cancels a PaymentIntent
     public func cancelPaymentIntent() -> Future<Void, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }
     }
 
     public func refundPayment(parameters: RefundParameters) -> AnyPublisher<String, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()
     }
 
     public func cancelRefund() -> AnyPublisher<Void, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()
     }
 
@@ -107,7 +107,7 @@ public struct NoOpCardReaderService: CardReaderService {
         beforePaymentConfirmation: @escaping (PaymentIntent) -> AnyPublisher<Void, Error>
     ) -> AnyPublisher<PaymentIntent, Error> {
         return Future() { promise in
-            promise(.failure(NSError.init(domain: "noopcardreader", code: 0, userInfo: nil)))
+            promise(.failure(NSError(domain: "noopcardreader", code: 0, userInfo: nil)))
         }.eraseToAnyPublisher()
     }
 

--- a/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
+++ b/Modules/Sources/UITestsFoundation/XCTest+Extensions.swift
@@ -147,7 +147,7 @@ extension XCUIElement {
     func verifyLabelContains(substring firstSubstring: String, and secondSubstring: String) throws -> Bool {
         let firstPredicate = NSPredicate(format: "label CONTAINS[c] %@", firstSubstring)
         let secondPredicate = NSPredicate(format: "label CONTAINS[c] %@", secondSubstring)
-        let predicateCompound = NSCompoundPredicate.init(type: .and, subpredicates: [firstPredicate, secondPredicate])
+        let predicateCompound = NSCompoundPredicate(type: .and, subpredicates: [firstPredicate, secondPredicate])
 
         return XCUIApplication().staticTexts.containing(predicateCompound).count == 1
     }

--- a/Modules/Sources/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/PaymentGatewayAccount+ReadOnlyConvertible.swift
@@ -26,7 +26,7 @@ extension Storage.PaymentGatewayAccount: ReadOnlyConvertible {
     /// Returns a ReadOnly version for Yosemite.
     ///
     public func toReadOnly() -> Yosemite.PaymentGatewayAccount {
-        let accountStatus = Yosemite.WCPayAccountStatusEnum.init(rawValue: status)
+        let accountStatus = Yosemite.WCPayAccountStatusEnum(rawValue: status)
 
         return PaymentGatewayAccount(siteID: siteID,
                                      gatewayID: gatewayID,

--- a/Modules/Tests/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/WCPayChargeMapperTests.swift
@@ -33,7 +33,7 @@ class WCPayChargeMapperTests: XCTestCase {
     func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present() throws {
         let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresent)
 
-        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643280767) //2022-01-27 10:52:47 UTC
+        let expectedCreatedDate = Date(timeIntervalSince1970: 1643280767) //2022-01-27 10:52:47 UTC
 
         let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.cardPresent(
             details: .init(brand: .visa,
@@ -66,7 +66,7 @@ class WCPayChargeMapperTests: XCTestCase {
     func test_WCPayCharge_map_parses_all_fields_in_result_for_interac_present() throws {
         let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .interacPresent)
 
-        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1647257154) //2022-03-14 11:25:54 UTC
+        let expectedCreatedDate = Date(timeIntervalSince1970: 1647257154) //2022-03-14 11:25:54 UTC
 
         let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.interacPresent(
             details: .init(brand: .visa,
@@ -132,7 +132,7 @@ class WCPayChargeMapperTests: XCTestCase {
         """.utf8)
         let wcpayCharge = try WCPayChargeMapper(siteID: dummySiteID).map(response: response)
 
-        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1778598369)
+        let expectedCreatedDate = Date(timeIntervalSince1970: 1778598369)
 
         let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.cardPresent(
             details: .init(brand: .eftposAu,
@@ -171,7 +171,7 @@ class WCPayChargeMapperTests: XCTestCase {
     func test_WCPayCharge_map_parses_all_fields_in_result_for_card_present_with_nulls() throws {
         let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .cardPresentMinimal)
 
-        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643799478) //2022-02-02 10:57:58 UTC
+        let expectedCreatedDate = Date(timeIntervalSince1970: 1643799478) //2022-02-02 10:57:58 UTC
 
         let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.cardPresent(
             details: .init(brand: .visa,
@@ -204,7 +204,7 @@ class WCPayChargeMapperTests: XCTestCase {
     func test_WCPayCharge_map_parses_all_fields_in_result_for_card() throws {
         let wcpayCharge = try mapRetrieveWCPayChargeResponse(responseName: .card)
 
-        let expectedCreatedDate = Date.init(timeIntervalSince1970: 1643378348) //2022-01-28 13:59:08 UTC
+        let expectedCreatedDate = Date(timeIntervalSince1970: 1643378348) //2022-01-28 13:59:08 UTC
 
         let expectedPaymentMethodDetails = WCPayPaymentMethodDetails.card(
             details: .init(brand: .amex, last4: "1111", funding: .credit))

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -929,7 +929,7 @@ struct PointOfSaleAggregateModelTests {
                 orderController: orderController)
             let configuration = MockOnboardingViewContainerConfiguration()
             configuration.state = .pluginNotActivated(plugin: .stripe)
-            let factory = CardPresentPaymentOnboardingViewContainer.init(configuration: configuration)
+            let factory = CardPresentPaymentOnboardingViewContainer(configuration: configuration)
             cardPresentPaymentService.paymentEvent = .idle
             try #require(sut.cardPresentPaymentOnboardingViewContainer == nil)
 
@@ -1053,7 +1053,7 @@ struct PointOfSaleAggregateModelTests {
 
             let configuration = MockOnboardingViewContainerConfiguration()
             configuration.state = .noConnectionError
-            let factory = CardPresentPaymentOnboardingViewContainer.init(configuration: configuration)
+            let factory = CardPresentPaymentOnboardingViewContainer(configuration: configuration)
 
             cardPresentPaymentService.paymentEvent = .showOnboarding(factory: factory, onCancel: {})
 

--- a/Modules/Tests/WooFoundationTests/Colors/Color+RGBStringDecoding-Tests.swift
+++ b/Modules/Tests/WooFoundationTests/Colors/Color+RGBStringDecoding-Tests.swift
@@ -14,7 +14,7 @@ final class Color_RGBStringDecoding_Tests: XCTestCase {
     func test_init_with_rgb_string_for_non_opaque_red_creates_expected_color() throws {
         let nonOpaqueRedRGBString = "rgba(255, 0, 0, 0.5)"
         let actualColor = try XCTUnwrap(try? Color(rgbString: nonOpaqueRedRGBString))
-        assertEqual(Color.init(red: 1, green: 0, blue: 0, opacity: 0.5), actualColor)
+        assertEqual(Color(red: 1, green: 0, blue: 0, opacity: 0.5), actualColor)
     }
 
     // N.B. decimals as color input isn't really a valid rgba string, but we can accept them

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemServiceTests.swift
@@ -386,7 +386,7 @@ final class PointOfSaleItemServiceTests: XCTestCase {
         ))
         mockItemMapper.mockMappedVariations = [expectedItem]
 
-        let parentProduct = POSVariableParentProduct.init(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
+        let parentProduct = POSVariableParentProduct(id: POSItemIdentifier(underlyingType: .product, itemID: 1),
                                                           name: "Test Variable Product",
                                                           productImageSource: nil,
                                                           productID: 1)

--- a/WooCommerce/Classes/Extensions/EdgeInsets+Woo.swift
+++ b/WooCommerce/Classes/Extensions/EdgeInsets+Woo.swift
@@ -2,5 +2,5 @@ import SwiftUI
 
 extension EdgeInsets {
     /// Insets with zero values for all edges
-    static let zero = EdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
+    static let zero = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -342,7 +342,7 @@ struct ConnectivityToolCard: View {
                 EmptyView()
             case .error:
                 Image(uiImage: .exclamationFilledImage)
-                    .foregroundColor(Color.init(uiColor: .error))
+                    .foregroundColor(Color(uiColor: .error))
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -850,6 +850,6 @@ extension ConnectivityTool.Card {
     /// Updates a card state to a new given state.
     ///
     func updatingState(_ newState: ConnectivityToolCard.ConnectivityState) -> ConnectivityTool.Card {
-        Self.init(testCase: testCase, title: title, icon: icon, state: newState)
+        Self(testCase: testCase, title: title, icon: icon, state: newState)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -644,7 +644,7 @@ private extension AnalyticsHubViewModel {
                                                                                 usageTracksEventEmitter: usageTracksEventEmitter)
 
                 // Update data on range selection change
-                Task.init {
+                Task {
                     await self.updateData()
                 }
             }.store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsLineChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsLineChart.swift
@@ -42,7 +42,7 @@ struct AnalyticsLineChart: UIViewRepresentable {
         // Adds provided `dataPoints` to data set
         var dataEntries: [ChartDataEntry] = []
         for count in (0..<dataPoints.count) {
-            dataEntries.append(ChartDataEntry.init(x: Double(count), y: dataPoints[count]))
+            dataEntries.append(ChartDataEntry(x: Double(count), y: dataPoints[count]))
         }
         let dataSet = LineChartDataSet(entries: dataEntries, label: "Data")
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -197,7 +197,7 @@ private extension SettingsViewController {
     }
 
     func configureWooCommmerceDetails(cell: HostingTableViewCell<PluginDetailsRowContent>) {
-        let view = PluginDetailsRowContent.init(viewModel: woocommercePluginViewModel)
+        let view = PluginDetailsRowContent(viewModel: woocommercePluginViewModel)
         cell.host(view, parent: self)
         let hasUpdates = woocommercePluginViewModel.updateURL != nil
         cell.accessoryType = hasUpdates ? .disclosureIndicator : .none

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBarViewModel.swift
@@ -52,15 +52,15 @@ class ProductCreationAIPromptProgressBarViewModel: ObservableObject {
         var color: Color {
             switch self {
             case .start:
-                return Color.init(uiColor: .gray(.shade50))
+                return Color(uiColor: .gray(.shade50))
             case .inProgress:
-                return Color.init(uiColor: .withColorStudio(.red, shade: .shade50))
+                return Color(uiColor: .withColorStudio(.red, shade: .shade50))
             case .halfway:
-                return Color.init(uiColor: .withColorStudio(.orange, shade: .shade50))
+                return Color(uiColor: .withColorStudio(.orange, shade: .shade50))
             case .almostDone:
-                return Color.init(uiColor: .withColorStudio(.yellow, shade: .shade50))
+                return Color(uiColor: .withColorStudio(.yellow, shade: .shade50))
             case .completed:
-                return Color.init(uiColor: .withColorStudio(.green, shade: .shade50))
+                return Color(uiColor: .withColorStudio(.green, shade: .shade50))
             }
         }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BadgeLabel.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BadgeLabel.swift
@@ -49,7 +49,7 @@ final class BadgeLabel: UILabel {
         borderColor.setStroke()
         path.stroke()
 
-        let insets = UIEdgeInsets.init(top: 0, left: horizontalPadding, bottom: 0, right: horizontalPadding)
+        let insets = UIEdgeInsets(top: 0, left: horizontalPadding, bottom: 0, right: horizontalPadding)
         super.drawText(in: rect.inset(by: insets))
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndToggleRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TitleAndToggleRow.swift
@@ -16,7 +16,7 @@ struct TitleAndToggleRow: View {
 
     var body: some View {
         toggle
-            .toggleStyle(SwitchToggleStyle.init(tint: isEnabled ? Color(.primary) : Color(.switchDisabledColor)))
+            .toggleStyle(SwitchToggleStyle(tint: isEnabled ? Color(.primary) : Color(.switchDisabledColor)))
             .fixedSize(horizontal: false, vertical: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebViewSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebViewSheet.swift
@@ -31,7 +31,7 @@ struct WebViewSheet: View {
 struct WebViewSheet_Previews: PreviewProvider {
     static var previews: some View {
         WebViewSheet(
-            viewModel: WebViewSheetViewModel.init(
+            viewModel: WebViewSheetViewModel(
                 url: URL(string: "https://woocommerce.com")!,
                 navigationTitle: "WooCommerce.com",
                 authenticated: true),

--- a/WooCommerce/WooCommerceTests/Mocks/MockUserNotification.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockUserNotification.swift
@@ -74,7 +74,7 @@ final class MockNotification: UNNotification {
 
 final class MockNotificationResponse: UNNotificationResponse {
     init?(actionIdentifier: String = "", requestIdentifier: String = "", notificationUserInfo: [AnyHashable: Any] = [:]) {
-        let request = UNNotificationRequest.init(identifier: requestIdentifier,
+        let request = UNNotificationRequest(identifier: requestIdentifier,
                                                  content: MockNotificationContent(userInfo: notificationUserInfo),
                                                  trigger: nil)
         super.init(coder: MockUserNotificationCoder(actionIdentifier: actionIdentifier, request: request))

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
@@ -7,7 +7,7 @@ final class BetaFeaturesConfigurationViewModelTests: XCTestCase {
     private var appSettings: GeneralAppSettingsStorage!
 
     override func setUpWithError() throws {
-        appSettings = GeneralAppSettingsStorage.init(fileStorage: MockInMemoryStorage())
+        appSettings = GeneralAppSettingsStorage(fileStorage: MockInMemoryStorage())
     }
 
     override func tearDownWithError() throws {

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesTests.swift
@@ -6,7 +6,7 @@ final class BetaFeaturesTests: XCTestCase {
     var appSettings: GeneralAppSettingsStorage!
 
     override func setUpWithError() throws {
-        appSettings = GeneralAppSettingsStorage.init(fileStorage: MockInMemoryStorage())
+        appSettings = GeneralAppSettingsStorage(fileStorage: MockInMemoryStorage())
     }
 
     override func tearDownWithError() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardReaderManualsViewModelTests.swift
@@ -85,7 +85,7 @@ class CardReaderManualsViewModelTests: XCTestCase {
                         settingGroupKey: SiteSettingGroup.general.rawValue
                     )
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
-        let viewModel = CardReaderManualsViewModel.init()
+        let viewModel = CardReaderManualsViewModel()
 
         // When
         let availableReaderTypes: [CardReaderType] = []

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -1424,7 +1424,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
             }
         }
 
-        let input = OrderSyncProductInput.init(product: .product(Product.fake()), quantity: 1, discount: 0)
+        let input = OrderSyncProductInput(product: .product(Product.fake()), quantity: 1, discount: 0)
         createOrder(on: synchronizer, input: input)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -94,7 +94,7 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
     func test_given_a_non_default_currency_when_updateOrder_then_order_is_updated_with_correct_values() {
         // Given
         let mockStores = MockStoresManager(sessionManager: .testingInstance)
-        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings.init(currencyCode: .AED,
+        let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings(currencyCode: .AED,
                                                                                           currencyPosition: .right,
                                                                                           thousandSeparator: ",",
                                                                                           decimalSeparator: ".",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewControllerTests.swift
@@ -24,7 +24,7 @@ final class BulkUpdateViewControllerTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
+                onCompletion(.failure(NSError(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Variations/Bulk Update/BulkUpdateViewModelTests.swift
@@ -99,7 +99,7 @@ final class BulkUpdateViewModelTests: XCTestCase {
         storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
             switch action {
             case let .synchronizeProductVariations(_, _, _, _, onCompletion):
-                onCompletion(.failure(NSError.init(domain: "sample error", code: 0, userInfo: nil)))
+                onCompletion(.failure(NSError(domain: "sample error", code: 0, userInfo: nil)))
             default:
                 XCTFail("Unsupported Action")
             }

--- a/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
+++ b/WooCommerce/WooCommerceUITests/Flows/MockDataReader.swift
@@ -39,7 +39,7 @@ class GetMocks {
 
         for index in 0..<updatedData.count {
             let rawStockStatus = updatedData[index].stock_status
-            let humanReadableStockStatus = GetMocks.init().stockStatus[rawStockStatus]!
+            let humanReadableStockStatus = GetMocks().stockStatus[rawStockStatus]!
             updatedData[index].stock_status = humanReadableStockStatus
         }
 
@@ -58,7 +58,7 @@ class GetMocks {
 
         for index in 0..<updatedData.count {
             let productId = updatedData[index].product_id
-            let productName = GetMocks.init().productName[productId]!
+            let productName = GetMocks().productName[productId]!
             updatedData[index].product_name = productName
         }
 

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
@@ -340,7 +340,7 @@ class WordPressComRestApiTests: XCTestCase {
 
     func testCancelationOfRequest() {
         stub(condition: isRestAPIMediaNewRequest()) { _ in
-            return HTTPStubsResponse.init(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
+            return HTTPStubsResponse(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")


### PR DESCRIPTION
## Description

Enables the SwiftLint [`explicit_init`](https://realm.github.io/SwiftLint/explicit_init.html) rule across the codebase.
The rule disallows explicit `.init(...)` calls when the type can be inferred from context — for example, `NSError.init(domain:)` becomes `NSError(domain:)` and `Task.init { ... }` becomes `Task { ... }`.

**46 violations were auto-fixed** across 28 files via `bundle exec rake lint:autocorrect`.
No manual fixes were needed.

This is part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard) — one rule, one PR.
It sits in Phase 5 ("Likely Needs Policy Discussion") because dropping the explicit `.init` is a stylistic choice rather than a clear correctness win.
Worth a quick look at the diff to confirm the team is happy with the convention before this lands.

## Test Steps

- Verify CI is green (Build, Unit Tests, UI Tests, SwiftLint, Danger).
- Spot-check a few of the autofixed diffs — they are all of the form `Type.init(args)` -> `Type(args)`.

## Screenshots

n/a — no user-visible changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

*Local build verification was skipped because this machine has Xcode 26.3 while `.xcode-version` pins `~> 26.2`, causing an unrelated `WooCommerce/StoreWidgets/StoreWidgetTheme.swift` compile failure in the `WatchWidgetsExtension` target that is not touched by this PR. Trunk Buildkite was green on the base commit (`7c68493dd5`); CI will validate the build on the pinned toolchain.*

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*