### PR TITLE
RSM-645 Add POS refund submission mapping

### DIFF
--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -1,0 +1,173 @@
+import Foundation
+import PointOfSale
+import Yosemite
+import WooFoundation
+
+struct POSRefundSubmissionMapping {
+    struct PreparedRefundContext {
+        let order: Order
+        let charge: WCPayCharge?
+        let paymentGateway: PaymentGateway?
+        let paymentGatewayAccount: PaymentGatewayAccount?
+        let refundableItems: [RefundableOrderItem]
+        let refundableFees: [OrderFeeLine]
+    }
+
+    private let currencyFormatter: CurrencyFormatter
+
+    init(currencyFormatter: CurrencyFormatter) {
+        self.currencyFormatter = currencyFormatter
+    }
+
+    func normalizedForPOSInteracRefund(charge: WCPayCharge) -> WCPayCharge {
+        switch charge.paymentMethodDetails {
+        case .cardPresent(let details) where details.brand == .interac:
+            return charge.copy(paymentMethodDetails: .interacPresent(details: details))
+        default:
+            return charge
+        }
+    }
+
+    func determineRefundableFees(from order: Order, with refunds: [Refund]) -> [OrderFeeLine] {
+        let refundedFeeIDs = Set(refunds.flatMap(\.feeLines).map { $0.refundedItemID ?? $0.feeID })
+        return order.fees.filter { !refundedFeeIDs.contains($0.feeID) }
+    }
+
+    func makeSelectableItems(refundableItems: [RefundableOrderItem],
+                             fees: [OrderFeeLine],
+                             currency: String) -> [POSRefundSelectableItem] {
+        var index = 0
+        var selectableItems: [POSRefundSelectableItem] = []
+
+        for refundableItem in refundableItems {
+            let item = refundableItem.item
+            let lineItemTotal = currencyFormatter.convertToDecimal(item.total) as Decimal? ?? (item.price as Decimal) * item.quantity
+            let totalTax = currencyFormatter.convertToDecimal(item.totalTax) as Decimal? ?? .zero
+            let formattedPrice = currencyFormatter.formatAmount(item.price, with: currency) ?? ""
+
+            for _ in 0..<refundableItem.quantity {
+                selectableItems.append(POSRefundSelectableItem(
+                    itemID: item.itemID,
+                    name: item.name,
+                    imageSrc: item.image?.src,
+                    lineItemTotal: lineItemTotal,
+                    totalTax: totalTax,
+                    originalQuantity: item.quantity,
+                    formattedPrice: formattedPrice,
+                    attributes: item.attributes,
+                    isSelected: true,
+                    index: index))
+                index += 1
+            }
+        }
+
+        for fee in fees {
+            let total = currencyFormatter.convertToDecimal(fee.total) as Decimal? ?? .zero
+            let totalTax = currencyFormatter.convertToDecimal(fee.totalTax) as Decimal? ?? .zero
+            selectableItems.append(POSRefundSelectableItem(
+                itemID: fee.feeID,
+                name: displayName(for: fee),
+                imageSrc: nil,
+                lineItemTotal: total,
+                totalTax: totalTax,
+                originalQuantity: 1,
+                formattedPrice: currencyFormatter.formatAmount(fee.total, with: currency) ?? "",
+                attributes: fee.attributes,
+                isLumpSum: true,
+                isSelected: true,
+                index: index))
+            index += 1
+        }
+
+        return selectableItems
+    }
+
+    func refundComponents(from selectedItems: [POSRefundSelectableItem],
+                          context: PreparedRefundContext) -> (items: [RefundableOrderItem], fees: [OrderFeeLine]) {
+        let selectedProductQuantities = selectedItems
+            .filter { !$0.isLumpSum }
+            .reduce(into: [Int64: Int]()) { quantities, item in
+                quantities[item.itemID, default: 0] += 1
+            }
+
+        let refundItems = context.refundableItems.compactMap { refundableItem -> RefundableOrderItem? in
+            guard let quantity = selectedProductQuantities[refundableItem.item.itemID], quantity > 0 else {
+                return nil
+            }
+            return RefundableOrderItem(item: refundableItem.item, quantity: quantity)
+        }
+
+        let selectedFeeIDs = Set(selectedItems.filter(\.isLumpSum).map(\.itemID))
+        let fees = context.refundableFees.filter { selectedFeeIDs.contains($0.feeID) }
+
+        return (refundItems, fees)
+    }
+
+    func refundValues(items: [RefundableOrderItem], fees: [OrderFeeLine]) -> (subtotal: Decimal, tax: Decimal, total: Decimal) {
+        let itemValues = RefundItemsValuesCalculationUseCase(refundItems: items, currencyFormatter: currencyFormatter).calculateRefundValues()
+        let feeValues = RefundFeesCalculationUseCase(fees: fees, currencyFormatter: currencyFormatter).calculateRefundValues()
+        let subtotal = itemValues.subtotal + feeValues.subtotal
+        let tax = itemValues.tax + feeValues.tax
+        return (subtotal, tax, subtotal + tax)
+    }
+
+    func apiAmountString(for amount: Decimal) -> String {
+        NSDecimalNumber(decimal: amount).stringValue
+    }
+
+    func gatewaySupportsAutomaticRefunds(context: PreparedRefundContext) -> Bool {
+        if let paymentGateway = context.paymentGateway {
+            return paymentGateway.features.contains(.refunds)
+        }
+        return context.order.paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
+    }
+
+    func paymentMethodDescription(for order: Order, charge: WCPayCharge?) -> String {
+        let paymentMethod = order.paymentMethodTitle.isEmpty ? Localization.manualPaymentMethod : order.paymentMethodTitle
+        switch charge?.paymentMethodDetails {
+        case .some(.cardPresent(let details)), .some(.interacPresent(let details)):
+            return String(format: Localization.viaCardPaymentMethodFormat,
+                          paymentMethod,
+                          cardDescription(brand: details.brand, last4: details.last4))
+        default:
+            return String(format: Localization.viaPaymentMethodFormat, paymentMethod)
+        }
+    }
+}
+
+private extension POSRefundSubmissionMapping {
+    func displayName(for fee: OrderFeeLine) -> String {
+        let trimmedName = (fee.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedName.isEmpty ? Localization.defaultFeeName : trimmedName
+    }
+
+    func cardDescription(brand: WCPayCardBrand, last4: String) -> String {
+        brand.refundCardDescription(last4: last4)
+    }
+}
+
+private enum Localization {
+    static let viaPaymentMethodFormat = NSLocalizedString(
+        "pos.refundSubmissionAdaptor.paymentMethodDescription.viaPaymentMethod",
+        value: "via %@",
+        comment: "Payment method description for POS refunds. %@ is the payment method title."
+    )
+
+    static let viaCardPaymentMethodFormat = NSLocalizedString(
+        "pos.refundSubmissionAdaptor.paymentMethodDescription.viaCardPaymentMethod",
+        value: "via %1$@ %2$@",
+        comment: "Payment method description for POS refunds. %1$@ is the payment method title, %2$@ is card details."
+    )
+
+    static let manualPaymentMethod = NSLocalizedString(
+        "pos.refundSubmissionAdaptor.paymentMethodDescription.manualPaymentMethod",
+        value: "manual payment",
+        comment: "Fallback payment method description for POS refunds when no payment method title is available."
+    )
+
+    static let defaultFeeName = NSLocalizedString(
+        "pos.refundSubmissionAdaptor.defaultFeeName",
+        value: "Custom amount",
+        comment: "Fallback name for a custom amount fee line in POS refunds."
+    )
+}

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -149,8 +149,8 @@ private extension POSRefundSubmissionMapping {
 private enum Localization {
     static let viaPaymentMethodFormat = NSLocalizedString(
         "pos.refundSubmissionAdaptor.paymentMethodDescription.viaPaymentMethod",
-        value: "via %@",
-        comment: "Payment method description for POS refunds. %@ is the payment method title."
+        value: "via %1$@",
+        comment: "Payment method description for POS refunds. %1$@ is the payment method title."
     )
 
     static let viaCardPaymentMethodFormat = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -309,17 +309,8 @@ private extension RefundConfirmationViewModel {
 }
 
 private extension WCPayCardBrand {
-    /// A displayable brand name and last 4 digits for a card. These are deliberately not localized, always in English,
-    /// because of various limitations on localization by the card companies. Care should be taken if localizing (some of)
-    /// these brand names in future – e.g. Mastercard allows only English, or specific authorized versions in Chinese (translation),
-    /// Arabic (transliteration), and Georgian (transliteration).
-    ///
-    /// Names taken from [Stripe's card branding in the API docs](https://stripe.com/docs/api/cards/object#card_object-brand):
-    /// American Express, Diners Club, Discover, JCB, Mastercard, UnionPay, Visa, or Unknown.
-    /// N.B. on review, we found that Mastercard should not have an uppercase "c" as it does in Stripe's documentation
-    /// https://brand.mastercard.com/brandcenter/branding-requirements/mastercard.html#name
     func cardDescription(last4: String) -> String {
-        return String(format: cardDescriptionFormatString(), last4)
+        refundCardDescription(last4: last4)
     }
 
     func cardAccessibilityDescription(last4: String) -> NSAttributedString {
@@ -334,33 +325,6 @@ private extension WCPayCardBrand {
         attributedLocalizedDescription.setAttributes([.accessibilitySpeechSpellOut: true], range: last4NSRange)
 
         return attributedLocalizedDescription
-    }
-
-    func cardDescriptionFormatString() -> String {
-        switch self {
-        case .amex:
-            return "•••• %1$@ (American Express)"
-        case .diners:
-            return "•••• %1$@ (Diners Club)"
-        case .discover:
-            return "•••• %1$@ (Discover)"
-        case .eftposAu:
-            return "•••• %1$@ (eftpos)"
-        case .interac:
-            return "•••• %1$@ (Interac)"
-        case .jcb:
-            return "•••• %1$@ (JCB)"
-        case .mastercard:
-            return "•••• %1$@ (Mastercard)"
-        case .unionpay:
-            return "•••• %1$@ (UnionPay)"
-        case .visa:
-            return "•••• %1$@ (Visa)"
-        case .cartesBancaires:
-            return "•••• %1$@ (Cartes Bancaires)"
-        case .unknown:
-            return "•••• %1$@"
-        }
     }
 
     func cardBrandName() -> String {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/WCPayCardBrand+RefundCardDescription.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/WCPayCardBrand+RefundCardDescription.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Yosemite
+
+extension WCPayCardBrand {
+    /// A displayable brand name and last 4 digits for a card. These are deliberately not localized, always in English,
+    /// because of various limitations on localization by the card companies. Care should be taken if localizing (some of)
+    /// these brand names in future - e.g. Mastercard allows only English, or specific authorized versions in Chinese (translation),
+    /// Arabic (transliteration), and Georgian (transliteration).
+    ///
+    /// Names taken from [Stripe's card branding in the API docs](https://stripe.com/docs/api/cards/object#card_object-brand):
+    /// American Express, Diners Club, Discover, JCB, Mastercard, UnionPay, Visa, or Unknown.
+    /// N.B. on review, we found that Mastercard should not have an uppercase "c" as it does in Stripe's documentation
+    /// https://brand.mastercard.com/brandcenter/branding-requirements/mastercard.html#name
+    func refundCardDescription(last4: String) -> String {
+        String(format: refundCardDescriptionFormatString, last4)
+    }
+
+    var refundCardDescriptionFormatString: String {
+        switch self {
+        case .amex:
+            return "•••• %1$@ (American Express)"
+        case .diners:
+            return "•••• %1$@ (Diners Club)"
+        case .discover:
+            return "•••• %1$@ (Discover)"
+        case .eftposAu:
+            return "•••• %1$@ (eftpos)"
+        case .interac:
+            return "•••• %1$@ (Interac)"
+        case .jcb:
+            return "•••• %1$@ (JCB)"
+        case .mastercard:
+            return "•••• %1$@ (Mastercard)"
+        case .unionpay:
+            return "•••• %1$@ (UnionPay)"
+        case .visa:
+            return "•••• %1$@ (Visa)"
+        case .cartesBancaires:
+            return "•••• %1$@ (Cartes Bancaires)"
+        case .unknown:
+            return "•••• %1$@"
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
@@ -1,0 +1,180 @@
+@testable import PointOfSale
+import XCTest
+@testable import WooCommerce
+import WooFoundation
+import Yosemite
+
+final class POSRefundSubmissionMappingTests: XCTestCase {
+    private var sut: POSRefundSubmissionMapping!
+
+    override func setUp() {
+        super.setUp()
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .left,
+                                                thousandSeparator: ",",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 2)
+        sut = POSRefundSubmissionMapping(currencyFormatter: CurrencyFormatter(currencySettings: currencySettings))
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_normalizedForPOSInteracRefund_converts_cardPresent_interac_to_interacPresent() {
+        let details = WCPayCardPresentPaymentDetails.fake().copy(brand: .interac, last4: "4242")
+        let charge = WCPayCharge.fake().copy(paymentMethodDetails: .cardPresent(details: details))
+
+        let normalizedCharge = sut.normalizedForPOSInteracRefund(charge: charge)
+
+        guard case .interacPresent(let normalizedDetails) = normalizedCharge.paymentMethodDetails else {
+            return XCTFail("Expected Interac card-present charge to be normalized to interac_present.")
+        }
+        XCTAssertEqual(normalizedDetails, details)
+    }
+
+    func test_normalizedForPOSInteracRefund_keeps_non_interac_cardPresent_charge_unchanged() {
+        let details = WCPayCardPresentPaymentDetails.fake().copy(brand: .visa, last4: "4242")
+        let charge = WCPayCharge.fake().copy(paymentMethodDetails: .cardPresent(details: details))
+
+        let normalizedCharge = sut.normalizedForPOSInteracRefund(charge: charge)
+
+        XCTAssertEqual(normalizedCharge, charge)
+    }
+
+    func test_gatewaySupportsAutomaticRefunds_uses_gateway_refunds_feature_when_gateway_is_available() {
+        let refundingGateway = PaymentGateway.fake().copy(features: [.refunds])
+        let nonRefundingGateway = PaymentGateway.fake().copy(features: [.products])
+
+        XCTAssertTrue(sut.gatewaySupportsAutomaticRefunds(context: makeContext(paymentGateway: refundingGateway)))
+        XCTAssertFalse(sut.gatewaySupportsAutomaticRefunds(context: makeContext(paymentGateway: nonRefundingGateway)))
+    }
+
+    func test_gatewaySupportsAutomaticRefunds_falls_back_to_order_payment_method_without_gateway() {
+        let cardOrder = Order.fake().copy(paymentMethodID: WCPayAccount.gatewayID)
+        let codOrder = Order.fake().copy(paymentMethodID: PaymentGateway.Constants.cashOnDeliveryGatewayID)
+
+        XCTAssertTrue(sut.gatewaySupportsAutomaticRefunds(context: makeContext(order: cardOrder, paymentGateway: nil)))
+        XCTAssertFalse(sut.gatewaySupportsAutomaticRefunds(context: makeContext(order: codOrder, paymentGateway: nil)))
+    }
+
+    func test_refundComponents_aggregates_selected_product_quantity_and_selected_fees() {
+        let item1 = orderItem(itemID: 10, quantity: 3)
+        let item2 = orderItem(itemID: 20, quantity: 1)
+        let fee1 = orderFee(feeID: 100)
+        let fee2 = orderFee(feeID: 200)
+        let context = makeContext(refundableItems: [
+            RefundableOrderItem(item: item1, quantity: 3),
+            RefundableOrderItem(item: item2, quantity: 1)
+        ], refundableFees: [fee1, fee2])
+        let selectedItems = [
+            selectableItem(itemID: item1.itemID, index: 0),
+            selectableItem(itemID: item1.itemID, index: 1),
+            selectableItem(itemID: fee2.feeID, isLumpSum: true, index: 2)
+        ]
+
+        let components = sut.refundComponents(from: selectedItems, context: context)
+
+        XCTAssertEqual(components.items, [RefundableOrderItem(item: item1, quantity: 2)])
+        XCTAssertEqual(components.fees, [fee2])
+    }
+
+    func test_determineRefundableFees_excludes_fees_refunded_by_original_or_refund_fee_id() {
+        let fee1 = orderFee(feeID: 100)
+        let fee2 = orderFee(feeID: 200)
+        let fee3 = orderFee(feeID: 300)
+        let order = Order.fake().copy(fees: [fee1, fee2, fee3])
+        let refundUsingOriginalFeeID = Refund.fake().copy(feeLines: [
+            orderFee(feeID: 900, refundedItemID: fee1.feeID)
+        ])
+        let refundUsingRefundFeeID = Refund.fake().copy(feeLines: [
+            orderFee(feeID: fee2.feeID, refundedItemID: nil)
+        ])
+
+        let refundableFees = sut.determineRefundableFees(from: order,
+                                                         with: [refundUsingOriginalFeeID, refundUsingRefundFeeID])
+
+        XCTAssertEqual(refundableFees, [fee3])
+    }
+
+    func test_makeSelectableItems_expands_refundable_product_quantities_and_appends_fees() {
+        let item = orderItem(itemID: 10,
+                             name: "Coffee",
+                             quantity: 2,
+                             price: 4,
+                             total: "8.00",
+                             totalTax: "0.80")
+        let fee = orderFee(feeID: 200, name: "   ", total: "3.50", totalTax: "0.35")
+
+        let selectableItems = sut.makeSelectableItems(refundableItems: [RefundableOrderItem(item: item, quantity: 2)],
+                                                      fees: [fee],
+                                                      currency: "USD")
+
+        XCTAssertEqual(selectableItems.count, 3)
+        XCTAssertEqual(selectableItems.map(\.itemID), [item.itemID, item.itemID, fee.feeID])
+        XCTAssertEqual(selectableItems.map(\.isLumpSum), [false, false, true])
+        XCTAssertEqual(selectableItems.map(\.isSelected), [true, true, true])
+        XCTAssertEqual(selectableItems[0].lineItemTotal, Decimal(8))
+        XCTAssertEqual(selectableItems[0].totalTax, NSDecimalNumber(string: "0.80").decimalValue)
+        XCTAssertEqual(selectableItems[2].name, "Custom amount")
+        XCTAssertEqual(selectableItems[2].lineItemTotal, NSDecimalNumber(string: "3.50").decimalValue)
+        XCTAssertEqual(selectableItems[2].totalTax, NSDecimalNumber(string: "0.35").decimalValue)
+    }
+}
+
+private extension POSRefundSubmissionMappingTests {
+    func makeContext(order: Order = Order.fake(),
+                     paymentGateway: PaymentGateway? = PaymentGateway.fake(),
+                     refundableItems: [RefundableOrderItem] = [],
+                     refundableFees: [OrderFeeLine] = []) -> POSRefundSubmissionMapping.PreparedRefundContext {
+        POSRefundSubmissionMapping.PreparedRefundContext(order: order,
+                                                         charge: nil,
+                                                         paymentGateway: paymentGateway,
+                                                         paymentGatewayAccount: nil,
+                                                         refundableItems: refundableItems,
+                                                         refundableFees: refundableFees)
+    }
+
+    func orderItem(itemID: Int64,
+                   name: String = "Product",
+                   quantity: Decimal,
+                   price: Decimal = 5,
+                   total: String = "5.00",
+                   totalTax: String = "0.50") -> OrderItem {
+        OrderItem.fake().copy(itemID: itemID,
+                              name: name,
+                              quantity: quantity,
+                              price: NSDecimalNumber(decimal: price),
+                              total: total,
+                              totalTax: totalTax,
+                              attributes: [])
+    }
+
+    func orderFee(feeID: Int64,
+                  name: String? = "Fee",
+                  total: String = "1.00",
+                  totalTax: String = "0.10",
+                  refundedItemID: Int64? = nil) -> OrderFeeLine {
+        OrderFeeLine.fake().copy(feeID: feeID,
+                                 name: name,
+                                 total: total,
+                                 totalTax: totalTax,
+                                 attributes: [],
+                                 refundedItemID: refundedItemID)
+    }
+
+    func selectableItem(itemID: Int64, isLumpSum: Bool = false, index: Int) -> POSRefundSelectableItem {
+        POSRefundSelectableItem(itemID: itemID,
+                                name: "Selected",
+                                imageSrc: nil,
+                                lineItemTotal: 1,
+                                totalTax: 0,
+                                originalQuantity: 1,
+                                formattedPrice: "$1.00",
+                                attributes: [],
+                                isLumpSum: isLumpSum,
+                                isSelected: true,
+                                index: index)
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
@@ -59,6 +59,24 @@ final class POSRefundSubmissionMappingTests: XCTestCase {
         XCTAssertFalse(sut.gatewaySupportsAutomaticRefunds(context: makeContext(order: codOrder, paymentGateway: nil)))
     }
 
+    func test_paymentMethodDescription_when_interac_present_charge_then_includes_card_description() {
+        let details = WCPayCardPresentPaymentDetails.fake().copy(brand: .interac, last4: "1234")
+        let charge = WCPayCharge.fake().copy(paymentMethodDetails: .interacPresent(details: details))
+        let order = Order.fake().copy(paymentMethodTitle: "WooPayments")
+
+        let description = sut.paymentMethodDescription(for: order, charge: charge)
+
+        XCTAssertEqual(description, "via WooPayments •••• 1234 (Interac)")
+    }
+
+    func test_paymentMethodDescription_when_payment_method_title_is_empty_then_uses_manual_payment() {
+        let order = Order.fake().copy(paymentMethodTitle: "")
+
+        let description = sut.paymentMethodDescription(for: order, charge: nil)
+
+        XCTAssertEqual(description, "via manual payment")
+    }
+
     func test_refundComponents_aggregates_selected_product_quantity_and_selected_fees() {
         let item1 = orderItem(itemID: 10, quantity: 3)
         let item2 = orderItem(itemID: 20, quantity: 1)


### PR DESCRIPTION
Part of: RSM-645

## Description
Adds the mapping from POS refund review data into the app-side refund submission inputs, including the card-brand description helper shared with the existing refund screen.

## Test Steps
Automated mapping coverage should be enough for this slice.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.