### PR TITLE
Add product filters, discounts, and bulk variation edits to the assistant

### DIFF
--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -462,6 +462,24 @@ public actor AgenticLoopOrchestrator {
             case .execute:
                 approvedIndices.append(index)
 
+            case .refusePreDispatch(let reason):
+                let payload = Self.errorJSON(reason)
+                continuation.yield(.toolCallStarted(id: call.id,
+                                                    name: call.function.name,
+                                                    argumentsJSON: call.function.arguments))
+                continuation.yield(.toolCallCompleted(id: call.id,
+                                                      name: call.function.name,
+                                                      resultJSON: payload))
+                if let telemetryContext {
+                    let canonical = Self.canonicalToolName(call.function.name, toolsByName: toolsByName)
+                    await emitTelemetry(.toolCallCompleted(context: telemetryContext,
+                                                           toolName: canonical,
+                                                           status: .failure,
+                                                           errorKind: .validationError,
+                                                           durationMs: nil))
+                }
+                resolvedResults[index] = payload
+
             case .requireConfirmation(let preview):
                 let proposal = ToolProposal(toolName: call.function.name,
                                             toolCallID: call.id,

--- a/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
@@ -70,26 +70,28 @@ struct ConfirmationCard: View {
     }
 
     private var bulkEntriesList: some View {
-        let visible = preview.bulkEntries.prefix(Layout.bulkVisibleLimit)
-        let overflow = preview.bulkEntries.count - visible.count
-        return VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
-            ForEach(Array(visible.enumerated()), id: \.offset) { _, entry in
-                // verbatim avoids locale-grouping the entity id (#1 234 vs #1234).
-                Text(verbatim: entry.displayName.map { "#\(entry.id)  \($0)" } ?? "#\(entry.id)")
-                    .font(.assistantBody)
-                    .foregroundStyle(Color.primary)
-                    .fixedSize(horizontal: false, vertical: true)
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
+                ForEach(Array(preview.bulkEntries.enumerated()), id: \.offset) { _, entry in
+                    bulkEntryRow(entry, indent: 0)
+                    ForEach(Array(entry.subEntries.enumerated()), id: \.offset) { _, sub in
+                        bulkEntryRow(sub, indent: Layout.subEntryIndent)
+                    }
+                }
             }
-            if overflow > 0 {
-                Text(String(format: NSLocalizedString(
-                    "assistantChat.confirmation.bulkEntries.more",
-                    value: "+%d more",
-                    comment: "Overflow row in the bulk confirmation entity list. %d is the count of additional entities not shown."
-                ), overflow))
-                    .font(.assistantBody)
-                    .foregroundStyle(Color.assistantMuted)
-            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxHeight: Layout.bulkListMaxHeight)
+    }
+
+    @ViewBuilder
+    private func bulkEntryRow(_ entry: ConfirmationBulkEntry, indent: CGFloat) -> some View {
+        // verbatim avoids locale-grouping the entity id (#1 234 vs #1234).
+        Text(verbatim: entry.displayName.map { "#\(entry.id)  \($0)" } ?? "#\(entry.id)")
+            .font(.assistantBody)
+            .foregroundStyle(indent > 0 ? Color.assistantMuted : Color.primary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.leading, indent)
     }
 
     @ViewBuilder
@@ -97,7 +99,9 @@ struct ConfirmationCard: View {
         if !preview.fields.isEmpty {
             VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
                 ForEach(Array(preview.fields.enumerated()), id: \.offset) { _, field in
-                    DiffFieldRow(field: field, isBulk: preview.isBulk)
+                    DiffFieldRow(field: field,
+                                 isBulk: preview.isBulk,
+                                 bulkEntries: preview.bulkEntries)
                 }
             }
         } else {
@@ -170,7 +174,9 @@ struct ConfirmationCard: View {
         static let shadowOpacity: Double = 0.06
         static let shadowRadius: CGFloat = 4
         static let shadowYOffset: CGFloat = 1
-        static let bulkVisibleLimit: Int = 5
+        /// Cap so a large fanout list stays scrollable instead of pushing the action buttons offscreen.
+        static let bulkListMaxHeight: CGFloat = 320
+        static let subEntryIndent: CGFloat = 16
     }
 
     private enum Localization {
@@ -211,11 +217,23 @@ private struct DiffFieldRow: View {
 
     let field: ConfirmationPreviewField
     let isBulk: Bool
+    let bulkEntries: [ConfirmationBulkEntry]
 
     var body: some View {
-        composedLine
-            .tint(Color.assistantBubbleAssistantText)
-            .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: AssistantSpacing.xSmall) {
+            composedLine
+                .tint(Color.assistantBubbleAssistantText)
+                .fixedSize(horizontal: false, vertical: true)
+            if let breakdown = orderedPerEntryRows() {
+                ForEach(Array(breakdown.enumerated()), id: \.offset) { _, row in
+                    Text(row)
+                        .font(.assistantBody)
+                        .foregroundStyle(Color.assistantMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.leading, Layout.breakdownIndent)
+                }
+            }
+        }
     }
 
     private var composedLine: Text {
@@ -240,6 +258,28 @@ private struct DiffFieldRow: View {
             .foregroundColor(Color.assistantBubbleAssistantText)
 
         return labelPart + beforePart + Text(" ") + afterPart
+    }
+
+    /// Preserve the merchant's bulkEntries order so the breakdown matches the entry list shown above.
+    /// Falls back to ascending id order for ids missing from bulkEntries.
+    private func orderedPerEntryRows() -> [String]? {
+        guard let perEntry = field.perEntryValues, !perEntry.isEmpty else { return nil }
+        var displayNames: [Int: String] = [:]
+        for entry in bulkEntries {
+            if let name = entry.displayName { displayNames[entry.id] = name }
+        }
+        let preferredIDs = bulkEntries.map(\.id).filter { perEntry[$0] != nil }
+        let leftoverIDs = perEntry.keys.filter { !preferredIDs.contains($0) }.sorted()
+        let orderedIDs = preferredIDs + leftoverIDs
+        return orderedIDs.compactMap { id in
+            guard let value = perEntry[id] else { return nil }
+            let prefix = displayNames[id] ?? "#\(id)"
+            return "\(prefix) -> \(value.flattened())"
+        }
+    }
+
+    private enum Layout {
+        static let breakdownIndent: CGFloat = 12
     }
 }
 

--- a/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
+++ b/Modules/Sources/WooAIAssistant/Presentation/ConfirmationCard.swift
@@ -104,7 +104,7 @@ struct ConfirmationCard: View {
                                  bulkEntries: preview.bulkEntries)
                 }
             }
-        } else {
+        } else if preview.showsSummaryInBody {
             Text(preview.summary.flattened())
                 .font(.assistantBody)
                 .foregroundStyle(Color.primary)

--- a/Modules/Sources/WooAIAssistant/Safety/ConfirmationPreview.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ConfirmationPreview.swift
@@ -18,6 +18,12 @@ public struct ConfirmationPreview: Equatable, Sendable {
         self.isBulk = isBulk
         self.bulkEntries = bulkEntries
     }
+
+    /// True only when there is nothing else to render in the card body. The summary already shows as
+    /// the card title, so repeating it in the body is redundant whenever fields or bulk rows exist.
+    public var showsSummaryInBody: Bool {
+        fields.isEmpty && bulkEntries.isEmpty
+    }
 }
 
 public struct ConfirmationPreviewField: Equatable, Sendable {

--- a/Modules/Sources/WooAIAssistant/Safety/ConfirmationPreview.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ConfirmationPreview.swift
@@ -25,15 +25,21 @@ public struct ConfirmationPreviewField: Equatable, Sendable {
     public let label: ConfirmationPreviewText
     public let value: ConfirmationPreviewText
     public let priorValue: ConfirmationPreviewText?
+    /// Per-entity rendered values keyed by target id. Populated when an update sets the same
+    /// field across multiple entries but the value diverges, so the card lists which id gets
+    /// which value instead of hiding it behind a "varies" placeholder.
+    public let perEntryValues: [Int: ConfirmationPreviewText]?
 
     public init(name: String,
                 label: ConfirmationPreviewText,
                 value: ConfirmationPreviewText,
-                priorValue: ConfirmationPreviewText? = nil) {
+                priorValue: ConfirmationPreviewText? = nil,
+                perEntryValues: [Int: ConfirmationPreviewText]? = nil) {
         self.name = name
         self.label = label
         self.value = value
         self.priorValue = priorValue
+        self.perEntryValues = perEntryValues
     }
 }
 

--- a/Modules/Sources/WooAIAssistant/Safety/ConfirmationSnapshot.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/ConfirmationSnapshot.swift
@@ -8,23 +8,42 @@ public struct ConfirmationSnapshot: Equatable, Sendable {
     /// Per-entity labels for bulk previews: one row per affected id with its
     /// resolved display name when the resolver can fetch it.
     public let bulkEntries: [ConfirmationBulkEntry]
+    /// Variation counts keyed by variable parent id. Populated when a products_update
+    /// entry sets `target.scope = "all_variations"` so the preview can show the real
+    /// fanout scope ("12 variations") instead of an opaque parent id.
+    public let parentVariationCounts: [Int: Int]
+    /// When set, the snapshot resolver has determined the call cannot proceed (e.g.
+    /// targets reference missing entities). Safety + orchestrator short-circuit: no
+    /// confirmation card, no executor dispatch; the model sees a typed tool failure.
+    public let refusalReason: String?
 
     public init(currentValues: [String: ConfirmationPreviewText],
                 displayName: String? = nil,
-                bulkEntries: [ConfirmationBulkEntry] = []) {
+                bulkEntries: [ConfirmationBulkEntry] = [],
+                parentVariationCounts: [Int: Int] = [:],
+                refusalReason: String? = nil) {
         self.currentValues = currentValues
         self.displayName = displayName
         self.bulkEntries = bulkEntries
+        self.parentVariationCounts = parentVariationCounts
+        self.refusalReason = refusalReason
     }
 }
 
 public struct ConfirmationBulkEntry: Equatable, Sendable {
     public let id: Int
     public let displayName: String?
+    /// Nested rows (typically the resolved variations under a variable parent
+    /// targeted with `scope=all_variations`) so the card can list what the
+    /// fanout actually mutates instead of just the parent id.
+    public let subEntries: [ConfirmationBulkEntry]
 
-    public init(id: Int, displayName: String? = nil) {
+    public init(id: Int,
+                displayName: String? = nil,
+                subEntries: [ConfirmationBulkEntry] = []) {
         self.id = id
         self.displayName = displayName
+        self.subEntries = subEntries
     }
 }
 

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationPreviewBuilder.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationPreviewBuilder.swift
@@ -142,7 +142,7 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
         guard breakdown.totalEntries > 0 else {
             return ConfirmationPreview(summary: .localized(Strings.productsUpdateFallback))
         }
-        let summary = Self.productsUpdateSummary(breakdown: breakdown)
+        let summary = Self.productsUpdateSummary(breakdown: breakdown, snapshot: snapshot)
         var combinedKeys: [String] = []
         var seenKeys: Set<String> = []
         for entry in updates {
@@ -165,8 +165,9 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
     private struct ProductsUpdateBreakdown {
         var simpleProductCount: Int = 0
         var variationCount: Int = 0
+        var fanoutParentIDs: [Int] = []
         var targetIDs: [Int] = []
-        var totalEntries: Int { simpleProductCount + variationCount }
+        var totalEntries: Int { simpleProductCount + variationCount + fanoutParentIDs.count }
     }
 
     private static func classify(updates: [ProductsUpdateEntry]) -> ProductsUpdateBreakdown {
@@ -176,6 +177,8 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
             breakdown.targetIDs.append(id)
             if target.kind == "variation" {
                 breakdown.variationCount += 1
+            } else if target.scope == "all_variations" {
+                breakdown.fanoutParentIDs.append(id)
             } else {
                 breakdown.simpleProductCount += 1
             }
@@ -183,7 +186,49 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
         return breakdown
     }
 
-    private static func productsUpdateSummary(breakdown: ProductsUpdateBreakdown) -> ConfirmationPreviewText {
+    private static func productsUpdateSummary(breakdown: ProductsUpdateBreakdown,
+                                              snapshot: ConfirmationSnapshot?) -> ConfirmationPreviewText {
+        let fanoutCount = breakdown.fanoutParentIDs.count
+        let nonFanoutCount = breakdown.simpleProductCount + breakdown.variationCount
+        if fanoutCount == 0 {
+            return nonFanoutSummary(breakdown: breakdown)
+        }
+        if nonFanoutCount == 0 && fanoutCount == 1 {
+            let parentID = breakdown.fanoutParentIDs[0]
+            let parentLabel = parentDisplayLabel(parentID: parentID, snapshot: snapshot)
+            if let variationCount = snapshot?.parentVariationCounts[parentID] {
+                return .localized(Strings.productsUpdateFanoutSingleParentNamed,
+                                  args: [.raw(String(variationCount)), .raw(parentLabel)])
+            }
+            return .localized(Strings.productsUpdateFanoutSingleParentUnknown,
+                              args: [.raw(parentLabel)])
+        }
+        let totalVariations = breakdown.fanoutParentIDs.reduce(0) { partial, parentID in
+            partial + (snapshot?.parentVariationCounts[parentID] ?? 0)
+        }
+        let countsKnown = breakdown.fanoutParentIDs.allSatisfy { snapshot?.parentVariationCounts[$0] != nil }
+        if nonFanoutCount == 0 {
+            if countsKnown {
+                return .localized(Strings.productsUpdateFanoutMultiParentCount,
+                                  args: [.raw(String(totalVariations)), .raw(String(fanoutCount))])
+            }
+            return .localized(Strings.productsUpdateFanoutMultiParentUnknown,
+                              args: [.raw(String(fanoutCount))])
+        }
+        // Mixed: render fanout subject first, then the leftover entries as a tail clause.
+        let leftover = nonFanoutCount
+        if countsKnown {
+            return .localized(Strings.productsUpdateMixedFanoutCount,
+                              args: [.raw(String(totalVariations)),
+                                     .raw(String(fanoutCount)),
+                                     .raw(String(leftover))])
+        }
+        return .localized(Strings.productsUpdateMixedFanoutUnknown,
+                          args: [.raw(String(fanoutCount)),
+                                 .raw(String(leftover))])
+    }
+
+    private static func nonFanoutSummary(breakdown: ProductsUpdateBreakdown) -> ConfirmationPreviewText {
         let products = breakdown.simpleProductCount
         let variations = breakdown.variationCount
         if variations == 0 {
@@ -215,6 +260,13 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
                           args: [productClause, variationClause])
     }
 
+    private static func parentDisplayLabel(parentID: Int, snapshot: ConfirmationSnapshot?) -> String {
+        if let entry = snapshot?.bulkEntries.first(where: { $0.id == parentID }), let name = entry.displayName {
+            return name
+        }
+        return "#\(parentID)"
+    }
+
     private struct ProductsUpdateArgs: Decodable {
         let updates: [ProductsUpdateEntry]?
     }
@@ -238,17 +290,48 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
                                      snapshot: ConfirmationSnapshot?,
                                      isBulk: Bool) -> ConfirmationPreviewField {
         let label = productFieldLabel(for: key)
+        // Pairs each entry's target id with its rendered value when the entry sets `key`. Used by the
+        // per-id breakdown so the card can show #3859 -> 10, #3860 -> 5, etc.
+        let valuesByID = perEntryValueMap(for: key, across: updates)
         let valuesWithEntries = updates.compactMap { entry -> ConfirmationPreviewText? in
             productFieldValue(for: key, entry: entry)
         }
+        // Partial coverage: only entries that set the key contribute, but the card still shows the per-id
+        // breakdown so the merchant sees which entries are affected rather than an opaque "varies".
+        if valuesWithEntries.count < updates.count {
+            let perEntry = valuesByID.isEmpty ? nil : valuesByID
+            return ConfirmationPreviewField(name: key,
+                                            label: label,
+                                            value: .localized(Strings.variesPerItem),
+                                            perEntryValues: perEntry)
+        }
         // Distinct on the flattened text so equivalent renderings (e.g. both "Cleared") collapse.
         let distinct = Set(valuesWithEntries.map { $0.flattened() })
-        if let only = valuesWithEntries.first, distinct.count == 1, valuesWithEntries.count == updates.count {
+        if let only = valuesWithEntries.first, distinct.count == 1 {
             let prior = isBulk ? nil : productPriorValue(for: key, in: snapshot, newValue: only)
             return ConfirmationPreviewField(name: key, label: label, value: only, priorValue: prior)
         }
-        // Divergent or partial coverage: a single placeholder is the most the base card can render.
-        return ConfirmationPreviewField(name: key, label: label, value: .localized(Strings.fieldValueUpdated))
+        if distinct.isEmpty {
+            return ConfirmationPreviewField(name: key, label: label, value: .localized(Strings.fieldValueUpdated))
+        }
+        let perEntry = valuesByID.isEmpty ? nil : valuesByID
+        return ConfirmationPreviewField(name: key,
+                                        label: label,
+                                        value: .localized(Strings.variesPerItem),
+                                        perEntryValues: perEntry)
+    }
+
+    /// Build a `[id: rendered]` map keyed by each entry's target id for the rows that set `key`.
+    /// Entries without a target id are skipped so a malformed payload can't produce a misleading row.
+    private static func perEntryValueMap(for key: String,
+                                         across updates: [ProductsUpdateEntry]) -> [Int: ConfirmationPreviewText] {
+        var result: [Int: ConfirmationPreviewText] = [:]
+        for entry in updates {
+            guard let id = entry.target?.id,
+                  let value = productFieldValue(for: key, entry: entry) else { continue }
+            result[id] = value
+        }
+        return result
     }
 
     private static func productPriorValue(for key: String,
@@ -409,6 +492,30 @@ private enum Strings {
         "ai.assistant.preview.products_update.clause.variation.plural",
         defaultValue: "%@ variations"
     )
+    static let productsUpdateFanoutSingleParentNamed = LocalizedStringResource(
+        "ai.assistant.preview.products_update.summary.fanout.single_parent_named",
+        defaultValue: "Apply changes to all %1$@ variations of %2$@"
+    )
+    static let productsUpdateFanoutSingleParentUnknown = LocalizedStringResource(
+        "ai.assistant.preview.products_update.summary.fanout.single_parent_unknown",
+        defaultValue: "Apply changes to all variations of %@"
+    )
+    static let productsUpdateFanoutMultiParentCount = LocalizedStringResource(
+        "ai.assistant.preview.products_update.summary.fanout.multi_parent_count",
+        defaultValue: "Apply changes to %1$@ variations across %2$@ parents"
+    )
+    static let productsUpdateFanoutMultiParentUnknown = LocalizedStringResource(
+        "ai.assistant.preview.products_update.summary.fanout.multi_parent_unknown",
+        defaultValue: "Apply changes to all variations across %@ parents"
+    )
+    static let productsUpdateMixedFanoutCount = LocalizedStringResource(
+        "ai.assistant.preview.products_update.summary.mixed_fanout.count",
+        defaultValue: "Apply changes to %1$@ variations across %2$@ parents, plus %3$@ other entries"
+    )
+    static let productsUpdateMixedFanoutUnknown = LocalizedStringResource(
+        "ai.assistant.preview.products_update.summary.mixed_fanout.unknown",
+        defaultValue: "Apply changes across %1$@ parents, plus %2$@ other entries"
+    )
 
     static let fieldStatus = LocalizedStringResource(
         "ai.assistant.preview.field.status",
@@ -457,6 +564,10 @@ private enum Strings {
     static let fieldValueCleared = LocalizedStringResource(
         "ai.assistant.preview.field.value.cleared_marker",
         defaultValue: "Cleared"
+    )
+    static let variesPerItem = LocalizedStringResource(
+        "ai.assistant.preview.products_update.field.varies",
+        defaultValue: "varies per item"
     )
     static let percentDiscountFormat = LocalizedStringResource(
         "ai.assistant.preview.field.percent_discount.value",

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationPreviewBuilder.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationPreviewBuilder.swift
@@ -223,6 +223,7 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
         switch key {
         case "regular_price": return .localized(Strings.fieldRegularPrice)
         case "sale_price": return .localized(Strings.fieldSalePrice)
+        case "percent_discount": return .localized(Strings.fieldPercentDiscount)
         case "stock_quantity": return .localized(Strings.fieldStockQuantity)
         case "status": return .localized(Strings.fieldStatus)
         case "name": return .localized(Strings.fieldName)
@@ -272,6 +273,9 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
             guard let value = entry.salePrice else { return nil }
             if value.isEmpty { return .localized(Strings.fieldValueCleared) }
             return .raw(value)
+        case "percent_discount":
+            guard let value = entry.percentDiscount else { return nil }
+            return .localized(Strings.percentDiscountFormat, args: [.raw(formatPercent(value))])
         case "stock_quantity":
             guard let value = entry.stockQuantity else { return nil }
             return .raw(String(value))
@@ -291,6 +295,11 @@ public struct DefaultConfirmationPreviewBuilder: ConfirmationPreviewBuilding {
         default:
             return nil
         }
+    }
+
+    private static func formatPercent(_ value: Double) -> String {
+        if value.rounded() == value { return String(Int(value)) }
+        return String(format: "%g", value)
     }
 
     // MARK: - Order field helpers
@@ -413,6 +422,10 @@ private enum Strings {
         "ai.assistant.preview.field.sale_price",
         defaultValue: "Sale"
     )
+    static let fieldPercentDiscount = LocalizedStringResource(
+        "ai.assistant.preview.field.percent_discount",
+        defaultValue: "Discount"
+    )
     static let fieldStockQuantity = LocalizedStringResource(
         "ai.assistant.preview.field.stock_quantity",
         defaultValue: "Stock"
@@ -444,6 +457,10 @@ private enum Strings {
     static let fieldValueCleared = LocalizedStringResource(
         "ai.assistant.preview.field.value.cleared_marker",
         defaultValue: "Cleared"
+    )
+    static let percentDiscountFormat = LocalizedStringResource(
+        "ai.assistant.preview.field.percent_discount.value",
+        defaultValue: "%@%% off"
     )
 
     static let statusValueEmailsCustomer = LocalizedStringResource(

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationSnapshotResolver.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultConfirmationSnapshotResolver.swift
@@ -58,11 +58,13 @@ public struct DefaultConfirmationSnapshotResolver: ConfirmationSnapshotResolving
         let kind: String?
         let id: Int?
         let parentID: Int?
+        let scope: String?
 
         enum CodingKeys: String, CodingKey {
             case kind
             case id
             case parentID = "parent_id"
+            case scope
         }
     }
 
@@ -76,7 +78,7 @@ public struct DefaultConfirmationSnapshotResolver: ConfirmationSnapshotResolving
         guard let parsed = decode(Args.self, from: arguments),
               let updates = parsed.updates else { return nil }
         let targets = updates.compactMap { $0.target }
-        // Parent ids we need product names for: top-level products + variation parents.
+        // Parent ids we need product names for: top-level + fanout parents + variation parents.
         let parentIDs = Self.parentIDsToFetch(targets: targets)
         guard !parentIDs.isEmpty else { return nil }
         let responses = await fetchBulkResponses(ids: parentIDs,
@@ -88,18 +90,125 @@ public struct DefaultConfirmationSnapshotResolver: ConfirmationSnapshotResolving
                 return (id, response)
             }
         )
-        let entries = Self.buildBulkEntries(targets: targets, parentByID: resolvedByID)
+        // Skip the missing check when the parents endpoint hit a non-2xx so transport hiccups
+        // degrade to the existing fallback rather than refusing a valid request.
+        if responses != nil,
+           let refusal = Self.missingProductsRefusal(targets: targets, resolvedByID: resolvedByID) {
+            return ConfirmationSnapshot(currentValues: [:], refusalReason: refusal)
+        }
+        let fanoutVariations = await fetchFanoutVariations(targets: targets, parentByID: resolvedByID)
+        let specificVariations = await fetchSpecificVariations(targets: targets, parentByID: resolvedByID)
+        if let refusal = Self.missingVariationsRefusal(targets: targets,
+                                                       parentByID: resolvedByID,
+                                                       specificVariations: specificVariations) {
+            return ConfirmationSnapshot(currentValues: [:], refusalReason: refusal)
+        }
+        let entries = Self.buildBulkEntries(targets: targets,
+                                            parentByID: resolvedByID,
+                                            fanoutVariations: fanoutVariations,
+                                            specificVariations: specificVariations.byID)
+        let parentVariationCounts = fanoutVariations.mapValues { $0.count }
         // Single-target previews still surface prior field values for the diff body.
         if targets.count == 1, let target = targets.first,
-           target.kind == "product",
+           target.kind == "product", target.scope == nil,
            let id = target.id, let response = resolvedByID[id] {
             let values = Self.productCurrentValues(from: response)
             let displayName = response.name?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmptyOrNil
             return ConfirmationSnapshot(currentValues: values,
                                         displayName: displayName,
-                                        bulkEntries: entries)
+                                        bulkEntries: entries,
+                                        parentVariationCounts: parentVariationCounts)
         }
-        return ConfirmationSnapshot(currentValues: [:], bulkEntries: entries)
+        return ConfirmationSnapshot(currentValues: [:],
+                                    bulkEntries: entries,
+                                    parentVariationCounts: parentVariationCounts)
+    }
+
+    /// Refusal text covering top-level products + variation parents that the WC API did not return.
+    /// Returns nil when every targeted product (or parent of a variation) is present in `resolvedByID`.
+    fileprivate static func missingProductsRefusal(targets: [ProductsUpdateTarget],
+                                                   resolvedByID: [Int: ProductSnapshotResponse]) -> String? {
+        var missingProducts: [Int] = []
+        var missingParents: [(variationID: Int, parentID: Int)] = []
+        var seenProducts: Set<Int> = []
+        var seenParents: Set<Int> = []
+        for target in targets {
+            if target.kind == "variation" {
+                guard let parentID = target.parentID else { continue }
+                if resolvedByID[parentID] == nil, seenParents.insert(parentID).inserted, let id = target.id {
+                    missingParents.append((id, parentID))
+                }
+            } else {
+                guard let id = target.id else { continue }
+                if resolvedByID[id] == nil, seenProducts.insert(id).inserted {
+                    missingProducts.append(id)
+                }
+            }
+        }
+        guard !missingProducts.isEmpty || !missingParents.isEmpty else { return nil }
+        return refusalText(missingProducts: missingProducts, missingParents: missingParents)
+    }
+
+    /// Refusal text when a variation target's parent exists but the variation id isn't in the per-parent
+    /// fetch result. Skips parents whose variation endpoint failed so a transport hiccup never refuses.
+    fileprivate static func missingVariationsRefusal(targets: [ProductsUpdateTarget],
+                                                     parentByID: [Int: ProductSnapshotResponse],
+                                                     specificVariations: SpecificVariationFetch) -> String? {
+        var missingPairs: [(variationID: Int, parentID: Int)] = []
+        var seen: Set<Int> = []
+        for target in targets {
+            guard target.kind == "variation",
+                  let id = target.id,
+                  let parentID = target.parentID,
+                  parentByID[parentID] != nil,
+                  specificVariations.fetchedParents.contains(parentID) else { continue }
+            guard specificVariations.byID[id] == nil, seen.insert(id).inserted else { continue }
+            missingPairs.append((id, parentID))
+        }
+        guard !missingPairs.isEmpty else { return nil }
+        return variationOnlyRefusalText(missingPairs: missingPairs)
+    }
+
+    private static func refusalText(missingProducts: [Int],
+                                    missingParents: [(variationID: Int, parentID: Int)]) -> String {
+        if missingParents.isEmpty {
+            if missingProducts.count == 1 {
+                return "I couldn't find product \(missingProducts[0]) in your store. Please verify the ID."
+            }
+            let joined = missingProducts.map(String.init).joined(separator: ", ")
+            return "I couldn't find products \(joined) in your store. Please verify the IDs."
+        }
+        if missingProducts.isEmpty, missingParents.count == 1 {
+            let pair = missingParents[0]
+            return "I couldn't find product \(pair.parentID) " +
+                   "(parent of variation \(pair.variationID)) in your store. Please verify the ID."
+        }
+        var parts: [String] = []
+        if !missingProducts.isEmpty {
+            let label = missingProducts.count == 1 ? "product" : "products"
+            parts.append("\(label) \(missingProducts.map(String.init).joined(separator: ", "))")
+        }
+        if !missingParents.isEmpty {
+            let parentIDs = missingParents.map { String($0.parentID) }
+            let label = parentIDs.count == 1 ? "parent" : "parents"
+            parts.append("\(label) \(parentIDs.joined(separator: ", "))")
+        }
+        return "I couldn't find \(parts.joined(separator: " or ")) in your store. Please verify the IDs."
+    }
+
+    private static func variationOnlyRefusalText(missingPairs: [(variationID: Int, parentID: Int)]) -> String {
+        if missingPairs.count == 1 {
+            let pair = missingPairs[0]
+            return "Product \(pair.parentID) doesn't have a variation with ID \(pair.variationID)."
+        }
+        let pairsByParent = Dictionary(grouping: missingPairs, by: { $0.parentID })
+        let phrases = pairsByParent
+            .sorted(by: { $0.key < $1.key })
+            .map { parentID, pairs -> String in
+                let ids = pairs.map { String($0.variationID) }.joined(separator: ", ")
+                return "\(ids) under product \(parentID)"
+            }
+        return "I couldn't find variations \(phrases.joined(separator: "; ")). Please verify the IDs."
     }
 
     private static func parentIDsToFetch(targets: [ProductsUpdateTarget]) -> [Int] {
@@ -119,18 +228,121 @@ public struct DefaultConfirmationSnapshotResolver: ConfirmationSnapshotResolving
     }
 
     private static func buildBulkEntries(targets: [ProductsUpdateTarget],
-                                         parentByID: [Int: ProductSnapshotResponse]) -> [ConfirmationBulkEntry] {
+                                         parentByID: [Int: ProductSnapshotResponse],
+                                         fanoutVariations: [Int: [VariationSnapshotResponse]],
+                                         specificVariations: [Int: VariationSnapshotResponse]) -> [ConfirmationBulkEntry] {
         targets.compactMap { target -> ConfirmationBulkEntry? in
-            switch target.kind {
-            case "variation":
+            switch (target.kind, target.scope) {
+            case ("variation", _):
                 guard let id = target.id else { return nil }
                 let parentName = target.parentID.flatMap { parentByID[$0]?.name }
-                return ConfirmationBulkEntry(id: id, displayName: parentName)
+                let label = specificVariations[id].flatMap { variationLabel(for: $0, parentName: parentName) }
+                return ConfirmationBulkEntry(id: id, displayName: label)
+            case ("product", "all_variations"?):
+                guard let id = target.id else { return nil }
+                let parentName = parentByID[id]?.name
+                let rows = fanoutVariations[id] ?? []
+                let subs = rows.compactMap { row -> ConfirmationBulkEntry? in
+                    guard let rowID = row.id else { return nil }
+                    return ConfirmationBulkEntry(id: rowID,
+                                                 displayName: variationLabel(for: row, parentName: parentName))
+                }
+                return ConfirmationBulkEntry(id: id, displayName: parentName, subEntries: subs)
             default:
                 guard let id = target.id else { return nil }
                 return ConfirmationBulkEntry(id: id, displayName: parentByID[id]?.name)
             }
         }
+    }
+
+    private func fetchFanoutVariations(targets: [ProductsUpdateTarget],
+                                       parentByID: [Int: ProductSnapshotResponse])
+    async -> [Int: [VariationSnapshotResponse]] {
+        let fanoutIDs = targets.compactMap { target -> Int? in
+            guard target.scope == "all_variations", target.kind == "product", let id = target.id else { return nil }
+            return id
+        }
+        guard !fanoutIDs.isEmpty else { return [:] }
+        var result: [Int: [VariationSnapshotResponse]] = [:]
+        // Sequential keeps request volume bounded; fanout consent is rare per turn.
+        // Omit failed parents so callers degrade to the unknown-count summary.
+        for parentID in fanoutIDs {
+            guard let rows = await fetchVariations(parentID: parentID, include: nil) else { continue }
+            result[parentID] = rows
+        }
+        return result
+    }
+
+    private func fetchSpecificVariations(targets: [ProductsUpdateTarget],
+                                         parentByID: [Int: ProductSnapshotResponse])
+    async -> SpecificVariationFetch {
+        var byParent: [Int: [Int]] = [:]
+        for target in targets {
+            guard target.kind == "variation", let id = target.id, let parentID = target.parentID else { continue }
+            byParent[parentID, default: []].append(id)
+        }
+        guard !byParent.isEmpty else { return SpecificVariationFetch(byID: [:], fetchedParents: []) }
+        var byID: [Int: VariationSnapshotResponse] = [:]
+        var fetchedParents: Set<Int> = []
+        for (parentID, variationIDs) in byParent {
+            guard let rows = await fetchVariations(parentID: parentID, include: variationIDs) else { continue }
+            fetchedParents.insert(parentID)
+            for row in rows {
+                guard let rowID = row.id else { continue }
+                byID[rowID] = row
+            }
+        }
+        return SpecificVariationFetch(byID: byID, fetchedParents: fetchedParents)
+    }
+
+    fileprivate struct SpecificVariationFetch {
+        let byID: [Int: VariationSnapshotResponse]
+        /// Parents whose variation fetch returned a 2xx. Missing-variation refusal only fires under
+        /// these so a transport hiccup never refuses a valid call.
+        let fetchedParents: Set<Int>
+    }
+
+    private func fetchVariations(parentID: Int, include: [Int]?) async -> [VariationSnapshotResponse]? {
+        var query: [String: String] = [
+            "per_page": String(100),
+            "_fields": "id,name,attributes"
+        ]
+        if let include, !include.isEmpty {
+            query["include"] = include.map(String.init).joined(separator: ",")
+        }
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/products/\(parentID)/variations",
+                                            query: query,
+                                            body: nil)
+        guard (200..<300).contains(response.statusCode) else {
+            DDLogError("DefaultConfirmationSnapshotResolver variations for \(parentID) returned HTTP \(response.statusCode)")
+            return nil
+        }
+        do {
+            return try JSONDecoder().decode([VariationSnapshotResponse].self, from: response.data)
+        } catch {
+            DDLogError("DefaultConfirmationSnapshotResolver variations decode failed for \(parentID): \(error)")
+            return nil
+        }
+    }
+
+    fileprivate static func variationLabel(for row: VariationSnapshotResponse, parentName: String?) -> String? {
+        let trimmedParent = parentName?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmptyOrNil
+        let optionParts = (row.attributes ?? []).compactMap { attribute -> String? in
+            attribute.option?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmptyOrNil
+        }
+        // Always carry the parent name so the merchant can tell a variation row from a simple product.
+        // Prefer attributes over the stored `name`; WC fills `name` inconsistently (bare attrs on some
+        // stores, already parent-prefixed on others), and double-prefixing reads worse than either.
+        if !optionParts.isEmpty {
+            let suffix = optionParts.joined(separator: ", ")
+            return trimmedParent.map { "\($0) - \(suffix)" } ?? suffix
+        }
+        guard let name = row.name?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmptyOrNil else {
+            return trimmedParent
+        }
+        guard let trimmedParent, !name.hasPrefix(trimmedParent) else { return name }
+        return "\(trimmedParent) - \(name)"
     }
 
     private static func productCurrentValues(from response: ProductSnapshotResponse) -> [String: ConfirmationPreviewText] {
@@ -264,6 +476,18 @@ fileprivate struct ProductSnapshotResponse: Decodable {
     let status: String?
     let stock_status: String?
     let sku: String?
+}
+
+fileprivate struct VariationSnapshotResponse: Decodable {
+    let id: Int?
+    let name: String?
+    let attributes: [VariationAttributeSnapshot]?
+}
+
+fileprivate struct VariationAttributeSnapshot: Decodable {
+    let id: Int?
+    let name: String?
+    let option: String?
 }
 
 private extension String {

--- a/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/DefaultSafetyPolicy.swift
@@ -15,6 +15,10 @@ public struct DefaultSafetyPolicy: SafetyPolicy {
             return .execute
         case .unsafe:
             let snapshot = await snapshotResolver?.resolve(toolName: name, arguments: arguments)
+            // Refusal short-circuits before preview to keep the card off-screen entirely.
+            if let reason = snapshot?.refusalReason {
+                return .refusePreDispatch(reason: reason)
+            }
             let preview = previewBuilder.build(toolName: name,
                                                arguments: arguments,
                                                snapshot: snapshot)

--- a/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
+++ b/Modules/Sources/WooAIAssistant/Safety/SafetyPolicy.swift
@@ -9,4 +9,8 @@ public enum SafetyDecision: Equatable, Sendable {
 
     /// Typed preview shown on the confirmation card.
     case requireConfirmation(preview: ConfirmationPreview)
+
+    /// Resolver determined the call can't proceed (e.g. missing entities). The
+    /// orchestrator surfaces this as a synthetic tool failure without showing a card.
+    case refusePreDispatch(reason: String)
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/LowInStockReportRunner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/LowInStockReportRunner.swift
@@ -92,7 +92,7 @@ struct LowInStockReportRunner {
         let variationsByParent: [Int: [Int]]
     }
 
-    static func splitReportRows(_ rows: [AnyCodableJSON]) -> ReportSplit {
+    private static func splitReportRows(_ rows: [AnyCodableJSON]) -> ReportSplit {
         var ordered: [ReportEntry] = []
         var productIDs: [Int] = []
         var variationsByParent: [Int: [Int]] = [:]
@@ -160,7 +160,7 @@ struct LowInStockReportRunner {
         return Self.keyByID(rows: rows)
     }
 
-    static func keyByID(rows: [AnyCodableJSON]) -> [Int: AnyCodableJSON] {
+    private static func keyByID(rows: [AnyCodableJSON]) -> [Int: AnyCodableJSON] {
         var keyed: [Int: AnyCodableJSON] = [:]
         for row in rows {
             guard let identifier = RESTResponseParsing.intField(row, "id") else { continue }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/LowInStockReportRunner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/LowInStockReportRunner.swift
@@ -28,10 +28,7 @@ struct LowInStockReportRunner {
         }
         let split = Self.splitReportRows(reportRows)
         if split.orderedIDs.isEmpty {
-            let summary = ProductsListSummary.make(tagged: [], canLoadMore: false)
-            return .success(.init(toolName: ProductsListTool.name,
-                                  structured: LLMPayloadCap.capped(summary, toolName: ProductsListTool.name),
-                                  uiStructured: nil))
+            return successResult(tagged: [], canLoadMore: false)
         }
         async let productLookup = enrichProducts(ids: split.productIDs)
         async let variationLookup = enrichVariations(grouped: split.variationsByParent)
@@ -49,6 +46,11 @@ struct LowInStockReportRunner {
         // Source page being full implies more low-stock pages may exist; post-filtering can shrink
         // the visible window below per_page but does not change that signal.
         let canLoadMore = reportRows.count >= perPage
+        return successResult(tagged: tagged, canLoadMore: canLoadMore)
+    }
+
+    private func successResult(tagged: [(AnyCodableJSON, ProductsListSummary.RowKind)],
+                               canLoadMore: Bool) -> ToolResult {
         let summary = ProductsListSummary.make(tagged: tagged, canLoadMore: canLoadMore)
         return .success(.init(toolName: ProductsListTool.name,
                               structured: LLMPayloadCap.capped(summary, toolName: ProductsListTool.name),

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/LowInStockReportRunner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/LowInStockReportRunner.swift
@@ -1,0 +1,171 @@
+import Foundation
+import CocoaLumberjackSwift
+
+struct LowInStockReportRunner {
+
+    let client: WCRESTClient
+
+    /// Hits wc-analytics' lowstock report (authoritative for WC's low-stock criteria),
+    /// then enriches the ids via `/products?include=` (top-level products) and
+    /// `/products/{parent}/variations?include=` (variation rows) so the merchant gets back the
+    /// full shape regardless of which kind the report surfaced. Returns nil to signal
+    /// "endpoint unavailable, fall back to heuristic".
+    func run(args: ProductsListTool.Args, perPage: Int) async -> ToolResult? {
+        let page = max(1, args.page ?? 1)
+        let reportQuery: [String: String] = [
+            "type": "lowstock",
+            "per_page": String(perPage),
+            "page": String(page)
+        ]
+        let report = await client.request(method: "GET",
+                                          path: "wc-analytics/reports/stock",
+                                          query: reportQuery,
+                                          body: nil)
+        guard HTTPStatusClassification.isSuccess(report.statusCode) else { return nil }
+        guard let reportPayload = RESTResponseParsing.decodeJSON(report.data),
+              let reportRows = RESTResponseParsing.arrayItems(reportPayload) else {
+            return nil
+        }
+        let split = Self.splitReportRows(reportRows)
+        if split.orderedIDs.isEmpty {
+            let summary = ProductsListSummary.make(tagged: [], canLoadMore: false)
+            return .success(.init(toolName: ProductsListTool.name,
+                                  structured: LLMPayloadCap.capped(summary, toolName: ProductsListTool.name),
+                                  uiStructured: nil))
+        }
+        async let productLookup = enrichProducts(ids: split.productIDs)
+        async let variationLookup = enrichVariations(grouped: split.variationsByParent)
+        let products = await productLookup
+        let variations = await variationLookup
+        if products == nil && split.productIDs.isEmpty == false {
+            return .failed(.init(toolName: ProductsListTool.name,
+                                 kind: .toolFailed,
+                                 reason: "Could not enrich low-stock product rows"))
+        }
+        let tagged = combine(orderedIDs: split.orderedIDs,
+                             products: products,
+                             variations: variations,
+                             args: args)
+        // Source page being full implies more low-stock pages may exist; post-filtering can shrink
+        // the visible window below per_page but does not change that signal.
+        let canLoadMore = reportRows.count >= perPage
+        let summary = ProductsListSummary.make(tagged: tagged, canLoadMore: canLoadMore)
+        return .success(.init(toolName: ProductsListTool.name,
+                              structured: LLMPayloadCap.capped(summary, toolName: ProductsListTool.name),
+                              uiStructured: nil))
+    }
+
+    private func combine(orderedIDs: [ReportEntry],
+                         products: [Int: AnyCodableJSON]?,
+                         variations: [Int: AnyCodableJSON],
+                         args: ProductsListTool.Args) -> [(AnyCodableJSON, ProductsListSummary.RowKind)] {
+        var tagged: [(AnyCodableJSON, ProductsListSummary.RowKind)] = []
+        for entry in orderedIDs {
+            switch entry.kind {
+            case .product:
+                guard let row = products?[entry.id] else { continue }
+                let filtered = ProductsListTool.applyLowInStockPostFilters(rows: [row],
+                                                                           args: args,
+                                                                           allowCategoryFilter: true)
+                guard let kept = filtered.first else { continue }
+                tagged.append((kept, .product))
+            case .variation:
+                guard let row = variations[entry.id] else { continue }
+                let filtered = ProductsListTool.applyLowInStockPostFilters(rows: [row],
+                                                                           args: args,
+                                                                           allowCategoryFilter: false)
+                guard let kept = filtered.first else { continue }
+                tagged.append((kept, .variation))
+            }
+        }
+        return tagged
+    }
+
+    struct ReportEntry {
+        let id: Int
+        let kind: ProductsListSummary.RowKind
+    }
+
+    struct ReportSplit {
+        let orderedIDs: [ReportEntry]
+        let productIDs: [Int]
+        let variationsByParent: [Int: [Int]]
+    }
+
+    static func splitReportRows(_ rows: [AnyCodableJSON]) -> ReportSplit {
+        var ordered: [ReportEntry] = []
+        var productIDs: [Int] = []
+        var variationsByParent: [Int: [Int]] = [:]
+        for row in rows {
+            guard let raw = RESTResponseParsing.intField(row, "id") else { continue }
+            let id = Int(raw)
+            let parentID = Int(RESTResponseParsing.intField(row, "parent_id") ?? 0)
+            if parentID > 0 {
+                ordered.append(ReportEntry(id: id, kind: .variation))
+                variationsByParent[parentID, default: []].append(id)
+            } else {
+                ordered.append(ReportEntry(id: id, kind: .product))
+                productIDs.append(id)
+            }
+        }
+        return ReportSplit(orderedIDs: ordered,
+                           productIDs: productIDs,
+                           variationsByParent: variationsByParent)
+    }
+
+    /// Returns nil when the enrichment HTTP call fails - distinguishing "no products requested"
+    /// (empty map) from "WC returned a non-2xx" so the caller can surface a failure.
+    private func enrichProducts(ids: [Int]) async -> [Int: AnyCodableJSON]? {
+        guard !ids.isEmpty else { return [:] }
+        return await fetchByInclude(path: "wc/v3/products", ids: ids)
+    }
+
+    /// One parent's variations failing to load shouldn't fail the whole request - merchants
+    /// rightly expect partial results over an opaque error when several parents are in play.
+    private func enrichVariations(grouped: [Int: [Int]]) async -> [Int: AnyCodableJSON] {
+        guard !grouped.isEmpty else { return [:] }
+        let client = client
+        let pairs = Array(grouped.map { ($0.key, $0.value) })
+        let partials = await BoundedTaskGroup.runOrdered(pairs,
+                                                         limit: ProductsUpdateTool.concurrencyCap) { pair in
+            let runner = LowInStockReportRunner(client: client)
+            if let result = await runner.fetchByInclude(path: "wc/v3/products/\(pair.0)/variations",
+                                                        ids: pair.1) {
+                return result
+            }
+            DDLogError("\(ProductsListTool.name): low-stock variation enrichment failed for parent \(pair.0)")
+            return [Int: AnyCodableJSON]()
+        }
+        return partials.reduce(into: [Int: AnyCodableJSON]()) { merged, partial in
+            merged.merge(partial) { _, new in new }
+        }
+    }
+
+    private func fetchByInclude(path: String, ids: [Int]) async -> [Int: AnyCodableJSON]? {
+        let response = await client.request(
+            method: "GET",
+            path: path,
+            query: [
+                "include": ids.map(String.init).joined(separator: ","),
+                "per_page": String(ids.count),
+                "orderby": "include"
+            ],
+            body: nil
+        )
+        guard HTTPStatusClassification.isSuccess(response.statusCode),
+              let payload = RESTResponseParsing.decodeJSON(response.data),
+              let rows = RESTResponseParsing.arrayItems(payload) else {
+            return nil
+        }
+        return Self.keyByID(rows: rows)
+    }
+
+    static func keyByID(rows: [AnyCodableJSON]) -> [Int: AnyCodableJSON] {
+        var keyed: [Int: AnyCodableJSON] = [:]
+        for row in rows {
+            guard let identifier = RESTResponseParsing.intField(row, "id") else { continue }
+            keyed[Int(identifier)] = row
+        }
+        return keyed
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListSummary.swift
@@ -8,12 +8,12 @@ enum ProductsListSummary {
 
     static func make(from rows: [AnyCodableJSON],
                      canLoadMore: Bool,
-                     kind: RowKind) -> AnyCodableJSON {
+                     kind: RowKind = .product) -> AnyCodableJSON {
         make(tagged: rows.map { ($0, kind) }, canLoadMore: canLoadMore)
     }
 
-    /// Use when the same response carries both product and variation rows so each row is
-    /// projected with its own shape and `kind` tag.
+    /// Use when the same response carries both product and variation rows (e.g. the low-stock
+    /// report covers either kind) so each row is projected with its own shape and `kind` tag.
     static func make(tagged rows: [(AnyCodableJSON, RowKind)],
                      canLoadMore: Bool) -> AnyCodableJSON {
         var ids: [AnyCodableJSON] = []

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsListTool.swift
@@ -5,6 +5,11 @@ public enum ProductsListTool {
 
     public static let name = "products_list"
     public static let maxIncludeIDs = 100
+    /// Fallback threshold used only when the wc-analytics stock report is unavailable
+    /// (older WC installs) and we scan paginated /products as a heuristic.
+    static let lowStockThreshold = 10
+    /// Bounds the heuristic multi-page scan that runs when wc-analytics is unavailable.
+    static let lowInStockMaxPagesScanned = 3
 
     public static func make() -> RESTTool {
         RESTTool(definition: definition, executor: execute)
@@ -16,9 +21,11 @@ public enum ProductsListTool {
         List, search, or look up product entities. Returns top-level products by default. \
         Pass `parent_id: N` to list variations of variable product N. Pass `ids: [N, M, ...]` \
         to fetch specific entities by id. Pass `search: "..."` to name-match. Filters: \
-        `stock_status`, `status`. Each row has `id`, `kind` ("product" or "variation"), \
-        `parent_id` (for variations), `name`, `sku`, `price`, `stock_status`, plus \
-        product-only fields like `type` and `variations_count`. \
+        `stock_status`, `status`, `low_in_stock` (returns products that meet WooCommerce's \
+        low-stock criteria - per-product `low_stock_amount` override or site-wide \
+        `woocommerce_notify_low_stock_amount`), `min_price`, `max_price`. Each row has `id`, \
+        `kind` ("product" or "variation"), `parent_id` (for variations), `name`, `sku`, \
+        `price`, `stock_status`, plus product-only fields like `type` and `variations_count`. \
         Each row also carries a `target` object {kind, id, parent_id?} you can pass directly \
         to products_update.updates[].target without interpreting the row shape yourself. \
         After calling, pass returned ids to `show_cards` to render rather than re-fetching. \
@@ -61,7 +68,24 @@ public enum ProductsListTool {
                 "stock_status": .object([
                     "type": .string("string"),
                     "enum": .array(AllowedListValues.stockStatuses.sorted().map { .string($0) }),
-                    "description": .string("Filter by exact stock status.")
+                    "description": .string("Filter by exact stock status. For 'low stock' or "
+                        + "'running low' queries use `low_in_stock` instead.")
+                ]),
+                "low_in_stock": .object([
+                    "type": .string("boolean"),
+                    "description": .string(
+                        "When true, returns products that meet WooCommerce's low-stock criteria "
+                        + "(per-product `low_stock_amount` or site-wide threshold). "
+                        + "Use for 'low stock' or 'running low' queries."
+                    )
+                ]),
+                "min_price": .object([
+                    "type": .string("string"),
+                    "description": .string("Lower bound on price. Decimal string, e.g. \"10.00\".")
+                ]),
+                "max_price": .object([
+                    "type": .string("string"),
+                    "description": .string("Upper bound on price. Decimal string, e.g. \"49.99\".")
                 ]),
                 "orderby": .object([
                     "type": .string("string"),
@@ -94,6 +118,9 @@ public enum ProductsListTool {
         let ids: [Int]?
         let parentID: Int?
         let stockStatus: String?
+        let lowInStock: Bool?
+        let minPrice: String?
+        let maxPrice: String?
         let orderby: String?
         let order: String?
         let page: Int?
@@ -103,13 +130,33 @@ public enum ProductsListTool {
             case search, status, category, sku, ids, orderby, order, page
             case parentID = "parent_id"
             case stockStatus = "stock_status"
+            case lowInStock = "low_in_stock"
+            case minPrice = "min_price"
+            case maxPrice = "max_price"
             case perPage = "per_page"
+        }
+
+        init(search: String?, status: String?, category: Int?, sku: String?, ids: [Int]?,
+             parentID: Int?, stockStatus: String?, lowInStock: Bool?, minPrice: String?,
+             maxPrice: String?, orderby: String?, order: String?, page: Int?, perPage: Int?) {
+            self.search = search; self.status = status; self.category = category; self.sku = sku
+            self.ids = ids; self.parentID = parentID; self.stockStatus = stockStatus
+            self.lowInStock = lowInStock; self.minPrice = minPrice; self.maxPrice = maxPrice
+            self.orderby = orderby; self.order = order; self.page = page; self.perPage = perPage
+        }
+
+        func copy(page: Int) -> Args {
+            Args(search: search, status: status, category: category, sku: sku, ids: ids,
+                 parentID: parentID, stockStatus: stockStatus, lowInStock: lowInStock,
+                 minPrice: minPrice, maxPrice: maxPrice, orderby: orderby, order: order,
+                 page: page, perPage: perPage)
         }
     }
 
     private enum AllowedListValues {
         static let arguments: Set<String> = [
             "search", "status", "category", "sku", "ids", "parent_id", "stock_status",
+            "low_in_stock", "min_price", "max_price",
             "orderby", "order", "page", "per_page"
         ]
         static let statuses: Set<String> = ["any", "draft", "pending", "private", "publish"]
@@ -143,6 +190,14 @@ public enum ProductsListTool {
            !stockStatus.isEmpty {
             query["stock_status"] = stockStatus
         }
+        if let minPrice = args.minPrice?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !minPrice.isEmpty {
+            query["min_price"] = minPrice
+        }
+        if let maxPrice = args.maxPrice?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !maxPrice.isEmpty {
+            query["max_price"] = maxPrice
+        }
         if let page = args.page, page > 1 { query["page"] = String(page) }
         return query
     }
@@ -165,6 +220,15 @@ public enum ProductsListTool {
         }
         let perPage = RESTToolDispatch.clampedPerPage(args.perPage)
         let path = args.parentID.map { "wc/v3/products/\($0)/variations" } ?? "wc/v3/products"
+        if args.lowInStock == true {
+            // wc-analytics' stock report is authoritative for low-stock and respects
+            // per-product overrides; fall back to a heuristic scan for older WC installs.
+            if args.parentID == nil,
+               let result = await LowInStockReportRunner(client: client).run(args: args, perPage: perPage) {
+                return result
+            }
+            return await scanLowInStockHeuristic(args: args, path: path, perPage: perPage, client: client)
+        }
         return await fetchAndSummarize(args: args, path: path, perPage: perPage, client: client)
     }
 
@@ -188,6 +252,51 @@ public enum ProductsListTool {
         let canLoadMore = canLoadMore(rowsCount: rawRows.count, perPage: perPage, args: args)
         let kind: ProductsListSummary.RowKind = args.parentID == nil ? .product : .variation
         let summary = ProductsListSummary.make(from: rawRows, canLoadMore: canLoadMore, kind: kind)
+        return .success(.init(toolName: name,
+                              structured: LLMPayloadCap.capped(summary, toolName: name),
+                              uiStructured: nil))
+    }
+
+    /// Narrows enriched low-stock rows by the merchant's other filters. The stock report ignores
+    /// non-stock parameters, so this is the only place those filters take effect for this path.
+    static func applyLowInStockPostFilters(rows: [AnyCodableJSON],
+                                           args: Args,
+                                           allowCategoryFilter: Bool) -> [AnyCodableJSON] {
+        let matcher = ProductsRowMatcher(args: args, allowCategoryFilter: allowCategoryFilter)
+        return rows.filter(matcher.matches)
+    }
+
+    private static func scanLowInStockHeuristic(args: Args,
+                                                path: String,
+                                                perPage: Int,
+                                                client: WCRESTClient) async -> ToolResult {
+        var collected: [AnyCodableJSON] = []
+        let startPage = max(1, args.page ?? 1)
+        var lastPageHadFullWindow = true
+        for offset in 0..<lowInStockMaxPagesScanned {
+            let pageArgs = args.copy(page: startPage + offset)
+            let response = await client.request(method: "GET",
+                                                path: path,
+                                                query: query(from: pageArgs),
+                                                body: nil)
+            guard HTTPStatusClassification.isSuccess(response.statusCode) else {
+                return .failed(RESTToolDispatch.failed(from: response, toolName: name))
+            }
+            guard let payload = RESTResponseParsing.decodeJSON(response.data),
+                  let rawRows = RESTResponseParsing.arrayItems(payload) else {
+                return .failed(.init(toolName: name, kind: .toolFailed, reason: "expected JSON array"))
+            }
+            lastPageHadFullWindow = rawRows.count >= perPage
+            collected.append(contentsOf: rawRows.filter(isLowInStock))
+            if collected.count >= perPage { break }
+            if !lastPageHadFullWindow { break }
+        }
+        let rows = Array(collected.prefix(perPage))
+        // Source pagination still full means more pages plausibly exist, regardless of
+        // whether the response window filled - low-stock matches are often sparse.
+        let canLoadMore = lastPageHadFullWindow
+        let kind: ProductsListSummary.RowKind = args.parentID == nil ? .product : .variation
+        let summary = ProductsListSummary.make(from: rows, canLoadMore: canLoadMore, kind: kind)
         return .success(.init(toolName: name,
                               structured: LLMPayloadCap.capped(summary, toolName: name),
                               uiStructured: nil))
@@ -234,5 +343,19 @@ public enum ProductsListTool {
             return ids.count > page * perPage
         }
         return rowsCount >= perPage
+    }
+
+    private static func isLowInStock(_ row: AnyCodableJSON) -> Bool {
+        guard case .object(let fields) = row, let raw = fields["stock_quantity"] else { return false }
+        let quantity: Int
+        switch raw {
+        case .int(let value): quantity = Int(value)
+        case .double(let value): quantity = Int(value)
+        case .string(let value):
+            guard let parsed = Int(value) else { return false }
+            quantity = parsed
+        default: return false
+        }
+        return quantity > 0 && quantity <= lowStockThreshold
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsRowMatcher.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsRowMatcher.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct ProductsRowMatcher {
+
+    let args: ProductsListTool.Args
+    let allowCategoryFilter: Bool
+
+    func matches(_ row: AnyCodableJSON) -> Bool {
+        matchesIDs(row)
+            && matchesCategory(row)
+            && matchesSKU(row)
+            && matchesStatus(row)
+            && matchesStockStatus(row)
+            && matchesPrice(row)
+            && matchesSearch(row)
+    }
+
+    private func matchesIDs(_ row: AnyCodableJSON) -> Bool {
+        let idsSet: Set<Int> = Set(args.ids ?? [])
+        guard !idsSet.isEmpty else { return true }
+        guard let id = RESTResponseParsing.intField(row, "id") else { return false }
+        return idsSet.contains(Int(id))
+    }
+
+    private func matchesCategory(_ row: AnyCodableJSON) -> Bool {
+        guard allowCategoryFilter, let category = args.category else { return true }
+        return Self.rowHasCategory(row, category: category)
+    }
+
+    private func matchesSKU(_ row: AnyCodableJSON) -> Bool {
+        let trimmedSKU = args.sku?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        guard !trimmedSKU.isEmpty else { return true }
+        let rowSKU = RESTResponseParsing.stringField(row, "sku")?
+            .trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        return rowSKU == trimmedSKU
+    }
+
+    private func matchesStatus(_ row: AnyCodableJSON) -> Bool {
+        let trimmed = args.status?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty, trimmed != "any" else { return true }
+        return RESTResponseParsing.stringField(row, "status") == trimmed
+    }
+
+    private func matchesStockStatus(_ row: AnyCodableJSON) -> Bool {
+        let trimmed = args.stockStatus?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return true }
+        return RESTResponseParsing.stringField(row, "stock_status") == trimmed
+    }
+
+    private func matchesPrice(_ row: AnyCodableJSON) -> Bool {
+        let minPrice = args.minPrice.flatMap { Decimal(string: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let maxPrice = args.maxPrice.flatMap { Decimal(string: $0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let price = Self.effectivePrice(row: row)
+        if let minPrice, let price, price < minPrice { return false }
+        if let maxPrice, let price, price > maxPrice { return false }
+        return true
+    }
+
+    private func matchesSearch(_ row: AnyCodableJSON) -> Bool {
+        let trimmed = args.search?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        guard !trimmed.isEmpty else { return true }
+        let name = RESTResponseParsing.stringField(row, "name")?.lowercased() ?? ""
+        let rowSKU = RESTResponseParsing.stringField(row, "sku")?.lowercased() ?? ""
+        return name.contains(trimmed) || rowSKU.contains(trimmed)
+    }
+
+    private static func rowHasCategory(_ row: AnyCodableJSON, category: Int) -> Bool {
+        guard case .object(let fields) = row,
+              case .array(let categories) = fields["categories"] ?? .null else {
+            return false
+        }
+        for entry in categories {
+            if let identifier = RESTResponseParsing.intField(entry, "id"), Int(identifier) == category {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Variations sometimes leave `price` blank when only `regular_price` is set, so fall back
+    /// to keep price filters matching the canonical price field WooCommerce displays.
+    private static func effectivePrice(row: AnyCodableJSON) -> Decimal? {
+        if let price = RESTResponseParsing.decimalField(row, "price") { return price }
+        return RESTResponseParsing.decimalField(row, "regular_price")
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateEntry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateEntry.swift
@@ -7,6 +7,7 @@ struct ProductsUpdateEntry: Decodable, Sendable {
     let target: Target?
     let regularPrice: String?
     let salePrice: String?
+    let percentDiscount: Double?
     let stockQuantity: Int?
     let status: String?
     let name: String?
@@ -30,6 +31,7 @@ struct ProductsUpdateEntry: Decodable, Sendable {
         case target
         case regularPrice = "regular_price"
         case salePrice = "sale_price"
+        case percentDiscount = "percent_discount"
         case stockQuantity = "stock_quantity"
         case status
         case name
@@ -38,7 +40,7 @@ struct ProductsUpdateEntry: Decodable, Sendable {
     }
 
     var hasAnyField: Bool {
-        regularPrice != nil || salePrice != nil
+        regularPrice != nil || salePrice != nil || percentDiscount != nil
             || stockQuantity != nil || status != nil
             || name != nil || stockStatus != nil || sku != nil
     }
@@ -47,6 +49,7 @@ struct ProductsUpdateEntry: Decodable, Sendable {
         var keys: [String] = []
         if regularPrice != nil { keys.append("regular_price") }
         if salePrice != nil { keys.append("sale_price") }
+        if percentDiscount != nil { keys.append("percent_discount") }
         if stockQuantity != nil { keys.append("stock_quantity") }
         if status != nil { keys.append("status") }
         if name != nil { keys.append("name") }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateEntry.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateEntry.swift
@@ -19,11 +19,13 @@ struct ProductsUpdateEntry: Decodable, Sendable {
         let kind: String?
         let id: Int?
         let parentID: Int?
+        let scope: String?
 
         enum CodingKeys: String, CodingKey {
             case kind
             case id
             case parentID = "parent_id"
+            case scope
         }
     }
 

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
@@ -53,7 +53,7 @@ struct ProductsUpdatePlanner {
         let type = RESTResponseParsing.stringField(entity, "type") ?? ""
         switch type {
         case "variable":
-            return planVariableParent(entry: entry)
+            return await planVariableParent(entry: entry)
         case "variation":
             let reason = "Product #\(entry.id) is a variation. Use target.kind=\"variation\" with "
                 + "parent_id and the variation id, not target.kind=\"product\"."
@@ -88,31 +88,127 @@ struct ProductsUpdatePlanner {
     }
 
     /// Variable parents accept name/status/sku on the parent row itself; price and stock live on
-    /// the variations, so those fields are refused here. An entry can produce a parent write for
-    /// the parent-level fields AND a refusal note for the price/stock fields at once.
-    private func planVariableParent(entry: ProductsUpdateTool.Entry) -> EntryPlan {
-        var patch: [String: AnyCodableJSON] = [:]
-        if let value = entry.name { patch["name"] = .string(value) }
-        if let value = entry.status { patch["status"] = .string(value) }
-        if let value = entry.sku { patch["sku"] = .string(value) }
-
-        var failures: [(Int, String)] = []
-        if entry.regularPrice != nil || entry.salePrice != nil
-            || entry.stockStatus != nil || entry.stockQuantity != nil {
-            let reason = "Product #\(entry.id) is a variable product. Price and stock changes must "
-                + "target individual variations (target.kind=\"variation\" with parent_id). Its name, "
-                + "status, and sku can be set on the parent."
-            failures.append((entry.id, reason))
+    /// the variations. Without `scope=all_variations` those variation-level fields are refused so the
+    /// model never silently writes across an entire variation set. With explicit scope they fan out
+    /// to every variation, and parent-only fields still land on the parent in the same entry.
+    private func planVariableParent(entry: ProductsUpdateTool.Entry) async -> EntryPlan {
+        if entry.stockQuantity != nil {
+            let reason = "Cannot set stock_quantity on a variable parent; target specific variations with "
+                + "target.kind=\"variation\" and update each."
+            return EntryPlan(preDispatchFailures: [(entry.id, reason)])
         }
+        var parentPatch: [String: AnyCodableJSON] = [:]
+        if let value = entry.status { parentPatch["status"] = .string(value) }
+        if let value = entry.name { parentPatch["name"] = .string(value) }
+        if let value = entry.sku { parentPatch["sku"] = .string(value) }
 
-        guard !patch.isEmpty else {
-            if failures.isEmpty {
+        let hasExpansionFields = entry.regularPrice != nil || entry.salePrice != nil
+            || entry.percentDiscount != nil || entry.stockStatus != nil
+        let scopedFanout = entry.target.scope == .allVariations
+
+        if hasExpansionFields && !scopedFanout {
+            let reason = "Cannot apply variation-level fields (regular_price, sale_price, "
+                + "percent_discount, stock_status) to variable parent #\(entry.id) without explicit "
+                + "fanout consent. To target a specific variation, use "
+                + "target.kind=\"variation\" with parent_id. To apply the change to ALL variations, "
+                + "set target.scope=\"all_variations\"."
+            return EntryPlan(preDispatchFailures: [(entry.id, reason)])
+        }
+        guard hasExpansionFields else {
+            guard !parentPatch.isEmpty else {
                 return EntryPlan(preDispatchFailures: [(entry.id, "no editable field resolved for this entry")])
             }
-            return EntryPlan(preDispatchFailures: failures)
+            let write = PlannedWrite(targetID: entry.id, expandedParent: nil, patch: parentPatch)
+            return EntryPlan(writes: [write])
         }
-        let write = PlannedWrite(targetID: entry.id, expandedParent: nil, patch: patch)
-        return EntryPlan(preDispatchFailures: failures, writes: [write])
+
+        let expansion = await planVariableParentExpansion(entry: entry, parentID: entry.id)
+        guard !parentPatch.isEmpty else { return expansion }
+        // If the per-variation expansion refused entirely, applying parent-only fields would be a
+        // surprise partial write that contradicts the tool description's "refused entirely" promise.
+        let expansionRefused = expansion.writes.isEmpty && !expansion.preDispatchFailures.isEmpty
+        if expansionRefused {
+            let combinedReason = "Cannot apply parent-only fields (e.g. name/status/sku) and per-variation "
+                + "fields (e.g. price/stock_status) in the same update for product #\(entry.id) because the "
+                + "per-variation expansion was refused. Issue two separate updates: one for the parent-only "
+                + "fields, and one with target.kind=\"variation\" entries for the per-variation fields."
+            return EntryPlan(preDispatchFailures: [(entry.id, combinedReason)])
+        }
+        let parentWrite = PlannedWrite(targetID: entry.id, expandedParent: nil, patch: parentPatch)
+        return EntryPlan(preDispatchFailures: expansion.preDispatchFailures,
+                         writes: [parentWrite] + expansion.writes)
+    }
+
+    private func planVariableParentExpansion(entry: ProductsUpdateTool.Entry,
+                                             parentID: Int) async -> EntryPlan {
+        let response = await client.request(method: "GET",
+                                            path: "wc/v3/products/\(parentID)/variations",
+                                            query: ["per_page": String(ProductsUpdateTool.variationsPerPage)],
+                                            body: nil)
+        guard HTTPStatusClassification.isSuccess(response.statusCode),
+              let payload = RESTResponseParsing.decodeJSON(response.data),
+              let rows = RESTResponseParsing.arrayItems(payload) else {
+            return EntryPlan(preDispatchFailures: [(entry.id, "Could not enumerate variations for parent \(parentID)")])
+        }
+        // Refuse partial application: writing only the first page would leave variations inconsistent.
+        // Also refuse when the page is full and no header info disambiguates, since we can't prove a
+        // second page doesn't exist (covers older adapters or mocks that drop X-WP-TotalPages).
+        let pageCapMet = rows.count >= ProductsUpdateTool.variationsPerPage
+        if Self.totalPagesValue(headers: response.headers) > 1 || pageCapMet {
+            let reason = "Cannot update variable product #\(entry.id): it has more than "
+                + "\(ProductsUpdateTool.variationsPerPage) variations and updating only the first "
+                + "\(ProductsUpdateTool.variationsPerPage) would leave the rest in an inconsistent state. "
+                + "Issue updates with target.kind=\"variation\" for specific variation ids instead."
+            return EntryPlan(preDispatchFailures: [(entry.id, reason)])
+        }
+        var writes: [PlannedWrite] = []
+        var failures: [(Int, String)] = []
+        for row in rows {
+            switch plannedVariationWrite(entry: entry, row: row, parentID: parentID) {
+            case .success(let write): writes.append(write)
+            case .failure(let failure): failures.append(failure)
+            case .none: continue
+            }
+        }
+        return EntryPlan(preDispatchFailures: failures, writes: writes)
+    }
+
+    /// `.none` means the row had no `id` to target; the loop skips it silently.
+    private enum VariationOutcome {
+        case success(PlannedWrite)
+        case failure((Int, String))
+        case none
+    }
+
+    private func plannedVariationWrite(entry: ProductsUpdateTool.Entry,
+                                       row: AnyCodableJSON,
+                                       parentID: Int) -> VariationOutcome {
+        guard let identifier = RESTResponseParsing.intField(row, "id") else { return .none }
+        let variationID = Int(identifier)
+        var patch: [String: AnyCodableJSON] = [:]
+        if let value = entry.regularPrice { patch["regular_price"] = .string(value) }
+        if let value = entry.salePrice { patch["sale_price"] = .string(value) }
+        if let percent = entry.percentDiscount {
+            guard let regular = RESTResponseParsing.decimalField(row, "regular_price"),
+                  let salePrice = Self.computeSalePrice(regular: regular, percent: percent) else {
+                return .failure((variationID, "Cannot compute percent discount: regular_price is empty"))
+            }
+            patch["sale_price"] = .string(salePrice)
+        }
+        if let value = entry.stockStatus { patch["stock_status"] = .string(value) }
+        guard !patch.isEmpty else {
+            return .failure((variationID, "no editable field resolved"))
+        }
+        return .success(PlannedWrite(targetID: variationID,
+                                     expandedParent: parentID,
+                                     patch: patch))
+    }
+
+    private static func totalPagesValue(headers: [String: String]) -> Int {
+        for (key, value) in headers where key.caseInsensitiveCompare("X-WP-TotalPages") == .orderedSame {
+            return Int(value) ?? 0
+        }
+        return 0
     }
 
     private func planVariation(entry: ProductsUpdateTool.Entry,

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
@@ -19,9 +19,9 @@ struct ProductsUpdatePlanner {
             guard let parentID = entry.target.parentID else {
                 return EntryPlan(preDispatchFailures: [(entry.id, "variation target missing parent_id")])
             }
-            return planVariation(entry: entry,
-                                 parentID: parentID,
-                                 variationID: entry.target.id)
+            return await planVariation(entry: entry,
+                                       parentID: parentID,
+                                       variationID: entry.target.id)
         case .product:
             return await planProductTarget(entry: entry, discovery: discovery)
         }
@@ -59,7 +59,7 @@ struct ProductsUpdatePlanner {
                 + "parent_id and the variation id, not target.kind=\"product\"."
             return EntryPlan(preDispatchFailures: [(entry.id, reason)])
         default:
-            return planProduct(entry: entry)
+            return planProduct(entry: entry, source: entity)
         }
     }
 
@@ -67,9 +67,12 @@ struct ProductsUpdatePlanner {
         statusCode == 404 ? "Product not found" : "Discovery request failed (HTTP \(statusCode))"
     }
 
-    private func planProduct(entry: ProductsUpdateTool.Entry) -> EntryPlan {
+    private func planProduct(entry: ProductsUpdateTool.Entry, source: AnyCodableJSON) -> EntryPlan {
         var patch: [String: AnyCodableJSON] = [:]
         applyExplicitPriceFields(entry: entry, into: &patch)
+        if let failure = applyPercentDiscount(entry: entry, source: source, into: &patch) {
+            return EntryPlan(preDispatchFailures: [(entry.id, failure)])
+        }
         applyCommonFields(entry: entry, into: &patch)
         if let value = entry.name { patch["name"] = .string(value) }
         if let value = entry.stockStatus { patch["stock_status"] = .string(value) }
@@ -114,7 +117,7 @@ struct ProductsUpdatePlanner {
 
     private func planVariation(entry: ProductsUpdateTool.Entry,
                                parentID: Int,
-                               variationID: Int) -> EntryPlan {
+                               variationID: Int) async -> EntryPlan {
         guard parentID > 0 else {
             return EntryPlan(preDispatchFailures: [(entry.id, "variation has no parent_id")])
         }
@@ -125,6 +128,20 @@ struct ProductsUpdatePlanner {
         }
         var patch: [String: AnyCodableJSON] = [:]
         applyExplicitPriceFields(entry: entry, into: &patch)
+        if entry.percentDiscount != nil {
+            // Only fetch the variation when we need its regular_price for percent math.
+            let probe = await client.request(method: "GET",
+                                             path: "wc/v3/products/\(parentID)/variations/\(variationID)",
+                                             query: nil,
+                                             body: nil)
+            guard HTTPStatusClassification.isSuccess(probe.statusCode),
+                  let decoded = RESTResponseParsing.decodeJSON(probe.data) else {
+                return EntryPlan(preDispatchFailures: [(entry.id, discoveryReason(probe.statusCode))])
+            }
+            if let failure = applyPercentDiscount(entry: entry, source: decoded, into: &patch) {
+                return EntryPlan(preDispatchFailures: [(entry.id, failure)])
+            }
+        }
         applyCommonFields(entry: entry, into: &patch)
         if let value = entry.stockStatus { patch["stock_status"] = .string(value) }
         if let value = entry.sku { patch["sku"] = .string(value) }
@@ -151,5 +168,25 @@ struct ProductsUpdatePlanner {
             patch["manage_stock"] = .bool(true)
         }
         if let value = entry.status { patch["status"] = .string(value) }
+    }
+
+    private func applyPercentDiscount(entry: ProductsUpdateTool.Entry,
+                                      source: AnyCodableJSON,
+                                      into patch: inout [String: AnyCodableJSON]) -> String? {
+        guard let percent = entry.percentDiscount else { return nil }
+        guard let regular = RESTResponseParsing.decimalField(source, "regular_price"),
+              let salePrice = Self.computeSalePrice(regular: regular, percent: percent) else {
+            return "Cannot compute percent discount: regular_price is empty"
+        }
+        patch["sale_price"] = .string(salePrice)
+        return nil
+    }
+
+    static func computeSalePrice(regular: Decimal, percent: Double) -> String? {
+        guard regular > 0 else { return nil }
+        let factorString = String(format: "%.6f", (100.0 - percent) / 100.0)
+        guard let factor = Decimal(string: factorString) else { return nil }
+        let computed = regular * factor
+        return RESTResponseParsing.formatDecimal(computed)
     }
 }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
@@ -278,7 +278,7 @@ struct ProductsUpdatePlanner {
         return nil
     }
 
-    static func computeSalePrice(regular: Decimal, percent: Double) -> String? {
+    private static func computeSalePrice(regular: Decimal, percent: Double) -> String? {
         guard regular > 0 else { return nil }
         let factorString = String(format: "%.6f", (100.0 - percent) / 100.0)
         guard let factor = Decimal(string: factorString) else { return nil }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdatePlanner.swift
@@ -151,8 +151,10 @@ struct ProductsUpdatePlanner {
             return EntryPlan(preDispatchFailures: [(entry.id, "Could not enumerate variations for parent \(parentID)")])
         }
         // Refuse partial application: writing only the first page would leave variations inconsistent.
-        // Also refuse when the page is full and no header info disambiguates, since we can't prove a
-        // second page doesn't exist (covers older adapters or mocks that drop X-WP-TotalPages).
+        // A parent with exactly variationsPerPage rows and no X-WP-TotalPages header is refused on
+        // purpose: a full page is indistinguishable from the first page of many, so we cannot prove a
+        // second page does not exist (covers older adapters or mocks that drop the header). This
+        // conservative refusal is intentional, not a bug.
         let pageCapMet = rows.count >= ProductsUpdateTool.variationsPerPage
         if Self.totalPagesValue(headers: response.headers) > 1 || pageCapMet {
             let reason = "Cannot update variable product #\(entry.id): it has more than "

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
@@ -28,10 +28,12 @@ public enum ProductsUpdateTool {
         Examples: `{target: {kind: "product", id: 42}, sale_price: "9.99"}` discounts simple \
         product 42; `{target: {kind: "variation", id: 58, parent_id: 41}, sale_price: "9.99"}` \
         discounts ONE variation - use this with the target object on order line_items. \
-        Editable fields: `regular_price`, `sale_price`, `stock_quantity`, `status`, `name`, \
-        `stock_status`, `sku`. On a variable parent only `name`, `status`, and `sku` apply; price \
-        and stock changes are rejected with a pointer to target specific variations. Variations do \
-        not have settable names. \
+        Editable fields: `regular_price`, `sale_price`, `percent_discount`, `stock_quantity`, \
+        `status`, `name`, `stock_status`, `sku`. For percentage-off discounts use \
+        `percent_discount` per entry and the server computes per-item `sale_price` from the \
+        entity's current regular price. Otherwise set `sale_price` explicitly. On a variable \
+        parent only `name`, `status`, and `sku` apply; price and stock changes are rejected with \
+        a pointer to target specific variations. Variations do not have settable names. \
         The result has an `updated` array of target objects ({kind:"product", id} or \
         {kind:"variation", id, parent_id}); pass each one to `show_cards` (a variation maps to \
         the combined parent/variation ref) or back into `products_update.updates[].target`.
@@ -78,6 +80,10 @@ public enum ProductsUpdateTool {
                             "sale_price": .object([
                                 "type": .string("string"),
                                 "description": .string("Decimal string. Empty string clears the sale price.")
+                            ]),
+                            "percent_discount": .object([
+                                "type": .string("number"),
+                                "description": .string("Percent off (1-99). Computed against the entity's current regular_price.")
                             ]),
                             "stock_quantity": .object([
                                 "type": .string("integer"),
@@ -130,6 +136,7 @@ public enum ProductsUpdateTool {
         let target: Target
         let regularPrice: String?
         let salePrice: String?
+        let percentDiscount: Double?
         let stockQuantity: Int?
         let status: String?
         let name: String?
@@ -153,6 +160,7 @@ public enum ProductsUpdateTool {
             self.target = target
             self.regularPrice = raw.regularPrice
             self.salePrice = raw.salePrice
+            self.percentDiscount = raw.percentDiscount
             self.stockQuantity = raw.stockQuantity
             self.status = raw.status
             self.name = raw.name
@@ -278,6 +286,11 @@ public enum ProductsUpdateTool {
             return .invalid(.init(toolName: name,
                                   kind: .invalidToolCall,
                                   reason: "stock_status must be one of: \(allowedStockStatuses.sorted().joined(separator: ", "))"))
+        }
+        if let percent = entry.percentDiscount, percent <= 0 || percent >= 100 {
+            return .invalid(.init(toolName: name,
+                                  kind: .invalidToolCall,
+                                  reason: "percent_discount must be between 0 and 100 (exclusive)"))
         }
         return .valid(ValidatedEntry(entry, target: target))
     }

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
@@ -8,6 +8,7 @@ public enum ProductsUpdateTool {
     public static let maxBatchSize = 100
 
     static let concurrencyCap = 5
+    static let variationsPerPage = 100
     /// Mirrors the WC REST `per_page` ceiling so a single `?include=` chunk covers up to 100 ids.
     static let discoveryChunkSize = 100
 
@@ -18,22 +19,30 @@ public enum ProductsUpdateTool {
     private static let definition = AITool(
         name: name,
         description: """
-        Update one or more EXISTING product entities (simple products or variations) in a single \
-        call. Each update needs a `target` object identifying what to write, plus at least one \
-        field to change. The target shape mirrors what orders_list/products_list/show_cards emit \
-        on each row, so copy that object verbatim. This tool does NOT create new products or \
-        delete products; for those, point the merchant at the Products tab in the app. \
+        Update one or more EXISTING product entities (simple products, variable products, or \
+        variations) in a single call. Each update needs a `target` object identifying what to \
+        write, plus at least one field to change. The target shape mirrors what \
+        orders_list/products_list/show_cards emit on each row, so copy that object verbatim. \
+        This tool does NOT create new products or delete products; for those, point the merchant \
+        at the Products tab in the app. \
         Target shapes: `{kind: "product", id: N}` for a top-level product (simple or variable \
-        parent); `{kind: "variation", id: V, parent_id: P}` for one specific variation. \
-        Examples: `{target: {kind: "product", id: 42}, sale_price: "9.99"}` discounts simple \
-        product 42; `{target: {kind: "variation", id: 58, parent_id: 41}, sale_price: "9.99"}` \
-        discounts ONE variation - use this with the target object on order line_items. \
+        parent); `{kind: "variation", id: V, parent_id: P}` for one specific variation; \
+        `{kind: "product", id: N, scope: "all_variations"}` to fan price/stock changes out to \
+        every variation of variable parent N. Without `scope`, variable-parent entries only \
+        apply parent-level fields (name, status, sku); price and stock changes are rejected with \
+        a pointer to target specific variations or to set scope=all_variations. Examples: \
+        `{target: {kind: "product", id: 42}, percent_discount: 10}` discounts simple product \
+        42; `{target: {kind: "variation", id: 58, parent_id: 41}, percent_discount: 10}` \
+        discounts ONE variation - use this with the target object on order line_items; \
+        `{target: {kind: "product", id: 821, scope: "all_variations"}, percent_discount: 10}` \
+        discounts ALL variations under variable parent 821. \
         Editable fields: `regular_price`, `sale_price`, `percent_discount`, `stock_quantity`, \
         `status`, `name`, `stock_status`, `sku`. For percentage-off discounts use \
         `percent_discount` per entry and the server computes per-item `sale_price` from the \
-        entity's current regular price. Otherwise set `sale_price` explicitly. On a variable \
-        parent only `name`, `status`, and `sku` apply; price and stock changes are rejected with \
-        a pointer to target specific variations. Variations do not have settable names. \
+        entity's current regular price. Otherwise set `sale_price` explicitly. `stock_quantity` \
+        on a variable parent is rejected even with scope; target specific variations. Variations \
+        do not have settable names. Variable parents with more than 100 variations are refused \
+        entirely when `scope: "all_variations"` is set; target specific variation ids instead. \
         The result has an `updated` array of target objects ({kind:"product", id} or \
         {kind:"variation", id, parent_id}); pass each one to `show_cards` (a variation maps to \
         the combined parent/variation ref) or back into `products_update.updates[].target`.
@@ -69,6 +78,12 @@ public enum ProductsUpdateTool {
                                         "type": .string("integer"),
                                         "description": .string("Required when kind=variation; "
                                             + "must equal the variation's parent product id.")
+                                    ]),
+                                    "scope": .object([
+                                        "type": .string("string"),
+                                        "enum": .array([.string("all_variations")]),
+                                        "description": .string("Only valid on kind=product variable parents. "
+                                            + "Set to \"all_variations\" to fan changes out to every variation.")
                                     ])
                                 ]),
                                 "required": .array([.string("kind"), .string("id")])
@@ -149,11 +164,16 @@ public enum ProductsUpdateTool {
             let kind: Kind
             let id: Int
             let parentID: Int?
+            let scope: Scope?
         }
 
         enum Kind: String, Sendable {
             case product
             case variation
+        }
+
+        enum Scope: String, Sendable {
+            case allVariations = "all_variations"
         }
 
         init(_ raw: ProductsUpdateEntry, target: Target) {
@@ -321,6 +341,15 @@ public enum ProductsUpdateTool {
                                   kind: .invalidToolCall,
                                   reason: "target.id is required and must be a positive integer"))
         }
+        var scope: ValidatedEntry.Scope?
+        if let scopeRaw = raw.scope {
+            guard let resolved = ValidatedEntry.Scope(rawValue: scopeRaw) else {
+                return .invalid(.init(toolName: name,
+                                      kind: .invalidToolCall,
+                                      reason: "target.scope must be \"all_variations\" or omitted"))
+            }
+            scope = resolved
+        }
         switch kind {
         case .product:
             if raw.parentID != nil {
@@ -328,8 +357,13 @@ public enum ProductsUpdateTool {
                                       kind: .invalidToolCall,
                                       reason: "target.parent_id is only valid when kind=\"variation\""))
             }
-            return .valid(.init(kind: .product, id: id, parentID: nil))
+            return .valid(.init(kind: .product, id: id, parentID: nil, scope: scope))
         case .variation:
+            if scope != nil {
+                return .invalid(.init(toolName: name,
+                                      kind: .invalidToolCall,
+                                      reason: "target.scope is not valid when kind=\"variation\""))
+            }
             guard let parentID = raw.parentID, parentID > 0 else {
                 return .invalid(.init(toolName: name,
                                       kind: .invalidToolCall,
@@ -340,7 +374,7 @@ public enum ProductsUpdateTool {
                                       kind: .invalidToolCall,
                                       reason: "target.parent_id must differ from target.id"))
             }
-            return .valid(.init(kind: .variation, id: id, parentID: parentID))
+            return .valid(.init(kind: .variation, id: id, parentID: parentID, scope: nil))
         }
     }
 

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Products/ProductsUpdateTool.swift
@@ -98,7 +98,8 @@ public enum ProductsUpdateTool {
                             ]),
                             "percent_discount": .object([
                                 "type": .string("number"),
-                                "description": .string("Percent off (1-99). Computed against the entity's current regular_price.")
+                                "description": .string("Percent off, greater than 0 and less than 100. "
+                                    + "Computed against the entity's current regular_price.")
                             ]),
                             "stock_quantity": .object([
                                 "type": .string("integer"),

--- a/Modules/Tests/WooAIAssistantTests/Loop/AgenticLoopOrchestratorTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/AgenticLoopOrchestratorTests.swift
@@ -203,4 +203,105 @@ struct AgenticLoopOrchestratorTests {
         let outcome = await orchestrator.lastOutcome
         #expect(outcome == .maxIterations(iterations: 3))
     }
+
+    @Test
+    func test_loop_when_snapshot_has_refusal_then_confirmation_card_not_shown_and_tool_result_carries_refusal_text() async throws {
+        // Given
+        let unsafeTool = AITool(name: "orders_update",
+                                description: "Update an order",
+                                parametersSchema: .object([:]),
+                                safetyLevel: .unsafe)
+        let chat = MockAIChatService()
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "orders_update", arguments: #"{"id":42,"status":"processing"}"#)
+        )
+        await chat.setScriptedTurns([
+            [.toolCall(toolCall), .completed(.toolCalls)],
+            [.textDelta("OK."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([unsafeTool])
+        let policy = ScriptedSafetyPolicy(decision: .refusePreDispatch(reason: "I couldn't find order 42."))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   safetyPolicy: policy)
+
+        // When
+        var events: [AssistantEvent] = []
+        for try await event in orchestrator.run(prompt: "Update 42") {
+            events.append(event)
+        }
+
+        // Then
+        let confirmationCount = events.filter {
+            if case .confirmationRequired = $0 { return true }
+            return false
+        }.count
+        #expect(confirmationCount == 0)
+        let invocations = await registry.invocationCount(for: "orders_update")
+        #expect(invocations == 0)
+        let completedResult: String? = events.compactMap { event in
+            if case .toolCallCompleted(_, _, let json) = event { return json }
+            return nil
+        }.first
+        let payload = try #require(completedResult)
+        #expect(payload.contains("I couldn't find order 42."))
+    }
+
+    @Test
+    func test_loop_when_snapshot_has_no_refusal_then_confirmation_flow_proceeds_as_before() async throws {
+        // Given
+        let unsafeTool = AITool(name: "orders_update",
+                                description: "Update an order",
+                                parametersSchema: .object([:]),
+                                safetyLevel: .unsafe)
+        let chat = MockAIChatService()
+        let toolCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "orders_update", arguments: #"{"id":42,"status":"processing"}"#)
+        )
+        await chat.setScriptedTurns([
+            [.toolCall(toolCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([unsafeTool])
+        await registry.setResult(for: "orders_update",
+                                 result: .success(.init(toolName: "orders_update",
+                                                        structured: .object(["id": .int(42)]))))
+        let preview = ConfirmationPreview(summary: .raw("Update order #42"))
+        let policy = ScriptedSafetyPolicy(decision: .requireConfirmation(preview: preview))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   safetyPolicy: policy)
+
+        // When
+        var events: [AssistantEvent] = []
+        let stream = orchestrator.run(prompt: "Update 42")
+        var pendingConfirmTask: Task<Void, Never>?
+        for try await event in stream {
+            events.append(event)
+            if case .confirmationRequired(let proposal) = event {
+                pendingConfirmTask = Task { await orchestrator.confirm(proposalID: proposal.id) }
+            }
+        }
+        await pendingConfirmTask?.value
+
+        // Then
+        let confirmationCount = events.filter {
+            if case .confirmationRequired = $0 { return true }
+            return false
+        }.count
+        #expect(confirmationCount == 1)
+        let invocations = await registry.invocationCount(for: "orders_update")
+        #expect(invocations == 1)
+    }
+}
+
+private struct ScriptedSafetyPolicy: SafetyPolicy {
+    let decision: SafetyDecision
+    func decision(for name: String, arguments: String, tool: AITool) async -> SafetyDecision {
+        decision
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Safety/ConfirmationPreviewTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/ConfirmationPreviewTests.swift
@@ -44,4 +44,34 @@ struct ConfirmationPreviewTests {
         #expect(preview.isBulk == false)
         #expect(preview.fields.isEmpty)
     }
+
+    @Test
+    func test_showsSummaryInBody_when_bulk_entries_present_then_false() {
+        // Given
+        let preview = ConfirmationPreview(summary: .raw("Update 2 orders"),
+                                          isBulk: true,
+                                          bulkEntries: [ConfirmationBulkEntry(id: 1)])
+
+        // When / Then
+        #expect(preview.showsSummaryInBody == false)
+    }
+
+    @Test
+    func test_showsSummaryInBody_when_fields_present_then_false() {
+        // Given
+        let field = ConfirmationPreviewField(name: "status", label: .raw("Status"), value: .raw("processing"))
+        let preview = ConfirmationPreview(summary: .raw("Update order #42"), fields: [field])
+
+        // When / Then
+        #expect(preview.showsSummaryInBody == false)
+    }
+
+    @Test
+    func test_showsSummaryInBody_when_only_summary_then_true() {
+        // Given
+        let preview = ConfirmationPreview(summary: .raw("Update order #42"))
+
+        // When / Then
+        #expect(preview.showsSummaryInBody == true)
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationPreviewBuilderTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationPreviewBuilderTests.swift
@@ -753,7 +753,7 @@ struct DefaultConfirmationPreviewBuilderTests {
     }
 
     @Test
-    func test_build_when_products_update_field_values_diverge_then_renders_updated_marker() throws {
+    func test_build_when_products_update_field_values_diverge_then_renders_varies_per_item() throws {
         // Given
         let builder = DefaultConfirmationPreviewBuilder()
 
@@ -767,7 +767,250 @@ struct DefaultConfirmationPreviewBuilderTests {
         // Then
         let unwrapped = try #require(preview)
         let saleField = try #require(unwrapped.fields.first(where: { $0.name == "sale_price" }))
-        #expect(saleField.value.flattened() == "Updated")
+        #expect(saleField.value.flattened() == "varies per item")
+    }
+
+    @Test
+    func test_build_when_products_update_percent_discount_then_summary_includes_percent() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"{"updates":[{"target":{"kind":"product","id":12},"percent_discount":10}]}"#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "percent_discount" }))
+        #expect(field.value.flattened() == "10% off")
+    }
+
+    @Test
+    func test_build_when_products_update_field_set_by_some_entries_then_renders_varies_per_item() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"product","id":1},"sale_price":"9.99"},
+              {"target":{"kind":"product","id":2},"name":"Tee"},
+              {"target":{"kind":"product","id":3},"name":"Shirt"}
+            ]}
+            """#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let saleField = try #require(unwrapped.fields.first(where: { $0.name == "sale_price" }))
+        #expect(saleField.value.flattened() == "varies per item")
+    }
+
+    @Test
+    func test_productField_when_values_diverge_then_perEntryValues_populated_per_id() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"product","id":3859},"stock_quantity":10},
+              {"target":{"kind":"product","id":3860},"stock_quantity":5},
+              {"target":{"kind":"product","id":3861},"stock_quantity":8}
+            ]}
+            """#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "stock_quantity" }))
+        let perEntry = try #require(field.perEntryValues)
+        #expect(perEntry[3859] == .raw("10"))
+        #expect(perEntry[3860] == .raw("5"))
+        #expect(perEntry[3861] == .raw("8"))
+    }
+
+    @Test
+    func test_productField_when_values_uniform_then_perEntryValues_nil() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"{"updates":[{"target":{"kind":"product","id":1},"sale_price":"10.00"},{"target":{"kind":"product","id":2},"sale_price":"10.00"}]}"#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let field = try #require(unwrapped.fields.first(where: { $0.name == "sale_price" }))
+        #expect(field.perEntryValues == nil)
+    }
+
+    @Test
+    func test_productField_when_some_entries_omit_field_then_still_renders_perEntryValues_only_for_set_entries() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"product","id":1},"sale_price":"9.99"},
+              {"target":{"kind":"product","id":2},"name":"Tee"},
+              {"target":{"kind":"product","id":3},"name":"Shirt"}
+            ]}
+            """#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let saleField = try #require(unwrapped.fields.first(where: { $0.name == "sale_price" }))
+        #expect(saleField.value.flattened() == "varies per item")
+        let perEntry = try #require(saleField.perEntryValues)
+        #expect(perEntry[1] == .raw("9.99"))
+        #expect(perEntry[2] == nil)
+        #expect(perEntry[3] == nil)
+    }
+
+    @Test
+    func test_build_when_scoped_fanout_with_snapshot_count_then_summary_names_parent_and_count() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let snapshot = ConfirmationSnapshot(
+            currentValues: [:],
+            bulkEntries: [ConfirmationBulkEntry(id: 821, displayName: "Hoodie")],
+            parentVariationCounts: [821: 12]
+        )
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":821,"scope":"all_variations"},"percent_discount":10}]}
+            """#,
+            snapshot: snapshot
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        #expect(unwrapped.summary.flattened() == "Apply changes to all 12 variations of Hoodie")
+    }
+
+    @Test
+    func test_build_when_scoped_fanout_without_snapshot_count_then_summary_degrades_gracefully() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let snapshot = ConfirmationSnapshot(
+            currentValues: [:],
+            bulkEntries: [ConfirmationBulkEntry(id: 821, displayName: "Hoodie")]
+        )
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":821,"scope":"all_variations"},"percent_discount":10}]}
+            """#,
+            snapshot: snapshot
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        #expect(unwrapped.summary.flattened() == "Apply changes to all variations of Hoodie")
+    }
+
+    @Test
+    func test_build_when_scoped_fanout_without_snapshot_then_summary_uses_parent_id_token() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":821,"scope":"all_variations"},"percent_discount":10}]}
+            """#,
+            snapshot: nil
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        #expect(unwrapped.summary.flattened() == "Apply changes to all variations of #821")
+    }
+
+    @Test
+    func test_build_when_two_scoped_fanouts_with_counts_then_summary_aggregates_across_parents() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let snapshot = ConfirmationSnapshot(
+            currentValues: [:],
+            bulkEntries: [
+                ConfirmationBulkEntry(id: 821, displayName: "Hoodie"),
+                ConfirmationBulkEntry(id: 822, displayName: "Tee")
+            ],
+            parentVariationCounts: [821: 8, 822: 4]
+        )
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"product","id":821,"scope":"all_variations"},"percent_discount":10},
+              {"target":{"kind":"product","id":822,"scope":"all_variations"},"percent_discount":10}
+            ]}
+            """#,
+            snapshot: snapshot
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        #expect(unwrapped.summary.flattened() == "Apply changes to 12 variations across 2 parents")
+    }
+
+    @Test
+    func test_productsUpdate_bulk_entries_use_variation_names_when_available() throws {
+        // Given
+        let builder = DefaultConfirmationPreviewBuilder()
+        let snapshot = ConfirmationSnapshot(
+            currentValues: [:],
+            bulkEntries: [
+                ConfirmationBulkEntry(id: 821, displayName: "Hoodie", subEntries: [
+                    ConfirmationBulkEntry(id: 901, displayName: "Hoodie - Red, Small"),
+                    ConfirmationBulkEntry(id: 902, displayName: "Hoodie - Red, Medium")
+                ])
+            ],
+            parentVariationCounts: [821: 2]
+        )
+
+        // When
+        let preview = builder.build(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":821,"scope":"all_variations"},"percent_discount":10}]}
+            """#,
+            snapshot: snapshot
+        )
+
+        // Then
+        let unwrapped = try #require(preview)
+        let parent = try #require(unwrapped.bulkEntries.first)
+        #expect(parent.id == 821)
+        #expect(parent.displayName == "Hoodie")
+        #expect(parent.subEntries.map(\.displayName) == ["Hoodie - Red, Small", "Hoodie - Red, Medium"])
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationSnapshotResolverTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationSnapshotResolverTests.swift
@@ -304,7 +304,6 @@ struct DefaultConfirmationSnapshotResolverTests {
         let client = StubRESTClient()
         await client.setResponse(forPath: "wc/v3/products",
                                  body: #"[{"id":41,"name":"Hoodie"}]"#)
-        // Parent fetch succeeds; per-parent variations fetch returns a different variation id so 99 is missing.
         await client.setResponse(forPath: "wc/v3/products/41/variations",
                                  body: #"[{"id":58,"name":"Hoodie - Red"}]"#)
         let resolver = DefaultConfirmationSnapshotResolver(client: client)

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationSnapshotResolverTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationSnapshotResolverTests.swift
@@ -148,7 +148,7 @@ struct DefaultConfirmationSnapshotResolverTests {
     }
 
     @Test
-    func test_resolveProductsUpdate_when_variation_target_then_no_variation_endpoint_hit() async {
+    func test_resolveProductsUpdate_when_no_scoped_fanout_then_no_variation_endpoint_hit() async {
         // Given
         let client = StubRESTClient()
         await client.setResponse(forPath: "wc/v3/products",
@@ -158,7 +158,9 @@ struct DefaultConfirmationSnapshotResolverTests {
         // When
         _ = await resolver.resolve(
             toolName: ProductsUpdateTool.name,
-            arguments: #"{"updates":[{"target":{"kind":"variation","id":101,"parent_id":50},"sale_price":"5"}]}"#
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":50},"name":"Renamed"}]}
+            """#
         )
 
         // Then
@@ -167,23 +169,197 @@ struct DefaultConfirmationSnapshotResolverTests {
     }
 
     @Test
-    func test_resolveProductsUpdate_when_variation_target_then_bulk_entry_uses_parent_name() async throws {
+    func test_resolveProductsUpdate_when_variation_targets_then_snapshot_includes_variation_names_by_parent() async throws {
         // Given
         let client = StubRESTClient()
         await client.setResponse(forPath: "wc/v3/products",
-                                 body: #"[{"id":50,"name":"Tee"}]"#)
+                                 body: #"[{"id":41,"name":"Hoodie"}]"#)
+        let variationsBody = """
+        [{"id":58,"name":"Hoodie - Red","attributes":[{"id":1,"name":"Color","option":"Red"}]},\
+        {"id":59,"name":"Hoodie - Blue","attributes":[{"id":1,"name":"Color","option":"Blue"}]}]
+        """
+        await client.setResponse(forPath: "wc/v3/products/41/variations", body: variationsBody)
         let resolver = DefaultConfirmationSnapshotResolver(client: client)
 
         // When
         let snapshot = await resolver.resolve(
             toolName: ProductsUpdateTool.name,
-            arguments: #"{"updates":[{"target":{"kind":"variation","id":101,"parent_id":50},"sale_price":"5"}]}"#
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"variation","id":58,"parent_id":41},"sale_price":"5"},
+              {"target":{"kind":"variation","id":59,"parent_id":41},"sale_price":"5"}
+            ]}
+            """#
         )
 
         // Then
         let entries = try #require(snapshot?.bulkEntries)
-        #expect(entries.map(\.id) == [101])
-        #expect(entries.first?.displayName == "Tee")
+        #expect(entries.map(\.id) == [58, 59])
+        #expect(entries.compactMap(\.displayName) == ["Hoodie - Red", "Hoodie - Blue"])
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_variation_name_is_bare_attributes_then_label_prepends_parent() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":820,"name":"Heavyweight Wool Cardigan"}]"#)
+        let variationsBody = """
+        [{"id":840,"name":"L, Gray","attributes":[{"id":1,"name":"Size","option":"L"},\
+        {"id":2,"name":"Color","option":"Gray"}]}]
+        """
+        await client.setResponse(forPath: "wc/v3/products/820/variations", body: variationsBody)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"variation","id":840,"parent_id":820},"sale_price":"5"}]}
+            """#
+        )
+
+        // Then
+        let entries = try #require(snapshot?.bulkEntries)
+        #expect(entries.compactMap(\.displayName) == ["Heavyweight Wool Cardigan - L, Gray"])
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_all_product_ids_missing_then_returns_refusal_with_all_listed() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products", body: "[]")
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"product","id":3859},"regular_price":"25"},
+              {"target":{"kind":"product","id":3860},"regular_price":"25"},
+              {"target":{"kind":"product","id":3861},"regular_price":"25"}
+            ]}
+            """#
+        )
+
+        // Then
+        let reason = try #require(snapshot?.refusalReason)
+        #expect(reason.contains("3859"))
+        #expect(reason.contains("3860"))
+        #expect(reason.contains("3861"))
+        #expect(snapshot?.bulkEntries.isEmpty == true)
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_one_of_three_ids_missing_then_returns_refusal_naming_just_that_id() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":3859,"name":"A"},{"id":3861,"name":"C"}]"#)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[
+              {"target":{"kind":"product","id":3859},"regular_price":"25"},
+              {"target":{"kind":"product","id":3860},"regular_price":"25"},
+              {"target":{"kind":"product","id":3861},"regular_price":"25"}
+            ]}
+            """#
+        )
+
+        // Then
+        let reason = try #require(snapshot?.refusalReason)
+        #expect(reason.contains("3860"))
+        #expect(!reason.contains("3859"))
+        #expect(!reason.contains("3861"))
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_variation_target_parent_missing_then_returns_refusal() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products", body: "[]")
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"variation","id":99,"parent_id":41},"sale_price":"5"}]}
+            """#
+        )
+
+        // Then
+        let reason = try #require(snapshot?.refusalReason)
+        #expect(reason.contains("41"))
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_variation_target_variation_missing_under_parent_then_returns_refusal() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":41,"name":"Hoodie"}]"#)
+        // Parent fetch succeeds; per-parent variations fetch returns a different variation id so 99 is missing.
+        await client.setResponse(forPath: "wc/v3/products/41/variations",
+                                 body: #"[{"id":58,"name":"Hoodie - Red"}]"#)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"variation","id":99,"parent_id":41},"sale_price":"5"}]}
+            """#
+        )
+
+        // Then
+        let reason = try #require(snapshot?.refusalReason)
+        #expect(reason.contains("99"))
+        #expect(reason.contains("41"))
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_all_ids_present_then_no_refusal() async {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":7,"name":"Cap"},{"id":8,"name":"Hat"}]"#)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"{"updates":[{"target":{"kind":"product","id":7},"sale_price":"5"},{"target":{"kind":"product","id":8},"sale_price":"5"}]}"#
+        )
+
+        // Then
+        #expect(snapshot?.refusalReason == nil)
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_variation_endpoint_fails_then_no_refusal_for_missing_variations() async {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":41,"name":"Hoodie"}]"#)
+        await client.setResponse(forPath: "wc/v3/products/41/variations",
+                                 body: "[]",
+                                 statusCode: 500)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"{"updates":[{"target":{"kind":"variation","id":99,"parent_id":41},"sale_price":"5"}]}"#
+        )
+
+        // Then
+        #expect(snapshot?.refusalReason == nil)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationSnapshotResolverTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultConfirmationSnapshotResolverTests.swift
@@ -363,6 +363,93 @@ struct DefaultConfirmationSnapshotResolverTests {
     }
 
     @Test
+    func test_resolveProductsUpdate_when_scoped_fanout_then_snapshot_carries_variation_count_from_rows() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":50,"name":"Tee"}]"#)
+        let variationsBody = """
+        [{"id":101,"name":"Tee - S"},{"id":102,"name":"Tee - M"},{"id":103,"name":"Tee - L"}]
+        """
+        await client.setResponse(forPath: "wc/v3/products/50/variations", body: variationsBody)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":50,"scope":"all_variations"},"percent_discount":10}]}
+            """#
+        )
+
+        // Then
+        let counts = try #require(snapshot?.parentVariationCounts)
+        #expect(counts[50] == 3)
+        let calls = await client.recordedCalls
+        #expect(calls.contains(where: { $0.path == "wc/v3/products/50/variations" }))
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_scoped_fanout_and_endpoint_fails_then_count_is_absent() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":50,"name":"Tee"}]"#)
+        await client.setResponse(forPath: "wc/v3/products/50/variations",
+                                 body: "[]",
+                                 statusCode: 500)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":50,"scope":"all_variations"},"percent_discount":10}]}
+            """#
+        )
+
+        // Then
+        #expect(snapshot?.parentVariationCounts[50] == nil)
+    }
+
+    @Test
+    func test_resolveProductsUpdate_when_variable_parent_with_scope_then_snapshot_includes_variation_names() async throws {
+        // Given
+        let client = StubRESTClient()
+        await client.setResponse(forPath: "wc/v3/products",
+                                 body: #"[{"id":50,"name":"Tee"}]"#)
+        let variationsBody = """
+        [{"id":101,"name":"Tee - Red, S","attributes":[{"id":1,"name":"Color","option":"Red"},\
+        {"id":2,"name":"Size","option":"S"}]},\
+        {"id":102,"name":"Tee - Red, M","attributes":[{"id":1,"name":"Color","option":"Red"},\
+        {"id":2,"name":"Size","option":"M"}]},\
+        {"id":103,"name":"Tee - Blue, S","attributes":[{"id":1,"name":"Color","option":"Blue"},\
+        {"id":2,"name":"Size","option":"S"}]},\
+        {"id":104,"name":"Tee - Blue, M","attributes":[{"id":1,"name":"Color","option":"Blue"},\
+        {"id":2,"name":"Size","option":"M"}]}]
+        """
+        await client.setResponse(forPath: "wc/v3/products/50/variations", body: variationsBody)
+        let resolver = DefaultConfirmationSnapshotResolver(client: client)
+
+        // When
+        let snapshot = await resolver.resolve(
+            toolName: ProductsUpdateTool.name,
+            arguments: #"""
+            {"updates":[{"target":{"kind":"product","id":50,"scope":"all_variations"},"percent_discount":10}]}
+            """#
+        )
+
+        // Then
+        let entries = try #require(snapshot?.bulkEntries)
+        let parent = try #require(entries.first)
+        #expect(parent.id == 50)
+        #expect(parent.displayName == "Tee")
+        let subLabels = parent.subEntries.compactMap(\.displayName)
+        #expect(subLabels == ["Tee - Red, S", "Tee - Red, M", "Tee - Blue, S", "Tee - Blue, M"])
+        #expect(snapshot?.parentVariationCounts[50] == 4)
+    }
+
+    @Test
     func test_resolve_when_unknown_tool_then_returns_nil() async {
         // Given
         let client = StubRESTClient()

--- a/Modules/Tests/WooAIAssistantTests/Safety/DefaultSafetyPolicyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Safety/DefaultSafetyPolicyTests.swift
@@ -71,6 +71,37 @@ struct DefaultSafetyPolicyTests {
         let field = preview.fields.first { $0.name == "status" }
         #expect(field?.priorValue == .raw("Processing"))
     }
+
+    @Test
+    func test_decision_when_snapshot_carries_refusal_then_refusePreDispatch() async {
+        // Given
+        let tool = AITool(name: ProductsUpdateTool.name,
+                          description: "Update products",
+                          parametersSchema: .object([:]),
+                          safetyLevel: .unsafe)
+        let resolver = StaticSnapshotResolver(snapshot: ConfirmationSnapshot(currentValues: [:],
+                                                                              refusalReason: "Missing 99."))
+        let policy = DefaultSafetyPolicy(snapshotResolver: resolver)
+
+        // When
+        let decision = await policy.decision(for: tool.name,
+                                             arguments: "{}",
+                                             tool: tool)
+
+        // Then
+        guard case .refusePreDispatch(let reason) = decision else {
+            Issue.record("expected .refusePreDispatch, got \(decision)")
+            return
+        }
+        #expect(reason == "Missing 99.")
+    }
+}
+
+private struct StaticSnapshotResolver: ConfirmationSnapshotResolving {
+    let snapshot: ConfirmationSnapshot?
+    func resolve(toolName: String, arguments: String) async -> ConfirmationSnapshot? {
+        snapshot
+    }
 }
 
 private actor StubRESTClient: WCRESTClient {

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -217,7 +217,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_descriptor_when_inspected_then_matches_consolidated_list_surface() {
-        // Given Android parity lands with its own consolidation; this pins the iOS-leading surface.
+        // Given
         let tool = ProductsListTool.make()
 
         // Then
@@ -451,7 +451,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_then_routes_to_wc_analytics_stock_report() async throws {
-        // Given a stock report returning two ids and a follow-up /products?include= enrichment.
+        // Given
         let reportBody = """
         [{"id": 21, "stock_quantity": 4}, {"id": 22, "stock_quantity": 2}]
         """
@@ -487,8 +487,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_then_falls_back_to_heuristic_when_stock_report_fails() async throws {
-        // Given the stock report returns 404 (older WC without WC Analytics installed) and
-        // the heuristic /products scan finds a match on page 1.
+        // Given
         let heuristicBody = """
         [
             {"id": 1, "stock_quantity": 3},
@@ -518,7 +517,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_empty_then_returns_empty_without_enrichment() async throws {
-        // Given the stock report returns an empty array - no enrichment call should fire.
+        // Given
         let client = RoutingMockWCRESTClient(routes: [
             "GET wc-analytics/reports/stock": StubResponses.ok("[]"),
             "GET wc/v3/products": StubResponses.ok("[\"should_not_be_used\"]")
@@ -541,8 +540,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_heuristic_full_page_then_can_load_more_is_true() async throws {
-        // Given the stock report is unavailable and the /products heuristic returns a full
-        // window of non-matching rows: can_load_more must stay true even though no matches filled.
+        // Given
         let fullPage = (1...20).map { #"{"id": \#($0), "stock_quantity": 50}"# }.joined(separator: ",")
         let client = RoutingMockWCRESTClient(routes: [
             "GET wc-analytics/reports/stock": StubResponses.failure(statusCode: 404),
@@ -658,8 +656,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_returns_variation_rows_then_enriches_via_parent_scoped_variations() async throws {
-        // Given a stock report that returns a mix of top-level products (parent_id=0) and
-        // variations (parent_id=42); both kinds should be enriched and projected.
+        // Given
         let reportBody = """
         [
             {"id": 11, "stock_quantity": 2},
@@ -711,7 +708,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_variation_enrichment_fails_for_one_parent_then_keeps_rest() async throws {
-        // Given two parents whose variations are needed; one fetch fails with 500.
+        // Given
         let reportBody = """
         [
             {"id": 501, "parent_id": 42, "stock_quantity": 1},
@@ -741,7 +738,7 @@ struct ProductsListToolTests {
 
     @Test
     func test_list_when_low_in_stock_combined_filters_apply_to_both_products_and_variations() async throws {
-        // Given a min_price filter applied to a mixed result set; under-priced rows of either kind drop.
+        // Given
         let reportBody = """
         [
             {"id": 11, "stock_quantity": 1},

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -229,6 +229,7 @@ struct ProductsListToolTests {
         let keys = Set(properties.keys)
         #expect(keys == [
             "search", "status", "category", "sku", "ids", "parent_id", "stock_status",
+            "low_in_stock", "min_price", "max_price",
             "orderby", "order", "page", "per_page"
         ])
     }
@@ -447,4 +448,369 @@ struct ProductsListToolTests {
             #expect(fields["parent_id"] == .int(99))
         }
     }
+
+    @Test
+    func test_list_when_low_in_stock_then_routes_to_wc_analytics_stock_report() async throws {
+        // Given a stock report returning two ids and a follow-up /products?include= enrichment.
+        let reportBody = """
+        [{"id": 21, "stock_quantity": 4}, {"id": 22, "stock_quantity": 2}]
+        """
+        let enrichBody = """
+        [
+            {"id": 21, "name": "Hoodie", "price": "49.00", "stock_status": "instock"},
+            {"id": 22, "name": "Tee", "price": "19.00", "stock_status": "instock"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(enrichBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(21), .int(22)]))
+        let calls = await client.calls
+        #expect(calls.count == 2)
+        #expect(calls.first?.path == "wc-analytics/reports/stock")
+        #expect(calls.first?.query["type"] == "lowstock")
+        #expect(calls.last?.path == "wc/v3/products")
+        #expect(calls.last?.query["include"] == "21,22")
+        #expect(calls.last?.query["orderby"] == "include")
+    }
+
+    @Test
+    func test_list_when_low_in_stock_then_falls_back_to_heuristic_when_stock_report_fails() async throws {
+        // Given the stock report returns 404 (older WC without WC Analytics installed) and
+        // the heuristic /products scan finds a match on page 1.
+        let heuristicBody = """
+        [
+            {"id": 1, "stock_quantity": 3},
+            {"id": 2, "stock_quantity": 50},
+            {"id": 3, "stock_quantity": 11}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.failure(statusCode: 404),
+            "GET wc/v3/products": StubResponses.ok(heuristicBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(1)]))
+        let calls = await client.calls
+        #expect(calls.first?.path == "wc-analytics/reports/stock")
+        #expect(calls.dropFirst().allSatisfy { $0.path == "wc/v3/products" })
+    }
+
+    @Test
+    func test_list_when_low_in_stock_empty_then_returns_empty_without_enrichment() async throws {
+        // Given the stock report returns an empty array - no enrichment call should fire.
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok("[]"),
+            "GET wc/v3/products": StubResponses.ok("[\"should_not_be_used\"]")
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([]))
+        let calls = await client.calls
+        #expect(calls.count == 1)
+        #expect(calls.first?.path == "wc-analytics/reports/stock")
+    }
+
+    @Test
+    func test_list_when_low_in_stock_heuristic_full_page_then_can_load_more_is_true() async throws {
+        // Given the stock report is unavailable and the /products heuristic returns a full
+        // window of non-matching rows: can_load_more must stay true even though no matches filled.
+        let fullPage = (1...20).map { #"{"id": \#($0), "stock_quantity": 50}"# }.joined(separator: ",")
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.failure(statusCode: 404),
+            "GET wc/v3/products": StubResponses.ok("[\(fullPage)]")
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([]))
+        #expect(fields["can_load_more"] == .bool(true))
+    }
+
+    @Test(arguments: [
+        LowInStockFilterCase(
+            label: "category",
+            reportBody: """
+            [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 2}, {"id": 23, "stock_quantity": 3}]
+            """,
+            enrichBody: """
+            [
+                {"id": 21, "name": "Hoodie", "categories": [{"id": 7, "name": "Apparel", "slug": "apparel"}]},
+                {"id": 22, "name": "Mug", "categories": [{"id": 9, "name": "Kitchen", "slug": "kitchen"}]},
+                {"id": 23, "name": "Tee", "categories": [{"id": 7, "name": "Apparel", "slug": "apparel"}]}
+            ]
+            """,
+            arguments: #"{"low_in_stock": true, "category": 7}"#,
+            expectedIDs: [21, 23]
+        ),
+        LowInStockFilterCase(
+            label: "sku",
+            reportBody: #"[{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 2}]"#,
+            enrichBody: """
+            [
+                {"id": 21, "name": "Hoodie", "sku": "HOOD-1"},
+                {"id": 22, "name": "Tee", "sku": "TEE-1"}
+            ]
+            """,
+            arguments: #"{"low_in_stock": true, "sku": "TEE-1"}"#,
+            expectedIDs: [22]
+        ),
+        LowInStockFilterCase(
+            label: "min_max_price",
+            reportBody: """
+            [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}, {"id": 23, "stock_quantity": 1}]
+            """,
+            enrichBody: """
+            [
+                {"id": 21, "name": "Cheap", "price": "5.00"},
+                {"id": 22, "name": "Mid", "price": "20.00"},
+                {"id": 23, "name": "Pricey", "price": "150.00"}
+            ]
+            """,
+            arguments: #"{"low_in_stock": true, "min_price": "10.00", "max_price": "100.00"}"#,
+            expectedIDs: [22]
+        ),
+        LowInStockFilterCase(
+            label: "search",
+            reportBody: """
+            [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}, {"id": 23, "stock_quantity": 1}]
+            """,
+            enrichBody: """
+            [
+                {"id": 21, "name": "Hoodie", "sku": "HOOD-1"},
+                {"id": 22, "name": "Tee Shirt", "sku": "TS-1"},
+                {"id": 23, "name": "Mug", "sku": "MUG-TEE-1"}
+            ]
+            """,
+            arguments: #"{"low_in_stock": true, "search": "tee"}"#,
+            expectedIDs: [22, 23]
+        ),
+        LowInStockFilterCase(
+            label: "ids",
+            reportBody: """
+            [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}, {"id": 23, "stock_quantity": 1}]
+            """,
+            enrichBody: """
+            [
+                {"id": 21, "name": "A"},
+                {"id": 22, "name": "B"},
+                {"id": 23, "name": "C"}
+            ]
+            """,
+            arguments: #"{"low_in_stock": true, "ids": [22, 23, 999]}"#,
+            expectedIDs: [22, 23]
+        )
+    ])
+    func test_list_when_low_in_stock_with_filter_then_filters_report_rows(testCase: LowInStockFilterCase) async throws {
+        // Given
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(testCase.reportBody),
+            "GET wc/v3/products": StubResponses.ok(testCase.enrichBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(testCase.arguments, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object for \(testCase.label)")
+            return
+        }
+        let expected = AnyCodableJSON.array(testCase.expectedIDs.map { .int(Int64($0)) })
+        #expect(fields["ids"] == expected)
+    }
+
+    @Test
+    func test_list_when_low_in_stock_returns_variation_rows_then_enriches_via_parent_scoped_variations() async throws {
+        // Given a stock report that returns a mix of top-level products (parent_id=0) and
+        // variations (parent_id=42); both kinds should be enriched and projected.
+        let reportBody = """
+        [
+            {"id": 11, "stock_quantity": 2},
+            {"id": 12, "stock_quantity": 1},
+            {"id": 501, "parent_id": 42, "stock_quantity": 1},
+            {"id": 502, "parent_id": 42, "stock_quantity": 2}
+        ]
+        """
+        let productsBody = """
+        [
+            {"id": 11, "name": "Hoodie", "type": "simple"},
+            {"id": 12, "name": "Tee", "type": "simple"}
+        ]
+        """
+        let variationsBody = """
+        [
+            {"id": 501, "parent_id": 42, "sku": "RED-S", "stock_status": "instock"},
+            {"id": 502, "parent_id": 42, "sku": "RED-M", "stock_status": "outofstock"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(productsBody),
+            "GET wc/v3/products/42/variations": StubResponses.ok(variationsBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(11), .int(12), .int(501), .int(502)]))
+        guard case .array(let products) = fields["products"] else {
+            Issue.record("expected products array")
+            return
+        }
+        let kinds = products.compactMap { row -> String? in
+            guard case .object(let dict) = row, case .string(let kind) = dict["kind"] else { return nil }
+            return kind
+        }
+        #expect(kinds == ["product", "product", "variation", "variation"])
+        let calls = await client.calls
+        #expect(calls.contains { $0.path == "wc/v3/products/42/variations" })
+    }
+
+    @Test
+    func test_list_when_low_in_stock_variation_enrichment_fails_for_one_parent_then_keeps_rest() async throws {
+        // Given two parents whose variations are needed; one fetch fails with 500.
+        let reportBody = """
+        [
+            {"id": 501, "parent_id": 42, "stock_quantity": 1},
+            {"id": 601, "parent_id": 88, "stock_quantity": 1}
+        ]
+        """
+        let okVariations = """
+        [{"id": 501, "parent_id": 42, "sku": "RED-S", "stock_status": "instock"}]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products/42/variations": StubResponses.ok(okVariations),
+            "GET wc/v3/products/88/variations": StubResponses.failure(statusCode: 500)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(501)]))
+    }
+
+    @Test
+    func test_list_when_low_in_stock_combined_filters_apply_to_both_products_and_variations() async throws {
+        // Given a min_price filter applied to a mixed result set; under-priced rows of either kind drop.
+        let reportBody = """
+        [
+            {"id": 11, "stock_quantity": 1},
+            {"id": 12, "stock_quantity": 1},
+            {"id": 501, "parent_id": 42, "stock_quantity": 1},
+            {"id": 502, "parent_id": 42, "stock_quantity": 1}
+        ]
+        """
+        let productsBody = """
+        [
+            {"id": 11, "name": "Cheap Product", "price": "5.00"},
+            {"id": 12, "name": "Pricey Product", "price": "55.00"}
+        ]
+        """
+        let variationsBody = """
+        [
+            {"id": 501, "parent_id": 42, "price": "8.00"},
+            {"id": 502, "parent_id": 42, "price": "60.00"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(productsBody),
+            "GET wc/v3/products/42/variations": StubResponses.ok(variationsBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true, "min_price": "10.00"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(12), .int(502)]))
+    }
+
+    @Test
+    func test_list_when_max_price_set_then_passes_to_rest() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        _ = await tool.executor(#"{"max_price": "49.99"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["max_price"] == "49.99")
+    }
+
+    @Test
+    func test_list_when_min_price_set_then_passes_to_rest() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsListTool.make()
+
+        // When
+        _ = await tool.executor(#"{"min_price": "10.00"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["min_price"] == "10.00")
+    }
+}
+
+struct LowInStockFilterCase: Sendable {
+    let label: String
+    let reportBody: String
+    let enrichBody: String
+    let arguments: String
+    let expectedIDs: [Int]
 }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsListToolTests.swift
@@ -802,6 +802,146 @@ struct ProductsListToolTests {
         // Then
         #expect(await client.calls.first?.query["min_price"] == "10.00")
     }
+
+    @Test
+    func test_list_when_low_in_stock_product_enrichment_fails_then_returns_toolFailed() async {
+        // Given
+        let reportBody = """
+        [{"id": 21, "stock_quantity": 4}, {"id": 22, "stock_quantity": 2}]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.failure(statusCode: 503)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+        #expect(failed.kind == .toolFailed)
+    }
+
+    @Test
+    func test_list_when_min_and_max_price_boundary_then_inclusive_at_bounds() async throws {
+        // Given
+        let reportBody = """
+        [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}, {"id": 23, "stock_quantity": 1}]
+        """
+        let enrichBody = """
+        [
+            {"id": 21, "name": "AtMin", "price": "10.00"},
+            {"id": 22, "name": "Inside", "price": "55.00"},
+            {"id": 23, "name": "AtMax", "price": "100.00"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(enrichBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true, "min_price": "10.00", "max_price": "100.00"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(21), .int(22), .int(23)]))
+    }
+
+    @Test
+    func test_list_when_low_in_stock_price_filter_uses_regular_price_when_price_blank() async throws {
+        // Given
+        let reportBody = """
+        [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}]
+        """
+        let enrichBody = """
+        [
+            {"id": 21, "name": "BlankPrice", "price": "", "regular_price": "20.00"},
+            {"id": 22, "name": "Cheap", "price": "", "regular_price": "5.00"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(enrichBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true, "min_price": "10.00"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(21)]))
+    }
+
+    @Test
+    func test_list_when_low_in_stock_with_status_filter_then_filters_rows() async throws {
+        // Given
+        let reportBody = """
+        [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}]
+        """
+        let enrichBody = """
+        [
+            {"id": 21, "name": "Published", "status": "publish"},
+            {"id": 22, "name": "Drafted", "status": "draft"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(enrichBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true, "status": "draft"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(22)]))
+    }
+
+    @Test
+    func test_list_when_low_in_stock_with_stock_status_filter_then_filters_rows() async throws {
+        // Given
+        let reportBody = """
+        [{"id": 21, "stock_quantity": 1}, {"id": 22, "stock_quantity": 1}]
+        """
+        let enrichBody = """
+        [
+            {"id": 21, "name": "InStock", "stock_status": "instock"},
+            {"id": 22, "name": "OnBackorder", "stock_status": "onbackorder"}
+        ]
+        """
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc-analytics/reports/stock": StubResponses.ok(reportBody),
+            "GET wc/v3/products": StubResponses.ok(enrichBody)
+        ])
+        let tool = ProductsListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"low_in_stock": true, "stock_status": "onbackorder"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["ids"] == .array([.int(22)]))
+    }
 }
 
 struct LowInStockFilterCase: Sendable {

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
@@ -59,7 +59,7 @@ struct ProductsUpdateToolTests {
     }
 
     @Test
-    func test_update_when_id_is_variable_parent_then_refuses_price_with_variation_routing_reason() async throws {
+    func test_update_when_id_is_variable_parent_with_stock_quantity_then_refuses_with_reason() async throws {
         // Given
         let probe = #"{"id": 50, "type": "variable"}"#
         let client = MockWCRESTClient(response: StubResponses.ok("[\(probe)]"))
@@ -79,8 +79,8 @@ struct ProductsUpdateToolTests {
         }
         #expect(entry["id"] == .int(50))
         if case .string(let reason) = entry["reason"] {
-            #expect(reason.contains("variable product"))
-            #expect(reason.contains("target.kind=\"variation\""))
+            #expect(reason.contains("variable parent"))
+            #expect(reason.contains("target specific variations"))
         } else {
             Issue.record("expected reason string")
         }
@@ -147,45 +147,37 @@ struct ProductsUpdateToolTests {
         }
         #expect(entry["id"] == .int(50))
         if case .string(let reason) = entry["reason"] {
-            #expect(reason.contains("Price and stock"))
+            #expect(reason.contains("variation-level"))
+            #expect(reason.contains("all_variations"))
         } else {
             Issue.record("expected reason string")
         }
     }
 
     @Test
-    func test_update_when_variable_parent_name_and_price_then_parent_write_plus_price_failure() async throws {
+    func test_update_when_variable_parent_variation_field_without_scope_then_rejected_with_scope_hint() async throws {
         // Given
         let probe = #"{"id": 50, "type": "variable"}"#
-        let client = RoutingMockWCRESTClient(routes: [
-            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
-            "POST wc/v3/products/batch": StubResponses.ok(#"{"update": [{"id": 50, "name": "Renamed"}]}"#)
-        ])
+        let client = MockWCRESTClient(response: StubResponses.ok("[\(probe)]"))
         let tool = ProductsUpdateTool.make()
 
         // When
         let result = await tool.executor(
-            #"{"updates": [{"target": {"kind": "product", "id": 50}, "name": "Renamed", "regular_price": "19.99"}]}"#,
+            #"{"updates": [{"target": {"kind": "product", "id": 50}, "sale_price": "9"}]}"#,
             client
         )
 
         // Then
         let receipt = try successReceipt(result)
-        let posts = await client.calls.filter { $0.method == "POST" }
-        #expect(posts.count == 1)
-        #expect(posts.first?.path == "wc/v3/products/batch")
-        let body = try requireBatchBody(posts.first?.body)
-        let entry = try #require(body.first)
-        #expect(entry["name"] as? String == "Renamed")
-        #expect(entry["regular_price"] == nil)
-        #expect(updatedProductIDs(receipt) == [50])
-        guard case .array(let failed) = receipt["failed"], case .object(let failure) = failed.first else {
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
             Issue.record("expected failed entry")
             return
         }
-        #expect(failure["id"] == .int(50))
-        if case .string(let reason) = failure["reason"] {
-            #expect(reason.contains("Price and stock"))
+        #expect(entry["id"] == .int(50))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("all_variations"))
+            #expect(reason.contains("variation-level"))
+            #expect(reason.contains("target.kind=\"variation\""))
         } else {
             Issue.record("expected reason string")
         }
@@ -1317,6 +1309,476 @@ struct ProductsUpdateToolTests {
         let entriesByID = batchEntriesByID(body)
         #expect(entriesByID[88]?["sale_price"] as? String == "27")
         #expect(updatedVariationIDs(receipt) == [88])
+    }
+
+    @Test(arguments: [
+        ("sale_price", "15.00"),
+        ("regular_price", "25.00"),
+        ("stock_status", "outofstock")
+    ])
+    func test_update_when_variable_parent_scoped_fanout_field_set_then_posts_to_variations_batch(jsonKey: String, value: String) async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable", "name": "Tee"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let batchResponse = "{\"update\": [{\"id\": 101, \"\(jsonKey)\": \"\(value)\"}, {\"id\": 102, \"\(jsonKey)\": \"\(value)\"}]}"
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList),
+            StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+        let arguments = "{\"updates\": [{\"target\": {\"kind\": \"product\", \"id\": 50, \"scope\": \"all_variations\"}, \"\(jsonKey)\": \"\(value)\"}]}"
+
+        // When
+        let result = await tool.executor(arguments, client)
+
+        // Then
+        let receipt = try successReceipt(result)
+        let calls = await client.calls
+        let posts = calls.filter { $0.method == "POST" }
+        #expect(posts.count == 1)
+        #expect(posts.first?.path == "wc/v3/products/50/variations/batch")
+        let body = try requireBatchBody(posts.first?.body)
+        #expect(body.count == 2)
+        let entriesByID = batchEntriesByID(body)
+        #expect(entriesByID[101]?[jsonKey] as? String == value)
+        #expect(entriesByID[102]?[jsonKey] as? String == value)
+        // Fanned-out variations land in `updated` as variation target objects carrying their parent.
+        #expect(updatedVariationIDs(receipt) == [101, 102])
+        for target in updatedTargets(receipt) where target.kind == "variation" {
+            #expect(target.parentID == 50)
+        }
+    }
+
+    @Test
+    func test_update_when_variable_parent_scoped_fanout_percent_discount_then_computes_per_variation_sale_price() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let batchResponse = #"{"update": [{"id": 101}, {"id": 102}]}"#
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList),
+            StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 50, "scope": "all_variations"}, "percent_discount": 10}]}"#,
+            client
+        )
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.count == 1)
+        #expect(posts.first?.path == "wc/v3/products/50/variations/batch")
+        let body = try requireBatchBody(posts.first?.body)
+        let entriesByID = batchEntriesByID(body)
+        #expect(entriesByID[101]?["sale_price"] as? String == "18")
+        #expect(entriesByID[102]?["sale_price"] as? String == "27")
+        for (_, entry) in entriesByID {
+            #expect(entry["percent_discount"] == nil)
+        }
+    }
+
+    @Test
+    func test_update_when_variable_parent_scoped_fanout_then_updated_lists_each_variation_target() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let batchResponse = #"{"update": [{"id": 101}, {"id": 102}]}"#
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList),
+            StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 50, "scope": "all_variations"}, "sale_price": "9.99"}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let variations = updatedTargets(receipt).filter { $0.kind == "variation" }
+        #expect(Set(variations.map(\.id)) == [101, 102])
+        #expect(variations.allSatisfy { $0.parentID == 50 })
+        #expect(updatedProductIDs(receipt).isEmpty)
+    }
+
+    @Test(arguments: [
+        ("status", "draft"),
+        ("name", "New Tee")
+    ])
+    func test_update_when_variable_parent_only_field_set_then_applied_to_parent_in_products_batch(jsonKey: String, value: String) async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let batchResponse = "{\"update\": [{\"id\": 50, \"\(jsonKey)\": \"\(value)\"}]}"
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "POST wc/v3/products/batch": StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+        let arguments = "{\"updates\": [{\"target\": {\"kind\": \"product\", \"id\": 50}, \"\(jsonKey)\": \"\(value)\"}]}"
+
+        // When
+        let result = await tool.executor(arguments, client)
+
+        // Then
+        let receipt = try successReceipt(result)
+        let calls = await client.calls
+        let posts = calls.filter { $0.method == "POST" }
+        #expect(posts.count == 1)
+        #expect(posts.first?.path == "wc/v3/products/batch")
+        let body = try requireBatchBody(posts.first?.body)
+        try requireSingleUpdate(body, id: 50, fields: [jsonKey: value])
+        #expect(body.first?["stock_status"] == nil)
+        #expect(updatedProductIDs(receipt) == [50])
+    }
+
+    @Test
+    func test_update_when_sku_set_on_variable_parent_then_applied_to_parent_only_not_expanded() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let batchResponse = #"{"update": [{"id": 50, "sku": "TEE-PARENT"}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "POST wc/v3/products/batch": StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 50}, "sku": "TEE-PARENT"}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let calls = await client.calls
+        let variationGets = calls.filter { $0.method == "GET" && $0.path == "wc/v3/products/50/variations" }
+        #expect(variationGets.isEmpty)
+        let posts = calls.filter { $0.method == "POST" }
+        #expect(posts.count == 1)
+        #expect(posts.first?.path == "wc/v3/products/batch")
+        let body = try requireBatchBody(posts.first?.body)
+        try requireSingleUpdate(body, id: 50, fields: ["sku": "TEE-PARENT"])
+        #expect(updatedProductIDs(receipt) == [50])
+    }
+
+    @Test
+    func test_update_when_scope_set_on_simple_product_then_applies_normally_without_fanout() async throws {
+        // Given - scope on a simple product has no variations to fan to; it must update the product itself.
+        let probe = #"{"id": 10, "type": "simple", "regular_price": "50.00"}"#
+        let batchResponse = #"{"update": [{"id": 10}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "POST wc/v3/products/batch": StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10, "scope": "all_variations"}, "sale_price": "45"}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let calls = await client.calls
+        #expect(!calls.contains { $0.path == "wc/v3/products/10/variations" })
+        let posts = calls.filter { $0.method == "POST" }
+        #expect(posts.first?.path == "wc/v3/products/batch")
+        #expect(updatedProductIDs(receipt) == [10])
+    }
+
+    @Test
+    func test_update_when_variable_parent_has_more_than_100_variations_then_refused_with_failed_entry() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList, headers: ["X-WP-TotalPages": "2", "X-WP-Total": "150"])
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 50, "scope": "all_variations"}, "sale_price": "15.00"}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        #expect(failed.count == 1)
+        #expect(entry["id"] == .int(50))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("more than 100 variations"))
+            #expect(reason.contains("inconsistent"))
+            #expect(reason.contains("specific variation ids"))
+        } else {
+            Issue.record("expected reason string")
+        }
+        #expect(updatedTargets(receipt).isEmpty)
+    }
+
+    @Test
+    func test_planVariableParent_when_full_page_and_no_total_pages_header_then_refused_as_unsafe() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let rows = (1...100).map { #"{"id": \#($0), "regular_price": "20.00"}"# }.joined(separator: ",")
+        let variationsList = "[\(rows)]"
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 50, "scope": "all_variations"}, "sale_price": "15.00"}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        #expect(entry["id"] == .int(50))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("more than 100 variations"))
+        } else {
+            Issue.record("expected reason string")
+        }
+    }
+
+    @Test
+    func test_planVariableParent_when_expansion_refused_with_parent_only_field_then_refuses_entire_entry() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList, headers: ["X-WP-TotalPages": "2", "X-WP-Total": "150"])
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"""
+            {"updates": [{
+              "target": {"kind": "product", "id": 50, "scope": "all_variations"},
+              "name": "Renamed", "percent_discount": 10
+            }]}
+            """#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        #expect(failed.count == 1)
+        #expect(entry["id"] == .int(50))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("parent-only fields"))
+            #expect(reason.contains("per-variation"))
+            #expect(reason.contains("two separate updates"))
+        } else {
+            Issue.record("expected reason string")
+        }
+        #expect(updatedTargets(receipt).isEmpty)
+    }
+
+    @Test
+    func test_planVariableParent_when_expansion_refused_with_no_parent_only_field_then_returns_expansion_refusal_only() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}]
+        """
+        let client = MockWCRESTClient(responses: [
+            StubResponses.ok("[\(probe)]"),
+            StubResponses.ok(variationsList, headers: ["X-WP-TotalPages": "2"])
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 50, "scope": "all_variations"}, "sale_price": "9.99"}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        #expect(entry["id"] == .int(50))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("more than 100 variations"))
+        } else {
+            Issue.record("expected reason string")
+        }
+        #expect(updatedTargets(receipt).isEmpty)
+    }
+
+    @Test
+    func test_planVariableParent_when_expansion_succeeds_with_parent_only_field_then_dispatches_both() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let parentBatch = #"{"update": [{"id": 50, "name": "Renamed"}]}"#
+        let variationsBatch = #"{"update": [{"id": 101, "sale_price": "18.00"}, {"id": 102, "sale_price": "27.00"}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "GET wc/v3/products/50/variations": StubResponses.ok(variationsList),
+            "POST wc/v3/products/batch": StubResponses.ok(parentBatch),
+            "POST wc/v3/products/50/variations/batch": StubResponses.ok(variationsBatch)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"""
+            {"updates": [{
+              "target": {"kind": "product", "id": 50, "scope": "all_variations"},
+              "name": "Renamed", "percent_discount": 10
+            }]}
+            """#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.count == 2)
+        #expect(updatedProductIDs(receipt) == [50])
+        #expect(updatedVariationIDs(receipt) == [101, 102])
+    }
+
+    @Test
+    func test_update_when_status_combined_with_sale_price_on_variable_parent_then_splits_into_parent_and_variation_writes() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let parentBatch = #"{"update": [{"id": 50, "status": "draft"}]}"#
+        let variationsBatch = #"{"update": [{"id": 101, "sale_price": "9.99"}, {"id": 102, "sale_price": "9.99"}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "GET wc/v3/products/50/variations": StubResponses.ok(variationsList),
+            "POST wc/v3/products/batch": StubResponses.ok(parentBatch),
+            "POST wc/v3/products/50/variations/batch": StubResponses.ok(variationsBatch)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"""
+            {"updates": [{
+              "target": {"kind": "product", "id": 50, "scope": "all_variations"},
+              "status": "draft", "sale_price": "9.99"
+            }]}
+            """#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.count == 2)
+        let parentPost = try #require(posts.first { $0.path == "wc/v3/products/batch" })
+        try requireSingleUpdate(try requireBatchBody(parentPost.body), id: 50, fields: ["status": "draft"])
+        let variationsPost = try #require(posts.first { $0.path == "wc/v3/products/50/variations/batch" })
+        let entriesByID = batchEntriesByID(try requireBatchBody(variationsPost.body))
+        #expect(entriesByID[101]?["sale_price"] as? String == "9.99")
+        #expect(entriesByID[102]?["sale_price"] as? String == "9.99")
+        #expect(updatedProductIDs(receipt) == [50])
+        #expect(updatedVariationIDs(receipt) == [101, 102])
+    }
+
+    @Test
+    func test_update_when_sku_and_percent_discount_set_on_variable_parent_then_parent_gets_sku_and_variations_get_computed_sale_price() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let variationsList = """
+        [{"id": 101, "regular_price": "20.00"}, {"id": 102, "regular_price": "30.00"}]
+        """
+        let parentBatch = #"{"update": [{"id": 50, "sku": "TEE-PARENT"}]}"#
+        let variationsBatch = #"{"update": [{"id": 101}, {"id": 102}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "GET wc/v3/products/50/variations": StubResponses.ok(variationsList),
+            "POST wc/v3/products/batch": StubResponses.ok(parentBatch),
+            "POST wc/v3/products/50/variations/batch": StubResponses.ok(variationsBatch)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"""
+            {"updates": [{
+              "target": {"kind": "product", "id": 50, "scope": "all_variations"},
+              "sku": "TEE-PARENT", "percent_discount": 10
+            }]}
+            """#,
+            client
+        )
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.count == 2)
+        let parentPost = try #require(posts.first { $0.path == "wc/v3/products/batch" })
+        try requireSingleUpdate(try requireBatchBody(parentPost.body), id: 50, fields: ["sku": "TEE-PARENT"])
+        let variationsPost = try #require(posts.first { $0.path == "wc/v3/products/50/variations/batch" })
+        let entriesByID = batchEntriesByID(try requireBatchBody(variationsPost.body))
+        #expect(entriesByID[101]?["sale_price"] as? String == "18")
+        #expect(entriesByID[102]?["sale_price"] as? String == "27")
+        #expect(entriesByID[101]?["sku"] == nil)
+        #expect(entriesByID[101]?["percent_discount"] == nil)
     }
 
     // MARK: Helpers

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
@@ -184,6 +184,50 @@ struct ProductsUpdateToolTests {
     }
 
     @Test
+    func test_update_when_variable_parent_name_and_price_without_scope_then_refuses_entire_entry() async throws {
+        // Given
+        let probe = #"{"id": 50, "type": "variable"}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
+            "POST wc/v3/products/batch": StubResponses.ok(#"{"update": [{"id": 50}]}"#)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"""
+            {"updates": [{
+              "target": {"kind": "product", "id": 50},
+              "name": "Renamed", "regular_price": "19.99"
+            }]}
+            """#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.isEmpty)
+        let nameWrites = posts.compactMap { try? requireBatchBody($0.body) }
+            .flatMap { $0 }
+            .filter { $0["name"] != nil }
+        #expect(nameWrites.isEmpty)
+        #expect(updatedTargets(receipt).isEmpty)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        #expect(failed.count == 1)
+        #expect(entry["id"] == .int(50))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("target.kind=\"variation\""))
+            #expect(reason.contains("target.scope=\"all_variations\""))
+        } else {
+            Issue.record("expected reason string")
+        }
+    }
+
+    @Test
     func test_update_when_mixed_simple_and_variations_then_routes_each_correctly() async throws {
         // Given
         let simpleProbe = #"{"id": 10, "type": "simple", "regular_price": "50.00"}"#
@@ -1256,6 +1300,94 @@ struct ProductsUpdateToolTests {
         } else {
             Issue.record("expected reason string")
         }
+    }
+
+    @Test
+    func test_update_when_percent_discount_is_zero_then_invalidToolCall() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": 0}]}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("percent_discount"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_update_when_percent_discount_is_100_then_invalidToolCall() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": 100}]}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("percent_discount"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_update_when_percent_discount_is_negative_then_invalidToolCall() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": -10}]}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("percent_discount"))
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_update_when_percent_discount_exceeds_100_then_invalidToolCall() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": 150}]}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed, got \(result)")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(failed.reason.contains("percent_discount"))
+        #expect(await client.calls.isEmpty)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
@@ -670,7 +670,7 @@ struct ProductsUpdateToolTests {
 
     @Test
     func test_update_when_batch_returns_403_then_failure_surfaces_in_failed_array() async throws {
-        // Given a 403 on the batch POST is preserved as a per-entry failure, not a hard tool error.
+        // Given
         let probe = #"{"id": 12, "type": "simple", "regular_price": "20.00"}"#
         let client = RoutingMockWCRESTClient(routes: [
             "GET wc/v3/products": StubResponses.ok("[\(probe)]"),
@@ -828,7 +828,7 @@ struct ProductsUpdateToolTests {
 
     @Test
     func test_update_when_discovery_chunk_returns_429_then_entry_failed_and_no_per_id_probe() async throws {
-        // Given the chunked discovery GET is rate-limited so no per-id fallback should fire.
+        // Given
         let client = RoutingMockWCRESTClient(routes: [
             "GET wc/v3/products": StubResponses.failure(statusCode: 429, body: "slow down"),
             "GET wc/v3/products/12": StubResponses.ok(#"{"id": 12, "type": "simple"}"#),
@@ -863,7 +863,7 @@ struct ProductsUpdateToolTests {
 
     @Test
     func test_update_when_discovery_chunk_succeeds_but_id_absent_then_one_per_id_probe_fires() async throws {
-        // Given a successful chunk that omits the id (variations are absent from products include).
+        // Given
         let client = RoutingMockWCRESTClient(routes: [
             "GET wc/v3/products": StubResponses.ok("[]"),
             "GET wc/v3/products/12": StubResponses.ok(#"{"id": 12, "type": "simple", "regular_price": "20.00"}"#),
@@ -1301,7 +1301,6 @@ struct ProductsUpdateToolTests {
         let receipt = try successReceipt(result)
         let calls = await client.calls
         let topLevelGets = calls.filter { $0.method == "GET" && $0.path == "wc/v3/products" }
-        // Variation targets must skip the chunked discovery GET on /products entirely.
         #expect(topLevelGets.isEmpty)
         let posts = calls.filter { $0.method == "POST" }
         #expect(posts.first?.path == "wc/v3/products/12/variations/batch")
@@ -1345,7 +1344,6 @@ struct ProductsUpdateToolTests {
         let entriesByID = batchEntriesByID(body)
         #expect(entriesByID[101]?[jsonKey] as? String == value)
         #expect(entriesByID[102]?[jsonKey] as? String == value)
-        // Fanned-out variations land in `updated` as variation target objects carrying their parent.
         #expect(updatedVariationIDs(receipt) == [101, 102])
         for target in updatedTargets(receipt) where target.kind == "variation" {
             #expect(target.parentID == 50)
@@ -1481,7 +1479,7 @@ struct ProductsUpdateToolTests {
 
     @Test
     func test_update_when_scope_set_on_simple_product_then_applies_normally_without_fanout() async throws {
-        // Given - scope on a simple product has no variations to fan to; it must update the product itself.
+        // Given
         let probe = #"{"id": 10, "type": "simple", "regular_price": "50.00"}"#
         let batchResponse = #"{"update": [{"id": 10}]}"#
         let client = RoutingMockWCRESTClient(routes: [

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Products/ProductsUpdateToolTests.swift
@@ -1177,6 +1177,148 @@ struct ProductsUpdateToolTests {
         #expect(chunkedGets.isEmpty)
     }
 
+    @Test
+    func test_update_when_per_id_percent_discount_then_uses_each_entitys_own_regular_price() async throws {
+        // Given
+        let probeA = #"{"id": 10, "type": "simple", "regular_price": "50.00"}"#
+        let probeB = #"{"id": 11, "type": "simple", "regular_price": "20.00"}"#
+        let batchResponse = #"{"update": [{"id": 10}, {"id": 11}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products": StubResponses.ok("[\(probeA),\(probeB)]"),
+            "POST wc/v3/products/batch": StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"""
+            {"updates": [
+              {"target": {"kind": "product", "id": 10}, "percent_discount": 20},
+              {"target": {"kind": "product", "id": 11}, "percent_discount": 20}
+            ]}
+            """#,
+            client
+        )
+
+        // Then
+        guard case .success = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        let posts = await client.calls.filter { $0.method == "POST" }
+        #expect(posts.count == 1)
+        let body = try requireBatchBody(posts.first?.body)
+        let entriesByID = batchEntriesByID(body)
+        #expect(entriesByID[10]?["sale_price"] as? String == "40")
+        #expect(entriesByID[11]?["sale_price"] as? String == "16")
+    }
+
+    @Test
+    func test_update_when_percent_discount_and_regular_price_empty_then_appends_failed_reason() async throws {
+        // Given
+        let probe = #"{"id": 10, "type": "simple", "regular_price": ""}"#
+        let client = MockWCRESTClient(response: StubResponses.ok("[\(probe)]"))
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": 10}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("regular_price"))
+        } else {
+            Issue.record("expected reason string")
+        }
+    }
+
+    @Test
+    func test_update_when_percent_discount_and_regular_price_is_zero_then_appends_failed_reason() async throws {
+        // Given
+        let probe = #"{"id": 10, "type": "simple", "regular_price": "0.00"}"#
+        let client = MockWCRESTClient(response: StubResponses.ok("[\(probe)]"))
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": 10}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        guard case .array(let failed) = receipt["failed"], case .object(let entry) = failed.first else {
+            Issue.record("expected failed entry")
+            return
+        }
+        #expect(entry["id"] == .int(10))
+        if case .string(let reason) = entry["reason"] {
+            #expect(reason.contains("regular_price"))
+        } else {
+            Issue.record("expected reason string")
+        }
+    }
+
+    @Test
+    func test_update_omits_percent_discount_from_outgoing_batch_body() async throws {
+        // Given
+        let probe = #"{"id": 10, "type": "simple", "regular_price": "100.00"}"#
+        let batchResponse = #"{"update": [{"id": 10}]}"#
+        let client = MockWCRESTClient(responses: [StubResponses.ok("[\(probe)]"), StubResponses.ok(batchResponse)])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        _ = await tool.executor(
+            #"{"updates": [{"target": {"kind": "product", "id": 10}, "percent_discount": 25}]}"#,
+            client
+        )
+
+        // Then
+        let post = try #require(await client.calls.last)
+        let body = try requireBatchBody(post.body)
+        let entriesByID = batchEntriesByID(body)
+        #expect(entriesByID[10]?["percent_discount"] == nil)
+        #expect(entriesByID[10]?["sale_price"] as? String == "75")
+    }
+
+    @Test
+    func test_update_when_variation_target_with_percent_discount_then_fetches_variation_and_routes_to_variations_batch() async throws {
+        // Given
+        let variationProbe = #"{"id": 88, "regular_price": "30.00"}"#
+        let batchResponse = #"{"update": [{"id": 88, "sale_price": "27.00"}]}"#
+        let client = RoutingMockWCRESTClient(routes: [
+            "GET wc/v3/products/12/variations/88": StubResponses.ok(variationProbe),
+            "POST wc/v3/products/12/variations/batch": StubResponses.ok(batchResponse)
+        ])
+        let tool = ProductsUpdateTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"updates": [{"target": {"kind": "variation", "id": 88, "parent_id": 12}, "percent_discount": 10}]}"#,
+            client
+        )
+
+        // Then
+        let receipt = try successReceipt(result)
+        let calls = await client.calls
+        let topLevelGets = calls.filter { $0.method == "GET" && $0.path == "wc/v3/products" }
+        // Variation targets must skip the chunked discovery GET on /products entirely.
+        #expect(topLevelGets.isEmpty)
+        let posts = calls.filter { $0.method == "POST" }
+        #expect(posts.first?.path == "wc/v3/products/12/variations/batch")
+        let body = try requireBatchBody(posts.first?.body)
+        let entriesByID = batchEntriesByID(body)
+        #expect(entriesByID[88]?["sale_price"] as? String == "27")
+        #expect(updatedVariationIDs(receipt) == [88])
+    }
+
     // MARK: Helpers
 
     private func requireBatchBody(_ body: Data?) throws -> [[String: Any]] {

--- a/Modules/Tests/WooAIAssistantTests/Tools/REST/MockWCRESTClient.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/REST/MockWCRESTClient.swift
@@ -33,8 +33,8 @@ actor MockWCRESTClient: WCRESTClient {
 }
 
 enum StubResponses {
-    static func ok(_ json: String) -> WCRESTResponse {
-        WCRESTResponse(data: Data(json.utf8), statusCode: 200)
+    static func ok(_ json: String, headers: [String: String] = [:]) -> WCRESTResponse {
+        WCRESTResponse(data: Data(json.utf8), statusCode: 200, headers: headers)
     }
 
     static func failure(statusCode: Int, body: String = "") -> WCRESTResponse {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.9
 -----
+- [Internal] AI Assistant: products_list gains low-stock and price-range filters, and products_update supports percentage discounts and applying price/stock changes across all variations of a variable product.
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 

--- a/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/WCRESTClientAdaptor.swift
@@ -37,8 +37,8 @@ struct WCRESTClientAdaptor: @unchecked Sendable, WCRESTClient {
                                             availableAsRESTRequest: true)
 
         do {
-            let (data, _) = try await network.responseDataAndHeaders(for: jetpackRequest)
-            return WCRESTResponse(data: unwrap(data), statusCode: 200)
+            let (data, headers) = try await network.responseDataAndHeaders(for: jetpackRequest)
+            return WCRESTResponse(data: unwrap(data), statusCode: 200, headers: headers ?? [:])
         } catch let error as NetworkError {
             let body = unwrap(error.responseData ?? Data())
             if case .timeout = error {


### PR DESCRIPTION
Depends on #17213 - when that merges, this PR rebases to its base automatically.

## What this does

Builds on the consolidated product tools (`products_list` + `products_update`) with four merchant capabilities:

- **`products_list`**: a `low_in_stock` filter (backed by the WooCommerce analytics stock report) and `min_price` / `max_price` filters.
- **`products_update`**: a `percent_discount` field (the server computes each entity's sale price from its own regular price) and a `scope=all_variations` option that applies a price or stock change to every variation of a variable product in one confirmation.

## Why

With the consolidation in place the assistant could address products but couldn't answer common merchant asks - "what's low in stock?", "show products under $30", "give these 20% off", "put this variable product on sale across all its variations." The model also had no safe way to do per-item discount math (it drifted to literal values) or to apply a change across a variable product's variations. These move that logic into the tools / server so the model passes intent, not arithmetic.

## What works now that didn't before

- "What's low in stock?" - a real low-stock filter, not the wrong `onbackorder` cohort.
- "Show me products under $30" and price ranges.
- "Give [product] 20% off" - correct per-item sale price (not a literal $0.20).
- "Apply 10% off to the products in my last order" - per-entity discount across the order's items.
- "Put [variable product] on sale across all its variations" - one confirmation, fans out to every variation with its own computed sale price.
- "Rename [variable product]" - parent-level edits (name/status/sku) write to the parent.
- The confirmation card shows the full fanout scope ("all N variations of X"), per-variation labels, and per-item value breakdowns, and no longer repeats the action summary on bulk cards.

## Key non-obvious decisions

- **`scope=all_variations` is required for variable-parent price/stock fanout.** Without it, a price/stock edit to a variable parent is refused with a pointer to target the variations or pass the scope, so the assistant never silently reprices every variation. Parent-only fields (name/status/sku) still apply to the parent; an entry mixing parent-only and price/stock without scope is refused whole rather than partially applied.
- **`percent_discount` is computed per entity from its own `regular_price`** (server-side), validated to greater-than-0 and less-than-100, and never sent literally in the write body.
- **Fanned-out variations appear in the receipt as variation target objects** (`{kind:"variation", id, parent_id}`) - the same shape reads emit - so a result card renders without the model reconstructing it. No separate "expanded" projection.
- **A missing product or variation is refused before the confirmation card** (fail-fast), so the merchant is never asked to approve a write that cannot land.
- **`low_in_stock`** is authoritative from the WooCommerce analytics stock report, enriched and post-filtered in Swift, with a bounded heuristic scan as a fallback when the report endpoint is unavailable.

## Known behavior (reviewer awareness)

On an ambiguous variable-parent price prompt ("set the price of [variable product] to 40"), a capable model may add `scope=all_variations` itself and propose a fanout. The confirmation card shows the full scope ("all N variations") so the merchant consents before anything changes - the card is the consent gate. Nudging the assistant to ask first on ambiguous destructive variable-parent edits is a prompt-level follow-up (WOOMOB-3121).

## Tests

Unit (757 pass): low-stock report path + heuristic fallback + post-filters; min/max price boundaries and the `effectivePrice` fallback; `percent_discount` per-entity math, range validation (0 / 100 / negative / >100), and omission from the batch body; `scope=all_variations` fanout (to N variations, >100 refusal, mixed parent-only + expansion, no-scope refusal, scope on a simple product); the pre-dispatch refusal chain for missing products/variations; fanned-out variations rendering as variation target objects; and the bulk-card summary de-duplication.

Headless smoke against the demo store on gpt-5.1 (default suite + capability scenarios, writes auto-declined): all capabilities verified - low_in_stock, max_price, percent_discount (single and from-order), the all-variations fanout, and the variable-parent rename. No consolidation regressions.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.