### PR TITLE
RSM-645 Handle POS refund reader insert and PIN transitions

### DIFF
--- a/Modules/Sources/Hardware/CardReader/CardReaderEvent.swift
+++ b/Modules/Sources/Hardware/CardReader/CardReaderEvent.swift
@@ -9,6 +9,9 @@ public enum CardReaderEvent: Equatable {
     /// the app should instruct the user to present the card again by swiping it.
     case displayMessage(String)
 
+    /// The reader has accepted cardholder input and the card can be removed.
+    case removeCardRequested(String)
+
     /// A card was inserted.
     case cardInserted
 

--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/CardReaderEvent+Stripe.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/CardReaderEvent+Stripe.swift
@@ -12,7 +12,12 @@ extension CardReaderEvent {
     /// Factory method
     /// - Parameter readerInputOptions: An instance of a StripeTerminal.ReaderDisplayMessage
     static func make(displayMessage: ReaderDisplayMessage) -> Self {
-        return .displayMessage(displayMessage.localizedMessage)
+        switch displayMessage {
+        case .removeCard:
+            return .removeCardRequested(displayMessage.localizedMessage)
+        default:
+            return .displayMessage(displayMessage.localizedMessage)
+        }
     }
 }
 #endif

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
@@ -23,6 +23,10 @@ final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtoco
         present(alertsProvider.tapOrInsertCard(title: title, amount: amount, inputMethods: inputMethods, onCancel: onCancel))
     }
 
+    func cardInserted(title: String, amount: String, onCancel: @escaping () -> Void) {
+        present(alertsProvider.cardInserted(title: title, amount: amount, onCancel: onCancel))
+    }
+
     func displayReaderMessage(message: String) {
         present(alertsProvider.displayReaderMessage(message: message))
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -21,6 +21,7 @@ final class CardPresentRefundOrchestrator {
     ///   - charge: details about how the order was charged to verify refund.
     ///   - paymentGatewayAccount: payment gateway (e.g. WCPay or Stripe extension).
     ///   - onWaitingForInput: called when the card reader is waiting for card input.
+    ///   - onCardInserted: called when a card is inserted into the reader.
     ///   - onProcessingMessage: called when the refund is processing.
     ///   - onDisplayMessage: called when the card reader sends a message to display to the user.
     ///   - onCompletion: called when the refund completes.
@@ -28,6 +29,7 @@ final class CardPresentRefundOrchestrator {
                 charge: WCPayCharge,
                 paymentGatewayAccount: PaymentGatewayAccount,
                 onWaitingForInput: @escaping (CardReaderInput) -> Void,
+                onCardInserted: @escaping () -> Void,
                 onProcessingMessage: @escaping () -> Void,
                 onDisplayMessage: @escaping (String) -> Void,
                 onCompletion: @escaping (Result<Void, Error>) -> Void) {
@@ -44,6 +46,10 @@ final class CardPresentRefundOrchestrator {
                 onWaitingForInput(inputMethods)
             case .displayMessage(let message):
                 onDisplayMessage(message)
+            case .removeCardRequested:
+                onProcessingMessage()
+            case .cardInserted:
+                onCardInserted()
             case .cardDetailsCollected:
                 onProcessingMessage()
             default:

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -119,6 +119,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                     onWaitingForInput(inputMethods)
                 case .displayMessage(let message):
                     onDisplayMessage(message)
+                case .removeCardRequested(let message):
+                    onDisplayMessage(message)
                 case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
                     onProcessingMessage()
                 case .cardInserted:
@@ -161,6 +163,8 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                 case .waitingForInput(let inputMethods):
                     handlers.onWaitingForInput(inputMethods)
                 case .displayMessage(let message):
+                    handlers.onDisplayMessage(message)
+                case .removeCardRequested(let message):
                     handlers.onDisplayMessage(message)
                 case .cardDetailsCollected, .cardRemovedAfterClientSidePaymentCapture:
                     handlers.onProcessingMessage()

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -64,6 +64,15 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
         presentViewModel(viewModel: viewModel)
     }
 
+    func cardInserted(title: String,
+                      amount: String,
+                      onCancel: @escaping () -> Void) {
+        let viewModel = alertsProvider.cardInserted(title: title,
+                                                    amount: amount,
+                                                    onCancel: onCancel)
+        presentViewModel(viewModel: viewModel)
+    }
+
     func displayReaderMessage(message: String) {
         let viewModel = alertsProvider.displayReaderMessage(message: message)
         presentViewModel(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlertsProtocol.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlertsProtocol.swift
@@ -9,6 +9,8 @@ protocol OrderDetailsPaymentAlertsProtocol {
 
     func tapOrInsertCard(title: String, amount: String, inputMethods: CardReaderInput, onCancel: @escaping () -> Void)
 
+    func cardInserted(title: String, amount: String, onCancel: @escaping () -> Void)
+
     func displayReaderMessage(message: String)
 
     func processingPayment(title: String)

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -321,6 +321,13 @@ private extension RefundSubmissionUseCase {
                                         onCancel: { [weak self] in
                 self?.cancelRefund(charge: charge, paymentGatewayAccount: paymentGatewayAccount, onCompletion: onCompletion)
             })
+        }, onCardInserted: { [weak self] in
+            guard let self else { return }
+            self.alerts.cardInserted(title: RefundSubmissionUseCaseDefinitions.Localization.refundPaymentTitle(username: self.order.billingAddress?.firstName),
+                                     amount: self.formattedAmount,
+                                     onCancel: { [weak self] in
+                self?.cancelRefund(charge: charge, paymentGatewayAccount: paymentGatewayAccount, onCompletion: onCompletion)
+            })
         }, onProcessingMessage: { [weak self] in
             // Shows waiting message.
             self?.alerts.processingPayment(

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -11,6 +11,8 @@ final class MockOrderDetailsPaymentAlerts {
     var cancelCardInsertedAlert: (() -> Void)?
 
     var cardInsertedWasCalled = false
+    var displayReaderMessageWasCalled = false
+    var processingPaymentWasCalled = false
     var error: Error?
     var retryFromError: (() -> Void)?
     var dismissErrorCompletion: (() -> Void)?
@@ -40,11 +42,11 @@ extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     }
 
     func displayReaderMessage(message: String) {
-        // no-op
+        displayReaderMessageWasCalled = true
     }
 
     func processingPayment(title: String) {
-        // no-op
+        processingPaymentWasCalled = true
     }
 
     func success(printReceipt: @escaping () -> Void, emailReceipt: @escaping () -> Void, noReceiptAction: @escaping () -> Void) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -9,6 +9,7 @@ import protocol Storage.StorageManagerType
 import protocol Storage.StorageType
 
 private typealias Dependencies = RefundSubmissionUseCase<MockCardReaderSettingsAlerts, MockCardPresentPaymentAlertsPresenter>.Dependencies
+private typealias RefundDetails = RefundSubmissionUseCase<MockCardReaderSettingsAlerts, MockCardPresentPaymentAlertsPresenter>.Details
 
 final class RefundSubmissionUseCaseTests: XCTestCase {
     private var stores: MockStoresManager!
@@ -88,6 +89,43 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(stores.receivedActions.contains(where: { $0 is CardPresentPaymentAction }))
+    }
+
+    func test_submitRefund_with_cardInserted_reader_event_shows_cardInserted_alert() {
+        // Given
+        let useCase = createUseCase(details: interacRefundDetails())
+        mockCardPresentPaymentActions(returnCardReaderMessage: .cardInserted)
+        mockServerSideRefund(result: .success(()))
+
+        // When
+        let result = waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertTrue(alerts.cardInsertedWasCalled)
+    }
+
+    func test_submitRefund_with_removeCardRequested_reader_event_shows_processing_alert() {
+        // Given
+        let useCase = createUseCase(details: interacRefundDetails())
+        mockCardPresentPaymentActions(returnCardReaderMessage: .removeCardRequested("Remove card"))
+        mockServerSideRefund(result: .success(()))
+
+        // When
+        let result = waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertTrue(alerts.processingPaymentWasCalled)
+        XCTAssertFalse(alerts.displayReaderMessageWasCalled)
     }
 
     func test_submitRefund_with_non_interac_payment_method_does_not_call_showOnboardingIfRequired() throws {
@@ -393,6 +431,19 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 }
 
 private extension RefundSubmissionUseCaseTests {
+    func interacRefundDetails(siteID: Int64 = Mocks.siteID) -> RefundDetails {
+        .init(order: .fake().copy(siteID: siteID, total: "2.28"),
+              charge: .fake().copy(paymentMethodDetails: .interacPresent(
+                details: .init(brand: .visa,
+                               last4: "9969",
+                               funding: .credit,
+                               receipt: .init(accountType: .credit,
+                                              applicationPreferredName: "Stripe Credit",
+                                              dedicatedFileName: "A000000003101001")))),
+              amount: "2.28",
+              paymentGatewayAccount: createPaymentGatewayAccount(siteID: siteID))
+    }
+
     func mockServerSideRefund(result: Result<Void, Error>) {
         stores.whenReceivingAction(ofType: RefundAction.self) { action in
             if case let .createRefund(_, _, _, completion) = action {


### PR DESCRIPTION
Part of: RSM-645

## Description
Updates card-present refund messaging for inserted-card and PIN-entry reader events so POS can reflect the shopper-facing Interac refund state more accurately.

## Test Steps
No separate manual pass needed here; test the reader flow after the connection prompt PR is applied.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.