### PR TITLE
QR-login [4/7]: Strategies & view model

### DIFF
--- a/Modules/Sources/Yosemite/Stores/QRLoginStore.swift
+++ b/Modules/Sources/Yosemite/Stores/QRLoginStore.swift
@@ -35,11 +35,11 @@ public final class QRLoginStore: DeauthenticatedStore {
                                                   clientSecret: wpComClientSecret))
     }
 
-    public override func registerSupportedActions(in dispatcher: Dispatcher) {
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
         dispatcher.register(processor: self, for: QRLoginAction.self)
     }
 
-    public override func onAction(_ action: Action) {
+    override public func onAction(_ action: Action) {
         guard let action = action as? QRLoginAction else {
             assertionFailure("QRLoginStore received an unsupported action: \(action)")
             return

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginViewModel.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Observation
+import WordPressAuthenticator
+
+/// Drives the QR-login flow once the user has scanned a self-hosted or wp.com
+/// payload. Owns the state machine — the UI layer just observes `state` and
+/// renders accordingly.
+///
+/// State transitions:
+///
+///   idle ─start()→ authenticating ─/scan ok→ numberMatch ─poll terminal approved→ authenticating ─/exchange ok→ done
+///                                                       ↘ poll terminal !approved | transient × 4 → error
+///        ↘ scan fails → error
+///
+/// `/exchange` resolves to `done` for the self-hosted flow (the merchant is
+/// fully signed in) or `handedOff` for wp.com (the magic link was opened in an
+/// in-app browser; sign-in completes via the magic-login redirect, not here).
+///
+/// Retry semantics (spec §6.1):
+///   - error during scan   → retry runs scan again.
+///   - error during poll   → retry resumes polling (same session_id + token_hash).
+///   - error during exchange → retry runs exchange again with the retained grant.
+///   - non-retryable error → primary CTA is "Scan a new code" — surfaced via
+///     `error.primaryAction == .scanAgain`. The coordinator handles that case
+///     by sending the user back to the scanner; the view model just reports it.
+@MainActor
+@Observable
+final class QRLoginViewModel {
+
+    enum State: Equatable {
+        case idle
+        case authenticating
+        case numberMatch(scan: QRLoginScanResult)
+        /// Self-hosted sign-in completed — the app can proceed to the store picker.
+        case done
+        /// wp.com magic link handed to an in-app browser — sign-in completes
+        /// asynchronously via the magic-login redirect, so the QR-login surface
+        /// must not route to the store picker itself (spec §10.1).
+        case handedOff
+        case error(QRLoginUserFacingError)
+    }
+
+    private(set) var state: State = .idle
+
+    /// Subtitle for the number-match screen. Convenience derived from `state`
+    /// to keep the SwiftUI binding terse.
+    var numberMatchSubtitle: QRLoginNumberMatchSubtitle? {
+        if case let .numberMatch(scan) = state {
+            return scan.subtitle
+        }
+        return nil
+    }
+
+    private let strategy: QRLoginStrategy
+    private let analytics: QRLoginAnalyticsTracking
+    private let pollIntervalSeconds: TimeInterval
+
+    /// Tracks the live polling task so cancel from number-match can interrupt
+    /// it without making a server call (spec §6.2).
+    private var pollingTask: Task<Void, Never>?
+
+    /// Last successful scan; held so a poll-retry resumes against the same
+    /// session.
+    private var lastScan: QRLoginScanResult?
+
+    /// Last approved grant; held so an exchange-retry doesn't re-run scan or
+    /// poll.
+    private var lastGrant: String?
+
+    init(strategy: QRLoginStrategy,
+         analytics: QRLoginAnalyticsTracking? = nil,
+         pollIntervalSeconds: TimeInterval = 2.0) {
+        self.strategy = strategy
+        // `DefaultQRLoginAnalyticsTracking()` is @MainActor-isolated, so it
+        // can't be a default parameter expression (those are evaluated in
+        // the caller's context). The view model is @MainActor so constructing
+        // it in the body is fine.
+        let analytics = analytics ?? DefaultQRLoginAnalyticsTracking()
+        self.analytics = analytics
+        self.pollIntervalSeconds = pollIntervalSeconds
+
+        analytics.setFlow(.loginQR)
+    }
+
+    /// Kicks the flow off from `idle`. Idempotent — calling `start()` while
+    /// already running is a no-op.
+    func start() async {
+        guard state == .idle || isErrorState else { return }
+        await runScan()
+    }
+
+    /// Re-runs the failed phase per spec §6.1.
+    func retry() async {
+        guard case .error(let error) = state else { return }
+        analytics.trackClick(.qrRetry)
+
+        switch error.phase {
+        case .scan, .prelude:
+            await runScan()
+        case .poll:
+            guard let lastScan else {
+                await runScan()
+                return
+            }
+            await runPolling(scan: lastScan)
+        case .exchange, .postExchange:
+            guard let lastGrant else {
+                await runScan()
+                return
+            }
+            await runExchange(grant: lastGrant)
+        }
+    }
+
+    /// Cancel from number-match (spec §6.2). Stops client-side polling and
+    /// returns to idle — **no server call**. The server keeps the session in
+    /// `scanned` until its 90-second window elapses; the matching browser
+    /// polls itself into the "denied" terminal state.
+    func cancelFromNumberMatch() {
+        guard case .numberMatch = state else { return }
+        analytics.trackClick(.qrCancelNumberMatch)
+        pollingTask?.cancel()
+        pollingTask = nil
+        state = .idle
+    }
+}
+
+// MARK: - Internal pipeline
+
+private extension QRLoginViewModel {
+
+    var isErrorState: Bool {
+        if case .error = state { return true }
+        return false
+    }
+
+    func runScan() async {
+        setAuthenticatingIfNeeded()
+        let result = await strategy.scan()
+        switch result {
+        case .success(let scan):
+            lastScan = scan
+            state = .numberMatch(scan: scan)
+            analytics.trackStep(.qrNumberMatch)
+            await runPolling(scan: scan)
+        case .failure(let error):
+            surface(error: error)
+        }
+    }
+
+    func runPolling(scan: QRLoginScanResult) async {
+        // Resume number-match presentation when retrying poll.
+        if state != .numberMatch(scan: scan) {
+            state = .numberMatch(scan: scan)
+            analytics.trackStep(.qrNumberMatch)
+        }
+
+        let loop = QRLoginPollingLoop(
+            protocol_: strategy.protocol_,
+            pollInterval: pollIntervalSeconds,
+            attempt: strategy.makePollAttempt()
+        )
+
+        pollingTask = Task { [weak self] in
+            let outcome = await loop.run()
+            await self?.handlePollingOutcome(outcome)
+        }
+        // Wait for completion so callers (`retry`) see the final state.
+        await pollingTask?.value
+        pollingTask = nil
+    }
+
+    func handlePollingOutcome(_ outcome: QRLoginPollingLoop.Outcome) async {
+        switch outcome {
+        case .approved(let grant):
+            lastGrant = grant
+            await runExchange(grant: grant)
+        case .error(let error):
+            surface(error: error)
+        case .cancelled:
+            // Cancel from number-match already reset state to idle.
+            if case .numberMatch = state {
+                state = .idle
+            }
+        }
+    }
+
+    func runExchange(grant: String) async {
+        setAuthenticatingIfNeeded()
+        switch await strategy.exchange(grant: grant) {
+        case .success(.authenticated):
+            state = .done
+        case .success(.magicLinkHandedOff):
+            state = .handedOff
+        case .failure(let error):
+            surface(error: error)
+        }
+    }
+
+    func setAuthenticatingIfNeeded() {
+        if state != .authenticating {
+            state = .authenticating
+            analytics.trackStep(.qrAuthenticating)
+        }
+    }
+
+    func surface(error: QRLoginUserFacingError) {
+        state = .error(error)
+        analytics.trackStep(.qrError)
+        analytics.trackFailure(QRLoginAnalyticsFailure.failureString(for: error))
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginViewModel.swift
@@ -16,7 +16,7 @@ import WordPressAuthenticator
 /// fully signed in) or `handedOff` for wp.com (the magic link was opened in an
 /// in-app browser; sign-in completes via the magic-login redirect, not here).
 ///
-/// Retry semantics (spec §6.1):
+/// Retry semantics:
 ///   - error during scan   → retry runs scan again.
 ///   - error during poll   → retry resumes polling (same session_id + token_hash).
 ///   - error during exchange → retry runs exchange again with the retained grant.
@@ -35,7 +35,7 @@ final class QRLoginViewModel {
         case done
         /// wp.com magic link handed to an in-app browser — sign-in completes
         /// asynchronously via the magic-login redirect, so the QR-login surface
-        /// must not route to the store picker itself (spec §10.1).
+        /// must not route to the store picker itself.
         case handedOff
         case error(QRLoginUserFacingError)
     }
@@ -56,7 +56,7 @@ final class QRLoginViewModel {
     private let pollIntervalSeconds: TimeInterval
 
     /// Tracks the live polling task so cancel from number-match can interrupt
-    /// it without making a server call (spec §6.2).
+    /// it without making a server call.
     private var pollingTask: Task<Void, Never>?
 
     /// Last successful scan; held so a poll-retry resumes against the same
@@ -89,7 +89,7 @@ final class QRLoginViewModel {
         await runScan()
     }
 
-    /// Re-runs the failed phase per spec §6.1.
+    /// Re-runs the failed phase.
     func retry() async {
         guard case .error(let error) = state else { return }
         analytics.trackClick(.qrRetry)
@@ -112,7 +112,7 @@ final class QRLoginViewModel {
         }
     }
 
-    /// Cancel from number-match (spec §6.2). Stops client-side polling and
+    /// Cancel from number-match. Stops client-side polling and
     /// returns to idle — **no server call**. The server keeps the session in
     /// `scanned` until its 90-second window elapses; the matching browser
     /// polls itself into the "denied" terminal state.

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginViewModel.swift
@@ -19,10 +19,11 @@ import WordPressAuthenticator
 /// Retry semantics:
 ///   - error during scan   → retry runs scan again.
 ///   - error during poll   → retry resumes polling (same session_id + token_hash).
-///   - error during exchange → retry runs exchange again with the retained grant.
+///   - error during exchange → retry runs exchange again with the retained grant
+///     only if `/exchange` itself failed before an AP was minted.
 ///   - non-retryable error → primary CTA is "Scan a new code" — surfaced via
-///     `error.primaryAction == .scanAgain`. The coordinator handles that case
-///     by sending the user back to the scanner; the view model just reports it.
+///     `error.primaryAction == .scanAgain`. If `retry()` is invoked for one of
+///     those errors, it starts a fresh scan rather than reusing retained state.
 @MainActor
 @Observable
 final class QRLoginViewModel {
@@ -92,6 +93,12 @@ final class QRLoginViewModel {
     /// Re-runs the failed phase.
     func retry() async {
         guard case .error(let error) = state else { return }
+
+        guard error.primaryAction == .retryFailedPhase else {
+            await runScan()
+            return
+        }
+
         analytics.trackClick(.qrRetry)
 
         switch error.phase {
@@ -103,12 +110,14 @@ final class QRLoginViewModel {
                 return
             }
             await runPolling(scan: lastScan)
-        case .exchange, .postExchange:
+        case .exchange:
             guard let lastGrant else {
                 await runScan()
                 return
             }
             await runExchange(grant: lastGrant)
+        case .postExchange:
+            await runScan()
         }
     }
 

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginPostExchangeService.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginPostExchangeService.swift
@@ -1,0 +1,136 @@
+import Foundation
+import WooFoundation
+import Yosemite
+import struct NetworkingCore.ApplicationPassword
+import protocol NetworkingCore.ApplicationPasswordUseCase
+import class NetworkingCore.OneTimeApplicationPasswordUseCase
+import enum NetworkingCore.Credentials
+import struct NetworkingCore.Secret
+
+/// Runs the self-hosted post-exchange sequence from spec §5.1.4 once the QR
+/// `/exchange` call has minted an Application Password:
+///
+///   1. Build `Credentials.applicationPassword` and authenticate the stores
+///      manager. Persists the AP to keychain via
+///      `OneTimeApplicationPasswordUseCase` so subsequent app-target REST
+///      calls can use it.
+///   2. Fetch the site via `WordPressSiteAction.fetchSiteInfo` (unauthenticated
+///      — `wp-json` root endpoint).
+///   3. If the site does not advertise WooCommerce → revoke the AP server-side
+///      (DELETE on the AP endpoint), deauthenticate the stores manager, and
+///      surface `.notAWooSite`.
+///   4. Run `RoleEligibilityUseCase` with `placeholderStoreID`. On
+///      `insufficientRole` → revoke + deauthenticate + `.userNotEligible`. On
+///      any other failure → revoke + deauthenticate + `.siteAuthFailure`.
+///   5. On full success: track `.signedIn` and return `.success(())`.
+///
+/// Failure paths always call `deletePassword(locally: true)`, which both
+/// revokes the AP server-side and removes it from local storage. The revoke
+/// is wrapped in `try?` so the user sees the original error even if the
+/// revoke itself fails — an orphan AP on the merchant's site is recoverable;
+/// a confusing UI state is not.
+@MainActor
+protocol QRLoginPostExchangeServicing {
+    func complete(_ response: SelfHostedQRLoginExchangeResponse) async -> Result<Void, QRLoginUserFacingError>
+}
+
+@MainActor
+final class QRLoginPostExchangeService: QRLoginPostExchangeServicing {
+
+    /// Factory for the AP use case so tests can plug in a mock that doesn't
+    /// touch keychain or the network.
+    typealias ApplicationPasswordUseCaseFactory =
+        @MainActor (ApplicationPassword, String) -> ApplicationPasswordUseCase
+
+    private let stores: StoresManager
+    private let roleEligibilityUseCase: RoleEligibilityUseCaseProtocol
+    private let applicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory
+    private let analytics: Analytics
+
+    init(stores: StoresManager = ServiceLocator.stores,
+         roleEligibilityUseCase: RoleEligibilityUseCaseProtocol? = nil,
+         applicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory? = nil,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.stores = stores
+        self.roleEligibilityUseCase = roleEligibilityUseCase ?? RoleEligibilityUseCase(stores: stores)
+        self.analytics = analytics
+        self.applicationPasswordUseCaseFactory = applicationPasswordUseCaseFactory ?? Self.defaultApplicationPasswordUseCaseFactory
+    }
+
+    func complete(_ response: SelfHostedQRLoginExchangeResponse) async -> Result<Void, QRLoginUserFacingError> {
+        let applicationPassword = ApplicationPassword(
+            wpOrgUsername: response.userLogin,
+            password: Secret(response.applicationPassword),
+            // The exchange response doesn't carry the AP UUID. OneTimeApplicationPasswordUseCase
+            // looks up the real one on delete via /wp/v2/users/me/application-passwords/introspect,
+            // so a placeholder is fine here.
+            uuid: UUID().uuidString
+        )
+        let useCase = applicationPasswordUseCaseFactory(applicationPassword, response.siteURL)
+
+        let credentials = Credentials.applicationPassword(username: response.userLogin,
+                                                          password: response.applicationPassword,
+                                                          siteAddress: response.siteURL)
+        _ = stores.authenticate(credentials: credentials)
+
+        let siteResult = await fetchSiteInfo(siteURL: response.siteURL)
+        let site: Site
+        switch siteResult {
+        case .success(let value):
+            site = value
+        case .failure:
+            return await fail(.siteAuthFailure, useCase: useCase)
+        }
+
+        guard site.isWooCommerceActive else {
+            return await fail(.notAWooSite, useCase: useCase)
+        }
+
+        switch await checkRoleEligibility() {
+        case .success:
+            analytics.track(.signedIn)
+            return .success(())
+        case .failure(.insufficientRole):
+            return await fail(.userNotEligible, useCase: useCase)
+        case .failure:
+            return await fail(.siteAuthFailure, useCase: useCase)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension QRLoginPostExchangeService {
+
+    func fetchSiteInfo(siteURL: String) async -> Result<Site, Error> {
+        await withCheckedContinuation { continuation in
+            let action = WordPressSiteAction.fetchSiteInfo(siteURL: siteURL) { result in
+                continuation.resume(returning: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    func checkRoleEligibility() async -> Result<Void, RoleEligibilityError> {
+        await withCheckedContinuation { continuation in
+            roleEligibilityUseCase.checkEligibility(for: WooConstants.placeholderStoreID) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    func fail(_ kind: QRLoginUserFacingError.Kind,
+              useCase: ApplicationPasswordUseCase) async -> Result<Void, QRLoginUserFacingError> {
+        // Best-effort revoke. We swallow errors here: spec §5.1.4 says the AP
+        // must be revoked, but if the revoke fails we still need to surface
+        // the original user-facing error rather than masking it with a
+        // network failure on revoke.
+        try? await useCase.deletePassword(locally: true)
+        _ = stores.deauthenticate()
+        return .failure(.init(kind: kind, phase: .postExchange, primaryAction: .scanAgain))
+    }
+
+    static let defaultApplicationPasswordUseCaseFactory: ApplicationPasswordUseCaseFactory = { ap, siteAddress in
+        OneTimeApplicationPasswordUseCase(applicationPassword: ap, siteAddress: siteAddress)
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginPostExchangeService.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginPostExchangeService.swift
@@ -7,7 +7,7 @@ import class NetworkingCore.OneTimeApplicationPasswordUseCase
 import enum NetworkingCore.Credentials
 import struct NetworkingCore.Secret
 
-/// Runs the self-hosted post-exchange sequence from spec §5.1.4 once the QR
+/// Runs the self-hosted post-exchange sequence once the QR
 /// `/exchange` call has minted an Application Password:
 ///
 ///   1. Build `Credentials.applicationPassword` and authenticate the stores
@@ -121,7 +121,7 @@ private extension QRLoginPostExchangeService {
 
     func fail(_ kind: QRLoginUserFacingError.Kind,
               useCase: ApplicationPasswordUseCase) async -> Result<Void, QRLoginUserFacingError> {
-        // Best-effort revoke. We swallow errors here: spec §5.1.4 says the AP
+        // Best-effort revoke. We swallow errors here: the AP
         // must be revoked, but if the revoke fails we still need to surface
         // the original user-facing error rather than masking it with a
         // network failure on revoke.

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginStrategy.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginStrategy.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Subtitle to display on the number-match screen. Per spec §4.3, the
+/// self-hosted flow shows the site host and the wp.com flow shows the user's
+/// wp.com email returned by `/scan`.
+enum QRLoginNumberMatchSubtitle: Equatable {
+    case host(String)
+    case email(String)
+}
+
+/// Outcome of the `/scan` step exposed to the view model. Protocol-agnostic so
+/// the view model doesn't care whether it came from `wc-admin` or `wp.com`.
+struct QRLoginScanResult: Equatable {
+    let sessionID: String
+    let realNumber: String
+    let expiresInSeconds: Int
+    /// Hash of the QR token sent on every poll. Recomputed by the strategy
+    /// once at scan time and reused for the lifetime of the session.
+    let tokenHash: String
+    /// Subtitle to display on the number-match screen.
+    let subtitle: QRLoginNumberMatchSubtitle
+}
+
+/// Outcome of a successful `/exchange` step. The two protocols finish a
+/// sign-in very differently, so the view model needs to tell them apart:
+///   - `authenticated`: the self-hosted flow has fully signed the merchant in
+///     (AP minted + persisted, eligibility checked) — the app can proceed to
+///     the store picker.
+///   - `magicLinkHandedOff`: the wp.com flow has handed a magic link to an
+///     in-app browser. Sign-in completes asynchronously via the existing
+///     `woocommerce://magic-login` redirect handler, NOT here — so the QR-login
+///     surface must not route to the store picker itself (spec §10.1).
+enum QRLoginExchangeOutcome: Equatable {
+    case authenticated
+    case magicLinkHandedOff
+}
+
+/// Protocol-specific façade for the QR-login flow.
+///
+/// Holds enough state (token, encrypted blob, siteURL, sessionID, grant) to
+/// run scan / poll / exchange + post-success against either the self-hosted
+/// or wp.com endpoints. The view model drives the state machine and asks the
+/// strategy to execute each phase.
+///
+/// The strategy carries protocol identity (`protocol_`) so the view model can
+/// pick the right entry in the error-mapping tables. `numberMatchSubtitle`
+/// returns the live subtitle for the number-match UI (the wp.com value is
+/// only known after `/scan` returns).
+@MainActor
+protocol QRLoginStrategy: AnyObject {
+    var protocol_: QRLoginErrorMapper.Protocol_ { get }
+
+    /// Run `/scan`. Stores the returned session ID + grant internally for
+    /// the subsequent poll / exchange.
+    func scan() async -> Result<QRLoginScanResult, QRLoginUserFacingError>
+
+    /// Returns a `PollAttempt` that runs `/session-status` once. The view
+    /// model hands it to `QRLoginPollingLoop`.
+    func makePollAttempt() -> QRLoginPollingLoop.PollAttempt
+
+    /// Run `/exchange` and the protocol-specific post-success work
+    /// (self-hosted: site fetch + AP save + eligibility; wp.com: open the
+    /// magic-link URL). The outcome tells the view model whether sign-in is
+    /// complete or has been handed off to an in-app browser.
+    func exchange(grant: String) async -> Result<QRLoginExchangeOutcome, QRLoginUserFacingError>
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginStrategy.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/QRLoginStrategy.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Subtitle to display on the number-match screen. Per spec §4.3, the
+/// Subtitle to display on the number-match screen. The
 /// self-hosted flow shows the site host and the wp.com flow shows the user's
 /// wp.com email returned by `/scan`.
 enum QRLoginNumberMatchSubtitle: Equatable {
@@ -29,7 +29,7 @@ struct QRLoginScanResult: Equatable {
 ///   - `magicLinkHandedOff`: the wp.com flow has handed a magic link to an
 ///     in-app browser. Sign-in completes asynchronously via the existing
 ///     `woocommerce://magic-login` redirect handler, NOT here — so the QR-login
-///     surface must not route to the store picker itself (spec §10.1).
+///     surface must not route to the store picker itself.
 enum QRLoginExchangeOutcome: Equatable {
     case authenticated
     case magicLinkHandedOff

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/SelfHostedQRLoginStrategy.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/SelfHostedQRLoginStrategy.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Yosemite
+
+/// Self-hosted (wp-admin) QR-login strategy. Wraps `QRLoginAction.selfHosted*`
+/// dispatches and translates `QRLoginNetworkError` into user-facing variants
+/// via `QRLoginErrorMapper`. After a successful `/exchange` it hands the minted
+/// Application Password to `QRLoginPostExchangeService` for site setup.
+@MainActor
+final class SelfHostedQRLoginStrategy: QRLoginStrategy {
+
+    let protocol_: QRLoginErrorMapper.Protocol_ = .selfHosted
+
+    private let token: String
+    private let siteURL: URL
+    private let stores: StoresManager
+    private let deviceInfoProvider: QRLoginDeviceInfoProvider
+    private let postExchangeService: QRLoginPostExchangeServicing
+
+    /// Set once `/scan` succeeds. Reused across poll attempts.
+    private var sessionID: String?
+    private var tokenHash: String?
+
+    /// Set once `/exchange` succeeds and post-exchange site setup completes.
+    /// Retry-after-success short-circuits to a no-op success rather than
+    /// minting a fresh AP, in case the user taps "Try again" on a transient
+    /// downstream failure.
+    private var exchangeResponse: SelfHostedQRLoginExchangeResponse?
+    private var postExchangeCompleted = false
+
+    init(token: String,
+         siteURL: URL,
+         stores: StoresManager = ServiceLocator.stores,
+         deviceInfoProvider: QRLoginDeviceInfoProvider = DefaultQRLoginDeviceInfoProvider(),
+         postExchangeService: QRLoginPostExchangeServicing? = nil) {
+        self.token = token
+        self.siteURL = siteURL
+        self.stores = stores
+        self.deviceInfoProvider = deviceInfoProvider
+        // `QRLoginPostExchangeService()` is @MainActor-isolated, so it can't be
+        // a default parameter expression (those are evaluated in the caller's
+        // context, which the compiler can't always prove is MainActor). The
+        // strategy itself is @MainActor, so constructing the service in the
+        // body is allowed.
+        self.postExchangeService = postExchangeService ?? QRLoginPostExchangeService()
+    }
+
+    func scan() async -> Result<QRLoginScanResult, QRLoginUserFacingError> {
+        let device = deviceInfoProvider.device
+        let response = await dispatch(scanWith: device)
+        switch response {
+        case .success(let scan):
+            let hash = QRLoginTokenHash.make(for: token)
+            sessionID = scan.sessionID
+            tokenHash = hash
+            return .success(QRLoginScanResult(
+                sessionID: scan.sessionID,
+                realNumber: scan.realNumber,
+                expiresInSeconds: scan.expiresInSeconds,
+                tokenHash: hash,
+                subtitle: .host(siteURL.host ?? siteURL.absoluteString)
+            ))
+        case .failure(let error):
+            return .failure(QRLoginErrorMapper.userFacingError(forScan: error, protocol_: protocol_))
+        }
+    }
+
+    func makePollAttempt() -> QRLoginPollingLoop.PollAttempt {
+        let siteURL = self.siteURL
+        let stores = self.stores
+        let sessionID = self.sessionID
+        let tokenHash = self.tokenHash
+        return {
+            guard let sessionID, let tokenHash else {
+                // Programming error: poll without prior successful scan.
+                throw QRLoginNetworkError.malformed
+            }
+            let status = try await Self.dispatch(stores: stores) { completion in
+                QRLoginAction.selfHostedPoll(siteURL: siteURL,
+                                             sessionID: sessionID,
+                                             tokenHash: tokenHash,
+                                             completion: completion)
+            }
+            return status.sessionState
+        }
+    }
+
+    func exchange(grant: String) async -> Result<QRLoginExchangeOutcome, QRLoginUserFacingError> {
+        // If post-exchange already completed in a prior retry, no work to do.
+        if postExchangeCompleted {
+            return .success(.authenticated)
+        }
+
+        let response: SelfHostedQRLoginExchangeResponse
+        if let cached = exchangeResponse {
+            // Retry path: exchange already succeeded server-side, but the
+            // post-exchange site setup failed. Don't mint a new AP — re-run
+            // post-exchange against the cached response.
+            response = cached
+        } else {
+            do {
+                response = try await Self.dispatch(stores: stores) { completion in
+                    QRLoginAction.selfHostedExchange(siteURL: siteURL,
+                                                     token: token,
+                                                     exchangeGrant: grant,
+                                                     completion: completion)
+                }
+                exchangeResponse = response
+            } catch let error as QRLoginNetworkError {
+                return .failure(QRLoginErrorMapper.userFacingError(forExchange: error, protocol_: protocol_))
+            } catch {
+                return .failure(QRLoginErrorMapper.userFacingError(forExchange: .network, protocol_: protocol_))
+            }
+        }
+
+        switch await postExchangeService.complete(response) {
+        case .success:
+            postExchangeCompleted = true
+            return .success(.authenticated)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}
+
+// MARK: - Dispatch helpers
+
+private extension SelfHostedQRLoginStrategy {
+
+    func dispatch(scanWith device: QRLoginScanDevice) async -> Result<SelfHostedQRLoginScanResponse, QRLoginNetworkError> {
+        do {
+            let response = try await Self.dispatch(stores: stores) { completion in
+                QRLoginAction.selfHostedScan(siteURL: siteURL,
+                                             token: token,
+                                             device: device,
+                                             completion: completion)
+            }
+            return .success(response)
+        } catch let error as QRLoginNetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(.network)
+        }
+    }
+
+    /// Bridges an `Action` whose completion delivers
+    /// `Result<T, QRLoginNetworkError>` into Swift Concurrency.
+    static func dispatch<T>(stores: StoresManager,
+                             _ build: (@escaping (Result<T, QRLoginNetworkError>) -> Void) -> Action) async throws -> T {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            let action = build { result in
+                continuation.resume(with: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/SelfHostedQRLoginStrategy.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/SelfHostedQRLoginStrategy.swift
@@ -20,13 +20,6 @@ final class SelfHostedQRLoginStrategy: QRLoginStrategy {
     private var sessionID: String?
     private var tokenHash: String?
 
-    /// Set once `/exchange` succeeds and post-exchange site setup completes.
-    /// Retry-after-success short-circuits to a no-op success rather than
-    /// minting a fresh AP, in case the user taps "Try again" on a transient
-    /// downstream failure.
-    private var exchangeResponse: SelfHostedQRLoginExchangeResponse?
-    private var postExchangeCompleted = false
-
     init(token: String,
          siteURL: URL,
          stores: StoresManager = ServiceLocator.stores,
@@ -85,39 +78,23 @@ final class SelfHostedQRLoginStrategy: QRLoginStrategy {
     }
 
     func exchange(grant: String) async -> Result<QRLoginExchangeOutcome, QRLoginUserFacingError> {
-        // If post-exchange already completed in a prior retry, no work to do.
-        if postExchangeCompleted {
-            return .success(.authenticated)
-        }
-
-        let response: SelfHostedQRLoginExchangeResponse
-        if let cached = exchangeResponse {
-            // Retry path: exchange already succeeded server-side, but the
-            // post-exchange site setup failed. Don't mint a new AP — re-run
-            // post-exchange against the cached response.
-            response = cached
-        } else {
-            do {
-                response = try await Self.dispatch(stores: stores) { completion in
-                    QRLoginAction.selfHostedExchange(siteURL: siteURL,
-                                                     token: token,
-                                                     exchangeGrant: grant,
-                                                     completion: completion)
-                }
-                exchangeResponse = response
-            } catch let error as QRLoginNetworkError {
-                return .failure(QRLoginErrorMapper.userFacingError(forExchange: error, protocol_: protocol_))
-            } catch {
-                return .failure(QRLoginErrorMapper.userFacingError(forExchange: .network, protocol_: protocol_))
+        do {
+            let response = try await Self.dispatch(stores: stores) { completion in
+                QRLoginAction.selfHostedExchange(siteURL: siteURL,
+                                                 token: token,
+                                                 exchangeGrant: grant,
+                                                 completion: completion)
             }
-        }
-
-        switch await postExchangeService.complete(response) {
-        case .success:
-            postExchangeCompleted = true
-            return .success(.authenticated)
-        case .failure(let error):
-            return .failure(error)
+            switch await postExchangeService.complete(response) {
+            case .success:
+                return .success(.authenticated)
+            case .failure(let error):
+                return .failure(error)
+            }
+        } catch let error as QRLoginNetworkError {
+            return .failure(QRLoginErrorMapper.userFacingError(forExchange: error, protocol_: protocol_))
+        } catch {
+            return .failure(QRLoginErrorMapper.userFacingError(forExchange: .network, protocol_: protocol_))
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/QRLogin/Strategy/WPComQRLoginStrategy.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/Strategy/WPComQRLoginStrategy.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Yosemite
+
+/// Closure that opens a magic-link URL in an in-app browser. Injected by the
+/// coordinator (Layer 6) — Layer 3 only declares the seam so the strategy is
+/// testable without a `UIApplication`.
+typealias QRLoginMagicLinkOpener = @MainActor (URL) async -> Void
+
+/// WP.com QR-login strategy. Wraps `QRLoginAction.wpCom*` dispatches and
+/// translates `QRLoginNetworkError` into user-facing variants via
+/// `QRLoginErrorMapper`.
+///
+/// `exchange` opens the returned magic-link URL through the injected opener;
+/// the existing magic-link intercept (`AuthenticationManager.handleAuthenticationUrl`
+/// for `WordPressAuthenticator.isWordPressAuthUrl`) completes wp.com OAuth.
+@MainActor
+final class WPComQRLoginStrategy: QRLoginStrategy {
+
+    let protocol_: QRLoginErrorMapper.Protocol_ = .wpCom
+
+    private let token: String
+    private let encrypted: String
+    private let stores: StoresManager
+    private let deviceInfoProvider: QRLoginDeviceInfoProvider
+    private let magicLinkOpener: QRLoginMagicLinkOpener
+
+    private var sessionID: String?
+    private var tokenHash: String?
+    private var exchangeResponse: WPComQRLoginExchangeResponse?
+
+    init(token: String,
+         encrypted: String,
+         stores: StoresManager = ServiceLocator.stores,
+         deviceInfoProvider: QRLoginDeviceInfoProvider = DefaultQRLoginDeviceInfoProvider(),
+         magicLinkOpener: QRLoginMagicLinkOpener? = nil) {
+        self.token = token
+        self.encrypted = encrypted
+        self.stores = stores
+        self.deviceInfoProvider = deviceInfoProvider
+        // `defaultMagicLinkOpener` is @MainActor-isolated (it lives on this
+        // @MainActor class), which prevents using it as a default parameter
+        // expression. The strategy itself is @MainActor so the lookup is
+        // safe inside the body.
+        self.magicLinkOpener = magicLinkOpener ?? WPComQRLoginStrategy.defaultMagicLinkOpener
+    }
+
+    func scan() async -> Result<QRLoginScanResult, QRLoginUserFacingError> {
+        let device = deviceInfoProvider.device
+        do {
+            let response = try await Self.dispatch(stores: stores) { completion in
+                QRLoginAction.wpComScan(token: token,
+                                        encrypted: encrypted,
+                                        device: device,
+                                        completion: completion)
+            }
+            let hash = QRLoginTokenHash.make(for: token)
+            sessionID = response.sessionID
+            tokenHash = hash
+            return .success(QRLoginScanResult(
+                sessionID: response.sessionID,
+                realNumber: response.realNumber,
+                expiresInSeconds: response.expiresInSeconds,
+                tokenHash: hash,
+                subtitle: .email(response.userEmail)
+            ))
+        } catch let error as QRLoginNetworkError {
+            return .failure(QRLoginErrorMapper.userFacingError(forScan: error, protocol_: protocol_))
+        } catch {
+            return .failure(QRLoginErrorMapper.userFacingError(forScan: .network, protocol_: protocol_))
+        }
+    }
+
+    func makePollAttempt() -> QRLoginPollingLoop.PollAttempt {
+        let stores = self.stores
+        let sessionID = self.sessionID
+        let tokenHash = self.tokenHash
+        return {
+            guard let sessionID, let tokenHash else {
+                throw QRLoginNetworkError.malformed
+            }
+            let status = try await Self.dispatch(stores: stores) { completion in
+                QRLoginAction.wpComPoll(sessionID: sessionID,
+                                        tokenHash: tokenHash,
+                                        completion: completion)
+            }
+            return status.sessionState
+        }
+    }
+
+    func exchange(grant: String) async -> Result<QRLoginExchangeOutcome, QRLoginUserFacingError> {
+        if let exchangeResponse {
+            await magicLinkOpener(exchangeResponse.magicLinkURL)
+            return .success(.magicLinkHandedOff)
+        }
+        do {
+            let response = try await Self.dispatch(stores: stores) { completion in
+                QRLoginAction.wpComExchange(token: token,
+                                            encrypted: encrypted,
+                                            exchangeGrant: grant,
+                                            completion: completion)
+            }
+            exchangeResponse = response
+            await magicLinkOpener(response.magicLinkURL)
+            return .success(.magicLinkHandedOff)
+        } catch let error as QRLoginNetworkError {
+            return .failure(QRLoginErrorMapper.userFacingError(forExchange: error, protocol_: protocol_))
+        } catch {
+            return .failure(QRLoginErrorMapper.userFacingError(forExchange: .network, protocol_: protocol_))
+        }
+    }
+
+    /// Default opener used outside tests. The coordinator (Layer 6) provides
+    /// the real implementation; until then we just log so the seam exists.
+    static let defaultMagicLinkOpener: QRLoginMagicLinkOpener = { url in
+        DDLogInfo("QR-login: ready to open magic link \(url.host ?? "<unknown host>")")
+    }
+}
+
+// MARK: - Dispatch helpers
+
+private extension WPComQRLoginStrategy {
+    static func dispatch<T>(stores: StoresManager,
+                             _ build: (@escaping (Result<T, QRLoginNetworkError>) -> Void) -> Action) async throws -> T {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            let action = build { result in
+                continuation.resume(with: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginViewModelTests.swift
@@ -121,6 +121,35 @@ struct QRLoginViewModelTests {
         #expect(strategy.exchangeCalls == ["grant-x", "grant-x"]) // exchange re-run with same grant
     }
 
+    @Test func retry_when_post_exchange_failed_then_starts_fresh_scan_instead_of_reusing_grant() async {
+        // Given — /exchange succeeded, but post-exchange cleanup failed and
+        // revoked the minted AP. The retained grant is spent at this point.
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = [.success(.approved(exchangeGrant: "spent-grant"))]
+        strategy.exchangeResult = .failure(.init(kind: .siteAuthFailure, phase: .postExchange, primaryAction: .scanAgain))
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+        await viewModel.start()
+
+        // Sanity
+        guard case .error = viewModel.state else {
+            Issue.record("Expected .error after post-exchange failure, got \(viewModel.state)")
+            return
+        }
+        #expect(strategy.scanCount == 1)
+        #expect(strategy.exchangeCalls == ["spent-grant"])
+
+        // When — the recovery path starts over with a fresh scan. Keep the
+        // second scan failing so the test can prove retry did not immediately
+        // reuse the spent exchange grant.
+        strategy.scanResult = .failure(.init(kind: .network, phase: .scan, primaryAction: .retryFailedPhase))
+        await viewModel.retry()
+
+        // Then
+        #expect(strategy.scanCount == 2)
+        #expect(strategy.exchangeCalls == ["spent-grant"])
+    }
+
     @Test func retry_when_poll_transient_storm_then_resumes_polling_without_rerunning_scan() async {
         // Given — 4 transient failures trips the threshold, then we retry and
         // the poll succeeds. "Poll retry resumes polling with the

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginViewModelTests.swift
@@ -32,7 +32,7 @@ struct QRLoginViewModelTests {
 
     @Test func start_when_exchange_hands_off_magic_link_then_state_is_handedOff() async {
         // Given — the wp.com exchange opens a magic link in an in-app browser
-        // instead of completing sign-in in-app (spec §10.1).
+        // instead of completing sign-in in-app.
         let strategy = MockQRLoginStrategy()
         strategy.scanResult = .success(makeScanResult())
         strategy.pollResults = [.success(.approved(exchangeGrant: "grant-1"))]
@@ -49,7 +49,7 @@ struct QRLoginViewModelTests {
         #expect(strategy.exchangeCalls == ["grant-1"])
     }
 
-    // MARK: - Cancel from number-match (spec §6.2)
+    // MARK: - Cancel from number-match
 
     @Test func cancelFromNumberMatch_when_polling_then_state_returns_to_idle_without_server_call() async {
         // Given — poll stays in scanned forever; we cancel mid-poll.
@@ -73,7 +73,7 @@ struct QRLoginViewModelTests {
         #expect(strategy.exchangeCalls.isEmpty)
     }
 
-    // MARK: - Retry semantics (spec §6.1)
+    // MARK: - Retry semantics
 
     @Test func retry_when_scan_failed_then_runs_scan_again() async {
         // Given
@@ -123,7 +123,7 @@ struct QRLoginViewModelTests {
 
     @Test func retry_when_poll_transient_storm_then_resumes_polling_without_rerunning_scan() async {
         // Given — 4 transient failures trips the threshold, then we retry and
-        // the poll succeeds. Spec §6.1: "Poll retry resumes polling with the
+        // the poll succeeds. "Poll retry resumes polling with the
         // same session_id and token_hash — /qr-login-scan is NOT re-run."
         let strategy = MockQRLoginStrategy()
         strategy.scanResult = .success(makeScanResult())

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginViewModelTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import Networking
+import Testing
+import WordPressAuthenticator
+@testable import WooCommerce
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct QRLoginViewModelTests {
+
+    // MARK: - Happy path
+
+    @Test func start_when_scan_then_poll_approved_then_exchange_then_state_is_done() async {
+        // Given
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = [
+            .success(.scanned),
+            .success(.approved(exchangeGrant: "grant-1"))
+        ]
+        strategy.exchangeResult = .success(.authenticated)
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+
+        // When
+        await viewModel.start()
+
+        // Then
+        #expect(viewModel.state == .done)
+        #expect(strategy.scanCount == 1)
+        #expect(strategy.exchangeCalls == ["grant-1"])
+    }
+
+    @Test func start_when_exchange_hands_off_magic_link_then_state_is_handedOff() async {
+        // Given — the wp.com exchange opens a magic link in an in-app browser
+        // instead of completing sign-in in-app (spec §10.1).
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = [.success(.approved(exchangeGrant: "grant-1"))]
+        strategy.exchangeResult = .success(.magicLinkHandedOff)
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+
+        // When
+        await viewModel.start()
+
+        // Then — the flow stops at .handedOff, never .done, so the coordinator
+        // won't route to the store picker before the magic-login redirect
+        // finishes the sign-in.
+        #expect(viewModel.state == .handedOff)
+        #expect(strategy.exchangeCalls == ["grant-1"])
+    }
+
+    // MARK: - Cancel from number-match (spec §6.2)
+
+    @Test func cancelFromNumberMatch_when_polling_then_state_returns_to_idle_without_server_call() async {
+        // Given — poll stays in scanned forever; we cancel mid-poll.
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = Array(repeating: .success(.scanned), count: 10)
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+
+        // When
+        let task = Task { await viewModel.start() }
+        await waitForState(viewModel) { state in
+            if case .numberMatch = state { return true }
+            return false
+        }
+        viewModel.cancelFromNumberMatch()
+        await task.value
+
+        // Then
+        #expect(viewModel.state == .idle)
+        // Strategy was never asked to exchange — confirms no server call on cancel.
+        #expect(strategy.exchangeCalls.isEmpty)
+    }
+
+    // MARK: - Retry semantics (spec §6.1)
+
+    @Test func retry_when_scan_failed_then_runs_scan_again() async {
+        // Given
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .failure(.init(kind: .network, phase: .scan, primaryAction: .retryFailedPhase))
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+        await viewModel.start()
+        #expect(strategy.scanCount == 1)
+
+        // When — next scan succeeds, then poll approves, then exchange OK.
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = [.success(.approved(exchangeGrant: "g"))]
+        strategy.exchangeResult = .success(.authenticated)
+        await viewModel.retry()
+
+        // Then
+        #expect(viewModel.state == .done)
+        #expect(strategy.scanCount == 2)
+    }
+
+    @Test func retry_when_exchange_failed_then_does_not_rerun_scan_or_poll() async {
+        // Given — initial flow gets us to exchange, which fails.
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = [.success(.approved(exchangeGrant: "grant-x"))]
+        strategy.exchangeResult = .failure(.init(kind: .network, phase: .exchange, primaryAction: .retryFailedPhase))
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+        await viewModel.start()
+
+        // Sanity
+        guard case .error = viewModel.state else {
+            Issue.record("Expected .error after first run, got \(viewModel.state)")
+            return
+        }
+        #expect(strategy.scanCount == 1)
+        #expect(strategy.exchangeCalls == ["grant-x"])
+
+        // When — next exchange succeeds.
+        strategy.exchangeResult = .success(.authenticated)
+        await viewModel.retry()
+
+        // Then
+        #expect(viewModel.state == .done)
+        #expect(strategy.scanCount == 1) // scan NOT re-run
+        #expect(strategy.exchangeCalls == ["grant-x", "grant-x"]) // exchange re-run with same grant
+    }
+
+    @Test func retry_when_poll_transient_storm_then_resumes_polling_without_rerunning_scan() async {
+        // Given — 4 transient failures trips the threshold, then we retry and
+        // the poll succeeds. Spec §6.1: "Poll retry resumes polling with the
+        // same session_id and token_hash — /qr-login-scan is NOT re-run."
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = Array(repeating: .failure(QRLoginNetworkError.network), count: 4)
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: SpyAnalytics(), pollIntervalSeconds: 0)
+        await viewModel.start()
+
+        // Sanity — polling-loop budget tripped, view model surfaced an error.
+        guard case .error = viewModel.state else {
+            Issue.record("Expected .error, got \(viewModel.state)")
+            return
+        }
+        let scansAtErrorTime = strategy.scanCount
+
+        // When
+        strategy.pollResults = [.success(.approved(exchangeGrant: "g"))]
+        strategy.exchangeResult = .success(.authenticated)
+        await viewModel.retry()
+
+        // Then
+        #expect(viewModel.state == .done)
+        #expect(strategy.scanCount == scansAtErrorTime) // scan NOT re-run on poll retry
+    }
+
+    // MARK: - Analytics
+
+    @Test func start_emits_qrAuthenticating_then_qrNumberMatch() async {
+        // Given
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .success(makeScanResult())
+        strategy.pollResults = [.success(.approved(exchangeGrant: "g"))]
+        strategy.exchangeResult = .success(.authenticated)
+        let analytics = SpyAnalytics()
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: analytics, pollIntervalSeconds: 0)
+
+        // When
+        await viewModel.start()
+
+        // Then — qrAuthenticating fires once on entry, again as the deduplicated
+        // single step across scan/exchange (the spec dedupes adjacent same-step
+        // calls, which the underlying tracker handles).
+        #expect(analytics.steps.contains(.qrAuthenticating))
+        #expect(analytics.steps.contains(.qrNumberMatch))
+    }
+
+    @Test func error_emits_qrError_step_and_failure_string() async {
+        // Given
+        let strategy = MockQRLoginStrategy()
+        strategy.scanResult = .failure(.init(kind: .network, phase: .scan, primaryAction: .retryFailedPhase))
+        let analytics = SpyAnalytics()
+        let viewModel = QRLoginViewModel(strategy: strategy, analytics: analytics, pollIntervalSeconds: 0)
+
+        // When
+        await viewModel.start()
+
+        // Then
+        #expect(analytics.steps.last == .qrError)
+        #expect(analytics.failures == ["Network:Scan"])
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeScanResult(realNumber: String = "428") -> QRLoginScanResult {
+    QRLoginScanResult(sessionID: "sess",
+                      realNumber: realNumber,
+                      expiresInSeconds: 90,
+                      tokenHash: "hash",
+                      subtitle: .host("shop.example"))
+}
+
+@MainActor
+private func waitForState(_ viewModel: QRLoginViewModel,
+                          matching predicate: @escaping @MainActor (QRLoginViewModel.State) -> Bool) async {
+    while predicate(viewModel.state) == false {
+        try? await Task.sleep(nanoseconds: 1_000_000)
+    }
+}
+
+// MARK: - Mocks
+
+@MainActor
+private final class MockQRLoginStrategy: QRLoginStrategy {
+    let protocol_: QRLoginErrorMapper.Protocol_ = .selfHosted
+
+    var scanResult: Result<QRLoginScanResult, QRLoginUserFacingError> = .failure(.init(kind: .unexpected,
+                                                                                       phase: .scan,
+                                                                                       primaryAction: .retryFailedPhase))
+    var pollResults: [Result<QRLoginSessionState, QRLoginNetworkError>] = []
+    var exchangeResult: Result<QRLoginExchangeOutcome, QRLoginUserFacingError> =
+        .failure(.init(kind: .unexpected, phase: .exchange, primaryAction: .retryFailedPhase))
+
+    private(set) var scanCount = 0
+    private(set) var exchangeCalls: [String] = []
+    private var pollIndex = 0
+
+    func scan() async -> Result<QRLoginScanResult, QRLoginUserFacingError> {
+        scanCount += 1
+        return scanResult
+    }
+
+    func makePollAttempt() -> QRLoginPollingLoop.PollAttempt {
+        return { [self] in
+            // The view model's `pollingTask` runs on the cooperative pool; it
+            // calls this attempt via the loop. The actor isolation isn't
+            // perfect from the static analyser's POV, but `@unchecked Sendable`
+            // would only paper over it — instead we keep mutation safe by
+            // running tests entirely on @MainActor with no concurrent calls.
+            await MainActor.run { [self] in }
+            let index = await MainActor.run { [self] in
+                let i = pollIndex
+                pollIndex += 1
+                return i
+            }
+            let result = await MainActor.run { [self] in
+                pollResults.indices.contains(index) ? pollResults[index] : pollResults.last ?? .failure(.malformed)
+            }
+            switch result {
+            case .success(let status):
+                return status
+            case .failure(let error):
+                throw error
+            }
+        }
+    }
+
+    func exchange(grant: String) async -> Result<QRLoginExchangeOutcome, QRLoginUserFacingError> {
+        exchangeCalls.append(grant)
+        return exchangeResult
+    }
+}
+
+@MainActor
+private final class SpyAnalytics: QRLoginAnalyticsTracking {
+    private(set) var steps: [AuthenticatorAnalyticsTracker.Step] = []
+    private(set) var clicks: [AuthenticatorAnalyticsTracker.ClickTarget] = []
+    private(set) var failures: [String] = []
+
+    func setFlow(_ flow: AuthenticatorAnalyticsTracker.Flow) {}
+    func trackStep(_ step: AuthenticatorAnalyticsTracker.Step) { steps.append(step) }
+    func trackClick(_ click: AuthenticatorAnalyticsTracker.ClickTarget) { clicks.append(click) }
+    func trackFailure(_ failure: String) { failures.append(failure) }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/Strategy/QRLoginPostExchangeServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/Strategy/QRLoginPostExchangeServiceTests.swift
@@ -41,7 +41,7 @@ struct QRLoginPostExchangeServiceTests {
         #expect(appPasswordUseCase.deletePasswordCallCount == 0)
     }
 
-    // MARK: - Failure paths (spec §5.1.4)
+    // MARK: - Failure paths
 
     @Test func complete_when_fetchSiteInfo_fails_then_revokes_ap_and_returns_siteAuthFailure() async {
         // Given

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/Strategy/QRLoginPostExchangeServiceTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/Strategy/QRLoginPostExchangeServiceTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import Networking
+import Testing
+import Yosemite
+import struct NetworkingCore.ApplicationPassword
+import protocol NetworkingCore.ApplicationPasswordUseCase
+import enum NetworkingCore.ApplicationPasswordUseCaseError
+import struct NetworkingCore.Secret
+@testable import WooCommerce
+
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct QRLoginPostExchangeServiceTests {
+
+    private let response = SelfHostedQRLoginExchangeResponse(userLogin: "shopkeeper",
+                                                             siteURL: "https://shop.example",
+                                                             applicationPassword: "ap-secret")
+
+    // MARK: - Happy path
+
+    @Test func complete_when_site_is_woo_and_user_is_eligible_then_returns_success_and_tracks_signedIn() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let analytics = MockAnalyticsProvider()
+        let appPasswordUseCase = MockApplicationPasswordUseCase()
+        stubFetchSiteInfo(stores: stores, result: .success(makeWooSite()))
+        let service = makeService(stores: stores,
+                                  roleEligibility: StubRoleEligibilityUseCase(result: .success(())),
+                                  appPasswordUseCase: appPasswordUseCase,
+                                  analytics: analytics)
+
+        // When
+        let result = await service.complete(response)
+
+        // Then
+        guard case .success = result else {
+            Issue.record("Expected .success, got \(result)")
+            return
+        }
+        #expect(analytics.receivedEvents.contains(WooAnalyticsStat.signedIn.rawValue))
+        #expect(appPasswordUseCase.deletePasswordCallCount == 0)
+    }
+
+    // MARK: - Failure paths (spec §5.1.4)
+
+    @Test func complete_when_fetchSiteInfo_fails_then_revokes_ap_and_returns_siteAuthFailure() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let analytics = MockAnalyticsProvider()
+        let appPasswordUseCase = MockApplicationPasswordUseCase()
+        stubFetchSiteInfo(stores: stores, result: .failure(NSError(domain: "test", code: 0)))
+        let service = makeService(stores: stores,
+                                  roleEligibility: StubRoleEligibilityUseCase(result: .success(())),
+                                  appPasswordUseCase: appPasswordUseCase,
+                                  analytics: analytics)
+
+        // When
+        let result = await service.complete(response)
+
+        // Then
+        guard case let .failure(error) = result else {
+            Issue.record("Expected .failure, got \(result)")
+            return
+        }
+        #expect(error.kind == .siteAuthFailure)
+        #expect(error.phase == .postExchange)
+        #expect(appPasswordUseCase.deletePasswordCallCount == 1)
+        #expect(appPasswordUseCase.deletePasswordLocally == true)
+        #expect(analytics.receivedEvents.contains(WooAnalyticsStat.signedIn.rawValue) == false)
+    }
+
+    @Test func complete_when_site_is_not_woo_then_revokes_ap_and_returns_notAWooSite() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let appPasswordUseCase = MockApplicationPasswordUseCase()
+        stubFetchSiteInfo(stores: stores, result: .success(makeNonWooSite()))
+        let service = makeService(stores: stores,
+                                  roleEligibility: StubRoleEligibilityUseCase(result: .success(())),
+                                  appPasswordUseCase: appPasswordUseCase)
+
+        // When
+        let result = await service.complete(response)
+
+        // Then
+        guard case let .failure(error) = result else {
+            Issue.record("Expected .failure, got \(result)")
+            return
+        }
+        #expect(error.kind == .notAWooSite)
+        #expect(appPasswordUseCase.deletePasswordCallCount == 1)
+    }
+
+    @Test func complete_when_user_role_insufficient_then_revokes_ap_and_returns_userNotEligible() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let appPasswordUseCase = MockApplicationPasswordUseCase()
+        stubFetchSiteInfo(stores: stores, result: .success(makeWooSite()))
+        let info = StorageEligibilityErrorInfo(name: "shopkeeper", roles: ["author"])
+        let service = makeService(stores: stores,
+                                  roleEligibility: StubRoleEligibilityUseCase(result: .failure(.insufficientRole(info: info))),
+                                  appPasswordUseCase: appPasswordUseCase)
+
+        // When
+        let result = await service.complete(response)
+
+        // Then
+        guard case let .failure(error) = result else {
+            Issue.record("Expected .failure, got \(result)")
+            return
+        }
+        #expect(error.kind == .userNotEligible)
+        #expect(appPasswordUseCase.deletePasswordCallCount == 1)
+    }
+
+    @Test func complete_when_role_check_errors_then_returns_siteAuthFailure() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let appPasswordUseCase = MockApplicationPasswordUseCase()
+        stubFetchSiteInfo(stores: stores, result: .success(makeWooSite()))
+        let underlying = NSError(domain: "test", code: 42)
+        let service = makeService(stores: stores,
+                                  roleEligibility: StubRoleEligibilityUseCase(result: .failure(.unknown(error: underlying))),
+                                  appPasswordUseCase: appPasswordUseCase)
+
+        // When
+        let result = await service.complete(response)
+
+        // Then
+        guard case let .failure(error) = result else {
+            Issue.record("Expected .failure, got \(result)")
+            return
+        }
+        #expect(error.kind == .siteAuthFailure)
+        #expect(appPasswordUseCase.deletePasswordCallCount == 1)
+    }
+
+    @Test func complete_when_revoke_itself_fails_then_still_surfaces_original_error() async {
+        // Given — revoke throws, we should still bubble up the original failure.
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stubFetchSiteInfo(stores: stores, result: .success(makeNonWooSite()))
+        let appPasswordUseCase = MockApplicationPasswordUseCase()
+        appPasswordUseCase.deletePasswordError = ApplicationPasswordUseCaseError.applicationPasswordsDisabled
+        let service = makeService(stores: stores,
+                                  roleEligibility: StubRoleEligibilityUseCase(result: .success(())),
+                                  appPasswordUseCase: appPasswordUseCase)
+
+        // When
+        let result = await service.complete(response)
+
+        // Then
+        guard case let .failure(error) = result else {
+            Issue.record("Expected .failure, got \(result)")
+            return
+        }
+        #expect(error.kind == .notAWooSite) // original error preserved
+        #expect(appPasswordUseCase.deletePasswordCallCount == 1) // revoke was attempted
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private extension QRLoginPostExchangeServiceTests {
+
+    func makeService(stores: MockStoresManager,
+                     roleEligibility: RoleEligibilityUseCaseProtocol,
+                     appPasswordUseCase: MockApplicationPasswordUseCase,
+                     analytics: MockAnalyticsProvider = MockAnalyticsProvider()) -> QRLoginPostExchangeService {
+        QRLoginPostExchangeService(
+            stores: stores,
+            roleEligibilityUseCase: roleEligibility,
+            applicationPasswordUseCaseFactory: { _, _ in appPasswordUseCase },
+            analytics: WooAnalytics(analyticsProvider: analytics)
+        )
+    }
+
+    func stubFetchSiteInfo(stores: MockStoresManager, result: Result<Site, Error>) {
+        stores.whenReceivingAction(ofType: WordPressSiteAction.self) { action in
+            if case let .fetchSiteInfo(_, completion) = action {
+                completion(result)
+            }
+        }
+    }
+
+    func makeWooSite() -> Site {
+        Site.fake().copy(siteID: 99, name: "Shop", isWooCommerceActive: true)
+    }
+
+    func makeNonWooSite() -> Site {
+        Site.fake().copy(siteID: 99, name: "Plain WP", isWooCommerceActive: false)
+    }
+}
+
+// MARK: - Mocks
+
+@MainActor
+private final class MockApplicationPasswordUseCase: ApplicationPasswordUseCase {
+    let applicationPassword: ApplicationPassword? = ApplicationPassword(
+        wpOrgUsername: "u",
+        password: Secret("p"),
+        uuid: "uuid"
+    )
+    let canRegenerateApplicationPassword: Bool = false
+
+    var deletePasswordCallCount = 0
+    var deletePasswordLocally = false
+    var deletePasswordError: Error?
+
+    func generateNewPassword() async throws -> ApplicationPassword {
+        throw ApplicationPasswordUseCaseError.notSupported
+    }
+
+    func deletePassword(locally: Bool) async throws {
+        deletePasswordCallCount += 1
+        deletePasswordLocally = locally
+        if let deletePasswordError {
+            throw deletePasswordError
+        }
+    }
+}
+
+private final class StubRoleEligibilityUseCase: RoleEligibilityUseCaseProtocol {
+    private let result: Result<Void, RoleEligibilityError>
+
+    init(result: Result<Void, RoleEligibilityError>) {
+        self.result = result
+    }
+
+    func checkEligibility(for storeID: Int64, completion: @escaping (Result<Void, RoleEligibilityError>) -> Void) {
+        completion(result)
+    }
+}


### PR DESCRIPTION
## Description
**Part 4 of 7** of the QR-code login feature (see **[1/7]** for context).

Adds the protocol-strategy layer (`QRLoginStrategy` + the self-hosted and WP.com implementations), the self-hosted `QRLoginPostExchangeService`, and the orchestrating `QRLoginViewModel`.

**Stack:** base **[3/7]** `feature/qr-login-step-3` → next **[5/7]** `feature/qr-login-step-5`. ~701 production lines.

## Test Steps
Infrastructure only, not user-testable. CI runs `QRLoginViewModelTests`, `QRLoginPostExchangeServiceTests`.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.