### PR TITLE
QR-login [6/7]: Flow & host UI

### DIFF
--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
@@ -13,20 +13,20 @@ struct QRLoginErrorView: View {
             Spacer(minLength: Constants.standardPadding)
 
             VStack(spacing: Constants.contentSpacing) {
-                Image(systemName: errorIconName)
+                Image(systemName: errorContent.iconName)
                     .resizable()
                     .scaledToFit()
                     .frame(width: Constants.iconSize, height: Constants.iconSize)
                     .foregroundColor(Color(uiColor: .systemRed))
                     .accessibilityHidden(true)
 
-                Text(title)
+                Text(errorContent.title)
                     .font(.title)
                     .fontWeight(.semibold)
                     .multilineTextAlignment(.center)
                     .accessibilityAddTraits(.isHeader)
 
-                Text(bodyText)
+                Text(errorContent.body)
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -48,58 +48,77 @@ struct QRLoginErrorView: View {
     }
 }
 
-// MARK: - Copy
+// MARK: - Content
 
 private extension QRLoginErrorView {
 
-    var errorIconName: String {
-        switch error.kind {
-        case .invalidPayload, .installQR, .scannerFailure: return "qrcode.viewfinder"
-        case .network: return "wifi.slash"
-        case .rateLimited: return "clock.badge.exclamationmark"
-        default: return "exclamationmark.triangle"
+    struct Content {
+        let iconName: String
+        let title: String
+        let body: String
+
+        init(iconName: String = "exclamationmark.triangle", title: String, body: String) {
+            self.iconName = iconName
+            self.title = title
+            self.body = body
         }
     }
 
-    var title: String {
+    var errorContent: Content {
         switch error.kind {
-        case .invalidPayload: return Localization.invalidPayloadTitle
-        case .installQR: return Localization.installQRTitle
-        case .scannerFailure: return Localization.scannerFailureTitle
-        case .codeExpired: return Localization.codeExpiredTitle
-        case .storeUnsupported: return Localization.storeUnsupportedTitle
-        case .rateLimited: return Localization.rateLimitedTitle
-        case .network: return Localization.networkTitle
-        case .unexpected: return Localization.unexpectedTitle
-        case .codeAlreadyUsed: return Localization.codeAlreadyUsedTitle
-        case .signInDenied: return Localization.signInDeniedTitle
-        case .signInTimedOut: return Localization.signInTimedOutTitle
-        case .signInInterrupted: return Localization.signInInterruptedTitle
-        case .alreadySignedInElsewhere: return Localization.alreadySignedInElsewhereTitle
-        case .siteAuthFailure: return Localization.siteAuthFailureTitle
-        case .notAWooSite: return Localization.notAWooSiteTitle
-        case .userNotEligible: return Localization.userNotEligibleTitle
-        }
-    }
-
-    var bodyText: String {
-        switch error.kind {
-        case .invalidPayload: return Localization.invalidPayloadBody
-        case .installQR: return Localization.installQRBody
-        case .scannerFailure: return Localization.scannerFailureBody
-        case .codeExpired: return Localization.codeExpiredBody
-        case .storeUnsupported: return Localization.storeUnsupportedBody
-        case .rateLimited: return Localization.rateLimitedBody
-        case .network: return Localization.networkBody
-        case .unexpected: return Localization.unexpectedBody
-        case .codeAlreadyUsed: return Localization.codeAlreadyUsedBody
-        case .signInDenied: return Localization.signInDeniedBody
-        case .signInTimedOut: return Localization.signInTimedOutBody
-        case .signInInterrupted: return Localization.signInInterruptedBody
-        case .alreadySignedInElsewhere: return Localization.alreadySignedInElsewhereBody
-        case .siteAuthFailure: return Localization.siteAuthFailureBody
-        case .notAWooSite: return Localization.notAWooSiteBody
-        case .userNotEligible: return Localization.userNotEligibleBody
+        case .invalidPayload:
+            Content(iconName: "qrcode.viewfinder",
+                    title: Localization.invalidPayloadTitle,
+                    body: Localization.invalidPayloadBody)
+        case .installQR:
+            Content(iconName: "qrcode.viewfinder",
+                    title: Localization.installQRTitle,
+                    body: Localization.installQRBody)
+        case .scannerFailure:
+            Content(iconName: "qrcode.viewfinder",
+                    title: Localization.scannerFailureTitle,
+                    body: Localization.scannerFailureBody)
+        case .network:
+            Content(iconName: "wifi.slash",
+                    title: Localization.networkTitle,
+                    body: Localization.networkBody)
+        case .rateLimited:
+            Content(iconName: "clock.badge.exclamationmark",
+                    title: Localization.rateLimitedTitle,
+                    body: Localization.rateLimitedBody)
+        case .codeExpired:
+            Content(title: Localization.codeExpiredTitle,
+                    body: Localization.codeExpiredBody)
+        case .storeUnsupported:
+            Content(title: Localization.storeUnsupportedTitle,
+                    body: Localization.storeUnsupportedBody)
+        case .unexpected:
+            Content(title: Localization.unexpectedTitle,
+                    body: Localization.unexpectedBody)
+        case .codeAlreadyUsed:
+            Content(title: Localization.codeAlreadyUsedTitle,
+                    body: Localization.codeAlreadyUsedBody)
+        case .signInDenied:
+            Content(title: Localization.signInDeniedTitle,
+                    body: Localization.signInDeniedBody)
+        case .signInTimedOut:
+            Content(title: Localization.signInTimedOutTitle,
+                    body: Localization.signInTimedOutBody)
+        case .signInInterrupted:
+            Content(title: Localization.signInInterruptedTitle,
+                    body: Localization.signInInterruptedBody)
+        case .alreadySignedInElsewhere:
+            Content(title: Localization.alreadySignedInElsewhereTitle,
+                    body: Localization.alreadySignedInElsewhereBody)
+        case .siteAuthFailure:
+            Content(title: Localization.siteAuthFailureTitle,
+                    body: Localization.siteAuthFailureBody)
+        case .notAWooSite:
+            Content(title: Localization.notAWooSiteTitle,
+                    body: Localization.notAWooSiteBody)
+        case .userNotEligible:
+            Content(title: Localization.userNotEligibleTitle,
+                    body: Localization.userNotEligibleBody)
         }
     }
 

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
@@ -9,14 +9,14 @@ struct QRLoginErrorView: View {
     let onEnterSiteURLTapped: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 24)
+        VStack(spacing: Constants.zeroSpacing) {
+            Spacer(minLength: Constants.standardPadding)
 
-            VStack(spacing: 20) {
+            VStack(spacing: Constants.contentSpacing) {
                 Image(systemName: errorIconName)
                     .resizable()
                     .scaledToFit()
-                    .frame(width: 88, height: 88)
+                    .frame(width: Constants.iconSize, height: Constants.iconSize)
                     .foregroundColor(Color(uiColor: .systemRed))
                     .accessibilityHidden(true)
 
@@ -30,20 +30,20 @@ struct QRLoginErrorView: View {
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, 32)
+                    .padding(.horizontal, Constants.largePadding)
             }
 
-            Spacer(minLength: 24)
+            Spacer(minLength: Constants.standardPadding)
 
-            VStack(spacing: 12) {
+            VStack(spacing: Constants.buttonSpacing) {
                 Button(primaryCTA, action: onPrimaryTapped)
                     .buttonStyle(PrimaryButtonStyle())
 
                 Button(Localization.enterSiteURL, action: onEnterSiteURLTapped)
                     .buttonStyle(SecondaryButtonStyle())
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 24)
+            .padding(.horizontal, Constants.standardPadding)
+            .padding(.bottom, Constants.standardPadding)
         }
     }
 }
@@ -118,6 +118,15 @@ private extension QRLoginErrorView {
 // MARK: - Localization
 
 private extension QRLoginErrorView {
+    enum Constants {
+        static let zeroSpacing: CGFloat = 0
+        static let buttonSpacing: CGFloat = 12
+        static let contentSpacing: CGFloat = 20
+        static let standardPadding: CGFloat = 24
+        static let largePadding: CGFloat = 32
+        static let iconSize: CGFloat = 88
+    }
+
     enum Localization {
         // Titles
         static let invalidPayloadTitle = NSLocalizedString(

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Fullscreen error variant for any failure surfaced by the QR-login flow.
 /// Title / body / primary CTA come from the user-facing error variant; the
-/// secondary CTA is always "Enter site URL instead" (spec §4.6).
+/// secondary CTA is always "Enter site URL instead".
 struct QRLoginErrorView: View {
     let error: QRLoginUserFacingError
     let onPrimaryTapped: () -> Void

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginErrorView.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+
+/// Fullscreen error variant for any failure surfaced by the QR-login flow.
+/// Title / body / primary CTA come from the user-facing error variant; the
+/// secondary CTA is always "Enter site URL instead" (spec §4.6).
+struct QRLoginErrorView: View {
+    let error: QRLoginUserFacingError
+    let onPrimaryTapped: () -> Void
+    let onEnterSiteURLTapped: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer(minLength: 24)
+
+            VStack(spacing: 20) {
+                Image(systemName: errorIconName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 88, height: 88)
+                    .foregroundColor(Color(uiColor: .systemRed))
+                    .accessibilityHidden(true)
+
+                Text(title)
+                    .font(.title)
+                    .fontWeight(.semibold)
+                    .multilineTextAlignment(.center)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(bodyText)
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Spacer(minLength: 24)
+
+            VStack(spacing: 12) {
+                Button(primaryCTA, action: onPrimaryTapped)
+                    .buttonStyle(PrimaryButtonStyle())
+
+                Button(Localization.enterSiteURL, action: onEnterSiteURLTapped)
+                    .buttonStyle(SecondaryButtonStyle())
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+    }
+}
+
+// MARK: - Copy
+
+private extension QRLoginErrorView {
+
+    var errorIconName: String {
+        switch error.kind {
+        case .invalidPayload, .installQR, .scannerFailure: return "qrcode.viewfinder"
+        case .network: return "wifi.slash"
+        case .rateLimited: return "clock.badge.exclamationmark"
+        default: return "exclamationmark.triangle"
+        }
+    }
+
+    var title: String {
+        switch error.kind {
+        case .invalidPayload: return Localization.invalidPayloadTitle
+        case .installQR: return Localization.installQRTitle
+        case .scannerFailure: return Localization.scannerFailureTitle
+        case .codeExpired: return Localization.codeExpiredTitle
+        case .storeUnsupported: return Localization.storeUnsupportedTitle
+        case .rateLimited: return Localization.rateLimitedTitle
+        case .network: return Localization.networkTitle
+        case .unexpected: return Localization.unexpectedTitle
+        case .codeAlreadyUsed: return Localization.codeAlreadyUsedTitle
+        case .signInDenied: return Localization.signInDeniedTitle
+        case .signInTimedOut: return Localization.signInTimedOutTitle
+        case .signInInterrupted: return Localization.signInInterruptedTitle
+        case .alreadySignedInElsewhere: return Localization.alreadySignedInElsewhereTitle
+        case .siteAuthFailure: return Localization.siteAuthFailureTitle
+        case .notAWooSite: return Localization.notAWooSiteTitle
+        case .userNotEligible: return Localization.userNotEligibleTitle
+        }
+    }
+
+    var bodyText: String {
+        switch error.kind {
+        case .invalidPayload: return Localization.invalidPayloadBody
+        case .installQR: return Localization.installQRBody
+        case .scannerFailure: return Localization.scannerFailureBody
+        case .codeExpired: return Localization.codeExpiredBody
+        case .storeUnsupported: return Localization.storeUnsupportedBody
+        case .rateLimited: return Localization.rateLimitedBody
+        case .network: return Localization.networkBody
+        case .unexpected: return Localization.unexpectedBody
+        case .codeAlreadyUsed: return Localization.codeAlreadyUsedBody
+        case .signInDenied: return Localization.signInDeniedBody
+        case .signInTimedOut: return Localization.signInTimedOutBody
+        case .signInInterrupted: return Localization.signInInterruptedBody
+        case .alreadySignedInElsewhere: return Localization.alreadySignedInElsewhereBody
+        case .siteAuthFailure: return Localization.siteAuthFailureBody
+        case .notAWooSite: return Localization.notAWooSiteBody
+        case .userNotEligible: return Localization.userNotEligibleBody
+        }
+    }
+
+    var primaryCTA: String {
+        switch error.primaryAction {
+        case .retryFailedPhase:
+            // Scanner-failure is treated as retryable but its CTA is "Try
+            // again" to scan again — same string applies.
+            return Localization.tryAgain
+        case .scanAgain:
+            return Localization.scanNewCode
+        }
+    }
+}
+
+// MARK: - Localization
+
+private extension QRLoginErrorView {
+    enum Localization {
+        // Titles
+        static let invalidPayloadTitle = NSLocalizedString(
+            "qrLogin.error.invalidPayload.title",
+            value: "Not a WooCommerce code",
+            comment: "QR-login error title when the scanned payload isn't recognised."
+        )
+        static let installQRTitle = NSLocalizedString(
+            "qrLogin.error.installQR.title",
+            value: "That's the install QR",
+            comment: "QR-login error title when the user scans the wp-admin install QR."
+        )
+        static let scannerFailureTitle = NSLocalizedString(
+            "qrLogin.error.scannerFailure.title",
+            value: "Couldn't read that code",
+            comment: "QR-login error title when the scanner pipeline fails."
+        )
+        static let codeExpiredTitle = NSLocalizedString(
+            "qrLogin.error.codeExpired.title",
+            value: "Code expired",
+            comment: "QR-login error title when the token was rejected by the server."
+        )
+        static let storeUnsupportedTitle = NSLocalizedString(
+            "qrLogin.error.storeUnsupported.title",
+            value: "This store can't complete QR login",
+            comment: "QR-login error title when the store's plugin doesn't support the QR flow."
+        )
+        static let rateLimitedTitle = NSLocalizedString(
+            "qrLogin.error.rateLimited.title",
+            value: "Too many attempts",
+            comment: "QR-login error title for HTTP 429 responses."
+        )
+        static let networkTitle = NSLocalizedString(
+            "qrLogin.error.network.title",
+            value: "Couldn't reach your store",
+            comment: "QR-login error title for transport failures."
+        )
+        static let unexpectedTitle = NSLocalizedString(
+            "qrLogin.error.unexpected.title",
+            value: "Something went wrong",
+            comment: "QR-login error title for 5xx / malformed / unmapped server responses."
+        )
+        static let codeAlreadyUsedTitle = NSLocalizedString(
+            "qrLogin.error.codeAlreadyUsed.title",
+            value: "Code already used",
+            comment: "QR-login error title for HTTP 409 — another device already scanned this QR."
+        )
+        static let signInDeniedTitle = NSLocalizedString(
+            "qrLogin.error.signInDenied.title",
+            value: "Sign-in denied",
+            comment: "QR-login error title when the merchant denied the sign-in in the desktop browser."
+        )
+        static let signInTimedOutTitle = NSLocalizedString(
+            "qrLogin.error.signInTimedOut.title",
+            value: "Sign-in timed out",
+            comment: "QR-login error title when the merchant didn't confirm in time."
+        )
+        static let signInInterruptedTitle = NSLocalizedString(
+            "qrLogin.error.signInInterrupted.title",
+            value: "Sign-in interrupted",
+            comment: "QR-login error title for invalid_exchange_grant / wp.com exchange 404."
+        )
+        static let alreadySignedInElsewhereTitle = NSLocalizedString(
+            "qrLogin.error.alreadySignedInElsewhere.title",
+            value: "Already signed in elsewhere",
+            comment: "QR-login error title for wp.com consumed / already_consumed."
+        )
+        static let siteAuthFailureTitle = NSLocalizedString(
+            "qrLogin.error.siteAuthFailure.title",
+            value: "Sign-in failed",
+            comment: "QR-login error title when post-exchange site fetch fails."
+        )
+        static let notAWooSiteTitle = NSLocalizedString(
+            "qrLogin.error.notAWooSite.title",
+            value: "Not a WooCommerce store",
+            comment: "QR-login error title when the fetched site doesn't have WooCommerce installed."
+        )
+        static let userNotEligibleTitle = NSLocalizedString(
+            "qrLogin.error.userNotEligible.title",
+            value: "Permission needed",
+            comment: "QR-login error title when the user's role doesn't allow app access."
+        )
+
+        // Bodies
+        static let invalidPayloadBody = NSLocalizedString(
+            "qrLogin.error.invalidPayload.body",
+            value: "This QR isn't a WooCommerce login code. Generate a new one from your store and try again.",
+            comment: "QR-login error body when the scanned payload isn't recognised."
+        )
+        static let installQRBody = NSLocalizedString(
+            "qrLogin.error.installQR.body",
+            value: "The app's already installed — this QR installs it. In wp-admin, tap the App is installed " +
+                "button to reveal the sign-in QR. Or visit woo.com/mobilelogin on your computer.",
+            comment: "QR-login error body when the user scans the wp-admin install QR."
+        )
+        static let scannerFailureBody = NSLocalizedString(
+            "qrLogin.error.scannerFailure.body",
+            value: "We couldn't read that QR code. Please try again.",
+            comment: "QR-login error body when the scanner pipeline fails."
+        )
+        static let codeExpiredBody = NSLocalizedString(
+            "qrLogin.error.codeExpired.body",
+            value: "That code expired or has already been used. Generate a new one in your store.",
+            comment: "QR-login error body for the token-rejected case."
+        )
+        static let storeUnsupportedBody = NSLocalizedString(
+            "qrLogin.error.storeUnsupported.body",
+            value: "Your WooCommerce plugin doesn't support QR login. Please update WooCommerce on your store " +
+                "and try again, or sign in by entering your site URL.",
+            comment: "QR-login error body for the store-can't-complete case."
+        )
+        static let rateLimitedBody = NSLocalizedString(
+            "qrLogin.error.rateLimited.body",
+            value: "Please wait a few minutes and try again.",
+            comment: "QR-login error body for HTTP 429."
+        )
+        static let networkBody = NSLocalizedString(
+            "qrLogin.error.network.body",
+            value: "Check your connection and try again.",
+            comment: "QR-login error body for transport failures."
+        )
+        static let unexpectedBody = NSLocalizedString(
+            "qrLogin.error.unexpected.body",
+            value: "Your store returned an unexpected error. Please try again in a moment.",
+            comment: "QR-login error body for 5xx / malformed responses."
+        )
+        static let codeAlreadyUsedBody = NSLocalizedString(
+            "qrLogin.error.codeAlreadyUsed.body",
+            value: "That code has already been scanned. Generate a new one in your store.",
+            comment: "QR-login error body when another device already scanned the QR."
+        )
+        static let signInDeniedBody = NSLocalizedString(
+            "qrLogin.error.signInDenied.body",
+            value: "For your security, this sign-in attempt was cancelled. Generate a new code in your store to try again.",
+            comment: "QR-login error body when sign-in was explicitly denied."
+        )
+        static let signInTimedOutBody = NSLocalizedString(
+            "qrLogin.error.signInTimedOut.body",
+            value: "You didn't confirm in time. Generate a new code in your store and try again.",
+            comment: "QR-login error body when the merchant didn't confirm in time."
+        )
+        static let signInInterruptedBody = NSLocalizedString(
+            "qrLogin.error.signInInterrupted.body",
+            value: "Your sign-in was interrupted. Generate a new code in your store and try again.",
+            comment: "QR-login error body for invalid_exchange_grant / wp.com exchange 404."
+        )
+        static let alreadySignedInElsewhereBody = NSLocalizedString(
+            "qrLogin.error.alreadySignedInElsewhere.body",
+            value: "This sign-in was already completed on another device. Generate a new code if you need to try again.",
+            comment: "QR-login error body for wp.com consumed / already_consumed."
+        )
+        static let siteAuthFailureBody = NSLocalizedString(
+            "qrLogin.error.siteAuthFailure.body",
+            value: "We couldn't authenticate with your store. Please try again.",
+            comment: "QR-login error body when post-exchange site fetch fails authentication."
+        )
+        static let notAWooSiteBody = NSLocalizedString(
+            "qrLogin.error.notAWooSite.body",
+            value: "This site doesn't have WooCommerce installed.",
+            comment: "QR-login error body when the fetched site doesn't have WooCommerce installed."
+        )
+        static let userNotEligibleBody = NSLocalizedString(
+            "qrLogin.error.userNotEligible.body",
+            value: "Your account doesn't have permission to use the app for this store.",
+            comment: "QR-login error body when the user's role doesn't allow app access."
+        )
+
+        // CTAs
+        static let tryAgain = NSLocalizedString(
+            "qrLogin.error.tryAgain",
+            value: "Try again",
+            comment: "Primary CTA on a retryable QR-login error."
+        )
+        static let scanNewCode = NSLocalizedString(
+            "qrLogin.error.scanNewCode",
+            value: "Scan a new code",
+            comment: "Primary CTA on a non-retryable QR-login error."
+        )
+        static let enterSiteURL = NSLocalizedString(
+            "qrLogin.error.enterSiteURL",
+            value: "Enter site URL instead",
+            comment: "Secondary CTA on every QR-login error — falls back to the site-address login."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginHostView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginHostView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// Root view for the live QR-login flow (post-scan). Binds to
+/// `QRLoginViewModel.state` and switches between the authenticating, number-
+/// match, and error sub-views.
+///
+/// Navigation out of this view is driven by callbacks: reaching `.done`
+/// invokes `onDone` so the coordinator routes to the home screen, and the
+/// number-match Cancel button invokes `onCancel` so the coordinator pops back
+/// to the scanner (camera mode) or exits (deep-link mode).
+struct QRLoginHostView: View {
+    @State var viewModel: QRLoginViewModel
+    /// Called when the merchant is signed in (state reaches `.done`).
+    let onDone: () -> Void
+    /// Called when the merchant cancels from the number-match screen — the
+    /// coordinator pops back to the scanner (camera mode) or exits (deep-link
+    /// mode). Wired directly to the cancel action rather than observed off the
+    /// `.idle` state, so the initial `.idle` (before `start()`) never triggers
+    /// navigation.
+    let onCancel: () -> Void
+    /// Called when the merchant taps the "Scan a new code" CTA on a
+    /// non-retryable error — the coordinator returns them to a fresh scanner
+    /// (camera mode) or exits the QR-login surface (deep-link mode). Retryable
+    /// errors re-run the failed phase via the view model instead.
+    let onScanAgain: () -> Void
+    let onEnterSiteURLTapped: () -> Void
+
+    var body: some View {
+        ZStack {
+            switch viewModel.state {
+            case .idle, .authenticating:
+                QRLoginAuthenticatingView()
+            case let .numberMatch(scan):
+                QRLoginNumberMatchView(
+                    realNumber: scan.realNumber,
+                    expiresAt: Date().addingTimeInterval(TimeInterval(scan.expiresInSeconds)),
+                    subtitle: scan.subtitle,
+                    onCancel: {
+                        viewModel.cancelFromNumberMatch()
+                        onCancel()
+                    }
+                )
+            case .done:
+                QRLoginAuthenticatingView()
+                    .task { onDone() }
+            case .handedOff:
+                // The magic link opened in the in-app auth session; sign-in
+                // completes there. Keep showing "signing in" underneath until
+                // the app swaps to the logged-in UI.
+                QRLoginAuthenticatingView()
+            case let .error(error):
+                QRLoginErrorView(
+                    error: error,
+                    onPrimaryTapped: {
+                        // The primary CTA's meaning depends on the error: a
+                        // retryable error re-runs the failed phase, a
+                        // non-retryable one ("Scan a new code") hands back to
+                        // the coordinator to start a fresh scan (spec §6.1).
+                        switch error.primaryAction {
+                        case .retryFailedPhase:
+                            Task { await viewModel.retry() }
+                        case .scanAgain:
+                            onScanAgain()
+                        }
+                    },
+                    onEnterSiteURLTapped: onEnterSiteURLTapped
+                )
+            }
+        }
+        .task {
+            // Idempotent — guarded inside the view model.
+            await viewModel.start()
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginHostView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginHostView.swift
@@ -55,7 +55,7 @@ struct QRLoginHostView: View {
                         // The primary CTA's meaning depends on the error: a
                         // retryable error re-runs the failed phase, a
                         // non-retryable one ("Scan a new code") hands back to
-                        // the coordinator to start a fresh scan (spec §6.1).
+                        // the coordinator to start a fresh scan.
                         switch error.primaryAction {
                         case .retryFailedPhase:
                             Task { await viewModel.retry() }

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginHostingController.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginHostingController.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import UIKit
+
+/// Navigation-bar treatment for a QR-login screen.
+enum QRLoginNavigationBarStyle {
+    /// Bar hidden entirely — used by the full-bleed camera scanner and the dark
+    /// prologue (which draws its own Back / Help controls).
+    case hidden
+    /// Inherit the navigation controller's existing bar — used by the light
+    /// number-match and error screens.
+    case inherited
+}
+
+/// Hosting controller for the QR-login SwiftUI screens.
+///
+/// The WordPress-Authenticator prologue hides the navigation bar in its own
+/// `viewWillAppear`, so each QR screen re-applies the navigation-bar state it
+/// needs when it appears.
+final class QRLoginHostingController<Content: View>: UIHostingController<Content> {
+
+    var navigationBarStyle: QRLoginNavigationBarStyle = .inherited
+
+    /// When `true`, the status bar uses light content — for the dark prologue.
+    var prefersLightStatusBar = false
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        prefersLightStatusBar ? .lightContent : .default
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        switch navigationBarStyle {
+        case .hidden:
+            navigationController?.setNavigationBarHidden(true, animated: animated)
+        case .inherited:
+            navigationController?.setNavigationBarHidden(false, animated: animated)
+        }
+        setNeedsStatusBarAppearanceUpdate()
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginSessionReplaceView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginSessionReplaceView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Warning shown when a `woocommerce://qr-login` deep link arrives while the
-/// merchant is already signed in (spec §4.4). Confirming signs the merchant out
+/// merchant is already signed in. Confirming signs the merchant out
 /// and resumes the QR sign-in; cancelling keeps the current session.
 struct QRLoginSessionReplaceView: View {
     /// Called when the merchant chooses to sign out and continue.

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginSessionReplaceView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginSessionReplaceView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Warning shown when a `woocommerce://qr-login` deep link arrives while the
+/// merchant is already signed in (spec §4.4). Confirming signs the merchant out
+/// and resumes the QR sign-in; cancelling keeps the current session.
+struct QRLoginSessionReplaceView: View {
+    /// Called when the merchant chooses to sign out and continue.
+    let onConfirm: () -> Void
+    /// Called when the merchant keeps the current session.
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(spacing: 20) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 44, height: 44)
+                        .foregroundColor(Color(uiColor: .warning))
+                        .padding(22)
+                        .background(
+                            Circle().fill(Color(uiColor: .warning).opacity(0.15))
+                        )
+                        .padding(.top, 48)
+                        .accessibilityHidden(true)
+
+                    Text(Localization.title)
+                        .font(.title)
+                        .fontWeight(.semibold)
+                        .multilineTextAlignment(.center)
+                        .accessibilityAddTraits(.isHeader)
+
+                    Text(Localization.body)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+            }
+
+            VStack(spacing: 12) {
+                Button(Localization.confirm, action: onConfirm)
+                    .buttonStyle(PrimaryButtonStyle())
+
+                Button(Localization.cancel, action: onCancel)
+                    .buttonStyle(SecondaryButtonStyle())
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
+        }
+        .background(Color(uiColor: .systemBackground))
+    }
+}
+
+// MARK: - Localization
+
+private extension QRLoginSessionReplaceView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "qrLogin.sessionReplace.title",
+            value: "You're already signed in",
+            comment: "Title of the QR-login warning shown when a signed-in merchant scans a sign-in QR code."
+        )
+        static let body = NSLocalizedString(
+            "qrLogin.sessionReplace.body",
+            value: "Continuing will sign you out of your current session and start a new sign-in.",
+            comment: "Body of the QR-login warning shown when a signed-in merchant scans a sign-in QR code."
+        )
+        static let confirm = NSLocalizedString(
+            "qrLogin.sessionReplace.confirm",
+            value: "Continue and sign out",
+            comment: "Primary CTA on the QR-login session-replace warning — signs out and resumes the QR sign-in."
+        )
+        static let cancel = NSLocalizedString(
+            "qrLogin.sessionReplace.cancel",
+            value: "Cancel",
+            comment: "Secondary CTA on the QR-login session-replace warning — keeps the current session."
+        )
+    }
+}

--- a/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginSessionReplaceView.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/UI/QRLoginSessionReplaceView.swift
@@ -10,19 +10,19 @@ struct QRLoginSessionReplaceView: View {
     let onCancel: () -> Void
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Constants.zeroSpacing) {
             ScrollView {
-                VStack(spacing: 20) {
+                VStack(spacing: Constants.contentSpacing) {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 44, height: 44)
+                        .frame(width: Constants.iconSize, height: Constants.iconSize)
                         .foregroundColor(Color(uiColor: .warning))
-                        .padding(22)
+                        .padding(Constants.iconPadding)
                         .background(
-                            Circle().fill(Color(uiColor: .warning).opacity(0.15))
+                            Circle().fill(Color(uiColor: .warning).opacity(Constants.warningBackgroundOpacity))
                         )
-                        .padding(.top, 48)
+                        .padding(.top, Constants.topPadding)
                         .accessibilityHidden(true)
 
                     Text(Localization.title)
@@ -35,19 +35,19 @@ struct QRLoginSessionReplaceView: View {
                         .font(.body)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
-                        .padding(.horizontal, 32)
+                        .padding(.horizontal, Constants.largePadding)
                 }
             }
 
-            VStack(spacing: 12) {
+            VStack(spacing: Constants.buttonSpacing) {
                 Button(Localization.confirm, action: onConfirm)
                     .buttonStyle(PrimaryButtonStyle())
 
                 Button(Localization.cancel, action: onCancel)
                     .buttonStyle(SecondaryButtonStyle())
             }
-            .padding(.horizontal, 24)
-            .padding(.bottom, 24)
+            .padding(.horizontal, Constants.standardPadding)
+            .padding(.bottom, Constants.standardPadding)
         }
         .background(Color(uiColor: .systemBackground))
     }
@@ -56,6 +56,18 @@ struct QRLoginSessionReplaceView: View {
 // MARK: - Localization
 
 private extension QRLoginSessionReplaceView {
+    enum Constants {
+        static let zeroSpacing: CGFloat = 0
+        static let buttonSpacing: CGFloat = 12
+        static let contentSpacing: CGFloat = 20
+        static let standardPadding: CGFloat = 24
+        static let largePadding: CGFloat = 32
+        static let iconSize: CGFloat = 44
+        static let iconPadding: CGFloat = 22
+        static let topPadding: CGFloat = 48
+        static let warningBackgroundOpacity = 0.15
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
             "qrLogin.sessionReplace.title",


### PR DESCRIPTION
## Description
**Part 6 of 7** of the QR-code login feature (see **[1/7]** for context).

Adds the remaining SwiftUI screens: the error view, the session-replace warning, the host view that composes the flow, and the hosting controller. Not yet wired into navigation.

**Stack:** base **[5/7]** `feature/qr-login-step-5` → next **[7/7]** `feature/qr-login-step-7`. ~501 production lines.

## Test Steps
UI components only, not yet reachable. Verify the app builds. End-to-end testing happens in **[7/7]**.

## Screenshots
See **[7/7]** for the assembled flow.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.