### PR TITLE
Add an orders product filter and a top-products analytics tool

### DIFF
--- a/Modules/Sources/WooAIAssistant/Headless/WooAssistantHeadless.swift
+++ b/Modules/Sources/WooAIAssistant/Headless/WooAssistantHeadless.swift
@@ -411,6 +411,7 @@ public actor WooAssistantHeadless {
             ProductsUpdateTool.make(),
             CustomersListTool.make(),
             AnalyticsOrdersTool.make(),
+            AnalyticsProductsTool.make(),
             ShowCardsTool.make()
         ]
     }

--- a/Modules/Sources/WooAIAssistant/Tools/Cards/CardFamily.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Cards/CardFamily.swift
@@ -177,7 +177,7 @@ struct CardFamily: Sendable {
         checkTrash: true
     )
 
-    private static let showCardsLineItemLimit = 5
+    private static let showCardsLineItemLimit = 7
 
     private static func showCardsLineItem(_ item: AnyCodableJSON) -> AnyCodableJSON {
         var out: [String: AnyCodableJSON] = [:]

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsProductsSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsProductsSummary.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum AnalyticsProductsSummary {
+    /// The report's `extended_info` is heavy (image HTML, permalink, category_ids,
+    /// variations), so only these few string fields are lifted into each compact row.
+    private static let extendedInfoStringKeys = ["name", "sku", "stock_status"]
+
+    static func make(from rows: [AnyCodableJSON],
+                     range: (after: String, before: String),
+                     orderby: String) -> AnyCodableJSON {
+        .object([
+            "after": .string(range.after),
+            "before": .string(range.before),
+            "orderby": .string(orderby),
+            "count": .int(Int64(rows.count)),
+            "products": .array(rows.compactMap(productRow))
+        ])
+    }
+
+    private static func productRow(_ row: AnyCodableJSON) -> AnyCodableJSON? {
+        guard let productID = RESTResponseParsing.intField(row, "product_id") else { return nil }
+        var out: [String: AnyCodableJSON] = ["product_id": .int(productID)]
+        if let itemsSold = RESTResponseParsing.intField(row, "items_sold") {
+            out["items_sold"] = .int(itemsSold)
+        }
+        if let netRevenue = RESTResponseParsing.decimalField(row, "net_revenue") {
+            out["net_revenue"] = .string(RESTResponseParsing.formatDecimal(netRevenue))
+        }
+        if let ordersCount = RESTResponseParsing.intField(row, "orders_count") {
+            out["orders_count"] = .int(ordersCount)
+        }
+        if let extended = RESTResponseParsing.objectField(row, "extended_info") {
+            mergeExtendedInfo(extended, into: &out)
+        }
+        // Pre-bakes the products_update / show_cards target so the model can chain a row straight in.
+        out["target"] = .object(["kind": .string("product"), "id": .int(productID)])
+        return .object(out)
+    }
+
+    private static func mergeExtendedInfo(_ extended: AnyCodableJSON, into out: inout [String: AnyCodableJSON]) {
+        if let price = RESTResponseParsing.decimalField(extended, "price") {
+            out["price"] = .string(RESTResponseParsing.formatDecimal(price))
+        }
+        for key in extendedInfoStringKeys {
+            if let value = RESTResponseParsing.stringField(extended, key), !value.isEmpty {
+                out[key] = .string(value)
+            }
+        }
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsProductsTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Analytics/AnalyticsProductsTool.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+public enum AnalyticsProductsTool {
+
+    public static let name = "analytics_products"
+
+    static let allowedOrderBy: Set<String> = ["items_sold", "net_revenue"]
+
+    public static func make() -> RESTTool {
+        RESTTool(definition: definition, executor: execute)
+    }
+
+    private static let definition = AITool(
+        name: name,
+        description: """
+        Top-selling products within a date range. Returns each product's product_id, items_sold, \
+        net_revenue, orders_count, plus name, sku, price, and stock_status, sorted highest first. \
+        Use this for "best sellers this week", "top products in April", "what sold the most last \
+        month", or any best/top-product question scoped to a time window. For all-time best sellers \
+        with no date range, use products_list with orderby=popularity instead. For revenue or order \
+        totals (not a per-product breakdown), use analytics_orders. Each row carries a `target` \
+        object {kind:"product", id} you can pass straight to show_cards (family `product`) to render \
+        the products, or to products_update.updates[].target. After calling, pass the returned \
+        product_ids to show_cards rather than describing each row in prose.
+        """,
+        parametersSchema: .object([
+            "type": .string("object"),
+            "additionalProperties": .bool(false),
+            "properties": .object([
+                "after": .object([
+                    "type": .string("string"),
+                    "description": .string("Inclusive start date YYYY-MM-DD.")
+                ]),
+                "before": .object([
+                    "type": .string("string"),
+                    "description": .string("Inclusive end date YYYY-MM-DD.")
+                ]),
+                "orderby": .object([
+                    "type": .string("string"),
+                    "enum": .array(allowedOrderBy.sorted().map { .string($0) }),
+                    "description": .string("Ranking metric; default 'items_sold'. Use 'net_revenue' "
+                        + "for top products by revenue.")
+                ]),
+                "per_page": .object([
+                    "type": .string("integer"),
+                    "description": .string("Max products; clamped 1-50, default 20.")
+                ])
+            ]),
+            "required": .array([.string("after"), .string("before")])
+        ]),
+        safetyLevel: .safe
+    )
+
+    private struct Args: Decodable, Sendable {
+        let after: String
+        let before: String
+        let orderby: String?
+        let perPage: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case after, before, orderby
+            case perPage = "per_page"
+        }
+    }
+
+    private static let allowedArguments: Set<String> = ["after", "before", "orderby", "per_page"]
+
+    private static let execute: @Sendable (String, WCRESTClient) async -> ToolResult = { arguments, client in
+        if let failed = ToolArgumentValidation.validate(arguments: arguments,
+                                                        allowed: allowedArguments,
+                                                        toolName: name) {
+            return .failed(failed)
+        }
+        let args: Args
+        switch RESTToolDispatch.decodeArguments(Args.self, from: arguments, toolName: name) {
+        case .success(let value): args = value
+        case .failure(let failed): return .failed(failed)
+        }
+        let orderby = args.orderby ?? "items_sold"
+        if !allowedOrderBy.contains(orderby) {
+            return .failed(.init(toolName: name,
+                                 kind: .invalidToolCall,
+                                 reason: "orderby must be items_sold or net_revenue"))
+        }
+        guard let bounds = RESTDateBounds.bounds(start: args.after, end: args.before) else {
+            return .failed(.init(toolName: name,
+                                 kind: .invalidToolCall,
+                                 reason: "after and before must be YYYY-MM-DD"))
+        }
+        let response = await client.request(method: "GET",
+                                            path: "wc-analytics/reports/products",
+                                            query: [
+                                                "after": bounds.after,
+                                                "before": bounds.before,
+                                                "orderby": orderby,
+                                                "order": "desc",
+                                                "per_page": String(RESTToolDispatch.clampedPerPage(args.perPage)),
+                                                "extended_info": "true"
+                                            ],
+                                            body: nil)
+        guard HTTPStatusClassification.isSuccess(response.statusCode) else {
+            return .failed(RESTToolDispatch.failed(from: response, toolName: name))
+        }
+        guard let payload = RESTResponseParsing.decodeJSON(response.data),
+              let rows = RESTResponseParsing.arrayItems(payload) else {
+            return .failed(.init(toolName: name,
+                                 kind: .toolFailed,
+                                 reason: "expected JSON array"))
+        }
+        let summary = AnalyticsProductsSummary.make(from: rows,
+                                                    range: (args.after, args.before),
+                                                    orderby: orderby)
+        return .success(.init(toolName: name,
+                              structured: LLMPayloadCap.capped(summary, toolName: name),
+                              uiStructured: nil))
+    }
+}

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrderSummary.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrderSummary.swift
@@ -1,8 +1,10 @@
 import Foundation
 
 enum OrderSummary {
-    static let detailLineItemLimit = 10
-    static let listLineItemLimit = 5
+    static let detailLineItemLimit = 15
+    // Kept modest because the list path multiplies this cap across every order row,
+    // so it weighs far heavier on the payload budget than the single-order detail cap.
+    static let listLineItemLimit = 7
     static let adjustmentLineLimit = 10
     static let customerNoteLimit = 500
 

--- a/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListTool.swift
+++ b/Modules/Sources/WooAIAssistant/Tools/Implementations/Orders/OrdersListTool.swift
@@ -11,9 +11,12 @@ public enum OrdersListTool {
     private static let definition = AITool(
         name: name,
         description: """
-        List orders, optionally filtered by status, date range, or customer. \
-        Use to find specific orders, list pending fulfilment, or pull the most \
-        recent N. For latest/last single-order questions, use per_page=1, \
+        List orders, optionally filtered by status, date range, customer, or \
+        product. Use to find specific orders, list pending fulfilment, or pull \
+        the most recent N. For "orders that sold X" / "orders containing product \
+        X", prefer the `product` filter over `search`: resolve the product id \
+        with products_list first, then pass that id as `product`. \
+        For latest/last single-order questions, use per_page=1, \
         orderby=date, order=desc, then pass the result to `show_cards`. \
         For aggregate sales numbers prefer analytics_orders. For prose \
         questions about a specific order's payment method, customer email, \
@@ -45,6 +48,11 @@ public enum OrdersListTool {
                 "customer": .object([
                     "type": .string("integer"),
                     "description": .string("Customer ID; resolve via customers_list first.")
+                ]),
+                "product": .object([
+                    "type": .string("integer"),
+                    "description": .string("Product ID; returns orders containing that product. "
+                        + "Resolve the id via products_list first.")
                 ]),
                 "include": .object([
                     "type": .string("array"),
@@ -87,6 +95,7 @@ public enum OrdersListTool {
         let status: String?
         let search: String?
         let customer: Int?
+        let product: Int?
         let include: [Int]?
         let after: String?
         let before: String?
@@ -96,7 +105,7 @@ public enum OrdersListTool {
         let perPage: Int?
 
         enum CodingKeys: String, CodingKey {
-            case status, search, customer, include, after, before, orderby, order, page
+            case status, search, customer, product, include, after, before, orderby, order, page
             case perPage = "per_page"
         }
     }
@@ -112,6 +121,9 @@ public enum OrdersListTool {
             query["search"] = search
         }
         if let customer = args.customer { query["customer"] = String(customer) }
+        // WC `?product=` accepts a single integer (a comma list 400s) and matches
+        // orders whose line items reference that product or any of its variations.
+        if let product = args.product { query["product"] = String(product) }
         if let include = args.include, !include.isEmpty {
             query["include"] = include.map(String.init).joined(separator: ",")
         }
@@ -138,7 +150,7 @@ public enum OrdersListTool {
     }
 
     private static let allowedArguments: Set<String> = [
-        "status", "search", "customer", "include", "after", "before",
+        "status", "search", "customer", "product", "include", "after", "before",
         "orderby", "order", "page", "per_page"
     ]
 

--- a/Modules/Tests/WooAIAssistantTests/Headless/WooAssistantHeadlessTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Headless/WooAssistantHeadlessTests.swift
@@ -6,6 +6,16 @@ import Testing
 struct WooAssistantHeadlessTests {
 
     @Test
+    func test_allTools_registers_the_analytics_products_tool() {
+        // When
+        let names = WooAssistantHeadless.allTools().map { $0.definition.name }
+
+        // Then
+        #expect(names.contains(AnalyticsProductsTool.name))
+        #expect(names.contains(AnalyticsOrdersTool.name))
+    }
+
+    @Test
     func test_send_when_text_only_response_then_assistantText_populated_and_no_cards() async throws {
         // Given
         let chat = MockAIChatService()

--- a/Modules/Tests/WooAIAssistantTests/Tools/Cards/OrderFamilyTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Cards/OrderFamilyTests.swift
@@ -81,9 +81,9 @@ struct OrderFamilyTests {
     }
 
     @Test
-    func test_show_cards_when_order_has_line_items_then_resolved_ref_summary_carries_line_items_capped_at_five() {
+    func test_show_cards_when_order_has_line_items_then_resolved_ref_summary_carries_line_items_capped_at_seven() {
         // Given
-        let items = (1...7).map { idx in
+        let items = (1...10).map { idx in
             AnyCodableJSON.object(["id": .int(Int64(idx)), "name": .string("Item \(idx)"), "quantity": .int(1)])
         }
         let entity: AnyCodableJSON = .object([
@@ -99,8 +99,8 @@ struct OrderFamilyTests {
             Issue.record("expected line_items array")
             return
         }
-        #expect(projected.count == 5)
-        #expect(fields["line_items_count"] == .int(7))
+        #expect(projected.count == 7)
+        #expect(fields["line_items_count"] == .int(10))
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsProductsToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Analytics/AnalyticsProductsToolTests.swift
@@ -1,0 +1,282 @@
+import Foundation
+import Testing
+@testable import WooAIAssistant
+
+@Suite(.timeLimit(.minutes(1)))
+struct AnalyticsProductsToolTests {
+    @Test
+    func test_analytics_products_definition_documents_time_window_versus_all_time_popularity() {
+        // Given
+        let tool = AnalyticsProductsTool.make()
+
+        // Then
+        #expect(tool.definition.description.contains("Top-selling products within a date range"))
+        #expect(tool.definition.description.contains("products_list with orderby=popularity"))
+        #expect(tool.definition.description.contains("show_cards"))
+    }
+
+    @Test
+    func test_analytics_products_when_response_ok_then_query_uses_iso_bounds_orderby_and_extended_info() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        _ = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","orderby":"net_revenue","per_page":5}"#,
+            client
+        )
+
+        // Then
+        let call = await client.calls.first
+        #expect(call?.path == "wc-analytics/reports/products")
+        #expect(call?.query["after"] == "2026-04-01T00:00:00")
+        #expect(call?.query["before"] == "2026-04-30T23:59:59")
+        #expect(call?.query["orderby"] == "net_revenue")
+        #expect(call?.query["order"] == "desc")
+        #expect(call?.query["per_page"] == "5")
+        #expect(call?.query["extended_info"] == "true")
+    }
+
+    @Test
+    func test_analytics_products_when_orderby_omitted_then_defaults_to_items_sold() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["orderby"] == "items_sold")
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["orderby"] == .string("items_sold"))
+    }
+
+    @Test
+    func test_analytics_products_when_rows_present_then_each_row_projects_metrics_and_extended_info() async {
+        // Given
+        let body = """
+        [
+            {
+                "product_id": 815, "items_sold": 4462, "net_revenue": 80455.38, "orders_count": 795,
+                "extended_info": {
+                    "name": "Ribbed Wool Beanie", "sku": "RWB-1", "price": 17.09, "stock_status": "instock",
+                    "image": "<img src=\\"x\\" />", "permalink": "https://example.com/p", "category_ids": [1, 2]
+                }
+            }
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let products) = fields["products"],
+              case .object(let first) = products.first else {
+            Issue.record("expected first product object")
+            return
+        }
+        #expect(first["product_id"] == .int(815))
+        #expect(first["items_sold"] == .int(4462))
+        #expect(first["net_revenue"] == .string("80455.38"))
+        #expect(first["orders_count"] == .int(795))
+        #expect(first["name"] == .string("Ribbed Wool Beanie"))
+        #expect(first["sku"] == .string("RWB-1"))
+        #expect(first["price"] == .string("17.09"))
+        #expect(first["stock_status"] == .string("instock"))
+        #expect(first["target"] == .object(["kind": .string("product"), "id": .int(815)]))
+        // Heavy extended_info fields must be projected away to protect the payload budget.
+        #expect(first["image"] == nil)
+        #expect(first["permalink"] == nil)
+        #expect(first["category_ids"] == nil)
+    }
+
+    @Test
+    func test_analytics_products_when_required_dates_missing_then_returns_failed_invalid_tool_call() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor("{}", client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_analytics_products_when_date_invalid_then_returns_failed_invalid_tool_call() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"last week","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(await client.calls.isEmpty)
+    }
+
+    @Test
+    func test_analytics_products_when_orderby_not_in_enum_then_returns_failed_invalid_tool_call() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","orderby":"date"}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+    }
+
+    @Test
+    func test_analytics_products_when_response_is_500_then_returns_failed_with_upstream_failure() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.failure(statusCode: 500))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .upstreamFailure)
+    }
+
+    @Test
+    func test_analytics_products_when_per_page_above_50_then_query_clamps_to_50() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        _ = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30","per_page":500}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["per_page"] == "50")
+    }
+
+    @Test
+    func test_analytics_products_when_per_page_below_1_then_query_clamps_to_1() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        _ = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30","per_page":0}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["per_page"] == "1")
+    }
+
+    @Test
+    func test_analytics_products_when_per_page_omitted_then_query_uses_default_of_20() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        _ = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["per_page"] == "20")
+    }
+
+    @Test
+    func test_analytics_products_when_empty_report_then_count_zero_and_products_empty() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .success(let success) = result, case .object(let fields) = success.structured else {
+            Issue.record("expected success object")
+            return
+        }
+        #expect(fields["count"] == .int(0))
+        #expect(fields["products"] == .array([]))
+        #expect(fields["truncated"] == nil)
+    }
+
+    @Test
+    func test_analytics_products_when_row_missing_product_id_then_row_dropped() async {
+        // Given
+        let body = """
+        [
+            {"items_sold": 10, "net_revenue": 99.0, "extended_info": {"name": "No ID"}},
+            {"product_id": 7, "items_sold": 5, "net_revenue": 50.0, "extended_info": {"name": "Has ID"}}
+        ]
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(#"{"after":"2026-04-01","before":"2026-04-30"}"#, client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let fields) = success.structured,
+              case .array(let products) = fields["products"],
+              case .object(let only) = products.first else {
+            Issue.record("expected one surviving product object")
+            return
+        }
+        #expect(products.count == 1)
+        #expect(only["product_id"] == .int(7))
+        #expect(only["name"] == .string("Has ID"))
+        #expect(only["target"] == .object(["kind": .string("product"), "id": .int(7)]))
+    }
+
+    @Test
+    func test_analytics_products_when_unknown_argument_then_invalidToolCall() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = AnalyticsProductsTool.make()
+
+        // When
+        let result = await tool.executor(
+            #"{"after":"2026-04-01","before":"2026-04-30","interval":"day"}"#,
+            client
+        )
+
+        // Then
+        guard case .failed(let failed) = result else {
+            Issue.record("expected failed")
+            return
+        }
+        #expect(failed.kind == .invalidToolCall)
+        #expect(await client.calls.isEmpty)
+    }
+}

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrderSummaryTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrderSummaryTests.swift
@@ -84,9 +84,9 @@ struct OrderSummaryTests {
     }
 
     @Test
-    func test_make_when_order_has_more_than_ten_line_items_then_line_items_truncated_is_true() {
+    func test_make_when_order_has_more_than_detail_limit_line_items_then_line_items_truncated_is_true() {
         // Given
-        let items = (0..<12).map { idx in
+        let items = (0..<18).map { idx in
             AnyCodableJSON.object(["id": .int(Int64(idx)), "name": .string("Item \(idx)"), "quantity": .int(1)])
         }
         let entity = AnyCodableJSON.object(["id": .int(7), "line_items": .array(items)])
@@ -100,9 +100,31 @@ struct OrderSummaryTests {
             Issue.record("expected line_items array")
             return
         }
-        #expect(projected.count == 10)
-        #expect(fields["line_items_count"] == .int(12))
+        #expect(projected.count == OrderSummary.detailLineItemLimit)
+        #expect(projected.count == 15)
+        #expect(fields["line_items_count"] == .int(18))
         #expect(fields["line_items_truncated"] == .bool(true))
+    }
+
+    @Test
+    func test_make_when_order_has_exactly_detail_limit_line_items_then_truncated_flag_is_absent() {
+        // Given
+        let items = (0..<OrderSummary.detailLineItemLimit).map { idx in
+            AnyCodableJSON.object(["id": .int(Int64(idx)), "name": .string("Item \(idx)"), "quantity": .int(1)])
+        }
+        let entity = AnyCodableJSON.object(["id": .int(7), "line_items": .array(items)])
+
+        // When
+        let summary = OrderSummary.make(from: entity)
+
+        // Then
+        guard case .object(let fields) = summary,
+              case .array(let projected) = fields["line_items"] else {
+            Issue.record("expected line_items array")
+            return
+        }
+        #expect(projected.count == 15)
+        #expect(fields["line_items_truncated"] == nil)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersGetToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersGetToolTests.swift
@@ -62,6 +62,33 @@ struct OrdersGetToolTests {
     }
 
     @Test
+    func test_orders_get_when_more_than_15_line_items_then_keeps_15() async {
+        // Given
+        let items = (0..<18).map { idx in
+            "{\"id\": \(idx), \"name\": \"Item \(idx)\", \"quantity\": 1, \"product_id\": \(100 + idx)}"
+        }.joined(separator: ", ")
+        let body = """
+        {"id": 3551, "status": "processing", "total": "120.00", "currency": "USD", "line_items": [\(items)]}
+        """
+        let client = MockWCRESTClient(response: StubResponses.ok(body))
+        let tool = OrdersGetTool.make()
+
+        // When
+        let result = await tool.executor(#"{"id": 3551}"#, client)
+
+        // Then
+        guard case .success(let success) = result,
+              case .object(let summary) = success.structured,
+              case .array(let lineItems) = summary["line_items"] else {
+            Issue.record("expected line_items array, got \(result)")
+            return
+        }
+        #expect(lineItems.count == 15)
+        #expect(summary["line_items_count"] == .int(18))
+        #expect(summary["line_items_truncated"] == .bool(true))
+    }
+
+    @Test
     func test_orders_get_when_id_missing_then_returns_failed_with_invalid_tool_call() async {
         // Given
         let client = MockWCRESTClient(response: StubResponses.ok("{}"))

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
@@ -16,6 +16,16 @@ struct OrdersListToolTests {
     }
 
     @Test
+    func test_orders_list_definition_documents_product_filter() {
+        // Given
+        let tool = OrdersListTool.make()
+
+        // Then
+        #expect(tool.definition.description.contains("prefer the `product` filter over `search`"))
+        #expect(tool.definition.description.contains("resolve the product id"))
+    }
+
+    @Test
     func test_orders_list_when_response_is_array_then_structured_summary_lists_ids_and_total_range() async throws {
         // Given
         let body = """
@@ -212,6 +222,46 @@ struct OrdersListToolTests {
 
         // Then
         #expect(await client.calls.first?.query["status"] == nil)
+    }
+
+    @Test
+    func test_orders_list_when_product_provided_then_query_carries_product_id() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersListTool.make()
+
+        // When
+        _ = await tool.executor(#"{"product": 3903}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["product"] == "3903")
+    }
+
+    @Test
+    func test_orders_list_when_product_and_status_provided_then_query_carries_both() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersListTool.make()
+
+        // When
+        _ = await tool.executor(#"{"product": 3903, "status": "completed"}"#, client)
+
+        // Then
+        #expect(await client.calls.first?.query["product"] == "3903")
+        #expect(await client.calls.first?.query["status"] == "completed")
+    }
+
+    @Test
+    func test_orders_list_when_product_omitted_then_query_has_no_product_param() async {
+        // Given
+        let client = MockWCRESTClient(response: StubResponses.ok("[]"))
+        let tool = OrdersListTool.make()
+
+        // When
+        _ = await tool.executor("{}", client)
+
+        // Then
+        #expect(await client.calls.first?.query["product"] == nil)
     }
 
     @Test

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
@@ -142,10 +142,12 @@ struct OrdersListToolTests {
     }
 
     @Test
-    func test_orders_list_when_full_page_of_dense_orders_then_payload_stays_under_llm_cap() async throws {
-        // Given a realistic full window: 50 orders, each with the list line-item cap of rich rows.
+    func test_orders_list_when_typical_full_page_then_summary_stays_under_llm_cap() async throws {
+        // Given a realistic full window of 50 orders carrying the common 1-3 line items each,
+        // which is the everyday shape the raised list cap must keep well under the payload budget.
         let orders = (0..<50).map { orderIndex -> String in
-            let lineItems = (0..<OrderSummary.listLineItemLimit).map { itemIndex in
+            let itemCount = (orderIndex % 3) + 1
+            let lineItems = (0..<itemCount).map { itemIndex in
                 """
                 {"id": \(itemIndex), "name": "Merino Wool Crew Neck Sweater \(itemIndex)", \
                 "quantity": 2, "sku": "MWCNS-\(orderIndex)-\(itemIndex)", "total": "129.00", \
@@ -174,10 +176,51 @@ struct OrdersListToolTests {
         }
         let encoded = try JSONEncoder().encode(success.structured)
         #expect(encoded.count < LLMPayloadCap.maxBytes)
-        // A truncation marker would prove the cap fired and the real summary was dropped.
+        // No truncation marker means the real summary survived rather than being dropped.
         if case .object(let fields) = success.structured {
             #expect(fields["truncated"] == nil)
             #expect(fields["count"] == .int(50))
+        } else {
+            Issue.record("expected object structured")
+        }
+    }
+
+    @Test
+    func test_orders_list_when_pathological_full_page_then_cap_fires_and_nudges_show_cards() async throws {
+        // Given the worst case the raised caps allow: 50 orders each maxed at the list line-item
+        // cap with long names/skus. This exceeds 64KB, so the cap must protect the context window.
+        let orders = (0..<50).map { orderIndex -> String in
+            let lineItems = (0..<OrderSummary.listLineItemLimit).map { itemIndex in
+                """
+                {"id": \(itemIndex), "name": "Merino Wool Crew Neck Sweater Extra Long Title \(itemIndex)", \
+                "quantity": 2, "sku": "MWCNS-LONG-SKU-\(orderIndex)-\(itemIndex)", "total": "129.00", \
+                "product_id": \(1000 + itemIndex), "variation_id": \(5000 + itemIndex)}
+                """
+            }.joined(separator: ", ")
+            return """
+            {"id": \(3000 + orderIndex), "number": "\(3000 + orderIndex)", "status": "processing", \
+            "total": "258.00", "currency": "USD", "date_created": "2026-05-20T10:00:00", \
+            "payment_method_title": "Stripe Credit Card", \
+            "billing": {"first_name": "Firstname", "last_name": "Lastname", "email": "buyer\(orderIndex)@example.com", \
+            "phone": "+1 555 0100", "city": "Portland", "state": "OR", "postcode": "97201", "country": "US"}, \
+            "line_items": [\(lineItems)]}
+            """
+        }.joined(separator: ", ")
+        let client = MockWCRESTClient(response: StubResponses.ok("[\(orders)]"))
+        let tool = OrdersListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 50}"#, client)
+
+        // Then
+        guard case .success(let success) = result else {
+            Issue.record("expected success")
+            return
+        }
+        let encoded = try JSONEncoder().encode(success.structured)
+        #expect(encoded.count < LLMPayloadCap.maxBytes)
+        if case .object(let fields) = success.structured {
+            #expect(fields["truncated"] == .bool(true))
         } else {
             Issue.record("expected object structured")
         }

--- a/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
+++ b/Modules/Tests/WooAIAssistantTests/Tools/Implementations/Orders/OrdersListToolTests.swift
@@ -111,9 +111,9 @@ struct OrdersListToolTests {
     }
 
     @Test
-    func test_orders_list_when_row_line_items_exceed_five_then_line_items_truncated_is_true_for_that_row() async throws {
+    func test_orders_list_when_row_line_items_exceed_list_limit_then_line_items_truncated_is_true_for_that_row() async throws {
         // Given
-        let items = (0..<7).map { idx in
+        let items = (0..<10).map { idx in
             "{\"id\": \(idx), \"name\": \"Item \(idx)\", \"quantity\": 1}"
         }.joined(separator: ", ")
         let body = """
@@ -136,9 +136,51 @@ struct OrdersListToolTests {
             Issue.record("expected line_items in first order")
             return
         }
-        #expect(lineItems.count == 5)
+        #expect(lineItems.count == 7)
         #expect(first["line_items_truncated"] == .bool(true))
-        #expect(first["line_items_count"] == .int(7))
+        #expect(first["line_items_count"] == .int(10))
+    }
+
+    @Test
+    func test_orders_list_when_full_page_of_dense_orders_then_payload_stays_under_llm_cap() async throws {
+        // Given a realistic full window: 50 orders, each with the list line-item cap of rich rows.
+        let orders = (0..<50).map { orderIndex -> String in
+            let lineItems = (0..<OrderSummary.listLineItemLimit).map { itemIndex in
+                """
+                {"id": \(itemIndex), "name": "Merino Wool Crew Neck Sweater \(itemIndex)", \
+                "quantity": 2, "sku": "MWCNS-\(orderIndex)-\(itemIndex)", "total": "129.00", \
+                "product_id": \(1000 + itemIndex), "variation_id": \(5000 + itemIndex)}
+                """
+            }.joined(separator: ", ")
+            return """
+            {"id": \(3000 + orderIndex), "number": "\(3000 + orderIndex)", "status": "processing", \
+            "total": "258.00", "currency": "USD", "date_created": "2026-05-20T10:00:00", \
+            "payment_method_title": "Stripe Credit Card", \
+            "billing": {"first_name": "Firstname", "last_name": "Lastname", "email": "buyer\(orderIndex)@example.com", \
+            "phone": "+1 555 0100", "city": "Portland", "state": "OR", "postcode": "97201", "country": "US"}, \
+            "line_items": [\(lineItems)]}
+            """
+        }.joined(separator: ", ")
+        let client = MockWCRESTClient(response: StubResponses.ok("[\(orders)]"))
+        let tool = OrdersListTool.make()
+
+        // When
+        let result = await tool.executor(#"{"per_page": 50}"#, client)
+
+        // Then
+        guard case .success(let success) = result else {
+            Issue.record("expected success")
+            return
+        }
+        let encoded = try JSONEncoder().encode(success.structured)
+        #expect(encoded.count < LLMPayloadCap.maxBytes)
+        // A truncation marker would prove the cap fired and the real summary was dropped.
+        if case .object(let fields) = success.structured {
+            #expect(fields["truncated"] == nil)
+            #expect(fields["count"] == .int(50))
+        } else {
+            Issue.record("expected object structured")
+        }
     }
 
     @Test

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 24.9
 -----
 - [Internal] AI Assistant: products_list gains low-stock and price-range filters, and products_update supports percentage discounts and applying price/stock changes across all variations of a variable product.
+- [Internal] AI Assistant: orders_list can filter by product, order cards surface more line items, and a new analytics_products tool reports top-selling products for a date range.
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 

--- a/WooCommerce/Classes/AIAssistant/AIAssistantDependencyAdaptor.swift
+++ b/WooCommerce/Classes/AIAssistant/AIAssistantDependencyAdaptor.swift
@@ -73,6 +73,7 @@ struct AIAssistantDependencyAdaptor: AssistantDependencyProviding {
             ProductsUpdateTool.make(),
             CustomersListTool.make(),
             AnalyticsOrdersTool.make(),
+            AnalyticsProductsTool.make(),
             ShowCardsTool.make()
         ]
     }


### PR DESCRIPTION
Depends on #17217 - when that merges, this PR rebases to its base automatically.

## What this does

Three additions on top of the consolidated product/order tools:

- **`orders_list` `product` filter** (single product id) - "orders that sold X".
- **A new `analytics_products` tool** - time-windowed top / best-selling products over the WooCommerce analytics products report.
- **Raised order line-item caps** so big orders and multi-order reads drop fewer items.

## Why

After the consolidation the assistant could update products and read orders, but three gaps remained: it could not find the orders that contain a given product (it fell back to a text search and acted on the wrong orders), it could not answer "top products this week" (the only ranking was `products_list orderby=popularity`, which is all-time), and it dropped order line items past a low cap on large baskets.

## What works now that didn't before

- "Show me the orders that contain [product]" - a structured `product` filter, not a text search.
- "What were my best-selling products this week?" / "Which products made the most revenue last month?" - a real time-windowed ranking, distinct from all-time popularity.
- "Show me the products in my last 3 orders" - more complete (raised line-item caps).

## Key non-obvious decisions

- **The orders `product` filter is a single integer.** WooCommerce orders REST 400s on a comma list, so the schema stays an integer; `?product=` already matches variation line items by their parent id.
- **No system-prompt change.** `analytics_products`'s routing guidance ("use this for top/best-selling products in a date range; for all-time popularity use `products_list orderby=popularity`") lives in the tool's own description, which the model sees.
- **`analytics_products` returns a compact projection** (product_id, items_sold, net_revenue, orders_count, plus name/sku/price/stock_status) and a pre-baked `target {kind:"product", id}`; the heavy `extended_info` fields (image, permalink, category_ids, variations) are dropped to protect the payload, and the model renders rows via `show_cards(family: product)` - no new card family.
- **The line-item cap raise is token-aware** - a small bump on the list cap (it multiplies across many orders) and a larger one on single-order detail. On a pathological dense full page the overall 64KB payload cap still fires and degrades gracefully to a "tap for details" marker rather than dropping items silently - a documented trade-off.

## Tests

Unit (793 pass): the orders `product` filter (alone, combined with status, omitted); `analytics_products` query building (ISO bounds + orderby + extended_info), date and orderby validation, the compact projection (heavy fields dropped), empty report, a row missing `product_id`, unknown-argument rejection, and registration in both tool catalogs; the raised caps with truncation-boundary tests and payload-cap behavior (typical full page stays under 64KB, pathological dense page fires the cap and degrades gracefully).

Headless smoke against the demo store on gpt-5.1 (default suite + capability scenarios): top-products-this-week, top-revenue-last-month, all-time-popularity-vs-windowed (the model picks the right tool), orders-by-product (the filter, not search), and products-of-recent-orders all pass; no regressions.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.