### PR TITLE
RSM-644/RSM-645 Enable Canadian POS Interac support

### DIFF
--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
@@ -10,16 +10,16 @@ import enum WooFoundation.CurrencyCode
 /// are temporary, the cache is a coarse per-site Boolean: the refresher decides
 /// which remote flag controls the current store country, then this validator
 /// applies the cached result to the set of countries that are still gated.
-/// US/PR/GB are always supported.
+/// US/PR/GB/CA are always supported.
 public enum POSCountryCurrencyValidator {
     /// Supported countries for POS feature.
-    /// Always includes US, PR, and GB. Gated countries are added when the supplied
+    /// Always includes US, PR, GB, and CA. Gated countries are added when the supplied
     /// eligibility service reports the current site country as eligible.
     public static func supportedCountries(
         siteID: Int64,
         eligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
     ) -> [CountryCode] {
-        var countries: [CountryCode] = [.US, .PR, .GB]
+        var countries: [CountryCode] = [.US, .PR, .GB, .CA]
         if eligibilityService.isEligible(siteID: siteID) {
             countries.append(contentsOf: remoteFlagGatedCountries)
         }
@@ -27,7 +27,7 @@ public enum POSCountryCurrencyValidator {
     }
 
     /// Supported currencies per country for POS feature.
-    /// Always includes US/USD, PR/USD, and GB/GBP. Gated entries are added when the supplied
+    /// Always includes US/USD, PR/USD, GB/GBP, and CA/CAD. Gated entries are added when the supplied
     /// eligibility service reports the current site country as eligible.
     public static func supportedCurrencies(
         siteID: Int64,
@@ -36,7 +36,8 @@ public enum POSCountryCurrencyValidator {
         var map: [CountryCode: [CurrencyCode]] = [
             .US: [.USD],
             .PR: [.USD],
-            .GB: [.GBP]
+            .GB: [.GBP],
+            .CA: [.CAD]
         ]
         if eligibilityService.isEligible(siteID: siteID) {
             for country in eeaEuroCountries {

--- a/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
@@ -39,27 +39,17 @@ struct POSCountryCurrencyValidatorTests {
         #expect(result == .eligible)
     }
 
-    // MARK: - Unsupported Countries (cached country eligibility off)
-
-    @Test("CA with USD is ineligible due to unsupported country when cached country eligibility is off")
-    func testCAWithUSDIsIneligible() {
+    @Test("CA with CAD is eligible without cached country eligibility")
+    func testCAWithCADIsEligible() {
         let result = POSCountryCurrencyValidator.validate(countryCode: .CA,
-                                                          currencyCode: .USD,
+                                                          currencyCode: .CAD,
                                                           siteID: siteID,
                                                           eligibilityService: ineligibleService)
 
-        guard case .ineligible(let reason) = result else {
-            Issue.record("Expected ineligible result")
-            return
-        }
-        guard case .unsupportedCountry(let supportedCountries) = reason else {
-            Issue.record("Expected unsupportedCountry reason")
-            return
-        }
-        #expect(supportedCountries.contains(.US))
-        #expect(supportedCountries.contains(.GB))
-        #expect(!supportedCountries.contains(.CA))
+        #expect(result == .eligible)
     }
+
+    // MARK: - Unsupported Countries (cached country eligibility off)
 
     @Test("AU with AUD is ineligible due to unsupported country when cached country eligibility is off")
     func testAUWithAUDIsIneligibleWhenCachedCountryEligibilityOff() {
@@ -166,15 +156,35 @@ struct POSCountryCurrencyValidatorTests {
         #expect(supportedCurrencies == [.GBP])
     }
 
+    @Test("CA with USD is ineligible due to unsupported currency")
+    func testCAWithUSDIsIneligible() {
+        let result = POSCountryCurrencyValidator.validate(countryCode: .CA,
+                                                          currencyCode: .USD,
+                                                          siteID: siteID,
+                                                          eligibilityService: ineligibleService)
+
+        guard case .ineligible(let reason) = result else {
+            Issue.record("Expected ineligible result")
+            return
+        }
+        guard case .unsupportedCurrency(let countryCode, let supportedCurrencies) = reason else {
+            Issue.record("Expected unsupportedCurrency reason")
+            return
+        }
+        #expect(countryCode == .CA)
+        #expect(supportedCurrencies == [.CAD])
+    }
+
     // MARK: - Supported Countries List
 
-    @Test("Supported countries list contains only US, PR, and GB when cached country eligibility is off")
+    @Test("Supported countries list contains only US, PR, GB, and CA when cached country eligibility is off")
     func testSupportedCountriesList() {
         let supportedCountries = POSCountryCurrencyValidator.supportedCountries(siteID: siteID, eligibilityService: ineligibleService)
-        #expect(supportedCountries.count == 3)
+        #expect(supportedCountries.count == 4)
         #expect(supportedCountries.contains(.US))
         #expect(supportedCountries.contains(.PR))
         #expect(supportedCountries.contains(.GB))
+        #expect(supportedCountries.contains(.CA))
     }
 
     @Test("Supported countries list includes the validator's gated-country set when the current site country is eligible")
@@ -184,6 +194,7 @@ struct POSCountryCurrencyValidatorTests {
         #expect(supportedCountries.contains(.US))
         #expect(supportedCountries.contains(.PR))
         #expect(supportedCountries.contains(.GB))
+        #expect(supportedCountries.contains(.CA))
         for country in validatorGatedCountrySet {
             #expect(supportedCountries.contains(country), "Expected \(country) to be present in the validator's gated-country set")
         }
@@ -191,14 +202,14 @@ struct POSCountryCurrencyValidatorTests {
 
     // MARK: - Supported Currencies Map
 
-    @Test("Supported currencies map only contains US, PR, and GB entries when cached country eligibility is off")
+    @Test("Supported currencies map only contains US, PR, GB, and CA entries when cached country eligibility is off")
     func testSupportedCurrenciesMap() {
         let supportedCurrencies = POSCountryCurrencyValidator.supportedCurrencies(siteID: siteID, eligibilityService: ineligibleService)
 
         #expect(supportedCurrencies[.US] == [.USD])
         #expect(supportedCurrencies[.PR] == [.USD])
         #expect(supportedCurrencies[.GB] == [.GBP])
-        #expect(supportedCurrencies[.CA] == nil)
+        #expect(supportedCurrencies[.CA] == [.CAD])
         #expect(supportedCurrencies[.AT] == nil)
         #expect(supportedCurrencies[.SG] == nil)
         #expect(supportedCurrencies[.NZ] == nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -102,7 +102,8 @@ struct POSTabEligibilityCheckerTests {
     @Test(arguments: [
         (country: Country.us, currency: CurrencyCode.USD),
         (country: Country.pr, currency: CurrencyCode.USD),
-        (country: Country.gb, currency: CurrencyCode.GBP)
+        (country: Country.gb, currency: CurrencyCode.GBP),
+        (country: Country.ca, currency: CurrencyCode.CAD)
     ])
     fileprivate func is_eligible_when_all_conditions_satisfied(country: Country, currency: CurrencyCode) async throws {
         // Given
@@ -120,7 +121,6 @@ struct POSTabEligibilityCheckerTests {
     }
 
     @Test(arguments: [
-        (country: Country.ca, currency: CurrencyCode.CAD),
         (country: Country.es, currency: CurrencyCode.EUR)
     ])
     fileprivate func is_ineligible_when_country_is_not_supported(country: Country, currency: CurrencyCode) async throws {
@@ -143,7 +143,8 @@ struct POSTabEligibilityCheckerTests {
         (country: Country.us, currency: CurrencyCode.GBP, expectedSupportedCurrencies: [CurrencyCode.USD]),
         (country: Country.us, currency: CurrencyCode.CAD, expectedSupportedCurrencies: [CurrencyCode.USD]),
         (country: Country.gb, currency: CurrencyCode.EUR, expectedSupportedCurrencies: [CurrencyCode.GBP]),
-        (country: Country.gb, currency: CurrencyCode.USD, expectedSupportedCurrencies: [CurrencyCode.GBP])
+        (country: Country.gb, currency: CurrencyCode.USD, expectedSupportedCurrencies: [CurrencyCode.GBP]),
+        (country: Country.ca, currency: CurrencyCode.USD, expectedSupportedCurrencies: [CurrencyCode.CAD])
     ])
     fileprivate func is_ineligible_when_currency_is_not_supported(country: Country,
                                                                   currency: CurrencyCode,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -30,7 +30,8 @@ struct POSTabVisibilityCheckerTests {
     @Test(arguments: [
         (country: Country.us, currency: CurrencyCode.USD),
         (country: Country.pr, currency: CurrencyCode.USD),
-        (country: Country.gb, currency: CurrencyCode.GBP)
+        (country: Country.gb, currency: CurrencyCode.GBP),
+        (country: Country.ca, currency: CurrencyCode.CAD)
     ])
     fileprivate func is_visible_when_all_conditions_satisfied(country: Country, currency: CurrencyCode) async throws {
         // Given
@@ -51,7 +52,6 @@ struct POSTabVisibilityCheckerTests {
     }
 
     @Test(arguments: [
-        (country: Country.ca, currency: CurrencyCode.CAD),
         (country: Country.es, currency: CurrencyCode.EUR),
         (country: Country.au, currency: CurrencyCode.AUD)
     ])
@@ -78,7 +78,8 @@ struct POSTabVisibilityCheckerTests {
         (country: Country.us, currency: CurrencyCode.GBP),
         (country: Country.us, currency: CurrencyCode.CAD),
         (country: Country.gb, currency: CurrencyCode.EUR),
-        (country: Country.gb, currency: CurrencyCode.USD)
+        (country: Country.gb, currency: CurrencyCode.USD),
+        (country: Country.ca, currency: CurrencyCode.USD)
     ])
     fileprivate func is_visible_when_currency_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
@@ -224,10 +225,10 @@ struct POSTabVisibilityCheckerTests {
             mockCountrySetting(country: .us),
             mockCurrencySetting(currency: .USD)
         ]
-        // New settings - makes site ineligible (Canada).
+        // New settings - makes site ineligible (unsupported expansion country).
         let newSettings = [
-            mockCountrySetting(country: .ca),
-            mockCurrencySetting(currency: .USD)
+            mockCountrySetting(country: .es),
+            mockCurrencySetting(currency: .EUR)
         ]
         siteSettings.mockSettingsStream = [
             // Emits cached settings first (should be skipped).
@@ -246,7 +247,7 @@ struct POSTabVisibilityCheckerTests {
         // When
         let result = await checker.checkVisibility()
 
-        // Then - Should be invisible because fresh settings show CA (not cached US)
+        // Then - Should be invisible because fresh settings show unsupported ES (not cached US)
         #expect(result == false)
     }
 


### PR DESCRIPTION
Part of: RSM-644
Part of: RSM-645

## Description
Enables Canadian POS eligibility so the Interac payment and refund paths can be exercised in POS. This is the shared country/currency support layer for the rest of the stack.

## Test Steps
No focused manual pass needed here beyond confirming the full stack in a Canadian CAD store.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.