### PR TITLE
RSM-645 Avoid refund confirmation fade after card cancellation

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -34,6 +34,7 @@ protocol POSOrderListControllerProtocol {
     func loadNextOrders() async
     func selectOrder(_ order: POSOrder?)
     func updateOrder(orderID: Int64) async throws
+    func preloadRefundDetails() async
     func startRefundFlow() async -> StartRefundFlowResult
     func toggleRefundItemSelection(at index: Int)
     func clearRefundSelection()
@@ -308,6 +309,15 @@ enum RefundActionAvailability {
     }
 
     // MARK: - Refund Item Selection
+
+    @MainActor
+    func preloadRefundDetails() async {
+        guard refundActionAvailability == .available,
+              let order = selectedOrder else {
+            return
+        }
+        await refundSubmissionProcessor.preloadRefund(for: order)
+    }
 
     @MainActor
     func startRefundFlow() async -> StartRefundFlowResult {

--- a/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSRefundSubmissionProcessing.swift
@@ -57,6 +57,8 @@ public enum POSRefundSubmissionError: Error, Equatable {
 public protocol POSRefundSubmissionProcessing: AnyObject {
     var stateModel: POSRefundSubmissionModel { get }
 
+    func preloadRefund(for order: POSOrder) async
+
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation
 
     func prepareReviewData(for order: POSOrder,
@@ -74,6 +76,8 @@ public final class POSNoOpRefundSubmissionProcessor: POSRefundSubmissionProcessi
     public let stateModel = POSRefundSubmissionModel()
 
     public nonisolated init() {}
+
+    public func preloadRefund(for order: POSOrder) async {}
 
     public func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
         POSRefundPreparation(orderID: order.id,

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -179,6 +179,9 @@ struct POSOrderDetailsView: View {
             guard shouldShowDedicatedRefundsSection else { return }
             await orderListModel.ordersController.loadOrderRefunds()
         }
+        .task {
+            await orderListModel.ordersController.preloadRefundDetails()
+        }
         .onAppear {
             if autoStartNextRefundFlow {
                 autoStartNextRefundFlow = false

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -63,7 +63,11 @@ private extension POSRefundConfirmationView {
     }
 
     var backgroundColor: Color {
-        primaryBackgroundCardPresentMessageType == nil ? .posSurfaceBright : .posPrimary
+        guard isProcessing else {
+            return .posSurfaceBright
+        }
+
+        return primaryBackgroundCardPresentMessageType == nil ? Color.posSurfaceBright : Color.posPrimary
     }
 
     var primaryBackgroundCardPresentMessageType: POSRefundCardPresentMessageType? {
@@ -95,15 +99,22 @@ private extension POSRefundConfirmationView {
     var processingCancelAction: (() -> Void)? {
         switch submissionState {
         case .onboarding(_, let onCancel):
-            return onCancel
+            return cancelAndReturnToConfirmation(onCancel)
         case .cardPresentEvent(let eventDetails):
-            return eventDetails.posRefundCancelAction
+            return eventDetails.posRefundCancelAction.map(cancelAndReturnToConfirmation)
         case .preparingReader(let cancel),
                 .waitingForCard(_, let cancel):
-            return cancel
+            return cancelAndReturnToConfirmation(cancel)
         case .idle, .loading, .processingReader, .displayingReaderMessage, .submitting, .submittingCardPresent,
                 .retryableError, .nonRetryableError, .completed:
             return nil
+        }
+    }
+
+    func cancelAndReturnToConfirmation(_ cancel: @escaping () -> Void) -> () -> Void {
+        {
+            onBack?()
+            cancel()
         }
     }
 
@@ -209,15 +220,15 @@ private extension POSRefundConfirmationView {
         case .paymentError(let error, let retryApproach, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: retryAction(for: retryApproach),
-                                cancelAction: cancelPayment))
+                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
         case .paymentCaptureError(let cancelPayment):
             return .error(.init(error: POSRefundCardPresentPresentationError.unableToConfirmRefund,
                                 retryAction: nil,
-                                cancelAction: cancelPayment))
+                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
         case .paymentIntentCreationError(let error, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: nil,
-                                cancelAction: cancelPayment))
+                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
         case .scanningForReaders, .scanningFailed, .bluetoothRequired, .connectingToReader, .connectingFailed,
                 .connectingFailedNonRetryable, .connectingFailedUpdatePostalCode, .connectingFailedChargeReader,
                 .connectingFailedUpdateAddress, .selectSearchType, .foundReader, .foundMultipleReaders, .updateProgress,
@@ -265,7 +276,7 @@ private enum POSRefundCardPresentPresentationError: LocalizedError {
     }
 }
 
-private extension CardPresentPaymentEventDetails {
+extension CardPresentPaymentEventDetails {
     var posRefundCancelAction: (() -> Void)? {
         switch self {
         case .scanningForReaders(let endSearch),

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -189,12 +189,12 @@ struct POSRefundModalContentView: View {
                 onConfirm: {
                     handleRefundConfirmation(reviewData: reviewData)
                 },
-                onBack: nil
+                onBack: { modalState = .review(reviewData) }
             )
         case .readerConnectionRequired(let reviewData):
             POSRefundReaderDisconnectedView(
                 onConnect: { startProcessingRefund(reviewData: reviewData) },
-                onCancel: { dismissModal?() },
+                onCancel: { dismissRefundFlow() },
                 onBack: { modalState = .confirmation(reviewData) }
             )
         case .processing(let reviewData):
@@ -205,7 +205,7 @@ struct POSRefundModalContentView: View {
                 submissionState: refundSubmissionModel.state,
                 onClose: {},
                 onConfirm: {},
-                onBack: nil
+                onBack: { returnToRefundConfirmation(reviewData: reviewData) }
             )
         case .success(let reviewData):
             POSRefundSuccessView(
@@ -240,7 +240,7 @@ struct POSRefundModalContentView: View {
                     .submitting, .retryableError, .nonRetryableError, .completed:
                 return .posSurfaceBright
             }
-        case .review, .confirmation, .success, .error:
+        case .review, .confirmation, .readerConnectionRequired, .success, .error:
             return .posSurfaceBright
         }
     }
@@ -282,7 +282,7 @@ struct POSRefundModalContentView: View {
     }
 
     private func updateCardPresentOnboardingItem() {
-        guard case .processing = state,
+        guard case .processing(let reviewData) = state,
               case .onboarding(let factory, let onCancel) = refundSubmissionModel.state else {
             cardPresentOnboardingItem = nil
             return
@@ -291,7 +291,10 @@ struct POSRefundModalContentView: View {
         cardPresentOnboardingItem = POSRefundCardPresentOnboardingItem(
             id: ObjectIdentifier(factory),
             factory: factory,
-            onCancel: onCancel
+            onCancel: {
+                returnToRefundConfirmation(reviewData: reviewData)
+                onCancel()
+            }
         )
     }
 
@@ -300,13 +303,22 @@ struct POSRefundModalContentView: View {
         guard let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: .init(
-                tryPaymentAgainBackToCheckoutAction: { modalState = .confirmation(reviewData) },
+                tryPaymentAgainBackToCheckoutAction: { returnToRefundConfirmation(reviewData: reviewData) },
                 nonRetryableErrorExitAction: { dismissRefundFlow() },
                 formattedOrderTotalPrice: reviewData.formattedRefundTotal,
-                paymentCaptureErrorTryAgainAction: { modalState = .confirmation(reviewData) },
+                paymentCaptureErrorTryAgainAction: { returnToRefundConfirmation(reviewData: reviewData) },
                 paymentCaptureErrorNewOrderAction: { dismissRefundFlow() },
-                paymentIntentCreationErrorEditOrderAction: { modalState = .review(reviewData) },
-                dismissReaderConnectionModal: { cardPresentAlertItem = nil }
+                paymentIntentCreationErrorEditOrderAction: {
+                    refundSubmissionModel.reset()
+                    modalState = .review(reviewData)
+                },
+                dismissReaderConnectionModal: {
+                    let shouldReturnToConfirmation = currentCardPresentEventCanCancel
+                    cardPresentAlertItem = nil
+                    if shouldReturnToConfirmation {
+                        returnToRefundConfirmation(reviewData: reviewData)
+                    }
+                }
             )) else {
             return nil
         }
@@ -327,8 +339,7 @@ struct POSRefundModalContentView: View {
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch POSRefundSubmissionError.canceledByUser {
-            refundSubmissionModel.reset()
-            modalState = .confirmation(reviewData)
+            returnToRefundConfirmation(reviewData: reviewData)
         } catch {
             DDLogError("⛔️ Failed to process POS refund: \(error)")
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
@@ -358,6 +369,24 @@ struct POSRefundModalContentView: View {
         Task { @MainActor in
             await processRefund(reviewData: reviewData)
         }
+    }
+
+    private func returnToRefundConfirmation(reviewData: POSRefundReviewData) {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            cardPresentAlertItem = nil
+            cardPresentOnboardingItem = nil
+            refundSubmissionModel.reset()
+            modalState = .confirmation(reviewData)
+        }
+    }
+
+    private var currentCardPresentEventCanCancel: Bool {
+        guard case .cardPresentEvent(let eventDetails) = refundSubmissionModel.state else {
+            return false
+        }
+        return eventDetails.posRefundCancelAction != nil
     }
 
     private func shouldRequireReaderConnection() -> Bool {

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalLayout.swift
@@ -40,7 +40,7 @@ struct POSRefundNavigationHeader: View {
     }
 
     var body: some View {
-        HStack(spacing: POSSpacing.medium) {
+        HStack(alignment: .top, spacing: POSSpacing.medium) {
             if let backAction {
                 POSPageHeaderBackButton(configuration: .init(state: .enabled, action: backAction))
                     .accessibilityLabel(backAccessibilityLabel)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSelectionFlowView.swift
@@ -42,6 +42,7 @@ struct POSRefundSelectionFlowView: View {
             .toolbar(.hidden, for: .navigationBar)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.posSurfaceBright)
+            .ignoresSafeArea(.container, edges: .bottom)
             .posHidesFloatingControl()
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/WavesProgressViewStyle.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/WavesProgressViewStyle.swift
@@ -12,6 +12,7 @@ private struct CardWaveProgressView: View {
     private let inactiveInset: CGFloat = 0.025
 
     @State private var activeArcIndex: Int = 0
+    @State private var animationTimer: Timer?
 
     private var waveCount: Int {
         radii.count
@@ -53,15 +54,27 @@ private struct CardWaveProgressView: View {
         .onAppear {
             startAnimating()
         }
+        .onDisappear {
+            stopAnimating()
+        }
         .accessibilityLabel(Localization.accessibilityLabel)
     }
 
     private func startAnimating() {
-        Timer.scheduledTimer(withTimeInterval: animationDuration, repeats: true) { _ in
-            withAnimation {
+        guard animationTimer == nil else {
+            return
+        }
+
+        animationTimer = Timer.scheduledTimer(withTimeInterval: animationDuration, repeats: true) { _ in
+            withAnimation(.easeInOut(duration: animationDuration)) {
                 activeArcIndex = (activeArcIndex + 1) % waveCount
             }
         }
+    }
+
+    private func stopAnimating() {
+        animationTimer?.invalidate()
+        animationTimer = nil
     }
 }
 

--- a/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
+++ b/Modules/Sources/PointOfSale/Utils/PreviewHelpers.swift
@@ -532,6 +532,7 @@ final class POSConfigurablePreviewOrderListController: POSSearchingOrderListCont
     func refreshOrders() async {}
     func selectOrder(_ order: POSOrder?) {}
     func updateOrder(orderID: Int64) async throws {}
+    func preloadRefundDetails() async {}
     func searchOrders(searchTerm: String) async {}
     func clearSearchOrders() {}
     func startRefundFlow() async -> StartRefundFlowResult { .hasItemsToRefund }

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -438,6 +438,39 @@ final class POSOrderListControllerTests {
     // MARK: - Refund Item Selection Tests
 
     @MainActor
+    @Test func preloadRefundDetails_when_refund_is_available_then_preloads_without_opening_refund_flow() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let order = makeOrder(id: 1, status: .completed)
+        sut.selectOrder(order)
+
+        // When
+        await sut.preloadRefundDetails()
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs == [order.id])
+        #expect(sut.refundSelectableItems.isEmpty)
+        guard case .idle = sut.selectedOrderRefundsState else {
+            Issue.record("Preloading should not move the visible refund flow state.")
+            return
+        }
+    }
+
+    @MainActor
+    @Test func preloadRefundDetails_when_refund_is_unavailable_then_does_not_preload() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        let order = makeOrder(id: 1, status: .processing)
+        sut.selectOrder(order)
+
+        // When
+        await sut.preloadRefundDetails()
+
+        // Then
+        #expect(refundSubmissionProcessor.preloadedOrderIDs.isEmpty)
+    }
+
+    @MainActor
     @Test func startRefundFlow_when_product_has_multiple_quantities_then_creates_one_row_per_unit() async throws {
         // Given
         let order = makeOrder(lineItems: [
@@ -1739,6 +1772,12 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
                      currencyFormatter: CurrencyFormatter) {
         self.refundsService = refundsService
         self.currencyFormatter = currencyFormatter
+    }
+
+    private(set) var preloadedOrderIDs: [Int64] = []
+
+    func preloadRefund(for order: POSOrder) async {
+        preloadedOrderIDs.append(order.id)
     }
 
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSOrderListController.swift
@@ -43,6 +43,8 @@ final class MockPOSOrderListController: POSSearchingOrderListControllerProtocol 
         }
     }
 
+    func preloadRefundDetails() async {}
+
     func searchOrders(searchTerm: String) async {}
 
     func clearSearchOrders() {}

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundCardPresentPaymentAlerts.swift
@@ -6,12 +6,15 @@ import Yosemite
 final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
     private let stateModel: POSRefundSubmissionModel
     private let onCancelRequested: () -> Void
+    private let isPresentationAllowed: () -> Bool
     private let alertsProvider = CardPresentPaymentsTransactionAlertsProvider()
 
     init(stateModel: POSRefundSubmissionModel,
-         onCancelRequested: @escaping () -> Void = {}) {
+         onCancelRequested: @escaping () -> Void = {},
+         isPresentationAllowed: @escaping () -> Bool = { true }) {
         self.stateModel = stateModel
         self.onCancelRequested = onCancelRequested
+        self.isPresentationAllowed = isPresentationAllowed
     }
 
     func presentViewModel(viewModel: CardPresentPaymentsModalViewModel) {
@@ -53,7 +56,8 @@ final class POSRefundOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtoco
 
     private func present(_ eventDetails: CardPresentPaymentEventDetails) {
         let eventDetails = eventDetails.markingPOSCancellation(onCancelRequested)
-        onMainQueue { [stateModel] in
+        onMainQueue { [stateModel, isPresentationAllowed] in
+            guard isPresentationAllowed() else { return }
             stateModel.state = .cardPresentEvent(eventDetails)
         }
     }
@@ -64,12 +68,15 @@ final class POSRefundCardPresentPaymentAlertsPresenter: CardPresentPaymentAlerts
 
     private let stateModel: POSRefundSubmissionModel
     private let onCancelRequested: () -> Void
+    private let isPresentationAllowed: () -> Bool
     private var latestReaderConnectionHandler: ((String?) -> Void)?
 
     init(stateModel: POSRefundSubmissionModel,
-         onCancelRequested: @escaping () -> Void = {}) {
+         onCancelRequested: @escaping () -> Void = {},
+         isPresentationAllowed: @escaping () -> Bool = { true }) {
         self.stateModel = stateModel
         self.onCancelRequested = onCancelRequested
+        self.isPresentationAllowed = isPresentationAllowed
     }
 
     func present(viewModel eventDetails: CardPresentPaymentEventDetails) {
@@ -153,7 +160,8 @@ final class POSRefundCardPresentPaymentAlertsPresenter: CardPresentPaymentAlerts
 
     private func present(_ eventDetails: CardPresentPaymentEventDetails) {
         let eventDetails = eventDetails.markingPOSCancellation(onCancelRequested)
-        onMainQueue { [stateModel] in
+        onMainQueue { [stateModel, isPresentationAllowed] in
+            guard isPresentationAllowed() else { return }
             stateModel.state = .cardPresentEvent(eventDetails)
         }
     }

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -120,16 +120,22 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
                 submittingState: submittingState,
                 cancellationState: cancellationState)
 
-        let alertPresenter = POSRefundCardPresentPaymentAlertsPresenter(stateModel: stateModel,
-                                                                        onCancelRequested: cancellationState.markCancelled)
+        let alertPresenter = POSRefundCardPresentPaymentAlertsPresenter(
+            stateModel: stateModel,
+            onCancelRequested: cancellationState.markCancelled,
+            isPresentationAllowed: { !cancellationState.wasCancelledByMerchant }
+        )
         let submissionUseCase = RefundSubmissionUseCase(
             details: .init(order: context.order,
                            charge: context.charge,
                            amount: amount,
                            paymentGatewayAccount: context.paymentGatewayAccount),
             rootViewController: NullViewControllerPresenting(),
-            alerts: POSRefundOrderDetailsPaymentAlerts(stateModel: stateModel,
-                                                       onCancelRequested: cancellationState.markCancelled),
+            alerts: POSRefundOrderDetailsPaymentAlerts(
+                stateModel: stateModel,
+                onCancelRequested: cancellationState.markCancelled,
+                isPresentationAllowed: { !cancellationState.wasCancelledByMerchant }
+            ),
             cardPresentConfiguration: CardPresentConfigurationLoader(stores: stores).configuration,
             cardReaderConnectionAlerts: CardPresentPaymentBluetoothReaderConnectionAlertsProvider(),
             alertPresenter: alertPresenter,
@@ -263,6 +269,7 @@ private extension POSRefundSubmissionAdaptor {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
                 guard let self else { return }
+                guard !cancellationState.wasCancelledByMerchant else { return }
                 switch event {
                 case .showOnboarding(let factory, let onCancel):
                     self.stateModel.state = .onboarding(factory: factory, onCancel: {

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -10,6 +10,11 @@ import WooFoundation
 final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     let stateModel = POSRefundSubmissionModel()
 
+    private struct PreparedRefundSnapshot {
+        let preparation: POSRefundPreparation
+        let context: POSRefundSubmissionMapping.PreparedRefundContext
+    }
+
     private let orderService: POSOrderServiceProtocol
     private let stores: StoresManager
     private let storageManager: StorageManagerType
@@ -19,6 +24,8 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
     private let analytics: Analytics
     private let refundOptionsDeterminer: OrderRefundsOptionsDeterminerProtocol
 
+    private var preloadedRefundSnapshots: [Int64: PreparedRefundSnapshot] = [:]
+    private var preloadTasks: [Int64: (id: UUID, task: Task<PreparedRefundSnapshot, Error>)] = [:]
     private var preparedContexts: [Int64: POSRefundSubmissionMapping.PreparedRefundContext] = [:]
     private var submissionUseCase: RefundSubmissionUseCase<CardPresentPaymentBluetoothReaderConnectionAlertsProvider, POSRefundCardPresentPaymentAlertsPresenter>?
     private var onboardingSubscription: AnyCancellable?
@@ -40,34 +47,45 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         self.refundOptionsDeterminer = refundOptionsDeterminer
     }
 
+    func preloadRefund(for order: POSOrder) async {
+        removePreloadedRefunds(except: order.id)
+
+        guard preloadedRefundSnapshots[order.id] == nil,
+              preloadTasks[order.id] == nil else {
+            return
+        }
+
+        let preloadID = UUID()
+        let preloadTask = Task { @MainActor in
+            try await loadPreparedRefundSnapshot(for: order)
+        }
+        preloadTasks[order.id] = (id: preloadID, task: preloadTask)
+
+        do {
+            let snapshot = try await preloadTask.value
+            guard preloadTasks[order.id]?.id == preloadID else {
+                return
+            }
+            preloadedRefundSnapshots[order.id] = snapshot
+            preloadTasks[order.id] = nil
+        } catch {
+            guard preloadTasks[order.id]?.id == preloadID else {
+                return
+            }
+            preloadTasks[order.id] = nil
+        }
+    }
+
     func prepareRefund(for order: POSOrder) async throws -> POSRefundPreparation {
         stateModel.state = .loading
+        defer {
+            stateModel.reset()
+        }
 
-        let fullOrder = try await orderService.loadOrder(orderID: order.id)
-        let refunds = try await loadDetailedRefunds(for: fullOrder)
-        let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
-        let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }
-        let paymentGateway = loadPaymentGateway(for: fullOrder)
-        let paymentGatewayAccount = await loadSelectedOrStoredPaymentGatewayAccount(for: fullOrder)
-        let refundableItems = refundOptionsDeterminer.determineRefundableOrderItems(from: fullOrder, with: refunds)
-        let refundableFees = refundMapping.determineRefundableFees(from: fullOrder, with: refunds)
-        let selectableItems = refundMapping.makeSelectableItems(refundableItems: refundableItems,
-                                                                fees: refundableFees,
-                                                                currency: fullOrder.currency)
-        let context = POSRefundSubmissionMapping.PreparedRefundContext(order: fullOrder,
-                                                                       charge: charge,
-                                                                       paymentGateway: paymentGateway,
-                                                                       paymentGatewayAccount: paymentGatewayAccount,
-                                                                       refundableItems: refundableItems,
-                                                                       refundableFees: refundableFees)
-        preparedContexts[fullOrder.orderID] = context
-        stateModel.reset()
+        let snapshot = try await preparedRefundSnapshot(for: order)
+        preparedContexts[snapshot.preparation.orderID] = snapshot.context
 
-        return POSRefundPreparation(orderID: fullOrder.orderID,
-                                    selectableItems: selectableItems,
-                                    paymentMethodDescription: refundMapping.paymentMethodDescription(for: fullOrder, charge: charge),
-                                    customerEmail: fullOrder.billingAddress?.email,
-                                    requiresCardPresentRefund: refundMapping.requiresCardPresentRefund(context: context))
+        return snapshot.preparation
     }
 
     func prepareReviewData(for order: POSOrder,
@@ -173,10 +191,62 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
         }
 
         stateModel.state = requiresCardPresentRefund ? .submittingCardPresent : .completed
+        removePreloadedRefund(for: preparation.orderID)
     }
 }
 
 private extension POSRefundSubmissionAdaptor {
+    func removePreloadedRefund(for orderID: Int64) {
+        preloadedRefundSnapshots[orderID] = nil
+        preloadTasks[orderID]?.task.cancel()
+        preloadTasks[orderID] = nil
+    }
+
+    func removePreloadedRefunds(except orderID: Int64) {
+        preloadedRefundSnapshots = preloadedRefundSnapshots.filter { $0.key == orderID }
+        for preloadedOrderID in Array(preloadTasks.keys) where preloadedOrderID != orderID {
+            removePreloadedRefund(for: preloadedOrderID)
+        }
+    }
+
+    private func preparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
+        if let snapshot = preloadedRefundSnapshots.removeValue(forKey: order.id) {
+            return snapshot
+        }
+
+        if let preloadTask = preloadTasks.removeValue(forKey: order.id) {
+            return try await preloadTask.task.value
+        }
+
+        return try await loadPreparedRefundSnapshot(for: order)
+    }
+
+    private func loadPreparedRefundSnapshot(for order: POSOrder) async throws -> PreparedRefundSnapshot {
+        let fullOrder = try await orderService.loadOrder(orderID: order.id)
+        let refunds = try await loadDetailedRefunds(for: fullOrder)
+        let fetchedCharge = try await fetchChargeIfNeeded(for: fullOrder)
+        let charge = fetchedCharge.map { refundMapping.normalizedForPOSInteracRefund(charge: $0) }
+        let paymentGateway = loadPaymentGateway(for: fullOrder)
+        let paymentGatewayAccount = await loadSelectedOrStoredPaymentGatewayAccount(for: fullOrder)
+        let refundableItems = refundOptionsDeterminer.determineRefundableOrderItems(from: fullOrder, with: refunds)
+        let refundableFees = refundMapping.determineRefundableFees(from: fullOrder, with: refunds)
+        let selectableItems = refundMapping.makeSelectableItems(refundableItems: refundableItems,
+                                                                fees: refundableFees,
+                                                                currency: fullOrder.currency)
+        let context = POSRefundSubmissionMapping.PreparedRefundContext(order: fullOrder,
+                                                                       charge: charge,
+                                                                       paymentGateway: paymentGateway,
+                                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                                       refundableItems: refundableItems,
+                                                                       refundableFees: refundableFees)
+        let preparation = POSRefundPreparation(orderID: fullOrder.orderID,
+                                               selectableItems: selectableItems,
+                                               paymentMethodDescription: refundMapping.paymentMethodDescription(for: fullOrder, charge: charge),
+                                               customerEmail: fullOrder.billingAddress?.email,
+                                               requiresCardPresentRefund: refundMapping.requiresCardPresentRefund(context: context))
+        return PreparedRefundSnapshot(preparation: preparation, context: context)
+    }
+
     func loadDetailedRefunds(for order: Order) async throws -> [Refund] {
         let refundIDs = order.refunds.map(\.refundID)
         if refundIDs.isNotEmpty {


### PR DESCRIPTION
Part of: RSM-645

## Description
Prevents the refund confirmation screen from showing a recycled fade/loading state after returning from a cancelled card-present refund operation.

## Test Steps
Cancel a card-present refund from the reader flow and confirm the refund confirmation screen returns without the repeated fade state.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.