### PR TITLE
RSM-645 Handle POS card-present refund cancellation state

### DIFF
--- a/Modules/Sources/Networking/Remote/RefundsRemote.swift
+++ b/Modules/Sources/Networking/Remote/RefundsRemote.swift
@@ -115,7 +115,14 @@ public final class RefundsRemote: Remote {
                                          parameters: parameters,
                                          availableAsRESTRequest: true)
 
-            enqueue(request, mapper: mapper, completion: completion)
+            enqueue(request, mapper: mapper) { result in
+                switch result {
+                case .success(let refund):
+                    completion(refund, nil)
+                case .failure(let error):
+                    completion(nil, error)
+                }
+            }
         } catch {
             completion(nil, error)
             DDLogError("Unable to serialize data for refunds: \(error)")

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -28,6 +28,7 @@ protocol POSOrderListControllerProtocol {
     var refundActionAvailability: RefundActionAvailability { get }
     var refundSelectableItems: [POSRefundSelectableItem] { get }
     var currentRefundRequiresCardPresentRefund: Bool { get }
+    var hasModifiedRefundSelection: Bool { get }
     func loadOrders() async
     func refreshOrders() async
     func loadNextOrders() async
@@ -69,6 +70,7 @@ enum RefundActionAvailability {
     private(set) var isLoadingOrderRefunds = false
     private(set) var selectedOrderRefundsState: POSOrderListSelectedOrderRefundsState = .idle
     private(set) var refundSelectableItems: [POSRefundSelectableItem] = []
+    private(set) var hasModifiedRefundSelection = false
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
@@ -264,6 +266,8 @@ enum RefundActionAvailability {
         selectedOrder = order
         isLoadingOrderRefunds = false
         selectedOrderRefundsState = .idle
+        refundSelectableItems = []
+        hasModifiedRefundSelection = false
     }
 
     @MainActor
@@ -319,6 +323,7 @@ enum RefundActionAvailability {
         }
 
         refundSelectableItems = preparation.selectableItems
+        hasModifiedRefundSelection = false
 
         return refundSelectableItems.isEmpty ? .nothingToRefund : .hasItemsToRefund
     }
@@ -328,20 +333,24 @@ enum RefundActionAvailability {
     func toggleRefundItemSelection(at index: Int) {
         guard refundSelectableItems.indices.contains(index) else { return }
         refundSelectableItems[index].isSelected.toggle()
+        hasModifiedRefundSelection = true
     }
 
     @MainActor
     func clearRefundSelection() {
         refundSelectableItems = []
+        hasModifiedRefundSelection = false
     }
 
     @MainActor
     func toggleAllRefundItemsSelection() {
+        guard !refundSelectableItems.isEmpty else { return }
         let allSelected = !refundSelectableItems.isEmpty && refundSelectableItems.allSatisfy { $0.isSelected }
         let newSelectionState = !allSelected
         for index in refundSelectableItems.indices {
             refundSelectableItems[index].isSelected = newSelectionState
         }
+        hasModifiedRefundSelection = true
     }
 
     // MARK: - Refund Review Data Preparation

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -62,6 +62,36 @@ enum RefundActionAvailability {
     case unavailable
 }
 
+enum POSRefundProcessingError: LocalizedError, Equatable {
+    case missingSelectedOrder
+    case missingRefundPreparation
+    case emptySelection
+    case refundAlreadyInProgress
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSelectedOrder, .missingRefundPreparation:
+            return NSLocalizedString(
+                "pos.refund.processing.error.missingPreparation",
+                value: "The refund could not be prepared. Please try again.",
+                comment: "Error shown when POS tries to process a refund without prepared order refund data."
+            )
+        case .emptySelection:
+            return NSLocalizedString(
+                "pos.refund.processing.error.emptySelection",
+                value: "Select at least one item to refund.",
+                comment: "Error shown when POS tries to process a refund without selected refund items."
+            )
+        case .refundAlreadyInProgress:
+            return NSLocalizedString(
+                "pos.refund.processing.error.alreadyInProgress",
+                value: "A refund is already in progress. Please wait for it to finish.",
+                comment: "Error shown when POS tries to process a second refund while another refund is in progress."
+            )
+        }
+    }
+}
+
 @Observable final class POSOrderListController: POSSearchingOrderListControllerProtocol {
     var ordersViewState: POSOrderListState
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
@@ -76,6 +106,7 @@ enum RefundActionAvailability {
     private let refundsService: POSRefundsServiceProtocol
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
     private let featureFlags: POSFeatureFlagProviding
+    private var isProcessingRefund = false
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
              return existing
@@ -385,20 +416,26 @@ enum RefundActionAvailability {
 
     @MainActor
     func processRefund(reason: String?) async throws {
+        guard !isProcessingRefund else {
+            throw POSRefundProcessingError.refundAlreadyInProgress
+        }
+
+        isProcessingRefund = true
+        defer {
+            isProcessingRefund = false
+        }
+
         guard let order = selectedOrder else {
-            assertionFailure("processRefund called without selected order")
-            return
+            throw POSRefundProcessingError.missingSelectedOrder
         }
 
         guard case .loaded(let preparation) = selectedOrderRefundsState else {
-            assertionFailure("processRefund called without loaded refunds state")
-            return
+            throw POSRefundProcessingError.missingRefundPreparation
         }
 
         let selectedItems = refundSelectableItems.filter { $0.isSelected }
         guard !selectedItems.isEmpty else {
-            assertionFailure("processRefund called without selected items")
-            return
+            throw POSRefundProcessingError.emptySelection
         }
 
         try await refundSubmissionProcessor.submitRefund(

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -34,6 +34,7 @@ protocol POSOrderListControllerProtocol {
     func loadNextOrders() async
     func selectOrder(_ order: POSOrder?)
     func updateOrder(orderID: Int64) async throws
+    func preloadRefundDetails() async
     func startRefundFlow() async -> StartRefundFlowResult
     func toggleRefundItemSelection(at index: Int)
     func clearRefundSelection()
@@ -308,6 +309,15 @@ enum RefundActionAvailability {
     }
 
     // MARK: - Refund Item Selection
+
+    @MainActor
+    func preloadRefundDetails() async {
+        guard refundActionAvailability == .available,
+              let order = selectedOrder else {
+            return
+        }
+        await refundSubmissionProcessor.preloadRefund(for: order)
+    }
 
     @MainActor
     func startRefundFlow() async -> StartRefundFlowResult {

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
@@ -57,6 +57,8 @@ public enum POSRefundSubmissionError: Error, Equatable {
 public protocol POSRefundSubmissionProcessing: AnyObject {
     var stateModel: POSRefundSubmissionModel { get }
 
+    func preloadRefund(for order: POSOrder) async
+
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation
 
     func prepareReviewData(for order: POSOrder,
@@ -74,6 +76,8 @@ public final class POSNoOpRefundSubmissionProcessor: POSRefundSubmissionProcessi
     public let stateModel = POSRefundSubmissionModel()
 
     public nonisolated init() {}
+
+    public func preloadRefund(for order: POSOrder) async {}
 
     public func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
         POSRefundPreparation(orderID: order.id,

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
@@ -33,9 +33,14 @@ public enum POSRefundSubmissionState {
     case processingReader
     case displayingReaderMessage(String)
     case submitting
+    case submittingCardPresent
     case retryableError(error: any Error, retry: () -> Void, cancel: () -> Void)
     case nonRetryableError(error: any Error, dismiss: () -> Void)
     case completed
+}
+
+public enum POSRefundSubmissionError: Error, Equatable {
+    case canceledByUser
 }
 
 @Observable public final class POSRefundSubmissionModel {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -8,9 +8,15 @@ import struct Yosemite.POSRefundItem
 import enum Yosemite.OrderStatusEnum
 import typealias Yosemite.OrderItemAttribute
 
+private enum POSOrderDetailsNavigationDestination: Hashable {
+    case refundSelection
+}
+
 struct POSOrderDetailsView: View {
     let order: POSOrder
     let onBack: () -> Void
+    @Binding private var detailNavigationPath: NavigationPath
+    @Binding private var activeRefundSelectionOrderID: Int64?
     @State var autoStartNextRefundFlow: Bool = false
     var onRefundSuccess: (() -> Void)? = nil
     var onRefundFailure: ((Error) -> Void)? = nil
@@ -22,8 +28,10 @@ struct POSOrderDetailsView: View {
     @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.posCurrencyProvider) private var currencyProvider
     @State private var isShowingEmailReceiptView = false
+    @State private var refundSelectionState: RefundSelectionState?
     @State private var refundModalState: RefundModalState?
     @State private var refundFlowPreparationID: UUID?
+    @State private var currentRefundReason: String?
     @State private var selectedRefundForDetail: POSOrderRefund?
 
     private var shouldShowBackButton: Bool {
@@ -36,6 +44,24 @@ struct POSOrderDetailsView: View {
 
     private var dateFormatter: DateFormatter {
         DateFormatter.posDateAndTimeFormatter(timeZone: siteTimezone)
+    }
+
+    init(
+        order: POSOrder,
+        detailNavigationPath: Binding<NavigationPath> = .constant(NavigationPath()),
+        activeRefundSelectionOrderID: Binding<Int64?> = .constant(nil),
+        onBack: @escaping () -> Void,
+        autoStartNextRefundFlow: Bool = false,
+        onRefundSuccess: (() -> Void)? = nil,
+        onRefundFailure: ((Error) -> Void)? = nil
+    ) {
+        self.order = order
+        self.onBack = onBack
+        self._detailNavigationPath = detailNavigationPath
+        self._activeRefundSelectionOrderID = activeRefundSelectionOrderID
+        self._autoStartNextRefundFlow = State(initialValue: autoStartNextRefundFlow)
+        self.onRefundSuccess = onRefundSuccess
+        self.onRefundFailure = onRefundFailure
     }
 
     var body: some View {
@@ -110,31 +136,36 @@ struct POSOrderDetailsView: View {
                 onClose: { selectedRefundForDetail = nil }
             )
         }
-        .posFullScreenCover(isPresented: isRefundFlowPresented, onDismiss: {
-            dismissRefundFlow()
-        }) {
+        .navigationDestination(for: POSOrderDetailsNavigationDestination.self) { destination in
+            switch destination {
+            case .refundSelection:
+                if let refundSelectionState {
+                    POSRefundSelectionFlowView(
+                        state: refundSelectionState,
+                        errorStrings: refundErrorStrings,
+                        onDismiss: { dismissRefundFlow() },
+                        onRetryLoading: { initiateRefundFlow() },
+                        onRetryPreparation: {
+                            self.refundSelectionState = .itemSelection
+                        },
+                        onContinue: { navigateToRefundReview() }
+                    )
+                }
+            }
+        }
+        .posFullScreenCover(isPresented: isRefundModalPresented) {
             if let state = refundModalState {
                 POSRefundModalContentView(
                     state: state,
                     modalState: $refundModalState,
                     order: order,
                     onDismiss: { dismissRefundFlow() },
-                    onRetryLoading: { initiateRefundFlow() },
-                    onRetryPreparation: {
-                        refundModalState = .itemSelection
-                    },
-                    onEditRefund: { refundModalState = .itemSelection },
-                    showsItemSelection: true,
+                    onReturnToSelection: { returnToRefundSelection() },
+                    initialRefundReason: currentRefundReason,
+                    onRefundReasonChanged: { currentRefundReason = $0 },
                     onRefundSuccess: onRefundSuccess,
                     onRefundFailure: onRefundFailure,
-                    errorStrings: .init(
-                        loadTitle: Localization.loadRefundErrorTitle,
-                        loadSubtitle: Localization.loadRefundErrorSubtitle,
-                        prepareTitle: Localization.prepareRefundErrorTitle,
-                        prepareSubtitle: Localization.prepareRefundErrorSubtitle,
-                        createTitle: Localization.createRefundErrorTitle,
-                        createSubtitle: Localization.createRefundErrorSubtitle
-                    )
+                    errorStrings: refundErrorStrings
                 )
             }
         }
@@ -552,11 +583,14 @@ private extension POSOrderDetailsView {
 // MARK: - Refund Flow Helpers
 
 private extension POSOrderDetailsView {
-    var isRefundFlowPresented: Binding<Bool> {
+    var isRefundModalPresented: Binding<Bool> {
         Binding(
             get: { refundModalState != nil },
             set: { isPresented in
                 if !isPresented {
+                    if refundModalState == nil, refundSelectionState != nil {
+                        return
+                    }
                     dismissRefundFlow()
                 }
             }
@@ -567,7 +601,9 @@ private extension POSOrderDetailsView {
         analytics.track(event: WooAnalyticsEvent.PointOfSale.refundFlowStarted())
         let preparationID = UUID()
         refundFlowPreparationID = preparationID
-        refundModalState = .loading
+        refundModalState = nil
+        refundSelectionState = .loading
+        presentRefundSelection()
         Task { @MainActor in
             let result = await orderListModel.ordersController.startRefundFlow()
             guard refundFlowPreparationID == preparationID else {
@@ -576,30 +612,75 @@ private extension POSOrderDetailsView {
             refundFlowPreparationID = nil
             switch result {
             case .hasItemsToRefund:
-                refundModalState = .itemSelection
+                refundSelectionState = .itemSelection
             case .nothingToRefund:
-                refundModalState = .nothingToRefund
+                refundSelectionState = .nothingToRefund
             case .failed:
-                refundModalState = .loadingError
+                refundSelectionState = .loadingError
             }
         }
     }
 
     func navigateToRefundReview() {
-        guard let reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
-            refundModalState = .preparationError
+        guard var reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
+            refundSelectionState = .preparationError
             return
         }
+        reviewData.refundReason = currentRefundReason
         refundModalState = .review(reviewData)
     }
 
+    func returnToRefundSelection() {
+        refundSelectionState = .itemSelection
+        refundModalState = nil
+    }
+
     func dismissRefundFlow() {
-        if let step = refundModalState?.abortStep {
+        let abortStep: WooAnalyticsEvent.PointOfSale.RefundStep?
+        if let refundModalState {
+            abortStep = refundModalState.abortStep
+        } else {
+            abortStep = refundSelectionState?.abortStep
+        }
+
+        if let step = abortStep {
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundFlowAborted(step: step))
         }
         refundFlowPreparationID = nil
+        refundSelectionState = nil
         refundModalState = nil
+        currentRefundReason = nil
         orderListModel.ordersController.clearRefundSelection()
+        dismissRefundSelectionIfNeeded()
+    }
+
+    func presentRefundSelection() {
+        guard activeRefundSelectionOrderID != order.id else {
+            return
+        }
+        activeRefundSelectionOrderID = order.id
+        detailNavigationPath.append(POSOrderDetailsNavigationDestination.refundSelection)
+    }
+
+    func dismissRefundSelectionIfNeeded() {
+        guard activeRefundSelectionOrderID == order.id else {
+            return
+        }
+        activeRefundSelectionOrderID = nil
+        if !detailNavigationPath.isEmpty {
+            detailNavigationPath.removeLast()
+        }
+    }
+
+    var refundErrorStrings: POSRefundErrorStrings {
+        .init(
+            loadTitle: Localization.loadRefundErrorTitle,
+            loadSubtitle: Localization.loadRefundErrorSubtitle,
+            prepareTitle: Localization.prepareRefundErrorTitle,
+            prepareSubtitle: Localization.prepareRefundErrorSubtitle,
+            createTitle: Localization.createRefundErrorTitle,
+            createSubtitle: Localization.createRefundErrorSubtitle
+        )
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -23,6 +23,7 @@ struct POSOrderDetailsView: View {
     @Environment(\.posCurrencyProvider) private var currencyProvider
     @State private var isShowingEmailReceiptView = false
     @State private var refundModalState: RefundModalState?
+    @State private var refundFlowPreparationID: UUID?
     @State private var selectedRefundForDetail: POSOrderRefund?
 
     private var shouldShowBackButton: Bool {
@@ -109,33 +110,33 @@ struct POSOrderDetailsView: View {
                 onClose: { selectedRefundForDetail = nil }
             )
         }
-        .posModal(item: $refundModalState, onDismiss: {
-            if let step = refundModalState?.abortStep {
-                analytics.track(event: WooAnalyticsEvent.PointOfSale.refundFlowAborted(step: step))
-            }
-            orderListModel.ordersController.clearRefundSelection()
-        }) { state in
-            POSRefundModalContentView(
-                state: state,
-                modalState: $refundModalState,
-                order: order,
-                onRetryLoading: { initiateRefundFlow() },
-                onRetryPreparation: {
-                    refundModalState = .itemSelection
-                },
-                onEditRefund: { refundModalState = .itemSelection },
-                showsItemSelection: true,
-                onRefundSuccess: onRefundSuccess,
-                onRefundFailure: onRefundFailure,
-                errorStrings: .init(
-                    loadTitle: Localization.loadRefundErrorTitle,
-                    loadSubtitle: Localization.loadRefundErrorSubtitle,
-                    prepareTitle: Localization.prepareRefundErrorTitle,
-                    prepareSubtitle: Localization.prepareRefundErrorSubtitle,
-                    createTitle: Localization.createRefundErrorTitle,
-                    createSubtitle: Localization.createRefundErrorSubtitle
+        .posFullScreenCover(isPresented: isRefundFlowPresented, onDismiss: {
+            dismissRefundFlow()
+        }) {
+            if let state = refundModalState {
+                POSRefundModalContentView(
+                    state: state,
+                    modalState: $refundModalState,
+                    order: order,
+                    onDismiss: { dismissRefundFlow() },
+                    onRetryLoading: { initiateRefundFlow() },
+                    onRetryPreparation: {
+                        refundModalState = .itemSelection
+                    },
+                    onEditRefund: { refundModalState = .itemSelection },
+                    showsItemSelection: true,
+                    onRefundSuccess: onRefundSuccess,
+                    onRefundFailure: onRefundFailure,
+                    errorStrings: .init(
+                        loadTitle: Localization.loadRefundErrorTitle,
+                        loadSubtitle: Localization.loadRefundErrorSubtitle,
+                        prepareTitle: Localization.prepareRefundErrorTitle,
+                        prepareSubtitle: Localization.prepareRefundErrorSubtitle,
+                        createTitle: Localization.createRefundErrorTitle,
+                        createSubtitle: Localization.createRefundErrorSubtitle
+                    )
                 )
-            )
+            }
         }
         .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
             POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
@@ -551,11 +552,28 @@ private extension POSOrderDetailsView {
 // MARK: - Refund Flow Helpers
 
 private extension POSOrderDetailsView {
+    var isRefundFlowPresented: Binding<Bool> {
+        Binding(
+            get: { refundModalState != nil },
+            set: { isPresented in
+                if !isPresented {
+                    dismissRefundFlow()
+                }
+            }
+        )
+    }
+
     func initiateRefundFlow() {
         analytics.track(event: WooAnalyticsEvent.PointOfSale.refundFlowStarted())
+        let preparationID = UUID()
+        refundFlowPreparationID = preparationID
         refundModalState = .loading
         Task { @MainActor in
             let result = await orderListModel.ordersController.startRefundFlow()
+            guard refundFlowPreparationID == preparationID else {
+                return
+            }
+            refundFlowPreparationID = nil
             switch result {
             case .hasItemsToRefund:
                 refundModalState = .itemSelection
@@ -573,6 +591,15 @@ private extension POSOrderDetailsView {
             return
         }
         refundModalState = .review(reviewData)
+    }
+
+    func dismissRefundFlow() {
+        if let step = refundModalState?.abortStep {
+            analytics.track(event: WooAnalyticsEvent.PointOfSale.refundFlowAborted(step: step))
+        }
+        refundFlowPreparationID = nil
+        refundModalState = nil
+        orderListModel.ordersController.clearRefundSelection()
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -179,6 +179,9 @@ struct POSOrderDetailsView: View {
             guard shouldShowDedicatedRefundsSection else { return }
             await orderListModel.ordersController.loadOrderRefunds()
         }
+        .task {
+            await orderListModel.ordersController.preloadRefundDetails()
+        }
         .onAppear {
             if autoStartNextRefundFlow {
                 autoStartNextRefundFlow = false

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -7,6 +7,7 @@ import enum Yosemite.SearchDebounceStrategy
 struct POSOrderListView: View {
     @Binding var isSearching: Bool
     @Binding var searchTerm: String
+    let onOrderSelected: (POSOrder) -> Void
     let onClose: () -> Void
 
     @Environment(POSOrderListModel.self) private var orderListModel
@@ -16,6 +17,18 @@ struct POSOrderListView: View {
 
     private var ordersViewState: POSOrderListState {
         orderListModel.ordersController.ordersViewState
+    }
+
+    init(
+        isSearching: Binding<Bool>,
+        searchTerm: Binding<String>,
+        onOrderSelected: @escaping (POSOrder) -> Void = { _ in },
+        onClose: @escaping () -> Void
+    ) {
+        self._isSearching = isSearching
+        self._searchTerm = searchTerm
+        self.onOrderSelected = onOrderSelected
+        self.onClose = onClose
     }
 
     var body: some View {
@@ -140,7 +153,7 @@ struct POSOrderListView: View {
                                 orderCreatedDate: order.dateCreated,
                                 siteTimezone: siteTimezone
                             ))
-                            orderListModel.ordersController.selectOrder(order)
+                            onOrderSelected(order)
                         }) {
                             POSOrderRowView(order: order, isSelected: orderListModel.ordersController.selectedOrder?.id == order.id)
                         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import struct WooFoundation.WooAnalyticsEvent
+import struct Yosemite.POSOrder
 
 struct POSOrdersView: View {
     @Binding var isPresented: Bool
@@ -9,6 +10,9 @@ struct POSOrdersView: View {
     @Environment(\.posAnalytics) private var analytics
     @State private var isSearching: Bool = false
     @State private var searchTerm: String = ""
+    @State private var activeRefundSelectionOrderID: Int64?
+    @State private var pendingOrderSelection: POSOrder?
+    @State private var isCancelRefundConfirmationPresented = false
 
     var body: some View {
         contentView
@@ -27,9 +31,13 @@ struct POSOrdersView: View {
         default:
             POSNavigationSplitView(selection: Binding(
                 get: { orderListModel.ordersController.selectedOrder },
-                set: { orderListModel.ordersController.selectOrder($0) }
+                set: { selectOrder($0) }
             )) { _ in
-                POSOrderListView(isSearching: $isSearching, searchTerm: $searchTerm) {
+                POSOrderListView(
+                    isSearching: $isSearching,
+                    searchTerm: $searchTerm,
+                    onOrderSelected: { handleOrderSelection($0) }
+                ) {
                     isPresented = false
                 }
                 .environment(orderListModel)
@@ -37,8 +45,9 @@ struct POSOrdersView: View {
                 POSOrderDetailsView(
                     order: selection,
                     detailNavigationPath: detailNavigationPath,
+                    activeRefundSelectionOrderID: $activeRefundSelectionOrderID,
                     onBack: {
-                        orderListModel.ordersController.selectOrder(nil)
+                        selectOrder(nil)
                     }
                 )
                 .id(selection.id)
@@ -52,14 +61,14 @@ struct POSOrdersView: View {
             } setDefaultValue: {
                 if orderListModel.ordersController.selectedOrder == nil,
                    let firstOrder = orderListModel.ordersController.ordersViewState.orders.first {
-                    orderListModel.ordersController.selectOrder(firstOrder)
+                    selectOrder(firstOrder)
                 }
             }
             .onChange(of: orderListModel.ordersController.ordersViewState.orders) { oldOrders, newOrders in
                 guard horizontalSizeClass == .regular else { return }
 
                 guard let firstOrder = newOrders.first else {
-                    orderListModel.ordersController.selectOrder(nil)
+                    selectOrder(nil)
                     return
                 }
 
@@ -67,14 +76,27 @@ struct POSOrdersView: View {
                     return
                 }
 
-                orderListModel.ordersController.selectOrder(firstOrder)
+                selectOrder(firstOrder)
             }
             .animation(.default, value: orderListModel.ordersController.ordersViewState.orders.isEmpty)
             .onAppear {
                 analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersListLoaded())
             }
             .onDisappear {
-                orderListModel.ordersController.selectOrder(nil)
+                activeRefundSelectionOrderID = nil
+                selectOrder(nil)
+            }
+            .alert(Localization.cancelRefundAlertTitle,
+                   isPresented: $isCancelRefundConfirmationPresented,
+                   presenting: pendingOrderSelection) { order in
+                Button(Localization.keepEditingRefundButton, role: .cancel) {
+                    pendingOrderSelection = nil
+                }
+                Button(Localization.cancelRefundButton, role: .destructive) {
+                    cancelActiveRefundSelectionAndSelect(order)
+                }
+            } message: { _ in
+                Text(Localization.cancelRefundAlertMessage)
             }
         }
     }
@@ -130,6 +152,67 @@ struct POSOrdersView: View {
             }
         }
     }
+}
+
+private extension POSOrdersView {
+    func handleOrderSelection(_ order: POSOrder) {
+        guard orderListModel.ordersController.selectedOrder?.id != order.id else {
+            return
+        }
+
+        guard activeRefundSelectionOrderID != nil else {
+            selectOrder(order)
+            return
+        }
+
+        if orderListModel.ordersController.hasModifiedRefundSelection {
+            pendingOrderSelection = order
+            isCancelRefundConfirmationPresented = true
+        } else {
+            cancelActiveRefundSelectionAndSelect(order)
+        }
+    }
+
+    func cancelActiveRefundSelectionAndSelect(_ order: POSOrder) {
+        activeRefundSelectionOrderID = nil
+        pendingOrderSelection = nil
+        orderListModel.ordersController.clearRefundSelection()
+        selectOrder(order)
+    }
+
+    func selectOrder(_ order: POSOrder?) {
+        if orderListModel.ordersController.selectedOrder?.id != order?.id {
+            activeRefundSelectionOrderID = nil
+            pendingOrderSelection = nil
+        }
+        orderListModel.ordersController.selectOrder(order)
+    }
+}
+
+private enum Localization {
+    static let cancelRefundAlertTitle = NSLocalizedString(
+        "pos.ordersView.cancelRefundAlert.title",
+        value: "Cancel this refund?",
+        comment: "Title for an alert asking whether to cancel an in-progress POS refund before selecting another order."
+    )
+
+    static let cancelRefundAlertMessage = NSLocalizedString(
+        "pos.ordersView.cancelRefundAlert.message",
+        value: "Your current refund selection will be discarded.",
+        comment: "Message for an alert asking whether to cancel an in-progress POS refund before selecting another order."
+    )
+
+    static let keepEditingRefundButton = NSLocalizedString(
+        "pos.ordersView.cancelRefundAlert.keepEditing.button",
+        value: "Keep editing",
+        comment: "Button to keep editing the current POS refund selection instead of selecting another order."
+    )
+
+    static let cancelRefundButton = NSLocalizedString(
+        "pos.ordersView.cancelRefundAlert.cancelRefund.button",
+        value: "Cancel refund",
+        comment: "Button to cancel the current POS refund selection and select another order."
+    )
 }
 
 #if DEBUG

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -33,9 +33,10 @@ struct POSOrdersView: View {
                     isPresented = false
                 }
                 .environment(orderListModel)
-            } detail: { selection, _ in
+            } detail: { selection, detailNavigationPath in
                 POSOrderDetailsView(
                     order: selection,
+                    detailNavigationPath: detailNavigationPath,
                     onBack: {
                         orderListModel.ordersController.selectOrder(nil)
                     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -8,6 +8,8 @@ struct POSRefundConfirmationView: View {
     let onClose: () -> Void
     let onConfirm: () -> Void
     let onBack: (() -> Void)?
+    var shouldUseCardPresentCompletionStyle = false
+    var onPaymentCaptureErrorCancel: ((@escaping () -> Void) -> Void)?
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -82,6 +84,8 @@ private extension POSRefundConfirmationView {
             return .processing(.processing)
         case .displayingReaderMessage(let message):
             return .displayReaderMessage(.displayReaderMessage(message))
+        case .completed where shouldUseCardPresentCompletionStyle:
+            return .processing(.processing)
         case .idle, .loading, .onboarding, .preparingReader, .waitingForCard, .submitting, .retryableError, .nonRetryableError, .completed:
             return nil
         case .submittingCardPresent:
@@ -177,6 +181,8 @@ private extension POSRefundConfirmationView {
                                onClose: dismiss)
         case .submittingCardPresent:
             cardPresentMessageView(.processing(.processing))
+        case .completed where shouldUseCardPresentCompletionStyle:
+            cardPresentMessageView(.processing(.processing))
         case .idle, .loading, .submitting, .completed:
             loadingSection
         }
@@ -224,7 +230,7 @@ private extension POSRefundConfirmationView {
         case .paymentCaptureError(let cancelPayment):
             return .error(.init(error: POSRefundCardPresentPresentationError.unableToConfirmRefund,
                                 retryAction: nil,
-                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
+                                cancelAction: paymentCaptureErrorCancelAction(cancelPayment)))
         case .paymentIntentCreationError(let error, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: nil,
@@ -245,6 +251,15 @@ private extension POSRefundConfirmationView {
             return retryAction
         case .dontRetry:
             return nil
+        }
+    }
+
+    func paymentCaptureErrorCancelAction(_ cancelPayment: @escaping () -> Void) -> () -> Void {
+        guard let onPaymentCaptureErrorCancel else {
+            return cancelAndReturnToConfirmation(cancelPayment)
+        }
+        return {
+            onPaymentCaptureErrorCancel(cancelPayment)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -63,7 +63,11 @@ private extension POSRefundConfirmationView {
     }
 
     var backgroundColor: Color {
-        primaryBackgroundCardPresentMessageType == nil ? .posSurfaceBright : .posPrimary
+        guard isProcessing else {
+            return .posSurfaceBright
+        }
+
+        return primaryBackgroundCardPresentMessageType == nil ? Color.posSurfaceBright : Color.posPrimary
     }
 
     var primaryBackgroundCardPresentMessageType: POSRefundCardPresentMessageType? {
@@ -95,15 +99,22 @@ private extension POSRefundConfirmationView {
     var processingCancelAction: (() -> Void)? {
         switch submissionState {
         case .onboarding(_, let onCancel):
-            return onCancel
+            return cancelAndReturnToConfirmation(onCancel)
         case .cardPresentEvent(let eventDetails):
-            return eventDetails.posRefundCancelAction
+            return eventDetails.posRefundCancelAction.map(cancelAndReturnToConfirmation)
         case .preparingReader(let cancel),
                 .waitingForCard(_, let cancel):
-            return cancel
+            return cancelAndReturnToConfirmation(cancel)
         case .idle, .loading, .processingReader, .displayingReaderMessage, .submitting, .submittingCardPresent,
                 .retryableError, .nonRetryableError, .completed:
             return nil
+        }
+    }
+
+    func cancelAndReturnToConfirmation(_ cancel: @escaping () -> Void) -> () -> Void {
+        {
+            onBack?()
+            cancel()
         }
     }
 
@@ -209,15 +220,15 @@ private extension POSRefundConfirmationView {
         case .paymentError(let error, let retryApproach, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: retryAction(for: retryApproach),
-                                cancelAction: cancelPayment))
+                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
         case .paymentCaptureError(let cancelPayment):
             return .error(.init(error: POSRefundCardPresentPresentationError.unableToConfirmRefund,
                                 retryAction: nil,
-                                cancelAction: cancelPayment))
+                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
         case .paymentIntentCreationError(let error, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: nil,
-                                cancelAction: cancelPayment))
+                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
         case .scanningForReaders, .scanningFailed, .bluetoothRequired, .connectingToReader, .connectingFailed,
                 .connectingFailedNonRetryable, .connectingFailedUpdatePostalCode, .connectingFailedChargeReader,
                 .connectingFailedUpdateAddress, .selectSearchType, .foundReader, .foundMultipleReaders, .updateProgress,
@@ -265,7 +276,7 @@ private enum POSRefundCardPresentPresentationError: LocalizedError {
     }
 }
 
-private extension CardPresentPaymentEventDetails {
+extension CardPresentPaymentEventDetails {
     var posRefundCancelAction: (() -> Void)? {
         switch self {
         case .scanningForReaders(let endSearch),

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -7,7 +7,7 @@ struct POSRefundConfirmationView: View {
     var submissionState: POSRefundSubmissionState = .idle
     let onClose: () -> Void
     let onConfirm: () -> Void
-    let onBack: () -> Void
+    let onBack: (() -> Void)?
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -59,7 +59,7 @@ private extension POSRefundConfirmationView {
                 return headerBackAction != nil
             }
         }
-        return true
+        return headerBackAction != nil
     }
 
     var backgroundColor: Color {
@@ -205,7 +205,7 @@ private extension POSRefundConfirmationView {
         case .displayReaderMessage(let message):
             return .displayReaderMessage(.displayReaderMessage(message))
         case .cancelledOnReader:
-            return .cancelledOnReader(.cancelledOnReader(backToRefund: onBack))
+            return .cancelledOnReader(.cancelledOnReader(backToRefund: onBack ?? onClose))
         case .paymentError(let error, let retryApproach, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: retryAction(for: retryApproach),

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -60,6 +60,8 @@ private extension POSRefundErrorView {
                 Text(subtitle)
                     .font(.posBodyLargeRegular())
                     .foregroundColor(Color.posOnSurface)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .multilineTextAlignment(.center)
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -4,11 +4,26 @@ struct POSRefundErrorView: View {
     let title: String
     let subtitle: String
     let onRetry: (() -> Void)?
+    let cancelButtonTitle: String?
     let onCancel: () -> Void
     let onClose: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    init(title: String,
+         subtitle: String,
+         onRetry: (() -> Void)?,
+         cancelButtonTitle: String? = nil,
+         onCancel: @escaping () -> Void,
+         onClose: @escaping () -> Void) {
+        self.title = title
+        self.subtitle = subtitle
+        self.onRetry = onRetry
+        self.cancelButtonTitle = cancelButtonTitle
+        self.onCancel = onCancel
+        self.onClose = onClose
+    }
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -59,7 +74,7 @@ private extension POSRefundErrorView {
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
             }
 
-            Button(Localization.cancelButton, action: onCancel)
+            Button(cancelButtonTitle ?? Localization.cancelButton, action: onCancel)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
         .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -9,7 +9,6 @@ struct POSRefundErrorView: View {
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var isViewLoaded: Bool = false
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -22,11 +21,6 @@ struct POSRefundErrorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
-        .onAppear {
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
-                isViewLoaded = true
-            }
-        }
     }
 }
 
@@ -41,22 +35,16 @@ private extension POSRefundErrorView {
     var contentView: some View {
         VStack(spacing: POSSpacing.xLarge) {
             POSErrorXMark()
-                .scaleEffect(isViewLoaded ? 1 : 0)
-                .opacity(isViewLoaded ? 1 : 0)
 
             VStack(spacing: POSSpacing.small) {
                 Text(title)
                     .font(.posHeadingBold)
                     .foregroundColor(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
 
                 Text(subtitle)
                     .font(.posBodyLargeRegular())
                     .foregroundColor(Color.posOnSurface)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
             }
             .multilineTextAlignment(.center)
         }
@@ -75,16 +63,6 @@ private extension POSRefundErrorView {
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
         .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
-        .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
-        .opacity(isViewLoaded ? 1 : 0)
-    }
-}
-
-// MARK: - Constants
-
-private extension POSRefundErrorView {
-    enum Constants {
-        static let animationOffset: CGFloat = 100
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -240,7 +240,7 @@ struct POSRefundModalContentView: View {
                     .submitting, .retryableError, .nonRetryableError, .completed:
                 return .posSurfaceBright
             }
-        case .review, .confirmation, .success, .error:
+        case .review, .confirmation, .readerConnectionRequired, .success, .error:
             return .posSurfaceBright
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -189,12 +189,12 @@ struct POSRefundModalContentView: View {
                 onConfirm: {
                     handleRefundConfirmation(reviewData: reviewData)
                 },
-                onBack: nil
+                onBack: { modalState = .review(reviewData) }
             )
         case .readerConnectionRequired(let reviewData):
             POSRefundReaderDisconnectedView(
                 onConnect: { startProcessingRefund(reviewData: reviewData) },
-                onCancel: { dismissModal?() },
+                onCancel: { dismissRefundFlow() },
                 onBack: { modalState = .confirmation(reviewData) }
             )
         case .processing(let reviewData):
@@ -205,7 +205,7 @@ struct POSRefundModalContentView: View {
                 submissionState: refundSubmissionModel.state,
                 onClose: {},
                 onConfirm: {},
-                onBack: nil
+                onBack: { returnToRefundConfirmation(reviewData: reviewData) }
             )
         case .success(let reviewData):
             POSRefundSuccessView(
@@ -240,7 +240,7 @@ struct POSRefundModalContentView: View {
                     .submitting, .retryableError, .nonRetryableError, .completed:
                 return .posSurfaceBright
             }
-        case .review, .confirmation, .success, .error:
+        case .review, .confirmation, .readerConnectionRequired, .success, .error:
             return .posSurfaceBright
         }
     }
@@ -282,7 +282,7 @@ struct POSRefundModalContentView: View {
     }
 
     private func updateCardPresentOnboardingItem() {
-        guard case .processing = state,
+        guard case .processing(let reviewData) = state,
               case .onboarding(let factory, let onCancel) = refundSubmissionModel.state else {
             cardPresentOnboardingItem = nil
             return
@@ -291,7 +291,10 @@ struct POSRefundModalContentView: View {
         cardPresentOnboardingItem = POSRefundCardPresentOnboardingItem(
             id: ObjectIdentifier(factory),
             factory: factory,
-            onCancel: onCancel
+            onCancel: {
+                returnToRefundConfirmation(reviewData: reviewData)
+                onCancel()
+            }
         )
     }
 
@@ -300,13 +303,22 @@ struct POSRefundModalContentView: View {
         guard let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: .init(
-                tryPaymentAgainBackToCheckoutAction: { modalState = .confirmation(reviewData) },
+                tryPaymentAgainBackToCheckoutAction: { returnToRefundConfirmation(reviewData: reviewData) },
                 nonRetryableErrorExitAction: { dismissRefundFlow() },
                 formattedOrderTotalPrice: reviewData.formattedRefundTotal,
-                paymentCaptureErrorTryAgainAction: { modalState = .confirmation(reviewData) },
+                paymentCaptureErrorTryAgainAction: { returnToRefundConfirmation(reviewData: reviewData) },
                 paymentCaptureErrorNewOrderAction: { dismissRefundFlow() },
-                paymentIntentCreationErrorEditOrderAction: { modalState = .review(reviewData) },
-                dismissReaderConnectionModal: { cardPresentAlertItem = nil }
+                paymentIntentCreationErrorEditOrderAction: {
+                    refundSubmissionModel.reset()
+                    modalState = .review(reviewData)
+                },
+                dismissReaderConnectionModal: {
+                    let shouldReturnToConfirmation = currentCardPresentEventCanCancel
+                    cardPresentAlertItem = nil
+                    if shouldReturnToConfirmation {
+                        returnToRefundConfirmation(reviewData: reviewData)
+                    }
+                }
             )) else {
             return nil
         }
@@ -327,8 +339,7 @@ struct POSRefundModalContentView: View {
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch POSRefundSubmissionError.canceledByUser {
-            refundSubmissionModel.reset()
-            modalState = .confirmation(reviewData)
+            returnToRefundConfirmation(reviewData: reviewData)
         } catch {
             DDLogError("⛔️ Failed to process POS refund: \(error)")
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
@@ -358,6 +369,24 @@ struct POSRefundModalContentView: View {
         Task { @MainActor in
             await processRefund(reviewData: reviewData)
         }
+    }
+
+    private func returnToRefundConfirmation(reviewData: POSRefundReviewData) {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            cardPresentAlertItem = nil
+            cardPresentOnboardingItem = nil
+            refundSubmissionModel.reset()
+            modalState = .confirmation(reviewData)
+        }
+    }
+
+    private var currentCardPresentEventCanCancel: Bool {
+        guard case .cardPresentEvent(let eventDetails) = refundSubmissionModel.state else {
+            return false
+        }
+        return eventDetails.posRefundCancelAction != nil
     }
 
     private func shouldRequireReaderConnection() -> Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -97,6 +97,7 @@ struct POSRefundModalContentView: View {
     @State private var cardPresentOnboardingItem: POSRefundCardPresentOnboardingItem?
     @State private var currentRefundReason: String?
     @State private var reasonInputReviewData: POSRefundReviewData?
+    @State private var isDismissingAfterAmbiguousRefund = false
 
     var body: some View {
         ZStack {
@@ -205,7 +206,11 @@ struct POSRefundModalContentView: View {
                 submissionState: refundSubmissionModel.state,
                 onClose: {},
                 onConfirm: {},
-                onBack: { returnToRefundConfirmation(reviewData: reviewData) }
+                onBack: { returnToRefundConfirmation(reviewData: reviewData) },
+                shouldUseCardPresentCompletionStyle: orderListModel.ordersController.currentRefundRequiresCardPresentRefund,
+                onPaymentCaptureErrorCancel: { cancelPayment in
+                    handleAmbiguousCardPresentRefund(cancelPayment: cancelPayment)
+                }
             )
         case .success(let reviewData):
             POSRefundSuccessView(
@@ -339,8 +344,14 @@ struct POSRefundModalContentView: View {
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch POSRefundSubmissionError.canceledByUser {
+            guard !isDismissingAfterAmbiguousRefund else {
+                return
+            }
             returnToRefundConfirmation(reviewData: reviewData)
         } catch {
+            guard !isDismissingAfterAmbiguousRefund else {
+                return
+            }
             DDLogError("⛔️ Failed to process POS refund: \(error)")
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
             onRefundFailure?(error)
@@ -379,6 +390,25 @@ struct POSRefundModalContentView: View {
             cardPresentOnboardingItem = nil
             refundSubmissionModel.reset()
             modalState = .confirmation(reviewData)
+        }
+    }
+
+    @MainActor
+    private func handleAmbiguousCardPresentRefund(cancelPayment: @escaping () -> Void) {
+        isDismissingAfterAmbiguousRefund = true
+        cardPresentAlertItem = nil
+        cardPresentOnboardingItem = nil
+        refundSubmissionModel.reset()
+        cancelPayment()
+        dismissRefundFlow()
+
+        Task { @MainActor in
+            do {
+                try await orderListModel.ordersController.updateOrder(orderID: order.id)
+            } catch {
+                DDLogError("⛔️ Failed to refresh POS order after ambiguous refund outcome: \(error)")
+            }
+            await orderListModel.ordersController.loadOrderRefunds()
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -203,8 +203,7 @@ struct POSRefundModalContentView: View {
                 paymentMethodDescription: reviewData.paymentMethodDescription,
                 customerEmail: reviewData.customerEmail,
                 onDone: { dismissModal?() },
-                onEmailReceipt: { isShowingEmailReceiptView = true },
-                onClose: { dismissModal?() }
+                onEmailReceipt: { isShowingEmailReceiptView = true }
             )
         case .error(let reviewData):
             POSRefundErrorView(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -221,12 +221,21 @@ struct POSRefundModalContentView: View {
                 onEmailReceipt: { isShowingEmailReceiptView = true }
             )
         case .error(let reviewData):
+            let isCardPresentRefundError = orderListModel.ordersController.currentRefundRequiresCardPresentRefund
+            let dismissError = {
+                if isCardPresentRefundError {
+                    dismissRefundFlowAndRefreshOrder()
+                } else {
+                    dismissRefundFlow()
+                }
+            }
             POSRefundErrorView(
-                title: errorStrings.createTitle,
-                subtitle: errorStrings.createSubtitle,
-                onRetry: { modalState = .confirmation(reviewData) },
-                onCancel: { dismissRefundFlow() },
-                onClose: { dismissRefundFlow() }
+                title: isCardPresentRefundError ? Localization.cardPresentCreateErrorTitle : errorStrings.createTitle,
+                subtitle: isCardPresentRefundError ? Localization.cardPresentCreateErrorSubtitle : errorStrings.createSubtitle,
+                onRetry: isCardPresentRefundError ? nil : { modalState = .confirmation(reviewData) },
+                cancelButtonTitle: isCardPresentRefundError ? Localization.backToOrderButton : nil,
+                onCancel: dismissError,
+                onClose: dismissError
             )
         }
     }
@@ -272,6 +281,12 @@ struct POSRefundModalContentView: View {
         } else {
             onDismiss()
         }
+    }
+
+    @MainActor
+    private func dismissRefundFlowAndRefreshOrder() {
+        dismissRefundFlow()
+        refreshOrderAfterPotentialCardPresentRefund()
     }
 
     private func updateCardPresentAlertItem() {
@@ -403,15 +418,18 @@ struct POSRefundModalContentView: View {
         cardPresentOnboardingItem = nil
         refundSubmissionModel.reset()
         cancelPayment()
-        dismissRefundFlow()
+        dismissRefundFlowAndRefreshOrder()
 
         // The submission task may still report cancellation/failure after dismissing; isDismissingAfterAmbiguousRefund
         // keeps that late callback from reopening the modal or tracking a normal refund failure.
+    }
+
+    private func refreshOrderAfterPotentialCardPresentRefund() {
         Task { @MainActor in
             do {
                 try await orderListModel.ordersController.updateOrder(orderID: order.id)
             } catch {
-                DDLogError("⛔️ Failed to refresh POS order after ambiguous refund outcome: \(error)")
+                DDLogError("⛔️ Failed to refresh POS order after card-present refund outcome: \(error)")
             }
             await orderListModel.ordersController.loadOrderRefunds()
         }
@@ -433,6 +451,30 @@ struct POSRefundModalContentView: View {
             return false
         }
         return true
+    }
+}
+
+// MARK: - Localization
+
+private extension POSRefundModalContentView {
+    enum Localization {
+        static let cardPresentCreateErrorTitle = NSLocalizedString(
+            "pos.refundModalContentView.cardPresentCreateError.title",
+            value: "Couldn't confirm refund",
+            comment: "Title shown when POS cannot confirm whether a card-present refund was recorded successfully."
+        )
+
+        static let cardPresentCreateErrorSubtitle = NSLocalizedString(
+            "pos.refundModalContentView.cardPresentCreateError.subtitle",
+            value: "Go back to the order and check it before trying again.",
+            comment: "Subtitle shown when POS cannot confirm whether a card-present refund was recorded successfully."
+        )
+
+        static let backToOrderButton = NSLocalizedString(
+            "pos.refundModalContentView.cardPresentCreateError.backToOrderButton",
+            value: "Back to order",
+            comment: "Button to leave the card-present refund error screen and return to the order."
+        )
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -284,7 +284,7 @@ struct POSRefundModalContentView: View {
                 return .posSurfaceBright
             }
         case .loading, .loadingError, .preparationError, .nothingToRefund, .itemSelection, .review, .confirmation,
-                .success, .error:
+                .readerConnectionRequired, .success, .error:
             return .posSurfaceBright
         }
     }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -6,11 +6,6 @@ import struct Yosemite.POSOrder
 // MARK: - Refund Modal State
 
 enum RefundModalState: Identifiable, Equatable {
-    case loading
-    case loadingError
-    case preparationError
-    case nothingToRefund
-    case itemSelection
     case review(POSRefundReviewData)
     case confirmation(POSRefundReviewData)
     case readerConnectionRequired(POSRefundReviewData)
@@ -20,11 +15,6 @@ enum RefundModalState: Identifiable, Equatable {
 
     var id: String {
         switch self {
-        case .loading: return "loading"
-        case .loadingError: return "loadingError"
-        case .preparationError: return "preparationError"
-        case .nothingToRefund: return "nothingToRefund"
-        case .itemSelection: return "itemSelection"
         case .review: return "review"
         case .confirmation: return "confirmation"
         case .readerConnectionRequired: return "readerConnectionRequired"
@@ -37,8 +27,6 @@ enum RefundModalState: Identifiable, Equatable {
     /// Returns the analytics step for abort tracking
     var abortStep: WooAnalyticsEvent.PointOfSale.RefundStep? {
         switch self {
-        case .itemSelection:
-            return .selectItems
         case .review:
             return .reviewRefund
         case .confirmation, .readerConnectionRequired:
@@ -95,10 +83,9 @@ struct POSRefundModalContentView: View {
 
     let order: POSOrder
     let onDismiss: () -> Void
-    let onRetryLoading: () -> Void
-    let onRetryPreparation: () -> Void
-    let onEditRefund: (() -> Void)?
-    let showsItemSelection: Bool
+    let onReturnToSelection: () -> Void
+    let initialRefundReason: String?
+    let onRefundReasonChanged: ((String?) -> Void)?
     let onRefundSuccess: (() -> Void)?
     let onRefundFailure: ((Error) -> Void)?
 
@@ -149,6 +136,7 @@ struct POSRefundModalContentView: View {
                         if var reviewData = reasonInputReviewData {
                             reviewData.refundReason = reason
                             currentRefundReason = reason
+                            onRefundReasonChanged?(reason)
                             modalState = .review(reviewData)
                         }
                         isShowingReasonInput = false
@@ -158,6 +146,7 @@ struct POSRefundModalContentView: View {
                 .posHeaderBackButtonIcon(systemName: "xmark")
             }
             .onAppear {
+                currentRefundReason = initialRefundReason
                 updateCardPresentAlertItem()
                 updateCardPresentOnboardingItem()
             }
@@ -172,41 +161,10 @@ struct POSRefundModalContentView: View {
     @ViewBuilder
     private var content: some View {
         switch state {
-        case .loading:
-            POSRefundLoadingView(onBack: { dismissRefundFlow() })
-        case .loadingError:
-            POSRefundErrorView(
-                title: errorStrings.loadTitle,
-                subtitle: errorStrings.loadSubtitle,
-                onRetry: onRetryLoading,
-                onCancel: { dismissRefundFlow() },
-                onClose: { dismissRefundFlow() }
-            )
-        case .preparationError:
-            POSRefundErrorView(
-                title: errorStrings.prepareTitle,
-                subtitle: errorStrings.prepareSubtitle,
-                onRetry: onRetryPreparation,
-                onCancel: { dismissRefundFlow() },
-                onClose: { dismissRefundFlow() }
-            )
-        case .nothingToRefund:
-            POSRefundNothingToRefundView(onClose: { dismissRefundFlow() })
-        case .itemSelection:
-            if showsItemSelection {
-                POSRefundItemsSelectionView(
-                    onClose: {
-                        dismissRefundFlow()
-                    },
-                    onContinue: { navigateToRefundReview() }
-                )
-            } else {
-                EmptyView()
-            }
         case .review(let reviewData):
             POSRefundReviewView(
                 onClose: {
-                    dismissRefundFlow()
+                    onReturnToSelection()
                 },
                 itemsCount: reviewData.itemsCount,
                 formattedItemsSubtotal: reviewData.formattedItemsSubtotal,
@@ -218,8 +176,7 @@ struct POSRefundModalContentView: View {
                     reasonInputReviewData = reviewData
                     isShowingReasonInput = true
                 },
-                onContinue: { modalState = .confirmation(reviewData) },
-                onEditRefund: onEditRefund
+                onContinue: { modalState = .confirmation(reviewData) }
             )
         case .confirmation(let reviewData):
             POSRefundConfirmationView(
@@ -232,7 +189,7 @@ struct POSRefundModalContentView: View {
                 onConfirm: {
                     handleRefundConfirmation(reviewData: reviewData)
                 },
-                onBack: { modalState = .review(reviewData) }
+                onBack: nil
             )
         case .readerConnectionRequired(let reviewData):
             POSRefundReaderDisconnectedView(
@@ -248,7 +205,7 @@ struct POSRefundModalContentView: View {
                 submissionState: refundSubmissionModel.state,
                 onClose: {},
                 onConfirm: {},
-                onBack: {}
+                onBack: nil
             )
         case .success(let reviewData):
             POSRefundSuccessView(
@@ -283,8 +240,7 @@ struct POSRefundModalContentView: View {
                     .submitting, .retryableError, .nonRetryableError, .completed:
                 return .posSurfaceBright
             }
-        case .loading, .loadingError, .preparationError, .nothingToRefund, .itemSelection, .review, .confirmation,
-                .success, .error:
+        case .review, .confirmation, .success, .error:
             return .posSurfaceBright
         }
     }
@@ -311,15 +267,6 @@ struct POSRefundModalContentView: View {
         } else {
             onDismiss()
         }
-    }
-
-    private func navigateToRefundReview() {
-        guard var reviewData = orderListModel.ordersController.preparePOSRefundReviewData() else {
-            modalState = .preparationError
-            return
-        }
-        reviewData.refundReason = currentRefundReason
-        modalState = .review(reviewData)
     }
 
     private func updateCardPresentAlertItem() {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -60,6 +60,25 @@ struct POSRefundErrorStrings {
     let createSubtitle: String
 }
 
+private struct POSRefundCardPresentAlertItem: Identifiable, Equatable {
+    let id: String
+    let alertType: PointOfSaleCardPresentPaymentAlertType
+
+    static func == (lhs: POSRefundCardPresentAlertItem, rhs: POSRefundCardPresentAlertItem) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+private struct POSRefundCardPresentOnboardingItem: Identifiable, Equatable {
+    let id: ObjectIdentifier
+    let factory: CardPresentPaymentOnboardingViewContainer
+    let onCancel: () -> Void
+
+    static func == (lhs: POSRefundCardPresentOnboardingItem, rhs: POSRefundCardPresentOnboardingItem) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
 // MARK: - Shared Refund Modal Content
 
 struct POSRefundModalContentView: View {
@@ -69,13 +88,13 @@ struct POSRefundModalContentView: View {
     @Environment(POSPaymentModel.self) private var paymentModel
     @Environment(POSRefundSubmissionModel.self) private var refundSubmissionModel
     @Environment(\.posAnalytics) private var analytics
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    /// Dismisses the modal directly, bypassing the `onChange(of:)` chain in `POSModalViewModifier`
-    /// which can fail to fire when the view is inside a pushed navigation destination.
+    /// Dismisses legacy POS modals directly. The order details refund flow now presents as a
+    /// full-screen cover and uses `onDismiss`; keep this fallback for previews or reused modal contexts.
     @Environment(\.posModalDismissAction) private var dismissModal
 
     let order: POSOrder
+    let onDismiss: () -> Void
     let onRetryLoading: () -> Void
     let onRetryPreparation: () -> Void
     let onEditRefund: (() -> Void)?
@@ -87,12 +106,36 @@ struct POSRefundModalContentView: View {
 
     @State private var isShowingEmailReceiptView = false
     @State private var isShowingReasonInput = false
+    @State private var cardPresentAlertItem: POSRefundCardPresentAlertItem?
+    @State private var cardPresentOnboardingItem: POSRefundCardPresentOnboardingItem?
     @State private var currentRefundReason: String?
     @State private var reasonInputReviewData: POSRefundReviewData?
 
     var body: some View {
-        content
-            .posModalFullScreen(horizontalSizeClass == .compact)
+        ZStack {
+            screenBackgroundColor
+                .ignoresSafeArea()
+
+            content
+                .environment(\.posRefundPresentationStyle, .fullScreen)
+        }
+            .ignoresSafeArea(.container, edges: .bottom)
+            .posModal(item: $cardPresentAlertItem, onDismiss: {
+                cardPresentAlertItem?.alertType.onDismiss?()
+            }) { item in
+                PointOfSaleCardPresentPaymentAlert(alertType: item.alertType)
+                    .posInteractiveDismissDisabled(item.alertType.isDismissDisabled)
+            }
+            .posModal(item: $cardPresentOnboardingItem, onDismiss: {
+                cardPresentOnboardingItem?.onCancel()
+            }) { item in
+                PointOfSaleCardPresentPaymentOnboardingView(viewModel: .init(
+                    onboardingViewContainer: item.factory,
+                    onDismissTap: {
+                        item.onCancel()
+                        cardPresentOnboardingItem = nil
+                    }))
+            }
             .posFullScreenCover(isPresented: $isShowingEmailReceiptView) {
                 POSSendReceiptView(isShowingSendReceiptView: $isShowingEmailReceiptView) { email in
                     try await orderListModel.sendReceipt(order: order, email: email)
@@ -114,36 +157,46 @@ struct POSRefundModalContentView: View {
                 )
                 .posHeaderBackButtonIcon(systemName: "xmark")
             }
+            .onAppear {
+                updateCardPresentAlertItem()
+                updateCardPresentOnboardingItem()
+            }
+            .onChange(of: cardPresentAlertID) { _, _ in
+                updateCardPresentAlertItem()
+            }
+            .onChange(of: cardPresentOnboardingID) { _, _ in
+                updateCardPresentOnboardingItem()
+            }
     }
 
     @ViewBuilder
     private var content: some View {
         switch state {
         case .loading:
-            POSRefundLoadingView()
+            POSRefundLoadingView(onBack: { dismissRefundFlow() })
         case .loadingError:
             POSRefundErrorView(
                 title: errorStrings.loadTitle,
                 subtitle: errorStrings.loadSubtitle,
                 onRetry: onRetryLoading,
-                onCancel: { dismissModal?() },
-                onClose: { dismissModal?() }
+                onCancel: { dismissRefundFlow() },
+                onClose: { dismissRefundFlow() }
             )
         case .preparationError:
             POSRefundErrorView(
                 title: errorStrings.prepareTitle,
                 subtitle: errorStrings.prepareSubtitle,
                 onRetry: onRetryPreparation,
-                onCancel: { dismissModal?() },
-                onClose: { dismissModal?() }
+                onCancel: { dismissRefundFlow() },
+                onClose: { dismissRefundFlow() }
             )
         case .nothingToRefund:
-            POSRefundNothingToRefundView(onClose: { dismissModal?() })
+            POSRefundNothingToRefundView(onClose: { dismissRefundFlow() })
         case .itemSelection:
             if showsItemSelection {
                 POSRefundItemsSelectionView(
                     onClose: {
-                        dismissModal?()
+                        dismissRefundFlow()
                     },
                     onContinue: { navigateToRefundReview() }
                 )
@@ -153,7 +206,7 @@ struct POSRefundModalContentView: View {
         case .review(let reviewData):
             POSRefundReviewView(
                 onClose: {
-                    dismissModal?()
+                    dismissRefundFlow()
                 },
                 itemsCount: reviewData.itemsCount,
                 formattedItemsSubtotal: reviewData.formattedItemsSubtotal,
@@ -174,7 +227,7 @@ struct POSRefundModalContentView: View {
                 paymentMethodDescription: reviewData.paymentMethodDescription,
                 isProcessing: false,
                 onClose: {
-                    dismissModal?()
+                    dismissRefundFlow()
                 },
                 onConfirm: {
                     handleRefundConfirmation(reviewData: reviewData)
@@ -202,18 +255,61 @@ struct POSRefundModalContentView: View {
                 formattedRefundTotal: reviewData.formattedRefundTotal,
                 paymentMethodDescription: reviewData.paymentMethodDescription,
                 customerEmail: reviewData.customerEmail,
-                onDone: { dismissModal?() },
-                onEmailReceipt: { isShowingEmailReceiptView = true },
-                onClose: { dismissModal?() }
+                onDone: { dismissRefundFlow() },
+                onEmailReceipt: { isShowingEmailReceiptView = true }
             )
         case .error(let reviewData):
             POSRefundErrorView(
                 title: errorStrings.createTitle,
                 subtitle: errorStrings.createSubtitle,
                 onRetry: { modalState = .confirmation(reviewData) },
-                onCancel: { dismissModal?() },
-                onClose: { dismissModal?() }
+                onCancel: { dismissRefundFlow() },
+                onClose: { dismissRefundFlow() }
             )
+        }
+    }
+
+    private var screenBackgroundColor: Color {
+        switch state {
+        case .processing:
+            switch refundSubmissionModel.state {
+            case .processingReader, .displayingReaderMessage:
+                return .posPrimary
+            case .cardPresentEvent(.processing), .cardPresentEvent(.displayReaderMessage), .cardPresentEvent(.paymentSuccess):
+                return .posPrimary
+            case .submittingCardPresent:
+                return .posPrimary
+            case .idle, .loading, .onboarding, .cardPresentEvent, .preparingReader, .waitingForCard,
+                    .submitting, .retryableError, .nonRetryableError, .completed:
+                return .posSurfaceBright
+            }
+        case .loading, .loadingError, .preparationError, .nothingToRefund, .itemSelection, .review, .confirmation,
+                .success, .error:
+            return .posSurfaceBright
+        }
+    }
+
+    private var cardPresentAlertID: String? {
+        guard case .processing = state,
+              case .cardPresentEvent(let eventDetails) = refundSubmissionModel.state else {
+            return nil
+        }
+        return eventDetails.posRefundConnectionAlertID
+    }
+
+    private var cardPresentOnboardingID: ObjectIdentifier? {
+        guard case .processing = state,
+              case .onboarding(let factory, _) = refundSubmissionModel.state else {
+            return nil
+        }
+        return ObjectIdentifier(factory)
+    }
+
+    private func dismissRefundFlow() {
+        if let dismissModal {
+            dismissModal()
+        } else {
+            onDismiss()
         }
     }
 
@@ -226,6 +322,54 @@ struct POSRefundModalContentView: View {
         modalState = .review(reviewData)
     }
 
+    private func updateCardPresentAlertItem() {
+        guard case .processing(let reviewData) = state,
+              case .cardPresentEvent(let eventDetails) = refundSubmissionModel.state,
+              let alertID = eventDetails.posRefundConnectionAlertID,
+              let alertType = cardPresentAlertType(for: eventDetails, reviewData: reviewData) else {
+            cardPresentAlertItem = nil
+            return
+        }
+
+        cardPresentAlertItem = POSRefundCardPresentAlertItem(id: alertID, alertType: alertType)
+    }
+
+    private func updateCardPresentOnboardingItem() {
+        guard case .processing = state,
+              case .onboarding(let factory, let onCancel) = refundSubmissionModel.state else {
+            cardPresentOnboardingItem = nil
+            return
+        }
+
+        cardPresentOnboardingItem = POSRefundCardPresentOnboardingItem(
+            id: ObjectIdentifier(factory),
+            factory: factory,
+            onCancel: onCancel
+        )
+    }
+
+    private func cardPresentAlertType(for eventDetails: CardPresentPaymentEventDetails,
+                                      reviewData: POSRefundReviewData) -> PointOfSaleCardPresentPaymentAlertType? {
+        guard let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
+            for: eventDetails,
+            dependencies: .init(
+                tryPaymentAgainBackToCheckoutAction: { modalState = .confirmation(reviewData) },
+                nonRetryableErrorExitAction: { dismissRefundFlow() },
+                formattedOrderTotalPrice: reviewData.formattedRefundTotal,
+                paymentCaptureErrorTryAgainAction: { modalState = .confirmation(reviewData) },
+                paymentCaptureErrorNewOrderAction: { dismissRefundFlow() },
+                paymentIntentCreationErrorEditOrderAction: { modalState = .review(reviewData) },
+                dismissReaderConnectionModal: { cardPresentAlertItem = nil }
+            )) else {
+            return nil
+        }
+
+        guard case .alert(let alertType) = presentationStyle else {
+            return nil
+        }
+        return alertType
+    }
+
     @MainActor
     private func processRefund(reviewData: POSRefundReviewData) async {
         analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingStarted())
@@ -235,6 +379,9 @@ struct POSRefundModalContentView: View {
             refundSubmissionModel.reset()
             modalState = .success(reviewData)
             onRefundSuccess?()
+        } catch POSRefundSubmissionError.canceledByUser {
+            refundSubmissionModel.reset()
+            modalState = .confirmation(reviewData)
         } catch {
             DDLogError("⛔️ Failed to process POS refund: \(error)")
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
@@ -272,5 +419,54 @@ struct POSRefundModalContentView: View {
         }
 
         return paymentModel.cardReaderConnectionStatus == .disconnected
+    }
+}
+
+private extension CardPresentPaymentEventDetails {
+    var posRefundConnectionAlertID: String? {
+        switch self {
+        case .scanningForReaders:
+            return "scanningForReaders"
+        case .scanningFailed(let error, _):
+            return "scanningFailed-\(error.localizedDescription)"
+        case .bluetoothRequired(let error, _):
+            return "bluetoothRequired-\(error.localizedDescription)"
+        case .connectingToReader:
+            return "connectingToReader"
+        case .connectingFailed(let error, _, _):
+            return "connectingFailed-\(error.localizedDescription)"
+        case .connectingFailedNonRetryable(let error, _):
+            return "connectingFailedNonRetryable-\(error.localizedDescription)"
+        case .connectingFailedUpdatePostalCode:
+            return "connectingFailedUpdatePostalCode"
+        case .connectingFailedChargeReader:
+            return "connectingFailedChargeReader"
+        case .connectingFailedUpdateAddress(let adminURL, _, _, _):
+            return "connectingFailedUpdateAddress-\(adminURL.absoluteString)"
+        case .foundReader(let name, _, _, _):
+            return "foundReader-\(name)"
+        case .foundMultipleReaders(let readerIDs, _):
+            return "foundMultipleReaders-\(readerIDs.joined(separator: ","))"
+        case .updateProgress(let requiredUpdate, let progress, _):
+            return "updateProgress-\(requiredUpdate)-\(progress)"
+        case .updateFailed:
+            return "updateFailed"
+        case .updateFailedNonRetryable:
+            return "updateFailedNonRetryable"
+        case .updateFailedLowBattery(let batteryLevel, _, _):
+            return "updateFailedLowBattery-\(batteryLevel)"
+        case .connectionSuccess:
+            return "connectionSuccess"
+        case .locationRequestPreAlert:
+            return "locationRequestPreAlert"
+        case .locationRequired:
+            return "locationRequired"
+        case .selectSearchType, .validatingOrder, .preparingForPayment,
+                .tapSwipeOrInsertCard, .cardInserted, .processing,
+                .displayReaderMessage, .paymentSuccess, .paymentError,
+                .paymentCaptureError, .paymentIntentCreationError,
+                .cancelledOnReader:
+            return nil
+        }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -395,6 +395,9 @@ struct POSRefundModalContentView: View {
 
     @MainActor
     private func handleAmbiguousCardPresentRefund(cancelPayment: @escaping () -> Void) {
+        // At this point the card-present refund may already have reached the gateway, but the app could not
+        // confirm the final result. Returning to confirmation would leave a live submit button that could create
+        // a duplicate refund, so exit the flow and refresh the order/refunds instead.
         isDismissingAfterAmbiguousRefund = true
         cardPresentAlertItem = nil
         cardPresentOnboardingItem = nil
@@ -402,6 +405,8 @@ struct POSRefundModalContentView: View {
         cancelPayment()
         dismissRefundFlow()
 
+        // The submission task may still report cancellation/failure after dismissing; isDismissingAfterAmbiguousRefund
+        // keeps that late callback from reopening the modal or tracking a normal refund failure.
         Task { @MainActor in
             do {
                 try await orderListModel.ordersController.updateOrder(orderID: order.id)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
@@ -40,7 +40,7 @@ struct POSRefundNavigationHeader: View {
     }
 
     var body: some View {
-        HStack(spacing: POSSpacing.medium) {
+        HStack(alignment: .top, spacing: POSSpacing.medium) {
             if let backAction {
                 POSPageHeaderBackButton(configuration: .init(state: .enabled, action: backAction))
                     .accessibilityLabel(backAccessibilityLabel)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundReviewView.swift
@@ -10,7 +10,6 @@ struct POSRefundReviewView: View {
     let refundReason: String?
     let onAddReason: () -> Void
     let onContinue: () -> Void
-    let onEditRefund: (() -> Void)?
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -33,7 +32,7 @@ struct POSRefundReviewView: View {
 private extension POSRefundReviewView {
     var headerView: some View {
         POSRefundNavigationHeader(title: Localization.title,
-                                  backAction: onEditRefund,
+                                  backAction: nil,
                                   backAccessibilityLabel: Localization.backButtonAccessibilityLabel)
     }
 
@@ -110,7 +109,7 @@ private extension POSRefundReviewView {
             Button(Localization.continueButton, action: onContinue)
                 .buttonStyle(POSFilledButtonStyle(size: .normal))
 
-            Button(Localization.cancelButton, action: onClose)
+            Button(Localization.backButton, action: onClose)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
         .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass,
@@ -206,10 +205,10 @@ private extension POSRefundReviewView {
             comment: "Button to continue with the refund"
         )
 
-        static let cancelButton = NSLocalizedString(
-            "pos.refundReviewView.cancelButton",
-            value: "Cancel",
-            comment: "Button to cancel and dismiss the refund review screen"
+        static let backButton = NSLocalizedString(
+            "pos.refundReviewView.backButton",
+            value: "Back",
+            comment: "Button to go back from the refund review screen to refund item selection"
         )
     }
 }
@@ -225,8 +224,7 @@ private extension POSRefundReviewView {
         paymentMethodDescription: "Via payment card ••••1456",
         refundReason: nil,
         onAddReason: {},
-        onContinue: {},
-        onEditRefund: {}
+        onContinue: {}
     )
     .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
 }
@@ -241,8 +239,7 @@ private extension POSRefundReviewView {
         paymentMethodDescription: "Via cash",
         refundReason: "Customer changed their mind",
         onAddReason: {},
-        onContinue: {},
-        onEditRefund: {}
+        onContinue: {}
     )
     .environment(\.posModalParentSize, CGSize(width: 1192, height: 822))
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
@@ -42,6 +42,7 @@ struct POSRefundSelectionFlowView: View {
             .toolbar(.hidden, for: .navigationBar)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.posSurfaceBright)
+            .ignoresSafeArea(.container, edges: .bottom)
             .posHidesFloatingControl()
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+import struct WooFoundation.WooAnalyticsEvent
+
+enum RefundSelectionState: Identifiable, Equatable {
+    case loading
+    case loadingError
+    case preparationError
+    case nothingToRefund
+    case itemSelection
+
+    var id: String {
+        switch self {
+        case .loading: return "loading"
+        case .loadingError: return "loadingError"
+        case .preparationError: return "preparationError"
+        case .nothingToRefund: return "nothingToRefund"
+        case .itemSelection: return "itemSelection"
+        }
+    }
+
+    var abortStep: WooAnalyticsEvent.PointOfSale.RefundStep? {
+        switch self {
+        case .itemSelection:
+            return .selectItems
+        case .loading, .loadingError, .preparationError, .nothingToRefund:
+            return nil
+        }
+    }
+}
+
+struct POSRefundSelectionFlowView: View {
+    let state: RefundSelectionState
+    let errorStrings: POSRefundErrorStrings
+    let onDismiss: () -> Void
+    let onRetryLoading: () -> Void
+    let onRetryPreparation: () -> Void
+    let onContinue: () -> Void
+
+    var body: some View {
+        content
+            .environment(\.posRefundPresentationStyle, .fullScreen)
+            .toolbar(.hidden, for: .navigationBar)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.posSurfaceBright)
+            .posHidesFloatingControl()
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch state {
+        case .loading:
+            POSRefundLoadingView(onBack: onDismiss)
+        case .loadingError:
+            POSRefundErrorView(
+                title: errorStrings.loadTitle,
+                subtitle: errorStrings.loadSubtitle,
+                onRetry: onRetryLoading,
+                onCancel: onDismiss,
+                onClose: onDismiss
+            )
+        case .preparationError:
+            POSRefundErrorView(
+                title: errorStrings.prepareTitle,
+                subtitle: errorStrings.prepareSubtitle,
+                onRetry: onRetryPreparation,
+                onCancel: onDismiss,
+                onClose: onDismiss
+            )
+        case .nothingToRefund:
+            POSRefundNothingToRefundView(onClose: onDismiss)
+        case .itemSelection:
+            POSRefundItemsSelectionView(
+                onClose: onDismiss,
+                onContinue: onContinue
+            )
+        }
+    }
+}
+
+#if DEBUG
+#Preview("POSRefundSelectionFlowView - Loading") {
+    POSRefundSelectionFlowView(
+        state: .loading,
+        errorStrings: .preview,
+        onDismiss: {},
+        onRetryLoading: {},
+        onRetryPreparation: {},
+        onContinue: {}
+    )
+}
+
+#Preview("POSRefundSelectionFlowView - Select Items") {
+    POSRefundSelectionFlowView(
+        state: .itemSelection,
+        errorStrings: .preview,
+        onDismiss: {},
+        onRetryLoading: {},
+        onRetryPreparation: {},
+        onContinue: {}
+    )
+    .environment(POSPreviewHelpers.makePreviewOrdersModel(state: POSPreviewHelpers.loadedState()))
+}
+
+private extension POSRefundErrorStrings {
+    static let preview = POSRefundErrorStrings(
+        loadTitle: "Couldn't load refund details",
+        loadSubtitle: "Please try again.",
+        prepareTitle: "Couldn't prepare refund",
+        prepareSubtitle: "Please try again.",
+        createTitle: "Failed to create refund",
+        createSubtitle: "Please try again."
+    )
+}
+#endif

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -9,7 +9,6 @@ struct POSRefundSuccessView: View {
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var isViewLoaded: Bool = false
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -25,11 +24,6 @@ struct POSRefundSuccessView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
-        .onAppear {
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
-                isViewLoaded = true
-            }
-        }
     }
 }
 
@@ -39,29 +33,21 @@ private extension POSRefundSuccessView {
     var contentView: some View {
         VStack(spacing: POSSpacing.xLarge) {
             POSSuccessIcon()
-                .scaleEffect(isViewLoaded ? 1 : 0)
-                .opacity(isViewLoaded ? 1 : 0)
 
             VStack(spacing: POSSpacing.small) {
                 Text(Localization.title)
                     .font(.posHeadingBold)
                     .foregroundColor(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
 
                 Text(String(format: Localization.messageFormat, formattedRefundTotal, paymentMethodDescription))
                     .font(.posBodyLargeRegular())
                     .foregroundColor(Color.posOnSurface)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
 
                 if let customerEmail, customerEmail.isNotEmpty {
                     Text(String(format: Localization.receiptSentFormat, customerEmail))
                         .font(.posBodyLargeRegular())
                         .foregroundColor(Color.posOnSurface)
-                        .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                        .opacity(isViewLoaded ? 1 : 0)
                 }
             }
             .multilineTextAlignment(.center)
@@ -81,17 +67,6 @@ private extension POSRefundSuccessView {
         }
         .padding(.horizontal, POSPadding.large)
         .frame(maxWidth: POSRefundModalLayout.fullScreenCompletionActionMaxWidth)
-        .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
-        .opacity(isViewLoaded ? 1 : 0)
-    }
-}
-
-
-// MARK: - Constants
-
-private extension POSRefundSuccessView {
-    enum Constants {
-        static let animationOffset: CGFloat = 100
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/WavesProgressViewStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/WavesProgressViewStyle.swift
@@ -12,6 +12,7 @@ private struct CardWaveProgressView: View {
     private let inactiveInset: CGFloat = 0.025
 
     @State private var activeArcIndex: Int = 0
+    @State private var animationTimer: Timer?
 
     private var waveCount: Int {
         radii.count
@@ -53,15 +54,27 @@ private struct CardWaveProgressView: View {
         .onAppear {
             startAnimating()
         }
+        .onDisappear {
+            stopAnimating()
+        }
         .accessibilityLabel(Localization.accessibilityLabel)
     }
 
     private func startAnimating() {
-        Timer.scheduledTimer(withTimeInterval: animationDuration, repeats: true) { _ in
-            withAnimation {
+        guard animationTimer == nil else {
+            return
+        }
+
+        animationTimer = Timer.scheduledTimer(withTimeInterval: animationDuration, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: animationDuration)) {
                 activeArcIndex = (activeArcIndex + 1) % waveCount
             }
         }
+    }
+
+    private func stopAnimating() {
+        animationTimer?.invalidate()
+        animationTimer = nil
     }
 }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -525,6 +525,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     var displayedCustomAmounts: [POSOrderCustomAmount] { selectedOrder?.customAmounts ?? [] }
     var refundActionAvailability: RefundActionAvailability { .available }
     var currentRefundRequiresCardPresentRefund: Bool { false }
+    var hasModifiedRefundSelection = false
 
     func loadOrders() async {}
     func loadNextOrders() async {}

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -532,6 +532,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     func refreshOrders() async {}
     func selectOrder(_ order: POSOrder?) {}
     func updateOrder(orderID: Int64) async throws {}
+    func preloadRefundDetails() async {}
     func searchOrders(searchTerm: String) async {}
     func clearSearchOrders() {}
     func startRefundFlow() async -> StartRefundFlowResult { .hasItemsToRefund }

--- a/Modules/Tests/NetworkingTests/Remote/RefundsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RefundsRemoteTests.swift
@@ -1,0 +1,88 @@
+import Alamofire
+import Combine
+import TestKit
+import XCTest
+@testable import Networking
+@testable import NetworkingCore
+
+final class RefundsRemoteTests: XCTestCase {
+    private let sampleSiteID: Int64 = 1234
+    private let sampleOrderID: Int64 = 560
+
+    func test_createRefund_returns_refund_on_success() async throws {
+        // Given
+        let network = MockNetwork()
+        let remote = RefundsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/refunds", filename: "refund-single")
+
+        // When
+        let refund = try await remote.createRefund(for: sampleSiteID, by: sampleOrderID, refund: sampleRefund())
+
+        // Then
+        XCTAssertEqual(refund.refundID, 562)
+    }
+
+    func test_createRefund_relays_network_error_when_response_data_is_present() async throws {
+        // Given
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500,
+                                                               response: Loader.contentsOf("refund-single"))
+        let network = RefundCreationNetwork(error: expectedError, responseData: Loader.contentsOf("refund-single"))
+        let remote = RefundsRemote(network: network)
+
+        // When / Then
+        await assertThrowsError({
+            _ = try await remote.createRefund(for: sampleSiteID, by: sampleOrderID, refund: sampleRefund())
+        }, errorAssert: { error in
+            (error as? NetworkError) == expectedError
+        })
+    }
+}
+
+private extension RefundsRemoteTests {
+    func sampleRefund() -> Refund {
+        Refund(refundID: 0,
+               orderID: sampleOrderID,
+               siteID: sampleSiteID,
+               dateCreated: Date(),
+               amount: "18",
+               reason: "",
+               refundedByUserID: 0,
+               isAutomated: nil,
+               createAutomated: true,
+               items: [],
+               shippingLines: nil)
+    }
+}
+
+private final class RefundCreationNetwork: Network {
+    let error: Error
+    let responseData: Data?
+    var session: URLSession { URLSession(configuration: .default) }
+
+    init(error: Error, responseData: Data?) {
+        self.error = error
+        self.responseData = responseData
+    }
+
+    func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+        completion(responseData, error)
+    }
+
+    func responseData(for request: URLRequestConvertible, completion: @escaping (Result<Data, Error>) -> Void) {
+        completion(.failure(error))
+    }
+
+    func responseDataAndHeaders(for request: URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
+        throw error
+    }
+
+    func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Result<Data, Error>, Never> {
+        Just(.failure(error)).eraseToAnyPublisher()
+    }
+
+    func uploadMultipartFormData(multipartFormData: @escaping (NetworkingCore.MultipartFormData) -> Void,
+                                 to request: URLRequestConvertible,
+                                 completion: @escaping (Data?, Error?) -> Void) {
+        completion(responseData, error)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -670,6 +670,24 @@ final class POSOrderListControllerTests {
         #expect(isSelectedAfterToggle == false)
     }
 
+    @MainActor
+    @Test func toggleRefundItemSelection_then_marks_refund_selection_as_modified() async throws {
+        // Given
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
+        ])
+
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        #expect(sut.hasModifiedRefundSelection == false)
+
+        // When
+        sut.toggleRefundItemSelection(at: 0)
+
+        // Then
+        #expect(sut.hasModifiedRefundSelection == true)
+    }
+
     @Test func toggleRefundItemSelection_when_index_out_of_bounds_then_does_not_crash() async throws {
         // When
         let items = await MainActor.run {
@@ -700,6 +718,25 @@ final class POSOrderListControllerTests {
     }
 
     @MainActor
+    @Test func clearRefundSelection_then_resets_modified_refund_selection() async throws {
+        // Given
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
+        ])
+
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        sut.toggleRefundItemSelection(at: 0)
+        try #require(sut.hasModifiedRefundSelection == true)
+
+        // When
+        sut.clearRefundSelection()
+
+        // Then
+        #expect(sut.hasModifiedRefundSelection == false)
+    }
+
+    @MainActor
     @Test func toggleAllRefundItemsSelection_when_all_selected_then_deselects_all() async throws {
         // Given
         let order = makeOrder(lineItems: [
@@ -716,6 +753,24 @@ final class POSOrderListControllerTests {
         for item in sut.refundSelectableItems {
             #expect(item.isSelected == false)
         }
+    }
+
+    @MainActor
+    @Test func toggleAllRefundItemsSelection_then_marks_refund_selection_as_modified() async throws {
+        // Given
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 2, formattedPrice: "$10.00", formattedTotal: "$20.00")
+        ])
+
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        #expect(sut.hasModifiedRefundSelection == false)
+
+        // When
+        sut.toggleAllRefundItemsSelection()
+
+        // Then
+        #expect(sut.hasModifiedRefundSelection == true)
     }
 
     @MainActor
@@ -756,6 +811,27 @@ final class POSOrderListControllerTests {
         for item in sut.refundSelectableItems {
             #expect(item.isSelected == true)
         }
+    }
+
+    @MainActor
+    @Test func selectOrder_then_clears_refund_selection_state() async throws {
+        // Given
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, formattedPrice: "$10.00", formattedTotal: "$10.00")
+        ])
+
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        sut.toggleRefundItemSelection(at: 0)
+        try #require(sut.hasModifiedRefundSelection == true)
+        try #require(sut.refundSelectableItems.isNotEmpty)
+
+        // When
+        sut.selectOrder(makeOrder(id: order.id + 1))
+
+        // Then
+        #expect(sut.refundSelectableItems.isEmpty)
+        #expect(sut.hasModifiedRefundSelection == false)
     }
 
     // MARK: - Prepare Refund Review Data Tests

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1257,6 +1257,93 @@ final class POSOrderListControllerTests {
     }
 
     @MainActor
+    @Test func processRefund_when_no_selected_order_then_throws_missingSelectedOrder() async throws {
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingSelectedOrder
+        })
+    }
+
+    @MainActor
+    @Test func processRefund_when_refund_is_not_prepared_then_throws_missingRefundPreparation() async throws {
+        // Given
+        sut.selectOrder(makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ]))
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingRefundPreparation
+        })
+    }
+
+    @MainActor
+    @Test func processRefund_when_no_items_are_selected_then_throws_emptySelection() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        sut.toggleAllRefundItemsSelection()
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .emptySelection
+        })
+    }
+
+    @MainActor
+    @Test func processRefund_when_refund_is_already_in_progress_then_throws_refundAlreadyInProgress() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        refundSubmissionProcessor.shouldSuspendSubmitRefund = true
+
+        var firstRefundTask: Task<Void, Error>?
+        await fireOnce { fire in
+            refundSubmissionProcessor.onSubmitRefundStarted = {
+                fire()
+            }
+            firstRefundTask = Task { @MainActor in
+                try await sut.processRefund(reason: .none)
+            }
+        }
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .refundAlreadyInProgress
+        })
+
+        refundSubmissionProcessor.resumeSubmitRefund()
+        try await firstRefundTask?.value
+    }
+
+    @MainActor
     @Test func processRefund_then_converts_items_with_correct_properties() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1767,6 +1854,9 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
     nonisolated(unsafe) private let currencyFormatter: CurrencyFormatter
     private var refundResultsByOrderID: [Int64: POSRefundsResult] = [:]
     var requiresCardPresentRefund = false
+    var shouldSuspendSubmitRefund = false
+    var onSubmitRefundStarted: (() -> Void)?
+    private var submitRefundContinuation: CheckedContinuation<Void, Never>?
 
     nonisolated init(refundsService: MockPOSRefundsService,
                      currencyFormatter: CurrencyFormatter) {
@@ -1847,6 +1937,13 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
                       preparation: POSRefundPreparation,
                       selectedItems: [POSRefundSelectableItem],
                       reason: String?) async throws {
+        onSubmitRefundStarted?()
+        if shouldSuspendSubmitRefund {
+            await withCheckedContinuation { continuation in
+                submitRefundContinuation = continuation
+            }
+        }
+
         let refundableItems = selectedItems.map { item in
             POSRefundableItem(
                 itemID: item.itemID,
@@ -1864,5 +1961,11 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
             isAutomaticRefund: refundResultsByOrderID[preparation.orderID]?.supportsAutomaticRefund ?? true
         )
         stateModel.state = .completed
+    }
+
+    func resumeSubmitRefund() {
+        shouldSuspendSubmitRefund = false
+        submitRefundContinuation?.resume()
+        submitRefundContinuation = nil
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -438,6 +438,39 @@ final class POSOrderListControllerTests {
     // MARK: - Refund Item Selection Tests
 
     @MainActor
+    @Test func preloadRefundDetails_when_refund_is_available_then_preloads_without_opening_refund_flow() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let order = makeOrder(id: 1, status: .completed)
+        sut.selectOrder(order)
+
+        // When
+        await sut.preloadRefundDetails()
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs == [order.id])
+        #expect(sut.refundSelectableItems.isEmpty)
+        guard case .idle = sut.selectedOrderRefundsState else {
+            Issue.record("Preloading should not move the visible refund flow state.")
+            return
+        }
+    }
+
+    @MainActor
+    @Test func preloadRefundDetails_when_refund_is_unavailable_then_does_not_preload() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let order = makeOrder(id: 1, status: .processing)
+        sut.selectOrder(order)
+
+        // When
+        await sut.preloadRefundDetails()
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs.isEmpty)
+    }
+
+    @MainActor
     @Test func startRefundFlow_when_product_has_multiple_quantities_then_creates_one_row_per_unit() async throws {
         // Given
         let order = makeOrder(lineItems: [
@@ -1739,6 +1772,12 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
                      currencyFormatter: CurrencyFormatter) {
         self.refundsService = refundsService
         self.currencyFormatter = currencyFormatter
+    }
+
+    private(set) var preloadedOrderIDs: [Int64] = []
+
+    func preloadRefund(for order: POSOrder) async {
+        preloadedOrderIDs.append(order.id)
     }
 
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -43,6 +43,8 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         }
     }
 
+    func preloadRefundDetails() async {}
+
     func searchOrders(searchTerm: String) async {}
 
     func clearSearchOrders() {}

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -13,6 +13,7 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
     var refundActionAvailability: RefundActionAvailability = .available
     var refundSelectableItems: [POSRefundSelectableItem] = []
     var currentRefundRequiresCardPresentRefund = false
+    var hasModifiedRefundSelection = false
     var updateOrderCalled = false
     var spyUpdateOrderID: Int64?
     var shouldThrowError = false
@@ -29,6 +30,8 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
 
     func selectOrder(_ order: POSOrder?) {
         selectedOrder = order
+        refundSelectableItems = []
+        hasModifiedRefundSelection = false
     }
 
     func updateOrder(orderID: Int64) async throws {
@@ -51,19 +54,30 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         refundSelectableItems = order.lineItems.map {
             POSRefundSelectableItem(from: $0, isSelected: true, index: 0)
         }
+        hasModifiedRefundSelection = false
         return stubStartRefundFlowResult
     }
 
     func toggleRefundItemSelection(at index: Int) {
         guard refundSelectableItems.indices.contains(index) else { return }
         refundSelectableItems[index].isSelected.toggle()
+        hasModifiedRefundSelection = true
     }
 
     func clearRefundSelection() {
         refundSelectableItems = []
+        hasModifiedRefundSelection = false
     }
 
-    func toggleAllRefundItemsSelection() {}
+    func toggleAllRefundItemsSelection() {
+        guard !refundSelectableItems.isEmpty else { return }
+        let allSelected = refundSelectableItems.allSatisfy { $0.isSelected }
+        let newSelectionState = !allSelected
+        for index in refundSelectableItems.indices {
+            refundSelectableItems[index].isSelected = newSelectionState
+        }
+        hasModifiedRefundSelection = true
+    }
 
     // MARK: - Refund Review Data
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
+- [**] POS available for CA users, POS refund flow improved [https://github.com/woocommerce/woocommerce-ios/pull/17256]
 
 
 24.8

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
@@ -5,10 +5,13 @@ import Yosemite
 
 final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     private let stateModel: POSRefundSubmissionModel
+    private let onCancelRequested: () -> Void
     private let alertsProvider = CardPresentPaymentsTransactionAlertsProvider()
 
-    init(stateModel: POSRefundSubmissionModel) {
+    init(stateModel: POSRefundSubmissionModel,
+         onCancelRequested: @escaping () -> Void = {}) {
         self.stateModel = stateModel
+        self.onCancelRequested = onCancelRequested
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
@@ -49,6 +52,7 @@ final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtoco
     }
 
     private func present(_ eventDetails: CardPresentPaymentEventDetails) {
+        let eventDetails = eventDetails.markingPOSCancellation(onCancelRequested)
         onMainQueue { [stateModel] in
             stateModel.state = .cardPresentEvent(eventDetails)
         }
@@ -59,10 +63,13 @@ final class POSRefundCardPresentPaymentAlertsPresenter: CardPresentPaymentAlerts
     typealias AlertDetails = CardPresentPaymentEventDetails
 
     private let stateModel: POSRefundSubmissionModel
+    private let onCancelRequested: () -> Void
     private var latestReaderConnectionHandler: ((String?) -> Void)?
 
-    init(stateModel: POSRefundSubmissionModel) {
+    init(stateModel: POSRefundSubmissionModel,
+         onCancelRequested: @escaping () -> Void = {}) {
         self.stateModel = stateModel
+        self.onCancelRequested = onCancelRequested
     }
 
     func present(viewModel eventDetails: CardPresentPaymentEventDetails) {
@@ -145,8 +152,99 @@ final class POSRefundCardPresentPaymentAlertsPresenter: CardPresentPaymentAlerts
     }
 
     private func present(_ eventDetails: CardPresentPaymentEventDetails) {
+        let eventDetails = eventDetails.markingPOSCancellation(onCancelRequested)
         onMainQueue { [stateModel] in
             stateModel.state = .cardPresentEvent(eventDetails)
+        }
+    }
+}
+
+private extension CardPresentPaymentEventDetails {
+    func markingPOSCancellation(_ markCancelled: @escaping () -> Void) -> Self {
+        let markAndRun: (@escaping () -> Void) -> () -> Void = { action in
+            {
+                markCancelled()
+                action()
+            }
+        }
+
+        switch self {
+        case .scanningForReaders(let endSearch):
+            return .scanningForReaders(endSearch: markAndRun(endSearch))
+        case .scanningFailed(let error, let endSearch):
+            return .scanningFailed(error: error, endSearch: markAndRun(endSearch))
+        case .bluetoothRequired(let error, let endSearch):
+            return .bluetoothRequired(error: error, endSearch: markAndRun(endSearch))
+        case .connectingFailed(let error, let retrySearch, let endSearch):
+            return .connectingFailed(error: error,
+                                     retrySearch: retrySearch,
+                                     endSearch: markAndRun(endSearch))
+        case .connectingFailedNonRetryable(let error, let endSearch):
+            return .connectingFailedNonRetryable(error: error,
+                                                 endSearch: markAndRun(endSearch))
+        case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
+            return .connectingFailedUpdatePostalCode(retrySearch: retrySearch,
+                                                     endSearch: markAndRun(endSearch))
+        case .connectingFailedChargeReader(let retrySearch, let endSearch):
+            return .connectingFailedChargeReader(retrySearch: retrySearch,
+                                                 endSearch: markAndRun(endSearch))
+        case .connectingFailedUpdateAddress(let adminURL, let showsInAuthenticatedWebView, let retrySearch, let endSearch):
+            return .connectingFailedUpdateAddress(wcSettingsAdminURL: adminURL,
+                                                  showsInAuthenticatedWebView: showsInAuthenticatedWebView,
+                                                  retrySearch: retrySearch,
+                                                  endSearch: markAndRun(endSearch))
+        case .preparingForPayment(let cancelPayment):
+            return .preparingForPayment(cancelPayment: markAndRun(cancelPayment))
+        case .selectSearchType(let tapToPay, let bluetooth, let endSearch):
+            return .selectSearchType(tapToPay: tapToPay,
+                                     bluetooth: bluetooth,
+                                     endSearch: markAndRun(endSearch))
+        case .foundReader(let name, let connect, let continueSearch, let endSearch):
+            return .foundReader(name: name,
+                                connect: connect,
+                                continueSearch: continueSearch,
+                                endSearch: markAndRun(endSearch))
+        case .foundMultipleReaders(let readerIDs, let selectionHandler):
+            return .foundMultipleReaders(readerIDs: readerIDs) { readerID in
+                if readerID == nil {
+                    markCancelled()
+                }
+                selectionHandler(readerID)
+            }
+        case .updateProgress(let requiredUpdate, let progress, let cancelUpdate):
+            return .updateProgress(requiredUpdate: requiredUpdate,
+                                   progress: progress,
+                                   cancelUpdate: cancelUpdate.map(markAndRun))
+        case .updateFailed(let tryAgain, let cancelUpdate):
+            return .updateFailed(tryAgain: tryAgain,
+                                 cancelUpdate: markAndRun(cancelUpdate))
+        case .updateFailedNonRetryable(let cancelUpdate):
+            return .updateFailedNonRetryable(cancelUpdate: markAndRun(cancelUpdate))
+        case .updateFailedLowBattery(let batteryLevel, let retrySearch, let cancelUpdate):
+            return .updateFailedLowBattery(batteryLevel: batteryLevel,
+                                           retrySearch: retrySearch,
+                                           cancelUpdate: markAndRun(cancelUpdate))
+        case .tapSwipeOrInsertCard(let inputMethods, let cancelPayment):
+            return .tapSwipeOrInsertCard(inputMethods: inputMethods,
+                                         cancelPayment: markAndRun(cancelPayment))
+        case .cardInserted(let cancelPayment):
+            return .cardInserted(cancelPayment: markAndRun(cancelPayment))
+        case .paymentError(let error, let retryApproach, let cancelPayment):
+            return .paymentError(error: error,
+                                 retryApproach: retryApproach,
+                                 cancelPayment: markAndRun(cancelPayment))
+        case .paymentCaptureError(let cancelPayment):
+            return .paymentCaptureError(cancelPayment: markAndRun(cancelPayment))
+        case .paymentIntentCreationError(let error, let cancelPayment):
+            return .paymentIntentCreationError(error: error,
+                                               cancelPayment: markAndRun(cancelPayment))
+        case .validatingOrder(let cancelPayment):
+            return .validatingOrder(cancelPayment: markAndRun(cancelPayment))
+        case .locationRequired(let cancel):
+            return .locationRequired(cancel: markAndRun(cancel))
+        case .connectingToReader, .connectionSuccess, .paymentSuccess, .processing,
+                .displayReaderMessage, .cancelledOnReader, .locationRequestPreAlert:
+            return self
         }
     }
 }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
@@ -6,12 +6,15 @@ import Yosemite
 final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     private let stateModel: POSRefundSubmissionModel
     private let onCancelRequested: () -> Void
+    private let isPresentationAllowed: () -> Bool
     private let alertsProvider = CardPresentPaymentsTransactionAlertsProvider()
 
     init(stateModel: POSRefundSubmissionModel,
-         onCancelRequested: @escaping () -> Void = {}) {
+         onCancelRequested: @escaping () -> Void = {},
+         isPresentationAllowed: @escaping () -> Bool = { true }) {
         self.stateModel = stateModel
         self.onCancelRequested = onCancelRequested
+        self.isPresentationAllowed = isPresentationAllowed
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
@@ -53,7 +56,8 @@ final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtoco
 
     private func present(_ eventDetails: CardPresentPaymentEventDetails) {
         let eventDetails = eventDetails.markingPOSCancellation(onCancelRequested)
-        onMainQueue { [stateModel] in
+        onMainQueue { [stateModel, isPresentationAllowed] in
+            guard isPresentationAllowed() else { return }
             stateModel.state = .cardPresentEvent(eventDetails)
         }
     }
@@ -64,12 +68,15 @@ final class POSRefundCardPresentPaymentAlertsPresenter: CardPresentPaymentAlerts
 
     private let stateModel: POSRefundSubmissionModel
     private let onCancelRequested: () -> Void
+    private let isPresentationAllowed: () -> Bool
     private var latestReaderConnectionHandler: ((String?) -> Void)?
 
     init(stateModel: POSRefundSubmissionModel,
-         onCancelRequested: @escaping () -> Void = {}) {
+         onCancelRequested: @escaping () -> Void = {},
+         isPresentationAllowed: @escaping () -> Bool = { true }) {
         self.stateModel = stateModel
         self.onCancelRequested = onCancelRequested
+        self.isPresentationAllowed = isPresentationAllowed
     }
 
     func present(viewModel eventDetails: CardPresentPaymentEventDetails) {
@@ -153,7 +160,8 @@ final class POSRefundCardPresentPaymentAlertsPresenter: CardPresentPaymentAlerts
 
     private func present(_ eventDetails: CardPresentPaymentEventDetails) {
         let eventDetails = eventDetails.markingPOSCancellation(onCancelRequested)
-        onMainQueue { [stateModel] in
+        onMainQueue { [stateModel, isPresentationAllowed] in
+            guard isPresentationAllowed() else { return }
             stateModel.state = .cardPresentEvent(eventDetails)
         }
     }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -110,19 +110,26 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
                                            currencyFormatter: currencyFormatter)
             .createRefund()
 
-        stateModel.state = .submitting
+        let requiresCardPresentRefund = refundMapping.requiresCardPresentRefund(context: context)
+        let submittingState: POSRefundSubmissionState = requiresCardPresentRefund ? .submittingCardPresent : .submitting
+        stateModel.state = submittingState
+        let cancellationState = POSRefundCancellationState()
 
         let onboardingPresenter = CardPresentPaymentsOnboardingPresenterAdaptor(stores: stores)
-        observe(onboardingPresenter: onboardingPresenter)
+        observe(onboardingPresenter: onboardingPresenter,
+                submittingState: submittingState,
+                cancellationState: cancellationState)
 
-        let alertPresenter = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel)
+        let alertPresenter = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel,
+                                                                        onCancelRequested: cancellationState.markCancelled)
         let submissionUseCase = RefundSubmissionUseCase(
             details: .init(order: context.order,
                            charge: context.charge,
                            amount: amount,
                            paymentGatewayAccount: context.paymentGatewayAccount),
             rootViewController: NullViewControllerPresenting(),
-            alerts: POSRefundOrderDetailsPaymentAlerts(stateModel: stateModel),
+            alerts: POSRefundOrderDetailsPaymentAlerts(stateModel: stateModel,
+                                                       onCancelRequested: cancellationState.markCancelled),
             cardPresentConfiguration: CardPresentConfigurationLoader(stores: stores).configuration,
             cardReaderConnectionAlerts: CardPresentPaymentBluetoothReaderConnectionAlertsProvider(),
             alertPresenter: alertPresenter,
@@ -139,19 +146,27 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
             self.onboardingSubscription = nil
         }
 
-        try await withCheckedThrowingContinuation { continuation in
-            var continuation: CheckedContinuation<Void, Error>? = continuation
-            submissionUseCase.submitRefund(refund, showInProgressUI: { [weak self] in
-                Task { @MainActor in
-                    self?.stateModel.state = .submitting
-                }
-            }, onCompletion: { result in
-                continuation?.resume(with: result)
-                continuation = nil
-            })
+        do {
+            try await withCheckedThrowingContinuation { continuation in
+                var continuation: CheckedContinuation<Void, Error>? = continuation
+                submissionUseCase.submitRefund(refund, showInProgressUI: { [weak self] in
+                    Task { @MainActor in
+                        self?.stateModel.state = submittingState
+                    }
+                }, onCompletion: { result in
+                    continuation?.resume(with: result)
+                    continuation = nil
+                })
+            }
+        } catch {
+            if cancellationState.wasCancelledByMerchant || error.isRefundSubmissionCancellation {
+                stateModel.reset()
+                throw POSRefundSubmissionError.canceledByUser
+            }
+            throw error
         }
 
-        stateModel.state = .completed
+        stateModel.state = requiresCardPresentRefund ? .submittingCardPresent : .completed
     }
 }
 
@@ -241,18 +256,37 @@ private extension POSRefundSubmissionAdaptor {
             .first { $0.isCardPresentEligible && $0.gatewayID == WCPayAccount.gatewayID }
     }
 
-    func observe(onboardingPresenter: CardPresentPaymentsOnboardingPresenterAdaptor) {
+    func observe(onboardingPresenter: CardPresentPaymentsOnboardingPresenterAdaptor,
+                 submittingState: POSRefundSubmissionState,
+                 cancellationState: POSRefundCancellationState) {
         onboardingSubscription = onboardingPresenter.onboardingScreenViewModelPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
                 guard let self else { return }
                 switch event {
                 case .showOnboarding(let factory, let onCancel):
-                    self.stateModel.state = .onboarding(factory: factory, onCancel: onCancel)
+                    self.stateModel.state = .onboarding(factory: factory, onCancel: {
+                        cancellationState.markCancelled()
+                        onCancel()
+                    })
                 case .onboardingComplete:
-                    self.stateModel.state = .submitting
+                    self.stateModel.state = submittingState
                 }
             }
+    }
+}
+
+private final class POSRefundCancellationState {
+    private(set) var wasCancelledByMerchant = false
+
+    func markCancelled() {
+        wasCancelledByMerchant = true
+    }
+}
+
+private extension Error {
+    var isRefundSubmissionCancellation: Bool {
+        (self as? RefundSubmissionUseCaseSubmissionError) == .canceledByUser
     }
 }
 

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -120,16 +120,22 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
                 submittingState: submittingState,
                 cancellationState: cancellationState)
 
-        let alertPresenter = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel,
-                                                                        onCancelRequested: cancellationState.markCancelled)
+        let alertPresenter = POSRefundCardPresentPaymentAlertsPresenter(
+            stateModel: stateModel,
+            onCancelRequested: cancellationState.markCancelled,
+            isPresentationAllowed: { !cancellationState.wasCancelledByMerchant }
+        )
         let submissionUseCase = RefundSubmissionUseCase(
             details: .init(order: context.order,
                            charge: context.charge,
                            amount: amount,
                            paymentGatewayAccount: context.paymentGatewayAccount),
             rootViewController: NullViewControllerPresenting(),
-            alerts: POSRefundOrderDetailsPaymentAlerts(stateModel: stateModel,
-                                                       onCancelRequested: cancellationState.markCancelled),
+            alerts: POSRefundOrderDetailsPaymentAlerts(
+                stateModel: stateModel,
+                onCancelRequested: cancellationState.markCancelled,
+                isPresentationAllowed: { !cancellationState.wasCancelledByMerchant }
+            ),
             cardPresentConfiguration: CardPresentConfigurationLoader(stores: stores).configuration,
             cardReaderConnectionAlerts: CardPresentPaymentBluetoothReaderConnectionAlertsProvider(),
             alertPresenter: alertPresenter,
@@ -263,6 +269,7 @@ private extension POSRefundSubmissionAdaptor {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
                 guard let self else { return }
+                guard !cancellationState.wasCancelledByMerchant else { return }
                 switch event {
                 case .showOnboarding(let factory, let onCancel):
                     self.stateModel.state = .onboarding(factory: factory, onCancel: {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -10,6 +10,11 @@ import WooFoundation
 final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     let stateModel = POSRefundSubmissionModel()
 
+    private struct PreparedRefundSnapshot {
+        let preparation: POSRefundPreparation
+        let context: POSRefundSubmissionMapping.PreparedRefundContext
+    }
+
     private let orderService: POSOrderServiceProtocol
     private let stores: StoresManager
     private let storageManager: StorageManagerType
@@ -19,6 +24,8 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     private let analytics: Analytics
     private let refundOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol
 
+    private var preloadedRefundSnapshots: [Int64: PreparedRefundSnapshot] = [:]
+    private var preloadTasks: [Int64: (id: UUID, task: Task<PreparedRefundSnapshot, Error>)] = [:]
     private var preparedContexts: [Int64: POSRefundSubmissionMapping.PreparedRefundContext] = [:]
     private var submissionUseCase: RefundSubmissionUseCase<CardPresentPaymentBluetoothReaderConnectionAlertsProvider, POSRefundCardPresentPaymentAlertsPresenter>?
     private var onboardingSubscription: AnyCancellable?
@@ -40,34 +47,45 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         self.refundOptionsDeterminer = refundOptionsDeterminer
     }
 
+    func preloadRefund(for order: POSOrder) async {
+        removePreloadedRefunds(except: order.id)
+
+        guard preloadedRefundSnapshots[order.id] == nil,
+              preloadTasks[order.id] == nil else {
+            return
+        }
+
+        let preloadID = UUID()
+        let preloadTask = Task { @MainActor in
+            try await loadPreparedRefundSnapshot(for: order)
+        }
+        preloadTasks[order.id] = (id: preloadID, task: preloadTask)
+
+        do {
+            let snapshot = try await preloadTask.value
+            guard preloadTasks[order.id]?.id == preloadID else {
+                return
+            }
+            preloadedRefundSnapshots[order.id] = snapshot
+            preloadTasks[order.id] = nil
+        } catch {
+            guard preloadTasks[order.id]?.id == preloadID else {
+                return
+            }
+            preloadTasks[order.id] = nil
+        }
+    }
+
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
         stateModel.state = .loading
+        defer {
+            stateModel.reset()
+        }
 
-        let fullOrder = try await orderService.loadOrder(orderID: order.id)
-        let refunds = try await loadDetailedRefunds(for: fullOrder)
-        let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
-        let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }
-        let paymentGateway = loadPaymentGateway(for: fullOrder)
-        let paymentGatewayAccount = await loadSelectedOrStoredPaymentGatewayAccount(for: fullOrder)
-        let refundableItems = refundOptionsDeterminer.determineRefundableOrderItems(from: fullOrder, with: refunds)
-        let refundableFees = refundMapping.determineRefundableFees(from: fullOrder, with: refunds)
-        let selectableItems = refundMapping.makeSelectableItems(refundableItems: refundableItems,
-                                                                fees: refundableFees,
-                                                                currency: fullOrder.currency)
-        let context = POSRefundSubmissionMapping.PreparedRefundContext(order: fullOrder,
-                                                                       charge: charge,
-                                                                       paymentGateway: paymentGateway,
-                                                                       paymentGatewayAccount: paymentGatewayAccount,
-                                                                       refundableItems: refundableItems,
-                                                                       refundableFees: refundableFees)
-        preparedContexts[fullOrder.orderID] = context
-        stateModel.reset()
+        let snapshot = try await preparedRefundSnapshot(for: order)
+        preparedContexts[snapshot.preparation.orderID] = snapshot.context
 
-        return POSRefundPreparation(orderID: fullOrder.orderID,
-                                    selectableItems: selectableItems,
-                                    paymentMethodDescription: refundMapping.paymentMethodDescription(for: fullOrder, charge: charge),
-                                    customerEmail: fullOrder.billingAddress?.email,
-                                    requiresCardPresentRefund: refundMapping.requiresCardPresentRefund(context: context))
+        return snapshot.preparation
     }
 
     func prepareReviewData(for order: POSOrder,
@@ -173,10 +191,62 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         }
 
         stateModel.state = requiresCardPresentRefund ? .submittingCardPresent : .completed
+        removePreloadedRefund(for: preparation.orderID)
     }
 }
 
 private extension POSRefundSubmissionAdaptor {
+    func removePreloadedRefund(for orderID: Int64) {
+        preloadedRefundSnapshots[orderID] = nil
+        preloadTasks[orderID]?.task.cancel()
+        preloadTasks[orderID] = nil
+    }
+
+    func removePreloadedRefunds(except orderID: Int64) {
+        preloadedRefundSnapshots = preloadedRefundSnapshots.filter { $0.key == orderID }
+        for preloadedOrderID in Array(preloadTasks.keys) where preloadedOrderID != orderID {
+            removePreloadedRefund(for: preloadedOrderID)
+        }
+    }
+
+    private func preparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
+        if let snapshot = preloadedRefundSnapshots.removeValue(forKey: order.id) {
+            return snapshot
+        }
+
+        if let preloadTask = preloadTasks.removeValue(forKey: order.id) {
+            return try await preloadTask.task.value
+        }
+
+        return try await loadPreparedRefundSnapshot(for: order)
+    }
+
+    private func loadPreparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
+        let fullOrder = try await orderService.loadOrder(orderID: order.id)
+        let refunds = try await loadDetailedRefunds(for: fullOrder)
+        let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
+        let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }
+        let paymentGateway = loadPaymentGateway(for: fullOrder)
+        let paymentGatewayAccount = await loadSelectedOrStoredPaymentGatewayAccount(for: fullOrder)
+        let refundableItems = refundOptionsDeterminer.determineRefundableOrderItems(from: fullOrder, with: refunds)
+        let refundableFees = refundMapping.determineRefundableFees(from: fullOrder, with: refunds)
+        let selectableItems = refundMapping.makeSelectableItems(refundableItems: refundableItems,
+                                                                fees: refundableFees,
+                                                                currency: fullOrder.currency)
+        let context = POSRefundSubmissionMapping.PreparedRefundContext(order: fullOrder,
+                                                                       charge: charge,
+                                                                       paymentGateway: paymentGateway,
+                                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                                       refundableItems: refundableItems,
+                                                                       refundableFees: refundableFees)
+        let preparation = POSRefundPreparation(orderID: fullOrder.orderID,
+                                               selectableItems: selectableItems,
+                                               paymentMethodDescription: refundMapping.paymentMethodDescription(for: fullOrder, charge: charge),
+                                               customerEmail: fullOrder.billingAddress?.email,
+                                               requiresCardPresentRefund: refundMapping.requiresCardPresentRefund(context: context))
+        return PreparedRefundSnapshot(preparation: preparation, context: context)
+    }
+
     func loadDetailedRefunds(for order: Order) async throws -> [Refund] {
         let refundIDs = order.refunds.map(\.refundID)
         if refundIDs.isNotEmpty {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -112,6 +112,10 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
                       preparation: POSRefundPreparation,
                       selectedItems: [POSRefundSelectableItem],
                       reason: String?) async throws {
+        guard submissionUseCase == nil else {
+            throw POSRefundSubmissionAdaptorError.refundAlreadyInProgress
+        }
+
         guard let context = preparedContexts[preparation.orderID] else {
             throw POSRefundSubmissionAdaptorError.missingPreparedRefund
         }
@@ -190,7 +194,7 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
             throw error
         }
 
-        stateModel.state = requiresCardPresentRefund ? .submittingCardPresent : .completed
+        stateModel.state = .completed
         removePreloadedRefund(for: preparation.orderID)
     }
 }
@@ -369,6 +373,7 @@ private extension Error {
 
 private enum POSRefundSubmissionAdaptorError: LocalizedError {
     case missingPreparedRefund
+    case refundAlreadyInProgress
 
     var errorDescription: String? {
         switch self {
@@ -377,6 +382,12 @@ private enum POSRefundSubmissionAdaptorError: LocalizedError {
                 "pos.refundSubmissionAdaptor.error.missingPreparedRefund",
                 value: "The refund could not be prepared. Please try again.",
                 comment: "Error shown when POS tries to submit a refund without prepared refund data."
+            )
+        case .refundAlreadyInProgress:
+            return NSLocalizedString(
+                "pos.refundSubmissionAdaptor.error.refundAlreadyInProgress",
+                value: "A refund is already in progress. Please wait for it to finish.",
+                comment: "Error shown when POS tries to submit a second refund while another refund is in progress."
             )
         }
     }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionMapping.swift
@@ -122,6 +122,15 @@ struct POSRefundSubmissionMapping {
         return context.order.paymentMethodID != PaymentGateway.Constants.cashOnDeliveryGatewayID
     }
 
+    func requiresCardPresentRefund(context: PreparedRefundContext) -> Bool {
+        switch context.charge?.paymentMethodDetails {
+        case .some(.interacPresent):
+            return true
+        default:
+            return false
+        }
+    }
+
     func paymentMethodDescription(for order: Order, charge: WCPayCharge?) -> String {
         let paymentMethod = order.paymentMethodTitle.isEmpty ? Localization.manualPaymentMethod : order.paymentMethodTitle
         switch charge?.paymentMethodDetails {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -46,8 +46,8 @@ final class CardPresentRefundOrchestrator {
                 onWaitingForInput(inputMethods)
             case .displayMessage(let message):
                 onDisplayMessage(message)
-            case .removeCardRequested:
-                onProcessingMessage()
+            case .removeCardRequested(let message):
+                onDisplayMessage(message)
             case .cardInserted:
                 onCardInserted()
             case .cardDetailsCollected:

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -403,15 +403,20 @@ private extension RefundSubmissionUseCase {
 
             guard let self else { return }
 
-            if let refundData {
-                // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
-                self.retrieveUpdatedRefundData(refund: refundData)
-            }
             if let error {
                 DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")
                 self.trackCreateRefundRequestFailed(error: error)
                 return onCompletion(.failure(error))
             }
+
+            guard let refundData else {
+                DDLogError("Error creating refund: \(refund)\nWith Error: missing created refund response")
+                self.trackCreateRefundRequestFailed(error: RefundSubmissionUseCaseSubmissionError.missingCreatedRefund)
+                return onCompletion(.failure(RefundSubmissionUseCaseSubmissionError.missingCreatedRefund))
+            }
+
+            // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
+            self.retrieveUpdatedRefundData(refund: refundData)
             onCompletion(.success(()))
             self.trackCreateRefundRequestSuccess()
         }
@@ -517,6 +522,7 @@ enum RefundSubmissionUseCaseSubmissionError: Error, Equatable {
     case invalidRefundAmount
     case unknownPaymentGatewayAccount
     case canceledByUser
+    case missingCreatedRefund
 }
 
 private enum RefundSubmissionUseCaseDefinitions {

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -12,6 +12,7 @@ final class MockOrderDetailsPaymentAlerts {
 
     var cardInsertedWasCalled = false
     var displayReaderMessageWasCalled = false
+    var spyDisplayReaderMessage: String?
     var processingPaymentWasCalled = false
     var error: Error?
     var retryFromError: (() -> Void)?
@@ -43,6 +44,7 @@ extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
 
     func displayReaderMessage(message: String) {
         displayReaderMessageWasCalled = true
+        spyDisplayReaderMessage = message
     }
 
     func processingPayment(title: String) {

--- a/WooCommerce/WooCommerceTests/POS/POSRefundCardPresentPaymentAlertsTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundCardPresentPaymentAlertsTests.swift
@@ -1,0 +1,90 @@
+@testable import PointOfSale
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class POSRefundCardPresentPaymentAlertsTests: XCTestCase {
+    func test_present_when_payment_cancellation_runs_then_marks_refund_as_cancelled() {
+        let stateModel = POSRefundSubmissionModel()
+        var didMarkCancelled = false
+        var didCancelPayment = false
+        let sut = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel) {
+            didMarkCancelled = true
+        }
+
+        sut.present(viewModel: .tapSwipeOrInsertCard(inputMethods: [.tap, .insert]) {
+            didCancelPayment = true
+        })
+
+        guard case .tapSwipeOrInsertCard(_, let cancelPayment) = waitForCardPresentEvent(in: stateModel) else {
+            return XCTFail("Expected tap, swipe, or insert card event.")
+        }
+        cancelPayment()
+
+        XCTAssertTrue(didMarkCancelled)
+        XCTAssertTrue(didCancelPayment)
+    }
+
+    func test_present_when_multiple_reader_search_is_cancelled_then_marks_refund_as_cancelled() {
+        let stateModel = POSRefundSubmissionModel()
+        var didMarkCancelled = false
+        var selectedReaderID: String?
+        let sut = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel) {
+            didMarkCancelled = true
+        }
+
+        sut.foundSeveralReaders(readerIDs: ["reader-1"]) { readerID in
+            selectedReaderID = readerID
+        } cancelSearch: {
+            selectedReaderID = nil
+        }
+
+        guard case .foundMultipleReaders(_, let selectionHandler) = waitForCardPresentEvent(in: stateModel) else {
+            return XCTFail("Expected multiple reader event.")
+        }
+        selectionHandler(nil)
+
+        XCTAssertTrue(didMarkCancelled)
+        XCTAssertNil(selectedReaderID)
+    }
+
+    func test_present_when_multiple_reader_is_selected_then_does_not_mark_refund_as_cancelled() {
+        let stateModel = POSRefundSubmissionModel()
+        var didMarkCancelled = false
+        var selectedReaderID: String?
+        let sut = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel) {
+            didMarkCancelled = true
+        }
+
+        sut.foundSeveralReaders(readerIDs: ["reader-1"]) { readerID in
+            selectedReaderID = readerID
+        } cancelSearch: {
+            selectedReaderID = nil
+        }
+
+        guard case .foundMultipleReaders(_, let selectionHandler) = waitForCardPresentEvent(in: stateModel) else {
+            return XCTFail("Expected multiple reader event.")
+        }
+        selectionHandler("reader-1")
+
+        XCTAssertFalse(didMarkCancelled)
+        XCTAssertEqual(selectedReaderID, "reader-1")
+    }
+}
+
+private extension POSRefundCardPresentPaymentAlertsTests {
+    func waitForCardPresentEvent(in stateModel: POSRefundSubmissionModel) -> CardPresentPaymentEventDetails {
+        var eventDetails: CardPresentPaymentEventDetails?
+        let expectation = expectation(description: "Card-present event is presented")
+
+        DispatchQueue.main.async {
+            if case .cardPresentEvent(let details) = stateModel.state {
+                eventDetails = details
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+        return eventDetails!
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSRefundSubmissionMappingTests.swift
@@ -59,6 +59,18 @@ final class POSRefundSubmissionMappingTests: XCTestCase {
         XCTAssertFalse(sut.gatewaySupportsAutomaticRefunds(context: makeContext(order: codOrder, paymentGateway: nil)))
     }
 
+    func test_requiresCardPresentRefund_when_charge_is_interacPresent_then_returns_true() {
+        let charge = WCPayCharge.fake().copy(paymentMethodDetails: .interacPresent(details: .fake()))
+
+        XCTAssertTrue(sut.requiresCardPresentRefund(context: makeContext(charge: charge)))
+    }
+
+    func test_requiresCardPresentRefund_when_charge_is_not_interacPresent_then_returns_false() {
+        let charge = WCPayCharge.fake().copy(paymentMethodDetails: .card(details: .fake()))
+
+        XCTAssertFalse(sut.requiresCardPresentRefund(context: makeContext(charge: charge)))
+    }
+
     func test_refundComponents_aggregates_selected_product_quantity_and_selected_fees() {
         let item1 = orderItem(itemID: 10, quantity: 3)
         let item2 = orderItem(itemID: 20, quantity: 1)
@@ -125,11 +137,12 @@ final class POSRefundSubmissionMappingTests: XCTestCase {
 
 private extension POSRefundSubmissionMappingTests {
     func makeContext(order: Order = Order.fake(),
+                     charge: WCPayCharge? = nil,
                      paymentGateway: PaymentGateway? = PaymentGateway.fake(),
                      refundableItems: [RefundableOrderItem] = [],
                      refundableFees: [OrderFeeLine] = []) -> POSRefundSubmissionMapping.PreparedRefundContext {
         POSRefundSubmissionMapping.PreparedRefundContext(order: order,
-                                                         charge: nil,
+                                                         charge: charge,
                                                          paymentGateway: paymentGateway,
                                                          paymentGatewayAccount: nil,
                                                          refundableItems: refundableItems,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -109,7 +109,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertTrue(alerts.cardInsertedWasCalled)
     }
 
-    func test_submitRefund_with_removeCardRequested_reader_event_shows_processing_alert() {
+    func test_submitRefund_with_removeCardRequested_reader_event_shows_reader_message() {
         // Given
         let useCase = createUseCase(details: interacRefundDetails())
         mockCardPresentPaymentActions(returnCardReaderMessage: .removeCardRequested("Remove card"))
@@ -124,8 +124,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertTrue(alerts.processingPaymentWasCalled)
-        XCTAssertFalse(alerts.displayReaderMessageWasCalled)
+        XCTAssertTrue(alerts.displayReaderMessageWasCalled)
+        XCTAssertEqual(alerts.spyDisplayReaderMessage, "Remove card")
     }
 
     func test_submitRefund_with_non_interac_payment_method_does_not_call_showOnboardingIfRequired() throws {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -153,6 +153,31 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertFalse(onboardingPresenter.spyShowOnboardingWasCalled)
     }
 
+    func test_submitRefund_with_missing_server_side_refund_response_returns_failure() throws {
+        // Given
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
+                                                   charge: .fake().copy(paymentMethodDetails: .cardPresent(
+                                                    details: .init(brand: .visa,
+                                                                   last4: "9969",
+                                                                   funding: .credit,
+                                                                   receipt: .init(accountType: .credit,
+                                                                                  applicationPreferredName: "Stripe Credit",
+                                                                                  dedicatedFileName: "A000000003101001")))),
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
+        mockServerSideRefund(refund: nil, error: nil)
+
+        // When
+        let result = waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .missingCreatedRefund)
+    }
+
     func test_submitRefund_with_interac_payment_method_calls_showOnboardingIfRequired() throws {
         // Given
         let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
@@ -445,14 +470,23 @@ private extension RefundSubmissionUseCaseTests {
     }
 
     func mockServerSideRefund(result: Result<Void, Error>) {
+        let refund: Refund?
+        let error: Error?
+        switch result {
+        case .success:
+            refund = .fake()
+            error = nil
+        case .failure(let failure):
+            refund = nil
+            error = failure
+        }
+        mockServerSideRefund(refund: refund, error: error)
+    }
+
+    func mockServerSideRefund(refund: Refund?, error: Error?) {
         stores.whenReceivingAction(ofType: RefundAction.self) { action in
             if case let .createRefund(_, _, _, completion) = action {
-                switch result {
-                case .success:
-                    completion(.fake(), nil)
-                case .failure(let error):
-                    completion(nil, error)
-                }
+                completion(refund, error)
             }
         }
     }


### PR DESCRIPTION
Part of: RSM-645

## Description
Improves cancellation handling for card-present POS refunds so user-initiated cancellation does not leave the flow in an error-like state.

## Test Steps
Spot-check cancelling/backing out of the card-present refund screens once the full-screen flow is wired.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.