### PR TITLE
QR-login [5/7]: Entry & scanner UI

### DIFF
--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginAuthenticatingView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginAuthenticatingView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// Fullscreen "Signing you in…" + spinner shown during the three logical
+/// authenticating phases (scan, exchange, complete) per spec §4.5.
+struct QRLoginAuthenticatingView: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color(uiColor: .accent))
+
+            Text(Localization.title)
+                .font(.title3)
+                .foregroundColor(.secondary)
+                .accessibilityAddTraits(.isHeader)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(uiColor: .systemBackground))
+    }
+}
+
+private extension QRLoginAuthenticatingView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "qrLogin.authenticating.title",
+            value: "Signing you in…",
+            comment: "Title on the QR-login authenticating screen."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginAuthenticatingView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginAuthenticatingView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// authenticating phases (scan, exchange, complete).
 struct QRLoginAuthenticatingView: View {
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: Constants.standardSpacing) {
             ProgressView()
                 .controlSize(.large)
                 .tint(Color(uiColor: .accent))
@@ -20,6 +20,10 @@ struct QRLoginAuthenticatingView: View {
 }
 
 private extension QRLoginAuthenticatingView {
+    enum Constants {
+        static let standardSpacing: CGFloat = 24
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "qrLogin.authenticating.title",

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginAuthenticatingView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginAuthenticatingView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Fullscreen "Signing you in…" + spinner shown during the three logical
-/// authenticating phases (scan, exchange, complete) per spec §4.5.
+/// authenticating phases (scan, exchange, complete).
 struct QRLoginAuthenticatingView: View {
     var body: some View {
         VStack(spacing: 24) {

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginCameraPermissionChecker.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginCameraPermissionChecker.swift
@@ -1,0 +1,19 @@
+import AVFoundation
+
+/// Async wrapper over `AVCaptureDevice` authorization. Injected into the
+/// coordinator so the prologue's "Scan QR code" tap can be flow-tested
+/// without a real device camera.
+protocol QRLoginCameraPermissionCheckerProtocol: Sendable {
+    var status: AVAuthorizationStatus { get }
+    func requestAccess() async -> Bool
+}
+
+struct DefaultQRLoginCameraPermissionChecker: QRLoginCameraPermissionCheckerProtocol {
+    var status: AVAuthorizationStatus {
+        AVCaptureDevice.authorizationStatus(for: .video)
+    }
+
+    func requestAccess() async -> Bool {
+        await AVCaptureDevice.requestAccess(for: .video)
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginNumberMatchView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginNumberMatchView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Number-matching overlay. Shown after `/scan` returns successfully (spec §4.3).
+///
+/// Drives a one-second countdown clamped at zero — purely a UI hint;
+/// termination is owned by the polling loop, not the timer.
+struct QRLoginNumberMatchView: View {
+    let realNumber: String
+    let expiresAt: Date
+    let subtitle: QRLoginNumberMatchSubtitle
+    let onCancel: () -> Void
+
+    @State private var now = Date()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            Text(Localization.title)
+                .font(.title)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.center)
+                .accessibilityAddTraits(.isHeader)
+
+            VStack(spacing: 8) {
+                Text(subtitleLabel)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Text(verbatim: subtitleValue)
+                    .font(.headline)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color(uiColor: .systemGray6))
+                    )
+            }
+
+            Text(Localization.tapHint)
+                .font(.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Text(verbatim: realNumber)
+                .font(.system(size: 56, weight: .semibold, design: .monospaced))
+                .padding(.horizontal, 32)
+                .padding(.vertical, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(Color(uiColor: .systemGray6))
+                )
+                .accessibilityLabel(realNumber)
+
+            Text(countdownText)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Text(Localization.securityNote)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+
+            Spacer()
+
+            Button(Localization.cancel, action: onCancel)
+                .buttonStyle(SecondaryButtonStyle())
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+        }
+        .onReceive(timer) { now = $0 }
+    }
+
+    private var subtitleLabel: String {
+        switch subtitle {
+        case .host: return Localization.subtitleLabelSelfHosted
+        case .email: return Localization.subtitleLabelWPCom
+        }
+    }
+
+    private var subtitleValue: String {
+        switch subtitle {
+        case .host(let host): return host
+        case .email(let email): return email
+        }
+    }
+
+    private var countdownText: String {
+        let remainingSeconds = max(0, Int(expiresAt.timeIntervalSince(now)))
+        return String(format: Localization.countdown, remainingSeconds)
+    }
+}
+
+// MARK: - Localization
+
+private extension QRLoginNumberMatchView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "qrLogin.numberMatch.title",
+            value: "Confirm sign-in",
+            comment: "Title on the QR number-match screen."
+        )
+        static let subtitleLabelSelfHosted = NSLocalizedString(
+            "qrLogin.numberMatch.subtitle.selfHosted",
+            value: "You're signing in to",
+            comment: "Label above the site host on the QR number-match screen."
+        )
+        static let subtitleLabelWPCom = NSLocalizedString(
+            "qrLogin.numberMatch.subtitle.wpCom",
+            value: "You're signing in as",
+            comment: "Label above the wp.com email on the QR number-match screen."
+        )
+        static let tapHint = NSLocalizedString(
+            "qrLogin.numberMatch.tapHint",
+            value: "Tap this number on your computer to finish.",
+            comment: "Instruction above the 3-digit number on the QR number-match screen."
+        )
+        static let securityNote = NSLocalizedString(
+            "qrLogin.numberMatch.securityNote",
+            value: "Both screens must show the same number for sign-in to complete.",
+            comment: "Security note on the QR number-match screen."
+        )
+        static let cancel = NSLocalizedString(
+            "qrLogin.numberMatch.cancel",
+            value: "Cancel",
+            comment: "Button to cancel sign-in from the QR number-match screen."
+        )
+        static let countdown = NSLocalizedString(
+            "qrLogin.numberMatch.countdown",
+            value: "Expires in %1$ds",
+            comment: "Countdown label on the QR number-match screen. %1$d is the number of seconds remaining."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginNumberMatchView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginNumberMatchView.swift
@@ -11,10 +11,10 @@ struct QRLoginNumberMatchView: View {
     let onCancel: () -> Void
 
     @State private var now = Date()
-    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    private let timer = Timer.publish(every: Constants.countdownTimerInterval, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: Constants.standardSpacing) {
             Spacer()
 
             Text(Localization.title)
@@ -23,7 +23,7 @@ struct QRLoginNumberMatchView: View {
                 .multilineTextAlignment(.center)
                 .accessibilityAddTraits(.isHeader)
 
-            VStack(spacing: 8) {
+            VStack(spacing: Constants.smallSpacing) {
                 Text(subtitleLabel)
                     .font(.body)
                     .foregroundColor(.secondary)
@@ -31,10 +31,10 @@ struct QRLoginNumberMatchView: View {
 
                 Text(verbatim: subtitleValue)
                     .font(.headline)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
+                    .padding(.horizontal, Constants.mediumPadding)
+                    .padding(.vertical, Constants.smallSpacing)
                     .background(
-                        RoundedRectangle(cornerRadius: 12)
+                        RoundedRectangle(cornerRadius: Constants.subtitleCornerRadius)
                             .fill(Color(uiColor: .systemGray6))
                     )
             }
@@ -45,11 +45,11 @@ struct QRLoginNumberMatchView: View {
                 .multilineTextAlignment(.center)
 
             Text(verbatim: realNumber)
-                .font(.system(size: 56, weight: .semibold, design: .monospaced))
-                .padding(.horizontal, 32)
-                .padding(.vertical, 16)
+                .font(.system(size: Constants.numberFontSize, weight: .semibold, design: .monospaced))
+                .padding(.horizontal, Constants.largePadding)
+                .padding(.vertical, Constants.mediumPadding)
                 .background(
-                    RoundedRectangle(cornerRadius: 16)
+                    RoundedRectangle(cornerRadius: Constants.numberCornerRadius)
                         .fill(Color(uiColor: .systemGray6))
                 )
                 .accessibilityLabel(realNumber)
@@ -62,14 +62,14 @@ struct QRLoginNumberMatchView: View {
                 .font(.footnote)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 32)
+                .padding(.horizontal, Constants.largePadding)
 
             Spacer()
 
             Button(Localization.cancel, action: onCancel)
                 .buttonStyle(SecondaryButtonStyle())
-                .padding(.horizontal, 24)
-                .padding(.bottom, 24)
+                .padding(.horizontal, Constants.standardPadding)
+                .padding(.bottom, Constants.standardPadding)
         }
         .onReceive(timer) { now = $0 }
     }
@@ -89,7 +89,7 @@ struct QRLoginNumberMatchView: View {
     }
 
     private var countdownText: String {
-        let remainingSeconds = max(0, Int(expiresAt.timeIntervalSince(now)))
+        let remainingSeconds = max(Constants.minimumRemainingSeconds, Int(expiresAt.timeIntervalSince(now)))
         return String(format: Localization.countdown, remainingSeconds)
     }
 }
@@ -97,6 +97,19 @@ struct QRLoginNumberMatchView: View {
 // MARK: - Localization
 
 private extension QRLoginNumberMatchView {
+    enum Constants {
+        static let countdownTimerInterval: TimeInterval = 1
+        static let minimumRemainingSeconds = 0
+        static let smallSpacing: CGFloat = 8
+        static let standardSpacing: CGFloat = 24
+        static let mediumPadding: CGFloat = 16
+        static let standardPadding: CGFloat = 24
+        static let largePadding: CGFloat = 32
+        static let subtitleCornerRadius: CGFloat = 12
+        static let numberCornerRadius: CGFloat = 16
+        static let numberFontSize: CGFloat = 56
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "qrLogin.numberMatch.title",

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginNumberMatchView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginNumberMatchView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Number-matching overlay. Shown after `/scan` returns successfully (spec §4.3).
+/// Number-matching overlay. Shown after `/scan` returns successfully.
 ///
 /// Drives a one-second countdown clamped at zero — purely a UI hint;
 /// termination is owned by the polling loop, not the timer.

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginPrologueView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginPrologueView.swift
@@ -1,0 +1,256 @@
+import SwiftUI
+import UIKit
+
+/// QR-login prologue. Pushed onto the login navigation stack when the user taps
+/// the primary "Log in" CTA and QR login is available (spec §4.1).
+///
+/// Two actions reach the coordinator via the callbacks:
+///   - Primary "Scan QR code" → coordinator requests camera permission and,
+///     if granted, presents the scanner.
+///   - Secondary "No computer? Log in with site address" → coordinator falls
+///     back to the legacy site-address login flow.
+///
+/// The screen reuses the standard login prologue's dark, bubble-textured
+/// background so the QR entry point feels like part of the same login surface.
+/// The shared navigation bar is hidden for this screen — Back and Help are
+/// drawn here as light controls over the dark background.
+struct QRLoginPrologueView: View {
+    let onBackTapped: () -> Void
+    let onHelpTapped: () -> Void
+    let onScanTapped: () -> Void
+    let onSiteAddressTapped: () -> Void
+    let onURLTapped: () -> Void
+
+    /// Drives the transient "copied" confirmation on the URL pill.
+    @State private var didCopyURL = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            topBar
+
+            ScrollView {
+                VStack(spacing: 24) {
+                    qrIcon
+
+                    Text(Localization.title)
+                        .font(.largeTitle)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.center)
+                        .accessibilityAddTraits(.isHeader)
+
+                    Text(Localization.subtitle)
+                        .font(.body)
+                        .foregroundColor(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+
+                    urlPill
+
+                    Text(Localization.stepHint)
+                        .font(.body)
+                        .foregroundColor(.white.opacity(0.7))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+                }
+                .padding(.horizontal, 32)
+                .padding(.vertical, 24)
+            }
+
+            buttons
+        }
+        .background(prologueBackground)
+    }
+
+    /// Light Back / Help controls drawn where a navigation bar would sit, since
+    /// the shared (purple-tinted) navigation bar is hidden for this screen. The
+    /// insets line up with the standard navigation-bar items on the other
+    /// QR-login screens.
+    private var topBar: some View {
+        HStack(spacing: 0) {
+            Button(action: onBackTapped) {
+                Image(systemName: "chevron.backward")
+                    .font(.body.weight(.semibold))
+                    .foregroundColor(.white)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel(Localization.back)
+
+            Spacer()
+
+            Button(action: onHelpTapped) {
+                Text(Localization.help)
+                    .font(.body)
+                    .foregroundColor(.white)
+                    .frame(height: 44)
+                    .padding(.horizontal, 16)
+            }
+        }
+    }
+
+    private var qrIcon: some View {
+        Image(systemName: "qrcode.viewfinder")
+            .resizable()
+            .scaledToFit()
+            .frame(width: 48, height: 48)
+            .foregroundColor(.white)
+            .padding(22)
+            .background(Circle().fill(Color.white.opacity(0.12)))
+            .padding(.top, 32)
+            .accessibilityHidden(true)
+    }
+
+    /// The URL the merchant should open on their computer — the most prominent
+    /// step on the screen, so it uses a larger font. Tapping copies it and
+    /// briefly confirms with a "copied" state.
+    private var urlPill: some View {
+        Button(action: copyURL) {
+            HStack(spacing: 8) {
+                Image(systemName: didCopyURL ? "checkmark.circle.fill" : "desktopcomputer")
+                Group {
+                    if didCopyURL {
+                        Text(Localization.urlCopied)
+                    } else {
+                        Text(verbatim: Localization.urlPillValue)
+                    }
+                }
+                .fontWeight(.semibold)
+            }
+            .font(.title3)
+            .foregroundColor(.white)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+            .background(
+                Capsule().fill(Color.white.opacity(0.12))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(Localization.urlPillAccessibilityHint)
+    }
+
+    private func copyURL() {
+        onURLTapped()
+        withAnimation { didCopyURL = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation { didCopyURL = false }
+        }
+    }
+
+    private var buttons: some View {
+        VStack(spacing: 12) {
+            // White primary CTA — the accent purple would blend into the
+            // purple background, so this mirrors the standard prologue's
+            // white "Log In" button.
+            Button(action: onScanTapped) {
+                Text(Localization.scanCTA)
+                    .font(.body.weight(.semibold))
+                    .foregroundColor(.black)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+                    .background(Color.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.plain)
+
+            Button(action: onSiteAddressTapped) {
+                Text(Localization.fallbackCTA)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.large)
+            .tint(.white)
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 12)
+        .padding(.bottom, 24)
+    }
+
+    /// The standard login prologue's dark background — a tinted "bubbles" image
+    /// over the prologue background colour. Rendered through a `UIImageView` so
+    /// the tinted template asset draws correctly (a SwiftUI `Image` re-tints it).
+    private var prologueBackground: some View {
+        PrologueBubblesBackground()
+            .ignoresSafeArea()
+    }
+}
+
+// MARK: - Background
+
+/// Bridges the standard login prologue's `UIImageView`-rendered background into
+/// SwiftUI, so the QR prologue is visually identical to the main login surface.
+private struct PrologueBubblesBackground: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIImageView {
+        let imageView = UIImageView(image: LoginPrologueViewController.backgroundImage)
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = LoginPrologueViewController.backgroundColor
+        return imageView
+    }
+
+    func updateUIView(_ uiView: UIImageView, context: Context) {}
+}
+
+// MARK: - Localization
+
+private extension QRLoginPrologueView {
+    enum Localization {
+        static let back = NSLocalizedString(
+            "qrLogin.prologue.back",
+            value: "Back",
+            comment: "Accessibility label for the back button on the QR-login prologue."
+        )
+        static let help = NSLocalizedString(
+            "qrLogin.prologue.help",
+            value: "Help",
+            comment: "Help button on the QR-login prologue."
+        )
+        static let title = NSLocalizedString(
+            "qrLogin.prologue.title",
+            value: "Scan to log in",
+            comment: "Title on the QR-login prologue screen."
+        )
+        static let subtitle = NSLocalizedString(
+            "qrLogin.prologue.subtitle",
+            value: "On your computer, visit:",
+            comment: "Subtitle on the QR-login prologue, introducing the URL the user should visit."
+        )
+        static let urlPillValue = "woo.com/mobilelogin"
+        static let urlCopied = NSLocalizedString(
+            "qrLogin.prologue.urlPill.copied",
+            value: "Link copied!",
+            comment: "Confirmation shown on the QR-login prologue URL pill after it is tapped to copy."
+        )
+        static let urlPillAccessibilityHint = NSLocalizedString(
+            "qrLogin.prologue.urlPill.accessibilityHint",
+            value: "Copies the URL to the clipboard.",
+            comment: "Accessibility hint for the tappable URL pill on the QR-login prologue."
+        )
+        static let stepHint = NSLocalizedString(
+            "qrLogin.prologue.stepHint",
+            value: "Then scan the QR code that appears.",
+            comment: "Hint below the URL pill on the QR-login prologue."
+        )
+        static let scanCTA = NSLocalizedString(
+            "qrLogin.prologue.scanCTA",
+            value: "Scan QR code",
+            comment: "Primary call-to-action on the QR-login prologue."
+        )
+        static let fallbackCTA = NSLocalizedString(
+            "qrLogin.prologue.fallbackCTA",
+            value: "No computer? Log in with site address",
+            comment: "Secondary call-to-action on the QR-login prologue."
+        )
+    }
+}
+
+#if DEBUG
+#Preview {
+    QRLoginPrologueView(
+        onBackTapped: {},
+        onHelpTapped: {},
+        onScanTapped: {},
+        onSiteAddressTapped: {},
+        onURLTapped: {}
+    )
+}
+#endif

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginPrologueView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginPrologueView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import UIKit
 
 /// QR-login prologue. Pushed onto the login navigation stack when the user taps
-/// the primary "Log in" CTA and QR login is available (spec §4.1).
+/// the primary "Log in" CTA and QR login is available.
 ///
 /// Two actions reach the coordinator via the callbacks:
 ///   - Primary "Scan QR code" → coordinator requests camera permission and,

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginPrologueView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginPrologueView.swift
@@ -25,11 +25,11 @@ struct QRLoginPrologueView: View {
     @State private var didCopyURL = false
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Constants.zeroSpacing) {
             topBar
 
             ScrollView {
-                VStack(spacing: 24) {
+                VStack(spacing: Constants.standardSpacing) {
                     qrIcon
 
                     Text(Localization.title)
@@ -41,19 +41,19 @@ struct QRLoginPrologueView: View {
 
                     Text(Localization.subtitle)
                         .font(.body)
-                        .foregroundColor(.white.opacity(0.7))
+                        .foregroundColor(.white.opacity(Constants.secondaryTextOpacity))
                         .multilineTextAlignment(.center)
 
                     urlPill
 
                     Text(Localization.stepHint)
                         .font(.body)
-                        .foregroundColor(.white.opacity(0.7))
+                        .foregroundColor(.white.opacity(Constants.secondaryTextOpacity))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal)
                 }
-                .padding(.horizontal, 32)
-                .padding(.vertical, 24)
+                .padding(.horizontal, Constants.largePadding)
+                .padding(.vertical, Constants.standardPadding)
             }
 
             buttons
@@ -66,12 +66,12 @@ struct QRLoginPrologueView: View {
     /// insets line up with the standard navigation-bar items on the other
     /// QR-login screens.
     private var topBar: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: Constants.zeroSpacing) {
             Button(action: onBackTapped) {
                 Image(systemName: "chevron.backward")
                     .font(.body.weight(.semibold))
                     .foregroundColor(.white)
-                    .frame(width: 44, height: 44)
+                    .frame(width: Constants.topBarControlSize, height: Constants.topBarControlSize)
             }
             .accessibilityLabel(Localization.back)
 
@@ -81,8 +81,8 @@ struct QRLoginPrologueView: View {
                 Text(Localization.help)
                     .font(.body)
                     .foregroundColor(.white)
-                    .frame(height: 44)
-                    .padding(.horizontal, 16)
+                    .frame(height: Constants.topBarControlSize)
+                    .padding(.horizontal, Constants.mediumPadding)
             }
         }
     }
@@ -91,11 +91,11 @@ struct QRLoginPrologueView: View {
         Image(systemName: "qrcode.viewfinder")
             .resizable()
             .scaledToFit()
-            .frame(width: 48, height: 48)
+            .frame(width: Constants.qrIconSize, height: Constants.qrIconSize)
             .foregroundColor(.white)
-            .padding(22)
-            .background(Circle().fill(Color.white.opacity(0.12)))
-            .padding(.top, 32)
+            .padding(Constants.qrIconPadding)
+            .background(Circle().fill(Color.white.opacity(Constants.translucentControlOpacity)))
+            .padding(.top, Constants.largePadding)
             .accessibilityHidden(true)
     }
 
@@ -104,7 +104,7 @@ struct QRLoginPrologueView: View {
     /// briefly confirms with a "copied" state.
     private var urlPill: some View {
         Button(action: copyURL) {
-            HStack(spacing: 8) {
+            HStack(spacing: Constants.smallSpacing) {
                 Image(systemName: didCopyURL ? "checkmark.circle.fill" : "desktopcomputer")
                 Group {
                     if didCopyURL {
@@ -117,10 +117,10 @@ struct QRLoginPrologueView: View {
             }
             .font(.title3)
             .foregroundColor(.white)
-            .padding(.horizontal, 24)
-            .padding(.vertical, 14)
+            .padding(.horizontal, Constants.standardPadding)
+            .padding(.vertical, Constants.urlPillVerticalPadding)
             .background(
-                Capsule().fill(Color.white.opacity(0.12))
+                Capsule().fill(Color.white.opacity(Constants.translucentControlOpacity))
             )
         }
         .buttonStyle(.plain)
@@ -130,13 +130,13 @@ struct QRLoginPrologueView: View {
     private func copyURL() {
         onURLTapped()
         withAnimation { didCopyURL = true }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.copyConfirmationDelay) {
             withAnimation { didCopyURL = false }
         }
     }
 
     private var buttons: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: Constants.mediumSpacing) {
             // White primary CTA — the accent purple would blend into the
             // purple background, so this mirrors the standard prologue's
             // white "Log In" button.
@@ -145,24 +145,24 @@ struct QRLoginPrologueView: View {
                     .font(.body.weight(.semibold))
                     .foregroundColor(.black)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 50)
+                    .frame(height: Constants.primaryButtonHeight)
                     .background(Color.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .clipShape(RoundedRectangle(cornerRadius: Constants.buttonCornerRadius))
             }
             .buttonStyle(.plain)
 
             Button(action: onSiteAddressTapped) {
                 Text(Localization.fallbackCTA)
                     .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, Constants.smallSpacing)
             }
             .buttonStyle(.borderless)
             .controlSize(.large)
             .tint(.white)
         }
-        .padding(.horizontal, 24)
-        .padding(.top, 12)
-        .padding(.bottom, 24)
+        .padding(.horizontal, Constants.standardPadding)
+        .padding(.top, Constants.mediumSpacing)
+        .padding(.bottom, Constants.standardPadding)
     }
 
     /// The standard login prologue's dark background — a tinted "bubbles" image
@@ -193,6 +193,25 @@ private struct PrologueBubblesBackground: UIViewRepresentable {
 // MARK: - Localization
 
 private extension QRLoginPrologueView {
+    enum Constants {
+        static let zeroSpacing: CGFloat = 0
+        static let smallSpacing: CGFloat = 8
+        static let mediumSpacing: CGFloat = 12
+        static let standardSpacing: CGFloat = 24
+        static let mediumPadding: CGFloat = 16
+        static let standardPadding: CGFloat = 24
+        static let largePadding: CGFloat = 32
+        static let secondaryTextOpacity = 0.7
+        static let translucentControlOpacity = 0.12
+        static let topBarControlSize: CGFloat = 44
+        static let qrIconSize: CGFloat = 48
+        static let qrIconPadding: CGFloat = 22
+        static let urlPillVerticalPadding: CGFloat = 14
+        static let copyConfirmationDelay: DispatchTimeInterval = .seconds(2)
+        static let primaryButtonHeight: CGFloat = 50
+        static let buttonCornerRadius: CGFloat = 8
+    }
+
     enum Localization {
         static let back = NSLocalizedString(
             "qrLogin.prologue.back",

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginScannerView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginScannerView.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+import Vision
+
+/// SwiftUI wrapper around `CodeScannerViewController`. Wraps it in a
+/// `UIViewControllerRepresentable` so we can compose it with the QR-login
+/// chrome (URL pill, close button) in SwiftUI.
+///
+/// `onScannedPayload` fires once per QR result; the coordinator is
+/// responsible for stopping further scans (e.g. by dismissing this view)
+/// once it accepts a payload.
+struct QRLoginScannerView: View {
+    let onScannedPayload: (String) -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            QRLoginScannerRepresentable(onScannedPayload: onScannedPayload)
+                .ignoresSafeArea()
+
+            VStack {
+                HStack {
+                    Button(action: onCancel) {
+                        Image(systemName: "xmark")
+                            .imageScale(.large)
+                            .padding(12)
+                            .background(
+                                Circle().fill(Color.black.opacity(0.4))
+                            )
+                            .foregroundColor(.white)
+                            .accessibilityLabel(Localization.cancelAccessibility)
+                    }
+                    Spacer()
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+
+                Spacer()
+
+                Text(Localization.urlPill)
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 18).fill(Color.black.opacity(0.5))
+                    )
+                    .padding(.bottom, 32)
+            }
+        }
+        .background(Color.black.ignoresSafeArea())
+    }
+}
+
+private struct QRLoginScannerRepresentable: UIViewControllerRepresentable {
+    let onScannedPayload: (String) -> Void
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        let scanner = CodeScannerViewController(
+            instructionText: QRLoginScannerView.Localization.instruction,
+            // The QR-login scanner draws its own close control over the camera
+            // feed, so the controller's built-in cancel button is hidden.
+            format: .barcode(completion: { result in
+                guard case let .success(barcodes) = result else { return }
+                guard let payload = barcodes
+                    .first(where: { $0.symbology == .qr })?
+                    .payloadStringValue else { return }
+                Task { @MainActor in
+                    context.coordinator.deliver(payload: payload)
+                }
+            }),
+            showsBuiltInCancelButton: false
+        )
+        return scanner
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onScannedPayload: onScannedPayload)
+    }
+
+    @MainActor
+    final class Coordinator {
+        private let onScannedPayload: (String) -> Void
+        private var delivered = false
+
+        init(onScannedPayload: @escaping (String) -> Void) {
+            self.onScannedPayload = onScannedPayload
+        }
+
+        func deliver(payload: String) {
+            guard delivered == false else { return }
+            delivered = true
+            onScannedPayload(payload)
+        }
+    }
+}
+
+// MARK: - Localization
+
+extension QRLoginScannerView {
+    enum Localization {
+        static let urlPill = NSLocalizedString(
+            "qrLogin.scanner.urlPill",
+            value: "Visit woo.com/mobilelogin",
+            comment: "URL pill shown above the scanner viewfinder."
+        )
+        static let instruction = NSLocalizedString(
+            "qrLogin.scanner.instruction",
+            value: "Center the QR code in the frame",
+            comment: "Instruction text shown below the scanner viewfinder."
+        )
+        static let cancelAccessibility = NSLocalizedString(
+            "qrLogin.scanner.cancel.accessibility",
+            value: "Cancel",
+            comment: "Accessibility label for the cancel button on the QR scanner."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginScannerView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginScannerView.swift
@@ -22,9 +22,9 @@ struct QRLoginScannerView: View {
                     Button(action: onCancel) {
                         Image(systemName: "xmark")
                             .imageScale(.large)
-                            .padding(12)
+                            .padding(Constants.standardPadding)
                             .background(
-                                Circle().fill(Color.black.opacity(0.4))
+                                Circle().fill(Color.black.opacity(Constants.cancelButtonBackgroundOpacity))
                             )
                             .foregroundColor(.white)
                             .accessibilityLabel(Localization.cancelAccessibility)
@@ -32,19 +32,20 @@ struct QRLoginScannerView: View {
                     Spacer()
                 }
                 .padding(.horizontal)
-                .padding(.top, 8)
+                .padding(.top, Constants.smallPadding)
 
                 Spacer()
 
                 Text(Localization.urlPill)
                     .font(.headline)
                     .foregroundColor(.white)
-                    .padding(.horizontal, 18)
-                    .padding(.vertical, 10)
+                    .padding(.horizontal, Constants.urlPillHorizontalPadding)
+                    .padding(.vertical, Constants.urlPillVerticalPadding)
                     .background(
-                        RoundedRectangle(cornerRadius: 18).fill(Color.black.opacity(0.5))
+                        RoundedRectangle(cornerRadius: Constants.urlPillCornerRadius)
+                            .fill(Color.black.opacity(Constants.urlPillBackgroundOpacity))
                     )
-                    .padding(.bottom, 32)
+                    .padding(.bottom, Constants.largePadding)
             }
         }
         .background(Color.black.ignoresSafeArea())
@@ -97,6 +98,19 @@ private struct QRLoginScannerRepresentable: UIViewControllerRepresentable {
 }
 
 // MARK: - Localization
+
+private extension QRLoginScannerView {
+    enum Constants {
+        static let smallPadding: CGFloat = 8
+        static let standardPadding: CGFloat = 12
+        static let largePadding: CGFloat = 32
+        static let cancelButtonBackgroundOpacity = 0.4
+        static let urlPillHorizontalPadding: CGFloat = 18
+        static let urlPillVerticalPadding: CGFloat = 10
+        static let urlPillCornerRadius: CGFloat = 18
+        static let urlPillBackgroundOpacity = 0.5
+    }
+}
 
 extension QRLoginScannerView {
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Scanner/CodeScannerViewController.swift
@@ -44,10 +44,15 @@ final class CodeScannerViewController: UIViewController {
 
     private let instructionText: String
     private let format: ScannedCodeFormat
+    private let showsBuiltInCancelButton: Bool
 
-    init(instructionText: String, format: ScannedCodeFormat) {
+    /// - Parameter showsBuiltInCancelButton: When `false`, the controller's own
+    ///   cancel button is hidden — for callers that embed the scanner and draw
+    ///   their own dismissal control (e.g. the QR-login scanner).
+    init(instructionText: String, format: ScannedCodeFormat, showsBuiltInCancelButton: Bool = true) {
         self.instructionText = instructionText
         self.format = format
+        self.showsBuiltInCancelButton = showsBuiltInCancelButton
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -72,6 +77,7 @@ final class CodeScannerViewController: UIViewController {
     }
 
     private func configureCancelButton() {
+        cancelButton.isHidden = !showsBuiltInCancelButton
         cancelButton.setTitle(Localization.cancel, for: .normal)
         cancelButton.tintColor = UIColor.white
         cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)


### PR DESCRIPTION
## Description
**Part 5 of 7** of the QR-code login feature (see **[1/7]** for context).

Adds the SwiftUI entry screens: the QR-login prologue, the scanner view, the camera-permission checker, and the number-match / authenticating views. Not yet wired into navigation.

**Stack:** base **[4/7]** `feature/qr-login-step-4` → next **[6/7]** `feature/qr-login-step-6`. ~568 production lines.

## Test Steps
UI components only, not yet reachable. Verify the app builds. End-to-end testing happens in **[7/7]**.

## Screenshots
See **[7/7]** for the assembled flow.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.