### PR TITLE
Update support chat push notification diagnostics

### DIFF
--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -67,7 +67,7 @@ final class WooPushNotificationSetupCoordinator {
 
 enum WooPluginRequirements {
     static let pluginPath = "woocommerce/woocommerce.php"
-    static let minimumVersion = "10.9.0"
+    static let minimumVersion = "10.8.0"
 }
 
 private extension WooPushNotificationSetupCoordinator {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -67,7 +67,7 @@ final class WooPushNotificationSetupCoordinator {
 
 enum WooPluginRequirements {
     static let pluginPath = "woocommerce/woocommerce.php"
-    static let minimumVersion = "10.8.0"
+    static let minimumVersion = "10.9.0"
 }
 
 private extension WooPushNotificationSetupCoordinator {

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -41,7 +41,7 @@ final class WooPushNotificationSetupCoordinator {
             onUpdatePlugin: { [weak navigationController, stores] onDismissed in
                 guard let navigationController,
                       let site = stores.sessionManager.defaultSite,
-                      let url = URL(string: site.adminURL + Constants.wooCommercePluginUpdatePath) else { return }
+                      let url = URL(string: site.adminURL + WooConstants.wooCommercePluginUpdatePath) else { return }
                 let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce, onDismiss: onDismissed)
                 let vc = UIHostingController(rootView: webView)
                 vc.modalPresentationStyle = .formSheet
@@ -73,7 +73,6 @@ enum WooPluginRequirements {
 private extension WooPushNotificationSetupCoordinator {
     enum Constants {
         static let magicLinkUrlHostname = "magic-login"
-        static let wooCommercePluginUpdatePath = "plugin-install.php?tab=plugin-information&plugin=woocommerce"
     }
     enum Localization {
         static let flowTitle = NSLocalizedString(

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -89,6 +89,10 @@ public enum WooConstants {
 
     static let wooPaymentsPluginPath = "woocommerce-payments/woocommerce-payments.php"
 
+    /// wp-admin path to the WooCommerce plugin update page.
+    ///
+    static let wooCommercePluginUpdatePath = "plugin-install.php?tab=plugin-information&plugin=woocommerce"
+
     /// Key used to identify track events sent between the phone and the watch.
     ///
     static let watchTracksKey = "watch-tracks-event"

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -156,7 +156,8 @@ final class ConnectivityToolViewModel {
     private func startConnectivityTest(sinceTest: ConnectivityTest = .internetConnection) async {
         let supportedTests: [ConnectivityTest] = {
             if stores.isAuthenticatedWithoutWPCom == false {
-                [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts, .analyticsSetting, .notifications]
+                // Push notification diagnostics are temporarily hidden until the check is updated.
+                [.internetConnection, .wpComServers, .site, .siteOrders, .loadingProducts, .analyticsSetting]
             } else {
                 [.internetConnection, .site, .siteOrders, .loadingProducts, .analyticsSetting]
             }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -9,6 +9,7 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
 
     /// Retains the Jetpack setup coordinator while the flow is active.
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
+    private var preferencesDismissHandler: PresentationDismissHandler?
 
     init(viewModel: SupportChatViewModel) {
         self.viewModel = viewModel
@@ -23,6 +24,9 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
         }
         viewModel.onUpdateWooCommercePlugin = { [weak self] onDismissed in
             self?.presentWooCommercePluginUpdate(onDismissed: onDismissed)
+        }
+        viewModel.onOpenPushNotificationPreferences = { [weak self] onDismissed in
+            self?.presentPushNotificationPreferences(onDismissed: onDismissed)
         }
     }
 
@@ -56,6 +60,41 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
         let viewController = UIHostingController(rootView: webView)
         viewController.modalPresentationStyle = .formSheet
         present(viewController, animated: true)
+    }
+
+    private func presentPushNotificationPreferences(onDismissed: @escaping () -> Void) {
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultSite?.siteID else {
+            onDismissed()
+            return
+        }
+
+        let navigationController = WooNavigationController()
+        let viewController = PushNotificationPreferencesHostingController(siteID: siteID)
+        viewController.navigationItem.leftBarButtonItem = UIBarButtonItem(
+            systemItem: .done,
+            primaryAction: UIAction { [weak navigationController] _ in
+                onDismissed()
+                navigationController?.dismiss(animated: true)
+            }
+        )
+        navigationController.viewControllers = [viewController]
+        navigationController.modalPresentationStyle = .formSheet
+        let dismissHandler = PresentationDismissHandler(onDismissed: onDismissed)
+        preferencesDismissHandler = dismissHandler
+        navigationController.presentationController?.delegate = dismissHandler
+        present(navigationController, animated: true)
+    }
+}
+
+private final class PresentationDismissHandler: NSObject, UIAdaptivePresentationControllerDelegate {
+    private let onDismissed: () -> Void
+
+    init(onDismissed: @escaping () -> Void) {
+        self.onDismissed = onDismissed
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        onDismissed()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -41,7 +41,7 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
     }
 
     private func startJetpackSetup() {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite else { return }
+        guard let site = viewModel.site else { return }
         let coordinator = JetpackSetupCoordinator(site: site, rootViewController: self, onCompletion: { [weak self] in
             self?.viewModel.replaceActionWithRetry()
             self?.jetpackSetupCoordinator = nil
@@ -51,7 +51,7 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
     }
 
     private func presentWooCommercePluginUpdate(onDismissed: @escaping () -> Void) {
-        guard let site = ServiceLocator.stores.sessionManager.defaultSite,
+        guard let site = viewModel.site,
               let url = URL(string: site.adminURL + WooConstants.wooCommercePluginUpdatePath) else {
             onDismissed()
             return
@@ -63,7 +63,7 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
     }
 
     private func presentPushNotificationPreferences(onDismissed: @escaping () -> Void) {
-        guard let siteID = ServiceLocator.stores.sessionManager.defaultSite?.siteID else {
+        guard let siteID = viewModel.site?.siteID else {
             onDismissed()
             return
         }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -21,6 +21,9 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
         viewModel.onStartJetpackSetup = { [weak self] in
             self?.startJetpackSetup()
         }
+        viewModel.onUpdateWooCommercePlugin = { [weak self] onDismissed in
+            self?.presentWooCommercePluginUpdate(onDismissed: onDismissed)
+        }
     }
 
     @available(*, unavailable)
@@ -41,6 +44,18 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
         })
         jetpackSetupCoordinator = coordinator
         coordinator.startSetup()
+    }
+
+    private func presentWooCommercePluginUpdate(onDismissed: @escaping () -> Void) {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite,
+              let url = URL(string: site.adminURL + Constants.wooCommercePluginUpdatePath) else {
+            onDismissed()
+            return
+        }
+        let webView = AuthenticatableWebView(url: url, title: Localization.updateWooCommerce, onDismiss: onDismissed)
+        let viewController = UIHostingController(rootView: webView)
+        viewController.modalPresentationStyle = .formSheet
+        present(viewController, animated: true)
     }
 }
 
@@ -65,11 +80,20 @@ extension SupportChatHostingController {
 // MARK: - Localization
 //
 private extension SupportChatHostingController {
+    enum Constants {
+        static let wooCommercePluginUpdatePath = "plugin-install.php?tab=plugin-information&plugin=woocommerce"
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "supportChatHostingController.title",
             value: "Chat with Support",
             comment: "Navigation title for the AI support chat screen"
+        )
+        static let updateWooCommerce = NSLocalizedString(
+            "supportChatHostingController.updateWooCommerce",
+            value: "Update WooCommerce",
+            comment: "Title of the web view to update WooCommerce plugin from support chat"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -52,7 +52,7 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
 
     private func presentWooCommercePluginUpdate(onDismissed: @escaping () -> Void) {
         guard let site = ServiceLocator.stores.sessionManager.defaultSite,
-              let url = URL(string: site.adminURL + Constants.wooCommercePluginUpdatePath) else {
+              let url = URL(string: site.adminURL + WooConstants.wooCommercePluginUpdatePath) else {
             onDismissed()
             return
         }
@@ -119,10 +119,6 @@ extension SupportChatHostingController {
 // MARK: - Localization
 //
 private extension SupportChatHostingController {
-    enum Constants {
-        static let wooCommercePluginUpdatePath = "plugin-install.php?tab=plugin-information&plugin=woocommerce"
-    }
-
     enum Localization {
         static let title = NSLocalizedString(
             "supportChatHostingController.title",

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -267,7 +267,7 @@ struct SupportChatView: View {
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isExecutingAction))
             }
- 
+
             Button(Localization.continueToChat) {
                 viewModel.proceedToChat()
             }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -266,6 +266,13 @@ struct SupportChatView: View {
                     Label(action.title, systemImage: action.systemImage)
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isExecutingAction))
+
+                if action == .openPushNotificationPreferences {
+                    Button(Localization.continueToChat) {
+                        viewModel.proceedToChat()
+                    }
+                    .buttonStyle(SecondaryButtonStyle())
+                }
             } else {
                 Button(Localization.continueToChat) {
                     viewModel.proceedToChat()

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -266,19 +266,12 @@ struct SupportChatView: View {
                     Label(action.title, systemImage: action.systemImage)
                 }
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isExecutingAction))
-
-                if action == .openPushNotificationPreferences {
-                    Button(Localization.continueToChat) {
-                        viewModel.proceedToChat()
-                    }
-                    .buttonStyle(SecondaryButtonStyle())
-                }
-            } else {
-                Button(Localization.continueToChat) {
-                    viewModel.proceedToChat()
-                }
-                .buttonStyle(SecondaryButtonStyle())
             }
+ 
+            Button(Localization.continueToChat) {
+                viewModel.proceedToChat()
+            }
+            .buttonStyle(SecondaryButtonStyle())
         }
         .padding(SupportChatLayout.bubblePadding)
         .background(Colors.botBubbleBackground)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -266,6 +266,7 @@ final class SupportChatViewModel {
     private var didTrackErrorEscalationButtonShown = false
     var onStartJetpackSetup: () -> Void
     var onUpdateWooCommercePlugin: (@escaping () -> Void) -> Void
+    var onOpenPushNotificationPreferences: (@escaping () -> Void) -> Void
     private let diagnosticsService: SupportDiagnosticsServicing
 
     /// Pre-fetched system status report, if available (e.g., from connectivity tool).
@@ -287,7 +288,8 @@ final class SupportChatViewModel {
          systemStatusReport: String? = nil,
          onContactHumanSupport: @escaping (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?, _ entryPoint: EntryPoint) -> Void,
          onStartJetpackSetup: @escaping () -> Void = {},
-         onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }) {
+         onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() },
+         onOpenPushNotificationPreferences: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }) {
         self.botSlug = botSlug
         self.entryPoint = entryPoint
         self.stores = stores
@@ -303,6 +305,7 @@ final class SupportChatViewModel {
         self.onContactHumanSupport = onContactHumanSupport
         self.onStartJetpackSetup = onStartJetpackSetup
         self.onUpdateWooCommercePlugin = onUpdateWooCommercePlugin
+        self.onOpenPushNotificationPreferences = onOpenPushNotificationPreferences
 
         analytics.track(event: WooAnalyticsEvent.SupportChat.entryPointTapped(
             entryPoint: entryPoint,
@@ -435,6 +438,11 @@ final class SupportChatViewModel {
                     await UIApplication.shared.open(selectedURL)
                 }
                 replaceActionWithRetry()
+
+            case .openPushNotificationPreferences:
+                onOpenPushNotificationPreferences { [weak self] in
+                    self?.replaceActionWithRetry()
+                }
 
             case .retryDiagnostics:
                 await rerunAllTests()

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -176,6 +176,10 @@ final class SupportChatViewModel {
     private(set) var hasProceededToChat: Bool = false
     private(set) var isExecutingAction: Bool = false
 
+    var site: Site? {
+        stores.sessionManager.defaultSite
+    }
+
     /// `true` when the view model was seeded with a prior `chatID` — i.e. the merchant
     /// tapped a history row rather than starting fresh. Drives the "Continuing conversation"
     /// header in the chat surface.

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -265,6 +265,7 @@ final class SupportChatViewModel {
     private var didTrackBotEscalationButtonShown = false
     private var didTrackErrorEscalationButtonShown = false
     var onStartJetpackSetup: () -> Void
+    var onUpdateWooCommercePlugin: (@escaping () -> Void) -> Void
     private let diagnosticsService: SupportDiagnosticsServicing
 
     /// Pre-fetched system status report, if available (e.g., from connectivity tool).
@@ -285,7 +286,8 @@ final class SupportChatViewModel {
          isChatResolved: Bool = false,
          systemStatusReport: String? = nil,
          onContactHumanSupport: @escaping (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?, _ entryPoint: EntryPoint) -> Void,
-         onStartJetpackSetup: @escaping () -> Void = {}) {
+         onStartJetpackSetup: @escaping () -> Void = {},
+         onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }) {
         self.botSlug = botSlug
         self.entryPoint = entryPoint
         self.stores = stores
@@ -300,6 +302,7 @@ final class SupportChatViewModel {
         self.prefetchedSystemStatusReport = systemStatusReport
         self.onContactHumanSupport = onContactHumanSupport
         self.onStartJetpackSetup = onStartJetpackSetup
+        self.onUpdateWooCommercePlugin = onUpdateWooCommercePlugin
 
         analytics.track(event: WooAnalyticsEvent.SupportChat.entryPointTapped(
             entryPoint: entryPoint,
@@ -420,6 +423,11 @@ final class SupportChatViewModel {
 
             case .setupJetpack:
                 onStartJetpackSetup()
+
+            case .updateWooCommercePlugin:
+                onUpdateWooCommercePlugin { [weak self] in
+                    self?.replaceActionWithRetry()
+                }
 
             case .openNotificationSettings:
                 if let selectedURL = diagnosticsService.openNotificationSettings(),

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -73,6 +73,7 @@ final class SupportDiagnosticsService {
         case setupJetpack
         case updateWooCommercePlugin
         case openNotificationSettings
+        case openPushNotificationPreferences
         case retryDiagnostics
 
         var title: String {
@@ -89,6 +90,8 @@ final class SupportDiagnosticsService {
                 return Localization.Action.updateWooCommercePlugin
             case .openNotificationSettings:
                 return Localization.Action.openSettings
+            case .openPushNotificationPreferences:
+                return Localization.Action.openPushNotificationPreferences
             case .retryDiagnostics:
                 return Localization.Action.retryDiagnostics
             }
@@ -102,7 +105,7 @@ final class SupportDiagnosticsService {
                 return "bolt.fill"
             case .updateWooCommercePlugin:
                 return "arrow.up.circle"
-            case .openNotificationSettings:
+            case .openNotificationSettings, .openPushNotificationPreferences:
                 return "gear"
             case .retryDiagnostics:
                 return "arrow.clockwise"
@@ -410,6 +413,9 @@ final class SupportDiagnosticsService {
         // Sub-check 3: Self-driven push notifications
         if pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) {
             DDLogInfo("SupportDiagnostics: ✅ Site registered for self-driven push notifications")
+            if let failure = await checkPushNotificationPreferences() {
+                return failure
+            }
             return nil
         } else {
             do {
@@ -436,6 +442,29 @@ final class SupportDiagnosticsService {
                 return Failure(errorMessage: Localization.Error.deviceNotRegistered,
                                suggestedAction: .registerDevice)
             }
+        }
+    }
+
+    private func checkPushNotificationPreferences() async -> Failure? {
+        do {
+            let preferences = try await loadPushNotificationPreferences()
+            if preferences.hasDisabledNotifications {
+                DDLogInfo("SupportDiagnostics: ⚠️ Some push notification preferences are disabled")
+                return Failure(errorMessage: Localization.Error.pushNotificationPreferencesDisabled,
+                               suggestedAction: .openPushNotificationPreferences)
+            }
+        } catch {
+            DDLogError("SupportDiagnostics: ❌ Failed to load push notification preferences\n\(error)")
+        }
+        return nil
+    }
+
+    private func loadPushNotificationPreferences() async throws -> PushNotificationPreferences {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = NotificationAction.loadPushNotificationPreferences(siteID: siteID) { result in
+                continuation.resume(with: result)
+            }
+            stores.dispatch(action)
         }
     }
 
@@ -688,6 +717,11 @@ private extension SupportDiagnosticsService {
                 value: "Open Settings",
                 comment: "Action button to open device notification settings"
             )
+            static let openPushNotificationPreferences = NSLocalizedString(
+                "supportDiagnosticsService.action.openPushNotificationPreferences",
+                value: "Notification Preferences",
+                comment: "Action button to open the store push notification preferences screen"
+            )
             static let retryDiagnostics = NSLocalizedString(
                 "supportDiagnosticsService.action.retryDiagnostics",
                 value: "Retry",
@@ -774,11 +808,25 @@ private extension SupportDiagnosticsService {
                 "Enable them to receive alerts when new orders come in.",
                 comment: "Message when order notifications are disabled"
             )
+            static let pushNotificationPreferencesDisabled = NSLocalizedString(
+                "supportDiagnosticsService.error.pushNotificationPreferencesDisabled",
+                value: "Some push notification preferences are disabled for this store.\n\n" +
+                "Open your preferences to choose which notifications you want to receive.",
+                comment: "Message when some store push notification preferences are disabled"
+            )
             static let notificationConfigCheckFailed = NSLocalizedString(
                 "supportDiagnosticsService.error.notificationConfigCheckFailed",
                 value: "We couldn't check your notification settings.",
                 comment: "Message when the notification config check fails"
             )
         }
+    }
+}
+
+private extension PushNotificationPreferences {
+    var hasDisabledNotifications: Bool {
+        storeOrder?.enabled == false ||
+        storeReview?.enabled == false ||
+        storeStock?.enabled == false
     }
 }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -71,6 +71,7 @@ final class SupportDiagnosticsService {
         case registerDevice
         case enableOrderNotifications(settings: NotificationSettings)
         case setupJetpack
+        case updateWooCommercePlugin
         case openNotificationSettings
         case retryDiagnostics
 
@@ -84,6 +85,8 @@ final class SupportDiagnosticsService {
                 return Localization.Action.enableOrderNotifications
             case .setupJetpack:
                 return Localization.Action.setupJetpack
+            case .updateWooCommercePlugin:
+                return Localization.Action.updateWooCommercePlugin
             case .openNotificationSettings:
                 return Localization.Action.openSettings
             case .retryDiagnostics:
@@ -97,6 +100,8 @@ final class SupportDiagnosticsService {
                 return "checkmark.circle"
             case .setupJetpack:
                 return "bolt.fill"
+            case .updateWooCommercePlugin:
+                return "arrow.up.circle"
             case .openNotificationSettings:
                 return "gear"
             case .retryDiagnostics:
@@ -170,6 +175,8 @@ final class SupportDiagnosticsService {
     private let systemStatusRemote: SystemStatusRemote
     private let ordersRemote: OrdersRemote
     private let productsRemote: ProductsRemote
+    private let pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking
+    private let pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol
 
     /// Active plugins from site status, cached after site test.
     ///
@@ -190,6 +197,8 @@ final class SupportDiagnosticsService {
          connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
          userNotificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
+         pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking = WooPushNotificationEligibilityCheck(),
+         pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol = PluginVersionCheckerFactory(),
          network: Network? = nil) {
         let network = network ?? AlamofireNetwork(credentials: session.defaultCredentials,
                                                    selectedSite: nil,
@@ -203,6 +212,8 @@ final class SupportDiagnosticsService {
         self.connectivityObserver = connectivityObserver
         self.userNotificationCenter = userNotificationCenter
         self.pushNotesManager = pushNotesManager
+        self.pushNotificationEligibilityChecker = pushNotificationEligibilityChecker
+        self.pluginVersionCheckerFactory = pluginVersionCheckerFactory
         self.siteID = session.defaultStoreID ?? .zero
         self.siteURL = session.defaultSite?.url
     }
@@ -352,13 +363,7 @@ final class SupportDiagnosticsService {
     }
 
     private func checkNotifications() async -> Failure? {
-        // Sub-check 1: Jetpack plugin is active
-        if !isJetpackPluginActive {
-            DDLogError("SupportDiagnostics: ❌ Jetpack not active")
-            return Failure(errorMessage: Localization.Error.jetpackNotActive, suggestedAction: .setupJetpack)
-        }
-
-        // Sub-check 2: iOS notification permission
+        // Sub-check 1: iOS notification permission
         let permissionResult = await checkNotificationPermission()
         if case .failure = permissionResult {
             DDLogInfo("SupportDiagnostics: ⚠️ Notifications not authorized")
@@ -366,31 +371,79 @@ final class SupportDiagnosticsService {
                            suggestedAction: .openNotificationSettings)
         }
 
+        let isEligibleForWooDrivenPushNotifications = await pushNotificationEligibilityChecker.checkEligibility()
+
+        // Sub-check 2: if not eligible for Woo-driven PN
+        if !isEligibleForWooDrivenPushNotifications {
+            // Subcheck 2.1: does device have Jetpack?
+            if !isJetpackPluginActive {
+                DDLogError("SupportDiagnostics: ❌ Jetpack not active")
+                return Failure(errorMessage: Localization.Error.jetpackNotActive, suggestedAction: .setupJetpack)
+            } else if pushNotesManager.deviceID == nil { // Subcheck 2.2: registered with WPCom?
+                DDLogError("SupportDiagnostics: ❌ device is not registered")
+                return Failure(errorMessage: Localization.Error.deviceNotRegistered,
+                               suggestedAction: .registerDevice)
+            } else {
+                // Sub-check 2.3: WPCom notification config
+                let configResult = await checkNotificationConfig()
+                switch configResult {
+                case .success:
+                    DDLogInfo("SupportDiagnostics: ✅ Notification settings configured")
+                    return nil
+                case .failure(let configError):
+                    DDLogInfo("SupportDiagnostics: ⚠️ Notification config issue: \(configError)")
+                    switch configError {
+                    case .deviceNotRegistered:
+                        return Failure(errorMessage: Localization.Error.deviceNotRegistered,
+                                       suggestedAction: .registerDevice)
+                    case .orderNotificationsDisabled(let settings):
+                        return Failure(errorMessage: Localization.Error.orderNotificationsDisabled,
+                                       suggestedAction: .enableOrderNotifications(settings: settings))
+                    case .requestFailed(let error):
+                        return Failure(errorMessage: Localization.Error.notificationConfigCheckFailed,
+                                       technicalDetails: error.formattedTechnicalDetails)
+                    }
+                }
+            }
+        }
+
         // Sub-check 3: Self-driven push notifications
         if pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID) {
             DDLogInfo("SupportDiagnostics: ✅ Site registered for self-driven push notifications")
             return nil
-        }
-
-        // Sub-check 4: WPCom notification config
-        let configResult = await checkNotificationConfig()
-        switch configResult {
-        case .success:
-            DDLogInfo("SupportDiagnostics: ✅ Notification settings configured")
-            return nil
-        case .failure(let configError):
-            DDLogInfo("SupportDiagnostics: ⚠️ Notification config issue: \(configError)")
-            switch configError {
-            case .deviceNotRegistered:
+        } else {
+            do {
+                let minimumVersion = WooPluginRequirements.minimumVersion
+                let pluginVersionChecker = pluginVersionCheckerFactory.makeChecker(
+                    siteID: siteID,
+                    pluginPath: WooPluginRequirements.pluginPath,
+                    minimumVersion: minimumVersion
+                )
+                let result = try await pluginVersionChecker.checkCompatibility()
+                if case .incompatible(let currentVersion, _) = result {
+                    DDLogError("SupportDiagnostics: ❌ Unable to register self-driven push token: " +
+                               "WooCommerce plugin version \(currentVersion) is below required \(minimumVersion)")
+                    return notificationFailure(
+                        for: .wooCommercePluginUpdateRequired(currentVersion: currentVersion, requiredVersion: minimumVersion)
+                    )
+                } else {
+                    DDLogError("SupportDiagnostics: ❌ device is not registered")
+                    return Failure(errorMessage: Localization.Error.deviceNotRegistered,
+                                   suggestedAction: .registerDevice)
+                }
+            } catch {
+                DDLogError("SupportDiagnostics: ❌ device is not registered")
                 return Failure(errorMessage: Localization.Error.deviceNotRegistered,
                                suggestedAction: .registerDevice)
-            case .orderNotificationsDisabled(let settings):
-                return Failure(errorMessage: Localization.Error.orderNotificationsDisabled,
-                               suggestedAction: .enableOrderNotifications(settings: settings))
-            case .requestFailed(let error):
-                return Failure(errorMessage: Localization.Error.notificationConfigCheckFailed,
-                               technicalDetails: error.formattedTechnicalDetails)
             }
+        }
+    }
+
+    private func notificationFailure(for error: NotificationRegistrationError) -> Failure {
+        switch error {
+        case .wooCommercePluginUpdateRequired(_, let requiredVersion):
+            return Failure(errorMessage: Localization.Error.wooCommercePluginUpdateRequired(requiredVersion: requiredVersion),
+                           suggestedAction: .updateWooCommercePlugin)
         }
     }
 
@@ -540,6 +593,10 @@ final class SupportDiagnosticsService {
         case orderNotificationsDisabled(settings: NotificationSettings)
         case requestFailed(Error)
     }
+
+    enum NotificationRegistrationError: Error, Equatable {
+        case wooCommercePluginUpdateRequired(currentVersion: String, requiredVersion: String)
+    }
 }
 
 extension SupportDiagnosticsService: SupportDiagnosticsServicing {}
@@ -621,6 +678,11 @@ private extension SupportDiagnosticsService {
                 value: "Setup Jetpack",
                 comment: "Action button to start the Jetpack setup flow"
             )
+            static let updateWooCommercePlugin = NSLocalizedString(
+                "supportDiagnosticsService.action.updateWooCommercePlugin",
+                value: "Update WooCommerce",
+                comment: "Action button to update the WooCommerce plugin"
+            )
             static let openSettings = NSLocalizedString(
                 "supportDiagnosticsService.action.openSettings",
                 value: "Open Settings",
@@ -696,6 +758,16 @@ private extension SupportDiagnosticsService {
                 value: "Your device doesn't appear to be registered for push notifications.",
                 comment: "Message when the device is not registered for push notifications"
             )
+            static func wooCommercePluginUpdateRequired(requiredVersion: String) -> String {
+                let format = NSLocalizedString(
+                    "supportDiagnosticsService.error.wooCommercePluginUpdateRequired",
+                    value: "Your WooCommerce plugin needs to be updated to enable push notifications.\n\n" +
+                    "Update WooCommerce to version %1$@ or newer, then try registering again.",
+                    comment: "Message when WooCommerce plugin must be updated for push notifications. " +
+                    "%1$@ is the required WooCommerce plugin version."
+                )
+                return String.localizedStringWithFormat(format, requiredVersion)
+            }
             static let orderNotificationsDisabled = NSLocalizedString(
                 "supportDiagnosticsService.error.orderNotificationsDisabled",
                 value: "Order notifications are not enabled for this store.\n\n" +

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportIssueType.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportIssueType.swift
@@ -15,13 +15,13 @@ enum SupportIssueType: String, CaseIterable {
     var testsToRun: [SupportDiagnosticsService.Test]? {
         switch self {
         case .loadingOrders:
-            return [.internetConnection, .wpComServers, .site, .siteOrders]
+            return [.internetConnection, .site, .siteOrders]
         case .loadingProducts:
-            return [.internetConnection, .wpComServers, .site, .loadingProducts]
+            return [.internetConnection, .site, .loadingProducts]
         case .loadingAnalytics:
-            return [.internetConnection, .wpComServers, .site, .analyticsSetting]
+            return [.internetConnection, .site, .analyticsSetting]
         case .receivingNotifications:
-            return [.internetConnection, .wpComServers, .site, .notifications]
+            return [.internetConnection, .site, .notifications]
         case .other:
             return nil
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -582,6 +582,39 @@ struct SupportChatViewModelTests {
         #expect(result.suggestedAction == .retryDiagnostics)
     }
 
+    @Test func executeAction_openPushNotificationPreferences_calls_handler_and_replaces_action_with_retry() async {
+        // Given
+        let diagnosticsService = MockSupportDiagnosticsService { tests in
+            tests.map { test in
+                .failure(
+                    test: test,
+                    failure: .init(errorMessage: "Preferences disabled", suggestedAction: .openPushNotificationPreferences)
+                )
+            }
+        }
+        var handlerCalled = false
+        let sut = makeSUT(
+            diagnosticsService: diagnosticsService,
+            onOpenPushNotificationPreferences: { onDismissed in
+                handlerCalled = true
+                onDismissed()
+            }
+        )
+        await sut.selectIssue(.receivingNotifications)
+
+        // When
+        await sut.executeAction(.openPushNotificationPreferences)
+
+        // Then
+        #expect(handlerCalled == true)
+        #expect(sut.isExecutingAction == false)
+        guard case .diagnosticsFailure(let result) = sut.messages.last?.content else {
+            Issue.record("Expected diagnostics failure message after open preferences action")
+            return
+        }
+        #expect(result.suggestedAction == .retryDiagnostics)
+    }
+
     // MARK: - Resume Chat Tests
 
     @Test(.timeLimit(.minutes(1)))
@@ -1927,7 +1960,8 @@ struct SupportChatViewModelTests {
         diagnosticsService: SupportDiagnosticsServicing? = nil,
         analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider(),
         onStartJetpackSetup: @escaping () -> Void = {},
-        onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }
+        onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() },
+        onOpenPushNotificationPreferences: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }
     ) -> SupportChatViewModel {
         let stores = stores ?? MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         let viewModel = SupportChatViewModel(
@@ -1936,7 +1970,8 @@ struct SupportChatViewModelTests {
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
             diagnosticsService: diagnosticsService,
             onContactHumanSupport: { _, _, _, _ in },
-            onUpdateWooCommercePlugin: onUpdateWooCommercePlugin
+            onUpdateWooCommercePlugin: onUpdateWooCommercePlugin,
+            onOpenPushNotificationPreferences: onOpenPushNotificationPreferences
         )
         viewModel.onStartJetpackSetup = onStartJetpackSetup
         return viewModel

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -549,6 +549,39 @@ struct SupportChatViewModelTests {
         #expect(sut.isExecutingAction == false)
     }
 
+    @Test func executeAction_updateWooCommercePlugin_calls_handler_and_replaces_action_with_retry() async {
+        // Given
+        let diagnosticsService = MockSupportDiagnosticsService { tests in
+            tests.map { test in
+                .failure(
+                    test: test,
+                    failure: .init(errorMessage: "Update required", suggestedAction: .updateWooCommercePlugin)
+                )
+            }
+        }
+        var handlerCalled = false
+        let sut = makeSUT(
+            diagnosticsService: diagnosticsService,
+            onUpdateWooCommercePlugin: { onDismissed in
+                handlerCalled = true
+                onDismissed()
+            }
+        )
+        await sut.selectIssue(.receivingNotifications)
+
+        // When
+        await sut.executeAction(.updateWooCommercePlugin)
+
+        // Then
+        #expect(handlerCalled == true)
+        #expect(sut.isExecutingAction == false)
+        guard case .diagnosticsFailure(let result) = sut.messages.last?.content else {
+            Issue.record("Expected diagnostics failure message after update plugin action")
+            return
+        }
+        #expect(result.suggestedAction == .retryDiagnostics)
+    }
+
     // MARK: - Resume Chat Tests
 
     @Test(.timeLimit(.minutes(1)))
@@ -1893,7 +1926,8 @@ struct SupportChatViewModelTests {
         stores: StoresManager? = nil,
         diagnosticsService: SupportDiagnosticsServicing? = nil,
         analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider(),
-        onStartJetpackSetup: @escaping () -> Void = {}
+        onStartJetpackSetup: @escaping () -> Void = {},
+        onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }
     ) -> SupportChatViewModel {
         let stores = stores ?? MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         let viewModel = SupportChatViewModel(
@@ -1901,7 +1935,8 @@ struct SupportChatViewModelTests {
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
             diagnosticsService: diagnosticsService,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _ in },
+            onUpdateWooCommercePlugin: onUpdateWooCommercePlugin
         )
         viewModel.onStartJetpackSetup = onStartJetpackSetup
         return viewModel

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -181,7 +181,9 @@ struct SupportDiagnosticsServiceTests {
 
     @Test func test_testNotifications_when_jetpack_not_active_then_returns_failure_with_setupJetpack_action() async {
         // Given
-        let sut = makeSUT()
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let sut = makeSUT(userNotificationCenter: mockUserNotificationCenter)
         // activeSystemPlugins is empty by default, so Jetpack is not active
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -22,7 +22,7 @@ struct SupportDiagnosticsServiceTests {
         let tests = issueType.testsToRun
 
         // Then
-        let expected: [Test] = [.internetConnection, .wpComServers, .site, .siteOrders]
+        let expected: [Test] = [.internetConnection, .site, .siteOrders]
         #expect(tests == expected)
     }
 
@@ -34,7 +34,7 @@ struct SupportDiagnosticsServiceTests {
         let tests = issueType.testsToRun
 
         // Then
-        let expected: [Test] = [.internetConnection, .wpComServers, .site, .loadingProducts]
+        let expected: [Test] = [.internetConnection, .site, .loadingProducts]
         #expect(tests == expected)
     }
 
@@ -46,7 +46,7 @@ struct SupportDiagnosticsServiceTests {
         let tests = issueType.testsToRun
 
         // Then
-        let expected: [Test] = [.internetConnection, .wpComServers, .site, .analyticsSetting]
+        let expected: [Test] = [.internetConnection, .site, .analyticsSetting]
         #expect(tests == expected)
     }
 
@@ -58,7 +58,7 @@ struct SupportDiagnosticsServiceTests {
         let tests = issueType.testsToRun
 
         // Then
-        let expected: [Test] = [.internetConnection, .wpComServers, .site, .notifications]
+        let expected: [Test] = [.internetConnection, .site, .notifications]
         #expect(tests == expected)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -212,6 +212,12 @@ struct SupportDiagnosticsServiceTests {
 
     @Test func test_testNotifications_when_registered_for_self_driven_PN_then_returns_success() async {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(Self.enabledPushNotificationPreferences()))
+            }
+        }
         let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
         mockUserNotificationCenter.authorizationStatus = .authorized
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123])
@@ -219,6 +225,7 @@ struct SupportDiagnosticsServiceTests {
         eligibilityChecker.isEligible = true
         let network = makeNetworkWithJetpackActive()
         let sut = makeSUT(
+            stores: stores,
             userNotificationCenter: mockUserNotificationCenter,
             pushNotesManager: mockPushNotesManager,
             pushNotificationEligibilityChecker: eligibilityChecker,
@@ -232,6 +239,71 @@ struct SupportDiagnosticsServiceTests {
         // Then
         #expect(results.count == 2)
         #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == true)
+    }
+
+    @Test func test_testNotifications_when_registered_for_self_driven_PN_and_some_preferences_disabled_then_returns_failure_with_openPreferences_action() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeOrder: .init(enabled: false),
+                                                                  storeReview: .init(enabled: true),
+                                                                  storeStock: .init(enabled: true))))
+            }
+        }
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let network = makeNetworkWithJetpackActive()
+        let sut = makeSUT(
+            stores: stores,
+            userNotificationCenter: mockUserNotificationCenter,
+            pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
+            network: network,
+            siteID: 123
+        )
+
+        // When
+        let results = await sut.runTests([Test.site, Test.notifications])
+
+        // Then
+        #expect(results.count == 2)
+        #expect(results[1].isSuccess == false)
+        #expect(results[1].suggestedAction == Action.openPushNotificationPreferences)
+    }
+
+    @Test func test_testNotifications_when_registered_for_self_driven_PN_and_preferences_fetch_fails_then_returns_success() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.failure(NSError(domain: "Test", code: 500)))
+            }
+        }
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let network = makeNetworkWithJetpackActive()
+        let sut = makeSUT(
+            stores: stores,
+            userNotificationCenter: mockUserNotificationCenter,
+            pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
+            network: network,
+            siteID: 123
+        )
+
+        // When
+        let results = await sut.runTests([Test.site, Test.notifications])
+
+        // Then
+        #expect(results.count == 2)
         #expect(results[1].isSuccess == true)
     }
 
@@ -461,6 +533,12 @@ struct SupportDiagnosticsServiceTests {
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "system_status", filename: "system-status-with-jetpack-active")
         return network
+    }
+
+    private static func enabledPushNotificationPreferences() -> PushNotificationPreferences {
+        PushNotificationPreferences(storeOrder: .init(enabled: true),
+                                    storeReview: .init(enabled: true),
+                                    storeStock: .init(enabled: true))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -215,10 +215,13 @@ struct SupportDiagnosticsServiceTests {
         let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
         mockUserNotificationCenter.authorizationStatus = .authorized
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
         let network = makeNetworkWithJetpackActive()
         let sut = makeSUT(
             userNotificationCenter: mockUserNotificationCenter,
             pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
             network: network,
             siteID: 123
         )
@@ -232,15 +235,18 @@ struct SupportDiagnosticsServiceTests {
         #expect(results[1].isSuccess == true)
     }
 
-    @Test func test_testNotifications_when_device_not_registered_then_returns_failure_with_registerDevice_action() async {
+    @Test func test_testNotifications_when_not_eligible_for_self_driven_PN_and_device_not_registered_then_returns_failure_with_registerDevice_action() async {
         // Given
         let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
         mockUserNotificationCenter.authorizationStatus = .authorized
         let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: nil)
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = false
         let network = makeNetworkWithJetpackActive()
         let sut = makeSUT(
             userNotificationCenter: mockUserNotificationCenter,
             pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
             network: network
         )
 
@@ -252,6 +258,61 @@ struct SupportDiagnosticsServiceTests {
         #expect(results[0].isSuccess == true)
         #expect(results[1].isSuccess == false)
         #expect(results[1].suggestedAction == Action.registerDevice)
+    }
+
+    @Test func test_testNotifications_when_eligible_for_self_driven_PN_and_site_not_registered_then_returns_failure_with_registerDevice_action() async {
+        // Given
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let network = makeNetworkWithJetpackActive()
+        let sut = makeSUT(
+            userNotificationCenter: mockUserNotificationCenter,
+            pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
+            network: network
+        )
+
+        // When
+        let results = await sut.runTests([Test.site, Test.notifications])
+
+        // Then
+        #expect(results.count == 2)
+        #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == false)
+        #expect(results[1].suggestedAction == Action.registerDevice)
+    }
+
+    @Test func test_testNotifications_when_eligible_for_self_driven_PN_and_plugin_is_outdated_then_returns_failure_with_updatePlugin_action() async {
+        // Given
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let pluginVersionChecker = MockPluginVersionChecker()
+        pluginVersionChecker.result = .success(.incompatible(currentVersion: "10.0.0", requiredVersion: WooPluginRequirements.minimumVersion))
+        let pluginVersionCheckerFactory = MockPluginVersionCheckerFactory(checker: pluginVersionChecker)
+        let network = makeNetworkWithJetpackActive()
+        let sut = makeSUT(
+            userNotificationCenter: mockUserNotificationCenter,
+            pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
+            pluginVersionCheckerFactory: pluginVersionCheckerFactory,
+            network: network
+        )
+
+        // When
+        let results = await sut.runTests([Test.site, Test.notifications])
+
+        // Then
+        #expect(results.count == 2)
+        #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == false)
+        #expect(results[1].suggestedAction == Action.updateWooCommercePlugin)
+        #expect(results[1].errorMessage?.contains(WooPluginRequirements.minimumVersion) == true)
     }
 
     // MARK: - Sequential Test Execution
@@ -377,6 +438,8 @@ struct SupportDiagnosticsServiceTests {
         connectivityObserver: ConnectivityObserver? = nil,
         userNotificationCenter: UserNotificationsCenterAdapter? = nil,
         pushNotesManager: PushNotesManager? = nil,
+        pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking? = nil,
+        pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol? = nil,
         network: MockNetwork? = nil,
         siteID: Int64 = 123
     ) -> SupportDiagnosticsService {
@@ -388,6 +451,8 @@ struct SupportDiagnosticsServiceTests {
             connectivityObserver: connectivityObserver ?? MockConnectivityObserver(),
             userNotificationCenter: userNotificationCenter ?? MockUserNotificationsCenterAdapter(),
             pushNotesManager: pushNotesManager ?? MockPushNotificationsManager(),
+            pushNotificationEligibilityChecker: pushNotificationEligibilityChecker ?? MockWooPushNotificationEligibilityChecker(),
+            pluginVersionCheckerFactory: pluginVersionCheckerFactory ?? MockPluginVersionCheckerFactory(),
             network: network
         )
     }
@@ -396,5 +461,17 @@ struct SupportDiagnosticsServiceTests {
         let network = MockNetwork()
         network.simulateResponse(requestUrlSuffix: "system_status", filename: "system-status-with-jetpack-active")
         return network
+    }
+}
+
+private final class MockPluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol {
+    private let checker: MockPluginVersionChecker
+
+    init(checker: MockPluginVersionChecker = MockPluginVersionChecker()) {
+        self.checker = checker
+    }
+
+    func makeChecker(siteID: Int64, pluginPath: String, minimumVersion: String) -> PluginVersionCheckerProtocol {
+        checker
     }
 }


### PR DESCRIPTION
## Description
Updates support chat diagnostics for push notification issues:

- removes the WordPress.com server check from support issue diagnostic flows.
- updates push notification diagnostics to account for Woo-driven push eligibility.
- surfaces actionable failures for outdated WooCommerce plugin versions, missing registration, and disabled push notification preferences.
- enables support chat actions even when there are other suggested actions to avoid blocking users.

Also, the diagnostic check for PN is hidden from the connectivity tool to be updated later.

## Test Steps
1. Log in with site credentials to a self-hosted site supporting Woo-driven PN and no Jetpack.
2. Open Support Chat from Help & Support.
3. Select "Receiving push notifications".
4. Confirm the diagnostics flow does not show a WordPress.com server check.
5. Confirm the flow does not fail with missing Jetpack
6. For a self-driven push site with disabled notification preferences, confirm the failure offers "Notification Preferences" and also allows continuing to chat.
7. For a self-driven push site with an outdated WooCommerce plugin, confirm the failure offers "Update WooCommerce".
8. Navigate to Menu > Settings > Troubleshoot Connection and confirm that the push notification check is no longer available.


## Screenshots

<img width="320" alt="IMG_1006" src="https://github.com/user-attachments/assets/052f920e-13b8-4220-8cbe-bd99d6446db3" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.