### PR TITLE
Add per-locale glossaries, style guides, and brand-safety validator

### DIFF
--- a/fastlane/ai_translation/README.md
+++ b/fastlane/ai_translation/README.md
@@ -53,12 +53,46 @@ fastlane/ai_translation/
 │   ├── constants.rb              # Version, model IDs, prompt version
 │   ├── ios_resources.rb          # .strings parser + writer
 │   ├── manifest.rb               # Source-only invalidation cache (per-locale JSON)
-│   └── translator.rb             # Batched JSON-in/JSON-out translator with split-retry
+│   ├── translator.rb             # Batched JSON-in/JSON-out translator with split-retry
+│   └── validator.rb              # Brand-safety + glossary enforcement
+├── glossary/
+│   ├── common.yml                # Brand names — never translate (hard validator)
+│   └── <locale>.yml × 31         # Per-locale UI term + noun mappings
+├── style/
+│   ├── default.md                # Fallback style guide
+│   └── <locale>.md               # Per-locale register / quirks (when applicable)
 ├── spec/                         # Minitest specs
 ├── scripts/                      # One-off bootstrap utilities (assemble, gap-fill)
 ├── Rakefile                      # Rake task wrappers
 └── translate-progress.json       # Audit checkpoint for the original bootstrap run
 ```
+
+### Glossaries and brand-safety
+
+`glossary/common.yml` lists the brand and product names that must appear
+verbatim in every translation regardless of target locale (WooCommerce,
+Woo, Stripe, Apple Pay, Tap to Pay, Blaze, Bluetooth, etc.). The
+`Validator` enforces this as a hard rule: if a source string contains a
+listed brand, the translation must contain the same brand unchanged. The
+violation is reported and the entry is rejected (counted in the
+`glossary_violations` summary line).
+
+`glossary/<locale>.yml` adds per-locale UI-term and noun mappings. When
+the source string is *exactly* one of those keys, the translation must
+match the mapped value. This pins terminology like "Cancel" → "Anuluj"
+(Polish) or "Orders" → "ऑर्डर" (Hindi) so terminology can't drift
+across PRs.
+
+The 15 new locales bootstrapped in PR #17220 ship with rich
+`<locale>.yml` files (seeded from the sub-agent translation prompts). The
+16 existing GlotPress locales (de, es, fr, …) ship with stub files that
+inherit only the brand-safety rules; future work will derive their UI
+terms from the existing translations.
+
+Style guides at `style/<locale>.md` are loaded as additional system-prompt
+context when translating that locale. They cover register choices,
+numerals, quotation conventions, and locale-specific pitfalls (e.g.,
+pt-PT vs pt-BR distinctions, Bahasa Malaysia vs Bahasa Indonesia).
 
 ### Why a separate `byte_sizer`
 

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -152,7 +152,7 @@ end
 
 def translate_file(input_path:, output_path:, translator:, locale:, model:, limit:, logger:,
                    incremental: false, manifest: nil, escalation_model: nil, validator: nil,
-                   smoke_run: !limit.nil?)
+                   style: nil, smoke_run: !limit.nil?)
   doc = WooAiTranslation::IosResources::Parser.parse_file(input_path)
   all_units = doc.translatable_units
   # Build the Set via Set.new (not Array#to_set): referencing the Set constant
@@ -181,7 +181,7 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
     return [0, [], [], []]
   end
 
-  results = run_translation(translator, locale, units_to_translate, model)
+  results = run_translation(translator, locale, units_to_translate, model, style: style)
   logger.call("[#{locale}] primary pass returned #{results.size} translations (model=#{model})")
 
   # In incremental mode we preserve existing values for unchanged keys by
@@ -207,7 +207,7 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
     retry_names = Set.new((failed_validation + failed_glossary).map { |f| f[:name] })
     retry_units = units_to_translate.select { |u| retry_names.include?(u.name) }
     logger.call("[#{locale}] escalating #{retry_units.size} failed entries to #{escalation_model}")
-    retry_results = run_translation(translator, locale, retry_units, escalation_model)
+    retry_results = run_translation(translator, locale, retry_units, escalation_model, style: style)
     extra_translated, _retry_missing, still_failing_v, still_failing_g = apply_results(
       retry_units, retry_results, by_name,
       manifest: record_manifest, model: escalation_model, origin: 'ai-opus-retry', validator: validator
@@ -270,9 +270,9 @@ ensure
   File.delete(tmp_path) if tmp_path && File.exist?(tmp_path)
 end
 
-def run_translation(translator, locale, units, model)
+def run_translation(translator, locale, units, model, style: nil)
   items = units.map { |u| { id: u.name, source: u.entries.first[:source], context: u.comment } }
-  translator.translate(locale: locale, items: items, model: model)
+  translator.translate(locale: locale, items: items, model: model, style: style)
 end
 
 # Walk units_to_translate, apply each result, and report counts. Mutates
@@ -358,6 +358,23 @@ def merge_with_existing(en_units, target_path)
   en_units
 end
 
+# Load the per-locale style guide (style/<locale>.md), falling back to
+# style/default.md. The text is passed to the translator as additional
+# system-prompt context (register, numerals, locale pitfalls). Returns nil when
+# neither file exists, in which case the translator uses its built-in
+# default_style copy.
+def load_style_guide(locale)
+  base = File.expand_path('../style', __dir__)
+  path = [File.join(base, "#{locale}.md"), File.join(base, 'default.md')].find { |p| File.exist?(p) }
+  return nil unless path
+
+  # Style guides are authored in UTF-8 (accents, non-Latin examples). Read with
+  # an explicit encoding so a non-UTF-8 default external encoding (some CI
+  # locales) doesn't raise on .strip / string ops.
+  text = File.read(path, encoding: Encoding::UTF_8).strip
+  text.empty? ? nil : [path, text]
+end
+
 def main(argv)
   opts = parse_args(argv)
   locale = opts[:locale]
@@ -405,6 +422,11 @@ def main(argv)
   end
   logger.call("validator loaded: brands=#{validator&.brands&.size || 0} terms=#{validator&.terms&.size || 0}") if validator
 
+  # Load the per-locale style guide (or the default) and thread it into the
+  # translator's system prompt so register/numeral/locale guidance is applied.
+  style_path, style = load_style_guide(locale)
+  logger.call(style ? "style guide loaded from #{File.basename(style_path)} (#{style.length} chars)" : 'no style guide; using built-in default')
+
   out_dir = File.join(TARGET_BASE, "#{locale}.lproj")
 
   # A --limit run is a smoke test of the whole locale, not just the first file.
@@ -420,7 +442,7 @@ def main(argv)
     translator: translator, locale: locale, model: opts[:model],
     limit: opts[:limit], logger: logger, incremental: opts[:incremental],
     manifest: manifest, escalation_model: escalation_model,
-    validator: validator, smoke_run: smoke_run
+    validator: validator, style: style, smoke_run: smoke_run
   )
   logger.call("Localizable.strings done in #{(Time.now - t0).round(1)}s")
   total_translated = trans
@@ -439,7 +461,7 @@ def main(argv)
         translator: translator, locale: locale, model: opts[:model],
         limit: nil, logger: logger, incremental: opts[:incremental],
         manifest: manifest, escalation_model: escalation_model,
-        validator: validator, smoke_run: smoke_run
+        validator: validator, style: style, smoke_run: smoke_run
       )
       logger.call("InfoPlist.strings done in #{(Time.now - t0).round(1)}s")
       total_translated += trans

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -32,6 +32,7 @@ require 'woo_ai_translation/anthropic_client'
 require 'woo_ai_translation/translator'
 require 'woo_ai_translation/byte_sizer'
 require 'woo_ai_translation/manifest'
+require 'woo_ai_translation/validator'
 
 REPO_ROOT = File.expand_path('../../..', __dir__)
 SOURCE_DIR = File.join(REPO_ROOT, 'WooCommerce/Resources/en.lproj')
@@ -150,7 +151,8 @@ def placeholders_match?(source, translation)
 end
 
 def translate_file(input_path:, output_path:, translator:, locale:, model:, limit:, logger:,
-                   incremental: false, manifest: nil, escalation_model: nil, smoke_run: !limit.nil?)
+                   incremental: false, manifest: nil, escalation_model: nil, validator: nil,
+                   smoke_run: !limit.nil?)
   doc = WooAiTranslation::IosResources::Parser.parse_file(input_path)
   all_units = doc.translatable_units
   # Build the Set via Set.new (not Array#to_set): referencing the Set constant
@@ -174,7 +176,9 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
 
   if units_to_translate.empty?
     logger.call("[#{locale}] nothing to translate; output left unchanged")
-    return [0, [], []]
+    # Four-value shape mirrors the success path so callers can always destructure
+    # [translated, missing, placeholder_errors, glossary_errors] safely.
+    return [0, [], [], []]
   end
 
   results = run_translation(translator, locale, units_to_translate, model)
@@ -187,22 +191,32 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
   units_for_write = incremental && File.exist?(output_path) ? merge_with_existing(units, output_path) : units
   by_name = units_for_write.to_h { |u| [u.name, u] }
 
-  translated, failed_missing, failed_validation = apply_results(
-    units_to_translate, results, by_name, manifest: record_manifest, model: model, origin: 'ai'
+  translated, failed_missing, failed_validation, failed_glossary = apply_results(
+    units_to_translate, results, by_name,
+    manifest: record_manifest, model: model, origin: 'ai', validator: validator
   )
 
-  # Opus fallback: retry validator-failed entries with the escalation model.
-  if escalation_model && !failed_validation.empty?
-    logger.call("[#{locale}] escalating #{failed_validation.size} failed entries to #{escalation_model}")
-    retry_units = units_to_translate.select { |u| failed_validation.any? { |f| f[:name] == u.name } }
+  # Opus fallback: retry validator-failed entries (placeholder OR glossary)
+  # with the escalation model. Successful retries are recorded with
+  # origin=ai-opus-retry so the audit trail shows why a stronger model
+  # produced the value.
+  if escalation_model && !(failed_validation.empty? && failed_glossary.empty?)
+    # Set.new (not Array#to_set): referencing the Set constant triggers Ruby 3.2's
+    # `autoload :Set`, whereas `to_set` alone raises NoMethodError on a minimal
+    # load path (CI). Same reason RuboCop flags an explicit `require 'set'`.
+    retry_names = Set.new((failed_validation + failed_glossary).map { |f| f[:name] })
+    retry_units = units_to_translate.select { |u| retry_names.include?(u.name) }
+    logger.call("[#{locale}] escalating #{retry_units.size} failed entries to #{escalation_model}")
     retry_results = run_translation(translator, locale, retry_units, escalation_model)
-    extra_translated, _retry_missing, still_failing = apply_results(
+    extra_translated, _retry_missing, still_failing_v, still_failing_g = apply_results(
       retry_units, retry_results, by_name,
-      manifest: record_manifest, model: escalation_model, origin: 'ai-opus-retry'
+      manifest: record_manifest, model: escalation_model, origin: 'ai-opus-retry', validator: validator
     )
     translated += extra_translated
-    failed_validation = still_failing
-    logger.call("[#{locale}] escalation recovered #{extra_translated} entries; #{still_failing.size} still failing")
+    failed_validation = still_failing_v
+    failed_glossary = still_failing_g
+    logger.call("[#{locale}] escalation recovered #{extra_translated} entries; " \
+                "#{still_failing_v.size} placeholder + #{still_failing_g.size} glossary still failing")
   end
 
   wrote = write_translations!(
@@ -212,8 +226,10 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
   manifest&.save! if wrote
 
   logger.call("[#{locale}] #{wrote ? 'wrote' : 'verified (smoke, not written)'} #{output_path} " \
-              "(#{translated} keys, #{failed_missing.size} missing, #{failed_validation.size} placeholder errors)")
-  [translated, failed_missing, failed_validation]
+              "(#{translated} keys, #{failed_missing.size} missing, " \
+              "#{failed_validation.size} placeholder errors, " \
+              "#{failed_glossary.size} glossary/brand violations)")
+  [translated, failed_missing, failed_validation, failed_glossary]
 end
 
 # Install `units_for_write` at `output_path` without ever leaving a corrupt or
@@ -261,10 +277,11 @@ end
 
 # Walk units_to_translate, apply each result, and report counts. Mutates
 # the corresponding entries inside `by_name` so the caller can write them.
-def apply_results(units_to_translate, results, by_name, manifest:, model:, origin:)
+def apply_results(units_to_translate, results, by_name, manifest:, model:, origin:, validator: nil)
   translated = 0
   failed_missing = []
   failed_validation = []
+  failed_glossary = []
 
   units_to_translate.each do |u|
     src = u.entries.first[:source]
@@ -282,13 +299,22 @@ def apply_results(units_to_translate, results, by_name, manifest:, model:, origi
       next
     end
 
+    if validator
+      glossary_violations = validator.validate(source: src, translation: tx)
+      unless glossary_violations.empty?
+        failed_glossary << { name: u.name, source: src, translation: tx,
+                             violations: glossary_violations }
+        next
+      end
+    end
+
     target_unit = by_name[u.name] or next
     target_unit.entries.first[:value] = tx
     manifest&.record!(key: u.name, source: src, model: model, origin: origin)
     translated += 1
   end
 
-  [translated, failed_missing, failed_validation]
+  [translated, failed_missing, failed_validation, failed_glossary]
 end
 
 # Write-then-parse sanity check: re-read the file we just wrote and make sure
@@ -372,6 +398,13 @@ def main(argv)
   logger.call("manifest #{manifest ? "loaded (#{manifest.size} entries, #{manifest.path})" : 'disabled'}")
   escalation_model = opts[:use_escalation] ? opts[:escalation_model] : nil
 
+  # Load glossary / brand-safety validator if files exist for this locale.
+  validator = begin
+    base = File.expand_path('../glossary', __dir__)
+    WooAiTranslation::Validator.for_locale(locale: locale, base_dir: base) if Dir.exist?(base)
+  end
+  logger.call("validator loaded: brands=#{validator&.brands&.size || 0} terms=#{validator&.terms&.size || 0}") if validator
+
   out_dir = File.join(TARGET_BASE, "#{locale}.lproj")
 
   # A --limit run is a smoke test of the whole locale, not just the first file.
@@ -381,17 +414,19 @@ def main(argv)
 
   # --- Localizable.strings (the main corpus) ----------------------------
   t0 = Time.now
-  trans, missing, errors = translate_file(
+  trans, missing, errors, glossary_errors = translate_file(
     input_path: File.join(SOURCE_DIR, 'Localizable.strings'),
     output_path: File.join(out_dir, 'Localizable.strings'),
     translator: translator, locale: locale, model: opts[:model],
     limit: opts[:limit], logger: logger, incremental: opts[:incremental],
-    manifest: manifest, escalation_model: escalation_model, smoke_run: smoke_run
+    manifest: manifest, escalation_model: escalation_model,
+    validator: validator, smoke_run: smoke_run
   )
   logger.call("Localizable.strings done in #{(Time.now - t0).round(1)}s")
   total_translated = trans
   all_missing = missing
   all_errors = errors
+  all_glossary_errors = glossary_errors
 
   # --- InfoPlist.strings (16 entries, small but important) --------------
   unless opts[:skip_infoplist]
@@ -399,16 +434,18 @@ def main(argv)
     info_in = File.join(SOURCE_DIR, 'InfoPlist.strings')
     info_out = File.join(out_dir, 'InfoPlist.strings')
     if File.exist?(info_in)
-      trans, missing, errors = translate_file(
+      trans, missing, errors, glossary_errors = translate_file(
         input_path: info_in, output_path: info_out,
         translator: translator, locale: locale, model: opts[:model],
         limit: nil, logger: logger, incremental: opts[:incremental],
-        manifest: manifest, escalation_model: escalation_model, smoke_run: smoke_run
+        manifest: manifest, escalation_model: escalation_model,
+        validator: validator, smoke_run: smoke_run
       )
       logger.call("InfoPlist.strings done in #{(Time.now - t0).round(1)}s")
       total_translated += trans
       all_missing.concat(missing)
       all_errors.concat(errors)
+      all_glossary_errors.concat(glossary_errors)
     else
       logger.call("no InfoPlist.strings at #{info_in}; skipping")
     end
@@ -417,12 +454,19 @@ def main(argv)
   # --- Summary ----------------------------------------------------------
   logger.call('===== summary =====')
   logger.call("locale=#{locale} translated=#{total_translated} missing=#{all_missing.size} " \
-              "placeholder_errors=#{all_errors.size}")
+              "placeholder_errors=#{all_errors.size} glossary_violations=#{all_glossary_errors.size}")
   unless all_errors.empty?
     logger.call('---- placeholder errors (first 10) ----')
     all_errors.first(10).each do |e|
       logger.call("  #{e[:name]}: src=#{e[:source].inspect} tx=#{e[:translation].inspect}")
       logger.call("    expected=#{e[:expected]} got=#{e[:got]}")
+    end
+  end
+  unless all_glossary_errors.empty?
+    logger.call('---- glossary/brand violations (first 10) ----')
+    all_glossary_errors.first(10).each do |e|
+      logger.call("  #{e[:name]}: src=#{e[:source].inspect} tx=#{e[:translation].inspect}")
+      e[:violations].each { |v| logger.call("    #{v[:rule]}: term=#{v[:term].inspect} expected=#{v[:expected].inspect}") }
     end
   end
   unless all_missing.empty?
@@ -432,7 +476,8 @@ def main(argv)
 
   logger.call("log written to #{log_path}")
   log_io.close
-  exit(all_errors.empty? && all_missing.empty? ? 0 : 2)
+  exit_code = all_errors.empty? && all_missing.empty? && all_glossary_errors.empty? ? 0 : 2
+  exit(exit_code)
 end
 
 main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/fastlane/ai_translation/glossary/ar.yml
+++ b/fastlane/ai_translation/glossary/ar.yml
@@ -1,0 +1,7 @@
+# Arabic (ar) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ar.lproj/.
+# Note: RTL script; .right alignments need natural-alignment treatment (see swift-style.md).
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/bg.yml
+++ b/fastlane/ai_translation/glossary/bg.yml
@@ -1,0 +1,29 @@
+# Bulgarian (bg) — UI terminology mappings.
+# Register: informal mobile UI; "ти" form.
+
+ui_terms:
+  Cancel: Отказ
+  Save: Запази
+  Done: Готово
+  OK: OK
+  Close: Затвори
+  Edit: Редактирай
+  Delete: Изтрий
+  Refresh: Опресни
+  Retry: Опитай отново
+  Try Again: Опитай отново
+  Continue: Продължи
+  Loading: Зареждане
+
+nouns:
+  Orders: Поръчки
+  Products: Продукти
+  Payments: Плащания
+  Customers: Клиенти
+  Reviews: Отзиви
+  Cart: Количка
+  Address: Адрес
+  Shipping: Доставка
+  Refund: Възстановяване
+  Stock: Наличност
+  Coupons: Купони

--- a/fastlane/ai_translation/glossary/common.yml
+++ b/fastlane/ai_translation/glossary/common.yml
@@ -5,6 +5,12 @@
 #
 # Adding to this list is a hard constraint: translators (human or AI) cannot
 # transliterate or localize these terms. Remove only with stakeholder review.
+#
+# The validator matches each entry on word boundaries (a standalone token), not
+# as a bare substring. Even so, do NOT add single letters or generic dictionary
+# words (e.g. "X", "Mail", "POS", "PIN"): as standalone tokens they collide with
+# ordinary copy ("5 x 3", "Mail" the verb, "PIN" the noun) and force spurious
+# verbatim retention. Prefer the unambiguous full form ("Point of Sale").
 
 # Top-level brands
 brands:
@@ -30,7 +36,6 @@ features:
   - Blaze
   - Spark
   - Point of Sale
-  - POS
 
 # Hardware / network technologies (treated as proper nouns in UI)
 tech:
@@ -47,13 +52,11 @@ apple:
   - iPad
   - iOS
   - Safari
-  - Mail
   - Apple Maps
 
 # Other third-party services that appear verbatim
 external:
   - Google
-  - X
   - Yahoo Mail
   - Microsoft Outlook
   - DHL
@@ -66,7 +69,6 @@ standards:
   - SKU
   - URL
   - URI
-  - PIN
   - QR
   - GTIN
   - UPC

--- a/fastlane/ai_translation/glossary/common.yml
+++ b/fastlane/ai_translation/glossary/common.yml
@@ -1,0 +1,81 @@
+# Brand and product names that MUST appear verbatim in every translation,
+# regardless of target locale. The validator treats any source string
+# containing one of these names as requiring the same name to appear,
+# untranslated, in the translation.
+#
+# Adding to this list is a hard constraint: translators (human or AI) cannot
+# transliterate or localize these terms. Remove only with stakeholder review.
+
+# Top-level brands
+brands:
+  - WooCommerce
+  - Woo
+  - WordPress
+  - WordPress.com
+  - Automattic
+  - Jetpack
+
+# Payment partners and product names
+payments:
+  - Stripe
+  - PayPal
+  - Apple Pay
+  - Tap to Pay
+  - Tap to Pay on iPhone
+  - Scan to Pay
+  - WooPayments
+
+# Marketing / feature names
+features:
+  - Blaze
+  - Spark
+  - Point of Sale
+  - POS
+
+# Hardware / network technologies (treated as proper nouns in UI)
+tech:
+  - Bluetooth
+  - Wi-Fi
+  - NFC
+  - HID
+
+# Apple ecosystem (always English in third-party app UI)
+apple:
+  - Apple ID
+  - iCloud
+  - iPhone
+  - iPad
+  - iOS
+  - Safari
+  - Mail
+  - Apple Maps
+
+# Other third-party services that appear verbatim
+external:
+  - Google
+  - X
+  - Yahoo Mail
+  - Microsoft Outlook
+  - DHL
+  - UPS
+  - USPS
+  - DudaMobile
+
+# Identifiers / standards — never translated
+standards:
+  - SKU
+  - URL
+  - URI
+  - PIN
+  - QR
+  - GTIN
+  - UPC
+  - EAN
+  - ISBN
+  - HTML
+  - SMS
+  - HAZMAT
+  - AES
+  - REST API
+  - WP-Admin
+  - Application Passwords

--- a/fastlane/ai_translation/glossary/cs.yml
+++ b/fastlane/ai_translation/glossary/cs.yml
@@ -1,0 +1,29 @@
+# Czech (cs) — UI terminology mappings.
+# Register: informal mobile UI; "ty" form.
+
+ui_terms:
+  Cancel: Zrušit
+  Save: Uložit
+  Done: Hotovo
+  OK: OK
+  Close: Zavřít
+  Edit: Upravit
+  Delete: Smazat
+  Refresh: Obnovit
+  Retry: Zkusit znovu
+  Try Again: Zkusit znovu
+  Continue: Pokračovat
+  Loading: Načítání
+
+nouns:
+  Orders: Objednávky
+  Products: Produkty
+  Payments: Platby
+  Customers: Zákazníci
+  Reviews: Recenze
+  Cart: Košík
+  Address: Adresa
+  Shipping: Doprava
+  Refund: Vrácení peněz
+  Stock: Sklad
+  Coupons: Kupóny

--- a/fastlane/ai_translation/glossary/da.yml
+++ b/fastlane/ai_translation/glossary/da.yml
@@ -1,0 +1,29 @@
+# Danish (da) — UI terminology mappings.
+# Register: informal mobile UI; "du" form.
+
+ui_terms:
+  Cancel: Annuller
+  Save: Gem
+  Done: Færdig
+  OK: OK
+  Close: Luk
+  Edit: Rediger
+  Delete: Slet
+  Refresh: Opdater
+  Retry: Prøv igen
+  Try Again: Prøv igen
+  Continue: Fortsæt
+  Loading: Indlæser
+
+nouns:
+  Orders: Ordrer
+  Products: Produkter
+  Payments: Betalinger
+  Customers: Kunder
+  Reviews: Anmeldelser
+  Cart: Kurv
+  Address: Adresse
+  Shipping: Forsendelse
+  Refund: Refusion
+  Stock: Lager
+  Coupons: Kuponer

--- a/fastlane/ai_translation/glossary/de.yml
+++ b/fastlane/ai_translation/glossary/de.yml
@@ -1,0 +1,7 @@
+# German (de) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/de.lproj/.
+# Brand-safety from common.yml applies until this is filled in.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/el.yml
+++ b/fastlane/ai_translation/glossary/el.yml
@@ -1,0 +1,29 @@
+# Greek (el) — UI terminology mappings.
+# Register: polite-neutral mobile UI.
+
+ui_terms:
+  Cancel: Ακύρωση
+  Save: Αποθήκευση
+  Done: Έγινε
+  OK: OK
+  Close: Κλείσιμο
+  Edit: Επεξεργασία
+  Delete: Διαγραφή
+  Refresh: Ανανέωση
+  Retry: Δοκιμή ξανά
+  Try Again: Δοκιμή ξανά
+  Continue: Συνέχεια
+  Loading: Φόρτωση
+
+nouns:
+  Orders: Παραγγελίες
+  Products: Προϊόντα
+  Payments: Πληρωμές
+  Customers: Πελάτες
+  Reviews: Κριτικές
+  Cart: Καλάθι
+  Address: Διεύθυνση
+  Shipping: Αποστολή
+  Refund: Επιστροφή χρημάτων
+  Stock: Απόθεμα
+  Coupons: Κουπόνια

--- a/fastlane/ai_translation/glossary/es.yml
+++ b/fastlane/ai_translation/glossary/es.yml
@@ -1,0 +1,6 @@
+# Spanish (es) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/es.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/fi.yml
+++ b/fastlane/ai_translation/glossary/fi.yml
@@ -1,0 +1,29 @@
+# Finnish (fi) — UI terminology mappings.
+# Register: neutral mobile UI; usually no explicit second-person pronoun.
+
+ui_terms:
+  Cancel: Peruuta
+  Save: Tallenna
+  Done: Valmis
+  OK: OK
+  Close: Sulje
+  Edit: Muokkaa
+  Delete: Poista
+  Refresh: Päivitä
+  Retry: Yritä uudelleen
+  Try Again: Yritä uudelleen
+  Continue: Jatka
+  Loading: Ladataan
+
+nouns:
+  Orders: Tilaukset
+  Products: Tuotteet
+  Payments: Maksut
+  Customers: Asiakkaat
+  Reviews: Arvostelut
+  Cart: Ostoskori
+  Address: Osoite
+  Shipping: Toimitus
+  Refund: Hyvitys
+  Stock: Varasto
+  Coupons: Kupongit

--- a/fastlane/ai_translation/glossary/fr.yml
+++ b/fastlane/ai_translation/glossary/fr.yml
@@ -1,0 +1,6 @@
+# French (fr) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/fr.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/he.yml
+++ b/fastlane/ai_translation/glossary/he.yml
@@ -1,0 +1,7 @@
+# Hebrew (he) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/he.lproj/.
+# Note: RTL script.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/hi.yml
+++ b/fastlane/ai_translation/glossary/hi.yml
@@ -1,0 +1,30 @@
+# Hindi (hi) — UI terminology mappings (Devanagari).
+# Register: light-formal mobile UI; "आप" form.
+# Numerals: Arabic (1, 2, 3) — NOT Devanagari numerals.
+
+ui_terms:
+  Cancel: रद्द करें
+  Save: सहेजें
+  Done: हो गया
+  OK: ठीक है
+  Close: बंद करें
+  Edit: संपादित करें
+  Delete: हटाएं
+  Refresh: रीफ्रेश करें
+  Retry: पुनः प्रयास करें
+  Try Again: पुनः प्रयास करें
+  Continue: जारी रखें
+  Loading: लोड हो रहा है
+
+nouns:
+  Orders: ऑर्डर
+  Products: उत्पाद
+  Payments: भुगतान
+  Customers: ग्राहक
+  Reviews: समीक्षाएं
+  Cart: कार्ट
+  Address: पता
+  Shipping: शिपिंग
+  Refund: रिफंड
+  Stock: स्टॉक
+  Coupons: कूपन

--- a/fastlane/ai_translation/glossary/hu.yml
+++ b/fastlane/ai_translation/glossary/hu.yml
@@ -1,0 +1,29 @@
+# Hungarian (hu) — UI terminology mappings.
+# Register: formal-neutral mobile UI; magázás avoided in favor of imperatives.
+
+ui_terms:
+  Cancel: Mégse
+  Save: Mentés
+  Done: Kész
+  OK: OK
+  Close: Bezárás
+  Edit: Szerkesztés
+  Delete: Törlés
+  Refresh: Frissítés
+  Retry: Újrapróbálkozás
+  Try Again: Próbáld újra
+  Continue: Folytatás
+  Loading: Betöltés
+
+nouns:
+  Orders: Rendelések
+  Products: Termékek
+  Payments: Fizetések
+  Customers: Vásárlók
+  Reviews: Vélemények
+  Cart: Kosár
+  Address: Cím
+  Shipping: Szállítás
+  Refund: Visszatérítés
+  Stock: Készlet
+  Coupons: Kuponok

--- a/fastlane/ai_translation/glossary/id.yml
+++ b/fastlane/ai_translation/glossary/id.yml
@@ -1,0 +1,7 @@
+# Indonesian (id) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/id.lproj/.
+# Note: Bahasa Indonesia — distinct from Malay (ms.yml).
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/it.yml
+++ b/fastlane/ai_translation/glossary/it.yml
@@ -1,0 +1,6 @@
+# Italian (it) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/it.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/ja.yml
+++ b/fastlane/ai_translation/glossary/ja.yml
@@ -1,0 +1,6 @@
+# Japanese (ja) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ja.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/ko.yml
+++ b/fastlane/ai_translation/glossary/ko.yml
@@ -1,0 +1,6 @@
+# Korean (ko) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ko.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/ms.yml
+++ b/fastlane/ai_translation/glossary/ms.yml
@@ -1,0 +1,30 @@
+# Malay (ms / Bahasa Malaysia) — UI terminology mappings.
+# Register: neutral; "anda" form.
+# Note: Bahasa Malaysia, NOT Bahasa Indonesia.
+
+ui_terms:
+  Cancel: Batal
+  Save: Simpan
+  Done: Selesai
+  OK: OK
+  Close: Tutup
+  Edit: Edit
+  Delete: Padam
+  Refresh: Muat semula
+  Retry: Cuba lagi
+  Try Again: Cuba lagi
+  Continue: Teruskan
+  Loading: Memuatkan
+
+nouns:
+  Orders: Pesanan
+  Products: Produk
+  Payments: Pembayaran
+  Customers: Pelanggan
+  Reviews: Ulasan
+  Cart: Troli
+  Address: Alamat
+  Shipping: Penghantaran
+  Refund: Bayaran Balik
+  Stock: Stok
+  Coupons: Kupon

--- a/fastlane/ai_translation/glossary/nb.yml
+++ b/fastlane/ai_translation/glossary/nb.yml
@@ -1,0 +1,29 @@
+# Norwegian Bokmål (nb) — UI terminology mappings.
+# Register: informal mobile UI; "du" form.
+
+ui_terms:
+  Cancel: Avbryt
+  Save: Lagre
+  Done: Ferdig
+  OK: OK
+  Close: Lukk
+  Edit: Rediger
+  Delete: Slett
+  Refresh: Oppdater
+  Retry: Prøv igjen
+  Try Again: Prøv igjen
+  Continue: Fortsett
+  Loading: Laster
+
+nouns:
+  Orders: Bestillinger
+  Products: Produkter
+  Payments: Betalinger
+  Customers: Kunder
+  Reviews: Anmeldelser
+  Cart: Handlekurv
+  Address: Adresse
+  Shipping: Frakt
+  Refund: Refusjon
+  Stock: Lager
+  Coupons: Kuponger

--- a/fastlane/ai_translation/glossary/nl.yml
+++ b/fastlane/ai_translation/glossary/nl.yml
@@ -1,0 +1,6 @@
+# Dutch (nl) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/nl.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/pl.yml
+++ b/fastlane/ai_translation/glossary/pl.yml
@@ -1,0 +1,32 @@
+# Polish (pl) — UI terminology mappings.
+# When the source string is exactly one of these keys (case-insensitive on
+# bare words, exact on phrases), the translation MUST use the mapped value.
+#
+# Register: informal mobile UI; "ty" form.
+
+ui_terms:
+  Cancel: Anuluj
+  Save: Zapisz
+  Done: Gotowe
+  OK: OK
+  Close: Zamknij
+  Edit: Edytuj
+  Delete: Usuń
+  Refresh: Odśwież
+  Retry: Spróbuj ponownie
+  Try Again: Spróbuj ponownie
+  Continue: Kontynuuj
+  Loading: Ładowanie
+
+nouns:
+  Orders: Zamówienia
+  Products: Produkty
+  Payments: Płatności
+  Customers: Klienci
+  Reviews: Recenzje
+  Cart: Koszyk
+  Address: Adres
+  Shipping: Wysyłka
+  Refund: Zwrot
+  Stock: Stan magazynowy
+  Coupons: Kupony

--- a/fastlane/ai_translation/glossary/pt-BR.yml
+++ b/fastlane/ai_translation/glossary/pt-BR.yml
@@ -1,0 +1,7 @@
+# Brazilian Portuguese (pt-BR) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/pt-BR.lproj/.
+# Note: NOT European Portuguese — distinct locale, see pt-PT.yml.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/pt-PT.yml
+++ b/fastlane/ai_translation/glossary/pt-PT.yml
@@ -1,0 +1,31 @@
+# European Portuguese (pt-PT) — UI terminology mappings.
+# Register: informal mobile UI; "tu" form.
+# Note: NOT Brazilian Portuguese. Use "ecrã" not "tela", "ficheiro" not
+# "arquivo", "telemóvel" not "celular", "encomenda" preferred for "order".
+
+ui_terms:
+  Cancel: Cancelar
+  Save: Guardar
+  Done: Concluído
+  OK: OK
+  Close: Fechar
+  Edit: Editar
+  Delete: Eliminar
+  Refresh: Atualizar
+  Retry: Tentar novamente
+  Try Again: Tentar novamente
+  Continue: Continuar
+  Loading: A carregar
+
+nouns:
+  Orders: Encomendas
+  Products: Produtos
+  Payments: Pagamentos
+  Customers: Clientes
+  Reviews: Avaliações
+  Cart: Carrinho
+  Address: Endereço
+  Shipping: Envio
+  Refund: Reembolso
+  Stock: Stock
+  Coupons: Cupões

--- a/fastlane/ai_translation/glossary/ro.yml
+++ b/fastlane/ai_translation/glossary/ro.yml
@@ -1,0 +1,29 @@
+# Romanian (ro) — UI terminology mappings.
+# Register: informal mobile UI; "tu" form.
+
+ui_terms:
+  Cancel: Anulează
+  Save: Salvează
+  Done: Gata
+  OK: OK
+  Close: Închide
+  Edit: Editează
+  Delete: Șterge
+  Refresh: Reîmprospătează
+  Retry: Încearcă din nou
+  Try Again: Încearcă din nou
+  Continue: Continuă
+  Loading: Se încarcă
+
+nouns:
+  Orders: Comenzi
+  Products: Produse
+  Payments: Plăți
+  Customers: Clienți
+  Reviews: Recenzii
+  Cart: Coș
+  Address: Adresă
+  Shipping: Livrare
+  Refund: Rambursare
+  Stock: Stoc
+  Coupons: Cupoane

--- a/fastlane/ai_translation/glossary/ru.yml
+++ b/fastlane/ai_translation/glossary/ru.yml
@@ -1,0 +1,6 @@
+# Russian (ru) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ru.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/sv.yml
+++ b/fastlane/ai_translation/glossary/sv.yml
@@ -1,0 +1,6 @@
+# Swedish (sv) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/sv.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/th.yml
+++ b/fastlane/ai_translation/glossary/th.yml
@@ -1,0 +1,30 @@
+# Thai (th) — UI terminology mappings.
+# Register: neutral polite mobile UI. No ครับ/ค่ะ at end of UI strings.
+# Numerals: Arabic (1, 2, 3) — not Thai numerals.
+
+ui_terms:
+  Cancel: ยกเลิก
+  Save: บันทึก
+  Done: เสร็จสิ้น
+  OK: ตกลง
+  Close: ปิด
+  Edit: แก้ไข
+  Delete: ลบ
+  Refresh: รีเฟรช
+  Retry: ลองอีกครั้ง
+  Try Again: ลองอีกครั้ง
+  Continue: ดำเนินการต่อ
+  Loading: กำลังโหลด
+
+nouns:
+  Orders: คำสั่งซื้อ
+  Products: สินค้า
+  Payments: การชำระเงิน
+  Customers: ลูกค้า
+  Reviews: รีวิว
+  Cart: ตะกร้า
+  Address: ที่อยู่
+  Shipping: การจัดส่ง
+  Refund: การคืนเงิน
+  Stock: สต๊อก
+  Coupons: คูปอง

--- a/fastlane/ai_translation/glossary/tr.yml
+++ b/fastlane/ai_translation/glossary/tr.yml
@@ -1,0 +1,6 @@
+# Turkish (tr) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/tr.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/uk.yml
+++ b/fastlane/ai_translation/glossary/uk.yml
@@ -1,0 +1,29 @@
+# Ukrainian (uk) — UI terminology mappings.
+# Register: informal mobile UI; "ти" form.
+
+ui_terms:
+  Cancel: Скасувати
+  Save: Зберегти
+  Done: Готово
+  OK: OK
+  Close: Закрити
+  Edit: Редагувати
+  Delete: Видалити
+  Refresh: Оновити
+  Retry: Спробувати знову
+  Try Again: Спробуй ще раз
+  Continue: Продовжити
+  Loading: Завантаження
+
+nouns:
+  Orders: Замовлення
+  Products: Товари
+  Payments: Платежі
+  Customers: Клієнти
+  Reviews: Відгуки
+  Cart: Кошик
+  Address: Адреса
+  Shipping: Доставка
+  Refund: Повернення коштів
+  Stock: Запас
+  Coupons: Купони

--- a/fastlane/ai_translation/glossary/vi.yml
+++ b/fastlane/ai_translation/glossary/vi.yml
@@ -1,0 +1,29 @@
+# Vietnamese (vi) — UI terminology mappings.
+# Register: polite-neutral mobile UI.
+
+ui_terms:
+  Cancel: Hủy
+  Save: Lưu
+  Done: Xong
+  OK: OK
+  Close: Đóng
+  Edit: Chỉnh sửa
+  Delete: Xóa
+  Refresh: Làm mới
+  Retry: Thử lại
+  Try Again: Thử lại
+  Continue: Tiếp tục
+  Loading: Đang tải
+
+nouns:
+  Orders: Đơn hàng
+  Products: Sản phẩm
+  Payments: Thanh toán
+  Customers: Khách hàng
+  Reviews: Đánh giá
+  Cart: Giỏ hàng
+  Address: Địa chỉ
+  Shipping: Vận chuyển
+  Refund: Hoàn tiền
+  Stock: Tồn kho
+  Coupons: Phiếu giảm giá

--- a/fastlane/ai_translation/glossary/zh-Hans.yml
+++ b/fastlane/ai_translation/glossary/zh-Hans.yml
@@ -1,0 +1,6 @@
+# Simplified Chinese (zh-Hans) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/zh-Hans.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/zh-Hant.yml
+++ b/fastlane/ai_translation/glossary/zh-Hant.yml
@@ -1,0 +1,6 @@
+# Traditional Chinese (zh-Hant) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/zh-Hant.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/lib/woo_ai_translation/validator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/validator.rb
@@ -83,6 +83,11 @@ module WooAiTranslation
     # in the source, we don't also flag Woo (which is a substring of it).
     # We sort brands by length descending and mask each found occurrence so
     # subsequent (shorter) brand checks don't double-count it.
+    #
+    # Matching is word-boundary anchored (not bare substring) so a brand only
+    # counts when it stands alone as a token: "POS" must not fire inside
+    # "POSITION", nor "PIN" inside "SHIPPING". The boundary is defined against
+    # Unicode letters/digits on either side, so it holds across scripts.
     def brand_violations(source, translation)
       src = source.to_s.dup
       tx = translation.to_s
@@ -90,16 +95,24 @@ module WooAiTranslation
 
       violations = []
       sorted.each do |brand|
-        next unless src.include?(brand)
+        pattern = brand_pattern(brand)
+        next unless src.match?(pattern)
 
         # Mask this brand in the working copy so shorter brands that are
         # substrings won't trigger.
-        src.gsub!(brand, "\u0001" * brand.length)
-        next if tx.include?(brand)
+        src.gsub!(pattern, "\u0001" * brand.length)
+        next if tx.match?(pattern)
 
         violations << { rule: :brand_safety, term: brand, expected: brand }
       end
       violations
+    end
+
+    # A case-sensitive, word-boundary match for one brand. Lookbehind/lookahead
+    # reject an adjacent letter or digit so the brand must appear as a standalone
+    # token. Regexp.escape keeps dotted brands like "WordPress.com" literal.
+    def brand_pattern(brand)
+      /(?<![\p{L}\p{N}])#{Regexp.escape(brand)}(?![\p{L}\p{N}])/
     end
 
     # The glossary rule fires only when the source EQUALS a glossary key

--- a/fastlane/ai_translation/lib/woo_ai_translation/validator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/validator.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module WooAiTranslation
+  # Translation validator. Loads glossary YAMLs and applies two hard rules
+  # per translated entry:
+  #
+  #   1. Brand-safety: every brand name from `glossary/common.yml` that
+  #      appears in the source MUST appear unchanged in the translation.
+  #
+  #   2. Glossary lookup: if the source text equals a key in the per-locale
+  #      glossary's `ui_terms` or `nouns` section, the translation MUST
+  #      equal the mapped value.
+  #
+  # Returns a list of violation hashes; an empty list means the translation
+  # is acceptable. Callers (the translator pipeline) decide whether to retry
+  # or reject the entry.
+  #
+  # The validator never mutates the translation. It only reports.
+  class Validator
+    GlossaryPaths = Struct.new(:common, :locale, keyword_init: true)
+
+    class << self
+      # Load brand list + a single locale's glossary.
+      # base_dir is the directory containing `common.yml` and `<locale>.yml`.
+      def for_locale(locale:, base_dir:)
+        common_path = File.join(base_dir, 'common.yml')
+        locale_path = File.join(base_dir, "#{locale}.yml")
+        new(
+          locale: locale,
+          common: load_yaml(common_path),
+          locale_glossary: load_yaml(locale_path)
+        )
+      end
+
+      def load_yaml(path)
+        return {} unless File.exist?(path)
+
+        YAML.safe_load_file(path) || {}
+      end
+    end
+
+    attr_reader :locale, :brands, :terms
+
+    def initialize(locale:, common:, locale_glossary:)
+      @locale = locale
+      @brands = collect_brands(common)
+      @terms = collect_terms(locale_glossary)
+    end
+
+    # Validate one (source, translation) pair.
+    # Returns an array of violation hashes; empty array means OK.
+    #
+    # A violation hash has:
+    #   - :rule (:brand_safety | :glossary)
+    #   - :term (the offending term)
+    #   - :expected (the expected translation, for glossary rule)
+    def validate(source:, translation:)
+      violations = []
+      violations.concat(brand_violations(source, translation))
+      violations.concat(glossary_violations(source, translation))
+      violations
+    end
+
+    private
+
+    def collect_brands(common)
+      vals = []
+      (common || {}).each_value { |list| vals.concat(Array(list)) }
+      vals.compact.map(&:to_s).uniq
+    end
+
+    def collect_terms(glossary)
+      h = {}
+      %w[ui_terms nouns].each do |section|
+        (glossary[section] || {}).each { |k, v| h[k.to_s] = v.to_s }
+      end
+      h
+    end
+
+    # Brand-safety check with "longest match wins": when WooCommerce appears
+    # in the source, we don't also flag Woo (which is a substring of it).
+    # We sort brands by length descending and mask each found occurrence so
+    # subsequent (shorter) brand checks don't double-count it.
+    def brand_violations(source, translation)
+      src = source.to_s.dup
+      tx = translation.to_s
+      sorted = @brands.sort_by { |b| -b.length }
+
+      violations = []
+      sorted.each do |brand|
+        next unless src.include?(brand)
+
+        # Mask this brand in the working copy so shorter brands that are
+        # substrings won't trigger.
+        src.gsub!(brand, "\u0001" * brand.length)
+        next if tx.include?(brand)
+
+        violations << { rule: :brand_safety, term: brand, expected: brand }
+      end
+      violations
+    end
+
+    # The glossary rule fires only when the source EQUALS a glossary key
+    # (case-insensitive, trimmed). This is intentionally narrow: short UI
+    # labels like "Cancel" or "Orders" should always map to the canonical
+    # term, but free-form sentences that happen to contain "orders" as a
+    # substring are not constrained.
+    def glossary_violations(source, translation)
+      key = source.to_s.strip
+      lookup = @terms.find { |term, _| term.downcase == key.downcase }
+      return [] unless lookup
+
+      expected = lookup.last
+      return [] if translation.to_s.strip == expected
+
+      [{ rule: :glossary, term: lookup.first, expected: expected }]
+    end
+  end
+end

--- a/fastlane/ai_translation/spec/translate_locale_test.rb
+++ b/fastlane/ai_translation/spec/translate_locale_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'tmpdir'
 require 'fileutils'
+require 'json'
 require_relative '../bin/translate_locale'
 
 # Regression coverage for the two data-loss bugs fixed in the engine PR:
@@ -45,8 +46,27 @@ class TranslateLocaleTest < Minitest::Test
   end
 
   FakeTranslator = Struct.new(:mapping) do
-    def translate(locale:, items:, model:)
+    def translate(locale:, items:, model:, style: nil)
+      _ = style # accepted to match the real translator signature; intentionally ignored
       items.to_h { |i| [i[:id], mapping.fetch(i[:id], "#{i[:source]}::#{locale}::#{model}")] }
+    end
+  end
+
+  # Records the system blocks it is handed and echoes each source back as its
+  # translation (covering every id, so the Translator never splits/retries).
+  # Used to prove the style guide reaches the per-locale system prompt block.
+  class RecordingClient
+    attr_reader :captured_system_blocks
+
+    def initialize
+      @captured_system_blocks = []
+    end
+
+    def complete(model:, system_blocks:, user_content:)
+      _ = model
+      @captured_system_blocks << system_blocks
+      payload = JSON.parse(user_content.lines.last)
+      JSON.generate(payload.to_h { |item| [item['id'], item['source']] })
     end
   end
 
@@ -264,5 +284,43 @@ class TranslateLocaleTest < Minitest::Test
     reparsed = WooAiTranslation::IosResources::Parser.parse_file(output)
     assert_equal Set.new(%w[a b c]), Set.new(reparsed.units.map(&:name))
     assert_empty tmp_artifacts_in(@dir)
+  end
+
+  # --- style guides reach the prompt -----------------------------------------
+
+  def test_load_style_guide_prefers_locale_specific_file
+    # 'pl' ships a style/pl.md guide.
+    path, text = load_style_guide('pl')
+    assert_equal 'pl.md', File.basename(path)
+    refute_empty text
+  end
+
+  def test_load_style_guide_falls_back_to_default
+    # 'zz' has no style file, so the default guide is used.
+    path, text = load_style_guide('zz')
+    assert_equal 'default.md', File.basename(path)
+    refute_empty text
+  end
+
+  def test_translate_file_threads_style_guide_into_system_prompt
+    # Given an EN source and a style guide string.
+    en = write_strings(File.join(@dir, 'en.strings'), [%w[a Cancel], %w[b Save]])
+    output = File.join(@dir, 'Localizable.strings')
+    client = RecordingClient.new
+    translator = WooAiTranslation::Translator.new(client: client, batch_size: 40, logger: NOOP_LOGGER)
+    style_text = 'STYLE-GUIDE-MARKER: prefer the formal register.'
+
+    # When we translate with that style guide threaded in.
+    translate_file(
+      input_path: en, output_path: output,
+      translator: translator, locale: 'pl', model: 'm',
+      limit: nil, logger: NOOP_LOGGER, incremental: false,
+      manifest: nil, escalation_model: nil, style: style_text
+    )
+
+    # Then the guide text lands in the per-locale system block of the prompt.
+    refute_empty client.captured_system_blocks
+    joined = client.captured_system_blocks.flatten.join("\n")
+    assert_includes joined, style_text
   end
 end

--- a/fastlane/ai_translation/spec/validator_test.rb
+++ b/fastlane/ai_translation/spec/validator_test.rb
@@ -103,4 +103,59 @@ class ValidatorTest < Minitest::Test
     assert_equal 'Anuluj', @v.terms['Cancel']
     assert_equal 'Zamówienia', @v.terms['Orders']
   end
+
+  # --- Word-boundary brand matching (regression for substring false positives) ---
+
+  def test_brand_safety_ignores_brand_as_substring_of_a_larger_word
+    # "Woo" is a brand, but here it only appears inside "Wood" — not a standalone
+    # token. Bare-substring matching used to flag this and demand "Woo" in the
+    # translation; word-boundary matching must let it pass.
+    out = @v.validate(source: 'Wood paneling', translation: 'Panele drewniane')
+    assert_empty out
+  end
+
+  def test_brand_safety_still_flags_standalone_brand_with_adjacent_punctuation
+    # Punctuation is a boundary, so "(WooCommerce)" is still a standalone token.
+    out = @v.validate(source: 'Open (WooCommerce)', translation: 'Otwórz (sklep)')
+    assert_equal 1, out.size
+    assert_equal 'WooCommerce', out.first[:term]
+  end
+
+  def test_brand_safety_passes_when_standalone_brand_preserved_with_punctuation
+    out = @v.validate(source: 'Open (WooCommerce)', translation: 'Otwórz (WooCommerce)')
+    assert_empty out
+  end
+
+  # --- Real shipped glossary: generic tokens were pruned (Finding A) ----------
+
+  REAL_GLOSSARY_DIR = File.expand_path('../glossary', __dir__)
+
+  # 'zz' has no per-locale glossary file, so the validator applies only the
+  # real common.yml brand rules — isolating these tests to brand-safety.
+  def real_common_validator(locale: 'zz')
+    WooAiTranslation::Validator.for_locale(locale: locale, base_dir: REAL_GLOSSARY_DIR)
+  end
+
+  def test_real_common_glossary_excludes_generic_substring_tokens
+    brands = real_common_validator.brands
+    %w[X Mail POS PIN].each do |token|
+      refute_includes brands, token, "#{token.inspect} must stay out of common.yml: it collides with ordinary copy"
+    end
+  end
+
+  def test_real_common_glossary_keeps_unambiguous_brands
+    brands = real_common_validator.brands
+    assert_includes brands, 'WooCommerce'
+    assert_includes brands, 'Point of Sale'
+  end
+
+  def test_real_common_glossary_does_not_flag_words_containing_dropped_tokens
+    v = real_common_validator
+    # Each source embeds a pruned token as a substring (PIN⊂SHIPPING, POS⊂Position,
+    # Mail⊂Email) or as a bare letter (X). None should raise a brand violation.
+    assert_empty v.validate(source: 'SHIPPING ADDRESS', translation: 'ENDEREÇO DE ENVIO')
+    assert_empty v.validate(source: 'Position', translation: 'Posição')
+    assert_empty v.validate(source: 'Email address', translation: 'Endereço de email')
+    assert_empty v.validate(source: 'Size: 5 x 3', translation: 'Tamanho: 5 x 3')
+  end
 end

--- a/fastlane/ai_translation/spec/validator_test.rb
+++ b/fastlane/ai_translation/spec/validator_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require_relative '../lib/woo_ai_translation/validator'
+
+class ValidatorTest < Minitest::Test
+  def setup
+    @dir = Dir.mktmpdir
+    File.write(File.join(@dir, 'common.yml'), <<~YAML)
+      brands:
+        - WooCommerce
+        - Woo
+      payments:
+        - Stripe
+        - Apple Pay
+    YAML
+    File.write(File.join(@dir, 'pl.yml'), <<~YAML)
+      ui_terms:
+        Cancel: Anuluj
+        Save: Zapisz
+      nouns:
+        Orders: Zamówienia
+    YAML
+    @v = WooAiTranslation::Validator.for_locale(locale: 'pl', base_dir: @dir)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir) if @dir && File.exist?(@dir)
+  end
+
+  def test_brand_safety_passes_when_brand_preserved
+    out = @v.validate(source: 'Connect WooCommerce', translation: 'Połącz WooCommerce')
+    assert_empty out
+  end
+
+  def test_brand_safety_fails_when_brand_translated_or_dropped
+    out = @v.validate(source: 'Connect WooCommerce', translation: 'Połącz sklep')
+    assert_equal 1, out.size
+    assert_equal :brand_safety, out.first[:rule]
+    assert_equal 'WooCommerce', out.first[:term]
+  end
+
+  def test_brand_safety_catches_multi_word_brand
+    out = @v.validate(source: 'Configure Apple Pay', translation: 'Skonfiguruj Płatność Apple')
+    assert_equal 1, out.size
+    assert_equal 'Apple Pay', out.first[:term]
+  end
+
+  def test_glossary_enforces_canonical_term_when_source_equals_key
+    out = @v.validate(source: 'Cancel', translation: 'Wstecz')
+    assert_equal 1, out.size
+    assert_equal :glossary, out.first[:rule]
+    assert_equal 'Cancel', out.first[:term]
+    assert_equal 'Anuluj', out.first[:expected]
+  end
+
+  def test_glossary_accepts_canonical_translation
+    out = @v.validate(source: 'Cancel', translation: 'Anuluj')
+    assert_empty out
+  end
+
+  def test_glossary_case_insensitive_key_match
+    out = @v.validate(source: 'cancel', translation: 'Anuluj')
+    assert_empty out
+  end
+
+  def test_glossary_only_enforces_on_exact_source_match
+    # "Cancel order" contains "Cancel" but is not the glossary key — no enforcement
+    out = @v.validate(source: 'Cancel order', translation: 'Anuluj zamówienie')
+    assert_empty out
+  end
+
+  def test_glossary_picks_up_nouns_section
+    out = @v.validate(source: 'Orders', translation: 'Zamowienia') # missing diacritic
+    assert_equal 1, out.size
+    assert_equal 'Orders', out.first[:term]
+    assert_equal 'Zamówienia', out.first[:expected]
+  end
+
+  def test_multiple_brand_violations_reported
+    out = @v.validate(source: 'WooCommerce + Stripe + Apple Pay', translation: 'Sklep + Pasek + Płatność')
+    assert_equal 3, out.size
+    rules = out.map { |v| v[:rule] }.uniq
+    assert_equal [:brand_safety], rules
+  end
+
+  def test_missing_glossary_file_falls_back_to_brands_only
+    v = WooAiTranslation::Validator.for_locale(locale: 'xx', base_dir: @dir)
+    assert_empty v.validate(source: 'Cancel', translation: 'whatever')
+    out = v.validate(source: 'WooCommerce', translation: 'sklep')
+    assert_equal 1, out.size
+    assert_equal :brand_safety, out.first[:rule]
+  end
+
+  def test_brands_list_collected_across_yaml_sections
+    assert_includes @v.brands, 'WooCommerce'
+    assert_includes @v.brands, 'Stripe'
+    assert_includes @v.brands, 'Apple Pay'
+  end
+
+  def test_terms_collected_from_ui_terms_and_nouns
+    assert_equal 'Anuluj', @v.terms['Cancel']
+    assert_equal 'Zamówienia', @v.terms['Orders']
+  end
+end

--- a/fastlane/ai_translation/style/bg.md
+++ b/fastlane/ai_translation/style/bg.md
@@ -1,0 +1,13 @@
+# Bulgarian (bg) — Translation style guide
+
+**Register:** Informal mobile UI. "Ти" form / 2nd person singular informal.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, direct.
+
+**Common pitfalls:**
+- Cyrillic script — never transliterate
+- Definite article is a suffix (-та, -ът, -то); don't add separate "the"
+- "Order" → "Поръчка"; verb "поръчвам"

--- a/fastlane/ai_translation/style/cs.md
+++ b/fastlane/ai_translation/style/cs.md
@@ -1,0 +1,13 @@
+# Czech (cs) — Translation style guide
+
+**Register:** Informal mobile UI. "Ty" form / 2nd person singular informal.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, direct, brief.
+
+**Common pitfalls:**
+- "Order" → "Objednávka"; verbal forms "objednat" (place an order)
+- "Refund" → "Vrácení peněz" (not "Refundace")
+- Diacritics matter — never strip them

--- a/fastlane/ai_translation/style/da.md
+++ b/fastlane/ai_translation/style/da.md
@@ -1,0 +1,13 @@
+# Danish (da) — Translation style guide
+
+**Register:** Informal mobile UI. "Du" form / 2nd person singular informal.
+**Quotation marks:** "..." or »...«
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, casual, short.
+
+**Common pitfalls:**
+- "Order" → "Ordre" (mobile UI) or "Bestilling" (older convention); prefer "Ordre" for consistency
+- æ/ø/å must be preserved (UTF-8 multi-byte)
+- "San Marino" stays English (the country name itself)

--- a/fastlane/ai_translation/style/default.md
+++ b/fastlane/ai_translation/style/default.md
@@ -1,0 +1,17 @@
+# Default style guide
+
+Fallback when no per-locale style guide is provided.
+
+**Tone:** Concise, friendly, action-oriented. Match the tone of modern mobile commerce apps.
+
+**Register:** Use whichever 2nd-person register is conventional for the target locale's mobile-app ecosystem. Avoid formal honorifics unless required (e.g., legal disclaimers).
+
+**Numerals:** Arabic digits (1, 2, 3). Do not localize to script-specific numeral systems (e.g., Devanagari १२३, Thai ๑๒๓) — the app's number formatting expects Arabic input.
+
+**Brands:** Keep all brand names verbatim — see `glossary/common.yml`.
+
+**Placeholders:** Preserve every `%@`, `%1$@`, `%d`, `%.0f`, `\n`, `\t`, etc. exactly. Never reorder positional placeholders.
+
+**Markup:** Preserve HTML tags (`<b>`, `<a href="...">`, `</a>`) and their attributes. Translate only the visible text inside them.
+
+**Length:** Aim for translations close to the source length. Mobile UI has limited space.

--- a/fastlane/ai_translation/style/el.md
+++ b/fastlane/ai_translation/style/el.md
@@ -1,0 +1,13 @@
+# Greek (el) — Translation style guide
+
+**Register:** Polite-neutral mobile UI. Mostly impersonal or 2nd person plural where address is needed.
+**Quotation marks:** «...» (guillemets)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Direct, modern, concise.
+
+**Common pitfalls:**
+- Distinguish "Customer" (Πελάτης) and "User" (Χρήστης)
+- "Refresh" → "Ανανέωση" (always, not "Φόρτωση")
+- Use polytonic only where standard requires; UI is monotonic Greek

--- a/fastlane/ai_translation/style/fi.md
+++ b/fastlane/ai_translation/style/fi.md
@@ -1,0 +1,13 @@
+# Finnish (fi) — Translation style guide
+
+**Register:** Neutral mobile UI. Usually no explicit second-person pronoun ("Sinä" only when emphasizing).
+**Quotation marks:** "..." (curly) or »...«
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1,99)
+
+**Tone:** Direct, concise. Finnish is often briefer than English.
+
+**Common pitfalls:**
+- Compound nouns (tilauksenseuranta = order tracking) — write as one word
+- Case suffixes change frequently; don't hand-stitch placeholders into inflected words without an explanatory context
+- "Refresh" → "Päivitä" (not "Lataa uudelleen")

--- a/fastlane/ai_translation/style/hi.md
+++ b/fastlane/ai_translation/style/hi.md
@@ -1,0 +1,16 @@
+# Hindi (hi) — Translation style guide
+
+**Register:** Light-formal mobile UI. "आप" form / formal you (avoid "तुम").
+**Script:** Devanagari (देवनागरी)
+**Quotation marks:** "..." (English-style)
+**Numerals:** Arabic (1, 2, 3) — NOT Devanagari numerals (१२३). The app's numeric formatting expects Arabic.
+**Decimals:** period (.)
+
+**Tone:** Direct, modern, action-oriented. Avoid heavy Sanskrit-derived vocabulary; prefer commonly-spoken Hindi.
+
+**Common pitfalls:**
+- DON'T use Hindi numerals (१२३) — they look "wrong" in mixed-numeral UI contexts
+- Brand names stay English: never transliterate "WooCommerce" to "वूकॉमर्स"
+- "Order" → "ऑर्डर" (transliteration is standard, "आदेश" sounds archaic)
+- Avoid गणक-style hyper-formal Sanskrit — keep it casual professional
+- सहायता (help) vs मदद (informal help) — use मदद for buttons

--- a/fastlane/ai_translation/style/hu.md
+++ b/fastlane/ai_translation/style/hu.md
@@ -1,0 +1,13 @@
+# Hungarian (hu) — Translation style guide
+
+**Register:** Formal-neutral mobile UI. Magázás (formal you) avoided; prefer imperatives or impersonal phrasing.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Direct, no contractions, action-focused.
+
+**Common pitfalls:**
+- "Order" → "Rendelés" (NOT "Megrendelés" except in formal contexts)
+- Capitalize only first letter of sentence, not every word
+- Avoid the English-style "Click here" — use "Tap here" → "Koppints ide" if needed

--- a/fastlane/ai_translation/style/ms.md
+++ b/fastlane/ai_translation/style/ms.md
@@ -1,0 +1,19 @@
+# Malay (ms / Bahasa Malaysia) — Translation style guide
+
+**Register:** Neutral mobile UI. "Anda" form.
+**Quotation marks:** "..." (English-style)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** period (.)
+
+**Tone:** Direct, modern, brief.
+
+**Common pitfalls:**
+- This is **Bahasa Malaysia**, NOT Bahasa Indonesia. Diverge intentionally:
+  - "kedai" (Malay) not "toko" (Indonesian)
+  - "pesanan" (Malay) not "pesan" (Indonesian as noun)
+  - "kemas kini" (Malay) not "perbarui" (Indonesian)
+  - "pemalam" not "plugin"
+  - "pemberitahuan tolak" for push notifications
+  - "kebenaran" not "izin" for permission
+- Plurals: don't inflect — "1 minggu" and "2 minggu" both use "minggu"
+- Verb stem changes: "membayar" (to pay) vs "bayaran" (payment, noun)

--- a/fastlane/ai_translation/style/nb.md
+++ b/fastlane/ai_translation/style/nb.md
@@ -1,0 +1,13 @@
+# Norwegian Bokmål (nb) — Translation style guide
+
+**Register:** Informal mobile UI. "Du" form / 2nd person singular informal.
+**Quotation marks:** "..." or «...»
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, casual.
+
+**Common pitfalls:**
+- "Order" → "Bestilling" (preferred over "Ordre" in Norwegian iOS apps)
+- æ/ø/å must be preserved
+- This is Bokmål, NOT Nynorsk; if there's any doubt, use Bokmål forms

--- a/fastlane/ai_translation/style/pl.md
+++ b/fastlane/ai_translation/style/pl.md
@@ -1,0 +1,13 @@
+# Polish (pl) — Translation style guide
+
+**Register:** Informal mobile UI. Direct address using imperatives or "ty" form.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1,99)
+
+**Tone:** Concise, friendly, action-oriented. Avoid formal "Pan/Pani" except where clearly business-customer (e.g., legal disclaimers).
+
+**Common pitfalls:**
+- "Order" → "Zamówienie" (NOT "Polecenie")
+- "Cart" → "Koszyk" (always)
+- Gender agreement matters: match adjectives to noun gender

--- a/fastlane/ai_translation/style/pt-PT.md
+++ b/fastlane/ai_translation/style/pt-PT.md
@@ -1,0 +1,27 @@
+# European Portuguese (pt-PT) — Translation style guide
+
+**Register:** Informal mobile UI. "Tu" form / 2nd person singular informal.
+**Quotation marks:** "..." or «...»
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1,99)
+
+**Tone:** Friendly, modern, direct. Consistent with WordPress.com mobile app style.
+
+**This is European Portuguese — NOT Brazilian.** Diverge intentionally:
+
+- "ecrã" not "tela" (screen)
+- "telemóvel" not "celular" (mobile phone)
+- "ficheiro" not "arquivo" (file)
+- "rato" not "mouse" (cursor)
+- "stock" kept English (Brazilian uses "estoque")
+- "encomenda" preferred for "order" (Brazilian "pedido")
+- "subscrição" not "assinatura" (subscription)
+- "cupão" not "cupom" (coupon)
+- "palavra-passe" not "senha" (password)
+- "ligação" can mean both "connection" and "link" — use "hiperligação" for clarity in link contexts
+- "endereço" for address
+- "Estás" not "Você está" (informal you, 2nd person singular present)
+
+**Verb forms (2nd person singular informal):** tens, queres, podes, introduz, verifica, aguarda, tenta, contacta
+
+**Gender agreement:** "encomenda" is feminine — "paga", "concluída"

--- a/fastlane/ai_translation/style/ro.md
+++ b/fastlane/ai_translation/style/ro.md
@@ -1,0 +1,13 @@
+# Romanian (ro) — Translation style guide
+
+**Register:** Informal mobile UI. "Tu" form / 2nd person singular informal.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, modern. Use diacritics correctly (ă, â, î, ș, ț).
+
+**Common pitfalls:**
+- "Cart" → "Coș" (with diacritic, not "Cos")
+- Distinguish "ș" (s-comma) from "ş" (s-cedilla); use s-comma (Unicode 0219)
+- "Order" → "Comandă"; verbal "a comanda" (to order)

--- a/fastlane/ai_translation/style/th.md
+++ b/fastlane/ai_translation/style/th.md
@@ -1,0 +1,18 @@
+# Thai (th) — Translation style guide
+
+**Register:** Neutral polite mobile UI. NO polite-particle ครับ/ค่ะ at end of UI strings.
+**Script:** Thai (ภาษาไทย)
+**Quotation marks:** "..." (English-style) or "..." (curly)
+**Numerals:** Arabic (1, 2, 3) — NOT Thai numerals (๑๒๓).
+**Decimals:** period (.)
+
+**Tone:** Direct, modern. Often omit the second-person pronoun (คุณ) where context is clear.
+
+**Common pitfalls:**
+- DON'T add ครับ/ค่ะ to button labels or short UI strings — they're for spoken/email contexts
+- DON'T use Thai numerals — Arabic only for app UI
+- No spaces between Thai words (Thai uses spaces only between phrases/sentences)
+- Brand names stay English: WooCommerce, Tap to Pay, etc.
+- "Order" → "คำสั่งซื้อ" (formal) or "ออเดอร์" (transliterated, slangy — avoid in UI)
+- "Cancel" → "ยกเลิก" (always)
+- "Refresh" → "รีเฟรช" or "โหลดใหม่" — prefer "รีเฟรช" for short UI

--- a/fastlane/ai_translation/style/uk.md
+++ b/fastlane/ai_translation/style/uk.md
@@ -1,0 +1,14 @@
+# Ukrainian (uk) — Translation style guide
+
+**Register:** Informal mobile UI. "Ти" form / 2nd person singular informal.
+**Quotation marks:** „..." or «...»
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, direct.
+
+**Common pitfalls:**
+- Cyrillic (Ukrainian variant — has і, ї, є, ґ that Russian does not)
+- "Order" → "Замовлення"
+- Apostrophe is U+02BC (modifier letter), not straight quote
+- DO NOT use Russian (ру/Ы/Э/Ъ); this is Ukrainian only

--- a/fastlane/ai_translation/style/vi.md
+++ b/fastlane/ai_translation/style/vi.md
@@ -1,0 +1,13 @@
+# Vietnamese (vi) — Translation style guide
+
+**Register:** Polite-neutral mobile UI. Omit second-person pronouns where possible.
+**Quotation marks:** "..." (English-style)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1.000,99)
+
+**Tone:** Direct, brief, modern.
+
+**Common pitfalls:**
+- All diacritic marks must be preserved (Vietnamese is fully accented)
+- "Order" → "Đơn hàng"; "Place order" → "Đặt đơn hàng" / "Đặt hàng"
+- Don't use Sino-Vietnamese where modern Vietnamese reads better in UI


### PR DESCRIPTION
## Description

PR 3 of the AI translation series. Stacked on [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221) (engine) — please merge that one first.

Adds the per-locale **glossaries** and **style guides** that prevent terminology drift across PRs, plus the **brand-safety validator** that enforces them at translation time.

### What ships

**`glossary/common.yml`** — 49 brand and product names that must NEVER be translated:
- Brands: WooCommerce, Woo, WordPress, WordPress.com, Automattic, Jetpack
- Payments: Stripe, PayPal, Apple Pay, Tap to Pay, Tap to Pay on iPhone, Scan to Pay, WooPayments
- Features: Blaze, Spark, Point of Sale
- Tech: Bluetooth, Wi-Fi, NFC, HID
- Apple ecosystem: Apple ID, iCloud, iPhone, iPad, iOS, Safari, Apple Maps
- External: Google, Yahoo Mail, Microsoft Outlook, DHL, UPS, USPS, DudaMobile
- Standards: SKU, URL, URI, QR, GTIN, UPC, EAN, ISBN, HTML, SMS, HAZMAT, AES, REST API, WP-Admin, Application Passwords

**`glossary/<locale>.yml`** × 31 — Per-locale UI terminology and noun mappings:

| Status | Locales | What |
|--------|---------|------|
| 🟢 Rich | 15 new: `pl cs el hu ro vi bg da fi nb uk hi ms pt-PT th` | ~23 mappings each, seeded from the sub-agent prompts that produced [#17220](https://github.com/woocommerce/woocommerce-ios/pull/17220). |
| 🟡 Stub | 16 existing: `de es fr it ja ko nl pt-BR ru sv tr zh-Hans zh-Hant ar he id` | Empty `ui_terms`/`nouns`; brand-safety still applies. TODO to derive from existing translations. |

**`style/<locale>.md`** × 15 new locales + `style/default.md` fallback — Register, formality, numerals, quotation conventions. Notable highlights:

- `pt-PT.md` flags every divergence from Brazilian (`ecrã` not `tela`, `encomenda` not `pedido`, etc.)
- `ms.md` lists every Bahasa Malaysia vs Bahasa Indonesia divergence
- `hi.md` explicitly forbids Devanagari numerals (use Arabic 1,2,3)
- `th.md` forbids polite-particle `ครับ`/`ค่ะ` at end of UI strings

**`lib/woo_ai_translation/validator.rb`** — Two hard validators:

1. **Brand-safety**: if source contains a brand from `common.yml`, translation MUST contain the same brand. Matching is **word-boundary anchored** (case-sensitive), so a brand only triggers as a standalone token — `Spark` won't fire inside another word and dotted brands like `WordPress.com` stay literal. Longest-match-wins ordering means `WooCommerce` doesn't double-trigger `Woo`.
2. **Glossary**: if source string equals a glossary key (case-insensitive), translation MUST equal the mapped value. Substring matches are ignored — `Cancel` is enforced, `Cancel order` is not.

**`bin/translate_locale.rb`** — Auto-loads the locale's glossary **and style guide** at startup. The style guide (`style/<locale>.md`, falling back to `style/default.md`) is threaded into the translator as the last system block, so it's prompt-cached across every batch call. Each batch's output runs through the validator; failures land in a new `glossary_violations` summary line and produce a non-zero exit code.

### Tests

```
spec/validator_test.rb          18 tests, 60 assertions, all green
spec/byte_sizer_test.rb         9 tests (no change from PR 2)
spec/ios_resources_test.rb      28 tests (no change from PR 2)
```

### Smoke test

```bash
$ ruby fastlane/ai_translation/bin/translate_locale.rb pl --offline --limit 3 \
       --skip-infoplist
[...] validator loaded: brands=49 terms=23
[...] style guide loaded from pl.md (528 chars)
[...] locale=pl translated=3 missing=0 placeholder_errors=0 glossary_violations=0
```

### Out of scope

- Filling the 16 GlotPress-locale stubs from existing translations. Mechanical but tedious; flagged in TODOs at the top of each stub file.
- Length-budget and Markdown-integrity validators (the other two from the original 4-validator plan). Placeholder + glossary cover the highest-risk failure modes; length/Markdown can land later when needed.

### Follow-up PRs

| # | Branch | Status |
|---|--------|--------|
| 1 | `ai-translations/cutover` | [#17220](https://github.com/woocommerce/woocommerce-ios/pull/17220) — 15 locale translations |
| 2 | `ai-translations/engine` | [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221) — engine + Rake tasks |
| 3 | `ai-translations/glossaries` | **this PR** |
| 4 | `ai-translations/ci` | next — Buildkite step, post-release health report |

## Test Steps

1. Pull the branch.
2. Run validator tests:
   ```bash
   ruby fastlane/ai_translation/spec/validator_test.rb
   ```
3. Smoke-test integration:
   ```bash
   ruby fastlane/ai_translation/bin/translate_locale.rb pl --offline \
        --limit 3 --skip-infoplist
   ```
   Should print `validator loaded: brands=49 terms=23` and `glossary_violations=0`.
4. (Optional) Inspect a few glossary YAMLs to sanity-check terminology choices.

## Release Notes

No user-facing changes; engine + content only.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
