### PR TITLE
QR-login [7/7]: Coordinator & integration

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -454,7 +454,13 @@ extension AppDelegate {
             case .jetpackSetup:
                 return handleAuthenticationUrlForJetpackSetup(url, rootViewController: rootViewController)
             case .none:
-                return false
+                // A woocommerce://qr-login deep link can arrive while signed in —
+                // offer to sign out and start the QR sign-in (spec §4.4).
+                let handled = ServiceLocator.authenticationManager.handleSignedInQRLoginDeepLink(url, rootViewController: rootViewController)
+                if handled == false {
+                    DDLogWarn("⚠️ Authentication URL received while signed in was not handled: \(url.scheme ?? "")://\(url.host ?? "")")
+                }
+                return handled
             }
         } else {
             return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -455,7 +455,7 @@ extension AppDelegate {
                 return handleAuthenticationUrlForJetpackSetup(url, rootViewController: rootViewController)
             case .none:
                 // A woocommerce://qr-login deep link can arrive while signed in —
-                // offer to sign out and start the QR sign-in (spec §4.4).
+                // offer to sign out and start the QR sign-in.
                 let handled = ServiceLocator.authenticationManager.handleSignedInQRLoginDeepLink(url, rootViewController: rootViewController)
                 if handled == false {
                     DDLogWarn("⚠️ Authentication URL received while signed in was not handled: \(url.scheme ?? "")://\(url.host ?? "")")

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -444,7 +444,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
 // MARK: - Magic link
 extension AppDelegate {
-    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
+    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) async -> Bool {
         if ServiceLocator.stores.isAuthenticated {
             let pendingAuthFlowStorage = PendingAuthFlowStorage()
             let flow = pendingAuthFlowStorage.current
@@ -456,14 +456,14 @@ extension AppDelegate {
             case .none:
                 // A woocommerce://qr-login deep link can arrive while signed in —
                 // offer to sign out and start the QR sign-in.
-                let handled = ServiceLocator.authenticationManager.handleSignedInQRLoginDeepLink(url, rootViewController: rootViewController)
+                let handled = await ServiceLocator.authenticationManager.handleSignedInQRLoginDeepLink(url, rootViewController: rootViewController)
                 if handled == false {
                     DDLogWarn("⚠️ Authentication URL received while signed in was not handled: \(url.scheme ?? "")://\(url.host ?? "")")
                 }
                 return handled
             }
         } else {
-            return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
+            return await ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
         }
     }
 

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -114,6 +114,13 @@ class AuthenticationManager: Authentication {
                 self.analytics.track(.loginPrologueContinueTapped)
                 return false
             }
+            // A coordinator is already driving the QR-login flow — e.g. a rapid
+            // second tap while the availability check from the first tap was
+            // still in flight. Don't build a second one; it would orphan the
+            // first along with its navigation stack.
+            guard self.qrLoginCoordinator == nil else {
+                return true
+            }
             // Track the click while the active flow is still `prologue`;
             // the QR coordinator's `start()` switches it to `login_qr`.
             DefaultQRLoginAnalyticsTracking().trackClick(.loginWithQR)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SafariServices
 import KeychainAccess
+import SwiftUI
 import WordPressAuthenticator
 import WordPressUI
 import Yosemite
@@ -61,6 +62,12 @@ class AuthenticationManager: Authentication {
     /// Keeps a reference to the use case
     private var siteCredentialLoginUseCase: SiteCredentialLoginUseCase?
 
+    /// Keeps a reference to the QR-login coordinator while the flow is active.
+    private var qrLoginCoordinator: QRLoginCoordinator?
+
+    /// Availability gate for the QR-login prologue / deep link entry.
+    private let qrLoginAvailability: QRLoginAvailabilityProvider
+
     /// Injected for unit test purposes
     private let switchStoreUseCase: SwitchStoreUseCaseProtocol?
 
@@ -72,7 +79,8 @@ class AuthenticationManager: Authentication {
          analytics: Analytics = ServiceLocator.analytics,
          abTestVariationProvider: ABTestVariationProvider = CachedABTestVariationProvider(),
          switchStoreUseCase: SwitchStoreUseCaseProtocol? = nil,
-         userDefaults: UserDefaults = .standard) {
+         userDefaults: UserDefaults = .standard,
+         qrLoginAvailability: QRLoginAvailabilityProvider = QRLoginAvailability()) {
         self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
@@ -80,6 +88,7 @@ class AuthenticationManager: Authentication {
         self.abTestVariationProvider = abTestVariationProvider
         self.switchStoreUseCase = switchStoreUseCase
         self.userDefaults = userDefaults
+        self.qrLoginAvailability = qrLoginAvailability
     }
 
     /// Initializes the WordPress Authenticator.
@@ -91,29 +100,76 @@ class AuthenticationManager: Authentication {
 
     /// Returns the Login Flow view controller.
     ///
+    /// When QR login is available, the primary "Log in" CTA on the standard prologue routes to
+    /// the QR-login prologue — pushed onto the same navigation stack — rather than the standard
+    /// site-address flow. The standard prologue stays as the app's first screen (spec §4.1).
+    ///
     func authenticationUI() -> UIViewController {
-        let loginViewController: UIViewController = {
-            let loginUI = WordPressAuthenticator.loginUI(onLoginButtonTapped: { [weak self] in
-                guard let self else { return }
-                // Resets Apple ID at the beginning of the authentication.
-                self.appleUserID = nil
-
+        let loginUI = WordPressAuthenticator.loginUI(onPrimaryLoginCTA: { [weak self] in
+            guard let self else { return false }
+            // Resets Apple ID at the beginning of the authentication.
+            self.appleUserID = nil
+            guard self.qrLoginAvailability.isAvailableForPrologue(),
+                  let navigationController = self.displayAuthenticatorIfLoggedOut?() else {
                 self.analytics.track(.loginPrologueContinueTapped)
-            })
-            guard let loginVC = loginUI else {
-                fatalError("Cannot instantiate login UI from WordPressAuthenticator")
+                return false
             }
-            return loginVC
-        }()
-        return loginViewController
+            // Track the click while the active flow is still `prologue`;
+            // the QR coordinator's `start()` switches it to `login_qr`.
+            DefaultQRLoginAnalyticsTracking().trackClick(.loginWithQR)
+            self.makeQRLoginCoordinator(mode: .camera, navigationController: navigationController).start()
+            return true
+        })
+        guard let loginVC = loginUI else {
+            fatalError("Cannot instantiate login UI from WordPressAuthenticator")
+        }
+        return loginVC
+    }
+
+    /// Builds a `QRLoginCoordinator` wired with the shared site-address
+    /// fallback and success handlers, and retains it as `qrLoginCoordinator`.
+    /// Starting it is the caller's responsibility.
+    @MainActor
+    private func makeQRLoginCoordinator(mode: QRLoginCoordinator.Mode,
+                                        navigationController: UINavigationController) -> QRLoginCoordinator {
+        let coordinator = QRLoginCoordinator(
+            mode: mode,
+            navigationController: navigationController,
+            onEnterSiteURL: { [weak navigationController] in
+                guard let navigationController else { return }
+                NavigateToEnterSite().execute(from: navigationController)
+            },
+            onShowHelp: { [weak self, weak navigationController] in
+                guard let self, let navigationController else { return }
+                let presenter = navigationController.topViewController ?? navigationController
+                self.presentSupport(from: presenter, sourceTag: .loginWithQRCode, siteURL: nil)
+            },
+            onSuccess: { [weak self, weak navigationController] in
+                guard let self, let navigationController else { return }
+                self.startStorePicker(with: WooConstants.placeholderStoreID, in: navigationController)
+            },
+            onFinished: { [weak self] in
+                // Release the coordinator once its UI is left for good, so a
+                // later deep link doesn't reuse a stale, dismissed instance.
+                self?.qrLoginCoordinator = nil
+            }
+        )
+        qrLoginCoordinator = coordinator
+        return coordinator
     }
 
     /// Handles an Authentication URL Callback. Returns *true* on success.
     ///
+    @MainActor
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
         if WordPressAuthenticator.shared.isWordPressAuthUrl(url) {
             return WordPressAuthenticator.shared.handleWordPressAuthUrl(url,
                                                                         rootViewController: rootViewController)
+        }
+
+        if isQRLoginUrl(url),
+           let handled = handleQRLoginUrl(url) {
+            return handled
         }
 
         if isAppLoginUrl(url) {
@@ -180,6 +236,110 @@ class AuthenticationManager: Authentication {
     private func isAppLoginUrl(_ url: URL) -> Bool {
         let expectedPrefix = WooConstants.appLoginURLPrefix
         return url.absoluteString.hasPrefix(expectedPrefix)
+    }
+
+    /// Case-insensitive match for `woocommerce://qr-login` deep links
+    /// (spec §3 footer: scheme + host check is case-insensitive). Uses a
+    /// prefix check — matching `isAppLoginUrl` — because `URL.host` is
+    /// unreliable for custom-scheme URLs across Foundation versions.
+    private func isQRLoginUrl(_ url: URL) -> Bool {
+        url.absoluteString.lowercased().hasPrefix(WooConstants.qrLoginURLPrefix)
+    }
+
+    /// Handles an inbound `woocommerce://qr-login?...` URL by driving the QR
+    /// coordinator's deep-link flow.
+    ///
+    /// Returns `nil` when the feature isn't available — the caller falls
+    /// through to the standard handlers so the user lands on the regular
+    /// prologue instead of a no-op (spec §2.2).
+    ///
+    /// Token / grant lifetime is not managed here: clearing the URL from the
+    /// launch state is the OS / scene-delegate's job; this method makes a
+    /// best-effort to not retain the payload anywhere persistent.
+    @MainActor
+    private func handleQRLoginUrl(_ url: URL) -> Bool? {
+        // The merchant chose this path by opening the link, so we just need
+        // the remote flag (or debug override) on — bucket and camera are
+        // bypassed. `false` (flag off, or not loaded yet) falls through to
+        // the standard handlers.
+        guard qrLoginAvailability.isAvailableForDeepLink() else {
+            return nil
+        }
+
+        guard let navigationController = displayAuthenticatorIfLoggedOut?() else {
+            DDLogWarn("QR-login deep link: cannot display authenticator UI.")
+            return false
+        }
+
+        let payload = QRLoginPayloadParser().parse(url)
+        if let qrLoginCoordinator {
+            // Displaying the authenticator already built the QR-login UI
+            // and started a coordinator on the prologue. Reuse it for the
+            // deep-link payload — starting a second coordinator would
+            // orphan the first and leave a dead prologue underneath the
+            // number-match screen.
+            qrLoginCoordinator.presentDeepLink(payload: payload)
+        } else {
+            // The legacy authenticator UI is the root; start a standalone
+            // deep-link coordinator on its navigation stack.
+            makeQRLoginCoordinator(mode: .deepLink(payload: payload),
+                                   navigationController: navigationController).start()
+        }
+        return true
+    }
+
+    /// Handles a `woocommerce://qr-login` deep link that arrived while the
+    /// merchant is already signed in (spec §4.4). Shows a warning; confirming
+    /// signs the merchant out and resumes the QR sign-in, cancelling keeps the
+    /// current session. Returns `true` when the URL was a QR-login deep link
+    /// this method took over, `false` otherwise (the caller then drops it).
+    @MainActor
+    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) -> Bool {
+        guard isQRLoginUrl(url) else {
+            return false
+        }
+        guard qrLoginAvailability.isAvailableForDeepLink() else {
+            return false
+        }
+        presentSessionReplaceWarning(for: url, from: rootViewController)
+        return true
+    }
+
+    @MainActor
+    private func presentSessionReplaceWarning(for url: URL, from presentingViewController: UIViewController) {
+        let analytics = DefaultQRLoginAnalyticsTracking()
+        analytics.setFlow(.loginQR)
+        analytics.trackStep(.qrSessionReplaceWarning)
+
+        let warningView = QRLoginSessionReplaceView(
+            onConfirm: { [weak self] in
+                analytics.trackClick(.submit)
+                presentingViewController.dismiss(animated: true) {
+                    self?.signOutAndResumeQRLogin(url: url)
+                }
+            },
+            onCancel: {
+                analytics.trackClick(.dismiss)
+                presentingViewController.dismiss(animated: true)
+            }
+        )
+        let hostingController = UIHostingController(rootView: warningView)
+        hostingController.modalPresentationStyle = .fullScreen
+        presentingViewController.present(hostingController, animated: true)
+    }
+
+    /// Signs the merchant out and resumes the QR sign-in. `deauthenticate()` is
+    /// best-effort local teardown that always leaves the app signed out, so the
+    /// QR sign-in can always resume. The deep link is re-handled on a later
+    /// main-actor turn, once `AppCoordinator` has reacted to the deauthentication
+    /// and installed the logged-out login UI — re-handling synchronously would
+    /// race that Combine-driven swap (spec §4.4).
+    @MainActor
+    private func signOutAndResumeQRLogin(url: URL) {
+        ServiceLocator.stores.deauthenticate()
+        Task { @MainActor [weak self] in
+            _ = self?.handleQRLoginUrl(url)
+        }
     }
 
     /// Injects `loggedOutAppSettings`

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -102,7 +102,7 @@ class AuthenticationManager: Authentication {
     ///
     /// When QR login is available, the primary "Log in" CTA on the standard prologue routes to
     /// the QR-login prologue — pushed onto the same navigation stack — rather than the standard
-    /// site-address flow. The standard prologue stays as the app's first screen (spec §4.1).
+    /// site-address flow. The standard prologue stays as the app's first screen.
     ///
     func authenticationUI() -> UIViewController {
         let loginUI = WordPressAuthenticator.loginUI(onPrimaryLoginCTA: { [weak self] in
@@ -239,7 +239,7 @@ class AuthenticationManager: Authentication {
     }
 
     /// Case-insensitive match for `woocommerce://qr-login` deep links
-    /// (spec §3 footer: scheme + host check is case-insensitive). Uses a
+    /// (scheme + host check is case-insensitive). Uses a
     /// prefix check — matching `isAppLoginUrl` — because `URL.host` is
     /// unreliable for custom-scheme URLs across Foundation versions.
     private func isQRLoginUrl(_ url: URL) -> Bool {
@@ -251,7 +251,7 @@ class AuthenticationManager: Authentication {
     ///
     /// Returns `nil` when the feature isn't available — the caller falls
     /// through to the standard handlers so the user lands on the regular
-    /// prologue instead of a no-op (spec §2.2).
+    /// prologue instead of a no-op.
     ///
     /// Token / grant lifetime is not managed here: clearing the URL from the
     /// launch state is the OS / scene-delegate's job; this method makes a
@@ -289,7 +289,7 @@ class AuthenticationManager: Authentication {
     }
 
     /// Handles a `woocommerce://qr-login` deep link that arrived while the
-    /// merchant is already signed in (spec §4.4). Shows a warning; confirming
+    /// merchant is already signed in. Shows a warning; confirming
     /// signs the merchant out and resumes the QR sign-in, cancelling keeps the
     /// current session. Returns `true` when the URL was a QR-login deep link
     /// this method took over, `false` otherwise (the caller then drops it).
@@ -333,7 +333,7 @@ class AuthenticationManager: Authentication {
     /// QR sign-in can always resume. The deep link is re-handled on a later
     /// main-actor turn, once `AppCoordinator` has reacted to the deauthentication
     /// and installed the logged-out login UI — re-handling synchronously would
-    /// race that Combine-driven swap (spec §4.4).
+    /// race that Combine-driven swap.
     @MainActor
     private func signOutAndResumeQRLogin(url: URL) {
         ServiceLocator.stores.deauthenticate()

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -109,7 +109,7 @@ class AuthenticationManager: Authentication {
             guard let self else { return false }
             // Resets Apple ID at the beginning of the authentication.
             self.appleUserID = nil
-            guard self.qrLoginAvailability.isAvailableForPrologue(),
+            guard await self.qrLoginAvailability.isAvailableForPrologue(),
                   let navigationController = self.displayAuthenticatorIfLoggedOut?() else {
                 self.analytics.track(.loginPrologueContinueTapped)
                 return false
@@ -161,14 +161,14 @@ class AuthenticationManager: Authentication {
     /// Handles an Authentication URL Callback. Returns *true* on success.
     ///
     @MainActor
-    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
+    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) async -> Bool {
         if WordPressAuthenticator.shared.isWordPressAuthUrl(url) {
             return WordPressAuthenticator.shared.handleWordPressAuthUrl(url,
                                                                         rootViewController: rootViewController)
         }
 
         if isQRLoginUrl(url),
-           let handled = handleQRLoginUrl(url) {
+           let handled = await handleQRLoginUrl(url) {
             return handled
         }
 
@@ -257,12 +257,12 @@ class AuthenticationManager: Authentication {
     /// launch state is the OS / scene-delegate's job; this method makes a
     /// best-effort to not retain the payload anywhere persistent.
     @MainActor
-    private func handleQRLoginUrl(_ url: URL) -> Bool? {
+    private func handleQRLoginUrl(_ url: URL) async -> Bool? {
         // The merchant chose this path by opening the link, so we just need
         // the remote flag (or debug override) on — bucket and camera are
         // bypassed. `false` (flag off, or not loaded yet) falls through to
         // the standard handlers.
-        guard qrLoginAvailability.isAvailableForDeepLink() else {
+        guard await qrLoginAvailability.isAvailableForDeepLink() else {
             return nil
         }
 
@@ -294,11 +294,11 @@ class AuthenticationManager: Authentication {
     /// current session. Returns `true` when the URL was a QR-login deep link
     /// this method took over, `false` otherwise (the caller then drops it).
     @MainActor
-    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) -> Bool {
+    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) async -> Bool {
         guard isQRLoginUrl(url) else {
             return false
         }
-        guard qrLoginAvailability.isAvailableForDeepLink() else {
+        guard await qrLoginAvailability.isAvailableForDeepLink() else {
             return false
         }
         presentSessionReplaceWarning(for: url, from: rootViewController)
@@ -338,7 +338,7 @@ class AuthenticationManager: Authentication {
     private func signOutAndResumeQRLogin(url: URL) {
         ServiceLocator.stores.deauthenticate()
         Task { @MainActor [weak self] in
-            _ = self?.handleQRLoginUrl(url)
+            _ = await self?.handleQRLoginUrl(url)
         }
     }
 

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -43,6 +43,12 @@ final class QRLoginCoordinator {
     /// Guards `onFinished` so it fires at most once.
     private var didFinish = false
 
+    /// Guards the camera-permission check + scanner presentation so a rapid
+    /// double-tap on "Scan QR code" can't run the check twice and push two
+    /// scanners onto the navigation stack. Cleared once the in-flight check
+    /// resolves (scanner shown or a denial alert presented).
+    private var isCheckingCameraPermission = false
+
     /// The prologue screen, held weakly so "Scan a new code" can pop back to it
     /// and present a fresh scanner. The previous scanner latches onto its
     /// consumed payload and the camera session keeps running, so it can never
@@ -124,7 +130,16 @@ private extension QRLoginCoordinator {
     /// honour the permission gate rather than pushing a scanner
     /// that has no camera access.
     func presentScannerAfterCameraPermissionCheck() {
+        // Reject a second tap that lands before the in-flight check resolves.
+        // The set is synchronous here (before the Task) so the guard is atomic
+        // on the main actor even when the `.notDetermined` path suspends on the
+        // permission prompt.
+        guard !isCheckingCameraPermission else {
+            return
+        }
+        isCheckingCameraPermission = true
         Task { @MainActor in
+            defer { isCheckingCameraPermission = false }
             switch cameraPermissionChecker.status {
             case .authorized:
                 showScanner()

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -13,7 +13,7 @@ import WordPressAuthenticator
 ///     payload straight into the live flow. Used when a `woocommerce://qr-login`
 ///     URL arrives (Layer 6).
 ///
-/// Cancel / scan-again behaviour differs by mode (spec §4.2): camera mode
+/// Cancel / scan-again behaviour differs by mode: camera mode
 /// returns to the scanner; deep-link mode dismisses the QR-login UI entirely
 /// so the merchant lands back where the deep link was opened from.
 @MainActor
@@ -121,7 +121,7 @@ private extension QRLoginCoordinator {
     /// Checks camera permission — requesting it when undetermined — and either
     /// presents the scanner or the appropriate denial alert. Shared by the
     /// prologue "Scan QR code" CTA and the error "Scan a new code" CTA so both
-    /// honour the permission gate (spec §4.1.1) rather than pushing a scanner
+    /// honour the permission gate rather than pushing a scanner
     /// that has no camera access.
     func presentScannerAfterCameraPermissionCheck() {
         Task { @MainActor in
@@ -201,13 +201,13 @@ private extension QRLoginCoordinator {
             showHostView(with: strategy)
 
         case let .magicLink(url):
-            // §10.1: hand the URL to the in-app auth session. WP.com redirects
+            // hand the URL to the in-app auth session. WP.com redirects
             // to woocommerce://magic-login, captured by the session. Finishing
             // is handled per outcome inside `openMagicLink`.
             openMagicLink(url)
 
         case let .siteURLOnly(url):
-            // §10.2: pre-fill the legacy site-address login screen with the URL
+            // pre-fill the legacy site-address login screen with the URL
             // and auto-submit on entry so the merchant skips manual typing.
             let loginFields = LoginFields()
             loginFields.siteAddress = url.absoluteString
@@ -217,7 +217,7 @@ private extension QRLoginCoordinator {
             finishIfDeepLink()
 
         case let .appLoginWPCom(siteURL, email):
-            // §10.3 / §3.3: pre-fill the WP.com email + password screen.
+            // pre-fill the WP.com email + password screen.
             let loginFields = LoginFields()
             loginFields.siteAddress = siteURL
             loginFields.restrictToWPCom = true
@@ -226,7 +226,7 @@ private extension QRLoginCoordinator {
             finishIfDeepLink()
 
         case let .appLoginUsername(siteURL, username):
-            // §10.3 / §3.3: pre-fill the wp-org site-credentials screen.
+            // pre-fill the wp-org site-credentials screen.
             let loginFields = LoginFields()
             loginFields.siteAddress = siteURL
             loginFields.restrictToWPCom = false
@@ -235,7 +235,7 @@ private extension QRLoginCoordinator {
             finishIfDeepLink()
 
         case .installQR:
-            // §10.4: the "install QR" is useless here — app is already installed.
+            // the "install QR" is useless here — app is already installed.
             let error = QRLoginUserFacingError(kind: .installQR, phase: .prelude, primaryAction: .scanAgain)
             showErrorOnly(error)
 
@@ -305,19 +305,17 @@ private extension QRLoginCoordinator {
 
     /// Merchant cancelled from the number-match screen. In camera mode the
     /// merchant gets the scanner back; in deep-link mode there's no scanner to
-    /// fall back to, so popping the host view exits the QR-login surface
-    /// (spec §4.2 / §6.2).
+    /// fall back to, so popping the host view exits the QR-login surface.
     func handleHostCancelled() {
         navigationController.popViewController(animated: true)
         finishIfDeepLink()
     }
 
-    /// Primary CTA on a non-retryable error ("Scan a new code", spec §6.1). In
+    /// Primary CTA on a non-retryable error ("Scan a new code"). In
     /// camera mode this returns the merchant to a *fresh* scanner — the
     /// previous scanner already consumed its payload and can't deliver again,
     /// so it is dropped from the stack rather than reused. In deep-link mode
-    /// there's no scanner to return to, so the QR-login surface is dismissed
-    /// (spec §4.2).
+    /// there's no scanner to return to, so the QR-login surface is dismissed.
     func handleScanAgain() {
         analytics.trackClick(.qrStartOver)
         switch mode {
@@ -428,7 +426,7 @@ private extension QRLoginCoordinator {
     }
 }
 
-// MARK: - Camera permission alerts (spec §4.1.1)
+// MARK: - Camera permission alerts
 
 private extension QRLoginCoordinator {
 

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -1,0 +1,579 @@
+import AVFoundation
+import AuthenticationServices
+import SwiftUI
+import UIKit
+import WordPressAuthenticator
+
+/// Drives the QR-login UI flow end-to-end.
+///
+/// Modes:
+///   - `.camera` (default): prologue → scanner → live flow. Used when the
+///     coordinator is entered from the standard login surface.
+///   - `.deepLink(payload:)`: skip prologue + scanner, feed the parsed
+///     payload straight into the live flow. Used when a `woocommerce://qr-login`
+///     URL arrives (Layer 6).
+///
+/// Cancel / scan-again behaviour differs by mode (spec §4.2): camera mode
+/// returns to the scanner; deep-link mode dismisses the QR-login UI entirely
+/// so the merchant lands back where the deep link was opened from.
+@MainActor
+final class QRLoginCoordinator {
+
+    enum Mode {
+        case camera
+        case deepLink(payload: QRLoginPayload)
+    }
+
+    private let mode: Mode
+    private let navigationController: UINavigationController
+    private let parser: QRLoginPayloadParser
+    private let cameraPermissionChecker: QRLoginCameraPermissionCheckerProtocol
+    private let analytics: QRLoginAnalyticsTracking
+    private let onEnterSiteURL: () -> Void
+    private let onShowHelp: () -> Void
+    private let onSuccess: () -> Void
+
+    /// Invoked once when the QR-login surface is left for good — success,
+    /// back-out, deep-link exit, navigating to a fallback login, or a wp.com
+    /// magic-link handoff — so the owner can release its reference to this
+    /// coordinator. Scoping the lifetime here (not just on success) keeps a
+    /// stale coordinator from being reused by the deep-link entry point.
+    private let onFinished: () -> Void
+
+    /// Guards `onFinished` so it fires at most once.
+    private var didFinish = false
+
+    /// The prologue screen, held weakly so "Scan a new code" can pop back to it
+    /// and present a fresh scanner. The previous scanner latches onto its
+    /// consumed payload and the camera session keeps running, so it can never
+    /// deliver a second result — it must be replaced, not reused.
+    private weak var prologueViewController: UIViewController?
+
+    init(mode: Mode = .camera,
+         navigationController: UINavigationController,
+         parser: QRLoginPayloadParser = QRLoginPayloadParser(),
+         cameraPermissionChecker: QRLoginCameraPermissionCheckerProtocol = DefaultQRLoginCameraPermissionChecker(),
+         analytics: QRLoginAnalyticsTracking? = nil,
+         onEnterSiteURL: @escaping () -> Void,
+         onShowHelp: @escaping () -> Void,
+         onSuccess: @escaping () -> Void,
+         onFinished: @escaping () -> Void) {
+        self.mode = mode
+        self.navigationController = navigationController
+        self.parser = parser
+        self.cameraPermissionChecker = cameraPermissionChecker
+        // `DefaultQRLoginAnalyticsTracking()` is @MainActor-isolated; can't be
+        // a default parameter expression. The coordinator is @MainActor so
+        // constructing it in the body is fine.
+        self.analytics = analytics ?? DefaultQRLoginAnalyticsTracking()
+        self.onEnterSiteURL = onEnterSiteURL
+        self.onShowHelp = onShowHelp
+        self.onSuccess = onSuccess
+        self.onFinished = onFinished
+    }
+
+    /// Entry point. The coordinator manages its own UI from here on.
+    func start() {
+        analytics.setFlow(.loginQR)
+        switch mode {
+        case .camera:
+            showPrologue()
+        case .deepLink(let payload):
+            handleScanned(payload: payload)
+        }
+    }
+
+    /// Feeds a deep-link payload into the live flow on an already-started
+    /// coordinator. Used when a `woocommerce://qr-login` URL arrives while this
+    /// coordinator is already presenting the prologue — reusing it avoids
+    /// orphaning a second coordinator on the same navigation stack.
+    func presentDeepLink(payload: QRLoginPayload) {
+        handleScanned(payload: payload)
+    }
+}
+
+// MARK: - Prologue + scanner
+
+private extension QRLoginCoordinator {
+
+    func showPrologue() {
+        analytics.trackStep(.qrPrologue)
+        let view = QRLoginPrologueView(
+            onBackTapped: { [weak self] in self?.handlePrologueBack() },
+            onHelpTapped: { [weak self] in self?.showHelp() },
+            onScanTapped: { [weak self] in self?.handleScanCTA() },
+            onSiteAddressTapped: { [weak self] in self?.fallbackToSiteAddress() },
+            onURLTapped: { Self.copyLoginURL() }
+        )
+        // The dark prologue hides the shared navigation bar and draws its own
+        // light Back / Help controls over the bubble background.
+        prologueViewController = pushScreen(view,
+                                            navigationBarStyle: .hidden,
+                                            prefersLightStatusBar: true,
+                                            showsHelpButton: false)
+    }
+
+    func handleScanCTA() {
+        analytics.trackClick(.qrLoginScan)
+        presentScannerAfterCameraPermissionCheck()
+    }
+
+    /// Checks camera permission — requesting it when undetermined — and either
+    /// presents the scanner or the appropriate denial alert. Shared by the
+    /// prologue "Scan QR code" CTA and the error "Scan a new code" CTA so both
+    /// honour the permission gate (spec §4.1.1) rather than pushing a scanner
+    /// that has no camera access.
+    func presentScannerAfterCameraPermissionCheck() {
+        Task { @MainActor in
+            switch cameraPermissionChecker.status {
+            case .authorized:
+                showScanner()
+            case .notDetermined:
+                analytics.trackClick(.qrCameraPermissionDialogShown)
+                let granted = await cameraPermissionChecker.requestAccess()
+                analytics.trackClick(granted ? .qrCameraPermissionGranted : .qrCameraPermissionDenied)
+                if granted {
+                    showScanner()
+                } else {
+                    showFirstDenialAlert()
+                }
+            case .denied:
+                showPermanentlyDeniedAlert()
+            case .restricted:
+                showPermanentlyDeniedAlert()
+            @unknown default:
+                showPermanentlyDeniedAlert()
+            }
+        }
+    }
+
+    func showScanner() {
+        analytics.trackStep(.qrScan)
+        let view = QRLoginScannerView(
+            onScannedPayload: { [weak self] payload in
+                guard let self else { return }
+                let parsed = self.parser.parse(payload)
+                self.handleScanned(payload: parsed)
+            },
+            onCancel: { [weak self] in self?.popScanner() }
+        )
+        // The scanner is full-bleed camera UI with its own in-view chrome, so it
+        // keeps the navigation bar hidden and does not use the toolbar Help item.
+        pushScreen(view, navigationBarStyle: .hidden, showsHelpButton: false)
+    }
+
+    func popScanner() {
+        navigationController.popViewController(animated: true)
+    }
+
+    func fallbackToSiteAddress() {
+        analytics.trackClick(.qrLoginFallback)
+        handleEnterSiteURL()
+    }
+
+    static func copyLoginURL() {
+        UIPasteboard.general.string = WooConstants.qrLoginInstructionsURL
+        // Snackbar / toast is owned by the prologue view — for now a Notice via
+        // NoticePresenter would belong, but presenting it requires a host
+        // controller. Left as a follow-up — the clipboard side is the
+        // load-bearing part.
+    }
+}
+
+// MARK: - Live flow
+
+private extension QRLoginCoordinator {
+
+    func handleScanned(payload: QRLoginPayload) {
+        switch payload {
+        case let .selfHosted(token, siteURL):
+            let strategy = SelfHostedQRLoginStrategy(token: token, siteURL: siteURL)
+            showHostView(with: strategy)
+
+        case let .wpCom(token, encrypted):
+            let strategy = WPComQRLoginStrategy(
+                token: token,
+                encrypted: encrypted,
+                magicLinkOpener: { [weak self] url in
+                    self?.openMagicLink(url)
+                }
+            )
+            showHostView(with: strategy)
+
+        case let .magicLink(url):
+            // §10.1: hand the URL to the in-app auth session. WP.com redirects
+            // to woocommerce://magic-login, captured by the session. Finishing
+            // is handled per outcome inside `openMagicLink`.
+            openMagicLink(url)
+
+        case let .siteURLOnly(url):
+            // §10.2: pre-fill the legacy site-address login screen with the URL
+            // and auto-submit on entry so the merchant skips manual typing.
+            let loginFields = LoginFields()
+            loginFields.siteAddress = url.absoluteString
+            loginFields.restrictToWPCom = false
+            NavigateToEnterSite(loginFields: loginFields,
+                                autoSubmitsPrefilledSiteAddress: true).execute(from: navigationController)
+            finishIfDeepLink()
+
+        case let .appLoginWPCom(siteURL, email):
+            // §10.3 / §3.3: pre-fill the WP.com email + password screen.
+            let loginFields = LoginFields()
+            loginFields.siteAddress = siteURL
+            loginFields.restrictToWPCom = true
+            loginFields.username = email
+            NavigateToEnterWPCOMPassword(loginFields: loginFields).execute(from: navigationController)
+            finishIfDeepLink()
+
+        case let .appLoginUsername(siteURL, username):
+            // §10.3 / §3.3: pre-fill the wp-org site-credentials screen.
+            let loginFields = LoginFields()
+            loginFields.siteAddress = siteURL
+            loginFields.restrictToWPCom = false
+            loginFields.username = username
+            NavigateToEnterSiteCredentials(loginFields: loginFields).execute(from: navigationController)
+            finishIfDeepLink()
+
+        case .installQR:
+            // §10.4: the "install QR" is useless here — app is already installed.
+            let error = QRLoginUserFacingError(kind: .installQR, phase: .prelude, primaryAction: .scanAgain)
+            showErrorOnly(error)
+
+        case .invalid:
+            let error = QRLoginUserFacingError(kind: .invalidPayload, phase: .prelude, primaryAction: .scanAgain)
+            showErrorOnly(error)
+        }
+    }
+
+    /// Hands a magic-link URL to an `ASWebAuthenticationSession`.
+    ///
+    /// The session runs the wp.com page in an in-app Safari sheet and captures
+    /// the `woocommerce://magic-login` callback itself — the merchant never
+    /// leaves Woo for the external browser, and there is no "Open in app?"
+    /// system prompt on the redirect back. The QR "signing in" screen stays
+    /// visible underneath the sheet.
+    ///
+    /// On a captured callback the auth sheet is dismissed and the URL then runs
+    /// through the existing `WordPressAuthenticator` handler — sign-in completes
+    /// and the app swaps to the logged-in UI — and the coordinator finishes. If
+    /// the merchant dismisses the sheet instead, `handleMagicLinkCancelled`
+    /// unwinds the QR surface so they can retry.
+    func openMagicLink(_ url: URL) {
+        let window = navigationController.view.window
+        let runner = QRLoginMagicLinkAuthRunner(
+            anchor: window,
+            onCallback: { [weak self] callbackURL in
+                guard let rootViewController = window?.rootViewController else {
+                    self?.finish()
+                    return
+                }
+                // `WordPressAuthenticator.openAuthenticationURL` presents the
+                // magic-link sign-in controller on whatever is topmost. The
+                // ASWebAuthenticationSession sheet is still being torn down when
+                // this callback fires, so handing the URL over right away would
+                // present that controller on the dismissing sheet — it would
+                // never reach the window and its navigation controller would
+                // deallocate before the login epilogue runs, tripping the
+                // `showLoginEpilogue` assertion. Dismiss the sheet first, then
+                // hand off from the now-stable root.
+                rootViewController.dismiss(animated: false) {
+                    _ = WordPressAuthenticator.shared.handleWordPressAuthUrl(callbackURL,
+                                                                             rootViewController: rootViewController)
+                }
+                // Sign-in proceeds through WordPressAuthenticator from here —
+                // release the coordinator; the login UI is about to be replaced.
+                self?.finish()
+            },
+            onCancel: { [weak self] in
+                self?.handleMagicLinkCancelled()
+            }
+        )
+        runner.start(url: url, callbackURLScheme: Bundle.main.dotcomAuthScheme)
+    }
+
+    func showHostView(with strategy: QRLoginStrategy) {
+        let viewModel = QRLoginViewModel(strategy: strategy)
+        let host = QRLoginHostView(
+            viewModel: viewModel,
+            onDone: { [weak self] in self?.handleSuccess() },
+            onCancel: { [weak self] in self?.handleHostCancelled() },
+            onScanAgain: { [weak self] in self?.handleScanAgain() },
+            onEnterSiteURLTapped: { [weak self] in self?.handleEnterSiteURL() }
+        )
+        pushScreen(host)
+    }
+
+    /// Merchant cancelled from the number-match screen. In camera mode the
+    /// merchant gets the scanner back; in deep-link mode there's no scanner to
+    /// fall back to, so popping the host view exits the QR-login surface
+    /// (spec §4.2 / §6.2).
+    func handleHostCancelled() {
+        navigationController.popViewController(animated: true)
+        finishIfDeepLink()
+    }
+
+    /// Primary CTA on a non-retryable error ("Scan a new code", spec §6.1). In
+    /// camera mode this returns the merchant to a *fresh* scanner — the
+    /// previous scanner already consumed its payload and can't deliver again,
+    /// so it is dropped from the stack rather than reused. In deep-link mode
+    /// there's no scanner to return to, so the QR-login surface is dismissed
+    /// (spec §4.2).
+    func handleScanAgain() {
+        analytics.trackClick(.qrStartOver)
+        switch mode {
+        case .camera:
+            if let prologueViewController {
+                navigationController.popToViewController(prologueViewController, animated: false)
+            }
+            presentScannerAfterCameraPermissionCheck()
+        case .deepLink:
+            navigationController.popViewController(animated: true)
+            finish()
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    /// The merchant backed out of the prologue — the QR-login surface is done.
+    func handlePrologueBack() {
+        navigationController.popViewController(animated: true)
+        finish()
+    }
+
+    /// Routes the merchant to the legacy site-address login, pushed *on top* of
+    /// the QR-login surface. The coordinator is deliberately kept alive: the QR
+    /// screen underneath stays on the stack and is reachable by going back, so
+    /// its controls must keep working. It is released later, when the QR screens
+    /// are popped (`handlePrologueBack`) or replaced on a successful sign-in.
+    func handleEnterSiteURL() {
+        onEnterSiteURL()
+    }
+
+    /// Self-hosted sign-in completed — hand off to the store picker and end the
+    /// QR-login flow.
+    func handleSuccess() {
+        onSuccess()
+        finish()
+    }
+
+    /// The merchant dismissed the magic-link auth sheet without finishing
+    /// sign-in. Unwind the QR surface so they can retry.
+    ///
+    /// In camera mode this unwinds to the prologue rather than the scanner: the
+    /// scanner keeps the camera live (the merchant may still be pointing at a
+    /// QR code, so it could capture another) and landing there re-enters the
+    /// scan step. Deep-link mode has no prologue, so it pops the host view and
+    /// exits the QR surface.
+    func handleMagicLinkCancelled() {
+        if let prologueViewController {
+            navigationController.popToViewController(prologueViewController, animated: false)
+        } else {
+            navigationController.popViewController(animated: false)
+        }
+        finishIfDeepLink()
+    }
+
+    /// Fires `onFinished` exactly once so the owner can release this coordinator.
+    func finish() {
+        guard didFinish == false else { return }
+        didFinish = true
+        onFinished()
+    }
+
+    /// Releases the coordinator only in deep-link mode. After a camera-mode
+    /// navigation the scanner and prologue stay on the stack, so the coordinator
+    /// must stay alive to keep driving them when the merchant navigates back.
+    func finishIfDeepLink() {
+        if case .deepLink = mode {
+            finish()
+        }
+    }
+
+    func showErrorOnly(_ error: QRLoginUserFacingError) {
+        analytics.trackStep(.qrError)
+        analytics.trackFailure(QRLoginAnalyticsFailure.failureString(for: error))
+        // `showErrorOnly` only ever carries a `.scanAgain` error (`.installQR`
+        // / `.invalidPayload`), so the primary CTA always routes to a fresh
+        // scanner.
+        let view = QRLoginErrorView(
+            error: error,
+            onPrimaryTapped: { [weak self] in self?.handleScanAgain() },
+            onEnterSiteURLTapped: { [weak self] in self?.handleEnterSiteURL() }
+        )
+        pushScreen(view)
+    }
+}
+
+// MARK: - Navigation
+
+private extension QRLoginCoordinator {
+    /// Wraps `view` in a `QRLoginHostingController` and pushes it onto the login
+    /// navigation stack, showing the navigation bar with a "Help" item by default.
+    @discardableResult
+    func pushScreen<Content: View>(_ view: Content,
+                                   navigationBarStyle: QRLoginNavigationBarStyle = .inherited,
+                                   prefersLightStatusBar: Bool = false,
+                                   showsHelpButton: Bool = true) -> QRLoginHostingController<Content> {
+        let hosting = QRLoginHostingController(rootView: view)
+        hosting.navigationBarStyle = navigationBarStyle
+        hosting.prefersLightStatusBar = prefersLightStatusBar
+        if showsHelpButton {
+            hosting.navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: Localization.help,
+                primaryAction: UIAction { [weak self] _ in self?.showHelp() }
+            )
+        }
+        navigationController.pushViewController(hosting, animated: true)
+        return hosting
+    }
+}
+
+// MARK: - Camera permission alerts (spec §4.1.1)
+
+private extension QRLoginCoordinator {
+
+    func showFirstDenialAlert() {
+        let alert = UIAlertController(
+            title: Localization.cameraFirstDenialTitle,
+            message: Localization.cameraFirstDenialBody,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Localization.cameraFirstDenialPrimary, style: .default) { [weak self] _ in
+            self?.handleScanCTA() // re-request OS permission
+        })
+        alert.addAction(UIAlertAction(title: Localization.cancel, style: .cancel))
+        navigationController.present(alert, animated: true)
+    }
+
+    func showPermanentlyDeniedAlert() {
+        let alert = UIAlertController(
+            title: Localization.cameraPermanentlyDeniedTitle,
+            message: Localization.cameraPermanentlyDeniedBody,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: Localization.cameraPermanentlyDeniedPrimary, style: .default) { _ in
+            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+            UIApplication.shared.open(url)
+        })
+        alert.addAction(UIAlertAction(title: Localization.cancel, style: .cancel))
+        navigationController.present(alert, animated: true)
+    }
+
+    func showHelp() {
+        analytics.trackClick(.showHelp)
+        onShowHelp()
+    }
+}
+
+// MARK: - Localization
+
+private extension QRLoginCoordinator {
+    enum Localization {
+        static let help = NSLocalizedString(
+            "qrLogin.help",
+            value: "Help",
+            comment: "Navigation-bar Help button on the QR-login screens."
+        )
+        static let cancel = NSLocalizedString(
+            "qrLogin.cameraPermission.cancel",
+            value: "Cancel",
+            comment: "Cancel button on the camera-permission alerts."
+        )
+        static let cameraFirstDenialTitle = NSLocalizedString(
+            "qrLogin.cameraPermission.firstDenial.title",
+            value: "Camera access needed",
+            comment: "Title of the alert shown the first time the user denies camera access."
+        )
+        static let cameraFirstDenialBody = NSLocalizedString(
+            "qrLogin.cameraPermission.firstDenial.body",
+            value: "Without camera access, you can still log in by entering your store address.",
+            comment: "Body of the alert shown the first time the user denies camera access."
+        )
+        static let cameraFirstDenialPrimary = NSLocalizedString(
+            "qrLogin.cameraPermission.firstDenial.primary",
+            value: "Allow camera access",
+            comment: "Primary action on the first-denial camera-permission alert."
+        )
+        static let cameraPermanentlyDeniedTitle = NSLocalizedString(
+            "qrLogin.cameraPermission.permanentlyDenied.title",
+            value: "Camera access is turned off",
+            comment: "Title of the alert shown when the OS will no longer prompt for camera access."
+        )
+        static let cameraPermanentlyDeniedBody = NSLocalizedString(
+            "qrLogin.cameraPermission.permanentlyDenied.body",
+            value: "Enable camera access in Settings or cancel to sign in with your store address instead.",
+            comment: "Body of the alert shown when the OS will no longer prompt for camera access."
+        )
+        static let cameraPermanentlyDeniedPrimary = NSLocalizedString(
+            "qrLogin.cameraPermission.permanentlyDenied.primary",
+            value: "Open Permissions Settings",
+            comment: "Primary action on the permanently-denied camera-permission alert."
+        )
+    }
+}
+
+// MARK: - Magic-link auth session
+
+/// Runs the wp.com QR magic-link handoff inside an `ASWebAuthenticationSession`.
+///
+/// `ASWebAuthenticationSession` opens the magic link in an in-app Safari sheet
+/// and captures the `woocommerce://magic-login` callback itself — no external
+/// browser, and no "Open in app?" system prompt on the redirect back.
+///
+/// The runner retains itself for the lifetime of the session and releases once
+/// it ends — delivering the captured callback URL (`onCallback`), or signalling
+/// cancellation (`onCancel`) if the merchant dismissed the sheet. The self-retain
+/// decouples the session's lifetime from the `QRLoginCoordinator`.
+@MainActor
+private final class QRLoginMagicLinkAuthRunner: NSObject, ASWebAuthenticationPresentationContextProviding {
+
+    private let anchor: ASPresentationAnchor?
+    private let onCallback: @MainActor (URL) -> Void
+    private let onCancel: @MainActor () -> Void
+    private var session: ASWebAuthenticationSession?
+    private var retainedSelf: QRLoginMagicLinkAuthRunner?
+
+    init(anchor: ASPresentationAnchor?,
+         onCallback: @escaping @MainActor (URL) -> Void,
+         onCancel: @escaping @MainActor () -> Void) {
+        self.anchor = anchor
+        self.onCallback = onCallback
+        self.onCancel = onCancel
+    }
+
+    /// Opens `url` in the auth session. `callbackURLScheme` is the custom scheme
+    /// the wp.com page redirects to — the session ends the moment it sees it.
+    func start(url: URL, callbackURLScheme: String) {
+        retainedSelf = self
+        let session = ASWebAuthenticationSession(url: url,
+                                                 callbackURLScheme: callbackURLScheme) { [weak self] callbackURL, _ in
+            Task { @MainActor in
+                // Hold a strong reference before clearing the self-retain:
+                // releasing `retainedSelf` first would deallocate the runner
+                // mid-closure and the callbacks below would be dropped.
+                guard let self else { return }
+                self.retainedSelf = nil
+                if let callbackURL {
+                    self.onCallback(callbackURL)
+                } else {
+                    // A nil callbackURL means the merchant dismissed the sheet
+                    // (or it failed) — hand back so the QR surface can recover.
+                    self.onCancel()
+                }
+            }
+        }
+        // A magic link is self-authenticating, so the session needs no shared
+        // Safari cookies — an ephemeral session also avoids the data-sharing
+        // consent prompt.
+        session.prefersEphemeralWebBrowserSession = true
+        session.presentationContextProvider = self
+        self.session = session
+        session.start()
+    }
+
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        MainActor.assumeIsolated {
+            anchor ?? ASPresentationAnchor()
+        }
+    }
+}

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -40,6 +40,12 @@ extension WordPressAuthenticator {
                                                                 enableManualSiteCredentialLogin: true,
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
+                                                                // `enableSiteAddressLoginOnlyInPrologue: true` selects the
+                                                                // stacked-buttons prologue layout, whose site-address CTA is
+                                                                // where QR login intercepts the primary login tap. Changing
+                                                                // this (or the other prologue flags) switches the layout and
+                                                                // silently drops the QR-login entry point — see
+                                                                // `LoginPrologueViewController.configureButtonVC()`.
                                                                 enableSiteAddressLoginOnlyInPrologue: true,
                                                                 enableSiteCreationGuide: false,
                                                                 enableSiteCredentialsLoginForWPCOMSuspendedSites: true)

--- a/WooCommerce/Classes/SceneDelegate.swift
+++ b/WooCommerce/Classes/SceneDelegate.swift
@@ -96,7 +96,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         if let rootVC = window?.rootViewController {
-            _ = AppDelegate.shared.handleAuthenticationUrl(url, options: [:], rootViewController: rootVC)
+            Task { @MainActor in
+                _ = await AppDelegate.shared.handleAuthenticationUrl(url, options: [:], rootViewController: rootVC)
+            }
         }
     }
 

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -23,7 +23,15 @@ protocol Authentication {
 
     /// Handles an Authentication URL Callback. Returns *true* on success.
     ///
+    @MainActor
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool
+
+    /// Handles a `woocommerce://qr-login` deep link that arrived while the merchant is
+    /// already signed in. Returns *true* when the URL was a QR-login deep link this
+    /// method took over, *false* otherwise.
+    ///
+    @MainActor
+    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) -> Bool
 
     /// Returns authentication UI for display by the caller.
     ///

--- a/WooCommerce/Classes/ServiceLocator/Authentication.swift
+++ b/WooCommerce/Classes/ServiceLocator/Authentication.swift
@@ -24,14 +24,14 @@ protocol Authentication {
     /// Handles an Authentication URL Callback. Returns *true* on success.
     ///
     @MainActor
-    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool
+    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) async -> Bool
 
     /// Handles a `woocommerce://qr-login` deep link that arrived while the merchant is
     /// already signed in. Returns *true* when the URL was a QR-login deep link this
     /// method took over, *false* otherwise.
     ///
     @MainActor
-    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) -> Bool
+    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) async -> Bool
 
     /// Returns authentication UI for display by the caller.
     ///

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -28,8 +28,10 @@ struct UniversalLinkRouter {
     func canHandle(url: URL) -> Bool {
         /// Ensure that the URL is not related to login
         ///
-        guard url.absoluteString.hasPrefix(WooConstants.appLoginURLPrefix) == false,
-              url.absoluteString.hasPrefix(WooConstants.appMagicLoginURLPrefix) == false else {
+        let loweredURL = url.absoluteString.lowercased()
+        guard loweredURL.hasPrefix(WooConstants.appLoginURLPrefix) == false,
+              loweredURL.hasPrefix(WooConstants.appMagicLoginURLPrefix) == false,
+              loweredURL.hasPrefix(WooConstants.qrLoginURLPrefix) == false else {
             return false
         }
 

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -346,6 +346,7 @@ final class AppCoordinatorTests: XCTestCase {
         _ = try XCTUnwrap(analytics.receivedEvents.firstIndex(where: { $0 == WooAnalyticsStat.loginOnboardingShown.rawValue}))
     }
 
+    @MainActor
     func test_authenticationManager_handleAuthenticationUrl_with_login_url_updates_root_to_LoginNavigationController_when_onboarding_is_shown() throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
@@ -369,6 +370,7 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(loginNavigationController.viewControllers.count, 2)
     }
 
+    @MainActor
     func test_authenticationManager_handleAuthenticationUrl_with_login_url_pushes_a_view_controller_when_onboarding_is_not_shown() throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
@@ -391,6 +393,7 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(loginNavigationController.viewControllers.count, 2)
     }
 
+    @MainActor
     func test_authenticationManager_handleAuthenticationUrl_with_login_url_dismisses_modal_and_pushes_view_controller_when_modal_is_shown() throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -347,7 +347,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func test_authenticationManager_handleAuthenticationUrl_with_login_url_updates_root_to_LoginNavigationController_when_onboarding_is_shown() async throws {
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_updates_root_to_LoginNavigationController_when_onboarding_is_shown() throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
                                              loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: false))
@@ -360,8 +360,10 @@ final class AppCoordinatorTests: XCTestCase {
 
         // When
         let rootViewController = try XCTUnwrap(window.rootViewController)
-        let result = await authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: rootViewController)
-        XCTAssertTrue(result)
+        Task { @MainActor in
+            let result = await self.authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: rootViewController)
+            XCTAssertTrue(result)
+        }
 
         // Then
         waitUntil {
@@ -372,7 +374,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func test_authenticationManager_handleAuthenticationUrl_with_login_url_pushes_a_view_controller_when_onboarding_is_not_shown() async throws {
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_pushes_a_view_controller_when_onboarding_is_not_shown() throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
                                              loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
@@ -387,16 +389,20 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(loginNavigationController.viewControllers.count, 1)
 
         // When
-        let result = await authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController)
-        XCTAssertTrue(result)
+        Task { @MainActor in
+            let result = await self.authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController)
+            XCTAssertTrue(result)
+        }
 
         // Then
+        waitUntil {
+            loginNavigationController.viewControllers.count == 2
+        }
         XCTAssertEqual(window.rootViewController, loginNavigationController)
-        XCTAssertEqual(loginNavigationController.viewControllers.count, 2)
     }
 
     @MainActor
-    func test_authenticationManager_handleAuthenticationUrl_with_login_url_dismisses_modal_and_pushes_view_controller_when_modal_is_shown() async throws {
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_dismisses_modal_and_pushes_view_controller_when_modal_is_shown() throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
                                              loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
@@ -416,8 +422,10 @@ final class AppCoordinatorTests: XCTestCase {
         waitUntil {
             loginNavigationController.presentedViewController != nil
         }
-        let result = await authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController)
-        XCTAssertTrue(result)
+        Task { @MainActor in
+            let result = await self.authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController)
+            XCTAssertTrue(result)
+        }
 
         // Then
         XCTAssertEqual(window.rootViewController, loginNavigationController)

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -347,7 +347,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func test_authenticationManager_handleAuthenticationUrl_with_login_url_updates_root_to_LoginNavigationController_when_onboarding_is_shown() throws {
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_updates_root_to_LoginNavigationController_when_onboarding_is_shown() async throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
                                              loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: false))
@@ -360,7 +360,8 @@ final class AppCoordinatorTests: XCTestCase {
 
         // When
         let rootViewController = try XCTUnwrap(window.rootViewController)
-        XCTAssertTrue(authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: rootViewController))
+        let result = await authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: rootViewController)
+        XCTAssertTrue(result)
 
         // Then
         waitUntil {
@@ -371,7 +372,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func test_authenticationManager_handleAuthenticationUrl_with_login_url_pushes_a_view_controller_when_onboarding_is_not_shown() throws {
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_pushes_a_view_controller_when_onboarding_is_not_shown() async throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
                                              loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
@@ -386,7 +387,8 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(loginNavigationController.viewControllers.count, 1)
 
         // When
-        XCTAssertTrue(authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController))
+        let result = await authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController)
+        XCTAssertTrue(result)
 
         // Then
         XCTAssertEqual(window.rootViewController, loginNavigationController)
@@ -394,7 +396,7 @@ final class AppCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func test_authenticationManager_handleAuthenticationUrl_with_login_url_dismisses_modal_and_pushes_view_controller_when_modal_is_shown() throws {
+    func test_authenticationManager_handleAuthenticationUrl_with_login_url_dismisses_modal_and_pushes_view_controller_when_modal_is_shown() async throws {
         // Given
         let appCoordinator = makeCoordinator(authenticationManager: authenticationManager,
                                              loggedOutAppSettings: MockLoggedOutAppSettings(hasFinishedOnboarding: true))
@@ -414,7 +416,8 @@ final class AppCoordinatorTests: XCTestCase {
         waitUntil {
             loginNavigationController.presentedViewController != nil
         }
-        XCTAssertTrue(authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController))
+        let result = await authenticationManager.handleAuthenticationUrl(url, options: [:], rootViewController: loginNavigationController)
+        XCTAssertTrue(result)
 
         // Then
         XCTAssertEqual(window.rootViewController, loginNavigationController)

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/AuthenticationManagerQRLoginTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/AuthenticationManagerQRLoginTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+import UIKit
+import WordPressAuthenticator
+@testable import WooCommerce
+
+/// Tests for the QR-login wiring in `AuthenticationManager` — the deep-link
+/// availability gates and the signed-in session-replace entry point that PR
+/// 7/7 added.
+///
+/// The flows are driven through the public `handleAuthenticationUrl` and
+/// `handleSignedInQRLoginDeepLink` methods. `displayAuthenticatorIfLoggedOut`
+/// is stubbed to a standalone navigation controller (no window) so the deep-link
+/// coordinator can push its host view without kicking off the live SwiftUI flow.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct AuthenticationManagerQRLoginTests {
+
+    init() {
+        WordPressAuthenticator.initializeAuthenticator()
+    }
+
+    // MARK: - handleSignedInQRLoginDeepLink
+
+    @Test func handleSignedInQRLoginDeepLink_when_not_a_qr_url_then_returns_false() async {
+        // Given — a non-QR deep link. Availability is on to prove the URL check
+        // is what rejects it.
+        let manager = makeManager(deepLinkAvailable: true)
+        let url = URL(string: "woocommerce://app-login?siteUrl=https://example.com&username=demo")!
+
+        // When
+        let handled = await manager.handleSignedInQRLoginDeepLink(url, rootViewController: UIViewController())
+
+        // Then
+        #expect(handled == false)
+    }
+
+    @Test func handleSignedInQRLoginDeepLink_when_qr_url_but_unavailable_then_returns_false() async {
+        // Given — a QR deep link but the feature flag is off.
+        let manager = makeManager(deepLinkAvailable: false)
+
+        // When
+        let handled = await manager.handleSignedInQRLoginDeepLink(Self.selfHostedURL, rootViewController: UIViewController())
+
+        // Then
+        #expect(handled == false)
+    }
+
+    @Test func handleSignedInQRLoginDeepLink_when_qr_url_and_available_then_takes_over() async {
+        // Given — a QR deep link with the feature available.
+        let manager = makeManager(deepLinkAvailable: true)
+
+        // When
+        let handled = await manager.handleSignedInQRLoginDeepLink(Self.selfHostedURL, rootViewController: UIViewController())
+
+        // Then — the manager took over to present the session-replace warning.
+        #expect(handled == true)
+    }
+
+    // MARK: - handleAuthenticationUrl (logged-out QR deep link)
+
+    @Test func handleAuthenticationUrl_when_qr_url_but_unavailable_then_does_not_take_over() async {
+        // Given — a QR deep link with the flag off; it must fall through rather
+        // than being handled.
+        let manager = makeManager(deepLinkAvailable: false)
+        manager.displayAuthenticatorIfLoggedOut = { UINavigationController() }
+
+        // When
+        let handled = await manager.handleAuthenticationUrl(Self.selfHostedURL,
+                                                            options: [:],
+                                                            rootViewController: UIViewController())
+
+        // Then — `handleQRLoginUrl` returns nil, the QR branch is skipped, and
+        // no handler claims the URL.
+        #expect(handled == false)
+    }
+
+    @Test func handleAuthenticationUrl_when_qr_url_available_and_logged_out_then_starts_deeplink_flow() async {
+        // Given — a QR deep link with the feature available and a logged-out
+        // authenticator stack to push onto.
+        let manager = makeManager(deepLinkAvailable: true)
+        let deepLinkNav = UINavigationController()
+        manager.displayAuthenticatorIfLoggedOut = { deepLinkNav }
+
+        // When
+        let handled = await manager.handleAuthenticationUrl(Self.selfHostedURL,
+                                                            options: [:],
+                                                            rootViewController: UIViewController())
+
+        // Then — the manager took over and the deep-link coordinator pushed its
+        // live-flow host view onto the authenticator stack.
+        #expect(handled == true)
+        #expect(deepLinkNav.viewControllers.count == 1)
+    }
+
+    @Test func handleAuthenticationUrl_when_qr_url_available_but_no_authenticator_then_returns_false() async {
+        // Given — the feature is available but there is no logged-out UI to
+        // display the flow on.
+        let manager = makeManager(deepLinkAvailable: true)
+        manager.displayAuthenticatorIfLoggedOut = { nil }
+
+        // When
+        let handled = await manager.handleAuthenticationUrl(Self.selfHostedURL,
+                                                            options: [:],
+                                                            rootViewController: UIViewController())
+
+        // Then
+        #expect(handled == false)
+    }
+}
+
+// MARK: - Helpers
+
+private extension AuthenticationManagerQRLoginTests {
+
+    /// A valid self-hosted QR deep link — 64-char token + https site URL — so
+    /// the internal parser yields `.selfHosted`, which pushes a plain host view
+    /// (no storyboard) when routed.
+    static let selfHostedURL: URL = {
+        let token = String(repeating: "a", count: 64)
+        return URL(string: "woocommerce://qr-login?token=\(token)&siteUrl=https://example.com")!
+    }()
+
+    func makeManager(deepLinkAvailable: Bool) -> AuthenticationManager {
+        AuthenticationManager(
+            qrLoginAvailability: MockQRLoginAvailability(deepLinkAvailable: deepLinkAvailable)
+        )
+    }
+}
+
+@MainActor
+private final class MockQRLoginAvailability: QRLoginAvailabilityProvider {
+    var prologueAvailable: Bool
+    var deepLinkAvailable: Bool
+
+    init(prologueAvailable: Bool = false, deepLinkAvailable: Bool = false) {
+        self.prologueAvailable = prologueAvailable
+        self.deepLinkAvailable = deepLinkAvailable
+    }
+
+    func isAvailableForPrologue() async -> Bool { prologueAvailable }
+    func isAvailableForDeepLink() async -> Bool { deepLinkAvailable }
+}

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginCoordinatorTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+import UIKit
+import WordPressAuthenticator
+@testable import WooCommerce
+
+/// Tests for `QRLoginCoordinator` — the payload routing, mode branching, and
+/// lifecycle that the manual test matrix otherwise covers end-to-end.
+///
+/// The coordinator drives a real `UINavigationController`; the tests keep it
+/// out of a window so pushing a SwiftUI host view never triggers the live
+/// flow's `.task`. Behaviour is observed through the pushed view-controller
+/// stack, the injected callbacks, and the analytics spy.
+@Suite(.timeLimit(.minutes(1)))
+@MainActor
+struct QRLoginCoordinatorTests {
+
+    @Test func start_when_camera_mode_then_pushes_prologue_and_does_not_finish() {
+        // Given
+        let nav = UINavigationController()
+        let spy = Spies()
+        let coordinator = makeCoordinator(mode: .camera, navigationController: nav, spies: spy)
+
+        // When
+        coordinator.start()
+
+        // Then — the dark prologue is the only screen and the coordinator stays
+        // alive to keep driving the camera-mode stack.
+        #expect(nav.viewControllers.count == 1)
+        #expect(spy.finishedCount == 0)
+        #expect(spy.analytics.flows == [.loginQR])
+        #expect(spy.analytics.steps == [.qrPrologue])
+    }
+
+    @Test func start_when_deepLink_selfHosted_then_pushes_host_and_stays_alive() {
+        // Given
+        let nav = UINavigationController()
+        let spy = Spies()
+        let payload = QRLoginPayload.selfHosted(token: Self.selfHostedToken,
+                                                siteURL: URL(string: "https://example.com")!)
+        let coordinator = makeCoordinator(mode: .deepLink(payload: payload),
+                                          navigationController: nav,
+                                          spies: spy)
+
+        // When
+        coordinator.start()
+
+        // Then — the live flow's host view is pushed; the coordinator must stay
+        // alive to run the scan → poll → exchange pipeline.
+        #expect(nav.viewControllers.count == 1)
+        #expect(spy.finishedCount == 0)
+    }
+
+    @Test func start_when_deepLink_wpCom_then_pushes_host_and_stays_alive() {
+        // Given
+        let nav = UINavigationController()
+        let spy = Spies()
+        let payload = QRLoginPayload.wpCom(token: "abc:def", encrypted: "blob")
+        let coordinator = makeCoordinator(mode: .deepLink(payload: payload),
+                                          navigationController: nav,
+                                          spies: spy)
+
+        // When
+        coordinator.start()
+
+        // Then
+        #expect(nav.viewControllers.count == 1)
+        #expect(spy.finishedCount == 0)
+    }
+
+    @Test func start_when_deepLink_invalid_then_shows_error_and_tracks_failure() {
+        // Given
+        let nav = UINavigationController()
+        let spy = Spies()
+        let coordinator = makeCoordinator(mode: .deepLink(payload: .invalid),
+                                          navigationController: nav,
+                                          spies: spy)
+
+        // When
+        coordinator.start()
+
+        // Then — an error screen is shown and a failure is tracked; the
+        // coordinator waits on the "Scan a new code" CTA rather than finishing.
+        #expect(nav.viewControllers.count == 1)
+        #expect(spy.analytics.steps.last == .qrError)
+        #expect(spy.analytics.failures.isEmpty == false)
+        #expect(spy.finishedCount == 0)
+    }
+
+    @Test func start_when_deepLink_installQR_then_shows_error_and_tracks_failure() {
+        // Given
+        let nav = UINavigationController()
+        let spy = Spies()
+        let coordinator = makeCoordinator(mode: .deepLink(payload: .installQR),
+                                          navigationController: nav,
+                                          spies: spy)
+
+        // When
+        coordinator.start()
+
+        // Then
+        #expect(nav.viewControllers.count == 1)
+        #expect(spy.analytics.steps.last == .qrError)
+        #expect(spy.analytics.failures.isEmpty == false)
+        #expect(spy.finishedCount == 0)
+    }
+
+    @Test func start_when_deepLink_siteURLOnly_then_finishes_coordinator() {
+        // Given — a legacy site-URL-only payload routes to the WPA site-address
+        // screen and, in deep-link mode, exits the QR-login surface.
+        WordPressAuthenticator.initializeAuthenticator()
+        let nav = UINavigationController()
+        let spy = Spies()
+        let payload = QRLoginPayload.siteURLOnly(siteURL: URL(string: "https://example.com")!)
+        let coordinator = makeCoordinator(mode: .deepLink(payload: payload),
+                                          navigationController: nav,
+                                          spies: spy)
+
+        // When
+        coordinator.start()
+
+        // Then — `finishIfDeepLink` releases the coordinator once routing is done.
+        #expect(spy.finishedCount == 1)
+    }
+
+    @Test func finish_fires_onFinished_exactly_once_across_repeated_exits() {
+        // Given — a deep-link self-hosted flow keeps the coordinator alive...
+        let nav = UINavigationController()
+        let spy = Spies()
+        let firstPayload = QRLoginPayload.selfHosted(token: Self.selfHostedToken,
+                                                     siteURL: URL(string: "https://example.com")!)
+        let coordinator = makeCoordinator(mode: .deepLink(payload: firstPayload),
+                                          navigationController: nav,
+                                          spies: spy)
+        coordinator.start()
+        #expect(spy.finishedCount == 0)
+
+        // When — re-feeding a terminal legacy payload routes + finishes, and a
+        // second terminal payload would finish again if the one-shot guard
+        // weren't there.
+        let terminalPayload = QRLoginPayload.siteURLOnly(siteURL: URL(string: "https://example.com")!)
+        WordPressAuthenticator.initializeAuthenticator()
+        coordinator.presentDeepLink(payload: terminalPayload)
+        coordinator.presentDeepLink(payload: terminalPayload)
+
+        // Then — `onFinished` fired at most once.
+        #expect(spy.finishedCount == 1)
+    }
+
+    @Test func presentDeepLink_when_camera_started_then_pushes_screen_on_top() {
+        // Given — a camera-mode coordinator already presenting the prologue.
+        let nav = UINavigationController()
+        let spy = Spies()
+        let coordinator = makeCoordinator(mode: .camera, navigationController: nav, spies: spy)
+        coordinator.start()
+        #expect(nav.viewControllers.count == 1)
+
+        // When — a deep link arrives and is fed into the same coordinator.
+        let payload = QRLoginPayload.selfHosted(token: Self.selfHostedToken,
+                                                siteURL: URL(string: "https://example.com")!)
+        coordinator.presentDeepLink(payload: payload)
+
+        // Then — the host view is pushed on top of the prologue; no second
+        // coordinator is needed.
+        #expect(nav.viewControllers.count == 2)
+        #expect(spy.finishedCount == 0)
+    }
+}
+
+// MARK: - Helpers
+
+private extension QRLoginCoordinatorTests {
+
+    /// A 64-char alphanumeric token, the minimum the self-hosted parser accepts.
+    static let selfHostedToken = String(repeating: "a", count: 64)
+
+    /// Bundles the injected coordinator callbacks + analytics so tests can spy
+    /// on lifecycle and tracking without reaching into the coordinator.
+    @MainActor
+    final class Spies {
+        let analytics = SpyQRLoginAnalytics()
+        private(set) var finishedCount = 0
+        private(set) var successCount = 0
+        private(set) var enterSiteURLCount = 0
+        private(set) var showHelpCount = 0
+
+        func onFinished() { finishedCount += 1 }
+        func onSuccess() { successCount += 1 }
+        func onEnterSiteURL() { enterSiteURLCount += 1 }
+        func onShowHelp() { showHelpCount += 1 }
+    }
+
+    func makeCoordinator(mode: QRLoginCoordinator.Mode,
+                         navigationController: UINavigationController,
+                         spies: Spies) -> QRLoginCoordinator {
+        QRLoginCoordinator(
+            mode: mode,
+            navigationController: navigationController,
+            analytics: spies.analytics,
+            onEnterSiteURL: { spies.onEnterSiteURL() },
+            onShowHelp: { spies.onShowHelp() },
+            onSuccess: { spies.onSuccess() },
+            onFinished: { spies.onFinished() }
+        )
+    }
+}
+
+@MainActor
+final class SpyQRLoginAnalytics: QRLoginAnalyticsTracking {
+    private(set) var flows: [AuthenticatorAnalyticsTracker.Flow] = []
+    private(set) var steps: [AuthenticatorAnalyticsTracker.Step] = []
+    private(set) var clicks: [AuthenticatorAnalyticsTracker.ClickTarget] = []
+    private(set) var failures: [String] = []
+
+    func setFlow(_ flow: AuthenticatorAnalyticsTracker.Flow) { flows.append(flow) }
+    func trackStep(_ step: AuthenticatorAnalyticsTracker.Step) { steps.append(step) }
+    func trackClick(_ click: AuthenticatorAnalyticsTracker.ClickTarget) { clicks.append(click) }
+    func trackFailure(_ failure: String) { failures.append(failure) }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
@@ -17,12 +17,12 @@ final class MockAuthentication: Authentication {
     }
 
     @MainActor
-    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
+    func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) async -> Bool {
         true
     }
 
     @MainActor
-    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) -> Bool {
+    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) async -> Bool {
         false
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockAuthentication.swift
@@ -16,8 +16,14 @@ final class MockAuthentication: Authentication {
         // no-op
     }
 
+    @MainActor
     func handleAuthenticationUrl(_ url: URL, options: [UIApplication.OpenURLOptionsKey: Any], rootViewController: UIViewController) -> Bool {
         true
+    }
+
+    @MainActor
+    func handleSignedInQRLoginDeepLink(_ url: URL, rootViewController: UIViewController) -> Bool {
+        false
     }
 
     func authenticationUI() -> UIViewController {

--- a/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WooCommerce/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -150,7 +150,7 @@ import WordPressUI
     /// - Returns: The root view controller for the login flow.
     public class func loginUI(showCancel: Bool = false,
                               restrictToWPCom: Bool = false,
-                              onPrimaryLoginCTA: @escaping @MainActor () -> Bool) -> UIViewController? {
+                              onPrimaryLoginCTA: @escaping @MainActor () async -> Bool) -> UIViewController? {
         let storyboard = Storyboard.login.instance
         guard let controller = storyboard.instantiateInitialViewController() else {
             assertionFailure("Cannot instantiate initial login controller from Login.storyboard")

--- a/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
+++ b/WooCommerce/WordPressAuthenticator/Signin/LoginPrologueViewController.swift
@@ -25,7 +25,7 @@ class LoginPrologueViewController: LoginViewController {
     /// WooCommerce addition. Called when the primary login CTA on the prologue is tapped. Return
     /// `true` when the host app has taken over navigation, so the prologue skips its default login
     /// action (used to route into the QR-login flow).
-    var onPrimaryLoginCTA: (@MainActor () -> Bool)?
+    var onPrimaryLoginCTA: (@MainActor () async -> Bool)?
 
     private let configuration = WordPressAuthenticator.shared.configuration
     private let style = WordPressAuthenticator.shared.style
@@ -185,11 +185,13 @@ class LoginPrologueViewController: LoginViewController {
         let createTitle = NSLocalizedString("Sign up for WordPress.com", comment: "Button title. Tapping begins the process of creating a WordPress.com account.")
 
         buttonViewController.setupTopButton(title: loginTitle, isPrimary: false, accessibilityIdentifier: "Prologue Log In Button") { [weak self] in
-            guard self?.onPrimaryLoginCTA?() != true else {
-                return
+            Task { @MainActor [weak self] in
+                guard await self?.onPrimaryLoginCTA?() != true else {
+                    return
+                }
+                self?.onLoginButtonTapped?()
+                self?.loginTapped()
             }
-            self?.onLoginButtonTapped?()
-            self?.loginTapped()
         }
 
         if configuration.enableSignUp {
@@ -356,10 +358,12 @@ class LoginPrologueViewController: LoginViewController {
     /// `defaultAction` (e.g. routing to QR login).
     private func primaryLoginCallback(default defaultAction: @escaping NUXButtonViewController.CallBackType) -> NUXButtonViewController.CallBackType {
         return { [weak self] in
-            guard self?.onPrimaryLoginCTA?() != true else {
-                return
+            Task { @MainActor [weak self] in
+                guard await self?.onPrimaryLoginCTA?() != true else {
+                    return
+                }
+                defaultAction()
             }
-            defaultAction()
         }
     }
 


### PR DESCRIPTION
## Description
**Part 7 of 7** — the final PR of the QR-code login feature (see **[1/7]** for context). This is the only PR that makes the feature reachable; it's the one to test end-to-end.

Adds `QRLoginCoordinator` and wires QR-login into `AuthenticationManager`, the `AppDelegate`, the deep-link router, and the service locator.

With all 7 PRs merged, the branch is byte-identical to `feature/qr-login` (minus the temporary `QR_LOGIN_DECISIONS.md` working note, which is intentionally excluded from the whole chain).

**Stack:** base **[6/7]** `feature/qr-login-step-6`. ~777 production lines.

## Test Steps

### Setup
- Enable the feature flag on a simulator/device:
  `xcrun simctl spawn booted defaults write com.automattic.woocommerce com.woocommerce.featureflag.override.remote.qrCodeLogin -bool YES`
- Have both a **self-hosted WooCommerce store** and a **WP.com-connected store** available, plus a generated QR code from `woo.com/mobilelogin` (or the relevant endpoint) for each.

### Entry points & availability gate
- [x] With the flag **off**, tapping **Log In** shows the standard login (no QR prologue).
- [x] With the flag **on**, tapping **Log In** shows the QR-login prologue.
- [x] Deep link while logged out — `woocommerce://qr-login?token=…&siteUrl=…` — opens the QR flow directly (reusing the existing coordinator, not a second one).
- [x] Camera permission denied → the permission-prompt path is shown rather than a black scanner.

### Self-hosted QR flow
- [x] Scan a valid self-hosted QR code → number-match screen → polling → exchange → **store picker / logged in**.
- [x] Post-exchange failure — non-WooCommerce site, or a role-ineligible user → error screen shown **and** the just-minted application password is revoked (no orphan AP, full logout).

### WP.com QR flow
- [x] Scan a valid WP.com QR code → number-match → exchange → magic link opens in an in-app `ASWebAuthenticationSession` (no external Safari, no "Open in app?" prompt) → `woocommerce://magic-login` callback completes sign-in → logged in.
- [x] Dismiss the auth sheet without finishing → unwinds to the prologue in camera mode (not the live scanner).

### Error & resilience scenarios
- [x] Sign-in timed out (412 `qr_login_not_approved`) → "Sign-in timed out".
- [x] Sign-in interrupted (412 `invalid_exchange_grant`) → "Sign-in interrupted".
- [x] Already signed in elsewhere (500 `already_consumed`, WP.com) → corresponding error.
- [x] Expired session (WP.com poll 404) → "expired" terminal state.
- [x] Transient network drops during polling → flow survives and recovers (4-strike threshold before failing).
- [x] **Retry at each phase** — retrying after a scan/poll/exchange error does not re-run earlier successful work.
- [x] Generic network error (unreachable store) → "Something went wrong" with **Try again** / **Enter site URL instead**.

### Non-protocol QR payloads (routed by the coordinator's payload handler)
- [x] Magic-link QR → in-app browser handoff.
- [x] Site-URL-only QR → WPA site-address screen, **pre-filled and auto-submitted** once.
- [x] App-login WP.com QR (site + email) → WPA WP.com email/password screen.
- [x] App-login username QR (site + username) → WPA site-credentials screen.
- [x] Install QR → "That's the install QR" error variant.
- [x] Unrecognized code → "Not a WooCommerce code" error variant.

### Session-replace (deep link while already signed in)
- [x] `woocommerce://qr-login` while logged in → "You're already signed in" warning.
- [x] Confirm → current session is torn down and the deep link resumes on the logged-out path.
- [x] Cancel → current session is kept, no QR flow.

### Navigation, cancel & support
- [x] Back / cancel from the prologue, scanner, number-match and error screens behaves correctly (no dead prologue underneath a pushed screen).
- [x] Help & Support is reachable from the prologue / scanner / error screens and opens with the `login-with-qr-code` origin.
- [x] The fallback CTA "No computer? Log in with site address" pushes the site-address screen.

### Analytics / cross-platform parity
- [x] Verify Tracks events fire with `flow = login_qr` set once at the start of the flow.
- [x] Step / click / failure events fire at the expected points (scan, number-match, exchange, success, each error).
- [x] Failure strings follow spec §9.3 (e.g. `Network:Scan`, `UserNotEligible:Auth`).
- [x] **Compare the emitted events 1:1 with the WooCommerce Android QR-login implementation** — event names, the `flow` value, step/click identifiers and failure strings must be identical across platforms so the funnels line up. Flag any divergence before this ships.

## Screenshots
Verified on the iPhone 16 simulator — prologue, scanner, network-error screen, the site-address fallback, and the invalid-code error variant all render correctly.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
