### PR TITLE
AI support chat: bug fixes and enable feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -120,7 +120,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .loggedOutFFPanel:
             return !buildConfig.isProduction
         case .aiSupportChat:
-            return !buildConfig.isProduction
+            return true
         case .wooAIAssistant:
             return true
         case .arParcelFitting:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
-- [***] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-ios/pull/17218]
+- [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-ios/pull/17218]
 
 
 24.8

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
+- [***] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-ios/pull/17218]
 
 
 24.8

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -140,11 +140,12 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     private func showSupportChat() {
         var viewModelHolder: SupportChatViewModel?
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
             self?.navigationController?.popViewController(animated: true)
             self?.handleContactHumanSupport(chatID: chatID,
                                             transcript: transcript,
                                             supportAreaInfo: supportAreaInfo,
+                                            siteAddress: siteAddress,
                                             entryPoint: entryPoint,
                                             onTicketCreated: { [weak viewModelHolder] in
                                                 viewModelHolder?.markChatTicketCreated()
@@ -159,6 +160,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     private func handleContactHumanSupport(chatID: Int64?,
                                            transcript: String,
                                            supportAreaInfo: SupportAreaInfo?,
+                                           siteAddress: String?,
                                            entryPoint: SupportChatViewModel.EntryPoint,
                                            onTicketCreated: @escaping () -> Void) {
         supportEscalationCoordinator = SupportEscalationCoordinator(
@@ -168,7 +170,11 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
             },
             onTicketCreated: onTicketCreated
         )
-        supportEscalationCoordinator?.handleEscalation(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo, entryPoint: entryPoint)
+        supportEscalationCoordinator?.handleEscalation(chatID: chatID,
+                                                       transcript: transcript,
+                                                       supportAreaInfo: supportAreaInfo,
+                                                       entryPoint: entryPoint,
+                                                       siteAddress: siteAddress)
     }
 
     private func buildTroubleshootingAttachment() -> [ZendeskAttachment] {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -140,12 +140,11 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
 
     private func showSupportChat() {
         var viewModelHolder: SupportChatViewModel?
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
             self?.navigationController?.popViewController(animated: true)
             self?.handleContactHumanSupport(chatID: chatID,
                                             transcript: transcript,
                                             supportAreaInfo: supportAreaInfo,
-                                            siteAddress: siteAddress,
                                             entryPoint: entryPoint,
                                             onTicketCreated: { [weak viewModelHolder] in
                                                 viewModelHolder?.markChatTicketCreated()
@@ -160,7 +159,6 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     private func handleContactHumanSupport(chatID: Int64?,
                                            transcript: String,
                                            supportAreaInfo: SupportAreaInfo?,
-                                           siteAddress: String?,
                                            entryPoint: SupportChatViewModel.EntryPoint,
                                            onTicketCreated: @escaping () -> Void) {
         supportEscalationCoordinator = SupportEscalationCoordinator(
@@ -174,7 +172,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
                                                        transcript: transcript,
                                                        supportAreaInfo: supportAreaInfo,
                                                        entryPoint: entryPoint,
-                                                       siteAddress: siteAddress)
+                                                       siteAddress: viewModel.siteURL)
     }
 
     private func buildTroubleshootingAttachment() -> [ZendeskAttachment] {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -215,13 +215,7 @@ final class ConnectivityToolViewModel {
     /// Creates a SupportChatViewModel with the current troubleshooting context.
     ///
     @MainActor
-    func makeSupportChatViewModel(onContactHumanSupport: @escaping (
-        _ chatID: Int64?,
-        _ transcript: String,
-        _ supportAreaInfo: SupportAreaInfo?,
-        _ siteAddress: String?,
-        _ entryPoint: SupportChatViewModel.EntryPoint
-    ) -> Void) -> SupportChatViewModel {
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping SupportChatViewModel.ContactHumanSupportCallback) -> SupportChatViewModel {
         var context: [String: Any] = [:]
 
         if let troubleshootingDescription = troubleshootingDescription() {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -219,6 +219,7 @@ final class ConnectivityToolViewModel {
         _ chatID: Int64?,
         _ transcript: String,
         _ supportAreaInfo: SupportAreaInfo?,
+        _ siteAddress: String?,
         _ entryPoint: SupportChatViewModel.EntryPoint
     ) -> Void) -> SupportChatViewModel {
         var context: [String: Any] = [:]

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
@@ -43,7 +43,7 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
 
     private func showSupportChat() {
         var viewModelHolder: SupportChatViewModel?
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
             self?.navigationController?.popViewController(animated: true)
             self?.handleContactHumanSupport(chatID: chatID,
                                             transcript: transcript,
@@ -71,7 +71,11 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
             },
             onTicketCreated: onTicketCreated
         )
-        supportEscalationCoordinator?.handleEscalation(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo, entryPoint: entryPoint)
+        supportEscalationCoordinator?.handleEscalation(chatID: chatID,
+                                                       transcript: transcript,
+                                                       supportAreaInfo: supportAreaInfo,
+                                                       entryPoint: entryPoint,
+                                                       siteAddress: viewModel.siteURL.absoluteString)
     }
 
     private func buildTroubleshootingAttachment() -> [ZendeskAttachment] {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
@@ -43,7 +43,7 @@ final class PreLoginConnectivityToolViewController: UIHostingController<PreLogin
 
     private func showSupportChat() {
         var viewModelHolder: SupportChatViewModel?
-        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
+        let chatViewModel = viewModel.makeSupportChatViewModel { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
             self?.navigationController?.popViewController(animated: true)
             self?.handleContactHumanSupport(chatID: chatID,
                                             transcript: transcript,

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
@@ -188,6 +188,7 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
         _ chatID: Int64?,
         _ transcript: String,
         _ supportAreaInfo: SupportAreaInfo?,
+        _ siteAddress: String?,
         _ entryPoint: SupportChatViewModel.EntryPoint
     ) -> Void) -> SupportChatViewModel {
         var context: [String: Any] = [:]

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolViewModel.swift
@@ -184,13 +184,7 @@ final class PreLoginConnectivityToolViewModel: ObservableObject {
 
     /// Creates a SupportChatViewModel with the current troubleshooting context.
     ///
-    func makeSupportChatViewModel(onContactHumanSupport: @escaping (
-        _ chatID: Int64?,
-        _ transcript: String,
-        _ supportAreaInfo: SupportAreaInfo?,
-        _ siteAddress: String?,
-        _ entryPoint: SupportChatViewModel.EntryPoint
-    ) -> Void) -> SupportChatViewModel {
+    func makeSupportChatViewModel(onContactHumanSupport: @escaping SupportChatViewModel.ContactHumanSupportCallback) -> SupportChatViewModel {
         var context: [String: Any] = [:]
 
         if let troubleshootingDescription = troubleshootingDescription() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -487,15 +487,16 @@ private extension HelpAndSupportViewController {
         let viewModel = SupportChatViewModel(
             entryPoint: entryPoint,
             initialContext: initialContext,
-            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
-                self?.handleContactHumanSupport(chatID: chatID,
-                                                transcript: transcript,
-                                                supportAreaInfo: supportAreaInfo,
-                                                entryPoint: entryPoint,
-                                                siteAddress: siteAddress ?? self?.loginSiteURL?.absoluteString,
-                                                onTicketCreated: { [weak viewModelHolder] in
-                                                    viewModelHolder?.markChatTicketCreated()
-                                                })
+            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
+                guard let self else { return }
+                handleContactHumanSupport(chatID: chatID,
+                                          transcript: transcript,
+                                          supportAreaInfo: supportAreaInfo,
+                                          entryPoint: entryPoint,
+                                          siteAddress: loginSiteURL?.absoluteString,
+                                          onTicketCreated: { [weak viewModelHolder] in
+                    viewModelHolder?.markChatTicketCreated()
+                })
             }
         )
         viewModelHolder = viewModel
@@ -543,15 +544,15 @@ private extension HelpAndSupportViewController {
             sessionID: summary.sessionID,
             hasCreatedTicket: summary.hasCreatedTicket,
             isChatResolved: summary.isResolved,
-            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
-                self?.handleContactHumanSupport(chatID: chatID,
-                                                transcript: transcript,
-                                                supportAreaInfo: supportAreaInfo,
-                                                entryPoint: entryPoint,
-                                                siteAddress: siteAddress,
-                                                onTicketCreated: { [weak viewModelHolder] in
-                                                    viewModelHolder?.markChatTicketCreated()
-                                                })
+            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
+                guard let self else { return }
+                handleContactHumanSupport(chatID: chatID,
+                                          transcript: transcript,
+                                          supportAreaInfo: supportAreaInfo,
+                                          entryPoint: entryPoint,
+                                          onTicketCreated: { [weak viewModelHolder] in
+                    viewModelHolder?.markChatTicketCreated()
+                })
             }
         )
         viewModelHolder = chatViewModel

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -480,14 +480,19 @@ private extension HelpAndSupportViewController {
         let entryPoint: SupportChatViewModel.EntryPoint = ServiceLocator.stores.isAuthenticated
             ? .helpAndSupport
             : .preLogin
+        let initialContext: [String: Any]? = loginSiteURL.map {
+            ["site_url": $0.absoluteString]
+        }
         var viewModelHolder: SupportChatViewModel?
         let viewModel = SupportChatViewModel(
             entryPoint: entryPoint,
-            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
+            initialContext: initialContext,
+            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
                 self?.handleContactHumanSupport(chatID: chatID,
                                                 transcript: transcript,
                                                 supportAreaInfo: supportAreaInfo,
                                                 entryPoint: entryPoint,
+                                                siteAddress: siteAddress ?? self?.loginSiteURL?.absoluteString,
                                                 onTicketCreated: { [weak viewModelHolder] in
                                                     viewModelHolder?.markChatTicketCreated()
                                                 })
@@ -502,10 +507,15 @@ private extension HelpAndSupportViewController {
                                            transcript: String,
                                            supportAreaInfo: SupportAreaInfo?,
                                            entryPoint: SupportChatViewModel.EntryPoint,
+                                           siteAddress: String? = nil,
                                            onTicketCreated: @escaping () -> Void) {
         supportEscalationCoordinator = SupportEscalationCoordinator(navigationController: navigationController,
                                                                     onTicketCreated: onTicketCreated)
-        supportEscalationCoordinator?.handleEscalation(chatID: chatID, transcript: transcript, supportAreaInfo: supportAreaInfo, entryPoint: entryPoint)
+        supportEscalationCoordinator?.handleEscalation(chatID: chatID,
+                                                       transcript: transcript,
+                                                       supportAreaInfo: supportAreaInfo,
+                                                       entryPoint: entryPoint,
+                                                       siteAddress: siteAddress)
     }
 
     /// Chat History action
@@ -533,11 +543,12 @@ private extension HelpAndSupportViewController {
             sessionID: summary.sessionID,
             hasCreatedTicket: summary.hasCreatedTicket,
             isChatResolved: summary.isResolved,
-            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, entryPoint in
+            onContactHumanSupport: { [weak self] chatID, transcript, supportAreaInfo, siteAddress, entryPoint in
                 self?.handleContactHumanSupport(chatID: chatID,
                                                 transcript: transcript,
                                                 supportAreaInfo: supportAreaInfo,
                                                 entryPoint: entryPoint,
+                                                siteAddress: siteAddress,
                                                 onTicketCreated: { [weak viewModelHolder] in
                                                     viewModelHolder?.markChatTicketCreated()
                                                 })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -8,6 +8,9 @@ import protocol WooFoundation.Analytics
 /// direct ticket creation, and success/failure UI feedback.
 ///
 final class SupportEscalationCoordinator {
+    typealias TranscriptConsentPresenter = (_ presentingViewController: UIViewController,
+                                             _ onSendTicket: @escaping () -> Void,
+                                             _ onShowContactForm: @escaping () -> Void) -> Void
 
     /// Tags used for AI chat escalation tickets.
     ///
@@ -22,6 +25,7 @@ final class SupportEscalationCoordinator {
     private let analytics: Analytics
     private let stores: StoresManager
     private let onTicketCreated: (() -> Void)?
+    private let transcriptConsentPresenter: TranscriptConsentPresenter
 
     /// The chat ID to update when a ticket is created. Set via `handleEscalation`.
     private var chatID: Int64?
@@ -42,13 +46,15 @@ final class SupportEscalationCoordinator {
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analytics: Analytics = ServiceLocator.analytics,
          stores: StoresManager = ServiceLocator.stores,
-         onTicketCreated: (() -> Void)? = nil) {
+         onTicketCreated: (() -> Void)? = nil,
+         transcriptConsentPresenter: TranscriptConsentPresenter? = nil) {
         self.navigationController = navigationController
         self.additionalAttachmentsProvider = additionalAttachmentsProvider
         self.zendeskProvider = zendeskProvider
         self.analytics = analytics
         self.stores = stores
         self.onTicketCreated = onTicketCreated
+        self.transcriptConsentPresenter = transcriptConsentPresenter ?? Self.presentTranscriptConsentAlert
     }
 
     /// Handles the escalation from AI chat to human support.
@@ -70,10 +76,10 @@ final class SupportEscalationCoordinator {
             return
         }
 
-        // Only create ticket directly if high confidence AND user identity exists.
-        // Without identity, Zendesk can't send email responses to the user.
-        if supportAreaInfo.isHighConfidence && zendeskProvider.haveUserIdentity {
-            createTicketDirectly(with: supportAreaInfo, entryPoint: entryPoint)
+        // Only offer direct ticket creation if high confidence, user identity exists, and
+        // a site URL is available. Otherwise the form lets users provide missing details.
+        if supportAreaInfo.isHighConfidence && zendeskProvider.haveUserIdentity && hasSiteAddress {
+            confirmTranscriptConsent(for: supportAreaInfo, entryPoint: entryPoint)
         } else {
             showSupportForm(transcript: transcript, supportAreaInfo: supportAreaInfo, entryPoint: entryPoint)
         }
@@ -89,7 +95,7 @@ final class SupportEscalationCoordinator {
 
         if let supportAreaInfo {
             prefilledSubject = SupportFormViewModel.subject(for: supportAreaInfo.areaType)
-            prefilledDescription = [Localization.transcriptHeader, transcript].joined(separator: "\n\n")
+            prefilledDescription = nil
         } else {
             prefilledSubject = nil
             prefilledDescription = nil
@@ -126,6 +132,20 @@ final class SupportEscalationCoordinator {
         if let navigationController {
             viewController.show(from: navigationController)
         }
+    }
+
+    private func confirmTranscriptConsent(for areaInfo: SupportAreaInfo, entryPoint: SupportChatViewModel.EntryPoint) {
+        guard let presentingVC = navigationController?.topViewController else { return }
+
+        transcriptConsentPresenter(
+            presentingVC,
+            { [weak self] in
+                self?.createTicketDirectly(with: areaInfo, entryPoint: entryPoint)
+            },
+            { [weak self] in
+                self?.showSupportForm(transcript: areaInfo.transcript, supportAreaInfo: areaInfo, entryPoint: entryPoint)
+            }
+        )
     }
 
     private func createTicketDirectly(with areaInfo: SupportAreaInfo, entryPoint: SupportChatViewModel.EntryPoint) {
@@ -206,6 +226,13 @@ final class SupportEscalationCoordinator {
         return tags
     }
 
+    private var hasSiteAddress: Bool {
+        guard let siteAddress = stores.sessionManager.defaultSite?.url else {
+            return false
+        }
+        return siteAddress.isNotEmpty
+    }
+
     private static func errorType(for error: Error) -> String {
         switch error {
         case ZendeskError.failedToCreateIdentity:
@@ -213,6 +240,24 @@ final class SupportEscalationCoordinator {
         default:
             return "zendesk_request_failed"
         }
+    }
+
+    private static func presentTranscriptConsentAlert(from presentingViewController: UIViewController,
+                                                      onSendTicket: @escaping () -> Void,
+                                                      onShowContactForm: @escaping () -> Void) {
+        let alert = UIAlertController(
+            title: Localization.transcriptConsentTitle,
+            message: Localization.transcriptConsentMessage,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Localization.sendTicket, style: .default) { _ in
+            onSendTicket()
+        })
+        alert.addAction(UIAlertAction(title: Localization.contactForm, style: .default) { _ in
+            onShowContactForm()
+        })
+        alert.addAction(UIAlertAction(title: Localization.cancel, style: .cancel))
+        presentingViewController.present(alert, animated: true)
     }
 }
 
@@ -239,6 +284,31 @@ private extension SupportEscalationCoordinator {
             "supportEscalationCoordinator.gotIt",
             value: "Got it",
             comment: "Button on the ticket created alert"
+        )
+        static let transcriptConsentTitle = NSLocalizedString(
+            "supportEscalationCoordinator.transcriptConsentTitle",
+            value: "Send this chat to support?",
+            comment: "Title for the alert asking consent to send an AI chat transcript to support"
+        )
+        static let transcriptConsentMessage = NSLocalizedString(
+            "supportEscalationCoordinator.transcriptConsentMessage",
+            value: "We can create a support request using this chat transcript, or you can open the contact form and enter the details yourself.",
+            comment: "Message for the alert asking consent to send an AI chat transcript to support"
+        )
+        static let contactForm = NSLocalizedString(
+            "supportEscalationCoordinator.contactForm",
+            value: "Contact Form",
+            comment: "Button on the transcript consent alert that opens the support contact form"
+        )
+        static let sendTicket = NSLocalizedString(
+            "supportEscalationCoordinator.sendTicket",
+            value: "Send Request",
+            comment: "Button on the transcript consent alert that sends the chat transcript as a support request"
+        )
+        static let cancel = NSLocalizedString(
+            "supportEscalationCoordinator.cancel",
+            value: "Cancel",
+            comment: "Button on the transcript consent alert that dismisses without taking action"
         )
         static let transcriptHeader = NSLocalizedString(
             "supportEscalationCoordinator.transcriptHeader",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -29,6 +29,7 @@ final class SupportEscalationCoordinator {
 
     /// The chat ID to update when a ticket is created. Set via `handleEscalation`.
     private var chatID: Int64?
+    private var escalationSiteAddress: String?
 
     /// Creates a new coordinator.
     ///
@@ -68,8 +69,14 @@ final class SupportEscalationCoordinator {
     ///   - transcript: The chat transcript.
     ///   - supportAreaInfo: Optional support area information from AI chat.
     ///   - entryPoint: The chat entry point for analytics tracking.
-    func handleEscalation(chatID: Int64?, transcript: String, supportAreaInfo: SupportAreaInfo?, entryPoint: SupportChatViewModel.EntryPoint) {
+    ///   - siteAddress: Optional site address to prefill the form or attach to a direct ticket.
+    func handleEscalation(chatID: Int64?,
+                          transcript: String,
+                          supportAreaInfo: SupportAreaInfo?,
+                          entryPoint: SupportChatViewModel.EntryPoint,
+                          siteAddress: String? = nil) {
         self.chatID = chatID
+        self.escalationSiteAddress = siteAddress
 
         guard let supportAreaInfo else {
             showSupportForm(transcript: transcript, supportAreaInfo: nil, entryPoint: entryPoint)
@@ -108,6 +115,7 @@ final class SupportEscalationCoordinator {
             attachments: attachments,
             preselectedArea: supportAreaInfo?.area,
             prefilledSubject: prefilledSubject,
+            prefilledSiteAddress: self.siteAddress,
             prefilledDescription: prefilledDescription,
             onTicketCreated: { [weak self] in
                 self?.analytics.track(event: WooAnalyticsEvent.SupportChat.ticketCreated(
@@ -159,7 +167,7 @@ final class SupportEscalationCoordinator {
         let description = [Localization.transcriptHeader, areaInfo.transcript].joined(separator: "\n\n")
         let attachments = additionalAttachmentsProvider()
 
-        let siteAddress = stores.sessionManager.defaultSite?.url ?? ""
+        let siteAddress = self.siteAddress ?? ""
         let tags = areaInfo.area.datasource.tags + additionalTags(for: areaInfo) + [Tags.sourceTag]
         let request = ZendeskSupportRequest(
             formID: areaInfo.area.datasource.formID,
@@ -227,10 +235,17 @@ final class SupportEscalationCoordinator {
     }
 
     private var hasSiteAddress: Bool {
-        guard let siteAddress = stores.sessionManager.defaultSite?.url else {
-            return false
+        self.siteAddress?.isNotEmpty == true
+    }
+
+    private var siteAddress: String? {
+        if let siteAddress = escalationSiteAddress, siteAddress.isNotEmpty {
+            return siteAddress
         }
-        return siteAddress.isNotEmpty
+        if let siteAddress = stores.sessionManager.defaultSite?.url, siteAddress.isNotEmpty {
+            return siteAddress
+        }
+        return nil
     }
 
     private static func errorType(for error: Error) -> String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportEscalationCoordinator.swift
@@ -115,7 +115,7 @@ final class SupportEscalationCoordinator {
             attachments: attachments,
             preselectedArea: supportAreaInfo?.area,
             prefilledSubject: prefilledSubject,
-            prefilledSiteAddress: self.siteAddress,
+            prefilledSiteAddress: siteAddress,
             prefilledDescription: prefilledDescription,
             onTicketCreated: { [weak self] in
                 self?.analytics.track(event: WooAnalyticsEvent.SupportChat.ticketCreated(
@@ -167,7 +167,7 @@ final class SupportEscalationCoordinator {
         let description = [Localization.transcriptHeader, areaInfo.transcript].joined(separator: "\n\n")
         let attachments = additionalAttachmentsProvider()
 
-        let siteAddress = self.siteAddress ?? ""
+        let siteAddress = siteAddress ?? ""
         let tags = areaInfo.area.datasource.tags + additionalTags(for: areaInfo) + [Tags.sourceTag]
         let request = ZendeskSupportRequest(
             formID: areaInfo.area.datasource.formID,
@@ -235,7 +235,7 @@ final class SupportEscalationCoordinator {
     }
 
     private var hasSiteAddress: Bool {
-        self.siteAddress?.isNotEmpty == true
+        siteAddress?.isNotEmpty == true
     }
 
     private var siteAddress: String? {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -115,6 +115,7 @@ public final class SupportFormViewModel: ObservableObject {
          attachments: [ZendeskAttachment] = [],
          preselectedArea: Area? = nil,
          prefilledSubject: String? = nil,
+         prefilledSiteAddress: String? = nil,
          prefilledDescription: String? = nil,
          onTicketCreated: (() -> Void)? = nil,
          onTicketCreationFailed: ((Error) -> Void)? = nil) {
@@ -133,6 +134,9 @@ public final class SupportFormViewModel: ObservableObject {
         if let prefilledSubject {
             self.subject = prefilledSubject
         }
+        if let prefilledSiteAddress {
+            self.siteAddress = prefilledSiteAddress
+        }
         if let prefilledDescription {
             self.description = prefilledDescription
         }
@@ -145,7 +149,9 @@ public final class SupportFormViewModel: ObservableObject {
         requestZendeskIdentityIfNeeded()
 
         // Populates the site address field if there is any.
-        self.siteAddress = defaultSite?.url ?? ""
+        if siteAddress.isEmpty {
+            self.siteAddress = defaultSite?.url ?? ""
+        }
     }
 
     /// Selects an area.

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -509,7 +509,7 @@ private extension SupportChatView {
         SupportChatView(
             viewModel: SupportChatViewModel(
                 entryPoint: .helpAndSupport,
-                onContactHumanSupport: { _, _, _, _, _ in }
+                onContactHumanSupport: { _, _, _, _ in }
             )
         )
     }
@@ -520,7 +520,7 @@ private extension SupportChatView {
         SupportChatView(
             viewModel: SupportChatViewModel(
                 entryPoint: .connectivityTool,
-                onContactHumanSupport: { _, _, _, _, _ in }
+                onContactHumanSupport: { _, _, _, _ in }
             )
         )
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -509,7 +509,7 @@ private extension SupportChatView {
         SupportChatView(
             viewModel: SupportChatViewModel(
                 entryPoint: .helpAndSupport,
-                onContactHumanSupport: { _, _, _, _ in }
+                onContactHumanSupport: { _, _, _, _, _ in }
             )
         )
     }
@@ -520,7 +520,7 @@ private extension SupportChatView {
         SupportChatView(
             viewModel: SupportChatViewModel(
                 entryPoint: .connectivityTool,
-                onContactHumanSupport: { _, _, _, _ in }
+                onContactHumanSupport: { _, _, _, _, _ in }
             )
         )
     }

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -189,11 +189,6 @@ final class SupportChatViewModel {
     /// When true, the escalation button should be hidden.
     private(set) var hasCreatedTicket: Bool = false
 
-    /// `true` once the merchant has typed and sent at least one message via the input field.
-    /// Distinct from `messages.contains(where: { $0.role == .user })`, which is also flipped
-    /// by issue-picker selections — we want the human-support entry to surface only after the
-    /// merchant has actually described their problem.
-    private(set) var hasSentChatMessage: Bool = false
     private(set) var isChatResolved: Bool = false
 
     /// Flips `hasCreatedTicket` so the chat surface (toolbar icon, inline banner) updates in real time
@@ -216,12 +211,13 @@ final class SupportChatViewModel {
 
     /// Whether the trailing toolbar entry point to human support should be visible.
     /// Shown once the merchant has reached the free-chat phase (past the issue picker / diagnostics)
-    /// AND has typed and sent at least one message, and only while no ticket has been created yet.
+    /// AND the conversation has at least one persisted bot response, and only while no ticket
+    /// has been created yet.
     var canEscalateToHumanSupport: Bool {
         guard shouldShowInputArea, !hasCreatedTicket, !isChatResolved else {
             return false
         }
-        return hasSentChatMessage
+        return hasRemoteBotResponse
     }
 
     var shouldShowResolvedButton: Bool {
@@ -704,7 +700,6 @@ final class SupportChatViewModel {
             sessionID: sessionID,
             context: context
         ) { [weak self] result in
-            self?.hasSentChatMessage = true
             self?.handleSendMessageResult(result,
                                           wasNewChat: wasNewChat,
                                           firstUserMessage: firstUserMessage)
@@ -983,6 +978,10 @@ final class SupportChatViewModel {
 
     private var latestBotResponse: ChatMessage? {
         messages.last { $0.role == .bot && $0.messageID != nil }
+    }
+
+    private var hasRemoteBotResponse: Bool {
+        messages.contains { $0.role == .bot && $0.messageID != nil }
     }
 
     private func trackTroubleshootingCompleted(issueType: SupportIssueType,

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -257,7 +257,13 @@ final class SupportChatViewModel {
     private let analytics: Analytics
     private var diagnosticsContext: [String: Any]?
     private let initialContext: [String: Any]?
-    private let onContactHumanSupport: (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?, _ entryPoint: EntryPoint) -> Void
+    private let onContactHumanSupport: (
+        _ chatID: Int64?,
+        _ transcript: String,
+        _ supportAreaInfo: SupportAreaInfo?,
+        _ siteAddress: String?,
+        _ entryPoint: EntryPoint
+    ) -> Void
     private var latestSupportArea: SupportChatSupportArea?
     private var userMessageCount = 0
     private var didTrackResolutionButtonShown = false
@@ -286,7 +292,13 @@ final class SupportChatViewModel {
          hasCreatedTicket: Bool = false,
          isChatResolved: Bool = false,
          systemStatusReport: String? = nil,
-         onContactHumanSupport: @escaping (_ chatID: Int64?, _ transcript: String, _ supportAreaInfo: SupportAreaInfo?, _ entryPoint: EntryPoint) -> Void,
+         onContactHumanSupport: @escaping (
+            _ chatID: Int64?,
+            _ transcript: String,
+            _ supportAreaInfo: SupportAreaInfo?,
+            _ siteAddress: String?,
+            _ entryPoint: EntryPoint
+         ) -> Void,
          onStartJetpackSetup: @escaping () -> Void = {},
          onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() },
          onOpenPushNotificationPreferences: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }) {
@@ -718,6 +730,7 @@ final class SupportChatViewModel {
 
         let transcript = generateTranscript()
         let supportAreaInfo: SupportAreaInfo?
+        let siteAddress = siteAddressForEscalation
         let systemStatusReport = prefetchedSystemStatusReport ?? diagnosticsService.formattedSystemStatusReport
 
         if let supportArea = latestSupportArea {
@@ -734,7 +747,7 @@ final class SupportChatViewModel {
             supportAreaInfo = nil
         }
 
-        onContactHumanSupport(chatID, transcript, supportAreaInfo, entryPoint)
+        onContactHumanSupport(chatID, transcript, supportAreaInfo, siteAddress, entryPoint)
     }
 
     private func generateTranscript() -> String {
@@ -770,6 +783,18 @@ final class SupportChatViewModel {
 
             return "[\(timestamp)] \(roleName): \(contentText)"
         }.joined(separator: "\n\n")
+    }
+
+    private var siteAddressForEscalation: String? {
+        if let siteAddress = stores.sessionManager.defaultSite?.url, siteAddress.isNotEmpty {
+            return siteAddress
+        }
+
+        let siteAddress = (diagnosticsContext?["site_url"] as? String) ?? (initialContext?["site_url"] as? String)
+        guard let siteAddress, siteAddress.isNotEmpty else {
+            return nil
+        }
+        return siteAddress
     }
 
     func dismissError() {

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatViewModel.swift
@@ -247,6 +247,13 @@ final class SupportChatViewModel {
 
     var inputText: String = ""
 
+    typealias ContactHumanSupportCallback = (
+        _ chatID: Int64?,
+        _ transcript: String,
+        _ supportAreaInfo: SupportAreaInfo?,
+        _ entryPoint: EntryPoint
+    ) -> Void
+
     // MARK: - Private Properties
 
     private var chatID: Int64?
@@ -257,13 +264,7 @@ final class SupportChatViewModel {
     private let analytics: Analytics
     private var diagnosticsContext: [String: Any]?
     private let initialContext: [String: Any]?
-    private let onContactHumanSupport: (
-        _ chatID: Int64?,
-        _ transcript: String,
-        _ supportAreaInfo: SupportAreaInfo?,
-        _ siteAddress: String?,
-        _ entryPoint: EntryPoint
-    ) -> Void
+    private let onContactHumanSupport: ContactHumanSupportCallback
     private var latestSupportArea: SupportChatSupportArea?
     private var userMessageCount = 0
     private var didTrackResolutionButtonShown = false
@@ -292,13 +293,7 @@ final class SupportChatViewModel {
          hasCreatedTicket: Bool = false,
          isChatResolved: Bool = false,
          systemStatusReport: String? = nil,
-         onContactHumanSupport: @escaping (
-            _ chatID: Int64?,
-            _ transcript: String,
-            _ supportAreaInfo: SupportAreaInfo?,
-            _ siteAddress: String?,
-            _ entryPoint: EntryPoint
-         ) -> Void,
+         onContactHumanSupport: @escaping ContactHumanSupportCallback,
          onStartJetpackSetup: @escaping () -> Void = {},
          onUpdateWooCommercePlugin: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() },
          onOpenPushNotificationPreferences: @escaping (@escaping () -> Void) -> Void = { onDismissed in onDismissed() }) {
@@ -730,7 +725,6 @@ final class SupportChatViewModel {
 
         let transcript = generateTranscript()
         let supportAreaInfo: SupportAreaInfo?
-        let siteAddress = siteAddressForEscalation
         let systemStatusReport = prefetchedSystemStatusReport ?? diagnosticsService.formattedSystemStatusReport
 
         if let supportArea = latestSupportArea {
@@ -747,7 +741,7 @@ final class SupportChatViewModel {
             supportAreaInfo = nil
         }
 
-        onContactHumanSupport(chatID, transcript, supportAreaInfo, siteAddress, entryPoint)
+        onContactHumanSupport(chatID, transcript, supportAreaInfo, entryPoint)
     }
 
     private func generateTranscript() -> String {
@@ -783,18 +777,6 @@ final class SupportChatViewModel {
 
             return "[\(timestamp)] \(roleName): \(contentText)"
         }.joined(separator: "\n\n")
-    }
-
-    private var siteAddressForEscalation: String? {
-        if let siteAddress = stores.sessionManager.defaultSite?.url, siteAddress.isNotEmpty {
-            return siteAddress
-        }
-
-        let siteAddress = (diagnosticsContext?["site_url"] as? String) ?? (initialContext?["site_url"] as? String)
-        guard let siteAddress, siteAddress.isNotEmpty else {
-            return nil
-        }
-        return siteAddress
     }
 
     func dismissError() {

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportDiagnosticsService.swift
@@ -378,36 +378,12 @@ final class SupportDiagnosticsService {
 
         // Sub-check 2: if not eligible for Woo-driven PN
         if !isEligibleForWooDrivenPushNotifications {
-            // Subcheck 2.1: does device have Jetpack?
+            // Subcheck 1: does device have Jetpack?
             if !isJetpackPluginActive {
                 DDLogError("SupportDiagnostics: ❌ Jetpack not active")
                 return Failure(errorMessage: Localization.Error.jetpackNotActive, suggestedAction: .setupJetpack)
-            } else if pushNotesManager.deviceID == nil { // Subcheck 2.2: registered with WPCom?
-                DDLogError("SupportDiagnostics: ❌ device is not registered")
-                return Failure(errorMessage: Localization.Error.deviceNotRegistered,
-                               suggestedAction: .registerDevice)
-            } else {
-                // Sub-check 2.3: WPCom notification config
-                let configResult = await checkNotificationConfig()
-                switch configResult {
-                case .success:
-                    DDLogInfo("SupportDiagnostics: ✅ Notification settings configured")
-                    return nil
-                case .failure(let configError):
-                    DDLogInfo("SupportDiagnostics: ⚠️ Notification config issue: \(configError)")
-                    switch configError {
-                    case .deviceNotRegistered:
-                        return Failure(errorMessage: Localization.Error.deviceNotRegistered,
-                                       suggestedAction: .registerDevice)
-                    case .orderNotificationsDisabled(let settings):
-                        return Failure(errorMessage: Localization.Error.orderNotificationsDisabled,
-                                       suggestedAction: .enableOrderNotifications(settings: settings))
-                    case .requestFailed(let error):
-                        return Failure(errorMessage: Localization.Error.notificationConfigCheckFailed,
-                                       technicalDetails: error.formattedTechnicalDetails)
-                    }
-                }
             }
+            return await checkWPComPushNotifications()
         }
 
         // Sub-check 3: Self-driven push notifications
@@ -417,7 +393,11 @@ final class SupportDiagnosticsService {
                 return failure
             }
             return nil
+        } else if isJetpackPluginActive, !stores.isAuthenticatedWithoutWPCom {
+            // User has Jetpack and authenticated with WPCom
+            return await checkWPComPushNotifications()
         } else {
+            // Check requirements for Woo PNs
             do {
                 let minimumVersion = WooPluginRequirements.minimumVersion
                 let pluginVersionChecker = pluginVersionCheckerFactory.makeChecker(
@@ -441,6 +421,36 @@ final class SupportDiagnosticsService {
                 DDLogError("SupportDiagnostics: ❌ device is not registered")
                 return Failure(errorMessage: Localization.Error.deviceNotRegistered,
                                suggestedAction: .registerDevice)
+            }
+        }
+    }
+
+    private func checkWPComPushNotifications() async -> Failure? {
+        // Registered with WPCom?
+        if pushNotesManager.deviceID == nil {
+            DDLogError("SupportDiagnostics: ❌ device is not registered")
+            return Failure(errorMessage: Localization.Error.deviceNotRegistered,
+                           suggestedAction: .registerDevice)
+        } else {
+            // WPCom notification config
+            let configResult = await checkNotificationConfig()
+            switch configResult {
+            case .success:
+                DDLogInfo("SupportDiagnostics: ✅ Notification settings configured")
+                return nil
+            case .failure(let configError):
+                DDLogInfo("SupportDiagnostics: ⚠️ Notification config issue: \(configError)")
+                switch configError {
+                case .deviceNotRegistered:
+                    return Failure(errorMessage: Localization.Error.deviceNotRegistered,
+                                   suggestedAction: .registerDevice)
+                case .orderNotificationsDisabled(let settings):
+                    return Failure(errorMessage: Localization.Error.orderNotificationsDisabled,
+                                   suggestedAction: .enableOrderNotifications(settings: settings))
+                case .requestFailed(let error):
+                    return Failure(errorMessage: Localization.Error.notificationConfigCheckFailed,
+                                   technicalDetails: error.formattedTechnicalDetails)
+                }
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import UIKit
+import Fakes
 import Yosemite
 @testable import WooCommerce
 
@@ -24,7 +25,7 @@ struct SupportEscalationCoordinatorTests {
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
     }
 
-    @Test func handleEscalation_when_high_confidence_and_has_identity_then_creates_ticket_directly() {
+    @Test func handleEscalation_when_high_confidence_and_has_identity_then_creates_ticket_directly_after_transcript_consent() {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -43,6 +44,87 @@ struct SupportEscalationCoordinatorTests {
         #expect(zendesk.latestInvokedTags.contains("woo_mobile_issue_orders"))
     }
 
+    @Test func handleEscalation_when_high_confidence_and_has_identity_then_asks_for_transcript_consent_before_creating_ticket() {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        var didAskForConsent = false
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            zendesk: zendesk,
+            transcriptConsentPresenter: { _, _, _ in
+                didAskForConsent = true
+            }
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .helpAndSupport)
+
+        // Then
+        #expect(didAskForConsent)
+        #expect(zendesk.latestInvokedTags.isEmpty)
+    }
+
+    @Test func handleEscalation_when_transcript_consent_contact_form_selected_then_shows_form_without_prefilled_transcript() {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            zendesk: zendesk,
+            transcriptConsentPresenter: { _, _, showContactForm in
+                showContactForm()
+            }
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .helpAndSupport)
+
+        // Then
+        #expect(zendesk.latestInvokedTags.isEmpty)
+        let viewModel = supportFormViewModel(from: navigationController)
+        #expect(viewModel?.description == "")
+        #expect(viewModel?.subject == SupportFormViewModel.subject(for: .mobileApp))
+    }
+
+    @Test func handleEscalation_when_transcript_consent_cancelled_then_takes_no_action() {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            zendesk: zendesk,
+            transcriptConsentPresenter: { _, _, _ in
+                // Simulate tapping the alert's Cancel action.
+            }
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .helpAndSupport)
+
+        // Then
+        #expect(zendesk.latestInvokedTags.isEmpty)
+        #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController } == false)
+    }
+
     @Test func handleEscalation_when_high_confidence_but_no_identity_then_shows_support_form() {
         // Given
         let zendesk = MockZendeskManager()
@@ -54,6 +136,34 @@ struct SupportEscalationCoordinatorTests {
 
         // When
         coordinator.handleEscalation(chatID: nil, transcript: "Test transcript", supportAreaInfo: areaInfo, entryPoint: .helpAndSupport)
+
+        // Then
+        #expect(zendesk.latestInvokedTags.isEmpty)
+        #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+    }
+
+    @Test func handleEscalation_when_high_confidence_but_no_site_address_then_shows_support_form() {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            zendesk: zendesk,
+            stores: stores,
+            transcriptConsentPresenter: { _, _, _ in
+                Issue.record("Expected missing site address to route directly to the contact form")
+            }
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .preLogin)
 
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
@@ -103,7 +213,7 @@ struct SupportEscalationCoordinatorTests {
         zendesk.whenCreateSupportRequest(thenReturn: .success(()))
 
         var dispatchedChatID: Int64?
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: Self.makeSite()))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
             if case let .markTicketCreated(chatID, onCompletion) = action {
                 dispatchedChatID = chatID
@@ -115,7 +225,8 @@ struct SupportEscalationCoordinatorTests {
         let coordinator = SupportEscalationCoordinator(
             navigationController: navigationController,
             zendeskProvider: zendesk,
-            stores: stores
+            stores: stores,
+            transcriptConsentPresenter: Self.sendTicketConsentPresenter
         )
         let areaInfo = makeHighConfidenceSupportAreaInfo()
 
@@ -133,7 +244,7 @@ struct SupportEscalationCoordinatorTests {
         zendesk.whenCreateSupportRequest(thenReturn: .success(()))
 
         var markTicketCreatedCalled = false
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: Self.makeSite()))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
             if case .markTicketCreated = action {
                 markTicketCreatedCalled = true
@@ -144,7 +255,8 @@ struct SupportEscalationCoordinatorTests {
         let coordinator = SupportEscalationCoordinator(
             navigationController: navigationController,
             zendeskProvider: zendesk,
-            stores: stores
+            stores: stores,
+            transcriptConsentPresenter: Self.sendTicketConsentPresenter
         )
         let areaInfo = makeHighConfidenceSupportAreaInfo()
 
@@ -162,7 +274,7 @@ struct SupportEscalationCoordinatorTests {
         zendesk.whenCreateSupportRequest(thenReturn: .failure(NSError(domain: "Test", code: 500)))
 
         var markTicketCreatedCalled = false
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: Self.makeSite()))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
             if case .markTicketCreated = action {
                 markTicketCreatedCalled = true
@@ -173,7 +285,8 @@ struct SupportEscalationCoordinatorTests {
         let coordinator = SupportEscalationCoordinator(
             navigationController: navigationController,
             zendeskProvider: zendesk,
-            stores: stores
+            stores: stores,
+            transcriptConsentPresenter: Self.sendTicketConsentPresenter
         )
         let areaInfo = makeHighConfidenceSupportAreaInfo()
 
@@ -338,12 +451,29 @@ struct SupportEscalationCoordinatorTests {
 private extension SupportEscalationCoordinatorTests {
     func makeCoordinator(navigationController: UINavigationController? = nil,
                          zendesk: MockZendeskManager,
-                         analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider()) -> SupportEscalationCoordinator {
+                         analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider(),
+                         stores: StoresManager = MockStoresManager(
+                            sessionManager: .makeForTesting(authenticated: true, defaultSite: SupportEscalationCoordinatorTests.makeSite())
+                         ),
+                         transcriptConsentPresenter: SupportEscalationCoordinator.TranscriptConsentPresenter? =
+                            SupportEscalationCoordinatorTests.sendTicketConsentPresenter) -> SupportEscalationCoordinator {
         SupportEscalationCoordinator(
             navigationController: navigationController,
             zendeskProvider: zendesk,
-            analytics: WooAnalytics(analyticsProvider: analyticsProvider)
+            analytics: WooAnalytics(analyticsProvider: analyticsProvider),
+            stores: stores,
+            transcriptConsentPresenter: transcriptConsentPresenter
         )
+    }
+
+    static func sendTicketConsentPresenter(presentingViewController: UIViewController,
+                                           onSendTicket: @escaping () -> Void,
+                                           onShowContactForm: @escaping () -> Void) {
+        onSendTicket()
+    }
+
+    static func makeSite(url: String = "https://example.com") -> Site {
+        Site.fake().copy(url: url)
     }
 
     func supportFormViewModel(from navigationController: UINavigationController) -> SupportFormViewModel? {

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -91,7 +91,7 @@ struct SupportEscalationCoordinatorTests {
         #expect(zendesk.latestInvokedTags.isEmpty)
     }
 
-    @Test func handleEscalation_when_transcript_consent_contact_form_selected_then_shows_form_without_prefilled_transcript() {
+    @Test func handleEscalation_when_transcript_consent_contact_form_selected_then_shows_form_without_prefilled_transcript() throws {
         // Given
         let zendesk = MockZendeskManager()
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
@@ -114,9 +114,9 @@ struct SupportEscalationCoordinatorTests {
 
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
-        let viewModel = supportFormViewModel(from: navigationController)
-        #expect(viewModel?.description == "")
-        #expect(viewModel?.subject == SupportFormViewModel.subject(for: .mobileApp))
+        let viewModel = try #require(supportFormViewModel(from: navigationController))
+        #expect(viewModel.description.isEmpty)
+        #expect(viewModel.subject == SupportFormViewModel.subject(for: .mobileApp))
     }
 
     @Test func handleEscalation_when_transcript_consent_cancelled_then_takes_no_action() {
@@ -499,7 +499,7 @@ private extension SupportEscalationCoordinatorTests {
                          zendesk: MockZendeskManager,
                          analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider(),
                          stores: StoresManager = MockStoresManager(
-                            sessionManager: .makeForTesting(authenticated: true, defaultSite: SupportEscalationCoordinatorTests.makeSite())
+                            sessionManager: .makeForTesting(authenticated: true, defaultSite: Site.fake().copy(url: "https://example.com"))
                          ),
                          transcriptConsentPresenter: SupportEscalationCoordinator.TranscriptConsentPresenter? =
                             SupportEscalationCoordinatorTests.sendTicketConsentPresenter) -> SupportEscalationCoordinator {

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportEscalationCoordinatorTests.swift
@@ -25,6 +25,26 @@ struct SupportEscalationCoordinatorTests {
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
     }
 
+    @Test func handleEscalation_when_supportAreaInfo_is_nil_and_siteAddress_is_available_then_prefills_siteAddress() {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(navigationController: navigationController, zendesk: zendesk)
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: nil,
+                                     entryPoint: .preLogin,
+                                     siteAddress: "https://prelogin.example.com")
+
+        // Then
+        let viewModel = supportFormViewModel(from: navigationController)
+        #expect(viewModel?.siteAddress == "https://prelogin.example.com")
+    }
+
     @Test func handleEscalation_when_high_confidence_and_has_identity_then_creates_ticket_directly_after_transcript_consent() {
         // Given
         let zendesk = MockZendeskManager()
@@ -168,6 +188,32 @@ struct SupportEscalationCoordinatorTests {
         // Then
         #expect(zendesk.latestInvokedTags.isEmpty)
         #expect(navigationController.viewControllers.contains { $0 is SupportFormHostingController })
+    }
+
+    @Test func handleEscalation_when_preLogin_has_site_address_then_can_create_ticket_directly_after_transcript_consent() {
+        // Given
+        let zendesk = MockZendeskManager()
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
+        let navigationController = UINavigationController(rootViewController: UIViewController())
+        let coordinator = makeCoordinator(
+            navigationController: navigationController,
+            zendesk: zendesk,
+            stores: stores
+        )
+
+        // When
+        coordinator.handleEscalation(chatID: nil,
+                                     transcript: "Test transcript",
+                                     supportAreaInfo: makeHighConfidenceSupportAreaInfo(),
+                                     entryPoint: .preLogin,
+                                     siteAddress: "https://prelogin.example.com")
+
+        // Then
+        #expect(zendesk.latestInvokedTags.contains("in_app_support_escalate"))
+        #expect(zendesk.latestInvokedCustomFields.values.contains("https://prelogin.example.com"))
     }
 
     @Test func handleEscalation_when_medium_confidence_then_shows_support_form() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -1037,7 +1037,7 @@ struct SupportChatViewModelTests {
         #expect(sut.canEscalateToHumanSupport == true)
     }
 
-    @Test func canEscalateToHumanSupport_becomes_true_when_sending_message_fails() async {
+    @Test func canEscalateToHumanSupport_remains_false_when_sending_message_fails() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -1052,7 +1052,7 @@ struct SupportChatViewModelTests {
         sut.sendMessage()
 
         // Then
-        #expect(sut.canEscalateToHumanSupport == true)
+        #expect(sut.canEscalateToHumanSupport == false)
     }
 
     @Test func canEscalateToHumanSupport_is_false_for_helpAndSupport_entry_until_proceedToChat() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -661,7 +661,7 @@ struct SupportChatViewModelTests {
                 entryPoint: .chatHistory,
                 stores: stores,
                 chatID: chatID,
-                onContactHumanSupport: { _, _, _, _ in }
+                onContactHumanSupport: { _, _, _, _, _ in }
             )
 
             // When
@@ -678,7 +678,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
 
         await confirmation { fetchCompleted in
@@ -734,7 +734,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
 
         await confirmation { fetchCompleted in
@@ -777,7 +777,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
 
         await confirmation { fetchCompleted in
@@ -850,7 +850,7 @@ struct SupportChatViewModelTests {
         let sut = SupportChatViewModel(
             entryPoint: .preLogin,
             stores: stores,
-            onContactHumanSupport: { chatID, _, _, _ in
+            onContactHumanSupport: { chatID, _, _, _, _ in
                 receivedChatID = chatID
             }
         )
@@ -908,7 +908,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             systemStatusReport: prefetchedReport,
-            onContactHumanSupport: { _, _, supportAreaInfo, _ in
+            onContactHumanSupport: { _, _, supportAreaInfo, _, _ in
                 receivedSupportAreaInfo = supportAreaInfo
             }
         )
@@ -922,6 +922,58 @@ struct SupportChatViewModelTests {
         // Then
         #expect(receivedSupportAreaInfo?.topic == "woo_mobile_issue_orders")
         #expect(receivedSupportAreaInfo?.systemStatusReport == prefetchedReport)
+    }
+
+    @Test func contactHumanSupport_when_initialContext_has_siteURL_then_passes_siteAddress_separately() async {
+        // Given
+        var receivedSiteAddress: String?
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
+
+        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+            switch action {
+            case let .sendMessage(_, _, _, _, _, completion):
+                let response = SupportChatResponse(
+                    chatID: 123,
+                    sessionID: "session-1",
+                    botSlug: "test-bot",
+                    botVersion: "1.0",
+                    messages: [
+                        SupportChatMessage(messageID: 1, role: .user, content: "Hello", context: nil),
+                        SupportChatMessage(
+                            messageID: 2,
+                            role: .bot,
+                            content: "Please contact support.",
+                            context: SupportChatMessageContext(
+                                sources: [],
+                                flags: nil,
+                                supportArea: SupportChatSupportArea(area: .mobileApp, topic: "woo_mobile_issue_orders", confidence: .high)
+                            )
+                        )
+                    ]
+                )
+                completion(.success(response))
+            default:
+                break
+            }
+        }
+
+        let sut = SupportChatViewModel(
+            entryPoint: .preLogin,
+            stores: stores,
+            initialContext: ["site_url": "https://prelogin.example.com"],
+            onContactHumanSupport: { _, _, _, siteAddress, _ in
+                receivedSiteAddress = siteAddress
+            }
+        )
+
+        sut.inputText = "Hello"
+        sut.sendMessage()
+
+        // When
+        sut.contactHumanSupport()
+
+        // Then
+        #expect(receivedSiteAddress == "https://prelogin.example.com")
     }
 
     @Test func contactHumanSupport_tracks_escalationTapped_with_source() {
@@ -1112,7 +1164,7 @@ struct SupportChatViewModelTests {
             entryPoint: .preLogin,
             stores: stores,
             hasCreatedTicket: true,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
 
         // When — append a user message so the only failing condition is hasCreatedTicket
@@ -1567,7 +1619,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Help"
         sut.sendMessage()
@@ -1615,7 +1667,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1658,7 +1710,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1700,7 +1752,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1743,7 +1795,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1838,7 +1890,7 @@ struct SupportChatViewModelTests {
         let sut = SupportChatViewModel(
             entryPoint: .connectivityTool,
             stores: stores,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Hello"
 
@@ -1873,7 +1925,7 @@ struct SupportChatViewModelTests {
         let sut = SupportChatViewModel(
             entryPoint: .connectivityTool,
             stores: stores,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         sut.inputText = "Hello"
 
@@ -1894,7 +1946,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
 
         await confirmation { fetchCompleted in
@@ -1937,7 +1989,7 @@ struct SupportChatViewModelTests {
             stores: stores,
             chatID: chatID,
             sessionID: sessionID,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         var receivedSessionID: String?
 
@@ -1975,7 +2027,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _ in }
+            onContactHumanSupport: { _, _, _, _, _ in }
         )
         var receivedChatID: Int64?
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -2011,7 +2063,7 @@ struct SupportChatViewModelTests {
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
             diagnosticsService: diagnosticsService,
-            onContactHumanSupport: { _, _, _, _ in },
+            onContactHumanSupport: { _, _, _, _, _ in },
             onUpdateWooCommercePlugin: onUpdateWooCommercePlugin,
             onOpenPushNotificationPreferences: onOpenPushNotificationPreferences
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -765,6 +765,48 @@ struct SupportChatViewModelTests {
         // Then
         #expect(sut.shouldPromptHumanSupport == false)
         #expect(sut.messages.count == 2)
+        #expect(sut.canEscalateToHumanSupport == true)
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func resumeIfNeeded_when_chat_has_no_persisted_bot_response_then_canEscalateToHumanSupport_is_false() async {
+        // Given
+        let chatID: Int64 = 123
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let sut = SupportChatViewModel(
+            entryPoint: .chatHistory,
+            stores: stores,
+            chatID: chatID,
+            onContactHumanSupport: { _, _, _, _ in }
+        )
+
+        await confirmation { fetchCompleted in
+            stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
+                switch action {
+                case let .fetchChat(_, _, _, completion):
+                    let response = SupportChatResponse(
+                        chatID: chatID,
+                        sessionID: "session-1",
+                        botSlug: "test-bot",
+                        botVersion: "1.0",
+                        messages: [
+                            SupportChatMessage(messageID: 1, role: .user, content: "Help", context: nil)
+                        ]
+                    )
+                    completion(.success(response))
+                    fetchCompleted()
+                default:
+                    break
+                }
+            }
+
+            // When
+            sut.resumeIfNeeded()
+        }
+
+        // Then
+        #expect(sut.messages.count == 1)
+        #expect(sut.canEscalateToHumanSupport == false)
     }
 
     @Test func contactHumanSupport_passes_chatID_in_callback() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportChatViewModelTests.swift
@@ -6,6 +6,7 @@ import enum Networking.NetworkError
 
 @MainActor
 struct SupportChatViewModelTests {
+    private static let noopContactHumanSupport: SupportChatViewModel.ContactHumanSupportCallback = { _, _, _, _ in }
 
     // MARK: - Greeting Tests
 
@@ -661,7 +662,7 @@ struct SupportChatViewModelTests {
                 entryPoint: .chatHistory,
                 stores: stores,
                 chatID: chatID,
-                onContactHumanSupport: { _, _, _, _, _ in }
+                onContactHumanSupport: Self.noopContactHumanSupport
             )
 
             // When
@@ -678,7 +679,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
 
         await confirmation { fetchCompleted in
@@ -734,7 +735,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
 
         await confirmation { fetchCompleted in
@@ -777,7 +778,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
 
         await confirmation { fetchCompleted in
@@ -850,7 +851,7 @@ struct SupportChatViewModelTests {
         let sut = SupportChatViewModel(
             entryPoint: .preLogin,
             stores: stores,
-            onContactHumanSupport: { chatID, _, _, _, _ in
+            onContactHumanSupport: { chatID, _, _, _ in
                 receivedChatID = chatID
             }
         )
@@ -908,7 +909,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             systemStatusReport: prefetchedReport,
-            onContactHumanSupport: { _, _, supportAreaInfo, _, _ in
+            onContactHumanSupport: { _, _, supportAreaInfo, _ in
                 receivedSupportAreaInfo = supportAreaInfo
             }
         )
@@ -922,58 +923,6 @@ struct SupportChatViewModelTests {
         // Then
         #expect(receivedSupportAreaInfo?.topic == "woo_mobile_issue_orders")
         #expect(receivedSupportAreaInfo?.systemStatusReport == prefetchedReport)
-    }
-
-    @Test func contactHumanSupport_when_initialContext_has_siteURL_then_passes_siteAddress_separately() async {
-        // Given
-        var receivedSiteAddress: String?
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
-
-        stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
-            switch action {
-            case let .sendMessage(_, _, _, _, _, completion):
-                let response = SupportChatResponse(
-                    chatID: 123,
-                    sessionID: "session-1",
-                    botSlug: "test-bot",
-                    botVersion: "1.0",
-                    messages: [
-                        SupportChatMessage(messageID: 1, role: .user, content: "Hello", context: nil),
-                        SupportChatMessage(
-                            messageID: 2,
-                            role: .bot,
-                            content: "Please contact support.",
-                            context: SupportChatMessageContext(
-                                sources: [],
-                                flags: nil,
-                                supportArea: SupportChatSupportArea(area: .mobileApp, topic: "woo_mobile_issue_orders", confidence: .high)
-                            )
-                        )
-                    ]
-                )
-                completion(.success(response))
-            default:
-                break
-            }
-        }
-
-        let sut = SupportChatViewModel(
-            entryPoint: .preLogin,
-            stores: stores,
-            initialContext: ["site_url": "https://prelogin.example.com"],
-            onContactHumanSupport: { _, _, _, siteAddress, _ in
-                receivedSiteAddress = siteAddress
-            }
-        )
-
-        sut.inputText = "Hello"
-        sut.sendMessage()
-
-        // When
-        sut.contactHumanSupport()
-
-        // Then
-        #expect(receivedSiteAddress == "https://prelogin.example.com")
     }
 
     @Test func contactHumanSupport_tracks_escalationTapped_with_source() {
@@ -1164,7 +1113,7 @@ struct SupportChatViewModelTests {
             entryPoint: .preLogin,
             stores: stores,
             hasCreatedTicket: true,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
 
         // When — append a user message so the only failing condition is hasCreatedTicket
@@ -1619,7 +1568,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Help"
         sut.sendMessage()
@@ -1667,7 +1616,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1710,7 +1659,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1752,7 +1701,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: MockAnalyticsProvider()),
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1795,7 +1744,7 @@ struct SupportChatViewModelTests {
             entryPoint: .connectivityTool,
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Hello"
         sut.sendMessage()
@@ -1890,7 +1839,7 @@ struct SupportChatViewModelTests {
         let sut = SupportChatViewModel(
             entryPoint: .connectivityTool,
             stores: stores,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Hello"
 
@@ -1925,7 +1874,7 @@ struct SupportChatViewModelTests {
         let sut = SupportChatViewModel(
             entryPoint: .connectivityTool,
             stores: stores,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         sut.inputText = "Hello"
 
@@ -1946,7 +1895,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
 
         await confirmation { fetchCompleted in
@@ -1989,7 +1938,7 @@ struct SupportChatViewModelTests {
             stores: stores,
             chatID: chatID,
             sessionID: sessionID,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         var receivedSessionID: String?
 
@@ -2027,7 +1976,7 @@ struct SupportChatViewModelTests {
             entryPoint: .chatHistory,
             stores: stores,
             chatID: chatID,
-            onContactHumanSupport: { _, _, _, _, _ in }
+            onContactHumanSupport: Self.noopContactHumanSupport
         )
         var receivedChatID: Int64?
         stores.whenReceivingAction(ofType: SupportChatAction.self) { action in
@@ -2063,7 +2012,7 @@ struct SupportChatViewModelTests {
             stores: stores,
             analytics: WooAnalytics(analyticsProvider: analyticsProvider),
             diagnosticsService: diagnosticsService,
-            onContactHumanSupport: { _, _, _, _, _ in },
+            onContactHumanSupport: Self.noopContactHumanSupport,
             onUpdateWooCommercePlugin: onUpdateWooCommercePlugin,
             onOpenPushNotificationPreferences: onOpenPushNotificationPreferences
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -433,7 +433,6 @@ struct SupportDiagnosticsServiceTests {
 
     @Test func test_testNotifications_when_eligible_for_self_driven_PN_and_plugin_is_outdated_then_returns_failure_with_updatePlugin_action() async {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
         mockUserNotificationCenter.authorizationStatus = .authorized
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
@@ -444,12 +443,12 @@ struct SupportDiagnosticsServiceTests {
         let pluginVersionCheckerFactory = MockPluginVersionCheckerFactory(checker: pluginVersionChecker)
         let network = makeNetworkWithJetpackActive()
         let sut = makeSUT(
-            stores: stores,
             userNotificationCenter: mockUserNotificationCenter,
             pushNotesManager: mockPushNotesManager,
             pushNotificationEligibilityChecker: eligibilityChecker,
             pluginVersionCheckerFactory: pluginVersionCheckerFactory,
-            network: network
+            network: network,
+            isWPCom: false
         )
 
         // When
@@ -589,10 +588,11 @@ struct SupportDiagnosticsServiceTests {
         pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking? = nil,
         pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol? = nil,
         network: MockNetwork? = nil,
+        isWPCom: Bool = true,
         siteID: Int64 = 123
     ) -> SupportDiagnosticsService {
         let site = Site.fake().copy(siteID: siteID)
-        let session = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        let session = SessionManager.makeForTesting(authenticated: true, isWPCom: isWPCom, defaultSite: site)
         return SupportDiagnosticsService(
             session: session,
             stores: stores ?? MockStoresManager(sessionManager: session),

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -398,7 +398,7 @@ struct SupportDiagnosticsServiceTests {
         #expect(didCheckPluginVersion == false)
     }
 
-    @Test func test_testNotifications_when_eligible_for_self_driven_PN_site_not_registered_and_WPCom_order_notifications_disabled_then_returns_failure_with_enable_action() async {
+    @Test func test_testNotifications_when_eligible_for_self_driven_PN_site_not_registered_and_WPCom_order_notifications_disabled_then_returns_failure() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         let settings = NotificationSettings(deviceID: 123, enabledSites: [], disabledSites: [123])

--- a/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/SupportChat/SupportDiagnosticsServiceTests.swift
@@ -359,8 +359,81 @@ struct SupportDiagnosticsServiceTests {
         #expect(results[1].suggestedAction == Action.registerDevice)
     }
 
+    @Test func test_testNotifications_when_eligible_for_self_driven_PN_site_not_registered_and_WPCom_notifications_enabled_then_returns_success() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            if case let .loadNotificationSettings(_, onCompletion) = action {
+                onCompletion(.success(NotificationSettings(deviceID: 123, enabledSites: [123], disabledSites: [])))
+            }
+        }
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123", siteIDsRegisteredForWooPNs: [])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let pluginVersionChecker = MockPluginVersionChecker()
+        var didCheckPluginVersion = false
+        pluginVersionChecker.onCheckCompatibility = {
+            didCheckPluginVersion = true
+        }
+        let pluginVersionCheckerFactory = MockPluginVersionCheckerFactory(checker: pluginVersionChecker)
+        let network = makeNetworkWithJetpackActive()
+        let sut = makeSUT(
+            stores: stores,
+            userNotificationCenter: mockUserNotificationCenter,
+            pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
+            pluginVersionCheckerFactory: pluginVersionCheckerFactory,
+            network: network
+        )
+
+        // When
+        let results = await sut.runTests([Test.site, Test.notifications])
+
+        // Then
+        #expect(results.count == 2)
+        #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == true)
+        #expect(didCheckPluginVersion == false)
+    }
+
+    @Test func test_testNotifications_when_eligible_for_self_driven_PN_site_not_registered_and_WPCom_order_notifications_disabled_then_returns_failure_with_enable_action() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        let settings = NotificationSettings(deviceID: 123, enabledSites: [], disabledSites: [123])
+        stores.whenReceivingAction(ofType: AccountAction.self) { action in
+            if case let .loadNotificationSettings(_, onCompletion) = action {
+                onCompletion(.success(settings))
+            }
+        }
+        let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
+        mockUserNotificationCenter.authorizationStatus = .authorized
+        let mockPushNotesManager = MockPushNotificationsManager(mockedDeviceID: "123", siteIDsRegisteredForWooPNs: [])
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let network = makeNetworkWithJetpackActive()
+        let sut = makeSUT(
+            stores: stores,
+            userNotificationCenter: mockUserNotificationCenter,
+            pushNotesManager: mockPushNotesManager,
+            pushNotificationEligibilityChecker: eligibilityChecker,
+            network: network
+        )
+
+        // When
+        let results = await sut.runTests([Test.site, Test.notifications])
+
+        // Then
+        #expect(results.count == 2)
+        #expect(results[0].isSuccess == true)
+        #expect(results[1].isSuccess == false)
+        #expect(results[1].suggestedAction == Action.enableOrderNotifications(settings: settings))
+    }
+
     @Test func test_testNotifications_when_eligible_for_self_driven_PN_and_plugin_is_outdated_then_returns_failure_with_updatePlugin_action() async {
         // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
         let mockUserNotificationCenter = MockUserNotificationsCenterAdapter()
         mockUserNotificationCenter.authorizationStatus = .authorized
         let mockPushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [])
@@ -371,6 +444,7 @@ struct SupportDiagnosticsServiceTests {
         let pluginVersionCheckerFactory = MockPluginVersionCheckerFactory(checker: pluginVersionChecker)
         let network = makeNetworkWithJetpackActive()
         let sut = makeSUT(
+            stores: stores,
             userNotificationCenter: mockUserNotificationCenter,
             pushNotesManager: mockPushNotesManager,
             pushNotificationEligibilityChecker: eligibilityChecker,


### PR DESCRIPTION
Closes WOOMOB-3108

## Description
Updates the AI support chat escalation flow to:
- show a consent alert before creating a support request with the chat transcript
- offer Send Request, Contact Form, and Cancel actions from the consent alert
- open the contact form without prefilled transcript content when users choose to enter details themselves
- require a site address before direct ticket creation and route users to the contact form when one is unavailable
- pass site addresses including pre-login Help context when available
- show Contact Support for resumed chats once there is at least one remote bot response
- enable the AI support chat feature flag by default

Also fixes a bug in PN diagnosis when logged in with WPCom to a Jetpack site and Woo PN feature flags enabled.

## Test Steps
TC1: Update logic to show contact support button:
1. From Help & Support, open AI support chat and send a message until a bot response appears.
2. Verify Contact Support is visible after the remote bot response is available.
3. Open a chat from history with at least one remote bot response and verify Contact Support is visible.

TC2: Show confirm alert before sending request:
1. Tap Contact Support on a high-confidence support chat with a site address available.
2. Verify the consent alert shows Send Request, Contact Form, and Cancel, with Send Request shown before Contact Form.
3. Choose Send Request and verify a support request is created with the chat transcript.
4. Repeat the flow, choose Contact Form, and verify the support form opens without the chat transcript prefilled.
5. Repeat the flow, choose Cancel, and verify no support request is created and the form is not opened.

TC3: Require site address to send ticket automatically:
1. In a logged-in flow with a default site URL, escalate from a high-confidence AI support chat and verify the direct request path is available after consent.
2. In a pre-login Help flow without a site address, escalate from AI support chat and verify the contact form opens instead of direct ticket creation.
3. Enter a site address before opening pre-login Help > chat with support and verify the contact form is prefilled with that site address when escalating.

TC4: Fixed PN diagnosis for WPCom PN
1. Log in to a Jetpack site with WPCom PN.
2. Enable feature flags for self-driven PN tokens.
3. Go to Help > Chat with support > select Receiving PN.
4. Confirm that diagnosis succeeds.

TC5: Enable feature flag:
1. Build the app with Release configuration.
5. Open Help & Support and verify Contact Support is replaced by AI support chat.

## Screenshots
<img width="320" alt="My Store" src="https://github.com/user-attachments/assets/93ef4306-65ed-438f-bdeb-c24f51ab04d5" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.