### PR TITLE
QR-login [1/7]: Networking layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ DerivedData/
 # entry catches stray copies that may end up elsewhere in the tree.
 ApiCredentials.swift
 
+# Files generated into WooCommerce/DerivedSources by build phases
+# (e.g. InfoPlist.h, bash_secrets). Only README.md is tracked.
+WooCommerce/DerivedSources/*
+!WooCommerce/DerivedSources/README.md
+
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -40,6 +40,7 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case pointOfSaleMarkOrderAsPaid
     case wooAIAssistant
     case arParcelFitting
+    case qrCodeLogin
 
     init?(rawValue: String) {
         switch rawValue {
@@ -69,6 +70,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .wooAIAssistant
         case "woo_ar_parcel_fitting":
             self = .arParcelFitting
+        case "woo_qr_code_login":
+            self = .qrCodeLogin
         default:
             return nil
         }

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginDTOs.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginDTOs.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+// The QR-login data layer is endpoint-shaped: each `Decodable` struct mirrors
+// exactly one endpoint's response contract. The self-hosted endpoints (the
+// merchant's WooCommerce plugin) and the wp.com endpoints (public-api.wordpress.com)
+// are owned by separate backends, so they get separate types even where the
+// shapes currently overlap — a match by convergent design, not a shared contract.
+//
+// The single exception is `QRLoginScanDevice`: it is request-side data the
+// client knows about itself, identical regardless of endpoint.
+
+// MARK: - Self-hosted responses
+
+/// Response of `POST {siteURL}/wp-json/wc-admin/mobile-app/qr-login-scan` (spec §5.1.1).
+///
+/// All fields are required; a missing or blank value makes the whole response
+/// malformed. The self-hosted scan carries no user identity — unlike wp.com,
+/// the merchant's own server has no wp.com email to return.
+public struct SelfHostedQRLoginScanResponse: Equatable {
+    public let sessionID: String
+    public let realNumber: String
+    public let expiresInSeconds: Int
+
+    public init(sessionID: String, realNumber: String, expiresInSeconds: Int) {
+        self.sessionID = sessionID
+        self.realNumber = realNumber
+        self.expiresInSeconds = expiresInSeconds
+    }
+}
+
+/// Response of `GET {siteURL}/wp-json/wc-admin/mobile-app/qr-login-session-status` (spec §5.1.2).
+public struct SelfHostedQRLoginSessionStatus: Equatable {
+    /// The states the self-hosted endpoint can report. It has no `consumed`
+    /// state — that "already signed in elsewhere" terminal is wp.com-only.
+    public enum State: String, Equatable {
+        case scanned
+        case approved
+        case rejected
+        case expired   // terminal "timed out"
+        case unknown   // any value the client doesn't recognise — treated defensively as expired
+    }
+
+    public let state: State
+
+    /// Only populated when `state == .approved`. A blank/missing value while
+    /// `state == .approved` MUST be treated as `expired` ("fail closed") by the
+    /// consumer (spec §5.1.2).
+    public let exchangeGrant: String?
+
+    public init(state: State, exchangeGrant: String?) {
+        self.state = state
+        self.exchangeGrant = exchangeGrant
+    }
+}
+
+/// Response of `POST {siteURL}/wp-json/wc-admin/mobile-app/qr-login-exchange` (spec §5.1.3).
+///
+/// Carries the freshly minted Application Password. All fields are required.
+public struct SelfHostedQRLoginExchangeResponse: Equatable {
+    public let userLogin: String
+    public let siteURL: String
+    public let applicationPassword: String
+
+    public init(userLogin: String, siteURL: String, applicationPassword: String) {
+        self.userLogin = userLogin
+        self.siteURL = siteURL
+        self.applicationPassword = applicationPassword
+    }
+}
+
+// MARK: - WP.com responses
+
+/// Response of `POST /wpcom/v2/auth/qr-code-app/scan` (spec §5.2.1).
+///
+/// Unlike the self-hosted scan, the wp.com endpoint also returns the signed-in
+/// user's wp.com email for the number-match screen. All fields are required.
+public struct WPComQRLoginScanResponse: Equatable {
+    public let sessionID: String
+    public let realNumber: String
+    public let expiresInSeconds: Int
+    public let userEmail: String
+
+    public init(sessionID: String, realNumber: String, expiresInSeconds: Int, userEmail: String) {
+        self.sessionID = sessionID
+        self.realNumber = realNumber
+        self.expiresInSeconds = expiresInSeconds
+        self.userEmail = userEmail
+    }
+}
+
+/// Response of `GET /wpcom/v2/auth/qr-code-app/session-status` (spec §5.2.2).
+public struct WPComQRLoginSessionStatus: Equatable {
+    /// The states the wp.com endpoint can report. `consumed` ("already signed
+    /// in elsewhere") is wp.com-only.
+    public enum State: String, Equatable {
+        case scanned
+        case approved
+        case rejected
+        case expired   // terminal "timed out"
+        case consumed  // terminal "already signed in elsewhere"
+        case unknown   // any value the client doesn't recognise — treated defensively as expired
+    }
+
+    public let state: State
+
+    /// Only populated when `state == .approved`. A blank/missing value while
+    /// `state == .approved` MUST be treated as `expired` ("fail closed") by the
+    /// consumer (spec §5.2.2).
+    public let exchangeGrant: String?
+
+    public init(state: State, exchangeGrant: String?) {
+        self.state = state
+        self.exchangeGrant = exchangeGrant
+    }
+}
+
+/// Response of `POST /wpcom/v2/auth/qr-code-app/exchange` (spec §5.2.3).
+///
+/// Carries a magic-link URL the app opens to finish wp.com sign-in.
+public struct WPComQRLoginExchangeResponse: Equatable {
+    public let magicLinkURL: URL
+
+    public init(magicLinkURL: URL) {
+        self.magicLinkURL = magicLinkURL
+    }
+}
+
+// MARK: - Shared request payload
+
+/// Device metadata sent on both `/scan` requests (spec §5.1.1 / §5.2.1).
+///
+/// This is the one QR-login data type genuinely shared by both protocols: it is
+/// request-side data the client knows about itself, so it carries the same
+/// shape no matter which endpoint receives it. Each field is whitelisted and
+/// capped server-side; values outside the whitelist are silently dropped.
+public struct QRLoginScanDevice: Equatable {
+    public let os: String
+    public let osVersion: String
+    public let model: String
+    public let brand: String
+    public let appVersion: String
+
+    public init(os: String, osVersion: String, model: String, brand: String, appVersion: String) {
+        self.os = os
+        self.osVersion = osVersion
+        self.model = model
+        self.brand = brand
+        self.appVersion = appVersion
+    }
+
+    var dictionary: [String: String] {
+        [
+            "os": os,
+            "os_version": osVersion,
+            "model": model,
+            "brand": brand,
+            "app_version": appVersion
+        ]
+    }
+}
+
+// MARK: - Decoding
+//
+// Each response type decodes itself, the way every other Networking model does.
+// Validation lives in `init(from:)`: the QR-login spec treats a blank required
+// field as a malformed response (§5.1.1 / §5.2.1), so a blank value fails
+// decoding. The Remotes funnel every decoding failure into
+// `QRLoginNetworkError.malformed` via `QRLoginResponseBody.decode`.
+
+extension SelfHostedQRLoginScanResponse: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case sessionID = "session_id"
+        case realNumber = "real_number"
+        case expiresInSeconds = "expires_in"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let sessionID = try container.decodeNonBlankString(forKey: .sessionID)
+        let realNumber = try container.decodeNonBlankString(forKey: .realNumber)
+        let expiresInSeconds = try container.decode(Int.self, forKey: .expiresInSeconds)
+        self.init(sessionID: sessionID, realNumber: realNumber, expiresInSeconds: expiresInSeconds)
+    }
+}
+
+extension SelfHostedQRLoginSessionStatus: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case exchangeGrant = "exchange_grant"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let raw = try container.decodeIfPresent(String.self, forKey: .state)
+        let grant = try container.decodeIfPresent(String.self, forKey: .exchangeGrant)
+        self.init(state: State(rawValue: raw ?? "") ?? .unknown, exchangeGrant: grant)
+    }
+}
+
+extension SelfHostedQRLoginExchangeResponse: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case userLogin = "user_login"
+        case siteURL = "site_url"
+        case applicationPassword = "application_password"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let userLogin = try container.decodeNonBlankString(forKey: .userLogin)
+        let siteURL = try container.decodeNonBlankString(forKey: .siteURL)
+        let applicationPassword = try container.decodeNonBlankString(forKey: .applicationPassword)
+        self.init(userLogin: userLogin, siteURL: siteURL, applicationPassword: applicationPassword)
+    }
+}
+
+extension WPComQRLoginScanResponse: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case sessionID = "session_id"
+        case realNumber = "real_number"
+        case expiresInSeconds = "expires_in"
+        case userEmail = "user_email"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let sessionID = try container.decodeNonBlankString(forKey: .sessionID)
+        let realNumber = try container.decodeNonBlankString(forKey: .realNumber)
+        let expiresInSeconds = try container.decode(Int.self, forKey: .expiresInSeconds)
+        let userEmail = try container.decodeNonBlankString(forKey: .userEmail)
+        self.init(sessionID: sessionID, realNumber: realNumber, expiresInSeconds: expiresInSeconds, userEmail: userEmail)
+    }
+}
+
+extension WPComQRLoginSessionStatus: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case state
+        case status // wp.com legacy alias for `state` (spec §5.2.2)
+        case exchangeGrant = "exchange_grant"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // `state` wins; fall back to the legacy `status` alias, then to an empty
+        // string so an unrecognised or absent value maps to `.unknown`.
+        let raw = try container.decodeIfPresent(String.self, forKey: .state)
+            ?? container.decodeIfPresent(String.self, forKey: .status)
+        let grant = try container.decodeIfPresent(String.self, forKey: .exchangeGrant)
+        self.init(state: State(rawValue: raw ?? "") ?? .unknown, exchangeGrant: grant)
+    }
+}
+
+extension WPComQRLoginExchangeResponse: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case magicLinkURL = "magic_link_url"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let raw = try container.decodeNonBlankString(forKey: .magicLinkURL)
+        guard let url = URL(string: raw) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: container.codingPath,
+                                                    debugDescription: "magic_link_url is not a valid URL"))
+        }
+        self.init(magicLinkURL: url)
+    }
+}
+
+private extension KeyedDecodingContainer {
+    /// Decodes a required `String` that the QR-login spec forbids from being
+    /// blank — an empty value fails decoding so the Remote can surface it as a
+    /// malformed response.
+    func decodeNonBlankString(forKey key: Key) throws -> String {
+        let value = try decode(String.self, forKey: key)
+        guard value.isEmpty == false else {
+            throw DecodingError.dataCorrupted(.init(codingPath: codingPath,
+                                                    debugDescription: "Required QR-login field '\(key.stringValue)' is blank"))
+        }
+        return value
+    }
+}

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginDTOs.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginDTOs.swift
@@ -11,7 +11,7 @@ import Foundation
 
 // MARK: - Self-hosted responses
 
-/// Response of `POST {siteURL}/wp-json/wc-admin/mobile-app/qr-login-scan` (spec §5.1.1).
+/// Response of `POST {siteURL}/wp-json/wc-admin/mobile-app/qr-login-scan`.
 ///
 /// All fields are required; a missing or blank value makes the whole response
 /// malformed. The self-hosted scan carries no user identity — unlike wp.com,
@@ -28,7 +28,7 @@ public struct SelfHostedQRLoginScanResponse: Equatable {
     }
 }
 
-/// Response of `GET {siteURL}/wp-json/wc-admin/mobile-app/qr-login-session-status` (spec §5.1.2).
+/// Response of `GET {siteURL}/wp-json/wc-admin/mobile-app/qr-login-session-status`.
 public struct SelfHostedQRLoginSessionStatus: Equatable {
     /// The states the self-hosted endpoint can report. It has no `consumed`
     /// state — that "already signed in elsewhere" terminal is wp.com-only.
@@ -44,7 +44,7 @@ public struct SelfHostedQRLoginSessionStatus: Equatable {
 
     /// Only populated when `state == .approved`. A blank/missing value while
     /// `state == .approved` MUST be treated as `expired` ("fail closed") by the
-    /// consumer (spec §5.1.2).
+    /// consumer.
     public let exchangeGrant: String?
 
     public init(state: State, exchangeGrant: String?) {
@@ -53,7 +53,7 @@ public struct SelfHostedQRLoginSessionStatus: Equatable {
     }
 }
 
-/// Response of `POST {siteURL}/wp-json/wc-admin/mobile-app/qr-login-exchange` (spec §5.1.3).
+/// Response of `POST {siteURL}/wp-json/wc-admin/mobile-app/qr-login-exchange`.
 ///
 /// Carries the freshly minted Application Password. All fields are required.
 public struct SelfHostedQRLoginExchangeResponse: Equatable {
@@ -70,7 +70,7 @@ public struct SelfHostedQRLoginExchangeResponse: Equatable {
 
 // MARK: - WP.com responses
 
-/// Response of `POST /wpcom/v2/auth/qr-code-app/scan` (spec §5.2.1).
+/// Response of `POST /wpcom/v2/auth/qr-code-app/scan`.
 ///
 /// Unlike the self-hosted scan, the wp.com endpoint also returns the signed-in
 /// user's wp.com email for the number-match screen. All fields are required.
@@ -88,7 +88,7 @@ public struct WPComQRLoginScanResponse: Equatable {
     }
 }
 
-/// Response of `GET /wpcom/v2/auth/qr-code-app/session-status` (spec §5.2.2).
+/// Response of `GET /wpcom/v2/auth/qr-code-app/session-status`.
 public struct WPComQRLoginSessionStatus: Equatable {
     /// The states the wp.com endpoint can report. `consumed` ("already signed
     /// in elsewhere") is wp.com-only.
@@ -105,7 +105,7 @@ public struct WPComQRLoginSessionStatus: Equatable {
 
     /// Only populated when `state == .approved`. A blank/missing value while
     /// `state == .approved` MUST be treated as `expired` ("fail closed") by the
-    /// consumer (spec §5.2.2).
+    /// consumer.
     public let exchangeGrant: String?
 
     public init(state: State, exchangeGrant: String?) {
@@ -114,7 +114,7 @@ public struct WPComQRLoginSessionStatus: Equatable {
     }
 }
 
-/// Response of `POST /wpcom/v2/auth/qr-code-app/exchange` (spec §5.2.3).
+/// Response of `POST /wpcom/v2/auth/qr-code-app/exchange`.
 ///
 /// Carries a magic-link URL the app opens to finish wp.com sign-in.
 public struct WPComQRLoginExchangeResponse: Equatable {
@@ -127,7 +127,7 @@ public struct WPComQRLoginExchangeResponse: Equatable {
 
 // MARK: - Shared request payload
 
-/// Device metadata sent on both `/scan` requests (spec §5.1.1 / §5.2.1).
+/// Device metadata sent on both `/scan` requests.
 ///
 /// This is the one QR-login data type genuinely shared by both protocols: it is
 /// request-side data the client knows about itself, so it carries the same
@@ -163,7 +163,7 @@ public struct QRLoginScanDevice: Equatable {
 //
 // Each response type decodes itself, the way every other Networking model does.
 // Validation lives in `init(from:)`: the QR-login spec treats a blank required
-// field as a malformed response (§5.1.1 / §5.2.1), so a blank value fails
+// field as a malformed response, so a blank value fails
 // decoding. The Remotes funnel every decoding failure into
 // `QRLoginNetworkError.malformed` via `QRLoginResponseBody.decode`.
 
@@ -234,7 +234,7 @@ extension WPComQRLoginScanResponse: Decodable {
 extension WPComQRLoginSessionStatus: Decodable {
     private enum CodingKeys: String, CodingKey {
         case state
-        case status // wp.com legacy alias for `state` (spec §5.2.2)
+        case status // wp.com legacy alias for `state`
         case exchangeGrant = "exchange_grant"
     }
 

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginHTTPStatusMapper.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginHTTPStatusMapper.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Maps an HTTP status code (+ optional body) into a `QRLoginNetworkError`.
+///
+/// The mapping is shared across the three QR-login phases (scan / poll /
+/// exchange) and across both protocols (self-hosted / wp.com). Protocol- and
+/// phase-specific *user-facing* mapping (e.g. self-hosted 404 → "This store
+/// can't complete QR login", wp.com 404 on poll → coerced-to-expired) happens
+/// one layer up, in `QRLoginErrorMapper`. This helper only deals in the
+/// network-level vocabulary.
+enum QRLoginHTTPStatusMapper {
+
+    /// Returns `nil` for 2xx responses (no error). Otherwise returns the
+    /// matching `QRLoginNetworkError`.
+    static func error(forStatusCode statusCode: Int, body: Data) -> QRLoginNetworkError? {
+        if (200..<300).contains(statusCode) {
+            return nil
+        }
+        let code = QRLoginResponseBody.errorCode(in: body)
+        switch statusCode {
+        case 400:
+            return .badRequest(code: code)
+        case 401, 403:
+            return .unauthorized
+        case 404:
+            return .notFound
+        case 409:
+            return .conflict
+        case 412:
+            return .preconditionFailed(code: code)
+        case 426:
+            return .upgradeRequired
+        case 429:
+            return .rateLimited
+        case 500:
+            return .internalServerError(code: code)
+        case 501..<600:
+            return .serverError(status: statusCode)
+        default:
+            return .clientError(status: statusCode)
+        }
+    }
+}

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginNetworkError.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginNetworkError.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Errors emitted by the QR-login `Remote`s. Captures just enough HTTP detail
+/// to drive the user-facing error mapping in spec §5.1 / §5.2 / §8.
+///
+/// The user-facing variant lives one layer up (`QRLoginErrorMapper`); this
+/// type is intentionally protocol-agnostic so the same value works for both
+/// self-hosted and wp.com responses.
+public enum QRLoginNetworkError: Error, Equatable {
+    /// HTTP 401 or 403 with no special body code.
+    case unauthorized
+    /// HTTP 404 — the merchant's WC plugin doesn't expose QR-login endpoints
+    /// (self-hosted), or a wp.com QR expired before reaching the server.
+    case notFound
+    /// HTTP 426 — "upgrade required". Self-hosted only.
+    case upgradeRequired
+    /// HTTP 409 — another device already scanned this QR.
+    case conflict
+    /// HTTP 429 — rate-limited.
+    case rateLimited
+
+    /// HTTP 412 (precondition failed) — `body.code` disambiguates between
+    /// `qr_login_not_approved`, `invalid_exchange_grant`, etc.
+    case preconditionFailed(code: String?)
+
+    /// HTTP 500 — `body.code` disambiguates wp.com's `already_consumed` from
+    /// generic failures.
+    case internalServerError(code: String?)
+
+    /// Any other 5xx response.
+    case serverError(status: Int)
+
+    /// HTTP 400 — `body.code` disambiguates wp.com's `no_number_matching`
+    /// from generic bad-request failures.
+    case badRequest(code: String?)
+
+    /// Any other 4xx response we didn't pattern-match above.
+    case clientError(status: Int)
+
+    /// Transport failure — DNS, socket, timeout, SSL.
+    case network
+
+    /// Response body wasn't parseable as the expected shape (missing required
+    /// fields, malformed JSON, unexpected types). Treated like an
+    /// unmapped-server error for UI purposes.
+    case malformed
+}

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginNetworkError.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginNetworkError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors emitted by the QR-login `Remote`s. Captures just enough HTTP detail
-/// to drive the user-facing error mapping in spec §5.1 / §5.2 / §8.
+/// to drive the user-facing error mapping.
 ///
 /// The user-facing variant lives one layer up (`QRLoginErrorMapper`); this
 /// type is intentionally protocol-agnostic so the same value works for both

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginResponseBody.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginResponseBody.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Helpers for turning a QR-login HTTP response body into a typed value.
+///
+/// QR-login Remotes go through `URLSession` directly (see `SelfHostedQRLoginRemote`),
+/// so they own JSON decoding rather than delegating to a `Mapper`. Both helpers
+/// are protocol-agnostic — they handle self-hosted and wp.com bodies the same
+/// way; the endpoint-specific shapes live in the `Decodable` response structs.
+enum QRLoginResponseBody {
+
+    /// Decodes `data` as `T`, translating *any* decoding failure — malformed
+    /// JSON, missing keys, blank required fields — into
+    /// `QRLoginNetworkError.malformed`. Spec §5.1.1 / §5.2.1: "all fields are
+    /// required; if any is missing or blank, the response is treated as
+    /// malformed."
+    static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            throw QRLoginNetworkError.malformed
+        }
+    }
+
+    /// Best-effort extraction of an error `code` field from a non-2xx response
+    /// body. WordPress REST endpoints return
+    /// `{ "code": "...", "message": "...", "data": { "status": <int> } }`.
+    /// Returns `nil` if the body isn't JSON-decodable or carries no `code`.
+    static func errorCode(in data: Data) -> String? {
+        struct ErrorEnvelope: Decodable {
+            let code: String?
+        }
+        return (try? JSONDecoder().decode(ErrorEnvelope.self, from: data))?.code
+    }
+}

--- a/Modules/Sources/Networking/Remote/QRLogin/QRLoginResponseBody.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/QRLoginResponseBody.swift
@@ -10,7 +10,7 @@ enum QRLoginResponseBody {
 
     /// Decodes `data` as `T`, translating *any* decoding failure — malformed
     /// JSON, missing keys, blank required fields — into
-    /// `QRLoginNetworkError.malformed`. Spec §5.1.1 / §5.2.1: "all fields are
+    /// `QRLoginNetworkError.malformed`. The spec is explicit: "all fields are
     /// required; if any is missing or blank, the response is treated as
     /// malformed."
     static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {

--- a/Modules/Sources/Networking/Remote/QRLogin/SelfHostedQRLoginRemote.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/SelfHostedQRLoginRemote.swift
@@ -1,0 +1,148 @@
+import Foundation
+import NetworkingCore
+
+/// Talks to the self-hosted QR-login endpoints exposed by the merchant's
+/// WooCommerce plugin under `{siteUrl}/wp-json/wc-admin/mobile-app/qr-login-*`.
+///
+/// These endpoints are unauthenticated — possession of the single-use token
+/// (and the matching grant nonce on `/exchange`) is the authorisation — so this
+/// type goes through `URLSession` directly, matching the precedent set by
+/// `SiteCredentialLoginUseCase` and `OneTimeApplicationPasswordUseCase`. Going
+/// through `AlamofireNetwork` is not an option for these endpoints because
+/// that abstraction doesn't expose `HTTPURLResponse.statusCode` to the caller,
+/// and the QR-login error tables (spec §5.1) branch on status code.
+public protocol SelfHostedQRLoginRemoteProtocol {
+    func scan(siteURL: URL,
+              token: String,
+              device: QRLoginScanDevice) async throws -> SelfHostedQRLoginScanResponse
+
+    func pollSessionStatus(siteURL: URL,
+                           sessionID: String,
+                           tokenHash: String) async throws -> SelfHostedQRLoginSessionStatus
+
+    func exchange(siteURL: URL,
+                  token: String,
+                  exchangeGrant: String) async throws -> SelfHostedQRLoginExchangeResponse
+}
+
+public final class SelfHostedQRLoginRemote: SelfHostedQRLoginRemoteProtocol {
+
+    private let session: URLSessionProtocol
+
+    public init(session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
+    }
+
+    public func scan(siteURL: URL,
+                     token: String,
+                     device: QRLoginScanDevice) async throws -> SelfHostedQRLoginScanResponse {
+        let request = try makeJSONRequest(
+            method: "POST",
+            url: endpoint(siteURL: siteURL, path: Paths.scan),
+            body: [
+                "token": token,
+                "supports_number_matching": true,
+                "device": device.dictionary
+            ]
+        )
+        let (data, statusCode) = try await perform(request)
+        if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
+            throw error
+        }
+        return try QRLoginResponseBody.decode(SelfHostedQRLoginScanResponse.self, from: data)
+    }
+
+    public func pollSessionStatus(siteURL: URL,
+                                  sessionID: String,
+                                  tokenHash: String) async throws -> SelfHostedQRLoginSessionStatus {
+        var components = endpointComponents(siteURL: siteURL, path: Paths.sessionStatus)
+        components.queryItems = [
+            URLQueryItem(name: "session_id", value: sessionID),
+            URLQueryItem(name: "token_hash", value: tokenHash)
+        ]
+        guard let url = components.url else {
+            throw QRLoginNetworkError.malformed
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("no-cache, no-store", forHTTPHeaderField: "Cache-Control")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, statusCode) = try await perform(request)
+        if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
+            throw error
+        }
+        return try QRLoginResponseBody.decode(SelfHostedQRLoginSessionStatus.self, from: data)
+    }
+
+    public func exchange(siteURL: URL,
+                         token: String,
+                         exchangeGrant: String) async throws -> SelfHostedQRLoginExchangeResponse {
+        let request = try makeJSONRequest(
+            method: "POST",
+            url: endpoint(siteURL: siteURL, path: Paths.exchange),
+            body: [
+                "token": token,
+                "exchange_grant": exchangeGrant
+            ]
+        )
+        let (data, statusCode) = try await perform(request)
+        if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
+            throw error
+        }
+        return try QRLoginResponseBody.decode(SelfHostedQRLoginExchangeResponse.self, from: data)
+    }
+}
+
+// MARK: - HTTP helpers
+
+private extension SelfHostedQRLoginRemote {
+
+    func endpoint(siteURL: URL, path: String) -> URL {
+        endpointComponents(siteURL: siteURL, path: path).url
+            ?? siteURL.appendingPathComponent(Paths.restRoot + path)
+    }
+
+    func endpointComponents(siteURL: URL, path: String) -> URLComponents {
+        var components = URLComponents()
+        components.scheme = siteURL.scheme
+        components.host = siteURL.host
+        components.port = siteURL.port
+        components.path = siteURL.path + Paths.restRoot + path
+        return components
+    }
+
+    func makeJSONRequest(method: String, url: URL, body: [String: Any]) throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        } catch {
+            throw QRLoginNetworkError.malformed
+        }
+        return request
+    }
+
+    func perform(_ request: URLRequest) async throws -> (Data, Int) {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw QRLoginNetworkError.malformed
+            }
+            return (data, http.statusCode)
+        } catch let error as QRLoginNetworkError {
+            throw error
+        } catch {
+            throw QRLoginNetworkError.network
+        }
+    }
+
+    enum Paths {
+        static let restRoot = "/wp-json/wc-admin/mobile-app"
+        static let scan = "/qr-login-scan"
+        static let sessionStatus = "/qr-login-session-status"
+        static let exchange = "/qr-login-exchange"
+    }
+}

--- a/Modules/Sources/Networking/Remote/QRLogin/SelfHostedQRLoginRemote.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/SelfHostedQRLoginRemote.swift
@@ -10,7 +10,7 @@ import NetworkingCore
 /// `SiteCredentialLoginUseCase` and `OneTimeApplicationPasswordUseCase`. Going
 /// through `AlamofireNetwork` is not an option for these endpoints because
 /// that abstraction doesn't expose `HTTPURLResponse.statusCode` to the caller,
-/// and the QR-login error tables (spec §5.1) branch on status code.
+/// and the QR-login error tables branch on status code.
 public protocol SelfHostedQRLoginRemoteProtocol {
     func scan(siteURL: URL,
               token: String,

--- a/Modules/Sources/Networking/Remote/QRLogin/SelfHostedQRLoginRemote.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/SelfHostedQRLoginRemote.swift
@@ -2,7 +2,7 @@ import Foundation
 import NetworkingCore
 
 /// Talks to the self-hosted QR-login endpoints exposed by the merchant's
-/// WooCommerce plugin under `{siteUrl}/wp-json/wc-admin/mobile-app/qr-login-*`.
+/// WooCommerce plugin under the site's discovered WordPress REST API root.
 ///
 /// These endpoints are unauthenticated — possession of the single-use token
 /// (and the matching grant nonce on `/exchange`) is the authorisation — so this
@@ -28,9 +28,23 @@ public protocol SelfHostedQRLoginRemoteProtocol {
 public final class SelfHostedQRLoginRemote: SelfHostedQRLoginRemoteProtocol {
 
     private let session: URLSessionProtocol
+    private let apiRootCache: RESTAPIRootCaching
+    private let discoverRESTAPIRoot: (_ siteURL: String) async -> String?
 
-    public init(session: URLSessionProtocol = URLSession.shared) {
+    public init(session: URLSessionProtocol = URLSession.shared,
+                apiRootCache: RESTAPIRootCaching = WordPressRESTAPIRootCache.shared,
+                discoverRESTAPIRoot: ((_ siteURL: String) async -> String?)? = nil) {
         self.session = session
+        self.apiRootCache = apiRootCache
+
+        if let discoverRESTAPIRoot {
+            self.discoverRESTAPIRoot = discoverRESTAPIRoot
+        } else {
+            let discovery = WordPressAPIDiscovery(session: session)
+            self.discoverRESTAPIRoot = {
+                await discovery.discoverRESTAPIRootURL(for: $0)
+            }
+        }
     }
 
     public func scan(siteURL: URL,
@@ -38,7 +52,7 @@ public final class SelfHostedQRLoginRemote: SelfHostedQRLoginRemoteProtocol {
                      device: QRLoginScanDevice) async throws -> SelfHostedQRLoginScanResponse {
         let request = try makeJSONRequest(
             method: "POST",
-            url: endpoint(siteURL: siteURL, path: Paths.scan),
+            url: try await endpoint(siteURL: siteURL, path: Paths.scan),
             body: [
                 "token": token,
                 "supports_number_matching": true,
@@ -55,14 +69,14 @@ public final class SelfHostedQRLoginRemote: SelfHostedQRLoginRemoteProtocol {
     public func pollSessionStatus(siteURL: URL,
                                   sessionID: String,
                                   tokenHash: String) async throws -> SelfHostedQRLoginSessionStatus {
-        var components = endpointComponents(siteURL: siteURL, path: Paths.sessionStatus)
-        components.queryItems = [
-            URLQueryItem(name: "session_id", value: sessionID),
-            URLQueryItem(name: "token_hash", value: tokenHash)
-        ]
-        guard let url = components.url else {
-            throw QRLoginNetworkError.malformed
-        }
+        let url = try await endpoint(
+            siteURL: siteURL,
+            path: Paths.sessionStatus,
+            queryItems: [
+                URLQueryItem(name: "session_id", value: sessionID),
+                URLQueryItem(name: "token_hash", value: tokenHash)
+            ]
+        )
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("no-cache, no-store", forHTTPHeaderField: "Cache-Control")
@@ -80,7 +94,7 @@ public final class SelfHostedQRLoginRemote: SelfHostedQRLoginRemoteProtocol {
                          exchangeGrant: String) async throws -> SelfHostedQRLoginExchangeResponse {
         let request = try makeJSONRequest(
             method: "POST",
-            url: endpoint(siteURL: siteURL, path: Paths.exchange),
+            url: try await endpoint(siteURL: siteURL, path: Paths.exchange),
             body: [
                 "token": token,
                 "exchange_grant": exchangeGrant
@@ -98,18 +112,46 @@ public final class SelfHostedQRLoginRemote: SelfHostedQRLoginRemoteProtocol {
 
 private extension SelfHostedQRLoginRemote {
 
-    func endpoint(siteURL: URL, path: String) -> URL {
-        endpointComponents(siteURL: siteURL, path: path).url
-            ?? siteURL.appendingPathComponent(Paths.restRoot + path)
+    func endpoint(siteURL: URL, path: String, queryItems: [URLQueryItem] = []) async throws -> URL {
+        let site = siteURL.absoluteString.trimSlashes()
+        let root: String = await {
+            if let cachedRoot = apiRootCache.root(for: site) {
+                return cachedRoot
+            } else if let discoveredRoot = await discoverRESTAPIRoot(site) {
+                return discoveredRoot
+            } else {
+                return site + Paths.restRouteRoot
+            }
+        }()
+
+        let urlString = [
+            root,
+            Paths.namespace,
+            path
+        ]
+            .map { $0.trimSlashes() }
+            .filter { $0.isEmpty == false }
+            .joined(separator: "/")
+
+        guard let url = URL(string: urlString) else {
+            throw QRLoginNetworkError.malformed
+        }
+
+        return try appendingQueryItems(queryItems, to: url)
     }
 
-    func endpointComponents(siteURL: URL, path: String) -> URLComponents {
-        var components = URLComponents()
-        components.scheme = siteURL.scheme
-        components.host = siteURL.host
-        components.port = siteURL.port
-        components.path = siteURL.path + Paths.restRoot + path
-        return components
+    func appendingQueryItems(_ queryItems: [URLQueryItem], to url: URL) throws -> URL {
+        guard queryItems.isEmpty == false else {
+            return url
+        }
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw QRLoginNetworkError.malformed
+        }
+        components.queryItems = (components.queryItems ?? []) + queryItems
+        guard let url = components.url else {
+            throw QRLoginNetworkError.malformed
+        }
+        return url
     }
 
     func makeJSONRequest(method: String, url: URL, body: [String: Any]) throws -> URLRequest {
@@ -140,9 +182,10 @@ private extension SelfHostedQRLoginRemote {
     }
 
     enum Paths {
-        static let restRoot = "/wp-json/wc-admin/mobile-app"
-        static let scan = "/qr-login-scan"
-        static let sessionStatus = "/qr-login-session-status"
-        static let exchange = "/qr-login-exchange"
+        static let restRouteRoot = "/?rest_route=/"
+        static let namespace = "wc-admin/mobile-app"
+        static let scan = "qr-login-scan"
+        static let sessionStatus = "qr-login-session-status"
+        static let exchange = "qr-login-exchange"
     }
 }

--- a/Modules/Sources/Networking/Remote/QRLogin/WPComQRLoginRemote.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/WPComQRLoginRemote.swift
@@ -1,0 +1,158 @@
+import Foundation
+import NetworkingCore
+
+/// Talks to the WordPress.com QR-login endpoints at
+/// `public-api.wordpress.com/wpcom/v2/auth/qr-code-app/...`.
+///
+/// Same URLSession-direct rationale as `SelfHostedQRLoginRemote`: the spec
+/// error tables branch on HTTP status code and on the body `code` field, and
+/// the existing `Network` abstraction can't surface either to the caller.
+///
+/// The OAuth `client_id` + `client_secret` are injected at construction so
+/// this type doesn't reach for the host app's `ApiCredentials` (which lives
+/// in the main app target).
+public protocol WPComQRLoginRemoteProtocol {
+    func scan(token: String,
+              encrypted: String,
+              device: QRLoginScanDevice) async throws -> WPComQRLoginScanResponse
+
+    func pollSessionStatus(sessionID: String,
+                           tokenHash: String) async throws -> WPComQRLoginSessionStatus
+
+    func exchange(token: String,
+                  encrypted: String,
+                  exchangeGrant: String) async throws -> WPComQRLoginExchangeResponse
+}
+
+public final class WPComQRLoginRemote: WPComQRLoginRemoteProtocol {
+
+    private let session: URLSessionProtocol
+    private let clientID: String
+    private let clientSecret: String
+
+    public init(clientID: String, clientSecret: String, session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+    }
+
+    public func scan(token: String,
+                     encrypted: String,
+                     device: QRLoginScanDevice) async throws -> WPComQRLoginScanResponse {
+        let request = try makeJSONRequest(
+            method: "POST",
+            url: endpoint(Paths.scan),
+            body: [
+                "client_id": clientID,
+                "client_secret": clientSecret,
+                "token": token,
+                "encrypted": encrypted,
+                "supports_number_matching": true,
+                "device": device.dictionary
+            ]
+        )
+        let (data, statusCode) = try await perform(request)
+        if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
+            throw error
+        }
+        return try QRLoginResponseBody.decode(WPComQRLoginScanResponse.self, from: data)
+    }
+
+    public func pollSessionStatus(sessionID: String,
+                                  tokenHash: String) async throws -> WPComQRLoginSessionStatus {
+        var components = endpointComponents(Paths.sessionStatus)
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "client_secret", value: clientSecret),
+            URLQueryItem(name: "session_id", value: sessionID),
+            URLQueryItem(name: "token_hash", value: tokenHash)
+        ]
+        guard let url = components.url else {
+            throw QRLoginNetworkError.malformed
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("no-cache, no-store", forHTTPHeaderField: "Cache-Control")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, statusCode) = try await perform(request)
+        if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
+            // Spec §5.2.2: wp.com poll 404 is coerced to the `expired` terminal
+            // (server keeps terminal records ~2 minutes; once evicted the
+            // lookup 404s). The UI shows the timeout copy, not a hard error.
+            if case .notFound = error {
+                return WPComQRLoginSessionStatus(state: .expired, exchangeGrant: nil)
+            }
+            throw error
+        }
+        return try QRLoginResponseBody.decode(WPComQRLoginSessionStatus.self, from: data)
+    }
+
+    public func exchange(token: String,
+                         encrypted: String,
+                         exchangeGrant: String) async throws -> WPComQRLoginExchangeResponse {
+        let request = try makeJSONRequest(
+            method: "POST",
+            url: endpoint(Paths.exchange),
+            body: [
+                "client_id": clientID,
+                "client_secret": clientSecret,
+                "token": token,
+                "encrypted": encrypted,
+                "exchange_grant": exchangeGrant
+            ]
+        )
+        let (data, statusCode) = try await perform(request)
+        if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
+            throw error
+        }
+        return try QRLoginResponseBody.decode(WPComQRLoginExchangeResponse.self, from: data)
+    }
+}
+
+// MARK: - HTTP helpers
+
+private extension WPComQRLoginRemote {
+
+    func endpoint(_ path: String) -> URL {
+        endpointComponents(path).url ?? URL(string: Settings.wordpressApiBaseURL + "wpcom/v2/auth/qr-code-app" + path)!
+    }
+
+    func endpointComponents(_ path: String) -> URLComponents {
+        URLComponents(string: Settings.wordpressApiBaseURL + "wpcom/v2/auth/qr-code-app" + path)
+            ?? URLComponents()
+    }
+
+    func makeJSONRequest(method: String, url: URL, body: [String: Any]) throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+        } catch {
+            throw QRLoginNetworkError.malformed
+        }
+        return request
+    }
+
+    func perform(_ request: URLRequest) async throws -> (Data, Int) {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw QRLoginNetworkError.malformed
+            }
+            return (data, http.statusCode)
+        } catch let error as QRLoginNetworkError {
+            throw error
+        } catch {
+            throw QRLoginNetworkError.network
+        }
+    }
+
+    enum Paths {
+        static let scan = "/scan"
+        static let sessionStatus = "/session-status"
+        static let exchange = "/exchange"
+    }
+}

--- a/Modules/Sources/Networking/Remote/QRLogin/WPComQRLoginRemote.swift
+++ b/Modules/Sources/Networking/Remote/QRLogin/WPComQRLoginRemote.swift
@@ -77,7 +77,7 @@ public final class WPComQRLoginRemote: WPComQRLoginRemoteProtocol {
 
         let (data, statusCode) = try await perform(request)
         if let error = QRLoginHTTPStatusMapper.error(forStatusCode: statusCode, body: data) {
-            // Spec §5.2.2: wp.com poll 404 is coerced to the `expired` terminal
+            // wp.com poll 404 is coerced to the `expired` terminal
             // (server keeps terminal records ~2 minutes; once evicted the
             // lookup 404s). The UI shows the timeout copy, not a hard error.
             if case .notFound = error {

--- a/Modules/Sources/Networking/Tools/QRLogin/QRLoginTokenHash.swift
+++ b/Modules/Sources/Networking/Tools/QRLogin/QRLoginTokenHash.swift
@@ -1,0 +1,21 @@
+import CryptoKit
+import Foundation
+
+/// Computes the `token_hash` value that the QR-login `/session-status`
+/// endpoints expect on every poll.
+///
+/// The hash is the lowercase-hex SHA-256 over the UTF-8 bytes of the plaintext
+/// token, matching PHP `hash('sha256', $token)` (spec §5.1.2 / §5.2.2). Server
+/// uses `hash_equals` against the bound session, so any deviation is rejected.
+///
+/// For the self-hosted protocol the input is the plaintext token from the QR.
+/// For the wp.com protocol the input is the **compound** `{64-hex}:{32-hex}`
+/// token exactly as it appeared in the QR.
+public enum QRLoginTokenHash {
+
+    /// Lowercase-hex SHA-256 of `token`'s UTF-8 bytes.
+    public static func make(for token: String) -> String {
+        let digest = SHA256.hash(data: Data(token.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/Modules/Sources/Networking/Tools/QRLogin/QRLoginTokenHash.swift
+++ b/Modules/Sources/Networking/Tools/QRLogin/QRLoginTokenHash.swift
@@ -5,7 +5,7 @@ import Foundation
 /// endpoints expect on every poll.
 ///
 /// The hash is the lowercase-hex SHA-256 over the UTF-8 bytes of the plaintext
-/// token, matching PHP `hash('sha256', $token)` (spec §5.1.2 / §5.2.2). Server
+/// token, matching PHP `hash('sha256', $token)`. Server
 /// uses `hash_equals` against the bound session, so any deviation is rejected.
 ///
 /// For the self-hosted protocol the input is the plaintext token from the QR.

--- a/Modules/Tests/NetworkingTests/QRLogin/QRLoginTokenHashTests.swift
+++ b/Modules/Tests/NetworkingTests/QRLogin/QRLoginTokenHashTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+@testable import Networking
+
+struct QRLoginTokenHashTests {
+
+    @Test func make_matches_PHP_hash_sha256_for_known_input() {
+        // Given — vector produced by PHP `hash('sha256', 'hello world')`.
+        let token = "hello world"
+
+        // When
+        let hash = QRLoginTokenHash.make(for: token)
+
+        // Then
+        #expect(hash == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+    }
+
+    @Test func make_returns_lowercase_hex() {
+        // Given
+        let token = String(repeating: "A", count: 64)
+
+        // When
+        let hash = QRLoginTokenHash.make(for: token)
+
+        // Then
+        #expect(hash == hash.lowercased())
+        #expect(hash.count == 64) // 32 bytes × 2 hex chars
+    }
+
+    @Test func make_treats_empty_string_as_valid_input() {
+        // Given — server has its own validation; the hasher just hashes what it
+        // is given. SHA-256 of an empty byte sequence is a well-known value.
+        let token = ""
+
+        // When
+        let hash = QRLoginTokenHash.make(for: token)
+
+        // Then
+        #expect(hash == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+    }
+
+    @Test func make_hashes_utf8_bytes_so_unicode_input_differs_from_ascii_fallback() {
+        // UTF-8 encoding is load-bearing for parity with the PHP server's
+        // `hash('sha256', $token)`. A non-ASCII token must produce a hash
+        // distinct from its ASCII-only neighbour.
+        let unicode = QRLoginTokenHash.make(for: "café")
+        let ascii = QRLoginTokenHash.make(for: "cafe")
+        #expect(unicode != ascii)
+    }
+
+    @Test func make_is_deterministic() {
+        // Given
+        let token = "deterministic-input"
+
+        // When
+        let first = QRLoginTokenHash.make(for: token)
+        let second = QRLoginTokenHash.make(for: token)
+
+        // Then
+        #expect(first == second)
+    }
+}

--- a/Modules/Tests/NetworkingTests/QRLogin/SelfHostedQRLoginRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/QRLogin/SelfHostedQRLoginRemoteTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+import Testing
+import NetworkingCore
+@testable import Networking
+
+/// Tests every row of spec §5.1.1, §5.1.2, §5.1.3 against the self-hosted
+/// QR-login Remote, plus the request-shape assertions that the spec calls out
+/// explicitly (Cache-Control on poll, no `device.*` on exchange).
+struct SelfHostedQRLoginRemoteTests {
+
+    private let siteURL = URL(string: "https://shop.example")!
+    private let token = String(repeating: "a", count: 64)
+    private let sessionID = "session-1"
+    private let grant = "grant-1"
+    private let device = QRLoginScanDevice(os: "iOS",
+                                           osVersion: "18.5",
+                                           model: "iPhone17,1",
+                                           brand: "Apple",
+                                           appVersion: "23.6")
+
+    // MARK: - /scan (§5.1.1)
+
+    @Test func scan_when_200_then_decodes_response() async throws {
+        // Given
+        let url = makeURL(path: "/qr-login-scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "abc",
+            "real_number": "428",
+            "expires_in": 90
+        ]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        let response = try await remote.scan(siteURL: siteURL, token: token, device: device)
+
+        // Then
+        #expect(response == SelfHostedQRLoginScanResponse(sessionID: "abc",
+                                                          realNumber: "428",
+                                                          expiresInSeconds: 90))
+    }
+
+    @Test func scan_sends_supports_number_matching_and_device_fields() async throws {
+        // Given
+        let url = makeURL(path: "/qr-login-scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "x", "real_number": "001", "expires_in": 90
+        ]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        _ = try await remote.scan(siteURL: siteURL, token: token, device: device)
+
+        // Then
+        let body = try requireBody(from: session)
+        let decoded = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        #expect(decoded?["token"] as? String == token)
+        #expect(decoded?["supports_number_matching"] as? Bool == true)
+        let deviceDict = decoded?["device"] as? [String: String]
+        #expect(deviceDict?["os"] == "iOS")
+        #expect(deviceDict?["app_version"] == "23.6")
+    }
+
+    @Test func scan_when_401_then_throws_unauthorized() async {
+        await expectScanError(statusCode: 401, body: Data(), expected: .unauthorized)
+    }
+
+    @Test func scan_when_403_then_throws_unauthorized() async {
+        await expectScanError(statusCode: 403, body: Data(), expected: .unauthorized)
+    }
+
+    @Test func scan_when_404_then_throws_notFound() async {
+        await expectScanError(statusCode: 404, body: Data(), expected: .notFound)
+    }
+
+    @Test func scan_when_426_then_throws_upgradeRequired() async {
+        await expectScanError(statusCode: 426, body: Data(), expected: .upgradeRequired)
+    }
+
+    @Test func scan_when_409_then_throws_conflict() async {
+        await expectScanError(statusCode: 409, body: Data(), expected: .conflict)
+    }
+
+    @Test func scan_when_429_then_throws_rateLimited() async {
+        await expectScanError(statusCode: 429, body: Data(), expected: .rateLimited)
+    }
+
+    @Test func scan_when_500_then_throws_internalServerError() async {
+        await expectScanError(statusCode: 500, body: Data(), expected: .internalServerError(code: nil))
+    }
+
+    @Test func scan_when_malformed_body_then_throws_malformed() async {
+        // Given — 200 OK but missing real_number
+        let url = makeURL(path: "/qr-login-scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "abc", "expires_in": 90
+        ]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.malformed) {
+            _ = try await remote.scan(siteURL: siteURL, token: token, device: device)
+        }
+    }
+
+    @Test func scan_when_network_failure_then_throws_network() async {
+        // Given
+        let url = makeURL(path: "/qr-login-scan")
+        let session = MockURLSession()
+        session.simulateError(for: url.absoluteString, error: URLError(.notConnectedToInternet))
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.network) {
+            _ = try await remote.scan(siteURL: siteURL, token: token, device: device)
+        }
+    }
+
+    // MARK: - /session-status (§5.1.2)
+
+    @Test func pollSessionStatus_sends_session_id_and_token_hash_and_no_cache_header() async throws {
+        // Given
+        let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json(["state": "scanned"]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
+
+        // Then
+        #expect(status == SelfHostedQRLoginSessionStatus(state: .scanned, exchangeGrant: nil))
+        #expect(session.requestCount == 1)
+        #expect(session.lastRequest?.value(forHTTPHeaderField: "Cache-Control") == "no-cache, no-store")
+    }
+
+    @Test func pollSessionStatus_when_approved_with_grant_then_returns_approved() async throws {
+        // Given
+        let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "state": "approved",
+            "exchange_grant": "grant-abc"
+        ]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
+
+        // Then
+        #expect(status == SelfHostedQRLoginSessionStatus(state: .approved, exchangeGrant: "grant-abc"))
+    }
+
+    @Test func pollSessionStatus_when_unknown_state_then_maps_to_unknown() async throws {
+        // Given — server returns a state value the client doesn't recognise.
+        let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json(["state": "spinning"]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
+
+        // Then — consumer translates `.unknown` to `expired` defensively.
+        #expect(status.state == .unknown)
+    }
+
+    @Test func pollSessionStatus_when_404_then_throws_notFound() async {
+        // Given
+        let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: Data(), statusCode: 404)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.notFound) {
+            _ = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
+        }
+    }
+
+    @Test func pollSessionStatus_when_429_then_throws_rateLimited() async {
+        // Given
+        let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: Data(), statusCode: 429)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.rateLimited) {
+            _ = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
+        }
+    }
+
+    // MARK: - /exchange (§5.1.3)
+
+    @Test func exchange_when_200_then_decodes_response() async throws {
+        // Given
+        let url = makeURL(path: "/qr-login-exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "user_login": "shopkeeper",
+            "site_url": "https://shop.example",
+            "application_password": "ap-1234"
+        ]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        let response = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
+
+        // Then
+        #expect(response == SelfHostedQRLoginExchangeResponse(userLogin: "shopkeeper",
+                                                              siteURL: "https://shop.example",
+                                                              applicationPassword: "ap-1234"))
+    }
+
+    @Test func exchange_does_not_send_device_metadata() async throws {
+        // Given — spec §5.1.3 explicitly: "The exchange request does not carry
+        // `device.*` metadata; that lives only on `/scan`."
+        let url = makeURL(path: "/qr-login-exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "user_login": "a", "site_url": "https://shop.example", "application_password": "p"
+        ]), statusCode: 200)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When
+        _ = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
+
+        // Then
+        let body = try requireBody(from: session)
+        let decoded = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        #expect(decoded?["token"] as? String == token)
+        #expect(decoded?["exchange_grant"] as? String == grant)
+        #expect(decoded?.keys.contains("device") == false)
+        #expect(decoded?.keys.contains("supports_number_matching") == false)
+    }
+
+    @Test func exchange_when_412_qr_login_not_approved_then_preconditionFailed_with_code() async {
+        // Given
+        let url = makeURL(path: "/qr-login-exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "code": "qr_login_not_approved",
+            "message": "Not approved yet"
+        ]), statusCode: 412)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.preconditionFailed(code: "qr_login_not_approved")) {
+            _ = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
+        }
+    }
+
+    @Test func exchange_when_412_invalid_exchange_grant_then_preconditionFailed_with_code() async {
+        // Given
+        let url = makeURL(path: "/qr-login-exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "code": "invalid_exchange_grant"
+        ]), statusCode: 412)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.preconditionFailed(code: "invalid_exchange_grant")) {
+            _ = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
+        }
+    }
+
+    @Test func exchange_when_412_unknown_code_then_preconditionFailed_with_nil_code() async {
+        // Given — 412 with a body that doesn't carry a usable `code`.
+        let url = makeURL(path: "/qr-login-exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: Data("not json".utf8), statusCode: 412)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.preconditionFailed(code: nil)) {
+            _ = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension SelfHostedQRLoginRemoteTests {
+
+    func makeURL(path: String, query: String? = nil) -> URL {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "shop.example"
+        components.path = "/wp-json/wc-admin/mobile-app" + path
+        components.query = query
+        return components.url!
+    }
+
+    func json(_ object: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    func requireBody(from session: MockURLSession) throws -> Data {
+        guard let body = session.lastRequest?.httpBody else {
+            Issue.record("Expected captured request body but none was recorded")
+            throw QRLoginNetworkError.malformed
+        }
+        return body
+    }
+
+    func expectScanError(statusCode: Int, body: Data, expected: QRLoginNetworkError) async {
+        // Given
+        let url = makeURL(path: "/qr-login-scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: body, statusCode: statusCode)
+        let remote = SelfHostedQRLoginRemote(session: session)
+
+        // When / Then
+        await #expect(throws: expected) {
+            _ = try await remote.scan(siteURL: siteURL, token: token, device: device)
+        }
+    }
+}

--- a/Modules/Tests/NetworkingTests/QRLogin/SelfHostedQRLoginRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/QRLogin/SelfHostedQRLoginRemoteTests.swift
@@ -29,7 +29,7 @@ struct SelfHostedQRLoginRemoteTests {
             "real_number": "428",
             "expires_in": 90
         ]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         let response = try await remote.scan(siteURL: siteURL, token: token, device: device)
@@ -47,7 +47,7 @@ struct SelfHostedQRLoginRemoteTests {
         session.simulateResponse(for: url.absoluteString, data: json([
             "session_id": "x", "real_number": "001", "expires_in": 90
         ]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         _ = try await remote.scan(siteURL: siteURL, token: token, device: device)
@@ -97,7 +97,7 @@ struct SelfHostedQRLoginRemoteTests {
         session.simulateResponse(for: url.absoluteString, data: json([
             "session_id": "abc", "expires_in": 90
         ]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.malformed) {
@@ -110,7 +110,7 @@ struct SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-scan")
         let session = MockURLSession()
         session.simulateError(for: url.absoluteString, error: URLError(.notConnectedToInternet))
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.network) {
@@ -125,7 +125,7 @@ struct SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
         let session = MockURLSession()
         session.simulateResponse(for: url.absoluteString, data: json(["state": "scanned"]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
@@ -144,7 +144,7 @@ struct SelfHostedQRLoginRemoteTests {
             "state": "approved",
             "exchange_grant": "grant-abc"
         ]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
@@ -158,7 +158,7 @@ struct SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
         let session = MockURLSession()
         session.simulateResponse(for: url.absoluteString, data: json(["state": "spinning"]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
@@ -172,7 +172,7 @@ struct SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
         let session = MockURLSession()
         session.simulateResponse(for: url.absoluteString, data: Data(), statusCode: 404)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.notFound) {
@@ -185,7 +185,7 @@ struct SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-session-status", query: "session_id=session-1&token_hash=hash-1")
         let session = MockURLSession()
         session.simulateResponse(for: url.absoluteString, data: Data(), statusCode: 429)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.rateLimited) {
@@ -204,7 +204,7 @@ struct SelfHostedQRLoginRemoteTests {
             "site_url": "https://shop.example",
             "application_password": "ap-1234"
         ]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         let response = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
@@ -223,7 +223,7 @@ struct SelfHostedQRLoginRemoteTests {
         session.simulateResponse(for: url.absoluteString, data: json([
             "user_login": "a", "site_url": "https://shop.example", "application_password": "p"
         ]), statusCode: 200)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When
         _ = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
@@ -245,7 +245,7 @@ struct SelfHostedQRLoginRemoteTests {
             "code": "qr_login_not_approved",
             "message": "Not approved yet"
         ]), statusCode: 412)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.preconditionFailed(code: "qr_login_not_approved")) {
@@ -260,7 +260,7 @@ struct SelfHostedQRLoginRemoteTests {
         session.simulateResponse(for: url.absoluteString, data: json([
             "code": "invalid_exchange_grant"
         ]), statusCode: 412)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.preconditionFailed(code: "invalid_exchange_grant")) {
@@ -273,18 +273,64 @@ struct SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-exchange")
         let session = MockURLSession()
         session.simulateResponse(for: url.absoluteString, data: Data("not json".utf8), statusCode: 412)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: QRLoginNetworkError.preconditionFailed(code: nil)) {
             _ = try await remote.exchange(siteURL: siteURL, token: token, exchangeGrant: grant)
         }
     }
+
+    // MARK: - Endpoint resolution
+
+    @Test func scan_when_discovery_returns_api_root_then_uses_discovered_root() async throws {
+        // Given
+        let url = makeURL(root: "https://shop.example/custom-json/", path: "qr-login-scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "abc",
+            "real_number": "428",
+            "expires_in": 90
+        ]), statusCode: 200)
+        let remote = makeRemote(session: session, cachedRoot: nil) { _ in
+            "https://shop.example/custom-json/"
+        }
+
+        // When
+        _ = try await remote.scan(siteURL: siteURL, token: token, device: device)
+
+        // Then
+        #expect(session.lastRequest?.url?.absoluteString == url.absoluteString)
+    }
+
+    @Test func pollSessionStatus_when_api_root_missing_then_uses_rest_route_fallback() async throws {
+        // Given
+        let url = URL(string: "https://shop.example/?rest_route=/wc-admin/mobile-app/qr-login-session-status&session_id=session-1&token_hash=hash-1")!
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json(["state": "scanned"]), statusCode: 200)
+        let remote = makeRemote(session: session, cachedRoot: nil) { _ in nil }
+
+        // When
+        let status = try await remote.pollSessionStatus(siteURL: siteURL, sessionID: "session-1", tokenHash: "hash-1")
+
+        // Then
+        #expect(status == SelfHostedQRLoginSessionStatus(state: .scanned, exchangeGrant: nil))
+        #expect(session.lastRequest?.url?.absoluteString == url.absoluteString)
+        #expect(session.requestCount == 1)
+    }
 }
 
 // MARK: - Helpers
 
 private extension SelfHostedQRLoginRemoteTests {
+
+    func makeRemote(session: MockURLSession,
+                    cachedRoot: String? = "https://shop.example/wp-json/",
+                    discoverRESTAPIRoot: @escaping (_ siteURL: String) async -> String? = { _ in nil }) -> SelfHostedQRLoginRemote {
+        SelfHostedQRLoginRemote(session: session,
+                                apiRootCache: MockRESTAPIRootCache(stubbedRoot: cachedRoot),
+                                discoverRESTAPIRoot: discoverRESTAPIRoot)
+    }
 
     func makeURL(path: String, query: String? = nil) -> URL {
         var components = URLComponents()
@@ -293,6 +339,18 @@ private extension SelfHostedQRLoginRemoteTests {
         components.path = "/wp-json/wc-admin/mobile-app" + path
         components.query = query
         return components.url!
+    }
+
+    func makeURL(root: String, path: String) -> URL {
+        let urlString = [
+            root,
+            "wc-admin/mobile-app",
+            path
+        ]
+            .map { $0.trimSlashes() }
+            .filter { $0.isEmpty == false }
+            .joined(separator: "/")
+        return URL(string: urlString)!
     }
 
     func json(_ object: [String: Any]) -> Data {
@@ -312,7 +370,7 @@ private extension SelfHostedQRLoginRemoteTests {
         let url = makeURL(path: "/qr-login-scan")
         let session = MockURLSession()
         session.simulateResponse(for: url.absoluteString, data: body, statusCode: statusCode)
-        let remote = SelfHostedQRLoginRemote(session: session)
+        let remote = makeRemote(session: session)
 
         // When / Then
         await #expect(throws: expected) {

--- a/Modules/Tests/NetworkingTests/QRLogin/SelfHostedQRLoginRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/QRLogin/SelfHostedQRLoginRemoteTests.swift
@@ -3,8 +3,8 @@ import Testing
 import NetworkingCore
 @testable import Networking
 
-/// Tests every row of spec §5.1.1, §5.1.2, §5.1.3 against the self-hosted
-/// QR-login Remote, plus the request-shape assertions that the spec calls out
+/// Tests the self-hosted QR-login Remote against every documented response,
+/// plus the request-shape assertions that the spec calls out
 /// explicitly (Cache-Control on poll, no `device.*` on exchange).
 struct SelfHostedQRLoginRemoteTests {
 
@@ -18,7 +18,7 @@ struct SelfHostedQRLoginRemoteTests {
                                            brand: "Apple",
                                            appVersion: "23.6")
 
-    // MARK: - /scan (§5.1.1)
+    // MARK: - /scan
 
     @Test func scan_when_200_then_decodes_response() async throws {
         // Given
@@ -118,7 +118,7 @@ struct SelfHostedQRLoginRemoteTests {
         }
     }
 
-    // MARK: - /session-status (§5.1.2)
+    // MARK: - /session-status
 
     @Test func pollSessionStatus_sends_session_id_and_token_hash_and_no_cache_header() async throws {
         // Given
@@ -193,7 +193,7 @@ struct SelfHostedQRLoginRemoteTests {
         }
     }
 
-    // MARK: - /exchange (§5.1.3)
+    // MARK: - /exchange
 
     @Test func exchange_when_200_then_decodes_response() async throws {
         // Given
@@ -216,7 +216,7 @@ struct SelfHostedQRLoginRemoteTests {
     }
 
     @Test func exchange_does_not_send_device_metadata() async throws {
-        // Given — spec §5.1.3 explicitly: "The exchange request does not carry
+        // Given — the spec is explicit: "The exchange request does not carry
         // `device.*` metadata; that lives only on `/scan`."
         let url = makeURL(path: "/qr-login-exchange")
         let session = MockURLSession()

--- a/Modules/Tests/NetworkingTests/QRLogin/WPComQRLoginRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/QRLogin/WPComQRLoginRemoteTests.swift
@@ -1,0 +1,315 @@
+import Foundation
+import Testing
+import NetworkingCore
+@testable import Networking
+
+/// Covers every row of spec §5.2.1 / §5.2.2 / §5.2.3 against the WP.com
+/// QR-login Remote, plus the protocol-specific behaviours called out in the
+/// spec: `client_id` / `client_secret` on every request, poll 404 coerced to
+/// `expired`, and the legacy `status` field name accepted in place of `state`.
+struct WPComQRLoginRemoteTests {
+
+    private let clientID = "55584"
+    private let clientSecret = "secret"
+    private let compoundToken = "\(String(repeating: "a", count: 64)):\(String(repeating: "b", count: 32))"
+    private let encrypted = "blob"
+    private let sessionID = "wpcom-session"
+    private let grant = "wpcom-grant"
+    private let device = QRLoginScanDevice(os: "iOS",
+                                           osVersion: "18.5",
+                                           model: "iPhone17,1",
+                                           brand: "Apple",
+                                           appVersion: "23.6")
+
+    // MARK: - /scan (§5.2.1)
+
+    @Test func scan_when_200_then_decodes_response_with_user_email() async throws {
+        // Given
+        let url = makeURL(path: "/scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "wpcom-1",
+            "real_number": "713",
+            "expires_in": 90,
+            "user_email": "user@example.com"
+        ]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        let response = try await remote.scan(token: compoundToken, encrypted: encrypted, device: device)
+
+        // Then
+        #expect(response == WPComQRLoginScanResponse(sessionID: "wpcom-1",
+                                                     realNumber: "713",
+                                                     expiresInSeconds: 90,
+                                                     userEmail: "user@example.com"))
+    }
+
+    @Test func scan_when_user_email_missing_then_malformed() async {
+        // Given
+        let url = makeURL(path: "/scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "x", "real_number": "001", "expires_in": 90
+        ]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.malformed) {
+            _ = try await remote.scan(token: self.compoundToken, encrypted: self.encrypted, device: self.device)
+        }
+    }
+
+    @Test func scan_sends_client_credentials_token_encrypted_and_device() async throws {
+        // Given
+        let url = makeURL(path: "/scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "session_id": "x", "real_number": "001", "expires_in": 90, "user_email": "u@e"
+        ]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        _ = try await remote.scan(token: compoundToken, encrypted: encrypted, device: device)
+
+        // Then
+        let body = try requireBody(from: session)
+        let decoded = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        #expect(decoded?["client_id"] as? String == clientID)
+        #expect(decoded?["client_secret"] as? String == clientSecret)
+        #expect(decoded?["token"] as? String == compoundToken)
+        #expect(decoded?["encrypted"] as? String == encrypted)
+        #expect(decoded?["supports_number_matching"] as? Bool == true)
+        #expect((decoded?["device"] as? [String: String])?["os"] == "iOS")
+    }
+
+    @Test func scan_when_403_then_throws_unauthorized() async {
+        await expectScanError(statusCode: 403, body: Data(), expected: .unauthorized)
+    }
+
+    @Test func scan_when_404_then_throws_notFound() async {
+        await expectScanError(statusCode: 404, body: Data(), expected: .notFound)
+    }
+
+    @Test func scan_when_409_then_throws_conflict() async {
+        await expectScanError(statusCode: 409, body: Data(), expected: .conflict)
+    }
+
+    @Test func scan_when_400_no_number_matching_then_badRequest_with_code() async {
+        await expectScanError(
+            statusCode: 400,
+            body: try! JSONSerialization.data(withJSONObject: ["code": "no_number_matching"]),
+            expected: .badRequest(code: "no_number_matching")
+        )
+    }
+
+    @Test func scan_when_429_then_throws_rateLimited() async {
+        await expectScanError(statusCode: 429, body: Data(), expected: .rateLimited)
+    }
+
+    // MARK: - /session-status (§5.2.2)
+
+    @Test func pollSessionStatus_sends_client_credentials_session_id_and_token_hash() async throws {
+        // Given
+        let url = makeURL(
+            path: "/session-status",
+            query: "client_id=\(clientID)&client_secret=\(clientSecret)&session_id=\(sessionID)&token_hash=hash-1"
+        )
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json(["state": "scanned"]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(sessionID: sessionID, tokenHash: "hash-1")
+
+        // Then
+        #expect(status == WPComQRLoginSessionStatus(state: .scanned, exchangeGrant: nil))
+        #expect(session.requestCount == 1)
+    }
+
+    @Test func pollSessionStatus_when_status_field_used_in_place_of_state_then_still_decodes() async throws {
+        // Given — wp.com legacy alias (§5.2.2).
+        let url = makeURL(
+            path: "/session-status",
+            query: "client_id=\(clientID)&client_secret=\(clientSecret)&session_id=\(sessionID)&token_hash=hash-1"
+        )
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json(["status": "approved", "exchange_grant": "g"]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(sessionID: sessionID, tokenHash: "hash-1")
+
+        // Then
+        #expect(status == WPComQRLoginSessionStatus(state: .approved, exchangeGrant: "g"))
+    }
+
+    @Test func pollSessionStatus_when_consumed_then_returns_consumed_state() async throws {
+        // Given
+        let url = makeURL(
+            path: "/session-status",
+            query: "client_id=\(clientID)&client_secret=\(clientSecret)&session_id=\(sessionID)&token_hash=hash-1"
+        )
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json(["state": "consumed"]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(sessionID: sessionID, tokenHash: "hash-1")
+
+        // Then
+        #expect(status.state == .consumed)
+    }
+
+    @Test func pollSessionStatus_when_404_then_coerced_to_expired_terminal() async throws {
+        // Given — spec §5.2.2: wp.com poll 404 → expired terminal, not surfaced
+        // as a hard error.
+        let url = makeURL(
+            path: "/session-status",
+            query: "client_id=\(clientID)&client_secret=\(clientSecret)&session_id=\(sessionID)&token_hash=hash-1"
+        )
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: Data(), statusCode: 404)
+        let remote = makeRemote(session: session)
+
+        // When
+        let status = try await remote.pollSessionStatus(sessionID: sessionID, tokenHash: "hash-1")
+
+        // Then
+        #expect(status == WPComQRLoginSessionStatus(state: .expired, exchangeGrant: nil))
+    }
+
+    @Test func pollSessionStatus_when_403_then_throws_unauthorized() async {
+        // Given — wp.com poll 403 = token_hash mismatch; terminal "Code expired".
+        let url = makeURL(
+            path: "/session-status",
+            query: "client_id=\(clientID)&client_secret=\(clientSecret)&session_id=\(sessionID)&token_hash=hash-1"
+        )
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: Data(), statusCode: 403)
+        let remote = makeRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.unauthorized) {
+            _ = try await remote.pollSessionStatus(sessionID: self.sessionID, tokenHash: "hash-1")
+        }
+    }
+
+    // MARK: - /exchange (§5.2.3)
+
+    @Test func exchange_when_200_then_decodes_magic_link_url() async throws {
+        // Given
+        let url = makeURL(path: "/exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "magic_link_url": "https://wordpress.com/wp-login.php?action=magic-login&scheme=woocommerce&token=abc"
+        ]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        let response = try await remote.exchange(token: compoundToken, encrypted: encrypted, exchangeGrant: grant)
+
+        // Then
+        #expect(response.magicLinkURL.absoluteString.hasPrefix("https://wordpress.com/wp-login.php"))
+    }
+
+    @Test func exchange_sends_client_credentials_token_encrypted_and_grant() async throws {
+        // Given
+        let url = makeURL(path: "/exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "magic_link_url": "https://wordpress.com/wp-login.php?token=x"
+        ]), statusCode: 200)
+        let remote = makeRemote(session: session)
+
+        // When
+        _ = try await remote.exchange(token: compoundToken, encrypted: encrypted, exchangeGrant: grant)
+
+        // Then
+        let body = try requireBody(from: session)
+        let decoded = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        #expect(decoded?["client_id"] as? String == clientID)
+        #expect(decoded?["client_secret"] as? String == clientSecret)
+        #expect(decoded?["token"] as? String == compoundToken)
+        #expect(decoded?["encrypted"] as? String == encrypted)
+        #expect(decoded?["exchange_grant"] as? String == grant)
+        #expect(decoded?.keys.contains("device") == false)
+        #expect(decoded?.keys.contains("supports_number_matching") == false)
+    }
+
+    @Test func exchange_when_412_qr_login_not_approved_then_preconditionFailed_with_code() async {
+        // Given
+        let url = makeURL(path: "/exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "code": "qr_login_not_approved"
+        ]), statusCode: 412)
+        let remote = makeRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.preconditionFailed(code: "qr_login_not_approved")) {
+            _ = try await remote.exchange(token: self.compoundToken,
+                                          encrypted: self.encrypted,
+                                          exchangeGrant: self.grant)
+        }
+    }
+
+    @Test func exchange_when_500_already_consumed_then_internalServerError_with_code() async {
+        // Given
+        let url = makeURL(path: "/exchange")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: json([
+            "code": "already_consumed"
+        ]), statusCode: 500)
+        let remote = makeRemote(session: session)
+
+        // When / Then
+        await #expect(throws: QRLoginNetworkError.internalServerError(code: "already_consumed")) {
+            _ = try await remote.exchange(token: self.compoundToken,
+                                          encrypted: self.encrypted,
+                                          exchangeGrant: self.grant)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension WPComQRLoginRemoteTests {
+
+    func makeRemote(session: MockURLSession) -> WPComQRLoginRemote {
+        WPComQRLoginRemote(clientID: clientID,
+                           clientSecret: clientSecret,
+                           session: session)
+    }
+
+    func makeURL(path: String, query: String? = nil) -> URL {
+        var components = URLComponents(string: Settings.wordpressApiBaseURL + "wpcom/v2/auth/qr-code-app" + path)!
+        components.query = query
+        return components.url!
+    }
+
+    func json(_ object: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    func requireBody(from session: MockURLSession) throws -> Data {
+        guard let body = session.lastRequest?.httpBody else {
+            Issue.record("Expected captured request body but none was recorded")
+            throw QRLoginNetworkError.malformed
+        }
+        return body
+    }
+
+    func expectScanError(statusCode: Int, body: Data, expected: QRLoginNetworkError) async {
+        // Given
+        let url = makeURL(path: "/scan")
+        let session = MockURLSession()
+        session.simulateResponse(for: url.absoluteString, data: body, statusCode: statusCode)
+        let remote = makeRemote(session: session)
+
+        // When / Then
+        await #expect(throws: expected) {
+            _ = try await remote.scan(token: self.compoundToken, encrypted: self.encrypted, device: self.device)
+        }
+    }
+}

--- a/Modules/Tests/NetworkingTests/QRLogin/WPComQRLoginRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/QRLogin/WPComQRLoginRemoteTests.swift
@@ -3,7 +3,7 @@ import Testing
 import NetworkingCore
 @testable import Networking
 
-/// Covers every row of spec §5.2.1 / §5.2.2 / §5.2.3 against the WP.com
+/// Covers the WP.com QR-login Remote against every documented response,
 /// QR-login Remote, plus the protocol-specific behaviours called out in the
 /// spec: `client_id` / `client_secret` on every request, poll 404 coerced to
 /// `expired`, and the legacy `status` field name accepted in place of `state`.
@@ -21,7 +21,7 @@ struct WPComQRLoginRemoteTests {
                                            brand: "Apple",
                                            appVersion: "23.6")
 
-    // MARK: - /scan (§5.2.1)
+    // MARK: - /scan
 
     @Test func scan_when_200_then_decodes_response_with_user_email() async throws {
         // Given
@@ -107,7 +107,7 @@ struct WPComQRLoginRemoteTests {
         await expectScanError(statusCode: 429, body: Data(), expected: .rateLimited)
     }
 
-    // MARK: - /session-status (§5.2.2)
+    // MARK: - /session-status
 
     @Test func pollSessionStatus_sends_client_credentials_session_id_and_token_hash() async throws {
         // Given
@@ -128,7 +128,7 @@ struct WPComQRLoginRemoteTests {
     }
 
     @Test func pollSessionStatus_when_status_field_used_in_place_of_state_then_still_decodes() async throws {
-        // Given — wp.com legacy alias (§5.2.2).
+        // Given — wp.com legacy alias.
         let url = makeURL(
             path: "/session-status",
             query: "client_id=\(clientID)&client_secret=\(clientSecret)&session_id=\(sessionID)&token_hash=hash-1"
@@ -162,7 +162,7 @@ struct WPComQRLoginRemoteTests {
     }
 
     @Test func pollSessionStatus_when_404_then_coerced_to_expired_terminal() async throws {
-        // Given — spec §5.2.2: wp.com poll 404 → expired terminal, not surfaced
+        // Given — wp.com poll 404 → expired terminal, not surfaced
         // as a hard error.
         let url = makeURL(
             path: "/session-status",
@@ -195,7 +195,7 @@ struct WPComQRLoginRemoteTests {
         }
     }
 
-    // MARK: - /exchange (§5.2.3)
+    // MARK: - /exchange
 
     @Test func exchange_when_200_then_decodes_magic_link_url() async throws {
         // Given


### PR DESCRIPTION
## Description
**Part 1 of 7** — QR-code login, split from `feature/qr-login` into a stacked chain of PRs for reviewability. Each PR builds on the previous; only **[7/7]** wires the feature into the UI and is end-to-end testable. Earlier PRs add cohesive, self-contained code that compiles but isn't reachable yet.

This PR adds the **Networking layer**: the `qrCodeLogin` remote feature flag, the token-hash utility, network error + HTTP-status mapping, response-body decoding, the QR-login DTOs, and the two `URLSession`-direct Remotes (self-hosted + WP.com).

**Stack:** base `trunk` → next **[2/7]** `feature/qr-login-step-2`.
~734 production lines — intentionally over the 300-line guideline; the feature was split into ≤800-line cohesive layers instead of 15+ tiny PRs.

## Test Steps
Infrastructure only, not user-testable. CI builds the `Networking` module and runs the QR-login unit tests (`QRLoginTokenHashTests`, `SelfHostedQRLoginRemoteTests`, `WPComQRLoginRemoteTests` — 43 tests).

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.