### PR TITLE
Add Stock notification preferences detail screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Detail screen for the Stock push notification preferences. Reached by
+/// tapping the Stock row in `PushNotificationPreferencesView`. Navigation
+/// chrome (title, Save bar button, discard confirmation) lives on the wrapping
+/// `NewStockNotificationPreferencesHostingController`.
+///
+struct NewStockNotificationPreferencesDetailView: View {
+
+    @Bindable private var viewModel: PushNotificationPreferencesViewModel
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        List {
+            masterToggleSection
+            customizationSection
+        }
+        .listStyle(.insetGrouped)
+        .background(Color(.listBackground))
+        .disabled(viewModel.isSaving)
+        .navigationTitle(Localization.title)
+        .navigationBarTitleDisplayMode(.inline)
+        // `leftBarButtonItem` set in UIKit doesn't suppress SwiftUI's own back
+        // button, so without this both render side-by-side and only the UIKit
+        // one routes through the discard handler.
+        .navigationBarBackButtonHidden(true)
+        .notice($viewModel.errorNotice)
+    }
+
+    private var masterToggleSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+                Toggle(Localization.enableTitle,
+                       isOn: Binding(get: { viewModel.isStoreStockEnabled },
+                                     set: { viewModel.setStoreStockEnabled($0) }))
+                Text(Localization.enableSubtitle)
+                    .foregroundStyle(Color(.secondaryLabel))
+                    .captionStyle()
+            }
+        }
+    }
+
+    private var customizationSection: some View {
+        Section {
+            toggleRow(title: Localization.lowStockTitle,
+                      subtitle: Localization.lowStockSubtitle,
+                      isOn: Binding(get: { viewModel.isStoreStockLowStock },
+                                    set: { viewModel.setStoreStockLowStock($0) }))
+            toggleRow(title: Localization.outOfStockTitle,
+                      subtitle: Localization.outOfStockSubtitle,
+                      isOn: Binding(get: { viewModel.isStoreStockOutOfStock },
+                                    set: { viewModel.setStoreStockOutOfStock($0) }))
+            toggleRow(title: Localization.onBackorderTitle,
+                      subtitle: Localization.onBackorderSubtitle,
+                      isOn: Binding(get: { viewModel.isStoreStockOnBackorder },
+                                    set: { viewModel.setStoreStockOnBackorder($0) }))
+        } header: {
+            Text(Localization.customizeHeader)
+        }
+        .disabled(!viewModel.isStoreStockEnabled)
+        .opacity(viewModel.isStoreStockEnabled ? 1.0 : Layout.disabledOpacity)
+    }
+
+    private func toggleRow(title: String,
+                           subtitle: String,
+                           isOn: Binding<Bool>) -> some View {
+        VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+            Toggle(title, isOn: isOn)
+            Text(subtitle)
+                .foregroundStyle(Color(.secondaryLabel))
+                .captionStyle()
+        }
+    }
+}
+
+private extension NewStockNotificationPreferencesDetailView {
+    enum Layout {
+        static let titleDetailSpacing: CGFloat = 4
+        static let disabledOpacity: Double = 0.5
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.title",
+            value: "Stock",
+            comment: "Title of the stock push notification preferences detail screen."
+        )
+        static let enableTitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.enable.title",
+            value: "Enable stock notifications",
+            comment: "Title of the master toggle for stock push notifications."
+        )
+        static let enableSubtitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.enable.subtitle",
+            value: "Get notified when product stock changes need your attention.",
+            comment: "Subtitle of the master toggle for stock push notifications."
+        )
+        static let customizeHeader = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.notifyMeFor.header",
+            value: "Notify me for",
+            comment: "Section header for stock notification customization options."
+        )
+        static let lowStockTitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.title",
+            value: "Low stock",
+            comment: "Title of the toggle row that enables notifications when a product crosses the low-stock threshold."
+        )
+        static let lowStockSubtitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.subtitle",
+            value: "When a product variant reaches its low stock threshold.",
+            comment: "Subtitle of the low-stock toggle row."
+        )
+        static let outOfStockTitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.outOfStock.title",
+            value: "Out of stock",
+            comment: "Title of the toggle row that enables notifications when a product reaches the no-stock amount."
+        )
+        static let outOfStockSubtitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.outOfStock.subtitle",
+            value: "When a product variant hits zero.",
+            comment: "Subtitle of the out-of-stock toggle row."
+        )
+        static let onBackorderTitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.onBackorder.title",
+            value: "On backorder",
+            comment: "Title of the toggle row that enables notifications when a product is backordered."
+        )
+        static let onBackorderSubtitle = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.onBackorder.subtitle",
+            value: "When a customer orders an item that's currently out of stock.",
+            comment: "Subtitle of the on-backorder toggle row."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesHostingController.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// Hosts `NewStockNotificationPreferencesDetailView`. Navigation chrome
+/// (Save, back button, discard alert, saving spinner) is inherited from
+/// `NotificationDetailHostingController`.
+///
+final class NewStockNotificationPreferencesHostingController:
+    NotificationDetailHostingController<NewStockNotificationPreferencesDetailView> {
+
+    init(viewModel: PushNotificationPreferencesViewModel) {
+        super.init(viewModel: viewModel,
+                   rootView: NewStockNotificationPreferencesDetailView(viewModel: viewModel),
+                   onDiscard: { [weak viewModel] in viewModel?.discardStoreStockEdits() })
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -15,6 +15,9 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
         rootView.onNewReviewTapped = { [weak self] in
             self?.showNewReviewDetail()
         }
+        rootView.onNewStockTapped = { [weak self] in
+            self?.showNewStockDetail()
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -28,6 +31,11 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
 
     private func showNewReviewDetail() {
         let detail = NewReviewNotificationPreferencesHostingController(viewModel: viewModel)
+        navigationController?.pushViewController(detail, animated: true)
+    }
+
+    private func showNewStockDetail() {
+        let detail = NewStockNotificationPreferencesHostingController(viewModel: viewModel)
         navigationController?.pushViewController(detail, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -13,6 +13,9 @@ struct PushNotificationPreferencesView: View {
     /// Set by the hosting controller after `super.init`. Default is a no-op so
     /// previews work without it.
     var onNewReviewTapped: () -> Void = {}
+    /// Set by the hosting controller after `super.init`. Default is a no-op so
+    /// previews work without it.
+    var onNewStockTapped: () -> Void = {}
 
     init(viewModel: PushNotificationPreferencesViewModel) {
         self.viewModel = viewModel
@@ -66,7 +69,9 @@ struct PushNotificationPreferencesView: View {
                     accessibilityHint: Localization.newReviewsAccessibilityHint,
                     action: onNewReviewTapped)
                 row(title: Localization.stockTitle,
-                    detail: viewModel.isStoreStockEnabled ? Localization.stockDetail : Localization.off)
+                    detail: viewModel.isStoreStockEnabled ? Localization.stockDetail : Localization.off,
+                    accessibilityHint: Localization.stockAccessibilityHint,
+                    action: onNewStockTapped)
             }
         }
         .listStyle(.insetGrouped)
@@ -153,6 +158,11 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.stock.title",
             value: "Stock",
             comment: "Title of the row that toggles stock push notifications."
+        )
+        static let stockAccessibilityHint = NSLocalizedString(
+            "pushNotificationPreferencesView.stock.accessibilityHint",
+            value: "Customize stock notifications",
+            comment: "VoiceOver hint announced when focused on the Stock row, describing that it opens a detail screen."
         )
         static let stockDetail = NSLocalizedString(
             "pushNotificationPreferencesView.stock.detail",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -69,7 +69,7 @@ struct PushNotificationPreferencesView: View {
                     accessibilityHint: Localization.newReviewsAccessibilityHint,
                     action: onNewReviewTapped)
                 row(title: Localization.stockTitle,
-                    detail: viewModel.isStoreStockEnabled ? Localization.stockDetail : Localization.off,
+                    detail: viewModel.isStoreStockEnabled ? viewModel.storeStockDetailText : Localization.off,
                     accessibilityHint: Localization.stockAccessibilityHint,
                     action: onNewStockTapped)
             }
@@ -163,11 +163,6 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.stock.accessibilityHint",
             value: "Customize stock notifications",
             comment: "VoiceOver hint announced when focused on the Stock row, describing that it opens a detail screen."
-        )
-        static let stockDetail = NSLocalizedString(
-            "pushNotificationPreferencesView.stock.detail",
-            value: "All stock alerts",
-            comment: "Detail text for the row that toggles stock push notifications."
         )
         static let off = NSLocalizedString(
             "pushNotificationPreferencesView.off",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -30,6 +30,9 @@ final class PushNotificationPreferencesViewModel {
     var isStoreOrderEnabled: Bool { displayed.storeOrder?.enabled ?? false }
     var isStoreReviewEnabled: Bool { displayed.storeReview?.enabled ?? false }
     var isStoreStockEnabled: Bool { displayed.storeStock?.enabled ?? false }
+    var isStoreStockLowStock: Bool { displayed.storeStock?.lowStock ?? false }
+    var isStoreStockOutOfStock: Bool { displayed.storeStock?.outOfStock ?? false }
+    var isStoreStockOnBackorder: Bool { displayed.storeStock?.onBackorder ?? false }
 
     /// `nil` means "all orders".
     var storeOrderMinAmount: Decimal? { displayed.storeOrder?.minAmount }
@@ -202,6 +205,39 @@ final class PushNotificationPreferencesViewModel {
                                                      lowStock: existing?.lowStock,
                                                      outOfStock: existing?.outOfStock,
                                                      onBackorder: existing?.onBackorder))
+    }
+
+    func setStoreStockLowStock(_ newValue: Bool) {
+        let existing = displayed.storeStock
+        displayed = displayed.with(storeStock: .init(enabled: existing?.enabled,
+                                                     lowStock: newValue,
+                                                     outOfStock: existing?.outOfStock,
+                                                     onBackorder: existing?.onBackorder))
+    }
+
+    func setStoreStockOutOfStock(_ newValue: Bool) {
+        let existing = displayed.storeStock
+        displayed = displayed.with(storeStock: .init(enabled: existing?.enabled,
+                                                     lowStock: existing?.lowStock,
+                                                     outOfStock: newValue,
+                                                     onBackorder: existing?.onBackorder))
+    }
+
+    func setStoreStockOnBackorder(_ newValue: Bool) {
+        let existing = displayed.storeStock
+        displayed = displayed.with(storeStock: .init(enabled: existing?.enabled,
+                                                     lowStock: existing?.lowStock,
+                                                     outOfStock: existing?.outOfStock,
+                                                     onBackorder: newValue))
+    }
+
+    /// Reverts only the stock section of `displayed` to `lastSaved`. Other
+    /// sections are left untouched — their detail screens own their own
+    /// discard paths.
+    func discardStoreStockEdits() {
+        displayed = PushNotificationPreferences(storeOrder: displayed.storeOrder,
+                                                storeReview: displayed.storeReview,
+                                                storeStock: lastSaved.storeStock)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -34,6 +34,23 @@ final class PushNotificationPreferencesViewModel {
     var isStoreStockOutOfStock: Bool { displayed.storeStock?.outOfStock ?? false }
     var isStoreStockOnBackorder: Bool { displayed.storeStock?.onBackorder ?? false }
 
+    var storeStockDetailText: String {
+        let enabledNames: [String] = [
+            (isStoreStockLowStock, Localization.stockDetailLowStock),
+            (isStoreStockOutOfStock, Localization.stockDetailOutOfStock),
+            (isStoreStockOnBackorder, Localization.stockDetailOnBackorder)
+        ].compactMap { isOn, name in isOn ? name : nil }
+
+        switch enabledNames.count {
+        case 0:
+            return Localization.stockDetailNone
+        case 3:
+            return Localization.stockDetailAll
+        default:
+            return ListFormatter.localizedString(byJoining: enabledNames)
+        }
+    }
+
     /// `nil` means "all orders".
     var storeOrderMinAmount: Decimal? { displayed.storeOrder?.minAmount }
 
@@ -353,6 +370,31 @@ extension PushNotificationPreferencesViewModel {
             "pushNotificationPreferencesViewModel.storeReview.reviewsBelowFormat.plural",
             value: "%1$@ stars and below",
             comment: "Detail text for the New reviews row when the maximum rating is 2-5. %1$@ is the formatted star count."
+        )
+        static let stockDetailAll = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeStock.detail.all",
+            value: "All stock alerts",
+            comment: "Detail text for the Stock row when all three stock sub-toggles (low, out of stock, on backorder) are enabled."
+        )
+        static let stockDetailNone = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeStock.detail.none",
+            value: "No alerts",
+            comment: "Detail text for the Stock row when the master toggle is on but none of the sub-toggles are enabled."
+        )
+        static let stockDetailLowStock = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeStock.detail.lowStock",
+            value: "Low stock",
+            comment: "Name of the low-stock alert, used in the Stock row's detail text when a partial set of sub-toggles is enabled."
+        )
+        static let stockDetailOutOfStock = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeStock.detail.outOfStock",
+            value: "Out of stock",
+            comment: "Name of the out-of-stock alert, used in the Stock row's detail text when a partial set of sub-toggles is enabled."
+        )
+        static let stockDetailOnBackorder = NSLocalizedString(
+            "pushNotificationPreferencesViewModel.storeStock.detail.onBackorder",
+            value: "On backorder",
+            comment: "Name of the on-backorder alert, used in the Stock row's detail text when a partial set of sub-toggles is enabled."
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -760,6 +760,182 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(PushNotificationPreferencesViewModel.StoreOrderThreshold.formatInput(-5).isEmpty)
     }
 
+    // MARK: - storeStock sub-toggles
+
+    @Test func test_setStoreStockLowStock_mutates_displayed_only_and_preserves_siblings() async {
+        // Given a loaded VM with all stock sub-fields set so we can prove they're preserved.
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: false,
+                                                                                    outOfStock: true,
+                                                                                    onBackorder: false))))
+            }
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreStockLowStock(true)
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreStockLowStock == true)
+        #expect(sut.displayed.storeStock?.enabled == true)
+        #expect(sut.displayed.storeStock?.outOfStock == true)
+        #expect(sut.displayed.storeStock?.onBackorder == false)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreStockOutOfStock_mutates_displayed_only_and_preserves_siblings() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: true,
+                                                                                    outOfStock: false,
+                                                                                    onBackorder: true))))
+            }
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreStockOutOfStock(true)
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreStockOutOfStock == true)
+        #expect(sut.displayed.storeStock?.enabled == true)
+        #expect(sut.displayed.storeStock?.lowStock == true)
+        #expect(sut.displayed.storeStock?.onBackorder == true)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreStockOnBackorder_mutates_displayed_only_and_preserves_siblings() async {
+        // Given
+        let stores = makeStores()
+        let dispatched = DispatchedChanges()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: true,
+                                                                                    outOfStock: false,
+                                                                                    onBackorder: false))))
+            }
+            if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
+                dispatched.append(changes)
+                onCompletion(.success(changes))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When
+        sut.setStoreStockOnBackorder(true)
+        await Task.yield()
+
+        // Then
+        #expect(sut.isStoreStockOnBackorder == true)
+        #expect(sut.displayed.storeStock?.enabled == true)
+        #expect(sut.displayed.storeStock?.lowStock == true)
+        #expect(sut.displayed.storeStock?.outOfStock == false)
+        #expect(sut.hasUnsavedChanges == true)
+        #expect(dispatched.calls.isEmpty)
+    }
+
+    @Test func test_setStoreStockEnabled_preserves_existing_sub_toggles_in_displayed() async {
+        // Given a loaded VM with sub-toggles set.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: true,
+                                                                                    outOfStock: true,
+                                                                                    onBackorder: false))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+
+        // When the user flips the master toggle off.
+        sut.setStoreStockEnabled(false)
+
+        // Then `displayed` retains the sub-toggle values so a later save preserves them.
+        #expect(sut.displayed.storeStock?.enabled == false)
+        #expect(sut.displayed.storeStock?.lowStock == true)
+        #expect(sut.displayed.storeStock?.outOfStock == true)
+        #expect(sut.displayed.storeStock?.onBackorder == false)
+    }
+
+    // MARK: - discardStoreStockEdits
+
+    @Test func test_discardStoreStockEdits_reverts_storeStock_to_lastSaved_and_clears_unsaved_flag() async {
+        // Given a loaded VM with sub-toggles the user then edits.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: true,
+                                                                                    outOfStock: true,
+                                                                                    onBackorder: true))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+        sut.setStoreStockEnabled(false)
+        sut.setStoreStockLowStock(false)
+        #expect(sut.hasUnsavedChanges == true)
+
+        // When
+        sut.discardStoreStockEdits()
+
+        // Then `displayed.storeStock` matches the server snapshot again.
+        #expect(sut.displayed.storeStock?.enabled == true)
+        #expect(sut.displayed.storeStock?.lowStock == true)
+        #expect(sut.displayed.storeStock?.outOfStock == true)
+        #expect(sut.displayed.storeStock?.onBackorder == true)
+        #expect(sut.hasUnsavedChanges == false)
+    }
+
+    @Test func test_discardStoreStockEdits_leaves_other_sections_untouched() async {
+        // Given a loaded VM where the user edits stock *and* order.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(
+                    storeOrder: .init(enabled: false),
+                    storeStock: .init(enabled: true, lowStock: true)
+                )))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+        await sut.load()
+        sut.setStoreOrderEnabled(true)
+        sut.setStoreStockLowStock(false)
+
+        // When the user discards the stock edits.
+        sut.discardStoreStockEdits()
+
+        // Then the order edit is preserved — the discard is scoped to the stock section.
+        #expect(sut.displayed.storeOrder?.enabled == true)
+        #expect(sut.displayed.storeStock?.lowStock == true)
+    }
+
     @Test func test_save_dispatches_only_changed_sections() async {
         // Given a loaded VM with one section edited.
         let stores = makeStores()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -936,6 +936,83 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(sut.displayed.storeStock?.lowStock == true)
     }
 
+    // MARK: - storeStockDetailText
+
+    @Test func test_storeStockDetailText_when_all_three_subtoggles_on_returns_all_stock_alerts() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: true,
+                                                                                    outOfStock: true,
+                                                                                    onBackorder: true))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.storeStockDetailText == "All stock alerts")
+    }
+
+    @Test func test_storeStockDetailText_when_no_subtoggle_on_returns_no_alerts() async {
+        // Given
+        let sut = makeSUT(stores: makeStores())
+
+        // Then (no load — sub-toggles default to false)
+        #expect(sut.storeStockDetailText == "No alerts")
+    }
+
+    @Test func test_storeStockDetailText_when_loaded_with_master_on_and_all_subtoggles_off_returns_no_alerts() async {
+        // Given a loaded VM with master on but all three sub-toggles off — the
+        // realistic "No alerts" branch that the user sees on the list row.
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: false,
+                                                                                    outOfStock: false,
+                                                                                    onBackorder: false))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(sut.storeStockDetailText == "No alerts")
+    }
+
+    @Test func test_storeStockDetailText_when_subset_on_returns_joined_localized_names() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences(storeStock: .init(enabled: true,
+                                                                                    lowStock: true,
+                                                                                    outOfStock: true,
+                                                                                    onBackorder: false))))
+            }
+        }
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.load()
+
+        // Then — joined via `ListFormatter`. The exact joiner is locale-dependent,
+        // so assert containment of both names rather than the joiner glyph.
+        let detail = sut.storeStockDetailText
+        #expect(detail.contains("Low stock"))
+        #expect(detail.contains("Out of stock"))
+        #expect(!detail.contains("On backorder"))
+        #expect(detail != "All stock alerts")
+        #expect(detail != "No alerts")
+    }
+
     @Test func test_save_dispatches_only_changed_sections() async {
         // Given a loaded VM with one section edited.
         let stores = makeStores()


### PR DESCRIPTION
## Description

Implements the **Stock** notification preferences detail screen for RSM-1632, mirroring the New orders / New reviews detail screens shipped on the base branch (RSM-1633). Tapping the *Stock* row on `PushNotificationPreferencesView` now pushes a detail screen with a master toggle + three independent sub-toggles (Low stock, Out of stock, On backorder). The list row's detail text reflects the saved sub-toggle state and stays in sync with the detail screen via the shared view model.

Closes RSM-1632

## Test Steps

1. Enable the `smarterNotifications` feature flag.
2. Open *Settings → Notifications*.
3. Tap **Stock** — the new detail screen pushes.
4. Verify the master toggle drives the *Customise* section's dimmed state and that the three sub-toggles remain visible (just dimmed) when master is off.
5. Flip sub-toggles, tap **Save** — verify the row's detail text on the list updates to reflect the new state (e.g. *All stock alerts* → *Low stock, Out of stock* → *No alerts* → *Off*).
6. Edit, tap **Back** — confirm the discard-changes action sheet appears and discarding restores the stock section only (other sections' unsaved edits should survive).
7. Try a network failure — verify the error notice appears on the detail screen and the optimistic state is preserved.
8. Confirm the *Save* bar item is disabled when there are no unsaved changes, enabled when there are, and replaced by a spinner while a save is in flight.

## Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-21 at 15 04 07" src="https://github.com/user-attachments/assets/957d2b60-0d59-43cd-9207-bcc879718558" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary. (No entry — feature is behind the \`smarterNotifications\` flag, matching the RSM-1631 / RSM-1633 sibling PRs which also have no release notes.)