### PR TITLE
QR-login [3/7]: Error handling, analytics & WordPressAuthenticator hooks

### DIFF
--- a/WooCommerce/Classes/Authentication/QRLogin/Analytics/QRLoginAnalyticsFailure.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Analytics/QRLoginAnalyticsFailure.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Formats the `failure` property of a `UNIFIED_LOGIN_FAILURE` event for the
-/// QR-login flow, per spec §9.3.
+/// QR-login flow.
 ///
 /// The common shape is `<reason>:<phase>`. Payload / scanner failures (raised
 /// before any flow starts) emit the reason alone, and session-replace logout
@@ -45,10 +45,10 @@ struct QRLoginAnalyticsFailure {
     static let scanner = "Scanner"
     static let installQrCode = "InstallQrCode"
 
-    /// Session-replace logout failure (§9.3 exception).
+    /// Session-replace logout failure.
     static let sessionReplaceLogoutFailed = "Network:session_replace_logout_failed"
 
-    /// Maps a user-facing error to the §9.3 failure string. Centralised so the
+    /// Maps a user-facing error to the failure string. Centralised so the
     /// iOS and Android emissions stay byte-identical.
     static func failureString(for error: QRLoginUserFacingError) -> String {
         let phase: Phase

--- a/WooCommerce/Classes/Authentication/QRLogin/Analytics/QRLoginAnalyticsFailure.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Analytics/QRLoginAnalyticsFailure.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Formats the `failure` property of a `UNIFIED_LOGIN_FAILURE` event for the
+/// QR-login flow, per spec §9.3.
+///
+/// The common shape is `<reason>:<phase>`. Payload / scanner failures (raised
+/// before any flow starts) emit the reason alone, and session-replace logout
+/// failure has its own dedicated value. Keeping these as compile-time-safe
+/// values prevents the analytics strings from drifting between iOS and
+/// Android.
+struct QRLoginAnalyticsFailure {
+
+    enum Reason: String {
+        case network = "Network"
+        case rateLimited = "RateLimited"
+        case serverError = "ServerError"
+        case unknown = "Unknown"
+        case endpointMissing = "EndpointMissing"
+        case tokenRejected = "TokenRejected"
+        case matchTimedOut = "MatchTimedOut"
+        case matchRejected = "MatchRejected"
+        case matchAlreadyScanned = "MatchAlreadyScanned"
+        case matchInvalidGrant = "MatchInvalidGrant"
+        case matchAlreadyCompleted = "MatchAlreadyCompleted"
+        case notAWooSite = "NotAWooSite"
+        case userNotEligible = "UserNotEligible"
+        case siteAuthFailure = "SiteAuthFailure"
+    }
+
+    enum Phase: String {
+        case scan = "Scan"
+        case poll = "Poll"
+        case approve = "Approve"
+        case exchange = "Exchange"
+        case auth = "Auth"
+    }
+
+    /// Standard `<reason>:<phase>` failures.
+    static func reason(_ reason: Reason, phase: Phase) -> String {
+        "\(reason.rawValue):\(phase.rawValue)"
+    }
+
+    /// Payload / scanner failures fired before any flow starts. No phase suffix.
+    static let invalidPayload = "InvalidPayload"
+    static let scanner = "Scanner"
+    static let installQrCode = "InstallQrCode"
+
+    /// Session-replace logout failure (§9.3 exception).
+    static let sessionReplaceLogoutFailed = "Network:session_replace_logout_failed"
+
+    /// Maps a user-facing error to the §9.3 failure string. Centralised so the
+    /// iOS and Android emissions stay byte-identical.
+    static func failureString(for error: QRLoginUserFacingError) -> String {
+        let phase: Phase
+        switch error.phase {
+        case .scan: phase = .scan
+        case .poll: phase = .poll
+        case .exchange: phase = .exchange
+        case .postExchange: phase = .auth
+        case .prelude:
+            // Payload / scanner failures never have a phase suffix.
+            switch error.kind {
+            case .invalidPayload: return invalidPayload
+            case .scannerFailure: return scanner
+            case .installQR: return installQrCode
+            default: return invalidPayload
+            }
+        }
+
+        let reason: Reason
+        switch error.kind {
+        case .network: reason = .network
+        case .rateLimited: reason = .rateLimited
+        case .unexpected: reason = .serverError
+        case .storeUnsupported: reason = .endpointMissing
+        case .codeExpired: reason = .tokenRejected
+        case .signInTimedOut: reason = .matchTimedOut
+        case .signInDenied: reason = .matchRejected
+        case .codeAlreadyUsed: reason = .matchAlreadyScanned
+        case .signInInterrupted: reason = .matchInvalidGrant
+        case .alreadySignedInElsewhere: reason = .matchAlreadyCompleted
+        case .notAWooSite: reason = .notAWooSite
+        case .userNotEligible: reason = .userNotEligible
+        case .siteAuthFailure: reason = .siteAuthFailure
+        case .invalidPayload, .installQR, .scannerFailure: reason = .unknown
+        }
+
+        return Self.reason(reason, phase: phase)
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginAnalyticsTracking.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginAnalyticsTracking.swift
@@ -1,0 +1,38 @@
+import Foundation
+import WordPressAuthenticator
+
+/// Façade around `AuthenticatorAnalyticsTracker` for the QR-login flow.
+/// Lets tests substitute a spy instead of poking at the shared singleton, and
+/// pins the `flow = login_qr` invariant in one place.
+@MainActor
+protocol QRLoginAnalyticsTracking {
+    func trackStep(_ step: AuthenticatorAnalyticsTracker.Step)
+    func trackClick(_ click: AuthenticatorAnalyticsTracker.ClickTarget)
+    func trackFailure(_ failure: String)
+    func setFlow(_ flow: AuthenticatorAnalyticsTracker.Flow)
+}
+
+@MainActor
+struct DefaultQRLoginAnalyticsTracking: QRLoginAnalyticsTracking {
+    private let tracker: AuthenticatorAnalyticsTracker
+
+    init(tracker: AuthenticatorAnalyticsTracker = .shared) {
+        self.tracker = tracker
+    }
+
+    func setFlow(_ flow: AuthenticatorAnalyticsTracker.Flow) {
+        tracker.set(flow: flow)
+    }
+
+    func trackStep(_ step: AuthenticatorAnalyticsTracker.Step) {
+        tracker.track(step: step)
+    }
+
+    func trackClick(_ click: AuthenticatorAnalyticsTracker.ClickTarget) {
+        tracker.track(click: click)
+    }
+
+    func trackFailure(_ failure: String) {
+        tracker.track(failure: failure)
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginErrorMapper.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginErrorMapper.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 
 /// Maps `QRLoginNetworkError`s and other Remote-level outcomes into the
-/// user-facing variants from spec §8.
+/// user-facing variants.
 ///
 /// Encodes the protocol + phase rules:
 ///   - Self-hosted 404 / 426 on scan → "This store can't complete QR login".

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginErrorMapper.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginErrorMapper.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Yosemite
+
+/// Maps `QRLoginNetworkError`s and other Remote-level outcomes into the
+/// user-facing variants from spec §8.
+///
+/// Encodes the protocol + phase rules:
+///   - Self-hosted 404 / 426 on scan → "This store can't complete QR login".
+///   - WP.com 404 on scan → "Code expired".
+///   - WP.com 404 on exchange → "Sign-in interrupted".
+///   - 412 on exchange → disambiguated by body code into "Sign-in timed out"
+///     (`qr_login_not_approved`) or "Sign-in interrupted"
+///     (`invalid_exchange_grant`).
+///   - 500 `already_consumed` on wp.com exchange → "Already signed in elsewhere".
+///   - 429 anywhere → "Too many attempts".
+///   - Transport / 5xx / unmapped → "Couldn't reach your store" /
+///     "Something went wrong".
+///
+/// The mapper is intentionally pure — no I/O, no logging — so it is exhaustively
+/// testable against the spec tables.
+enum QRLoginErrorMapper {
+
+    enum Protocol_ {
+        case selfHosted
+        case wpCom
+    }
+
+    /// Map a network error from /scan into a user-facing variant.
+    static func userFacingError(forScan error: QRLoginNetworkError,
+                                protocol_: Protocol_) -> QRLoginUserFacingError {
+        switch error {
+        case .unauthorized:
+            return .init(kind: .codeExpired, phase: .scan, primaryAction: .scanAgain)
+
+        case .notFound:
+            switch protocol_ {
+            case .selfHosted:
+                return .init(kind: .storeUnsupported, phase: .scan, primaryAction: .retryFailedPhase)
+            case .wpCom:
+                return .init(kind: .codeExpired, phase: .scan, primaryAction: .scanAgain)
+            }
+
+        case .upgradeRequired:
+            return .init(kind: .storeUnsupported, phase: .scan, primaryAction: .retryFailedPhase)
+
+        case .conflict:
+            return .init(kind: .codeAlreadyUsed, phase: .scan, primaryAction: .scanAgain)
+
+        case .rateLimited:
+            return .init(kind: .rateLimited, phase: .scan, primaryAction: .retryFailedPhase)
+
+        case .network:
+            return .init(kind: .network, phase: .scan, primaryAction: .retryFailedPhase)
+
+        case .badRequest, .clientError, .preconditionFailed, .internalServerError, .serverError, .malformed:
+            return .init(kind: .unexpected, phase: .scan, primaryAction: .retryFailedPhase)
+        }
+    }
+
+    /// Map a network error from /session-status into a user-facing variant.
+    /// Returns `nil` for transient errors that should be absorbed by the
+    /// 4-strike threshold — the caller decides when to surface them.
+    ///
+    /// Note: wp.com's poll 404 is handled inside `WPComQRLoginRemote` (it is
+    /// coerced to a `.expired` session status, not surfaced as an error).
+    static func userFacingError(forPoll error: QRLoginNetworkError,
+                                protocol_: Protocol_) -> QRLoginUserFacingError? {
+        switch error {
+        case .notFound:
+            // Self-hosted poll 404 is terminal (the merchant's WC plugin
+            // doesn't expose the endpoint).
+            return .init(kind: .storeUnsupported, phase: .poll, primaryAction: .retryFailedPhase)
+
+        case .rateLimited:
+            // 429 is terminal for both protocols.
+            return .init(kind: .rateLimited, phase: .poll, primaryAction: .retryFailedPhase)
+
+        case .unauthorized:
+            // WP.com poll 403 = token_hash mismatch; treat the token as
+            // compromised, require a fresh scan.
+            return .init(kind: .codeExpired, phase: .poll, primaryAction: .scanAgain)
+
+        case .network, .badRequest, .clientError, .preconditionFailed,
+             .internalServerError, .serverError, .malformed, .upgradeRequired, .conflict:
+            return nil // transient — handled by the polling loop's 4-strike budget
+        }
+    }
+
+    /// Used after the 4-strike threshold has fired — converts a transient
+    /// network error into the final user-facing variant.
+    static func userFacingError(forPollAfterThreshold error: QRLoginNetworkError) -> QRLoginUserFacingError {
+        switch error {
+        case .network:
+            return .init(kind: .network, phase: .poll, primaryAction: .retryFailedPhase)
+        default:
+            return .init(kind: .unexpected, phase: .poll, primaryAction: .retryFailedPhase)
+        }
+    }
+
+    /// Map a terminal poll *state* into a user-facing variant.
+    static func userFacingError(forTerminalState state: QRLoginSessionState,
+                                protocol_: Protocol_) -> QRLoginUserFacingError? {
+        switch state {
+        case .rejected:
+            return .init(kind: .signInDenied, phase: .poll, primaryAction: .scanAgain)
+        case .expired, .unknown:
+            return .init(kind: .signInTimedOut, phase: .poll, primaryAction: .scanAgain)
+        case .consumed:
+            return .init(kind: .alreadySignedInElsewhere, phase: .poll, primaryAction: .scanAgain)
+        case .approved, .scanned:
+            return nil // not terminal
+        }
+    }
+
+    /// Map a network error from /exchange into a user-facing variant.
+    static func userFacingError(forExchange error: QRLoginNetworkError,
+                                protocol_: Protocol_) -> QRLoginUserFacingError {
+        switch error {
+        case .unauthorized:
+            return .init(kind: .codeExpired, phase: .exchange, primaryAction: .scanAgain)
+
+        case .notFound:
+            switch protocol_ {
+            case .selfHosted:
+                return .init(kind: .storeUnsupported, phase: .exchange, primaryAction: .retryFailedPhase)
+            case .wpCom:
+                return .init(kind: .signInInterrupted, phase: .exchange, primaryAction: .scanAgain)
+            }
+
+        case .rateLimited:
+            return .init(kind: .rateLimited, phase: .exchange, primaryAction: .retryFailedPhase)
+
+        case .preconditionFailed(let code):
+            switch code {
+            case "qr_login_not_approved":
+                return .init(kind: .signInTimedOut, phase: .exchange, primaryAction: .scanAgain)
+            case "invalid_exchange_grant":
+                return .init(kind: .signInInterrupted, phase: .exchange, primaryAction: .scanAgain)
+            default:
+                return .init(kind: .unexpected, phase: .exchange, primaryAction: .retryFailedPhase)
+            }
+
+        case .internalServerError(let code):
+            switch code {
+            case "already_consumed" where protocol_ == .wpCom:
+                return .init(kind: .alreadySignedInElsewhere, phase: .exchange, primaryAction: .scanAgain)
+            default:
+                return .init(kind: .unexpected, phase: .exchange, primaryAction: .retryFailedPhase)
+            }
+
+        case .network:
+            return .init(kind: .network, phase: .exchange, primaryAction: .retryFailedPhase)
+
+        case .badRequest, .clientError, .conflict, .upgradeRequired, .serverError, .malformed:
+            return .init(kind: .unexpected, phase: .exchange, primaryAction: .retryFailedPhase)
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginPollingLoop.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginPollingLoop.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Yosemite
+
+/// Drives the `GET /qr-login-session-status` poll until a terminal outcome is
+/// reached.
+///
+/// Behaviour from spec §5.3 / §6.1:
+///   - Cadence: 2 seconds between attempts. The first tick is *immediate* —
+///     no leading delay.
+///   - Transient-error budget: up to 3 consecutive transient errors are
+///     tolerated; the 4th consecutive failure surfaces. Any non-error
+///     response resets the counter.
+///   - "Fail closed" on `approved` with a missing / blank `exchange_grant` —
+///     treated as `expired` so the UI shows a terminal screen instead of
+///     spinning forever.
+///   - Unknown state values are routed through the terminal-state mapper,
+///     which translates them defensively to `signInTimedOut`.
+///   - Cancellation: cooperative — observes `Task.checkCancellation()` before
+///     every poll and sleep.
+final class QRLoginPollingLoop {
+
+    enum Outcome: Equatable {
+        case approved(exchangeGrant: String)
+        case error(QRLoginUserFacingError)
+        case cancelled
+    }
+
+    /// A single poll attempt. Implementations call the appropriate Remote and
+    /// map its endpoint-specific session status into the shared `QRLoginSessionState`.
+    typealias PollAttempt = () async throws -> QRLoginSessionState
+
+    /// Async sleep — injectable so tests can run the loop instantly.
+    typealias Sleeper = (TimeInterval) async throws -> Void
+
+    private let attempt: PollAttempt
+    private let sleeper: Sleeper
+    private let protocol_: QRLoginErrorMapper.Protocol_
+    private let pollInterval: TimeInterval
+    private let transientErrorBudget: Int
+
+    init(protocol_: QRLoginErrorMapper.Protocol_,
+                pollInterval: TimeInterval = 2.0,
+                transientErrorBudget: Int = 3,
+                sleeper: @escaping Sleeper = QRLoginPollingLoop.defaultSleeper,
+                attempt: @escaping PollAttempt) {
+        self.protocol_ = protocol_
+        self.pollInterval = pollInterval
+        self.transientErrorBudget = transientErrorBudget
+        self.sleeper = sleeper
+        self.attempt = attempt
+    }
+
+    func run() async -> Outcome {
+        var transientFailures = 0
+
+        while true {
+            if Task.isCancelled { return .cancelled }
+
+            do {
+                let state = try await attempt()
+                transientFailures = 0 // any non-error response resets the budget
+
+                switch state {
+                case .approved(let grant):
+                    if let grant, grant.isEmpty == false {
+                        return .approved(exchangeGrant: grant)
+                    }
+                    // Fail closed (spec §5.1.2 / §5.2.2).
+                    return .error(.init(kind: .signInTimedOut, phase: .poll, primaryAction: .scanAgain))
+
+                case .scanned:
+                    break // keep polling
+
+                case .rejected, .expired, .consumed, .unknown:
+                    if let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: state,
+                                                                       protocol_: protocol_) {
+                        return .error(mapped)
+                    }
+                    // Defensive: should be unreachable, but if the mapper says
+                    // "not terminal" we treat as expired.
+                    return .error(.init(kind: .signInTimedOut, phase: .poll, primaryAction: .scanAgain))
+                }
+            } catch let networkError as QRLoginNetworkError {
+                if let mapped = QRLoginErrorMapper.userFacingError(forPoll: networkError, protocol_: protocol_) {
+                    return .error(mapped) // terminal HTTP error
+                }
+                transientFailures += 1
+                if transientFailures > transientErrorBudget {
+                    return .error(QRLoginErrorMapper.userFacingError(forPollAfterThreshold: networkError))
+                }
+            } catch is CancellationError {
+                return .cancelled
+            } catch {
+                // Any non-QRLoginNetworkError throws are unexpected — count
+                // them toward the transient budget so we don't spin forever.
+                transientFailures += 1
+                if transientFailures > transientErrorBudget {
+                    return .error(.init(kind: .unexpected, phase: .poll, primaryAction: .retryFailedPhase))
+                }
+            }
+
+            do {
+                try await sleeper(pollInterval)
+            } catch {
+                return .cancelled
+            }
+        }
+    }
+
+    static let defaultSleeper: Sleeper = { interval in
+        try await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginPollingLoop.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginPollingLoop.swift
@@ -4,8 +4,7 @@ import Yosemite
 /// Drives the `GET /qr-login-session-status` poll until a terminal outcome is
 /// reached.
 ///
-/// Behaviour from spec §5.3 / §6.1:
-///   - Cadence: 2 seconds between attempts. The first tick is *immediate* —
+/// Behaviour from ///   - Cadence: 2 seconds between attempts. The first tick is *immediate* —
 ///     no leading delay.
 ///   - Transient-error budget: up to 3 consecutive transient errors are
 ///     tolerated; the 4th consecutive failure surfaces. Any non-error
@@ -65,7 +64,7 @@ final class QRLoginPollingLoop {
                     if let grant, grant.isEmpty == false {
                         return .approved(exchangeGrant: grant)
                     }
-                    // Fail closed (spec §5.1.2 / §5.2.2).
+                    // Fail closed.
                     return .error(.init(kind: .signInTimedOut, phase: .poll, primaryAction: .scanAgain))
 
                 case .scanned:

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginSessionState.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginSessionState.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Yosemite
+
+/// Behaviour-layer view of a QR-login session's state during polling.
+///
+/// The data layer has one session-status struct per endpoint
+/// (`SelfHostedQRLoginSessionStatus` / `WPComQRLoginSessionStatus`); this is the
+/// shared concept they both map into, so `QRLoginPollingLoop` and
+/// `QRLoginErrorMapper` stay protocol-agnostic. The grant rides on `.approved`
+/// because it only ever exists for that state.
+enum QRLoginSessionState: Equatable {
+    case scanned
+    case approved(exchangeGrant: String?)
+    case rejected
+    case expired
+    /// "Already signed in elsewhere" — only the wp.com endpoint reports this.
+    case consumed
+    /// Any state value the client doesn't recognise — treated defensively as a
+    /// timeout by the consumer.
+    case unknown
+}
+
+extension SelfHostedQRLoginSessionStatus {
+    /// Behaviour-layer view of this poll result. The self-hosted endpoint never
+    /// reports `consumed`, so that case is unreachable here.
+    var sessionState: QRLoginSessionState {
+        switch state {
+        case .scanned: return .scanned
+        case .approved: return .approved(exchangeGrant: exchangeGrant)
+        case .rejected: return .rejected
+        case .expired: return .expired
+        case .unknown: return .unknown
+        }
+    }
+}
+
+extension WPComQRLoginSessionStatus {
+    /// Behaviour-layer view of this poll result.
+    var sessionState: QRLoginSessionState {
+        switch state {
+        case .scanned: return .scanned
+        case .approved: return .approved(exchangeGrant: exchangeGrant)
+        case .rejected: return .rejected
+        case .expired: return .expired
+        case .consumed: return .consumed
+        case .unknown: return .unknown
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginUserFacingError.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginUserFacingError.swift
@@ -1,13 +1,12 @@
 import Foundation
 
-/// All the user-facing failure variants the QR-login flow can surface, drawn
-/// from spec §8.
+/// All the user-facing failure variants the QR-login flow can surface.
 ///
 /// Each variant encodes:
 ///   - the *kind* (drives the title / body / illustration choice in the UI)
 ///   - the *primary CTA action* (retry-the-failed-phase vs. scan-a-new-code)
 ///   - the *phase* the failure originated in (used for analytics and to
-///     know which Remote method to re-run on retry — §6.1).
+///     know which Remote method to re-run on retry).
 ///
 /// The user-facing copy (title / body / button labels) lives in the UI layer
 /// (`QRLoginErrorView`); this type only carries the structured kind / phase /
@@ -70,7 +69,7 @@ struct QRLoginUserFacingError: Error, Equatable {
 
     enum PrimaryAction: Equatable {
         /// "Try again" — re-runs the failed step (`scan`, `poll`, or
-        /// `exchange`) per spec §6.1.
+        /// `exchange`).
         case retryFailedPhase
         /// "Scan a new code" — returns to the scanner. In deep-link mode the
         /// caller exits the QR-login surface instead.

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginUserFacingError.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginUserFacingError.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// All the user-facing failure variants the QR-login flow can surface, drawn
+/// from spec §8.
+///
+/// Each variant encodes:
+///   - the *kind* (drives the title / body / illustration choice in the UI)
+///   - the *primary CTA action* (retry-the-failed-phase vs. scan-a-new-code)
+///   - the *phase* the failure originated in (used for analytics and to
+///     know which Remote method to re-run on retry — §6.1).
+///
+/// The user-facing copy (title / body / button labels) lives in the UI layer
+/// (`QRLoginErrorView`); this type only carries the structured kind / phase /
+/// CTA so it stays free of localised strings.
+struct QRLoginUserFacingError: Error, Equatable {
+
+    enum Kind: Equatable {
+        // Payload / scanner (raised before the network flow starts).
+        /// "Not a WooCommerce code".
+        case invalidPayload
+        /// "That's the install QR".
+        case installQR
+        /// "Couldn't read that code".
+        case scannerFailure
+
+        // Token / server.
+        /// "Code expired".
+        case codeExpired
+        /// "This store can't complete QR login" — self-hosted only.
+        case storeUnsupported
+        /// "Too many attempts".
+        case rateLimited
+        /// "Couldn't reach your store".
+        case network
+        /// "Something went wrong".
+        case unexpected
+        /// "Code already used".
+        case codeAlreadyUsed
+
+        // Poll terminal outcomes.
+        /// "Sign-in denied".
+        case signInDenied
+        /// "Sign-in timed out".
+        case signInTimedOut
+        /// "Sign-in interrupted".
+        case signInInterrupted
+        /// "Already signed in elsewhere" — wp.com only.
+        case alreadySignedInElsewhere
+
+        // Self-hosted post-exchange.
+        /// "Sign-in failed" — site fetch auth failure.
+        case siteAuthFailure
+        /// "Not a WooCommerce store".
+        case notAWooSite
+        /// "Permission needed" — eligibility check failed.
+        case userNotEligible
+    }
+
+    enum Phase: Equatable {
+        case scan
+        case poll
+        case exchange
+        /// Self-hosted post-exchange site setup (site fetch, AP save,
+        /// eligibility, store selection).
+        case postExchange
+        /// Failures that happened before the network flow started — payload
+        /// parse, install-QR detection, scanner pipeline.
+        case prelude
+    }
+
+    enum PrimaryAction: Equatable {
+        /// "Try again" — re-runs the failed step (`scan`, `poll`, or
+        /// `exchange`) per spec §6.1.
+        case retryFailedPhase
+        /// "Scan a new code" — returns to the scanner. In deep-link mode the
+        /// caller exits the QR-login surface instead.
+        case scanAgain
+    }
+
+    let kind: Kind
+    let phase: Phase
+    let primaryAction: PrimaryAction
+
+    init(kind: Kind, phase: Phase, primaryAction: PrimaryAction) {
+        self.kind = kind
+        self.phase = phase
+        self.primaryAction = primaryAction
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginDeviceInfoProvider.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginDeviceInfoProvider.swift
@@ -1,0 +1,35 @@
+import Foundation
+import UIKit
+import Yosemite
+
+/// Produces the `device.*` metadata sent on every QR-login `/scan`. Injectable
+/// so tests can pin the values without touching `UIDevice` / `Bundle`.
+protocol QRLoginDeviceInfoProvider {
+    var device: QRLoginScanDevice { get }
+}
+
+struct DefaultQRLoginDeviceInfoProvider: QRLoginDeviceInfoProvider {
+    var device: QRLoginScanDevice {
+        QRLoginScanDevice(
+            os: "iOS",
+            osVersion: UIDevice.current.systemVersion,
+            model: Self.hardwareIdentifier,
+            brand: "Apple",
+            appVersion: Bundle.main.marketingVersion
+        )
+    }
+
+    /// e.g. `iPhone17,1`. Falls back to `UIDevice.current.model` (e.g. `iPhone`)
+    /// when the sysctl call yields nothing — server applies a per-field cap and
+    /// whitelist anyway.
+    private static var hardwareIdentifier: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let mirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = mirror.children.compactMap { element -> String? in
+            guard let value = element.value as? Int8, value != 0 else { return nil }
+            return String(UnicodeScalar(UInt8(value)))
+        }.joined()
+        return identifier.isEmpty ? UIDevice.current.model : identifier
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginErrorMapperTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginErrorMapperTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import Networking
+import Testing
+@testable import WooCommerce
+
+/// Walks every cell of the spec §8 error catalog through the mapper. Each test
+/// names the spec row it covers in its `// Given` comment.
+struct QRLoginErrorMapperTests {
+
+    // MARK: - /scan
+
+    @Test func scan_unauthorized_on_both_protocols_maps_to_codeExpired() {
+        // §8 row: "Code expired" — fires on 401/403 at scan.
+        for proto: QRLoginErrorMapper.Protocol_ in [.selfHosted, .wpCom] {
+            let mapped = QRLoginErrorMapper.userFacingError(forScan: .unauthorized, protocol_: proto)
+            #expect(mapped.kind == .codeExpired)
+            #expect(mapped.primaryAction == .scanAgain)
+            #expect(mapped.phase == .scan)
+        }
+    }
+
+    @Test func scan_self_hosted_404_maps_to_storeUnsupported() {
+        // §8 row: "This store can't complete QR login" — self-hosted only,
+        // 404 / 426 on /scan or /session-status.
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .notFound, protocol_: .selfHosted)
+        #expect(mapped.kind == .storeUnsupported)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func scan_self_hosted_426_maps_to_storeUnsupported() {
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .upgradeRequired, protocol_: .selfHosted)
+        #expect(mapped.kind == .storeUnsupported)
+    }
+
+    @Test func scan_wpcom_404_maps_to_codeExpired() {
+        // §8 wp.com row: 404 on wp.com scan = QR expired before reaching server.
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .notFound, protocol_: .wpCom)
+        #expect(mapped.kind == .codeExpired)
+        #expect(mapped.primaryAction == .scanAgain)
+    }
+
+    @Test func scan_409_maps_to_codeAlreadyUsed() {
+        // §8 row: "Code already used" — 409 on /scan, both protocols.
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .conflict, protocol_: .wpCom)
+        #expect(mapped.kind == .codeAlreadyUsed)
+        #expect(mapped.primaryAction == .scanAgain)
+    }
+
+    @Test func scan_429_maps_to_rateLimited_retry() {
+        // §8 row: "Too many attempts" — 429 anywhere, retry.
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .rateLimited, protocol_: .selfHosted)
+        #expect(mapped.kind == .rateLimited)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func scan_network_maps_to_network_retry() {
+        // §8 row: "Couldn't reach your store" — network failure, retry.
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .network, protocol_: .selfHosted)
+        #expect(mapped.kind == .network)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func scan_server_error_maps_to_unexpected_retry() {
+        // §8 row: "Something went wrong" — 5xx / malformed, retry.
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .internalServerError(code: nil), protocol_: .selfHosted)
+        #expect(mapped.kind == .unexpected)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func scan_malformed_maps_to_unexpected() {
+        let mapped = QRLoginErrorMapper.userFacingError(forScan: .malformed, protocol_: .wpCom)
+        #expect(mapped.kind == .unexpected)
+    }
+
+    // MARK: - /session-status (terminal HTTP errors)
+
+    @Test func poll_404_self_hosted_terminal_maps_to_storeUnsupported() {
+        let mapped = QRLoginErrorMapper.userFacingError(forPoll: .notFound, protocol_: .selfHosted)
+        #expect(mapped?.kind == .storeUnsupported)
+    }
+
+    @Test func poll_429_terminal_maps_to_rateLimited() {
+        let mapped = QRLoginErrorMapper.userFacingError(forPoll: .rateLimited, protocol_: .wpCom)
+        #expect(mapped?.kind == .rateLimited)
+    }
+
+    @Test func poll_wpcom_403_token_hash_mismatch_maps_to_codeExpired_scan_again() {
+        // §5.2.2 wp.com: 403 = token_hash mismatch, terminal, "Code expired".
+        let mapped = QRLoginErrorMapper.userFacingError(forPoll: .unauthorized, protocol_: .wpCom)
+        #expect(mapped?.kind == .codeExpired)
+        #expect(mapped?.primaryAction == .scanAgain)
+    }
+
+    @Test func poll_transient_errors_return_nil_so_loop_can_absorb_them() {
+        // §5.1.2 / §5.2.2: 5xx / malformed / network → transient; the polling
+        // loop's 4-strike threshold decides when to surface.
+        #expect(QRLoginErrorMapper.userFacingError(forPoll: .network, protocol_: .selfHosted) == nil)
+        #expect(QRLoginErrorMapper.userFacingError(forPoll: .internalServerError(code: nil), protocol_: .wpCom) == nil)
+        #expect(QRLoginErrorMapper.userFacingError(forPoll: .malformed, protocol_: .selfHosted) == nil)
+    }
+
+    @Test func poll_after_threshold_network_maps_to_network_retry() {
+        let mapped = QRLoginErrorMapper.userFacingError(forPollAfterThreshold: .network)
+        #expect(mapped.kind == .network)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func poll_after_threshold_server_error_maps_to_unexpected_retry() {
+        let mapped = QRLoginErrorMapper.userFacingError(forPollAfterThreshold: .serverError(status: 503))
+        #expect(mapped.kind == .unexpected)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    // MARK: - Terminal poll states
+
+    @Test func terminal_rejected_maps_to_signInDenied() {
+        // §8 row: "Sign-in denied".
+        let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .rejected, protocol_: .selfHosted)
+        #expect(mapped?.kind == .signInDenied)
+    }
+
+    @Test func terminal_expired_maps_to_signInTimedOut() {
+        // §8 row: "Sign-in timed out".
+        let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .expired, protocol_: .wpCom)
+        #expect(mapped?.kind == .signInTimedOut)
+    }
+
+    @Test func terminal_unknown_state_maps_to_signInTimedOut_defensively() {
+        // Spec §5.1.2 / §5.2.2: unknown state → treated defensively as expired.
+        let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .unknown, protocol_: .selfHosted)
+        #expect(mapped?.kind == .signInTimedOut)
+    }
+
+    @Test func terminal_consumed_maps_to_alreadySignedInElsewhere() {
+        // §8 wp.com row: "Already signed in elsewhere".
+        let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .consumed, protocol_: .wpCom)
+        #expect(mapped?.kind == .alreadySignedInElsewhere)
+    }
+
+    @Test func non_terminal_states_return_nil() {
+        #expect(QRLoginErrorMapper.userFacingError(forTerminalState: .scanned, protocol_: .selfHosted) == nil)
+        #expect(QRLoginErrorMapper.userFacingError(forTerminalState: .approved(exchangeGrant: "g"), protocol_: .wpCom) == nil)
+    }
+
+    // MARK: - /exchange
+
+    @Test func exchange_unauthorized_maps_to_codeExpired() {
+        let mapped = QRLoginErrorMapper.userFacingError(forExchange: .unauthorized, protocol_: .selfHosted)
+        #expect(mapped.kind == .codeExpired)
+        #expect(mapped.primaryAction == .scanAgain)
+    }
+
+    @Test func exchange_self_hosted_404_maps_to_storeUnsupported() {
+        let mapped = QRLoginErrorMapper.userFacingError(forExchange: .notFound, protocol_: .selfHosted)
+        #expect(mapped.kind == .storeUnsupported)
+    }
+
+    @Test func exchange_wpcom_404_maps_to_signInInterrupted() {
+        // §8 wp.com row: 404 on wp.com exchange → "Sign-in interrupted".
+        let mapped = QRLoginErrorMapper.userFacingError(forExchange: .notFound, protocol_: .wpCom)
+        #expect(mapped.kind == .signInInterrupted)
+        #expect(mapped.primaryAction == .scanAgain)
+    }
+
+    @Test func exchange_412_qr_login_not_approved_maps_to_signInTimedOut() {
+        // §8 row: "Sign-in timed out".
+        let mapped = QRLoginErrorMapper.userFacingError(
+            forExchange: .preconditionFailed(code: "qr_login_not_approved"),
+            protocol_: .selfHosted
+        )
+        #expect(mapped.kind == .signInTimedOut)
+        #expect(mapped.primaryAction == .scanAgain)
+    }
+
+    @Test func exchange_412_invalid_exchange_grant_maps_to_signInInterrupted() {
+        // §8 row: "Sign-in interrupted".
+        let mapped = QRLoginErrorMapper.userFacingError(
+            forExchange: .preconditionFailed(code: "invalid_exchange_grant"),
+            protocol_: .selfHosted
+        )
+        #expect(mapped.kind == .signInInterrupted)
+    }
+
+    @Test func exchange_412_unknown_code_maps_to_unexpected() {
+        // §8 row: "Something went wrong" — 412 with a body code we don't
+        // recognise.
+        let mapped = QRLoginErrorMapper.userFacingError(
+            forExchange: .preconditionFailed(code: "some_other_code"),
+            protocol_: .selfHosted
+        )
+        #expect(mapped.kind == .unexpected)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func exchange_wpcom_500_already_consumed_maps_to_alreadySignedInElsewhere() {
+        // §8 wp.com row: 500 `already_consumed` on exchange.
+        let mapped = QRLoginErrorMapper.userFacingError(
+            forExchange: .internalServerError(code: "already_consumed"),
+            protocol_: .wpCom
+        )
+        #expect(mapped.kind == .alreadySignedInElsewhere)
+        #expect(mapped.primaryAction == .scanAgain)
+    }
+
+    @Test func exchange_self_hosted_500_already_consumed_falls_through_to_unexpected() {
+        // §8 note: self-hosted protocol can't distinguish "already signed in
+        // elsewhere" from generic server failures, so a self-hosted 500
+        // (even with a body code) does not surface that variant.
+        let mapped = QRLoginErrorMapper.userFacingError(
+            forExchange: .internalServerError(code: "already_consumed"),
+            protocol_: .selfHosted
+        )
+        #expect(mapped.kind == .unexpected)
+    }
+
+    @Test func exchange_429_maps_to_rateLimited_retry() {
+        let mapped = QRLoginErrorMapper.userFacingError(forExchange: .rateLimited, protocol_: .wpCom)
+        #expect(mapped.kind == .rateLimited)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+
+    @Test func exchange_network_maps_to_network_retry() {
+        let mapped = QRLoginErrorMapper.userFacingError(forExchange: .network, protocol_: .selfHosted)
+        #expect(mapped.kind == .network)
+        #expect(mapped.primaryAction == .retryFailedPhase)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginErrorMapperTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginErrorMapperTests.swift
@@ -3,14 +3,14 @@ import Networking
 import Testing
 @testable import WooCommerce
 
-/// Walks every cell of the spec §8 error catalog through the mapper. Each test
+/// Walks every cell of the spec error catalog through the mapper. Each test
 /// names the spec row it covers in its `// Given` comment.
 struct QRLoginErrorMapperTests {
 
     // MARK: - /scan
 
     @Test func scan_unauthorized_on_both_protocols_maps_to_codeExpired() {
-        // §8 row: "Code expired" — fires on 401/403 at scan.
+        // "Code expired" — fires on 401/403 at scan.
         for proto: QRLoginErrorMapper.Protocol_ in [.selfHosted, .wpCom] {
             let mapped = QRLoginErrorMapper.userFacingError(forScan: .unauthorized, protocol_: proto)
             #expect(mapped.kind == .codeExpired)
@@ -20,7 +20,7 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func scan_self_hosted_404_maps_to_storeUnsupported() {
-        // §8 row: "This store can't complete QR login" — self-hosted only,
+        // "This store can't complete QR login" — self-hosted only,
         // 404 / 426 on /scan or /session-status.
         let mapped = QRLoginErrorMapper.userFacingError(forScan: .notFound, protocol_: .selfHosted)
         #expect(mapped.kind == .storeUnsupported)
@@ -33,35 +33,35 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func scan_wpcom_404_maps_to_codeExpired() {
-        // §8 wp.com row: 404 on wp.com scan = QR expired before reaching server.
+        // 404 on wp.com scan = QR expired before reaching server.
         let mapped = QRLoginErrorMapper.userFacingError(forScan: .notFound, protocol_: .wpCom)
         #expect(mapped.kind == .codeExpired)
         #expect(mapped.primaryAction == .scanAgain)
     }
 
     @Test func scan_409_maps_to_codeAlreadyUsed() {
-        // §8 row: "Code already used" — 409 on /scan, both protocols.
+        // "Code already used" — 409 on /scan, both protocols.
         let mapped = QRLoginErrorMapper.userFacingError(forScan: .conflict, protocol_: .wpCom)
         #expect(mapped.kind == .codeAlreadyUsed)
         #expect(mapped.primaryAction == .scanAgain)
     }
 
     @Test func scan_429_maps_to_rateLimited_retry() {
-        // §8 row: "Too many attempts" — 429 anywhere, retry.
+        // "Too many attempts" — 429 anywhere, retry.
         let mapped = QRLoginErrorMapper.userFacingError(forScan: .rateLimited, protocol_: .selfHosted)
         #expect(mapped.kind == .rateLimited)
         #expect(mapped.primaryAction == .retryFailedPhase)
     }
 
     @Test func scan_network_maps_to_network_retry() {
-        // §8 row: "Couldn't reach your store" — network failure, retry.
+        // "Couldn't reach your store" — network failure, retry.
         let mapped = QRLoginErrorMapper.userFacingError(forScan: .network, protocol_: .selfHosted)
         #expect(mapped.kind == .network)
         #expect(mapped.primaryAction == .retryFailedPhase)
     }
 
     @Test func scan_server_error_maps_to_unexpected_retry() {
-        // §8 row: "Something went wrong" — 5xx / malformed, retry.
+        // "Something went wrong" — 5xx / malformed, retry.
         let mapped = QRLoginErrorMapper.userFacingError(forScan: .internalServerError(code: nil), protocol_: .selfHosted)
         #expect(mapped.kind == .unexpected)
         #expect(mapped.primaryAction == .retryFailedPhase)
@@ -85,14 +85,14 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func poll_wpcom_403_token_hash_mismatch_maps_to_codeExpired_scan_again() {
-        // §5.2.2 wp.com: 403 = token_hash mismatch, terminal, "Code expired".
+        // 403 = token_hash mismatch, terminal, "Code expired".
         let mapped = QRLoginErrorMapper.userFacingError(forPoll: .unauthorized, protocol_: .wpCom)
         #expect(mapped?.kind == .codeExpired)
         #expect(mapped?.primaryAction == .scanAgain)
     }
 
     @Test func poll_transient_errors_return_nil_so_loop_can_absorb_them() {
-        // §5.1.2 / §5.2.2: 5xx / malformed / network → transient; the polling
+        // 5xx / malformed / network → transient; the polling
         // loop's 4-strike threshold decides when to surface.
         #expect(QRLoginErrorMapper.userFacingError(forPoll: .network, protocol_: .selfHosted) == nil)
         #expect(QRLoginErrorMapper.userFacingError(forPoll: .internalServerError(code: nil), protocol_: .wpCom) == nil)
@@ -114,25 +114,25 @@ struct QRLoginErrorMapperTests {
     // MARK: - Terminal poll states
 
     @Test func terminal_rejected_maps_to_signInDenied() {
-        // §8 row: "Sign-in denied".
+        // "Sign-in denied".
         let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .rejected, protocol_: .selfHosted)
         #expect(mapped?.kind == .signInDenied)
     }
 
     @Test func terminal_expired_maps_to_signInTimedOut() {
-        // §8 row: "Sign-in timed out".
+        // "Sign-in timed out".
         let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .expired, protocol_: .wpCom)
         #expect(mapped?.kind == .signInTimedOut)
     }
 
     @Test func terminal_unknown_state_maps_to_signInTimedOut_defensively() {
-        // Spec §5.1.2 / §5.2.2: unknown state → treated defensively as expired.
+        // unknown state → treated defensively as expired.
         let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .unknown, protocol_: .selfHosted)
         #expect(mapped?.kind == .signInTimedOut)
     }
 
     @Test func terminal_consumed_maps_to_alreadySignedInElsewhere() {
-        // §8 wp.com row: "Already signed in elsewhere".
+        // "Already signed in elsewhere".
         let mapped = QRLoginErrorMapper.userFacingError(forTerminalState: .consumed, protocol_: .wpCom)
         #expect(mapped?.kind == .alreadySignedInElsewhere)
     }
@@ -156,14 +156,14 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func exchange_wpcom_404_maps_to_signInInterrupted() {
-        // §8 wp.com row: 404 on wp.com exchange → "Sign-in interrupted".
+        // 404 on wp.com exchange → "Sign-in interrupted".
         let mapped = QRLoginErrorMapper.userFacingError(forExchange: .notFound, protocol_: .wpCom)
         #expect(mapped.kind == .signInInterrupted)
         #expect(mapped.primaryAction == .scanAgain)
     }
 
     @Test func exchange_412_qr_login_not_approved_maps_to_signInTimedOut() {
-        // §8 row: "Sign-in timed out".
+        // "Sign-in timed out".
         let mapped = QRLoginErrorMapper.userFacingError(
             forExchange: .preconditionFailed(code: "qr_login_not_approved"),
             protocol_: .selfHosted
@@ -173,7 +173,7 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func exchange_412_invalid_exchange_grant_maps_to_signInInterrupted() {
-        // §8 row: "Sign-in interrupted".
+        // "Sign-in interrupted".
         let mapped = QRLoginErrorMapper.userFacingError(
             forExchange: .preconditionFailed(code: "invalid_exchange_grant"),
             protocol_: .selfHosted
@@ -182,7 +182,7 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func exchange_412_unknown_code_maps_to_unexpected() {
-        // §8 row: "Something went wrong" — 412 with a body code we don't
+        // "Something went wrong" — 412 with a body code we don't
         // recognise.
         let mapped = QRLoginErrorMapper.userFacingError(
             forExchange: .preconditionFailed(code: "some_other_code"),
@@ -193,7 +193,7 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func exchange_wpcom_500_already_consumed_maps_to_alreadySignedInElsewhere() {
-        // §8 wp.com row: 500 `already_consumed` on exchange.
+        // 500 `already_consumed` on exchange.
         let mapped = QRLoginErrorMapper.userFacingError(
             forExchange: .internalServerError(code: "already_consumed"),
             protocol_: .wpCom
@@ -203,7 +203,7 @@ struct QRLoginErrorMapperTests {
     }
 
     @Test func exchange_self_hosted_500_already_consumed_falls_through_to_unexpected() {
-        // §8 note: self-hosted protocol can't distinguish "already signed in
+        // self-hosted protocol can't distinguish "already signed in
         // elsewhere" from generic server failures, so a self-hosted 500
         // (even with a body code) does not surface that variant.
         let mapped = QRLoginErrorMapper.userFacingError(

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginPollingLoopTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginPollingLoopTests.swift
@@ -1,0 +1,310 @@
+import Foundation
+import Testing
+import Networking
+@testable import WooCommerce
+
+@Suite(.timeLimit(.minutes(1)))
+struct QRLoginPollingLoopTests {
+
+    // MARK: - Terminal success outcomes
+
+    @Test func run_when_approved_with_grant_then_returns_approved() async {
+        // Given
+        let queue = ResponseQueue(responses: [
+            .success(.approved(exchangeGrant: "grant-abc"))
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        #expect(outcome == .approved(exchangeGrant: "grant-abc"))
+        await #expect(queue.callCount == 1)
+        await #expect(queue.sleepCalls == 0) // terminal first attempt — no sleep
+    }
+
+    @Test func run_when_approved_with_blank_grant_then_fails_closed_as_signInTimedOut() async {
+        // Given — spec §5.1.2 / §5.2.2 fail-closed rule.
+        let queue = ResponseQueue(responses: [
+            .success(.approved(exchangeGrant: nil))
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .signInTimedOut)
+    }
+
+    @Test func run_keeps_polling_on_scanned_then_returns_on_terminal_state() async {
+        // Given
+        let queue = ResponseQueue(responses: [
+            .success(.scanned),
+            .success(.scanned),
+            .success(.approved(exchangeGrant: "g"))
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        #expect(outcome == .approved(exchangeGrant: "g"))
+        await #expect(queue.callCount == 3)
+        await #expect(queue.sleepCalls == 2) // one sleep between each pair of attempts
+    }
+
+    @Test func run_when_terminal_rejected_then_returns_signInDenied() async {
+        // Given
+        let queue = ResponseQueue(responses: [
+            .success(.rejected)
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .signInDenied)
+    }
+
+    @Test func run_when_terminal_expired_then_returns_signInTimedOut() async {
+        // Given
+        let queue = ResponseQueue(responses: [
+            .success(.expired)
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .signInTimedOut)
+    }
+
+    @Test func run_when_terminal_consumed_on_wpCom_then_returns_alreadySignedInElsewhere() async {
+        // Given
+        let queue = ResponseQueue(responses: [
+            .success(.consumed)
+        ])
+        let loop = makeLoop(queue: queue, protocol_: .wpCom)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .alreadySignedInElsewhere)
+    }
+
+    @Test func run_when_unknown_state_then_returns_signInTimedOut_defensively() async {
+        // Given
+        let queue = ResponseQueue(responses: [
+            .success(.unknown)
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .signInTimedOut)
+    }
+
+    // MARK: - Transient-error budget (spec §5.1.2)
+
+    @Test func run_when_three_transient_errors_followed_by_success_then_budget_resets() async {
+        // Given — three transient errors are absorbed, the 4th would surface.
+        let queue = ResponseQueue(responses: [
+            .failure(.network),
+            .failure(.network),
+            .failure(.network),
+            .success(.approved(exchangeGrant: "g"))
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        #expect(outcome == .approved(exchangeGrant: "g"))
+        await #expect(queue.callCount == 4)
+    }
+
+    @Test func run_when_four_consecutive_transient_errors_then_surfaces_user_facing_error() async {
+        // Given
+        let queue = ResponseQueue(responses: Array(repeating: .failure(.network), count: 4))
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .network)
+        #expect(error.primaryAction == .retryFailedPhase)
+        await #expect(queue.callCount == 4)
+    }
+
+    @Test func run_when_three_transients_then_scanned_then_three_more_transients_then_keeps_polling() async {
+        // Given — the spec is explicit: "any non-error poll response
+        // (`scanned`) resets the counter to zero". So we should be able to
+        // sustain repeated transient-failure runs as long as a `scanned`
+        // arrives within 3.
+        let queue = ResponseQueue(responses: [
+            .failure(.network), .failure(.network), .failure(.network),
+            .success(.scanned),
+            .failure(.network), .failure(.network), .failure(.network),
+            .success(.approved(exchangeGrant: "g"))
+        ])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        #expect(outcome == .approved(exchangeGrant: "g"))
+    }
+
+    // MARK: - Terminal HTTP errors
+
+    @Test func run_when_terminal_http_error_then_surfaces_immediately() async {
+        // Given — 404 on self-hosted poll is terminal (the merchant's plugin
+        // does not expose the endpoint).
+        let queue = ResponseQueue(responses: [.failure(.notFound)])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .storeUnsupported)
+        await #expect(queue.callCount == 1)
+    }
+
+    @Test func run_when_rate_limited_then_terminal_rateLimited() async {
+        // Given
+        let queue = ResponseQueue(responses: [.failure(.rateLimited)])
+        let loop = makeLoop(queue: queue)
+
+        // When
+        let outcome = await loop.run()
+
+        // Then
+        guard case let .error(error) = outcome else {
+            Issue.record("Expected .error, got \(outcome)")
+            return
+        }
+        #expect(error.kind == .rateLimited)
+    }
+
+    // MARK: - Cancellation
+
+    @Test func run_when_task_cancelled_then_returns_cancelled() async {
+        // Given — block forever so we can cancel the parent task.
+        let queue = ResponseQueue(responses: [
+            .success(.scanned)
+        ], hangAfterRunningOut: true)
+        let loop = makeLoop(queue: queue)
+
+        let task = Task { await loop.run() }
+
+        // When — cancel after the first attempt.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+
+        // Then
+        let outcome = await task.value
+        #expect(outcome == .cancelled)
+    }
+}
+
+// MARK: - Test doubles
+
+private extension QRLoginPollingLoopTests {
+
+    func makeLoop(queue: ResponseQueue,
+                  protocol_: QRLoginErrorMapper.Protocol_ = .selfHosted) -> QRLoginPollingLoop {
+        QRLoginPollingLoop(
+            protocol_: protocol_,
+            pollInterval: 0, // skip waiting in tests
+            sleeper: { _ in try await queue.recordSleep() },
+            attempt: { try await queue.next() }
+        )
+    }
+}
+
+/// Plays back a scripted sequence of poll responses, captures call/sleep
+/// counts, and (optionally) hangs once the script runs out so cancellation
+/// tests have something to interrupt.
+private final actor ResponseQueue {
+    enum Response {
+        case success(QRLoginSessionState)
+        case failure(QRLoginNetworkError)
+    }
+
+    private var responses: [Response]
+    private var index = 0
+    private(set) var callCount = 0
+    private(set) var sleepCalls = 0
+    private let hangAfterRunningOut: Bool
+
+    init(responses: [Response], hangAfterRunningOut: Bool = false) {
+        self.responses = responses
+        self.hangAfterRunningOut = hangAfterRunningOut
+    }
+
+    func next() async throws -> QRLoginSessionState {
+        callCount += 1
+        if index < responses.count {
+            let response = responses[index]
+            index += 1
+            switch response {
+            case .success(let status):
+                return status
+            case .failure(let error):
+                throw error
+            }
+        }
+        guard hangAfterRunningOut else {
+            // Default: keep producing the last response so we don't infinite-loop.
+            return .scanned
+        }
+        // Suspend forever — cancellation tests rely on this.
+        try await Task.sleep(nanoseconds: UInt64.max)
+        return .scanned
+    }
+
+    func recordSleep() async throws {
+        sleepCalls += 1
+        try Task.checkCancellation()
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginPollingLoopTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginPollingLoopTests.swift
@@ -25,7 +25,7 @@ struct QRLoginPollingLoopTests {
     }
 
     @Test func run_when_approved_with_blank_grant_then_fails_closed_as_signInTimedOut() async {
-        // Given — spec §5.1.2 / §5.2.2 fail-closed rule.
+        // Given — spec fail-closed rule.
         let queue = ResponseQueue(responses: [
             .success(.approved(exchangeGrant: nil))
         ])
@@ -132,7 +132,7 @@ struct QRLoginPollingLoopTests {
         #expect(error.kind == .signInTimedOut)
     }
 
-    // MARK: - Transient-error budget (spec §5.1.2)
+    // MARK: - Transient-error budget
 
     @Test func run_when_three_transient_errors_followed_by_success_then_budget_resets() async {
         // Given — three transient errors are absorbed, the 4th would surface.

--- a/WooCommerce/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
+++ b/WooCommerce/WordPressAuthenticator/Analytics/AuthenticatorAnalyticsTracker.swift
@@ -95,6 +95,10 @@ public class AuthenticatorAnalyticsTracker {
         /// This flow represents the prologue screen.
         ///
         case prologue
+
+        /// QR-driven login flow (scan/poll/exchange).
+        ///
+        case loginQR = "login_qr"
     }
 
     public enum Step: String {
@@ -143,6 +147,34 @@ public class AuthenticatorAnalyticsTracker {
         /// Triggered when a magic link is automatically requested after filling in email address and the requested screen is shown
         ///
         case magicLinkAutoRequested = "magic_link_auto_requested"
+
+        // MARK: - QR-driven login flow (`flow = login_qr`)
+
+        /// QR-login prologue is first shown.
+        ///
+        case qrPrologue = "qr_prologue"
+
+        /// QR scanner screen is first shown.
+        ///
+        case qrScan = "qr_scan"
+
+        /// Session-replace warning screen is shown (a signed-in user scanned).
+        ///
+        case qrSessionReplaceWarning = "qr_session_replace_warning"
+
+        /// First entry into the `Authenticating` state. Deduplicated across the
+        /// scan / exchange / complete phases — only fired when the previous step
+        /// wasn't already `qrAuthenticating`.
+        ///
+        case qrAuthenticating = "qr_authenticating"
+
+        /// Number-matching screen is shown.
+        ///
+        case qrNumberMatch = "qr_number_match"
+
+        /// Any error is surfaced.
+        ///
+        case qrError = "qr_error"
     }
 
     public enum ClickTarget: String {
@@ -271,6 +303,45 @@ public class AuthenticatorAnalyticsTracker {
         /// When the user falls back to WordPress.com username and password login from the magic link screen
         ///
         case loginWithWPComUsernamePassword = "login_with_wp_com_username_password"
+
+        // MARK: - QR-driven login flow
+
+        /// Primary login CTA tapped while QR login is available. Fired before the
+        /// QR prologue is shown — the active flow at firing time is still `prologue`.
+        ///
+        case loginWithQR = "login_with_qr"
+
+        /// "Scan QR code" tapped on the QR prologue.
+        ///
+        case qrLoginScan = "login_qr_scan"
+
+        /// "No computer? Log in with site address" tapped on the QR prologue.
+        ///
+        case qrLoginFallback = "login_qr_fallback"
+
+        /// OS camera-permission dialog is about to be requested.
+        ///
+        case qrCameraPermissionDialogShown = "qr_camera_permission_dialog_shown"
+
+        /// OS camera permission was just granted.
+        ///
+        case qrCameraPermissionGranted = "qr_camera_permission_granted"
+
+        /// OS camera permission was just denied (either rationale variant).
+        ///
+        case qrCameraPermissionDenied = "qr_camera_permission_denied"
+
+        /// Cancel tapped on the number-matching screen.
+        ///
+        case qrCancelNumberMatch = "qr_cancel_number_match"
+
+        /// Primary CTA on a non-retryable error ("Scan a new code") tapped.
+        ///
+        case qrStartOver = "qr_start_over"
+
+        /// Primary CTA on a retryable error ("Try again") tapped.
+        ///
+        case qrRetry = "qr_retry"
     }
 
     public enum Failure: String {

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -137,6 +137,36 @@ import WordPressUI
         return controller
     }
 
+    /// WooCommerce addition — a `loginUI` variant whose primary-CTA callback can take over navigation.
+    ///
+    /// Returning `true` from `onPrimaryLoginCTA` tells the prologue the host app handled navigation,
+    /// so it skips its default login action (used to route into the QR-login flow). Returning `false`
+    /// lets the default login navigation proceed.
+    ///
+    /// - Parameters:
+    ///   - showCancel: Whether a cancel CTA is shown on the login prologue screen.
+    ///   - restrictToWPCom: Whether only WordPress.com login is enabled.
+    ///   - onPrimaryLoginCTA: Called when the primary login CTA on the prologue is tapped.
+    /// - Returns: The root view controller for the login flow.
+    public class func loginUI(showCancel: Bool = false,
+                              restrictToWPCom: Bool = false,
+                              onPrimaryLoginCTA: @escaping @MainActor () -> Bool) -> UIViewController? {
+        let storyboard = Storyboard.login.instance
+        guard let controller = storyboard.instantiateInitialViewController() else {
+            assertionFailure("Cannot instantiate initial login controller from Login.storyboard")
+            return nil
+        }
+
+        if let loginNavController = controller as? LoginNavigationController,
+           let loginPrologueViewController = loginNavController.viewControllers.first as? LoginPrologueViewController {
+            loginPrologueViewController.showCancel = showCancel
+            loginPrologueViewController.onPrimaryLoginCTA = onPrimaryLoginCTA
+        }
+
+        controller.modalPresentationStyle = .fullScreen
+        return controller
+    }
+
     /// Used to present the new wpcom-only login flow from the app delegate
     @objc public class func showLoginForJustWPCom(from presenter: UIViewController, jetpackLogin: Bool = false, connectedEmail: String? = nil, siteURL: String? = nil) {
         defer {
@@ -342,10 +372,13 @@ import WordPressUI
             return false
         }
 
-        guard let flowRawValue = queryDictionary.string(forKey: "flow") else {
-            WPAuthenticatorLogError("Magic link error: we couldn't retrieve the flow from the sign-in URL.")
-            return false
-        }
+        // A magic-login callback is a login unless it explicitly says `signup`,
+        // so default a missing `flow` to `login`. The email magic-link login
+        // always sets it (the `auth/send-login-email` request injects
+        // `flow=login`), but the wp.com QR-login `/exchange` endpoint mints its
+        // magic link without `flow` — without this default that callback would
+        // be dropped.
+        let flowRawValue = queryDictionary.string(forKey: "flow") ?? "login"
 
         let loginFields = LoginFields()
 

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressSupportSourceTag.swift
@@ -41,6 +41,9 @@ extension WordPressSupportSourceTag {
     public static var loginSiteAddress: WordPressSupportSourceTag {
         return WordPressSupportSourceTag(name: "loginSiteAddress", origin: "origin:login-site-address")
     }
+    public static var loginWithQRCode: WordPressSupportSourceTag {
+        return WordPressSupportSourceTag(name: "loginWithQRCode", origin: "origin:login-with-qr-code")
+    }
 
     /// For `VerifyEmailViewController`
     public static var verifyEmailInstructions: WordPressSupportSourceTag {

--- a/WooCommerce/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
+++ b/WooCommerce/WordPressAuthenticator/Navigation/NavigateToEnterSite.swift
@@ -3,9 +3,22 @@ import Foundation
 /// Navigates to the unified site address login flow.
 ///
 public struct NavigateToEnterSite: NavigationCommand {
-    public init() {}
+    private let loginFields: LoginFields?
+    private let autoSubmitsPrefilledSiteAddress: Bool
+
+    /// - Parameters:
+    ///   - loginFields: When provided, its `siteAddress` pre-fills the site-address field.
+    ///   - autoSubmitsPrefilledSiteAddress: When `true`, the screen submits the pre-filled
+    ///     site address once, on first appearance, so the caller can hand the merchant
+    ///     straight to the next login step.
+    public init(loginFields: LoginFields? = nil, autoSubmitsPrefilledSiteAddress: Bool = false) {
+        self.loginFields = loginFields
+        self.autoSubmitsPrefilledSiteAddress = autoSubmitsPrefilledSiteAddress
+    }
+
     public func execute(from: UIViewController?) {
-        presentUnifiedSiteAddressView(navigationController: from?.navigationController)
+        let navigationController = (from as? UINavigationController) ?? from?.navigationController
+        presentUnifiedSiteAddressView(navigationController: navigationController)
     }
 }
 
@@ -15,6 +28,11 @@ private extension NavigateToEnterSite {
             WPAuthenticatorLogError("Failed to navigate from LoginViewController to SiteAddressViewController")
             return
         }
+
+        if let loginFields {
+            vc.loginFields = loginFields
+        }
+        vc.autoSubmitsPrefilledSiteAddress = autoSubmitsPrefilledSiteAddress
 
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -22,6 +22,11 @@ class LoginPrologueViewController: LoginViewController {
     // Called when login button is tapped
     var onLoginButtonTapped: (() -> Void)?
 
+    /// WooCommerce addition. Called when the primary login CTA on the prologue is tapped. Return
+    /// `true` when the host app has taken over navigation, so the prologue skips its default login
+    /// action (used to route into the QR-login flow).
+    var onPrimaryLoginCTA: (@MainActor () -> Bool)?
+
     private let configuration = WordPressAuthenticator.shared.configuration
     private let style = WordPressAuthenticator.shared.style
 
@@ -180,6 +185,9 @@ class LoginPrologueViewController: LoginViewController {
         let createTitle = NSLocalizedString("Sign up for WordPress.com", comment: "Button title. Tapping begins the process of creating a WordPress.com account.")
 
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
+            guard self?.onPrimaryLoginCTA?() != true else {
+                return
+            }
             self?.onLoginButtonTapped?()
             self?.loginTapped()
         }
@@ -286,7 +294,7 @@ class LoginPrologueViewController: LoginViewController {
                                  configureBodyFontForTitle: true,
                                  accessibilityIdentifier: "Prologue Self Hosted Button",
                                  style: secondaryButtonStyle,
-                                 onTap: siteAddressTapCallback())
+                                 onTap: primaryLoginCallback(default: siteAddressTapCallback()))
         }()
 
         let createSiteButton: StackedButton? = {
@@ -340,6 +348,18 @@ class LoginPrologueViewController: LoginViewController {
     private func siteAddressTapCallback() -> NUXButtonViewController.CallBackType {
         return { [weak self] in
             self?.siteAddressTapped()
+        }
+    }
+
+    /// Wraps a prologue button's default action so the host app can intercept the primary login
+    /// CTA via `onPrimaryLoginCTA` — returning `true` to take over navigation and skip
+    /// `defaultAction` (e.g. routing to QR login).
+    private func primaryLoginCallback(default defaultAction: @escaping NUXButtonViewController.CallBackType) -> NUXButtonViewController.CallBackType {
+        return { [weak self] in
+            guard self?.onPrimaryLoginCTA?() != true else {
+                return
+            }
+            defaultAction()
         }
     }
 

--- a/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Unified Auth/View Related/Site Address/SiteAddressViewController.swift
@@ -18,6 +18,12 @@ final class SiteAddressViewController: LoginViewController {
     private var errorMessage: String?
     private var shouldChangeVoiceOverFocus: Bool = false
 
+    /// When `true`, the screen submits its pre-filled `loginFields.siteAddress`
+    /// once on first appearance. Set by callers that already know the site
+    /// address (e.g. the QR-login site-URL payload). Consumed on first use so
+    /// rotation or re-appearance never re-submits.
+    var autoSubmitsPrefilledSiteAddress = false
+
     /// A state variable that is `true` if network calls are currently happening and so the
     /// view should be showing a loading indicator.
     ///
@@ -100,6 +106,18 @@ final class SiteAddressViewController: LoginViewController {
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
         configureViewForEditingIfNeeded()
+        autoSubmitPrefilledSiteAddressIfNeeded()
+    }
+
+    /// Submits the pre-filled site address once, when the screen was opened by a
+    /// flow that supplied one (e.g. the QR-login site-URL payload). Consumed on
+    /// first appearance so rotation or re-appearance never re-submits.
+    private func autoSubmitPrefilledSiteAddressIfNeeded() {
+        guard autoSubmitsPrefilledSiteAddress, loginFields.siteAddress.isEmpty == false else {
+            return
+        }
+        autoSubmitsPrefilledSiteAddress = false
+        validateForm()
     }
 
     // MARK: - Overrides


### PR DESCRIPTION
## Description
**Part 3 of 7** of the QR-code login feature (see **[1/7]** for context).

Two cohesive groups:
- **WordPressAuthenticator hooks** — purely additive changes to the vendored module: the `loginQR` analytics flow, the primary-CTA `loginUI` hook, the `loginWithQRCode` support tag, and pre-filled / auto-submitting site-address support. They land here because later steps reference the new `.loginQR` flow.
- **QR error/polling/analytics layer** — `QRLoginUserFacingError`, `QRLoginSessionState`, `QRLoginErrorMapper`, `QRLoginPollingLoop`, the analytics façade, and `QRLoginDeviceInfoProvider`.

**Stack:** base **[2/7]** `feature/qr-login-step-2` → next **[4/7]** `feature/qr-login-step-4`. ~742 production lines.

## Test Steps
Infrastructure only, not user-testable. CI runs `QRLoginErrorMapperTests`, `QRLoginPollingLoopTests`.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.