### PR TITLE
Gate Push Notification preferences on system permission

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -17,26 +17,20 @@ struct PushNotificationPreferencesView: View {
 
     var body: some View {
         Group {
-            switch viewModel.loadState {
-            case .loading, .loaded:
-                preferencesList
-                    .disabled(viewModel.loadState == .loading)
-            case .error:
-                EmptyState(title: Localization.errorTitle,
-                           description: Localization.errorMessage,
-                           image: .errorImage,
-                           buttonTitle: Localization.retry,
-                           buttonAction: {
-                    Task { await viewModel.load() }
-                })
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            switch viewModel.notificationsEnabled {
+            case .none:
+                ProgressView().progressViewStyle(.circular)
+            case .some(false):
+                notificationsDisabledView
+            case .some(true):
+                preferencesContent
             }
         }
         .background(Color(.listBackground))
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            if viewModel.loadState == .loading {
+            if viewModel.notificationsEnabled == true && viewModel.loadState == .loading {
                 ToolbarItem(placement: .topBarTrailing) {
                     ProgressView()
                         .progressViewStyle(.circular)
@@ -44,6 +38,7 @@ struct PushNotificationPreferencesView: View {
             }
         }
         .task {
+            await viewModel.checkNotificationPermission()
             if viewModel.loadState == .loading {
                 await viewModel.load()
             }
@@ -51,8 +46,66 @@ struct PushNotificationPreferencesView: View {
         .notice($viewModel.errorNotice)
     }
 
+    @ViewBuilder
+    private var preferencesContent: some View {
+        switch viewModel.loadState {
+        case .loading, .loaded:
+            preferencesList
+        case .error:
+            EmptyState(title: Localization.errorTitle,
+                       description: Localization.errorMessage,
+                       image: .errorImage,
+                       buttonTitle: Localization.retry,
+                       buttonAction: {
+                Task { await viewModel.load() }
+            })
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private var notificationsDisabledView: some View {
+        VStack(spacing: Layout.emptyStateContentSpacing) {
+            Spacer()
+
+            Image(uiImage: .bellIcon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Layout.emptyStateImageWidth)
+
+            Text(Localization.notificationsDisabled)
+
+            Button(Localization.enableNotificationsCTA) {
+                Task { await openSettingsApp() }
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Spacer()
+        }
+        .scrollVerticallyIfNeeded()
+        .padding(.horizontal)
+    }
+
+    private func openSettingsApp() async {
+        guard let url = URL(string: UIApplication.openNotificationSettingsURLString) else {
+            return
+        }
+        await UIApplication.shared.open(url)
+    }
+
     private var preferencesList: some View {
         List {
+            Section {
+                HStack {
+                    Text(Localization.notificationsEnabled)
+                    Spacer()
+                    Button(Localization.settingsAppCTA) {
+                        Task { await openSettingsApp() }
+                    }
+                }
+            } footer: {
+                Text(Localization.notificationsFooter)
+            }
+
             Section {
                 row(title: Localization.newOrdersTitle,
                     detail: viewModel.isStoreOrderEnabled ? viewModel.storeOrderDetailText : Localization.off,
@@ -63,6 +116,7 @@ struct PushNotificationPreferencesView: View {
                 row(title: Localization.stockTitle,
                     detail: viewModel.isStoreStockEnabled ? Localization.stockDetail : Localization.off)
             }
+            .disabled(viewModel.loadState == .loading)
         }
         .listStyle(.insetGrouped)
     }
@@ -114,6 +168,8 @@ private extension PushNotificationPreferencesView {
     enum Layout {
         static let contentSpacing: CGFloat = 8
         static let titleDetailSpacing: CGFloat = 4
+        static let emptyStateContentSpacing: CGFloat = 16
+        static let emptyStateImageWidth: CGFloat = 120
     }
 }
 
@@ -173,6 +229,31 @@ extension PushNotificationPreferencesView {
             "pushNotificationPreferencesView.retry",
             value: "Retry",
             comment: "Button on the error state to retry loading push notification preferences."
+        )
+        static let notificationsEnabled = NSLocalizedString(
+            "pushNotificationPreferencesView.notificationsEnabled",
+            value: "Notifications enabled",
+            comment: "Label indicating notifications are enabled, shown at the top of the push notification preferences screen."
+        )
+        static let settingsAppCTA = NSLocalizedString(
+            "pushNotificationPreferencesView.settingsAppCTA",
+            value: "Change",
+            comment: "Button on the push notification preferences screen that opens the app's notification settings in the iOS Settings app."
+        )
+        static let notificationsFooter = NSLocalizedString(
+            "pushNotificationPreferencesView.notificationsFooter",
+            value: "Including reminders and remote push notifications.",
+            comment: "Footer of the notifications-enabled section on the push notification preferences screen."
+        )
+        static let notificationsDisabled = NSLocalizedString(
+            "pushNotificationPreferencesView.notificationsDisabled",
+            value: "Notifications are disabled for Woo",
+            comment: "Empty state title shown on the push notification preferences screen when iOS notifications are disabled for Woo."
+        )
+        static let enableNotificationsCTA = NSLocalizedString(
+            "pushNotificationPreferencesView.enableNotificationsCTA",
+            value: "Enable notifications",
+            comment: "Primary button on the push notification preferences empty state that opens the iOS Settings app to enable notifications."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -1,5 +1,7 @@
+import Combine
 import Foundation
 import Observation
+import UIKit
 import Yosemite
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
@@ -19,6 +21,9 @@ final class PushNotificationPreferencesViewModel {
     }
 
     private(set) var loadState: LoadState = .loading
+
+    /// `nil` while the system-level permission status is being read.
+    private(set) var notificationsEnabled: Bool?
 
     private(set) var displayed = PushNotificationPreferences()
     private(set) var lastSaved = PushNotificationPreferences()
@@ -60,14 +65,36 @@ final class PushNotificationPreferencesViewModel {
     private let stores: StoresManager
     private let currencyFormatter: CurrencyFormatter
     private let currencySettings: CurrencySettings
+    private let notificationCenter: UserNotificationsCenterAdapter
+
+    private var appStateSubscription: AnyCancellable?
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current()) {
         self.siteID = siteID
         self.stores = stores
         self.currencySettings = currencySettings
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.notificationCenter = notificationCenter
+        observeAppState()
+    }
+
+    func checkNotificationPermission() async {
+        let isEnabled = await withCheckedContinuation { continuation in
+            notificationCenter.loadAuthorizationStatus(queue: .main) { status in
+                switch status {
+                case .authorized:
+                    continuation.resume(returning: true)
+                case .denied, .notDetermined, .provisional, .ephemeral:
+                    continuation.resume(returning: false)
+                @unknown default:
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+        notificationsEnabled = isEnabled
     }
 
     func load() async {
@@ -163,6 +190,17 @@ final class PushNotificationPreferencesViewModel {
 }
 
 private extension PushNotificationPreferencesViewModel {
+    /// Re-checks the system permission whenever the app returns to the
+    /// foreground so toggles flipped in iOS Settings are reflected immediately.
+    func observeAppState() {
+        appStateSubscription = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    await self?.checkNotificationPermission()
+                }
+            }
+    }
+
     /// Populates only the sections that differ between `baseline` and `target`.
     /// Whole-section comparison: any change inside a section emits the section
     /// as a complete object, matching the server's section-level merge.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -66,18 +66,21 @@ final class PushNotificationPreferencesViewModel {
     private let currencyFormatter: CurrencyFormatter
     private let currencySettings: CurrencySettings
     private let notificationCenter: UserNotificationsCenterAdapter
+    private let appStateNotificationCenter: NotificationCenter
 
     private var appStateSubscription: AnyCancellable?
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current()) {
+         notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
+         appStateNotificationCenter: NotificationCenter = .default) {
         self.siteID = siteID
         self.stores = stores
         self.currencySettings = currencySettings
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.notificationCenter = notificationCenter
+        self.appStateNotificationCenter = appStateNotificationCenter
         observeAppState()
     }
 
@@ -193,7 +196,7 @@ private extension PushNotificationPreferencesViewModel {
     /// Re-checks the system permission whenever the app returns to the
     /// foreground so toggles flipped in iOS Settings are reflected immediately.
     func observeAppState() {
-        appStateSubscription = NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+        appStateSubscription = appStateNotificationCenter.publisher(for: UIApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
                 Task { @MainActor in
                     await self?.checkNotificationPermission()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -22,10 +22,14 @@ struct PushNotificationPreferencesViewModelTests {
                          currencySettings: CurrencySettings = Self.testCurrencySettings,
                          notificationCenter: UserNotificationsCenterAdapter = MockUserNotificationsCenterAdapter())
     -> PushNotificationPreferencesViewModel {
+        // Use a fresh `NotificationCenter` so simulator-posted system
+        // notifications don't queue work on the main actor and add contention
+        // to timing-sensitive concurrent-save tests.
         PushNotificationPreferencesViewModel(siteID: siteID,
                                              stores: stores,
                                              currencySettings: currencySettings,
-                                             notificationCenter: notificationCenter)
+                                             notificationCenter: notificationCenter,
+                                             appStateNotificationCenter: NotificationCenter())
     }
 
     private func makeStores() -> MockStoresManager {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import UserNotifications
 import Yosemite
 import class WooFoundation.CurrencySettings
 @testable import WooCommerce
@@ -18,10 +19,13 @@ struct PushNotificationPreferencesViewModelTests {
                                                                numberOfDecimals: 0)
 
     private func makeSUT(stores: MockStoresManager,
-                         currencySettings: CurrencySettings = Self.testCurrencySettings) -> PushNotificationPreferencesViewModel {
+                         currencySettings: CurrencySettings = Self.testCurrencySettings,
+                         notificationCenter: UserNotificationsCenterAdapter = MockUserNotificationsCenterAdapter())
+    -> PushNotificationPreferencesViewModel {
         PushNotificationPreferencesViewModel(siteID: siteID,
                                              stores: stores,
-                                             currencySettings: currencySettings)
+                                             currencySettings: currencySettings,
+                                             notificationCenter: notificationCenter)
     }
 
     private func makeStores() -> MockStoresManager {
@@ -593,6 +597,46 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(dispatched.last?.storeOrder?.enabled == true)
         #expect(dispatched.last?.storeReview == nil)
         #expect(dispatched.last?.storeStock == nil)
+    }
+
+    // MARK: - Notification permission
+
+    @Test func test_notificationsEnabled_starts_as_nil_before_check_runs() {
+        // Given / When
+        let sut = makeSUT(stores: makeStores())
+
+        // Then
+        #expect(sut.notificationsEnabled == nil)
+    }
+
+    @Test func test_checkNotificationPermission_when_status_is_authorized_then_notificationsEnabled_is_true() async {
+        // Given
+        let notificationCenter = MockUserNotificationsCenterAdapter()
+        notificationCenter.authorizationStatus = .authorized
+        let sut = makeSUT(stores: makeStores(), notificationCenter: notificationCenter)
+
+        // When
+        await sut.checkNotificationPermission()
+
+        // Then
+        #expect(sut.notificationsEnabled == true)
+    }
+
+    @Test(arguments: [UNAuthorizationStatus.denied,
+                      .notDetermined,
+                      .provisional,
+                      .ephemeral])
+    func test_checkNotificationPermission_when_status_is_non_authorized_then_notificationsEnabled_is_false(status: UNAuthorizationStatus) async {
+        // Given
+        let notificationCenter = MockUserNotificationsCenterAdapter()
+        notificationCenter.authorizationStatus = status
+        let sut = makeSUT(stores: makeStores(), notificationCenter: notificationCenter)
+
+        // When
+        await sut.checkNotificationPermission()
+
+        // Then
+        #expect(sut.notificationsEnabled == false)
     }
 }
 


### PR DESCRIPTION
## Description

The new Smarter Notifications `PushNotificationPreferencesView` (introduced in RSM-1630) lets the merchant toggle per-section preferences but never inspects the iOS system-level notification authorization, so with push disabled in Settings every toggle is silently inert and the user has no in-app affordance to re-enable.

This PR mirrors the gate that already ships on the legacy `NotificationSettingsView`:

Implements RSM-3729.

## Test Steps
On a build with `smarterNotifications` enabled and a site registered for Woo-driven push notifications:
1. In iOS Settings → Woo, **disable** notifications. Launch the app and navigate to Settings → Notifications.
   - Expected: bell-icon empty state with "Notifications are disabled for Woo" + "Enable notifications" button. The per-section list is hidden.
2. Tap **Enable notifications**.
   - Expected: deep-link to the Woo app's Notifications page in iOS Settings.
3. In iOS Settings, **enable** notifications. Return to the app.
   - Expected: the screen automatically swaps to the list, prefixed with a "Notifications enabled / Change" row and the "Including reminders and remote push notifications." footer. No manual navigation is needed.
4. Tap **Change**.
   - Expected: deep-link to the Woo app's Notifications page in iOS Settings.
5. Disable notifications again and return.
   - Expected: screen swaps back to the empty state automatically.

## Screenshots

| Off | On |
|---|---|
| <img width="498" height="1076" alt="Screenshot 2026-05-21 at 14 48 50" src="https://github.com/user-attachments/assets/3bcecf9d-7dcd-45f7-b569-ad70d7a6657f" /> | <img width="499" height="1071" alt="Screenshot 2026-05-21 at 14 49 04" src="https://github.com/user-attachments/assets/6debe860-47ba-4e3c-9fe3-7f119e1763de" /> |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.