### PR TITLE
RSM-645 Render POS-native refund submission progress

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -4,24 +4,30 @@ struct POSRefundConfirmationView: View {
     let formattedRefundTotal: String
     let paymentMethodDescription: String
     let isProcessing: Bool
+    var submissionState: POSRefundSubmissionState = .idle
     let onClose: () -> Void
     let onConfirm: () -> Void
     let onBack: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Namespace private var paymentMessageNamespace
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
-            headerView
-            messageView
+            if shouldShowHeader {
+                headerView
+            }
+            if shouldShowMessageView {
+                messageView
+            }
             if isProcessing {
-                loadingSection
+                processingSection
             } else {
                 buttonsSection
             }
         }
-        .background(Color.posSurfaceBright)
+        .background(backgroundColor)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
     }
 }
@@ -37,18 +43,64 @@ private extension POSRefundConfirmationView {
                 .lineLimit(1)
                 .minimumScaleFactor(horizontalSizeClass == .compact ? 0.7 : 1.0)
             Spacer()
-            Button {
-                onClose()
-            } label: {
-                Text(Image(systemName: "xmark"))
-                    .font(.posButtonSymbolLarge)
+            if let closeAction = headerCloseAction {
+                Button {
+                    closeAction()
+                } label: {
+                    Text(Image(systemName: "xmark"))
+                        .font(.posButtonSymbolLarge)
+                }
+                .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
             }
-            .accessibilityLabel(Localization.closeButtonAccessibilityLabel)
-            .disabled(isProcessing)
-            .opacity(isProcessing ? 0.5 : 1.0)
         }
         .foregroundColor(Color.posOnSurface)
         .padding(POSPadding.xLarge)
+    }
+
+    var shouldShowHeader: Bool {
+        primaryBackgroundCardPresentMessageType == nil
+    }
+
+    var backgroundColor: Color {
+        primaryBackgroundCardPresentMessageType == nil ? .posSurfaceBright : .posPrimary
+    }
+
+    var primaryBackgroundCardPresentMessageType: POSRefundCardPresentMessageType? {
+        switch submissionState {
+        case .cardPresentEvent(let eventDetails):
+            guard let messageType = refundMessageType(for: eventDetails),
+                  messageType.usesPrimaryBackground else {
+                return nil
+            }
+            return messageType
+        case .processingReader:
+            return .processing(.processing)
+        case .displayingReaderMessage(let message):
+            return .displayReaderMessage(.displayReaderMessage(message))
+        case .idle, .loading, .onboarding, .preparingReader, .waitingForCard, .submitting, .retryableError, .nonRetryableError, .completed:
+            return nil
+        }
+    }
+
+    var headerCloseAction: (() -> Void)? {
+        guard isProcessing else {
+            return onClose
+        }
+        return processingCancelAction
+    }
+
+    var processingCancelAction: (() -> Void)? {
+        switch submissionState {
+        case .onboarding(_, let onCancel):
+            return onCancel
+        case .cardPresentEvent(let eventDetails):
+            return eventDetails.posRefundCancelAction
+        case .preparingReader(let cancel),
+                .waitingForCard(_, let cancel):
+            return cancel
+        case .idle, .loading, .processingReader, .displayingReaderMessage, .submitting, .retryableError, .nonRetryableError, .completed:
+            return nil
+        }
     }
 
     var messageView: some View {
@@ -63,6 +115,60 @@ private extension POSRefundConfirmationView {
             .padding(.horizontal, POSPadding.xLarge)
     }
 
+    var shouldShowMessageView: Bool {
+        switch submissionState {
+        case .onboarding, .cardPresentEvent, .preparingReader, .waitingForCard, .processingReader, .displayingReaderMessage:
+            return false
+        case .idle, .loading, .submitting, .retryableError, .nonRetryableError, .completed:
+            return true
+        }
+    }
+
+    @ViewBuilder
+    var processingSection: some View {
+        switch submissionState {
+        case .onboarding(let factory, let onCancel):
+            PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(
+                onboardingViewContainer: factory,
+                onDismissTap: onCancel))
+            .padding(POSPadding.xLarge)
+        case .cardPresentEvent(let eventDetails):
+            if let messageType = refundMessageType(for: eventDetails) {
+                cardPresentMessageView(messageType)
+            } else if let alertType = cardPresentAlertType(for: eventDetails) {
+                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                    .padding(POSPadding.xLarge)
+            } else {
+                loadingSection
+            }
+        case .preparingReader:
+            POSPaymentLoadingView(title: Localization.preparingReaderTitle,
+                                  message: Localization.preparingReaderMessage,
+                                  animation: .init(namespace: paymentMessageNamespace))
+            .padding(POSPadding.xLarge)
+        case .waitingForCard(let inputMethods, _):
+            cardPresentMessageView(.waitingForCard(.init(inputMethods: inputMethods)))
+        case .processingReader:
+            cardPresentMessageView(.processing(.processing))
+        case .displayingReaderMessage(let message):
+            cardPresentMessageView(.displayReaderMessage(.displayReaderMessage(message)))
+        case .retryableError(let error, let retry, let cancel):
+            POSRefundErrorView(title: Localization.readerErrorTitle,
+                               subtitle: error.localizedDescription,
+                               onRetry: retry,
+                               onCancel: cancel,
+                               onClose: cancel)
+        case .nonRetryableError(let error, let dismiss):
+            POSRefundErrorView(title: Localization.readerErrorTitle,
+                               subtitle: error.localizedDescription,
+                               onRetry: nil,
+                               onCancel: dismiss,
+                               onClose: dismiss)
+        case .idle, .loading, .submitting, .completed:
+            loadingSection
+        }
+    }
+
     var loadingSection: some View {
         VStack {
             ProgressView()
@@ -70,6 +176,82 @@ private extension POSRefundConfirmationView {
         }
         .frame(maxWidth: .infinity)
         .padding(POSPadding.xLarge)
+    }
+
+    func cardPresentMessageView(_ messageType: POSRefundCardPresentMessageType) -> some View {
+        POSRefundCardPresentMessageView(messageType: messageType,
+                                        animation: .init(namespace: paymentMessageNamespace))
+        .padding(POSPadding.xLarge)
+        .frame(maxWidth: .infinity)
+        .background(messageType.usesPrimaryBackground ? Color.posPrimary : Color.clear)
+    }
+
+    func refundMessageType(for eventDetails: CardPresentPaymentEventDetails) -> POSRefundCardPresentMessageType? {
+        switch eventDetails {
+        case .validatingOrder:
+            return .preparingReader(.checkingRefund)
+        case .preparingForPayment:
+            return .preparingReader(.preparingReader)
+        case .tapSwipeOrInsertCard(let inputMethods, _):
+            return .waitingForCard(.init(inputMethods: inputMethods))
+        case .cardInserted:
+            return .cardInserted(.cardInserted)
+        case .processing:
+            return .processing(.processing)
+        case .displayReaderMessage(let message):
+            return .displayReaderMessage(.displayReaderMessage(message))
+        case .cancelledOnReader:
+            return .cancelledOnReader(.cancelledOnReader(backToRefund: onBack))
+        case .paymentError(let error, let retryApproach, let cancelPayment):
+            return .error(.init(error: error,
+                                retryAction: retryAction(for: retryApproach),
+                                cancelAction: cancelPayment))
+        case .paymentCaptureError(let cancelPayment):
+            return .error(.init(error: POSRefundCardPresentPresentationError.unableToConfirmRefund,
+                                retryAction: nil,
+                                cancelAction: cancelPayment))
+        case .paymentIntentCreationError(let error, let cancelPayment):
+            return .error(.init(error: error,
+                                retryAction: nil,
+                                cancelAction: cancelPayment))
+        case .scanningForReaders, .scanningFailed, .bluetoothRequired, .connectingToReader, .connectingFailed,
+                .connectingFailedNonRetryable, .connectingFailedUpdatePostalCode, .connectingFailedChargeReader,
+                .connectingFailedUpdateAddress, .selectSearchType, .foundReader, .foundMultipleReaders, .updateProgress,
+                .updateFailed, .updateFailedNonRetryable, .updateFailedLowBattery, .connectionSuccess, .paymentSuccess,
+                .locationRequestPreAlert, .locationRequired:
+            return nil
+        }
+    }
+
+    func retryAction(for retryApproach: CardPresentPaymentRetryApproach) -> (() -> Void)? {
+        switch retryApproach {
+        case .tryAgain(let retryAction),
+                .tryAnotherPaymentMethod(let retryAction):
+            return retryAction
+        case .dontRetry:
+            return nil
+        }
+    }
+
+    func cardPresentAlertType(for eventDetails: CardPresentPaymentEventDetails) -> PointOfSaleCardPresentPaymentAlertType? {
+        guard let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
+            for: eventDetails,
+            dependencies: .init(
+                tryPaymentAgainBackToCheckoutAction: onBack,
+                nonRetryableErrorExitAction: onClose,
+                formattedOrderTotalPrice: formattedRefundTotal,
+                paymentCaptureErrorTryAgainAction: onBack,
+                paymentCaptureErrorNewOrderAction: onClose,
+                paymentIntentCreationErrorEditOrderAction: onBack,
+                dismissReaderConnectionModal: {}
+            )) else {
+            return nil
+        }
+
+        guard case .alert(let alertType) = presentationStyle else {
+            return nil
+        }
+        return alertType
     }
 
     var buttonsSection: some View {
@@ -81,6 +263,65 @@ private extension POSRefundConfirmationView {
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
         .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
+    }
+}
+
+private enum POSRefundCardPresentPresentationError: LocalizedError {
+    case unableToConfirmRefund
+
+    var errorDescription: String? {
+        switch self {
+        case .unableToConfirmRefund:
+            return NSLocalizedString(
+                "pos.refundConfirmationView.cardPresent.unableToConfirmRefund",
+                value: "We’re unable to confirm that the refund succeeded. Check the order before trying again.",
+                comment: "Error shown when POS cannot confirm whether a card reader refund succeeded."
+            )
+        }
+    }
+}
+
+private extension CardPresentPaymentEventDetails {
+    var posRefundCancelAction: (() -> Void)? {
+        switch self {
+        case .scanningForReaders(let endSearch),
+                .scanningFailed(_, let endSearch),
+                .bluetoothRequired(_, let endSearch),
+                .connectingFailedNonRetryable(_, let endSearch):
+            return endSearch
+        case .connectingFailed(_, _, let endSearch),
+                .connectingFailedUpdatePostalCode(_, let endSearch),
+                .connectingFailedChargeReader(_, let endSearch),
+                .connectingFailedUpdateAddress(_, _, _, let endSearch):
+            return endSearch
+        case .selectSearchType(_, _, let endSearch),
+                .foundReader(_, _, _, let endSearch):
+            return endSearch
+        case .foundMultipleReaders(_, let selectionHandler):
+            return {
+                selectionHandler(nil)
+            }
+        case .updateProgress(_, _, let cancelUpdate):
+            return cancelUpdate
+        case .updateFailed(_, let cancelUpdate),
+                .updateFailedNonRetryable(let cancelUpdate),
+                .updateFailedLowBattery(_, _, let cancelUpdate):
+            return cancelUpdate
+        case .preparingForPayment(let cancelPayment),
+                .tapSwipeOrInsertCard(_, let cancelPayment),
+                .cardInserted(let cancelPayment),
+                .paymentError(_, _, let cancelPayment),
+                .paymentCaptureError(let cancelPayment),
+                .paymentIntentCreationError(_, let cancelPayment),
+                .validatingOrder(let cancelPayment):
+            return cancelPayment
+        case .locationRequired(let cancel):
+            return cancel
+        case .connectingToReader, .connectionSuccess, .paymentSuccess, .processing,
+                .locationRequestPreAlert,
+                .displayReaderMessage, .cancelledOnReader:
+            return nil
+        }
     }
 }
 
@@ -116,6 +357,24 @@ private extension POSRefundConfirmationView {
             "pos.refundConfirmationView.processingMessage",
             value: "Please wait while we process the refund.",
             comment: "Message shown while the refund is being processed."
+        )
+
+        static let preparingReaderTitle = NSLocalizedString(
+            "pos.refundConfirmationView.preparingReaderTitle",
+            value: "Preparing reader",
+            comment: "Title shown while preparing a card reader for an in-person refund."
+        )
+
+        static let preparingReaderMessage = NSLocalizedString(
+            "pos.refundConfirmationView.preparingReaderMessage",
+            value: "Keep this screen open while the card reader gets ready.",
+            comment: "Message shown while preparing a card reader for an in-person refund."
+        )
+
+        static let readerErrorTitle = NSLocalizedString(
+            "pos.refundConfirmationView.readerErrorTitle",
+            value: "Refund failed",
+            comment: "Title shown when an in-person refund fails."
         )
 
         static let confirmButton = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -367,7 +367,7 @@ private extension POSRefundConfirmationView {
 
         static let preparingReaderMessage = NSLocalizedString(
             "pos.refundConfirmationView.preparingReaderMessage",
-            value: "Keep this screen open while the card reader gets ready.",
+            value: "Preparing reader for refund",
             comment: "Message shown while preparing a card reader for an in-person refund."
         )
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct POSRefundErrorView: View {
     let title: String
     let subtitle: String
-    let onRetry: () -> Void
+    let onRetry: (() -> Void)?
     let onCancel: () -> Void
     let onClose: () -> Void
 
@@ -73,8 +73,10 @@ private extension POSRefundErrorView {
 
     var buttonsSection: some View {
         VStack(spacing: POSSpacing.medium) {
-            Button(Localization.retryButton, action: onRetry)
-                .buttonStyle(POSFilledButtonStyle(size: .normal))
+            if let onRetry {
+                Button(Localization.retryButton, action: onRetry)
+                    .buttonStyle(POSFilledButtonStyle(size: .normal))
+            }
 
             Button(Localization.cancelButton, action: onCancel)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -64,6 +64,7 @@ struct POSRefundModalContentView: View {
     let state: RefundModalState
     @Binding var modalState: RefundModalState?
     @Environment(POSOrderListModel.self) private var orderListModel
+    @Environment(POSRefundSubmissionModel.self) private var refundSubmissionModel
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
@@ -188,6 +189,7 @@ struct POSRefundModalContentView: View {
                 formattedRefundTotal: reviewData.formattedRefundTotal,
                 paymentMethodDescription: reviewData.paymentMethodDescription,
                 isProcessing: true,
+                submissionState: refundSubmissionModel.state,
                 onClose: {},
                 onConfirm: {},
                 onBack: {}
@@ -227,12 +229,14 @@ struct POSRefundModalContentView: View {
         do {
             try await orderListModel.ordersController.processRefund(reason: reviewData.refundReason)
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingSuccess())
+            refundSubmissionModel.reset()
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch {
             DDLogError("⛔️ Failed to process POS refund: \(error)")
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
             onRefundFailure?(error)
+            refundSubmissionModel.reset()
             modalState = .error(reviewData)
         }
     }


### PR DESCRIPTION
Part of: RSM-645

## Description
Wires the POS refund confirmation view to show POS-native submission progress and errors, including the card-present refund message views from the previous PRs.

## Test Steps
A quick visual smoke test of automatic refund submission is useful here. Full Interac reader testing is covered later in the stack.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.