### PR TITLE
RSM-645 Cancel in-flight checkout when opening POS orders

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -803,6 +803,8 @@ extension POSPaymentModel {
     /// payment state and order data so `activate()` can resume where we left off.
     func deactivate() {
         DDLogInfo("⏸️ [Session] deactivate called - card state: \(paymentState.card), cash state: \(paymentState.cash)")
+        cancelConnectCardReaderTask()
+        cancelTapToPayConnectTask()
         paymentSessionCancellables.removeAll()
         stopScanToPayPolling()
         cancelReaderPreparation()
@@ -832,6 +834,7 @@ extension POSPaymentModel {
 extension POSPaymentModel {
     func reset() {
         cancelConnectCardReaderTask()
+        cancelTapToPayConnectTask()
         stopScanToPayPolling()
         paymentSessionCancellables.removeAll()
         paymentState = .idle
@@ -852,12 +855,18 @@ extension POSPaymentModel {
         connectCardReaderTask = nil
     }
 
+    private func cancelTapToPayConnectTask() {
+        tapToPayConnectTask?.cancel()
+        tapToPayConnectTask = nil
+    }
+
     private func cancelReaderPreparation() {
         cardPresentPaymentService.cancelPayment()
         resetCardReaderObservation()
     }
 
     private func resetCardReaderObservation() {
+        startPaymentGeneration += 1
         startPaymentOnCardReaderConnection?.cancel()
         startPaymentOnCardReaderConnection = nil
         cardReaderDisconnection?.cancel()
@@ -1259,6 +1268,7 @@ extension POSPaymentModel {
     /// and risking a shopper paying for the wrong order.
     func tearDown() {
         cancelConnectCardReaderTask()
+        cancelTapToPayConnectTask()
         stopScanToPayPolling()
         cardPresentPaymentService.cancelPayment()
         resetCardReaderObservation()

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -32,6 +32,7 @@ protocol PointOfSaleAggregateModelProtocol {
 
 @Observable final class PointOfSaleAggregateModel: PointOfSaleAggregateModelProtocol {
     private(set) var orderStage: PointOfSaleOrderStage = .building
+    private var checkoutGeneration = 0
 
     let paymentModel: POSPaymentModel
 
@@ -250,6 +251,11 @@ extension PointOfSaleAggregateModel {
     }
 
     @MainActor
+    func cancelInFlightCheckout() {
+        setStateForEditing()
+    }
+
+    @MainActor
     func startNewCart() {
         removeAllItemsFromCart()
         orderController.clearOrder()
@@ -259,6 +265,7 @@ extension PointOfSaleAggregateModel {
 
     @MainActor
     private func setStateForEditing() {
+        checkoutGeneration += 1
         orderStage = .building
         paymentModel.reset()
     }
@@ -529,13 +536,26 @@ extension PointOfSaleAggregateModel {
 extension PointOfSaleAggregateModel {
     @MainActor
     func checkOut() async {
+        checkoutGeneration += 1
+        let currentCheckoutGeneration = checkoutGeneration
+
         collectOrderPaymentAnalyticsTracker.trackCheckoutTapped()
         orderStage = .finalizing
         let syncOrderResult = await orderController.syncOrder(for: cart, retryHandler: { [weak self] in
             await self?.checkOut()
         })
+
+        guard checkoutGeneration == currentCheckoutGeneration else {
+            return
+        }
+
         trackOrderSyncState(syncOrderResult)
         await removeMissingProductsFromCatalogAfterSync()
+
+        guard checkoutGeneration == currentCheckoutGeneration else {
+            return
+        }
+
         triggerIncrementalSyncIfPriceChanged()
         await paymentModel.startPayment()
     }

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -11,18 +11,20 @@ struct POSFloatingControlView: View {
     @Binding private var showSupport: Bool
     @Binding private var showDocumentation: Bool
     @Binding private var showSettings: Bool
+    private let onOrdersSelected: () -> Void
     @State private var showProductRestrictionsModal: Bool = false
     @State private var showBarcodeScanningModal: Bool = false
-    @State private var showOrders: Bool = false
 
     init(showExitPOSModal: Binding<Bool>,
          showSupport: Binding<Bool>,
          showDocumentation: Binding<Bool>,
-         showSettings: Binding<Bool>) {
+         showSettings: Binding<Bool>,
+         onOrdersSelected: @escaping () -> Void) {
         self._showExitPOSModal = showExitPOSModal
         self._showSupport = showSupport
         self._showDocumentation = showDocumentation
         self._showSettings = showSettings
+        self.onOrdersSelected = onOrdersSelected
     }
 
     var body: some View {
@@ -58,9 +60,6 @@ struct POSFloatingControlView: View {
         .posModal(isPresented: $showBarcodeScanningModal) {
             POSBarcodeScannerSetup(isPresented: $showBarcodeScanningModal, analytics: analytics)
         }
-        .posFullScreenCover(isPresented: $showOrders) {
-            POSOrdersView(isPresented: $showOrders)
-        }
         .frame(height: Constants.size)
         .background(Color.clear)
         .animation(.default, value: backgroundAppearance)
@@ -94,7 +93,7 @@ private extension POSFloatingControlView {
             if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
                 Button {
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
-                    showOrders = true
+                    onOrdersSelected()
                 } label: {
                     Label(
                         title: { Text(Localization.orders) },
@@ -166,7 +165,8 @@ private extension POSFloatingControlView {
     POSFloatingControlView(showExitPOSModal: .constant(false),
                            showSupport: .constant(false),
                            showDocumentation: .constant(false),
-                           showSettings: .constant(false))
+                           showSettings: .constant(false),
+                           onOrdersSelected: {})
         .environment(\.posBackgroundAppearance, .primary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }
@@ -180,7 +180,8 @@ private extension POSFloatingControlView {
     return POSFloatingControlView(showExitPOSModal: .constant(false),
                                   showSupport: .constant(false),
                                   showDocumentation: .constant(false),
-                                  showSettings: .constant(false))
+                                  showSettings: .constant(false),
+                                  onOrdersSelected: {})
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
 }
@@ -189,7 +190,8 @@ private extension POSFloatingControlView {
     POSFloatingControlView(showExitPOSModal: .constant(false),
                            showSupport: .constant(false),
                            showDocumentation: .constant(false),
-                           showSettings: .constant(false))
+                           showSettings: .constant(false),
+                           onOrdersSelected: {})
         .environment(\.posBackgroundAppearance, .secondary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -116,7 +116,8 @@ struct PointOfSaleDashboardView: View {
             POSFloatingControlView(showExitPOSModal: $showExitPOSModal,
                                    showSupport: $showSupport,
                                    showDocumentation: $showDocumentation,
-                                   showSettings: $showSettings)
+                                   showSettings: $showSettings,
+                                   onOrdersSelected: presentOrders)
             .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
@@ -162,8 +163,8 @@ struct PointOfSaleDashboardView: View {
         .posFullScreenCover(isPresented: $showSettings) {
             POSSettingsView(settingsController: posModel.settingsController)
         }
-        .posFullScreenCover(isPresented: $phoneShowOrders) {
-            POSOrdersView(isPresented: $phoneShowOrders)
+        .posFullScreenCover(isPresented: $showOrders) {
+            POSOrdersView(isPresented: $showOrders)
         }
         .onChange(of: showSettings) { oldValue, newValue in
             guard !newValue, oldValue else { return }
@@ -323,7 +324,7 @@ struct PointOfSaleDashboardView: View {
         .toolbar(.hidden, for: .navigationBar)
     }
 
-    @State private var phoneShowOrders: Bool = false
+    @State private var showOrders: Bool = false
     @State private var phoneShowingBarcodeScannerSetup: Bool = false
     @State private var phoneCartButtonPulse: Bool = false
 
@@ -353,7 +354,7 @@ struct PointOfSaleDashboardView: View {
             if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
                 Button {
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
-                    phoneShowOrders = true
+                    presentOrders()
                 } label: {
                     Label(Localization.phoneMenuOrders, systemImage: "text.document")
                 }
@@ -587,6 +588,11 @@ private extension PointOfSaleDashboardView {
             await posModel.couponsController.loadItems(base: .root)
             await posModel.popularPurchasableItemsController.loadItems(base: .root)
         }
+    }
+
+    func presentOrders() {
+        posModel.cancelInFlightCheckout()
+        showOrders = true
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -66,6 +66,74 @@ struct POSPaymentModelTests {
         #expect(service.collectPaymentWasCalled == true)
     }
 
+    @Test("reset cancels pending card collection while waiting for reader connection")
+    @MainActor
+    func reset_whenWaitingForReaderConnection_cancelsPendingCardCollection() async {
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider)
+
+        await sut.startPayment()
+        #expect(service.collectPaymentWasCalled == false)
+        #expect(sut.isPaymentSessionActive == true)
+
+        sut.reset()
+        #expect(sut.isPaymentSessionActive == false)
+        #expect(sut.paymentState == .idle)
+
+        await fireOnce { fire in
+            withObservationTracking {
+                _ = sut.cardReaderConnectionStatus
+            } onChange: {
+                Task { @MainActor in fire() }
+            }
+            service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        }
+
+        #expect(service.collectPaymentWasCalled == false)
+    }
+
+    @Test("reset invalidates a reader-connected callback already cancelling stale payment")
+    @MainActor
+    func reset_whenReaderConnectedCallbackIsCancelling_stopsCardCollection() async {
+        let service = MockCardPresentPaymentService()
+        let orderProvider = MockPOSPaymentOrderProvider()
+        orderProvider.orderToReturn = Order.fake().copy(total: "10.00")
+        orderProvider.totalDecimalToReturn = 10
+        var releaseCancelPayment: (() -> Void)?
+
+        let sut = makePaymentController(
+            cardPresentPaymentService: service,
+            orderProvider: orderProvider)
+
+        await sut.startPayment()
+
+        await fireOnce { fire in
+            service.onCancelPaymentCalled = {
+                await withCheckedContinuation { continuation in
+                    releaseCancelPayment = {
+                        continuation.resume()
+                    }
+                    fire()
+                }
+            }
+            service.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        }
+
+        sut.reset()
+        releaseCancelPayment?()
+        await Task.yield()
+        await Task.yield()
+
+        #expect(service.collectPaymentWasCalled == false)
+        #expect(sut.paymentState == .idle)
+    }
+
     // MARK: - Cash Payment
 
     @Test("startCashPayment transitions to cash immediately and cancels card payment in background")

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleOrderController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPointOfSaleOrderController.swift
@@ -15,6 +15,7 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
     var spyCartProducts: [Cart.PurchasableItem]?
     var spyRetryHandler: (() async -> Void)?
     var syncOrderResultToReturn: Result<SyncOrderState, Error> = .success(.newOrder)
+    var onSyncOrderCalled: (() async -> Void)?
 
     @discardableResult
     func syncOrder(for cart: Cart,
@@ -22,6 +23,7 @@ final class MockPointOfSaleOrderController: PointOfSaleOrderControllerProtocol {
         syncOrderWasCalled = true
         spyCartProducts = cart.purchasableItems
         spyRetryHandler = retryHandler
+        await onSyncOrderCalled?()
 
         guard let orderStateToReturn else {
             orderState = .syncing

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -422,6 +422,45 @@ struct PointOfSaleAggregateModelTests {
             #expect(cardPresentPaymentService.collectPaymentChannel == .pos)
         }
 
+        @Test func cancelInFlightCheckout_whileSyncing_prevents_card_collection_when_sync_finishes() async throws {
+            // Given
+            let cardPresentPaymentService = MockCardPresentPaymentService()
+            let orderController = MockPointOfSaleOrderController()
+            let itemsController = MockPointOfSaleItemsController()
+            var releaseSyncOrder: (() -> Void)?
+            var checkoutTask: Task<Void, Never>?
+            cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
+            orderController.orderStateToReturn = makeLoadedOrderState(orderTotal: "$1.00", orderTotalDecimal: 1)
+            let sut = makePointOfSaleAggregateModel(
+                itemsController: itemsController,
+                cardPresentPaymentService: cardPresentPaymentService,
+                orderController: orderController)
+            sut.addToCart(makePurchasableItem())
+
+            // When
+            await fireOnce { fire in
+                orderController.onSyncOrderCalled = {
+                    await withCheckedContinuation { continuation in
+                        releaseSyncOrder = {
+                            continuation.resume()
+                        }
+                        fire()
+                    }
+                }
+                checkoutTask = Task { @MainActor in
+                    await sut.checkOut()
+                }
+            }
+
+            sut.cancelInFlightCheckout()
+            releaseSyncOrder?()
+            await checkoutTask?.value
+
+            // Then
+            #expect(sut.orderStage == .building)
+            #expect(cardPresentPaymentService.collectPaymentWasCalled == false)
+        }
+
         @Test func sendReceipt_when_invoked_then_calls_receiptSender() async throws {
             // Given
             let receiptSender = MockPOSReceiptSender()


### PR DESCRIPTION
Part of: RSM-645

## Description
Cancels stale checkout work when Orders is opened, including checkout sync that finishes after the merchant has already moved into an order/refund flow. This prevents an old sale payment from starting underneath a card-present refund.

## Test Steps
Optional targeted check: start checkout with the reader disconnected, open Orders while checkout is still progressing, then start a card-present refund and confirm retry/back does not resume the sale payment underneath.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.