### PR TITLE
RSM-645 Add POS refund submission facade

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -6,18 +6,11 @@ import protocol Yosemite.POSOrderListFetchStrategyFactoryProtocol
 import protocol Yosemite.POSOrderListFetchStrategy
 import protocol Yosemite.POSRefundsServiceProtocol
 import struct Yosemite.POSOrder
-import struct Yosemite.POSRefund
-import struct Yosemite.POSRefundItem
-import struct Yosemite.POSRefundsResult
-import struct Yosemite.POSRefundableItem
-import struct Yosemite.POSRefundAmounts
 import struct Yosemite.POSOrderItem
 import struct Yosemite.POSOrderCustomAmount
 import struct Yosemite.POSOrderRefund
-import class Yosemite.Store
 import class Yosemite.AsyncPaginationTracker
 import protocol Experiments.FeatureFlagService
-import class WooFoundation.CurrencyFormatter
 import CocoaLumberjackSwift
 
 enum StartRefundFlowResult {
@@ -56,7 +49,7 @@ protocol POSSearchingOrderListControllerProtocol: POSOrderListControllerProtocol
 enum POSOrderListSelectedOrderRefundsState {
     case idle
     case loading
-    case loaded(POSRefundsResult)
+    case loaded(POSRefundPreparation)
     case failed(Error)
 }
 
@@ -77,9 +70,8 @@ enum RefundActionAvailability {
     private(set) var refundSelectableItems: [POSRefundSelectableItem] = []
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
+    private let refundSubmissionProcessor: POSRefundSubmissionProcessing
     private let featureFlags: POSFeatureFlagProviding
-    private let currencySettingsProvider: POSCurrencySettingsProviding
-    private let currencyFormatter: CurrencyFormatter
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
              return existing
@@ -91,17 +83,15 @@ enum RefundActionAvailability {
 
     init(orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol,
          refundsService: POSRefundsServiceProtocol,
+         refundSubmissionProcessor: POSRefundSubmissionProcessing,
          featureFlags: POSFeatureFlagProviding,
-         currencySettingsProvider: POSCurrencySettingsProviding,
-         currencyFormatter: CurrencyFormatter,
          initialState: POSOrderListState = .loading([])) {
         self.ordersViewState = initialState
         self.orderListFetchStrategyFactory = orderListFetchStrategyFactory
         self.fetchStrategy = orderListFetchStrategyFactory.defaultStrategy()
         self.refundsService = refundsService
+        self.refundSubmissionProcessor = refundSubmissionProcessor
         self.featureFlags = featureFlags
-        self.currencySettingsProvider = currencySettingsProvider
-        self.currencyFormatter = currencyFormatter
     }
 
     @MainActor
@@ -310,41 +300,16 @@ enum RefundActionAvailability {
     func startRefundFlow() async -> StartRefundFlowResult {
         guard let order = selectedOrder else { return .failed }
 
-        // Fetch refunds from API
-        let refundsResult: POSRefundsResult
+        let preparation: POSRefundPreparation
         do {
-            refundsResult = try await refundsService.providePointOfSaleRefunds(for: order)
-            selectedOrderRefundsState = .loaded(refundsResult)
+            preparation = try await refundSubmissionProcessor.prepareRefund(for: order)
+            selectedOrderRefundsState = .loaded(preparation)
         } catch {
             selectedOrderRefundsState = .failed(error)
             return .failed
         }
 
-        // Calculate already refunded quantities per itemID
-        let refundedQuantitiesByItemID = refundsResult.refunds.flatMap(\.items).refundedQuantitiesByItemID()
-
-        // Build selectable items excluding already refunded quantities
-        let productSelectables = order.lineItems.flatMap { item -> [POSRefundSelectableItem] in
-            let originalQuantity = NSDecimalNumber(decimal: item.quantity).intValue
-            let refundedQuantity = refundedQuantitiesByItemID[item.itemID] ?? 0
-            let availableQuantity = originalQuantity - refundedQuantity
-            guard availableQuantity > 0 else { return [] }
-
-            return (0..<availableQuantity).map { index in
-                POSRefundSelectableItem(from: item, isSelected: true, index: index)
-            }
-        }
-
-        let alreadyRefundedItemIDs: Set<Int64> = Set(
-            refundsResult.refunds
-                .flatMap(\.items)
-                .compactMap(\.refundedItemID)
-        )
-        let feeSelectables = order.customAmounts
-            .filter { !alreadyRefundedItemIDs.contains($0.id) }
-            .map { POSRefundSelectableItem(from: $0, isSelected: true) }
-
-        refundSelectableItems = productSelectables + feeSelectables
+        refundSelectableItems = preparation.selectableItems
 
         return refundSelectableItems.isEmpty ? .nothingToRefund : .hasItemsToRefund
     }
@@ -375,44 +340,17 @@ enum RefundActionAvailability {
     @MainActor
     func preparePOSRefundReviewData() -> POSRefundReviewData? {
         guard let order = selectedOrder else { return nil }
+        guard case .loaded(let preparation) = selectedOrderRefundsState else { return nil }
 
         let selectedItems = refundSelectableItems.filter { $0.isSelected }
         guard !selectedItems.isEmpty else { return nil }
 
-        let refundableItems = selectedItems.map { item in
-            POSRefundableItem(
-                itemID: item.itemID,
-                lineItemTotal: item.lineItemTotal,
-                totalTax: item.totalTax,
-                originalQuantity: item.originalQuantity,
-                isLumpSum: item.isLumpSum
-            )
-        }
-
-        let amounts = refundsService.calculateRefundAmounts(for: refundableItems)
-
-        guard let formattedSubtotal = currencyFormatter.formatAmount(amounts.subtotal),
-              let formattedTax = currencyFormatter.formatAmount(amounts.tax),
-              let formattedTotal = currencyFormatter.formatAmount(amounts.total) else {
-            return nil
-        }
-
-        let paymentMethodDescription = createPaymentMethodDescription(for: order)
-
-        return POSRefundReviewData(
-            itemsCount: selectedItems.count,
-            formattedItemsSubtotal: formattedSubtotal,
-            formattedTax: formattedTax,
-            formattedRefundTotal: formattedTotal,
-            paymentMethodDescription: paymentMethodDescription,
-            customerEmail: order.customerEmail,
-            refundReason: nil,
-            isFullRefund: selectedItems.count == refundSelectableItems.count
+        return refundSubmissionProcessor.prepareReviewData(
+            for: order,
+            preparation: preparation,
+            selectedItems: selectedItems,
+            reason: nil
         )
-    }
-
-    private func createPaymentMethodDescription(for order: POSOrder) -> String {
-        String(format: Localization.viaPaymentMethodFormat, order.paymentMethodTitle)
     }
 
     // MARK: - Refund Processing
@@ -424,7 +362,7 @@ enum RefundActionAvailability {
             return
         }
 
-        guard case .loaded(let refundsResult) = selectedOrderRefundsState else {
+        guard case .loaded(let preparation) = selectedOrderRefundsState else {
             assertionFailure("processRefund called without loaded refunds state")
             return
         }
@@ -435,21 +373,11 @@ enum RefundActionAvailability {
             return
         }
 
-        let refundableItems = selectedItems.map { item in
-            POSRefundableItem(
-                itemID: item.itemID,
-                lineItemTotal: item.lineItemTotal,
-                totalTax: item.totalTax,
-                originalQuantity: item.originalQuantity,
-                isLumpSum: item.isLumpSum
-            )
-        }
-
-        try await refundsService.createRefund(
-            orderID: order.id,
-            items: refundableItems,
-            reason: reason,
-            isAutomaticRefund: refundsResult.supportsAutomaticRefund
+        try await refundSubmissionProcessor.submitRefund(
+            for: order,
+            preparation: preparation,
+            selectedItems: selectedItems,
+            reason: reason
         )
 
         clearRefundSelection()
@@ -471,17 +399,5 @@ enum RefundActionAvailability {
             DDLogError("⛔️ Failed to load refund details: \(error)")
         }
         isLoadingOrderRefunds = false
-    }
-}
-
-// MARK: - Localization
-
-private extension POSOrderListController {
-    enum Localization {
-        static let viaPaymentMethodFormat = NSLocalizedString(
-            "pos.orderListController.refund.viaPaymentMethodFormat",
-            value: "Via %@",
-            comment: "Description for refund via a specific payment method. %@ is the payment method name"
-        )
     }
 }

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Observation
+import struct Yosemite.CardReaderInput
+import struct Yosemite.POSOrder
+
+public struct POSRefundPreparation: Equatable {
+    public let orderID: Int64
+    public let selectableItems: [POSRefundSelectableItem]
+    public let paymentMethodDescription: String
+    public let customerEmail: String?
+
+    public init(orderID: Int64,
+                selectableItems: [POSRefundSelectableItem],
+                paymentMethodDescription: String,
+                customerEmail: String?) {
+        self.orderID = orderID
+        self.selectableItems = selectableItems
+        self.paymentMethodDescription = paymentMethodDescription
+        self.customerEmail = customerEmail
+    }
+}
+
+public enum POSRefundSubmissionState {
+    case idle
+    case loading
+    case onboarding(factory: CardPresentPaymentOnboardingViewContainer, onCancel: () -> Void)
+    case cardPresentEvent(CardPresentPaymentEventDetails)
+    case preparingReader(cancel: () -> Void)
+    case waitingForCard(inputMethods: CardReaderInput, cancel: () -> Void)
+    case processingReader
+    case displayingReaderMessage(String)
+    case submitting
+    case retryableError(error: any Error, retry: () -> Void, cancel: () -> Void)
+    case nonRetryableError(error: any Error, dismiss: () -> Void)
+    case completed
+}
+
+@Observable public final class POSRefundSubmissionModel {
+    public var state: POSRefundSubmissionState = .idle
+
+    public init() {}
+
+    public func reset() {
+        state = .idle
+    }
+}
+
+@MainActor
+public protocol POSRefundSubmissionProcessing: AnyObject {
+    var stateModel: POSRefundSubmissionModel { get }
+
+    func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation
+
+    func prepareReviewData(for order: POSOrder,
+                           preparation: POSRefundPreparation,
+                           selectedItems: [POSRefundSelectableItem],
+                           reason: String?) -> POSRefundReviewData?
+
+    func submitRefund(for order: POSOrder,
+                      preparation: POSRefundPreparation,
+                      selectedItems: [POSRefundSelectableItem],
+                      reason: String?) async throws
+}
+
+public final class POSNoOpRefundSubmissionProcessor: POSRefundSubmissionProcessing {
+    public let stateModel = POSRefundSubmissionModel()
+
+    public nonisolated init() {}
+
+    public func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
+        POSRefundPreparation(orderID: order.id,
+                             selectableItems: [],
+                             paymentMethodDescription: String(format: Localization.viaPaymentMethodFormat, order.paymentMethodTitle),
+                             customerEmail: order.customerEmail)
+    }
+
+    public func prepareReviewData(for order: POSOrder,
+                                  preparation: POSRefundPreparation,
+                                  selectedItems: [POSRefundSelectableItem],
+                                  reason: String?) -> POSRefundReviewData? {
+        nil
+    }
+
+    public func submitRefund(for order: POSOrder,
+                             preparation: POSRefundPreparation,
+                             selectedItems: [POSRefundSelectableItem],
+                             reason: String?) async throws {
+        stateModel.state = .completed
+    }
+}
+
+private extension POSNoOpRefundSubmissionProcessor {
+    enum Localization {
+        static let viaPaymentMethodFormat = NSLocalizedString(
+            "pointOfSale.refunds.paymentMethodDescription.viaPaymentMethod",
+            value: "via %@",
+            comment: "Payment method description for POS refunds. %@ is the payment method title."
+        )
+    }
+}

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
@@ -93,8 +93,8 @@ private extension POSNoOpRefundSubmissionProcessor {
     enum Localization {
         static let viaPaymentMethodFormat = NSLocalizedString(
             "pointOfSale.refunds.paymentMethodDescription.viaPaymentMethod",
-            value: "via %@",
-            comment: "Payment method description for POS refunds. %@ is the payment method title."
+            value: "via %1$@",
+            comment: "Payment method description for POS refunds. %1$@ is the payment method title."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Models/POSOrderListModel.swift
+++ b/Modules/Sources/PointOfSale/Models/POSOrderListModel.swift
@@ -5,11 +5,14 @@ import struct Yosemite.POSOrder
 @Observable final class POSOrderListModel {
     let ordersController: POSSearchingOrderListControllerProtocol
     let receiptSender: POSReceiptSending
+    let refundSubmissionModel: POSRefundSubmissionModel
 
     init(ordersController: POSSearchingOrderListControllerProtocol,
-         receiptSender: POSReceiptSending) {
+         receiptSender: POSReceiptSending,
+         refundSubmissionModel: POSRefundSubmissionModel) {
         self.ordersController = ordersController
         self.receiptSender = receiptSender
+        self.refundSubmissionModel = refundSubmissionModel
     }
 
     func sendReceipt(order: POSOrder, email: String) async throws {

--- a/Modules/Sources/PointOfSale/Models/POSRefundReviewData.swift
+++ b/Modules/Sources/PointOfSale/Models/POSRefundReviewData.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Data model for displaying the refund review screen.
 /// Contains pre-calculated and formatted values ready for display.
-struct POSRefundReviewData: Equatable {
+public struct POSRefundReviewData: Equatable {
     let itemsCount: Int
     let formattedItemsSubtotal: String
     let formattedTax: String
@@ -11,4 +11,22 @@ struct POSRefundReviewData: Equatable {
     let customerEmail: String?
     var refundReason: String?
     let isFullRefund: Bool
+
+    public init(itemsCount: Int,
+                formattedItemsSubtotal: String,
+                formattedTax: String,
+                formattedRefundTotal: String,
+                paymentMethodDescription: String,
+                customerEmail: String?,
+                refundReason: String?,
+                isFullRefund: Bool) {
+        self.itemsCount = itemsCount
+        self.formattedItemsSubtotal = formattedItemsSubtotal
+        self.formattedTax = formattedTax
+        self.formattedRefundTotal = formattedRefundTotal
+        self.paymentMethodDescription = paymentMethodDescription
+        self.customerEmail = customerEmail
+        self.refundReason = refundReason
+        self.isFullRefund = isFullRefund
+    }
 }

--- a/Modules/Sources/PointOfSale/Models/POSRefundSelectableItem.swift
+++ b/Modules/Sources/PointOfSale/Models/POSRefundSelectableItem.swift
@@ -3,8 +3,8 @@ import struct Yosemite.POSOrderCustomAmount
 import struct Yosemite.POSOrderItem
 import typealias Yosemite.OrderItemAttribute
 
-struct POSRefundSelectableItem: Identifiable, Equatable {
-    let itemID: Int64
+public struct POSRefundSelectableItem: Identifiable, Equatable {
+    public let itemID: Int64
     let name: String
     let imageSrc: String?
     let lineItemTotal: Decimal
@@ -14,23 +14,23 @@ struct POSRefundSelectableItem: Identifiable, Equatable {
     let attributes: [OrderItemAttribute]
     /// `true` when this row represents a lump-sum line such as a custom amount / fee.
     /// Lump-sum rows have no quantity / unit-level breakdown — they refund as a single line.
-    let isLumpSum: Bool
+    public let isLumpSum: Bool
     var isSelected: Bool
 
     /// Unique identifier for the selectable item (combines itemID and index for multiple units)
-    let id: String
+    public let id: String
 
-    init(itemID: Int64,
-         name: String,
-         imageSrc: String?,
-         lineItemTotal: Decimal,
-         totalTax: Decimal,
-         originalQuantity: Decimal,
-         formattedPrice: String,
-         attributes: [OrderItemAttribute],
-         isLumpSum: Bool = false,
-         isSelected: Bool,
-         index: Int) {
+    public init(itemID: Int64,
+                name: String,
+                imageSrc: String?,
+                lineItemTotal: Decimal,
+                totalTax: Decimal,
+                originalQuantity: Decimal,
+                formattedPrice: String,
+                attributes: [OrderItemAttribute],
+                isLumpSum: Bool = false,
+                isSelected: Bool,
+                index: Int) {
         self.itemID = itemID
         self.name = name
         self.imageSrc = imageSrc

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import class WooFoundation.CurrencyFormatter
 import protocol Storage.GRDBManagerProtocol
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
 import protocol Yosemite.POSCartProductObserving
@@ -37,6 +36,7 @@ public struct PointOfSaleEntryPointView: View {
     private let couponsController: PointOfSaleCouponsControllerProtocol
     private let couponsSearchController: PointOfSaleSearchingItemsControllerProtocol
     private let cardPresentPaymentService: CardPresentPaymentFacade
+    private let refundSubmissionProcessor: POSRefundSubmissionProcessing
     private let orderController: PointOfSaleOrderControllerProtocol
     private let settingsController: POSSettingsControllerProtocol
     private let collectOrderPaymentAnalyticsTracker: POSCollectOrderPaymentAnalyticsTracking
@@ -63,6 +63,7 @@ public struct PointOfSaleEntryPointView: View {
          orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol,
          orderService: POSOrderServiceProtocol,
          refundsService: POSRefundsServiceProtocol,
+         refundSubmissionProcessor: POSRefundSubmissionProcessing,
          onPointOfSaleModeActiveStateChange: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
          receiptService: POSReceiptServiceProtocol,
@@ -117,6 +118,7 @@ public struct PointOfSaleEntryPointView: View {
                                                                     fetchStrategyFactory: couponFetchStrategyFactory,
                                                                     analyticsProvider: services.analytics)
         self.cardPresentPaymentService = cardPresentPaymentService
+        self.refundSubmissionProcessor = refundSubmissionProcessor
         let receiptSender = POSReceiptSender(siteID: siteID,
                                              orderService: orderService,
                                              receiptService: receiptService,
@@ -147,10 +149,11 @@ public struct PointOfSaleEntryPointView: View {
         self.posEntryPointController = POSEntryPointController(eligibilityChecker: posEligibilityChecker)
         let ordersController = POSOrderListController(orderListFetchStrategyFactory: orderListFetchStrategyFactory,
                                                       refundsService: refundsService,
-                                                      featureFlags: services.featureFlags,
-                                                      currencySettingsProvider: services.currency,
-                                                      currencyFormatter: CurrencyFormatter(currencySettings: services.currency.currencySettings))
-        self.orderListModel = POSOrderListModel(ordersController: ordersController, receiptSender: receiptSender)
+                                                      refundSubmissionProcessor: refundSubmissionProcessor,
+                                                      featureFlags: services.featureFlags)
+        self.orderListModel = POSOrderListModel(ordersController: ordersController,
+                                                receiptSender: receiptSender,
+                                                refundSubmissionModel: refundSubmissionProcessor.stateModel)
         if isLocalCatalogEligible, let grdbManager {
             self.cartProductObserver = POSCartProductObserver(
                 siteID: siteID,
@@ -220,6 +223,7 @@ public struct PointOfSaleEntryPointView: View {
         .environmentObject(posSheetManager)
         .environmentObject(posCoverManager)
         .environment(orderListModel)
+        .environment(orderListModel.refundSubmissionModel)
         .environment(\.siteTimezone, siteTimezone)
         .environment(\.posLayoutScale, horizontalSizeClass == .compact ? .phone : .tablet)
         .injectKeyboardObserver()
@@ -245,6 +249,7 @@ public struct PointOfSaleEntryPointView: View {
         orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryPreview(),
         orderService: POSOrderServicePreview(),
         refundsService: POSRefundsServicePreview(),
+        refundSubmissionProcessor: POSNoOpRefundSubmissionProcessor(),
         onPointOfSaleModeActiveStateChange: { _ in },
         cardPresentPaymentService: CardPresentPaymentPreviewService(),
         receiptService: POSReceiptServicePreview(),

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -261,7 +261,8 @@ struct POSPreviewHelpers {
     static func makePreviewOrdersModel(state: POSOrderListState) -> POSOrderListModel {
         return POSOrderListModel(
             ordersController: POSConfigurablePreviewOrderListController(state: state),
-            receiptSender: POSReceiptSenderPreview())
+            receiptSender: POSReceiptSenderPreview(),
+            refundSubmissionModel: POSRefundSubmissionModel())
     }
 
     static func makePreviewOrders() -> [POSOrder] {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -26,11 +26,12 @@ final class POSOrderListControllerTests {
     private lazy var featureFlags = MockFeatureFlagService()
     private lazy var currencySettingsProvider = MockCurrencySettingsProvider()
     private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettingsProvider.currencySettings)
+    private lazy var refundSubmissionProcessor = MockPOSRefundSubmissionProcessor(refundsService: refundsService,
+                                                                                  currencyFormatter: currencyFormatter)
     private lazy var sut = POSOrderListController(orderListFetchStrategyFactory: fetchStrategyFactory,
                                                    refundsService: refundsService,
-                                                   featureFlags: featureFlags,
-                                                   currencySettingsProvider: currencySettingsProvider,
-                                                   currencyFormatter: currencyFormatter)
+                                                   refundSubmissionProcessor: refundSubmissionProcessor,
+                                                   featureFlags: featureFlags)
 
     @Test func loadOrders_requests_first_page_after_loading_two_pages() async throws {
         try #require(sut.ordersViewState.isLoading)
@@ -1553,14 +1554,13 @@ final class POSOrderListControllerTests {
 
 private extension POSOrderListControllerTests {
     func makeController(currencySettings: CurrencySettings) -> POSOrderListController {
-        let provider = MockCurrencySettingsProvider(currencySettings: currencySettings)
         let formatter = CurrencyFormatter(currencySettings: currencySettings)
         return POSOrderListController(
             orderListFetchStrategyFactory: fetchStrategyFactory,
             refundsService: refundsService,
-            featureFlags: featureFlags,
-            currencySettingsProvider: provider,
-            currencyFormatter: formatter
+            refundSubmissionProcessor: MockPOSRefundSubmissionProcessor(refundsService: refundsService,
+                                                                        currencyFormatter: formatter),
+            featureFlags: featureFlags
         )
     }
 
@@ -1632,5 +1632,104 @@ private extension POSOrderListControllerTests {
             imageSrc: imageSrc,
             attributes: attributes
         )
+    }
+}
+
+private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcessing {
+    let stateModel = POSRefundSubmissionModel()
+
+    nonisolated(unsafe) private let refundsService: MockPOSRefundsService
+    nonisolated(unsafe) private let currencyFormatter: CurrencyFormatter
+    private var refundResultsByOrderID: [Int64: POSRefundsResult] = [:]
+
+    nonisolated init(refundsService: MockPOSRefundsService,
+                     currencyFormatter: CurrencyFormatter) {
+        self.refundsService = refundsService
+        self.currencyFormatter = currencyFormatter
+    }
+
+    func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
+        let refundsResult = try await refundsService.providePointOfSaleRefunds(for: order)
+        refundResultsByOrderID[order.id] = refundsResult
+
+        let refundedQuantitiesByItemID = refundsResult.refunds.flatMap(\.items).refundedQuantitiesByItemID()
+        let productSelectables = order.lineItems.flatMap { item -> [POSRefundSelectableItem] in
+            let originalQuantity = NSDecimalNumber(decimal: item.quantity).intValue
+            let refundedQuantity = refundedQuantitiesByItemID[item.itemID] ?? 0
+            let availableQuantity = originalQuantity - refundedQuantity
+            guard availableQuantity > 0 else { return [] }
+
+            return (0..<availableQuantity).map { index in
+                POSRefundSelectableItem(from: item, isSelected: true, index: index)
+            }
+        }
+
+        let alreadyRefundedItemIDs = Set(refundsResult.refunds.flatMap(\.items).compactMap(\.refundedItemID))
+        let feeSelectables = order.customAmounts
+            .filter { !alreadyRefundedItemIDs.contains($0.id) }
+            .map { POSRefundSelectableItem(from: $0, isSelected: true) }
+
+        return POSRefundPreparation(
+            orderID: order.id,
+            selectableItems: productSelectables + feeSelectables,
+            paymentMethodDescription: String(format: "Via %@", order.paymentMethodTitle),
+            customerEmail: order.customerEmail
+        )
+    }
+
+    func prepareReviewData(for order: POSOrder,
+                           preparation: POSRefundPreparation,
+                           selectedItems: [POSRefundSelectableItem],
+                           reason: String?) -> POSRefundReviewData? {
+        let refundableItems = selectedItems.map { item in
+            POSRefundableItem(
+                itemID: item.itemID,
+                lineItemTotal: item.lineItemTotal,
+                totalTax: item.totalTax,
+                originalQuantity: item.originalQuantity,
+                isLumpSum: item.isLumpSum
+            )
+        }
+
+        let amounts = refundsService.calculateRefundAmounts(for: refundableItems)
+        guard let formattedSubtotal = currencyFormatter.formatAmount(amounts.subtotal),
+              let formattedTax = currencyFormatter.formatAmount(amounts.tax),
+              let formattedTotal = currencyFormatter.formatAmount(amounts.total) else {
+            return nil
+        }
+
+        return POSRefundReviewData(
+            itemsCount: selectedItems.count,
+            formattedItemsSubtotal: formattedSubtotal,
+            formattedTax: formattedTax,
+            formattedRefundTotal: formattedTotal,
+            paymentMethodDescription: preparation.paymentMethodDescription,
+            customerEmail: preparation.customerEmail,
+            refundReason: reason,
+            isFullRefund: selectedItems.count == preparation.selectableItems.count
+        )
+    }
+
+    func submitRefund(for order: POSOrder,
+                      preparation: POSRefundPreparation,
+                      selectedItems: [POSRefundSelectableItem],
+                      reason: String?) async throws {
+        let refundableItems = selectedItems.map { item in
+            POSRefundableItem(
+                itemID: item.itemID,
+                lineItemTotal: item.lineItemTotal,
+                totalTax: item.totalTax,
+                originalQuantity: item.originalQuantity,
+                isLumpSum: item.isLumpSum
+            )
+        }
+
+        try await refundsService.createRefund(
+            orderID: order.id,
+            items: refundableItems,
+            reason: reason,
+            isAutomaticRefund: refundResultsByOrderID[preparation.orderID]?.supportsAutomaticRefund ?? true
+        )
+        stateModel.state = .completed
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1672,7 +1672,7 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
         return POSRefundPreparation(
             orderID: order.id,
             selectableItems: productSelectables + feeSelectables,
-            paymentMethodDescription: String(format: "Via %@", order.paymentMethodTitle),
+            paymentMethodDescription: String(format: "via %1$@", order.paymentMethodTitle),
             customerEmail: order.customerEmail
         )
     }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -875,7 +875,7 @@ final class POSOrderListControllerTests {
         _ = await sut.startRefundFlow()
 
         // Then
-        #expect(sut.preparePOSRefundReviewData()?.paymentMethodDescription == "Via WooCommerce In-Person Payments")
+        #expect(sut.preparePOSRefundReviewData()?.paymentMethodDescription == "via WooCommerce In-Person Payments")
     }
 
     @MainActor

--- a/Modules/Tests/PointOfSaleTests/Models/POSOrderListModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/POSOrderListModelTests.swift
@@ -9,7 +9,8 @@ final class POSOrderListModelTests {
     private let mockReceiptSender = MockPOSReceiptSender()
     private lazy var sut = POSOrderListModel(
         ordersController: mockOrdersController,
-        receiptSender: mockReceiptSender
+        receiptSender: mockReceiptSender,
+        refundSubmissionModel: POSRefundSubmissionModel()
     )
 
     @Test func sendReceipt_when_successful_then_calls_receipt_controller_and_updates_order() async throws {

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -304,6 +304,7 @@ private extension POSTabCoordinator {
                     ),
                     orderService: orderService,
                     refundsService: refundsService,
+                    refundSubmissionProcessor: POSNoOpRefundSubmissionProcessor(),
                     onPointOfSaleModeActiveStateChange: { [weak self] isEnabled in
                         self?.updateDefaultConfigurationForPointOfSale(isEnabled)
                     },

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -8,7 +8,9 @@ final class MockOrderDetailsPaymentAlerts {
     var cancelPreparingReaderAlert: (() -> Void)?
 
     var cancelTapOrInsertCardAlert: (() -> Void)?
+    var cancelCardInsertedAlert: (() -> Void)?
 
+    var cardInsertedWasCalled = false
     var error: Error?
     var retryFromError: (() -> Void)?
     var dismissErrorCompletion: (() -> Void)?
@@ -30,6 +32,11 @@ extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
 
     func tapOrInsertCard(title: String, amount: String, inputMethods: Yosemite.CardReaderInput, onCancel: @escaping () -> Void) {
         cancelTapOrInsertCardAlert = onCancel
+    }
+
+    func cardInserted(title: String, amount: String, onCancel: @escaping () -> Void) {
+        cardInsertedWasCalled = true
+        cancelCardInsertedAlert = onCancel
     }
 
     func displayReaderMessage(message: String) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -463,7 +463,7 @@ private extension RefundSubmissionUseCaseTests {
 
         return RefundSubmissionUseCase(
             details: details,
-            rootViewController: .init(),
+            rootViewController: UIViewController(),
             alerts: alerts,
             cardPresentConfiguration: Mocks.configuration,
             cardReaderConnectionAlerts: cardReaderConnectionAlerts,


### PR DESCRIPTION
Part of: RSM-645

## Description
Adds a small POS refund submission facade so the POS order list can delegate refund submission instead of owning the submission details directly. This keeps the Point of Sale module decoupled from the app-side refund implementation while setting up the later adaptor work.

## Test Steps
Automated coverage should be enough for this slice; manual testing is more useful once the card-present flow is wired in later PRs.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.