### PR TITLE
Cap and merge AI Assistant product updates into one batch per turn

### DIFF
--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -11,6 +11,8 @@ public actor AgenticLoopOrchestrator {
     public static let defaultPerToolPerTurnCap = 4
 
     /// Tools that must be batched in a single call per merchant turn rather than fanned out.
+    /// Keep this in sync with `mergeableToolNames`: merging only helps a capped tool, so the two
+    /// lists travel together and a future editor should add a tool to both or neither.
     public static let defaultPerToolCapOverrides: [String: Int] = [
         ProductsUpdateTool.name: 1
     ]
@@ -425,16 +427,14 @@ public actor AgenticLoopOrchestrator {
             let toolName = call.function.name
             let priorToolCount = liveTurnTallies[toolName, default: 0]
             liveTurnTallies[toolName] = priorToolCount + 1
-            let hasOverride = perToolCapOverrides[toolName] != nil
-            let effectiveCap = perToolCapOverrides[toolName] ?? perToolPerTurnCap
-            // Override tools cap on prior successes + this batch's position so failures don't burn the slot.
-            let countAgainstCap = hasOverride
-                ? liveTurnSuccessTallies[toolName, default: 0] + inBatchApprovals[toolName, default: 0]
-                : priorToolCount
-            if countAgainstCap >= effectiveCap {
+            let capCheck = perToolCapCheck(toolName: toolName,
+                                           priorToolCount: priorToolCount,
+                                           successTallies: liveTurnSuccessTallies,
+                                           inBatchApprovals: inBatchApprovals)
+            if capCheck.exceeded {
                 let payload = Self.perToolCapJSON(toolName: toolName,
-                                                  cap: effectiveCap,
-                                                  isBatchingTool: hasOverride)
+                                                  cap: capCheck.cap,
+                                                  isBatchingTool: capCheck.isOverride)
                 continuation.yield(.toolCallStarted(id: call.id,
                                                     name: toolName,
                                                     argumentsJSON: call.function.arguments))
@@ -636,6 +636,27 @@ public actor AgenticLoopOrchestrator {
             }
             return payload
         }
+    }
+
+    private struct PerToolCapCheck {
+        let exceeded: Bool
+        let cap: Int
+        let isOverride: Bool
+    }
+
+    /// Resolves the per-tool cap for one call so the dispatch loop reads as a single guard. Override
+    /// tools count prior successes plus this batch's approvals so a failed write never burns the slot;
+    /// non-override tools count every prior call this turn.
+    private func perToolCapCheck(toolName: String,
+                                 priorToolCount: Int,
+                                 successTallies: [String: Int],
+                                 inBatchApprovals: [String: Int]) -> PerToolCapCheck {
+        let isOverride = perToolCapOverrides[toolName] != nil
+        let cap = perToolCapOverrides[toolName] ?? perToolPerTurnCap
+        let countAgainstCap = isOverride
+            ? successTallies[toolName, default: 0] + inBatchApprovals[toolName, default: 0]
+            : priorToolCount
+        return PerToolCapCheck(exceeded: countAgainstCap >= cap, cap: cap, isOverride: isOverride)
     }
 
     private func handleToolResult(_ result: ToolResult,
@@ -845,8 +866,9 @@ public actor AgenticLoopOrchestrator {
         return #"{"outcome":"unknown"}"#
     }
 
-    /// Tools whose argument shape supports merging multiple calls into one. Keep the merger generic
-    /// so other batched writers can opt in later by adding their name + concat helper here.
+    /// Tools whose argument shape supports merging multiple calls into one. Must list the same tools
+    /// as `defaultPerToolCapOverrides`: merging only makes sense for a tool the cap forces into a
+    /// single batch.
     static let mergeableToolNames: Set<String> = [ProductsUpdateTool.name]
 
     struct IntraBatchMergeOutcome {
@@ -912,6 +934,8 @@ public actor AgenticLoopOrchestrator {
                       let updates = obj["updates"] as? [Any] else {
                     return nil
                 }
+                // Targets are concatenated as-is; the downstream tool rejects "Duplicate target", so we
+                // intentionally do not pre-dedupe here.
                 mergedUpdates.append(contentsOf: updates)
             } catch {
                 DDLogError("AgenticLoopOrchestrator mergeProductsUpdateArgs decode failed: \(error)")
@@ -930,7 +954,9 @@ public actor AgenticLoopOrchestrator {
     }
 
     /// Success-shaped envelope handed back to merged-away calls so the model still gets a result
-    /// for every tool_call_id while learning that the batch was consolidated.
+    /// for every tool_call_id while learning that the batch was consolidated. It classifies as a
+    /// success independent of the leader's dispatch outcome, so a failed merged leader can still leave
+    /// the cap consumed via the secondary's success tally.
     static func mergedIntoCallJSON(leaderCallID: String) -> String {
         let body: [String: Any] = [
             "merged_into_call": leaderCallID,

--- a/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
+++ b/Modules/Sources/WooAIAssistant/Loop/AgenticLoopOrchestrator.swift
@@ -10,12 +10,18 @@ public actor AgenticLoopOrchestrator {
     /// 4 keeps "list + 3 drill-downs" flows legitimate while catching varied-args fanouts.
     public static let defaultPerToolPerTurnCap = 4
 
+    /// Tools that must be batched in a single call per merchant turn rather than fanned out.
+    public static let defaultPerToolCapOverrides: [String: Int] = [
+        ProductsUpdateTool.name: 1
+    ]
+
     private let chatService: AIChatService
     private let toolRegistry: ToolRegistry?
     private let safetyPolicy: SafetyPolicy
     private let systemPrompt: String?
     private let maxIterations: Int
     private let perToolPerTurnCap: Int
+    private let perToolCapOverrides: [String: Int]
     private let telemetryTracker: AssistantTelemetryTracker
     private let clock: SystemClock
 
@@ -30,6 +36,7 @@ public actor AgenticLoopOrchestrator {
                 systemPrompt: String? = nil,
                 maxIterations: Int = AgenticLoopOrchestrator.defaultMaxIterations,
                 perToolPerTurnCap: Int = AgenticLoopOrchestrator.defaultPerToolPerTurnCap,
+                perToolCapOverrides: [String: Int] = AgenticLoopOrchestrator.defaultPerToolCapOverrides,
                 telemetryTracker: AssistantTelemetryTracker = NoopAssistantTelemetryTracker(),
                 clock: SystemClock = MonotonicSystemClock()) {
         self.chatService = chatService
@@ -38,6 +45,7 @@ public actor AgenticLoopOrchestrator {
         self.systemPrompt = systemPrompt
         self.maxIterations = maxIterations
         self.perToolPerTurnCap = perToolPerTurnCap
+        self.perToolCapOverrides = perToolCapOverrides
         self.telemetryTracker = telemetryTracker
         self.clock = clock
     }
@@ -276,12 +284,14 @@ public actor AgenticLoopOrchestrator {
                 let priorSignatures = Self.computePriorCallSignatures(in: messages)
                 let priorResults = Self.computePriorResultsBySignature(in: messages)
                 let priorTurnTallies = Self.computePerToolPriorTallies(in: messages)
+                let priorTurnSuccessTallies = Self.computePerToolPriorSuccessTallies(in: messages)
 
                 let payloads = try await dispatchTools(calls,
                                                        toolsByName: toolsByName,
                                                        priorCallSignatures: priorSignatures,
                                                        priorResultsBySignature: priorResults,
                                                        priorPerToolTallies: priorTurnTallies,
+                                                       priorPerToolSuccessTallies: priorTurnSuccessTallies,
                                                        telemetryContext: telemetryContext,
                                                        continuation: continuation)
                 for (call, payload) in zip(calls, payloads) {
@@ -349,6 +359,7 @@ public actor AgenticLoopOrchestrator {
                                priorCallSignatures: [String: Int],
                                priorResultsBySignature: [String: String],
                                priorPerToolTallies: [String: Int],
+                               priorPerToolSuccessTallies: [String: Int],
                                telemetryContext: AssistantTelemetryContext?,
                                continuation: AsyncThrowingStream<AssistantEvent, Error>.Continuation)
     async throws -> [String] {
@@ -373,35 +384,65 @@ public actor AgenticLoopOrchestrator {
             return calls.map { _ in #"{"error":"No tool registry is configured for this client."}"# }
         }
 
+        // Merge adjacent same-tool calls (currently only products_update) before any check fires.
+        // Belt+suspenders with the cap override: the model may still fan out in one batch even though
+        // the system prompt asks for batching, and the underlying REST stays a single batch either way.
+        let mergeOutcome = Self.applyIntraBatchMerges(calls: calls)
+        let calls = mergeOutcome.calls
+        let mergedSecondaryToLeader = mergeOutcome.mergedSecondaryToLeader
+
         var approvedIndices: [Int] = []
         var resolvedResults = [String?](repeating: nil, count: calls.count)
         var liveSignatures = priorCallSignatures
         let liveResults = priorResultsBySignature
         var liveTurnTallies = priorPerToolTallies
+        var liveTurnSuccessTallies = priorPerToolSuccessTallies
+        // Counts approvals this batch so same-batch fanout still hits the cap before any dispatch resolves.
+        var inBatchApprovals: [String: Int] = [:]
 
         // Without intra-batch dedupe the task group fires the registry once per duplicate in parallel.
         var firstPrimaryByIntraSignature: [String: Int] = [:]
         var intraBatchSecondaryToPrimary: [Int: Int] = [:]
 
         for (index, call) in calls.enumerated() {
+            if let leaderIndex = mergedSecondaryToLeader[index] {
+                let leaderID = calls[leaderIndex].id
+                continuation.yield(.toolCallStarted(id: call.id,
+                                                    name: call.function.name,
+                                                    argumentsJSON: call.function.arguments))
+                let payload = Self.mergedIntoCallJSON(leaderCallID: leaderID)
+                continuation.yield(.toolCallCompleted(id: call.id,
+                                                      name: call.function.name,
+                                                      resultJSON: payload))
+                resolvedResults[index] = payload
+                continue
+            }
             let signature = Self.canonicalCallSignature(name: call.function.name,
                                                         argumentsJSON: call.function.arguments)
             let priorSeen = liveSignatures[signature, default: 0]
             liveSignatures[signature] = priorSeen + 1
 
-            let priorToolCount = liveTurnTallies[call.function.name, default: 0]
-            liveTurnTallies[call.function.name] = priorToolCount + 1
-            if priorToolCount >= perToolPerTurnCap {
-                let payload = Self.perToolCapJSON(toolName: call.function.name,
-                                                  cap: perToolPerTurnCap)
+            let toolName = call.function.name
+            let priorToolCount = liveTurnTallies[toolName, default: 0]
+            liveTurnTallies[toolName] = priorToolCount + 1
+            let hasOverride = perToolCapOverrides[toolName] != nil
+            let effectiveCap = perToolCapOverrides[toolName] ?? perToolPerTurnCap
+            // Override tools cap on prior successes + this batch's position so failures don't burn the slot.
+            let countAgainstCap = hasOverride
+                ? liveTurnSuccessTallies[toolName, default: 0] + inBatchApprovals[toolName, default: 0]
+                : priorToolCount
+            if countAgainstCap >= effectiveCap {
+                let payload = Self.perToolCapJSON(toolName: toolName,
+                                                  cap: effectiveCap,
+                                                  isBatchingTool: hasOverride)
                 continuation.yield(.toolCallStarted(id: call.id,
-                                                    name: call.function.name,
+                                                    name: toolName,
                                                     argumentsJSON: call.function.arguments))
                 continuation.yield(.toolCallCompleted(id: call.id,
-                                                      name: call.function.name,
+                                                      name: toolName,
                                                       resultJSON: payload))
                 if let telemetryContext {
-                    let canonical = Self.canonicalToolName(call.function.name, toolsByName: toolsByName)
+                    let canonical = Self.canonicalToolName(toolName, toolsByName: toolsByName)
                     await emitTelemetry(.toolCallCompleted(context: telemetryContext,
                                                            toolName: canonical,
                                                            status: .failure,
@@ -461,6 +502,7 @@ public actor AgenticLoopOrchestrator {
             switch decision {
             case .execute:
                 approvedIndices.append(index)
+                inBatchApprovals[call.function.name, default: 0] += 1
 
             case .refusePreDispatch(let reason):
                 let payload = Self.errorJSON(reason)
@@ -489,6 +531,7 @@ public actor AgenticLoopOrchestrator {
                 continuation.yield(.confirmationResolved(proposalID: proposal.id, approved: approved))
                 if approved {
                     approvedIndices.append(index)
+                    inBatchApprovals[call.function.name, default: 0] += 1
                 } else {
                     let payload = Self.userCancelledJSON()
                     continuation.yield(.toolCallStarted(id: call.id,
@@ -539,6 +582,9 @@ public actor AgenticLoopOrchestrator {
                                                         for: call,
                                                         continuation: continuation)
                     resolvedResults[index] = payload
+                    if case .success = result {
+                        liveTurnSuccessTallies[call.function.name, default: 0] += 1
+                    }
                     if let telemetryContext, let startMs = startTimesByIndex[index] {
                         let duration = max(0, clock.nowMs() - startMs)
                         await emitToolDecisionTelemetry(result: result,
@@ -799,14 +845,123 @@ public actor AgenticLoopOrchestrator {
         return #"{"outcome":"unknown"}"#
     }
 
-    private static func perToolCapJSON(toolName: String, cap: Int) -> String {
+    /// Tools whose argument shape supports merging multiple calls into one. Keep the merger generic
+    /// so other batched writers can opt in later by adding their name + concat helper here.
+    static let mergeableToolNames: Set<String> = [ProductsUpdateTool.name]
+
+    struct IntraBatchMergeOutcome {
+        let calls: [OpenAIChat.ToolCall]
+        let mergedSecondaryToLeader: [Int: Int]
+    }
+
+    /// Groups adjacent same-tool calls (currently only products_update) and rewrites each group's
+    /// leader with merged `updates[]`. Secondary indices map to their leader so the per-call loop
+    /// can emit a `merged_into_call` envelope rather than re-dispatching.
+    static func applyIntraBatchMerges(calls: [OpenAIChat.ToolCall]) -> IntraBatchMergeOutcome {
+        guard !calls.isEmpty else {
+            return IntraBatchMergeOutcome(calls: calls, mergedSecondaryToLeader: [:])
+        }
+        var workingCalls = calls
+        var secondaryToLeader: [Int: Int] = [:]
+        var groupStart = 0
+        for index in 1...calls.count {
+            let endOfGroup = index == calls.count
+                || calls[index].function.name != calls[groupStart].function.name
+            if endOfGroup {
+                let groupEnd = index - 1
+                let toolName = calls[groupStart].function.name
+                if groupEnd > groupStart, mergeableToolNames.contains(toolName) {
+                    let groupArgs = (groupStart...groupEnd).map { calls[$0].function.arguments }
+                    if let merged = mergedArgsForTool(name: toolName, groupArgs: groupArgs) {
+                        let leader = calls[groupStart]
+                        workingCalls[groupStart] = OpenAIChat.ToolCall(
+                            id: leader.id,
+                            function: .init(name: toolName, arguments: merged)
+                        )
+                        for secondary in (groupStart + 1)...groupEnd {
+                            secondaryToLeader[secondary] = groupStart
+                        }
+                    }
+                }
+                groupStart = index
+            }
+        }
+        return IntraBatchMergeOutcome(calls: workingCalls, mergedSecondaryToLeader: secondaryToLeader)
+    }
+
+    /// Dispatch to the per-tool merger. Returns nil when the tool isn't mergeable or the args can't
+    /// be combined (decode failure, size cap, etc).
+    private static func mergedArgsForTool(name: String, groupArgs: [String]) -> String? {
+        switch name {
+        case ProductsUpdateTool.name:
+            return mergeProductsUpdateArgs(jsonArgs: groupArgs)
+        default:
+            return nil
+        }
+    }
+
+    /// Concat each call's `updates[]` array into one. Returns nil if any payload fails to decode or
+    /// the merged total exceeds `ProductsUpdateTool.maxBatchSize`; the caller leaves the calls split
+    /// in that case so the cap path can reject the overflow.
+    static func mergeProductsUpdateArgs(jsonArgs: [String]) -> String? {
+        var mergedUpdates: [Any] = []
+        for argString in jsonArgs {
+            guard let data = argString.data(using: .utf8) else { return nil }
+            do {
+                guard let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let updates = obj["updates"] as? [Any] else {
+                    return nil
+                }
+                mergedUpdates.append(contentsOf: updates)
+            } catch {
+                DDLogError("AgenticLoopOrchestrator mergeProductsUpdateArgs decode failed: \(error)")
+                return nil
+            }
+        }
+        if mergedUpdates.count > ProductsUpdateTool.maxBatchSize { return nil }
+        do {
+            let data = try JSONSerialization.data(withJSONObject: ["updates": mergedUpdates],
+                                                  options: [.sortedKeys])
+            return String(data: data, encoding: .utf8)
+        } catch {
+            DDLogError("AgenticLoopOrchestrator mergeProductsUpdateArgs encode failed: \(error)")
+            return nil
+        }
+    }
+
+    /// Success-shaped envelope handed back to merged-away calls so the model still gets a result
+    /// for every tool_call_id while learning that the batch was consolidated.
+    static func mergedIntoCallJSON(leaderCallID: String) -> String {
+        let body: [String: Any] = [
+            "merged_into_call": leaderCallID,
+            "note": "Your earlier call in this batch was combined with the same-tool calls " +
+                    "that followed, so all your requested updates ran in a single batch."
+        ]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+            if let json = String(data: data, encoding: .utf8) { return json }
+        } catch {
+            DDLogError("AgenticLoopOrchestrator mergedIntoCallJSON encode failed: \(error)")
+        }
+        return #"{"merged_into_call":""}"#
+    }
+
+    private static func perToolCapJSON(toolName: String, cap: Int, isBatchingTool: Bool = false) -> String {
+        let hint: String
+        if isBatchingTool {
+            hint = "You've already called this tool. To update multiple entities, " +
+                   "include them all in one call's updates[] array. Do not call " +
+                   "this tool again unless the previous call failed."
+        } else {
+            hint = "You've already called this tool \(cap) times this turn. " +
+                   "Answer the merchant now using show_cards or plain text. " +
+                   "Do not call this tool again."
+        }
         let body: [String: Any] = [
             "error": "per_tool_cap_exceeded",
             "tool": toolName,
             "cap": cap,
-            "hint": "You've already called this tool \(cap) times this turn. " +
-                    "Answer the merchant now using show_cards or plain text. " +
-                    "Do not call this tool again."
+            "hint": hint
         ]
         do {
             let data = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
@@ -950,6 +1105,49 @@ public actor AgenticLoopOrchestrator {
             }
         }
         return counts
+    }
+
+    /// Per-tool tallies counting only successful prior dispatches. Failed/cancelled/outcome-unknown
+    /// payloads are excluded so a tool can be retried after a failure without hitting an override cap.
+    static func computePerToolPriorSuccessTallies(in messages: [OpenAIChat.Message]) -> [String: Int] {
+        guard let lastUserIdx = messages.lastIndex(where: { $0.role == .user }) else { return [:] }
+        var upperBound = messages.count
+        if let last = messages.last, last.role == .assistant, last.toolCalls != nil {
+            upperBound -= 1
+        }
+        guard lastUserIdx + 1 < upperBound else { return [:] }
+        var resultByCallID: [String: String] = [:]
+        for msg in messages[(lastUserIdx + 1)..<upperBound] {
+            guard msg.role == .tool, let id = msg.toolCallID, let content = msg.content else { continue }
+            if resultByCallID[id] == nil {
+                resultByCallID[id] = content
+            }
+        }
+        var counts: [String: Int] = [:]
+        for msg in messages[(lastUserIdx + 1)..<upperBound] {
+            guard msg.role == .assistant, let calls = msg.toolCalls else { continue }
+            for call in calls {
+                guard let payload = resultByCallID[call.id], payloadIsToolSuccess(payload) else { continue }
+                counts[call.function.name, default: 0] += 1
+            }
+        }
+        return counts
+    }
+
+    /// A tool result counts as success when it isn't an error envelope, a user-cancelled marker,
+    /// or an outcome-unknown shape. The cap-override path uses this to leave room for retries.
+    static func payloadIsToolSuccess(_ payload: String) -> Bool {
+        guard let data = payload.data(using: .utf8) else { return false }
+        do {
+            let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            if parsed?["error"] != nil { return false }
+            if let status = parsed?["status"] as? String, status == "user_cancelled" { return false }
+            if let outcome = parsed?["outcome"] as? String, outcome == "unknown" { return false }
+            return true
+        } catch {
+            DDLogError("AgenticLoopOrchestrator payloadIsToolSuccess parse failed: \(error)")
+            return false
+        }
     }
 
     private static func encodeJSON(_ value: AnyCodableJSON) -> String {

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopIntraBatchMergeTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopIntraBatchMergeTests.swift
@@ -195,4 +195,281 @@ struct LoopIntraBatchMergeTests {
             .first { ($0.content ?? "").contains("merged_into_call") }
         #expect(mergeMarker == nil)
     }
+
+    @Test
+    func test_merge_when_three_products_update_in_one_batch_then_all_updates_present_once() async throws {
+        // Given three adjacent products_update calls in one batch.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"B"}]}"#)
+        )
+        let thirdCall = OpenAIChat.ToolCall(
+            id: "call_3",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"C"}]}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .toolCall(secondCall), .toolCall(thirdCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(3)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update A, B and C") {}
+
+        // Then the three calls collapse into one dispatch carrying every update exactly once.
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let mergedArgs = await registry.lastArguments(for: "products_update")
+        let unwrapped = try #require(mergedArgs)
+        #expect(occurrences(of: "\"target\":\"A\"", in: unwrapped) == 1)
+        #expect(occurrences(of: "\"target\":\"B\"", in: unwrapped) == 1)
+        #expect(occurrences(of: "\"target\":\"C\"", in: unwrapped) == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let mergedSecondaries = capturedRequests
+            .flatMap { $0.messages }
+            .filter { $0.role == .tool && ($0.content ?? "").contains("merged_into_call") }
+            .compactMap { $0.toolCallID }
+        #expect(Set(mergedSecondaries) == ["call_2", "call_3"])
+    }
+
+    @Test
+    func test_merge_when_non_adjacent_same_tool_calls_then_only_adjacent_merge() async throws {
+        // Given products_update, products_list, products_update: the two updates are not adjacent.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let listTool = AITool(name: "products_list",
+                              description: "List products",
+                              parametersSchema: .object([:]),
+                              safetyLevel: .safe)
+        let firstUpdate = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let listCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_list", arguments: #"{}"#)
+        )
+        let secondUpdate = OpenAIChat.ToolCall(
+            id: "call_3",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"B"}]}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstUpdate), .toolCall(listCall), .toolCall(secondUpdate), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool, listTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        await registry.setResult(for: "products_list",
+                                 result: .success(.init(toolName: "products_list",
+                                                        structured: .object(["count": .int(0)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update A, list, update B") {}
+
+        // Then the two updates never merge; only the first dispatches and cap-1 rejects the second.
+        let updateInvocations = await registry.invocationCount(for: "products_update")
+        #expect(updateInvocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let mergeMarker = capturedRequests
+            .flatMap { $0.messages }
+            .first { ($0.content ?? "").contains("merged_into_call") }
+        #expect(mergeMarker == nil)
+
+        let secondUpdateMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_3" }
+        let content = try #require(secondUpdateMessage?.content)
+        #expect(content.contains("per_tool_cap_exceeded"))
+    }
+
+    @Test
+    func test_merge_when_one_call_has_empty_updates_then_merge_skipped() async throws {
+        // Given two products_update calls where the second omits the updates array entirely, so the
+        // merger returns nil rather than silently dropping it.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: #"{"note":"no updates here"}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update A then nothing") {}
+
+        // Then the calls stay split and cap-1 rejects the leftover second call.
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let mergeMarker = capturedRequests
+            .flatMap { $0.messages }
+            .first { ($0.content ?? "").contains("merged_into_call") }
+        #expect(mergeMarker == nil)
+
+        let secondMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_2" }
+        let content = try #require(secondMessage?.content)
+        #expect(content.contains("per_tool_cap_exceeded"))
+    }
+
+    @Test
+    func test_cap_when_two_split_products_update_in_one_batch_then_second_rejected() async throws {
+        // Given two products_update calls in one batch whose updates overflow maxBatchSize, so they
+        // stay split. The in-batch approval count must trip cap-1 on the second within the same batch.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstUpdates = (0..<60).map { #"{"target":"A\#($0)"}"# }.joined(separator: ",")
+        let secondUpdates = (0..<60).map { #"{"target":"B\#($0)"}"# }.joined(separator: ",")
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: "{\"updates\":[\(firstUpdates)]}")
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: "{\"updates\":[\(secondUpdates)]}")
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(60)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Bulk update twice") {}
+
+        // Then only one call dispatches and the second is capped within the same batch.
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let secondMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_2" }
+        let content = try #require(secondMessage?.content)
+        #expect(content.contains("per_tool_cap_exceeded"))
+    }
+
+    @Test
+    func test_merge_overflow_boundary_then_merges_at_max_and_splits_above() async throws {
+        // Given updates summing to exactly maxBatchSize (100): the batch merges into one dispatch.
+        let atMaxArgs = try await runProductsUpdateBatch(firstCount: 50, secondCount: 50)
+        #expect(atMaxArgs.invocations == 1)
+        let mergedArgs = try #require(atMaxArgs.lastArguments)
+        #expect(mergedArgs.contains("\"target\":\"A0\""))
+        #expect(mergedArgs.contains("\"target\":\"B49\""))
+        #expect(!atMaxArgs.sawCapRejection)
+
+        // Given updates summing to maxBatchSize + 1 (101): the merger gives up and the calls stay
+        // split, so the first dispatches and cap-1 rejects the second.
+        let overMaxArgs = try await runProductsUpdateBatch(firstCount: 50, secondCount: 51)
+        #expect(overMaxArgs.invocations == 1)
+        #expect(overMaxArgs.sawCapRejection)
+    }
+
+    private struct ProductsUpdateBatchResult {
+        let invocations: Int
+        let lastArguments: String?
+        let sawCapRejection: Bool
+    }
+
+    private func runProductsUpdateBatch(firstCount: Int, secondCount: Int) async throws -> ProductsUpdateBatchResult {
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstUpdates = (0..<firstCount).map { #"{"target":"A\#($0)"}"# }.joined(separator: ",")
+        let secondUpdates = (0..<secondCount).map { #"{"target":"B\#($0)"}"# }.joined(separator: ",")
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: "{\"updates\":[\(firstUpdates)]}")
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: "{\"updates\":[\(secondUpdates)]}")
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        for try await _ in orchestrator.run(prompt: "Bulk update boundary") {}
+
+        let invocations = await registry.invocationCount(for: "products_update")
+        let lastArguments = await registry.lastArguments(for: "products_update")
+        let capturedRequests = await chat.capturedRequests
+        let sawCapRejection = capturedRequests
+            .flatMap { $0.messages }
+            .contains { ($0.content ?? "").contains("per_tool_cap_exceeded") }
+        return ProductsUpdateBatchResult(invocations: invocations,
+                                         lastArguments: lastArguments,
+                                         sawCapRejection: sawCapRejection)
+    }
+
+    private func occurrences(of needle: String, in haystack: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchRange = haystack.startIndex..<haystack.endIndex
+        while let found = haystack.range(of: needle, range: searchRange) {
+            count += 1
+            searchRange = found.upperBound..<haystack.endIndex
+        }
+        return count
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopIntraBatchMergeTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopIntraBatchMergeTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct LoopIntraBatchMergeTests {
+
+    @Test
+    func test_dispatch_when_model_emits_two_products_update_in_one_batch_then_calls_merged_before_dispatch() async throws {
+        // Given
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"B"}]}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(2)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update A and B") {}
+
+        // Then
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let mergedArgs = await registry.lastArguments(for: "products_update")
+        let unwrapped = try #require(mergedArgs)
+        #expect(unwrapped.contains("\"target\":\"A\""))
+        #expect(unwrapped.contains("\"target\":\"B\""))
+
+        let capturedRequests = await chat.capturedRequests
+        let secondaryMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_2" }
+        let secondaryContent = try #require(secondaryMessage?.content)
+        #expect(secondaryContent.contains("merged_into_call"))
+        #expect(secondaryContent.contains("call_1"))
+
+        let leaderMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_1" }
+        let leaderContent = try #require(leaderMessage?.content)
+        #expect(leaderContent.contains("\"updated\":2"))
+        #expect(!leaderContent.contains("merged_into_call"))
+    }
+
+    @Test
+    func test_dispatch_when_merge_would_exceed_max_batch_size_then_calls_dispatch_separately() async throws {
+        // Given a 60-entry payload + a 60-entry payload; total 120 > 100 max so merge is skipped.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstUpdates = (0..<60).map { #"{"target":"A\#($0)"}"# }.joined(separator: ",")
+        let secondUpdates = (0..<60).map { #"{"target":"B\#($0)"}"# }.joined(separator: ",")
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: "{\"updates\":[\(firstUpdates)]}")
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: "{\"updates\":[\(secondUpdates)]}")
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(60)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Bulk update") {}
+
+        // Then merger gave up; first dispatches, cap-1 rejects the second.
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let secondaryMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_2" }
+        let content = try #require(secondaryMessage?.content)
+        #expect(content.contains("per_tool_cap_exceeded"))
+        #expect(!content.contains("merged_into_call"))
+    }
+
+    @Test
+    func test_dispatch_when_calls_are_different_tools_then_no_merge() async throws {
+        // Given a products_update next to an orders_list - no merge across tool boundaries.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let listTool = AITool(name: "orders_list",
+                              description: "List orders",
+                              parametersSchema: .object([:]),
+                              safetyLevel: .safe)
+        let updateCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let listCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "orders_list", arguments: #"{}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(updateCall), .toolCall(listCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool, listTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        await registry.setResult(for: "orders_list",
+                                 result: .success(.init(toolName: "orders_list",
+                                                        structured: .object(["count": .int(0)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update then list") {}
+
+        // Then both tools execute independently.
+        let updateInvocations = await registry.invocationCount(for: "products_update")
+        let listInvocations = await registry.invocationCount(for: "orders_list")
+        #expect(updateInvocations == 1)
+        #expect(listInvocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let mergeMarker = capturedRequests
+            .flatMap { $0.messages }
+            .first { ($0.content ?? "").contains("merged_into_call") }
+        #expect(mergeMarker == nil)
+    }
+
+    @Test
+    func test_dispatch_when_only_one_products_update_then_no_merge_attempted() async throws {
+        // Given a single products_update call: behavior matches pre-merger.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let call = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(call), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update A") {}
+
+        // Then
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let lastArgs = await registry.lastArguments(for: "products_update")
+        let unwrapped = try #require(lastArgs)
+        #expect(unwrapped.contains("\"target\":\"A\""))
+
+        let capturedRequests = await chat.capturedRequests
+        let mergeMarker = capturedRequests
+            .flatMap { $0.messages }
+            .first { ($0.content ?? "").contains("merged_into_call") }
+        #expect(mergeMarker == nil)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopPerToolCapOverrideTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopPerToolCapOverrideTests.swift
@@ -134,4 +134,65 @@ struct LoopPerToolCapOverrideTests {
             .contains { ($0.content ?? "").contains("per_tool_cap_exceeded") }
         #expect(!anyCapRejection)
     }
+
+    @Test
+    func test_cap_when_confirmation_declined_then_cap_not_burned_and_retry_allowed() async throws {
+        // Given a products_update declined at confirmation, then retried in a follow-up turn. A decline
+        // yields a non-success user_cancelled payload, so the cap-1 slot must stay free for the retry.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let retryCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}],"retry":true}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .completed(.toolCalls)],
+            [.toolCall(retryCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   safetyPolicy: DefaultSafetyPolicy())
+
+        // When the first proposal is declined and the second is confirmed.
+        var pendingDecisionTasks: [Task<Void, Never>] = []
+        for try await event in orchestrator.run(prompt: "Update A, decline, then retry") {
+            if case .confirmationRequired(let proposal) = event {
+                if proposal.toolCallID == "call_1" {
+                    pendingDecisionTasks.append(Task { await orchestrator.cancel(proposalID: proposal.id) })
+                } else {
+                    pendingDecisionTasks.append(Task { await orchestrator.confirm(proposalID: proposal.id) })
+                }
+            }
+        }
+        for task in pendingDecisionTasks { await task.value }
+
+        // Then the declined call never ran, the retry executed, and no cap rejection fired.
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let declinedMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_1" }
+        let declinedContent = try #require(declinedMessage?.content)
+        #expect(declinedContent.contains("user_cancelled"))
+
+        let capRejection = capturedRequests
+            .flatMap { $0.messages }
+            .first { ($0.content ?? "").contains("per_tool_cap_exceeded") }
+        #expect(capRejection == nil)
+    }
 }

--- a/Modules/Tests/WooAIAssistantTests/Loop/LoopPerToolCapOverrideTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Loop/LoopPerToolCapOverrideTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct LoopPerToolCapOverrideTests {
+
+    @Test
+    func test_dispatch_when_model_calls_products_update_twice_then_second_call_rejected_with_cap_message() async throws {
+        // Given two products_update calls split across consecutive assistant turns. The cap-1
+        // override fires across batches even when the first call already succeeded.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let secondCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"B"}]}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .completed(.toolCalls)],
+            [.toolCall(secondCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        await registry.setResult(for: "products_update",
+                                 result: .success(.init(toolName: "products_update",
+                                                        structured: .object(["updated": .int(1)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Update A then B") {}
+
+        // Then
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 1)
+
+        let capturedRequests = await chat.capturedRequests
+        let secondToolMessage = capturedRequests
+            .flatMap { $0.messages }
+            .first { $0.role == .tool && $0.toolCallID == "call_2" }
+        let content = try #require(secondToolMessage?.content)
+        #expect(content.contains("per_tool_cap_exceeded"))
+        #expect(content.contains("\"cap\":1"))
+        #expect(content.contains("include them all in one call"))
+        #expect(content.contains("unless the previous call failed"))
+    }
+
+    @Test
+    func test_dispatch_when_first_products_update_call_failed_then_second_call_allowed() async throws {
+        // Given a write tool whose first invocation fails, then a retry in a follow-up assistant turn.
+        let writeTool = AITool(name: "products_update",
+                               description: "Update products",
+                               parametersSchema: .object([:]),
+                               safetyLevel: .unsafe)
+        let firstCall = OpenAIChat.ToolCall(
+            id: "call_1",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}]}"#)
+        )
+        let retryCall = OpenAIChat.ToolCall(
+            id: "call_2",
+            function: .init(name: "products_update", arguments: #"{"updates":[{"target":"A"}],"retry":true}"#)
+        )
+        let chat = MockAIChatService()
+        await chat.setScriptedTurns([
+            [.toolCall(firstCall), .completed(.toolCalls)],
+            [.toolCall(retryCall), .completed(.toolCalls)],
+            [.textDelta("Done."), .completed(.stop)]
+        ])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([writeTool])
+        // Failed result lets retry pass the cap; otherwise the second call would be rejected.
+        await registry.setResult(for: "products_update",
+                                 result: .failed(.init(toolName: "products_update",
+                                                       kind: .upstreamFailure,
+                                                       reason: "Network blip.")))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat, toolRegistry: registry)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Retry update for A") {}
+
+        // Then
+        let invocations = await registry.invocationCount(for: "products_update")
+        #expect(invocations == 2)
+
+        let capturedRequests = await chat.capturedRequests
+        let capRejection = capturedRequests
+            .flatMap { $0.messages }
+            .first { ($0.content ?? "").contains("per_tool_cap_exceeded") }
+        #expect(capRejection == nil)
+    }
+
+    @Test
+    func test_per_tool_cap_override_does_not_affect_other_tools() async throws {
+        // Given a non-overridden tool fanned out four times; default cap is 4 so all succeed.
+        let listTool = AITool(name: "orders_list",
+                              description: "List orders",
+                              parametersSchema: .object([:]),
+                              safetyLevel: .safe)
+        let chat = MockAIChatService()
+        let scripted: [[ChatStreamEvent]] = (0..<4).map { i in
+            let call = OpenAIChat.ToolCall(
+                id: "call_\(i)",
+                function: .init(name: "orders_list", arguments: #"{"page":\#(i + 1)}"#)
+            )
+            return [.toolCall(call), .completed(.toolCalls)]
+        }
+        await chat.setScriptedTurns(scripted + [[.textDelta("Done."), .completed(.stop)]])
+        let registry = MockToolRegistry()
+        await registry.setAvailableTools([listTool])
+        await registry.setResult(for: "orders_list",
+                                 result: .success(.init(toolName: "orders_list",
+                                                        structured: .object(["count": .int(0)]))))
+        let orchestrator = AgenticLoopOrchestrator(chatService: chat,
+                                                   toolRegistry: registry,
+                                                   maxIterations: 6)
+
+        // When
+        for try await _ in orchestrator.run(prompt: "Walk all pages") {}
+
+        // Then
+        let invocations = await registry.invocationCount(for: "orders_list")
+        #expect(invocations == 4)
+
+        let capturedRequests = await chat.capturedRequests
+        let anyCapRejection = capturedRequests
+            .flatMap { $0.messages }
+            .contains { ($0.content ?? "").contains("per_tool_cap_exceeded") }
+        #expect(!anyCapRejection)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Mocks/MockToolRegistry.swift
+++ b/Modules/Tests/WooAIAssistantTests/Mocks/MockToolRegistry.swift
@@ -9,6 +9,7 @@ actor MockToolRegistry: ToolRegistry {
     var defaultResult: ToolResult = .success(.init(toolName: "default", structured: .object([:])))
 
     private var invocationCountsByName: [String: Int] = [:]
+    private var lastArgumentsByName: [String: String] = [:]
 
     func availableTools() async throws -> [AITool] {
         if let availableToolsError {
@@ -19,6 +20,7 @@ actor MockToolRegistry: ToolRegistry {
 
     func execute(name: String, arguments: String, toolCallID: String) async -> ToolResult {
         invocationCountsByName[name, default: 0] += 1
+        lastArgumentsByName[name] = arguments
         let result: ToolResult
         if let scripted = resultsByToolCallID[toolCallID] {
             result = scripted
@@ -32,6 +34,10 @@ actor MockToolRegistry: ToolRegistry {
 
     func invocationCount(for toolName: String) -> Int {
         invocationCountsByName[toolName, default: 0]
+    }
+
+    func lastArguments(for toolName: String) -> String? {
+        lastArgumentsByName[toolName]
     }
 
     func setAvailableTools(_ tools: [AITool]) {


### PR DESCRIPTION
Depends on #17216 - when that merges, this PR rebases to its base automatically.

## What this does

Two loop-level guardrails for `products_update`:

- **Cap-1**: the model gets one `products_update` call per turn (a per-tool iteration-cap override). The cap counts confirmed/successful writes, not failures, so a failed or declined write leaves the slot free for a legitimate retry.
- **Intra-batch auto-merge**: if the model emits several `products_update` calls in the same batch, they are merged into one call (the `updates[]` arrays concatenated) before dispatch, with a `merged_into_call` marker returned for the secondaries. A merge that would exceed the batch-size limit stays split, and the cap rejects the leftover.

## Why

`products_update` already takes a batch of targets, but a model can still fan out - emitting several update calls in one turn, or one per iteration. That means several confirmation cards for what the merchant meant as one change, several REST batches, and wasted iterations. Capping and merging collapse that into a single confirmed batch per turn: "set the price of these five products" becomes one card and one write, and the model cannot loop on repeated update calls.

## What works now that didn't before

- A multi-product update is one confirmation and one batch, even when the model initially fans out into several calls.
- The model cannot burn iterations re-issuing `products_update`; after one it gets a clear "include them all in one call's updates[]" hint.
- A failed or declined write does not consume the cap, so a legitimate retry still works.

## Key non-obvious decisions

- **The cap counts successes and in-batch approvals, not failures.** A failed or declined `products_update` leaves the slot free so the merchant can retry.
- **Merge runs before dispatch and only on adjacent same-tool calls.** An overflow beyond the batch-size limit stays split and the cap rejects the leftover - recoverable, never a silent drop.
- **Only `products_update` is capped and merged** (it is the batch-capable write). The cap-override set and the mergeable set list the same tool and are meant to travel together.
- **Identical targets are not pre-deduped** - the tool rejects a duplicate target downstream (safe).
- **A merged-secondary call classifies as success independent of the merged leader's dispatch outcome** (consistent with existing behavior; tightening this so a failed leader frees the cap is a possible follow-up).

## Tests

Unit (770 pass): cap-1 across turns; failed and declined writes do not burn the cap; the override does not affect other tools; merge of two and three-plus calls (every target preserved exactly once); adjacent-only grouping; empty-`updates` skip; the overflow boundary (merges at the limit, splits above); no cross-tool merge.

Headless smoke against the demo store on gpt-5.1 (default suite + batching scenarios, writes auto-declined): multi-product price, multi-product stock, and a five-product fan-out each collapse to a single `products_update` carrying every target in `updates[]` with one confirmation - never N fanned-out calls. No batching regressions across the default suite.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.