### PR TITLE
RSM-645 Preload POS refund preparation

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -34,6 +34,7 @@ protocol POSOrderListControllerProtocol {
     func loadNextOrders() async
     func selectOrder(_ order: POSOrder?)
     func updateOrder(orderID: Int64) async throws
+    func preloadRefundDetails() async
     func startRefundFlow() async -> StartRefundFlowResult
     func toggleRefundItemSelection(at index: Int)
     func clearRefundSelection()
@@ -308,6 +309,15 @@ enum RefundActionAvailability {
     }
 
     // MARK: - Refund Item Selection
+
+    @MainActor
+    func preloadRefundDetails() async {
+        guard refundActionAvailability == .available,
+              let order = selectedOrder else {
+            return
+        }
+        await refundSubmissionProcessor.preloadRefund(for: order)
+    }
 
     @MainActor
     func startRefundFlow() async -> StartRefundFlowResult {

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
@@ -57,6 +57,8 @@ public enum POSRefundSubmissionError: Error, Equatable {
 public protocol POSRefundSubmissionProcessing: AnyObject {
     var stateModel: POSRefundSubmissionModel { get }
 
+    func preloadRefund(for order: POSOrder) async
+
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation
 
     func prepareReviewData(for order: POSOrder,
@@ -74,6 +76,8 @@ public final class POSNoOpRefundSubmissionProcessor: POSRefundSubmissionProcessi
     public let stateModel = POSRefundSubmissionModel()
 
     public nonisolated init() {}
+
+    public func preloadRefund(for order: POSOrder) async {}
 
     public func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
         POSRefundPreparation(orderID: order.id,

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -179,6 +179,9 @@ struct POSOrderDetailsView: View {
             guard shouldShowDedicatedRefundsSection else { return }
             await orderListModel.ordersController.loadOrderRefunds()
         }
+        .task {
+            await orderListModel.ordersController.preloadRefundDetails()
+        }
         .onAppear {
             if autoStartNextRefundFlow {
                 autoStartNextRefundFlow = false

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -532,6 +532,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     func refreshOrders() async {}
     func selectOrder(_ order: POSOrder?) {}
     func updateOrder(orderID: Int64) async throws {}
+    func preloadRefundDetails() async {}
     func searchOrders(searchTerm: String) async {}
     func clearSearchOrders() {}
     func startRefundFlow() async -> StartRefundFlowResult { .hasItemsToRefund }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -438,6 +438,39 @@ final class POSOrderListControllerTests {
     // MARK: - Refund Item Selection Tests
 
     @MainActor
+    @Test func preloadRefundDetails_when_refund_is_available_then_preloads_without_opening_refund_flow() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let order = makeOrder(id: 1, status: .completed)
+        sut.selectOrder(order)
+
+        // When
+        await sut.preloadRefundDetails()
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs == [order.id])
+        #expect(sut.refundSelectableItems.isEmpty)
+        guard case .idle = sut.selectedOrderRefundsState else {
+            Issue.record("Preloading should not move the visible refund flow state.")
+            return
+        }
+    }
+
+    @MainActor
+    @Test func preloadRefundDetails_when_refund_is_unavailable_then_does_not_preload() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let order = makeOrder(id: 1, status: .processing)
+        sut.selectOrder(order)
+
+        // When
+        await sut.preloadRefundDetails()
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs.isEmpty)
+    }
+
+    @MainActor
     @Test func startRefundFlow_when_product_has_multiple_quantities_then_creates_one_row_per_unit() async throws {
         // Given
         let order = makeOrder(lineItems: [
@@ -1739,6 +1772,12 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
                      currencyFormatter: CurrencyFormatter) {
         self.refundsService = refundsService
         self.currencyFormatter = currencyFormatter
+    }
+
+    private(set) var preloadedOrderIDs: [Int64] = []
+
+    func preloadRefund(for order: POSOrder) async {
+        preloadedOrderIDs.append(order.id)
     }
 
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -43,6 +43,8 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         }
     }
 
+    func preloadRefundDetails() async {}
+
     func searchOrders(searchTerm: String) async {}
 
     func clearSearchOrders() {}

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -10,6 +10,11 @@ import WooFoundation
 final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     let stateModel = POSRefundSubmissionModel()
 
+    private struct PreparedRefundSnapshot {
+        let preparation: POSRefundPreparation
+        let context: POSRefundSubmissionMapping.PreparedRefundContext
+    }
+
     private let orderService: POSOrderServiceProtocol
     private let stores: StoresManager
     private let storageManager: StorageManagerType
@@ -19,6 +24,8 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     private let analytics: Analytics
     private let refundOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol
 
+    private var preloadedRefundSnapshots: [Int64: PreparedRefundSnapshot] = [:]
+    private var preloadTasks: [Int64: (id: UUID, task: Task<PreparedRefundSnapshot, Error>)] = [:]
     private var preparedContexts: [Int64: POSRefundSubmissionMapping.PreparedRefundContext] = [:]
     private var submissionUseCase: RefundSubmissionUseCase<CardPresentPaymentBluetoothReaderConnectionAlertsProvider, POSRefundCardPresentPaymentAlertsPresenter>?
     private var onboardingSubscription: AnyCancellable?
@@ -40,34 +47,45 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         self.refundOptionsDeterminer = refundOptionsDeterminer
     }
 
+    func preloadRefund(for order: POSOrder) async {
+        removePreloadedRefunds(except: order.id)
+
+        guard preloadedRefundSnapshots[order.id] == nil,
+              preloadTasks[order.id] == nil else {
+            return
+        }
+
+        let preloadID = UUID()
+        let preloadTask = Task { @MainActor in
+            try await loadPreparedRefundSnapshot(for: order)
+        }
+        preloadTasks[order.id] = (id: preloadID, task: preloadTask)
+
+        do {
+            let snapshot = try await preloadTask.value
+            guard preloadTasks[order.id]?.id == preloadID else {
+                return
+            }
+            preloadedRefundSnapshots[order.id] = snapshot
+            preloadTasks[order.id] = nil
+        } catch {
+            guard preloadTasks[order.id]?.id == preloadID else {
+                return
+            }
+            preloadTasks[order.id] = nil
+        }
+    }
+
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
         stateModel.state = .loading
+        defer {
+            stateModel.reset()
+        }
 
-        let fullOrder = try await orderService.loadOrder(orderID: order.id)
-        let refunds = try await loadDetailedRefunds(for: fullOrder)
-        let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
-        let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }
-        let paymentGateway = loadPaymentGateway(for: fullOrder)
-        let paymentGatewayAccount = await loadSelectedOrStoredPaymentGatewayAccount(for: fullOrder)
-        let refundableItems = refundOptionsDeterminer.determineRefundableOrderItems(from: fullOrder, with: refunds)
-        let refundableFees = refundMapping.determineRefundableFees(from: fullOrder, with: refunds)
-        let selectableItems = refundMapping.makeSelectableItems(refundableItems: refundableItems,
-                                                                fees: refundableFees,
-                                                                currency: fullOrder.currency)
-        let context = POSRefundSubmissionMapping.PreparedRefundContext(order: fullOrder,
-                                                                       charge: charge,
-                                                                       paymentGateway: paymentGateway,
-                                                                       paymentGatewayAccount: paymentGatewayAccount,
-                                                                       refundableItems: refundableItems,
-                                                                       refundableFees: refundableFees)
-        preparedContexts[fullOrder.orderID] = context
-        stateModel.reset()
+        let snapshot = try await preparedRefundSnapshot(for: order)
+        preparedContexts[snapshot.preparation.orderID] = snapshot.context
 
-        return POSRefundPreparation(orderID: fullOrder.orderID,
-                                    selectableItems: selectableItems,
-                                    paymentMethodDescription: refundMapping.paymentMethodDescription(for: fullOrder, charge: charge),
-                                    customerEmail: fullOrder.billingAddress?.email,
-                                    requiresCardPresentRefund: refundMapping.requiresCardPresentRefund(context: context))
+        return snapshot.preparation
     }
 
     func prepareReviewData(for order: POSOrder,
@@ -173,10 +191,62 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         }
 
         stateModel.state = requiresCardPresentRefund ? .submittingCardPresent : .completed
+        removePreloadedRefund(for: preparation.orderID)
     }
 }
 
 private extension POSRefundSubmissionAdaptor {
+    func removePreloadedRefund(for orderID: Int64) {
+        preloadedRefundSnapshots[orderID] = nil
+        preloadTasks[orderID]?.task.cancel()
+        preloadTasks[orderID] = nil
+    }
+
+    func removePreloadedRefunds(except orderID: Int64) {
+        preloadedRefundSnapshots = preloadedRefundSnapshots.filter { $0.key == orderID }
+        for preloadedOrderID in Array(preloadTasks.keys) where preloadedOrderID != orderID {
+            removePreloadedRefund(for: preloadedOrderID)
+        }
+    }
+
+    private func preparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
+        if let snapshot = preloadedRefundSnapshots.removeValue(forKey: order.id) {
+            return snapshot
+        }
+
+        if let preloadTask = preloadTasks.removeValue(forKey: order.id) {
+            return try await preloadTask.task.value
+        }
+
+        return try await loadPreparedRefundSnapshot(for: order)
+    }
+
+    private func loadPreparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
+        let fullOrder = try await orderService.loadOrder(orderID: order.id)
+        let refunds = try await loadDetailedRefunds(for: fullOrder)
+        let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
+        let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }
+        let paymentGateway = loadPaymentGateway(for: fullOrder)
+        let paymentGatewayAccount = await loadSelectedOrStoredPaymentGatewayAccount(for: fullOrder)
+        let refundableItems = refundOptionsDeterminer.determineRefundableOrderItems(from: fullOrder, with: refunds)
+        let refundableFees = refundMapping.determineRefundableFees(from: fullOrder, with: refunds)
+        let selectableItems = refundMapping.makeSelectableItems(refundableItems: refundableItems,
+                                                                fees: refundableFees,
+                                                                currency: fullOrder.currency)
+        let context = POSRefundSubmissionMapping.PreparedRefundContext(order: fullOrder,
+                                                                       charge: charge,
+                                                                       paymentGateway: paymentGateway,
+                                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                                       refundableItems: refundableItems,
+                                                                       refundableFees: refundableFees)
+        let preparation = POSRefundPreparation(orderID: fullOrder.orderID,
+                                               selectableItems: selectableItems,
+                                               paymentMethodDescription: refundMapping.paymentMethodDescription(for: fullOrder, charge: charge),
+                                               customerEmail: fullOrder.billingAddress?.email,
+                                               requiresCardPresentRefund: refundMapping.requiresCardPresentRefund(context: context))
+        return PreparedRefundSnapshot(preparation: preparation, context: context)
+    }
+
     func loadDetailedRefunds(for order: Order) async throws -> [Refund] {
         let refundIDs = order.refunds.map(\.refundID)
         if refundIDs.isNotEmpty {


### PR DESCRIPTION
Part of: RSM-645

## Description
Preloads the refund preparation details when an order is opened, without blocking order details or changing the app-side refund flow. This reduces the wait when the merchant chooses to start a refund.

## Test Steps
Recommended final checkpoint: run the top of the stack in a Canadian CAD store and complete a POS Interac refund end to end. It is also worth opening orders with refund preparation still loading or failing to confirm order details remain usable.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.