### PR TITLE
Track Smarter Notifications settings UI analytics (RSM-2710)

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -385,8 +385,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "EventHorizonSDK",
-            url: "https://a8c-libs.s3.amazonaws.com/ios/EventHorizon/woocommerce-2026-05-18-07-24-01/EventHorizon-woocommerce-2026-05-18-07-24-01.xcframework.zip",
-            checksum: "6102a42bb973ff8be2b8b2aa7aa4089d7fd1ed43d3df2aed87955a0e62abce69"
+            url: "https://a8c-libs.s3.amazonaws.com/ios/EventHorizon/woocommerce-2026-05-22-09-23-44/EventHorizon-woocommerce-2026-05-22-09-23-44.xcframework.zip",
+            checksum: "f200c7ad8d807b48e333cefbde40500d83c798a6b592af6fa3f166c528bad083"
         ),
     ]
 )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesDetailView.swift
@@ -33,6 +33,9 @@ struct NewOrderNotificationPreferencesDetailView: View {
         // one routes through the discard handler.
         .navigationBarBackButtonHidden(true)
         .notice($viewModel.errorNotice)
+        .onAppear {
+            viewModel.detailDidAppear(notificationType: .newOrder)
+        }
         .onChange(of: thresholdInput) { oldValue, newValue in
             // Reject any input that isn't a positive integer (no "0", leading
             // zeros, decimals, or non-digits). Reverting through the binding

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewOrderNotificationPreferencesHostingController.swift
@@ -10,6 +10,7 @@ final class NewOrderNotificationPreferencesHostingController:
     init(viewModel: PushNotificationPreferencesViewModel) {
         super.init(viewModel: viewModel,
                    rootView: NewOrderNotificationPreferencesDetailView(viewModel: viewModel),
+                   notificationType: .newOrder,
                    onDiscard: { [weak viewModel] in viewModel?.discardStoreOrderEdits() })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesDetailView.swift
@@ -28,6 +28,9 @@ struct NewReviewNotificationPreferencesDetailView: View {
         // one routes through the discard handler.
         .navigationBarBackButtonHidden(true)
         .notice($viewModel.errorNotice)
+        .onAppear {
+            viewModel.detailDidAppear(notificationType: .newReview)
+        }
     }
 
     private var masterToggleSection: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewReviewNotificationPreferencesHostingController.swift
@@ -10,6 +10,7 @@ final class NewReviewNotificationPreferencesHostingController:
     init(viewModel: PushNotificationPreferencesViewModel) {
         super.init(viewModel: viewModel,
                    rootView: NewReviewNotificationPreferencesDetailView(viewModel: viewModel),
+                   notificationType: .newReview,
                    onDiscard: { [weak viewModel] in viewModel?.discardStoreReviewEdits() })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
@@ -28,6 +28,9 @@ struct NewStockNotificationPreferencesDetailView: View {
         // one routes through the discard handler.
         .navigationBarBackButtonHidden(true)
         .notice($viewModel.errorNotice)
+        .onAppear {
+            viewModel.detailDidAppear(notificationType: .stockAlert)
+        }
     }
 
     private var masterToggleSection: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesHostingController.swift
@@ -10,6 +10,7 @@ final class NewStockNotificationPreferencesHostingController:
     init(viewModel: PushNotificationPreferencesViewModel) {
         super.init(viewModel: viewModel,
                    rootView: NewStockNotificationPreferencesDetailView(viewModel: viewModel),
+                   notificationType: .stockAlert,
                    onDiscard: { [weak viewModel] in viewModel?.discardStoreStockEdits() })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationDetailHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NotificationDetailHostingController.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 import UIKit
+import EventHorizonSDK
+import protocol WooFoundation.Analytics
 
 /// Generic base for per-section push-notification preference detail screens.
 /// Owns navigation chrome — Save bar button, custom back button, spinner
@@ -19,6 +21,8 @@ class NotificationDetailHostingController<Content: View>: UIHostingController<Co
 
     let viewModel: PushNotificationPreferencesViewModel
     private let onDiscard: () -> Void
+    private let notificationType: NotificationTypeValue
+    private let analytics: Analytics
 
     private lazy var saveBarButtonItem: UIBarButtonItem = {
         let item = UIBarButtonItem(title: NotificationDetailHostingControllerStrings.save,
@@ -47,9 +51,13 @@ class NotificationDetailHostingController<Content: View>: UIHostingController<Co
 
     init(viewModel: PushNotificationPreferencesViewModel,
          rootView: Content,
-         onDiscard: @escaping () -> Void) {
+         notificationType: NotificationTypeValue,
+         onDiscard: @escaping () -> Void,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.viewModel = viewModel
         self.onDiscard = onDiscard
+        self.notificationType = notificationType
+        self.analytics = analytics
         super.init(rootView: rootView)
     }
 
@@ -93,11 +101,15 @@ class NotificationDetailHostingController<Content: View>: UIHostingController<Co
 
     @objc private func handleSaveTapped() {
         guard !viewModel.isSaving else { return }
+        analytics.track(.notificationsSettingsUpdateStarted(notificationType: notificationType))
         Task { @MainActor [weak self] in
             guard let self else { return }
             let success = await viewModel.save()
             if success {
+                analytics.track(.notificationsSettingsUpdateSuccess(notificationType: notificationType))
                 navigationController?.popViewController(animated: true)
+            } else {
+                analytics.track(.notificationsSettingsUpdateFailed(notificationType: notificationType))
             }
         }
     }
@@ -130,8 +142,16 @@ class NotificationDetailHostingController<Content: View>: UIHostingController<Co
     private func presentBackNavigationActionSheet() {
         UIAlertController.presentDiscardChangesActionSheet(viewController: self,
                                                            onDiscard: { [weak self] in
-            self?.onDiscard()
-            self?.navigationController?.popViewController(animated: true)
+            guard let self else { return }
+            analytics.track(.notificationsDetailDismissUnsavedChangesResolved(notificationType: notificationType,
+                                                                               outcome: .discard))
+            onDiscard()
+            navigationController?.popViewController(animated: true)
+        },
+                                                           onCancel: { [weak self] in
+            guard let self else { return }
+            analytics.track(.notificationsDetailDismissUnsavedChangesResolved(notificationType: notificationType,
+                                                                               outcome: .cancel))
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import EventHorizonSDK
+import protocol WooFoundation.Analytics
 
 /// Settings screen showing per-site Woo-driven push notification preferences:
 /// new orders, new reviews and stock alerts.
@@ -6,6 +8,7 @@ import SwiftUI
 struct PushNotificationPreferencesView: View {
 
     @Bindable private var viewModel: PushNotificationPreferencesViewModel
+    private let analytics: Analytics
 
     /// Set by the hosting controller after `super.init`. Default is a no-op so
     /// previews work without it.
@@ -17,8 +20,10 @@ struct PushNotificationPreferencesView: View {
     /// previews work without it.
     var onNewStockTapped: () -> Void = {}
 
-    init(viewModel: PushNotificationPreferencesViewModel) {
+    init(viewModel: PushNotificationPreferencesViewModel,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.viewModel = viewModel
+        self.analytics = analytics
     }
 
     var body: some View {
@@ -49,6 +54,9 @@ struct PushNotificationPreferencesView: View {
                 await viewModel.load()
             }
         }
+        .onAppear {
+            analytics.track(.notificationsSettingsView)
+        }
         .notice($viewModel.errorNotice)
     }
 
@@ -63,6 +71,7 @@ struct PushNotificationPreferencesView: View {
                        image: .errorImage,
                        buttonTitle: Localization.retry,
                        buttonAction: {
+                analytics.track(.notificationsSettingsLoadRetryTapped)
                 Task { await viewModel.load() }
             })
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -3,6 +3,8 @@ import Foundation
 import Observation
 import UIKit
 import Yosemite
+import EventHorizonSDK
+import protocol WooFoundation.Analytics
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
@@ -107,6 +109,7 @@ final class PushNotificationPreferencesViewModel {
     private let currencySettings: CurrencySettings
     private let notificationCenter: UserNotificationsCenterAdapter
     private let appStateNotificationCenter: NotificationCenter
+    private let analytics: Analytics
 
     private var appStateSubscription: AnyCancellable?
 
@@ -114,13 +117,15 @@ final class PushNotificationPreferencesViewModel {
          stores: StoresManager = ServiceLocator.stores,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          notificationCenter: UserNotificationsCenterAdapter = UNUserNotificationCenter.current(),
-         appStateNotificationCenter: NotificationCenter = .default) {
+         appStateNotificationCenter: NotificationCenter = .default,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.currencySettings = currencySettings
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.notificationCenter = notificationCenter
         self.appStateNotificationCenter = appStateNotificationCenter
+        self.analytics = analytics
         observeAppState()
     }
 
@@ -160,6 +165,7 @@ final class PushNotificationPreferencesViewModel {
         } catch {
             DDLogError("⛔️ Error loading push notification preferences for siteID=\(siteID): \(error)")
             loadState = .error
+            analytics.track(.notificationsSettingsLoadFailed)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -239,6 +239,8 @@ final class PushNotificationPreferencesViewModel {
     func setStoreReviewEnabled(_ newValue: Bool) {
         displayed = displayed.with(storeReview: .init(enabled: newValue,
                                                       maxRating: displayed.storeReview?.maxRating))
+        analytics.track(.notificationsDetailPushToggle(notificationType: .newReview,
+                                                       isEnabled: newValue))
     }
 
     /// Reverts only the new-review section of `displayed` to `lastSaved`.
@@ -251,6 +253,7 @@ final class PushNotificationPreferencesViewModel {
     }
 
     func setStoreReviewMaxRating(_ newValue: Int?) {
+        let previous = displayed.storeReview?.maxRating
         // Clamp any non-nil value to the server-supported `1...5` range; nil
         // stays nil ("all reviews").
         let normalized: Int? = {
@@ -260,6 +263,7 @@ final class PushNotificationPreferencesViewModel {
         rememberLastKnownMaxRating(from: normalized)
         displayed = displayed.with(storeReview: .init(enabled: isStoreReviewEnabled,
                                                       maxRating: normalized))
+        trackStoreReviewMaxRatingTransition(previous: previous, current: normalized)
     }
 
     func setStoreStockEnabled(_ newValue: Bool) {
@@ -353,6 +357,25 @@ private extension PushNotificationPreferencesViewModel {
         case let (oldValue?, newValue?) where oldValue != newValue:
             analytics.track(.notificationsDetailFilterValueChange(notificationType: .newOrder,
                                                                    filterValue: NSDecimalNumber(decimal: newValue).floatValue))
+        default:
+            break
+        }
+    }
+
+    /// Maps a transition on the new-review max rating to the analytics
+    /// event that best describes the user's intent. Mirrors the new-order
+    /// rules; see `trackStoreOrderMinAmountTransition`.
+    func trackStoreReviewMaxRatingTransition(previous: Int?, current: Int?) {
+        switch (previous, current) {
+        case (.some, nil):
+            analytics.track(.notificationsDetailFilterOptionSelect(notificationType: .newReview,
+                                                                    filterOption: .all))
+        case (nil, .some):
+            analytics.track(.notificationsDetailFilterOptionSelect(notificationType: .newReview,
+                                                                    filterOption: .filtered))
+        case let (oldValue?, newValue?) where oldValue != newValue:
+            analytics.track(.notificationsDetailFilterValueChange(notificationType: .newReview,
+                                                                   filterValue: Float(newValue)))
         default:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -272,6 +272,8 @@ final class PushNotificationPreferencesViewModel {
                                                      lowStock: existing?.lowStock,
                                                      outOfStock: existing?.outOfStock,
                                                      onBackorder: existing?.onBackorder))
+        analytics.track(.notificationsDetailPushToggle(notificationType: .stockAlert,
+                                                       isEnabled: newValue))
     }
 
     func setStoreStockLowStock(_ newValue: Bool) {
@@ -280,6 +282,7 @@ final class PushNotificationPreferencesViewModel {
                                                      lowStock: newValue,
                                                      outOfStock: existing?.outOfStock,
                                                      onBackorder: existing?.onBackorder))
+        analytics.track(.notificationsStockOptionToggle(option: .lowStock, isEnabled: newValue))
     }
 
     func setStoreStockOutOfStock(_ newValue: Bool) {
@@ -288,6 +291,7 @@ final class PushNotificationPreferencesViewModel {
                                                      lowStock: existing?.lowStock,
                                                      outOfStock: newValue,
                                                      onBackorder: existing?.onBackorder))
+        analytics.track(.notificationsStockOptionToggle(option: .outOfStock, isEnabled: newValue))
     }
 
     func setStoreStockOnBackorder(_ newValue: Bool) {
@@ -296,6 +300,7 @@ final class PushNotificationPreferencesViewModel {
                                                      lowStock: existing?.lowStock,
                                                      outOfStock: existing?.outOfStock,
                                                      onBackorder: newValue))
+        analytics.track(.notificationsStockOptionToggle(option: .onBackorder, isEnabled: newValue))
     }
 
     /// Reverts only the stock section of `displayed` to `lastSaved`. Other

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesViewModel.swift
@@ -202,9 +202,17 @@ final class PushNotificationPreferencesViewModel {
         }
     }
 
+    /// Fires `notificationsDetailView` for the given screen. Called by the
+    /// detail views from `.onAppear`.
+    func detailDidAppear(notificationType: NotificationTypeValue) {
+        analytics.track(.notificationsDetailView(notificationType: notificationType))
+    }
+
     func setStoreOrderEnabled(_ newValue: Bool) {
         displayed = displayed.with(storeOrder: .init(enabled: newValue,
                                                      minAmount: displayed.storeOrder?.minAmount))
+        analytics.track(.notificationsDetailPushToggle(notificationType: .newOrder,
+                                                       isEnabled: newValue))
     }
 
     /// Reverts only the new-order section of `displayed` to `lastSaved`.
@@ -217,6 +225,7 @@ final class PushNotificationPreferencesViewModel {
     }
 
     func setStoreOrderMinAmount(_ newValue: Decimal?) {
+        let previous = displayed.storeOrder?.minAmount
         let normalized: Decimal? = {
             guard let value = newValue, value > 0 else { return nil }
             return value
@@ -224,6 +233,7 @@ final class PushNotificationPreferencesViewModel {
         rememberLastKnownMinAmount(from: normalized)
         displayed = displayed.with(storeOrder: .init(enabled: isStoreOrderEnabled,
                                                      minAmount: normalized))
+        trackStoreOrderMinAmountTransition(previous: previous, current: normalized)
     }
 
     func setStoreReviewEnabled(_ newValue: Bool) {
@@ -326,6 +336,26 @@ private extension PushNotificationPreferencesViewModel {
     func rememberLastKnownMaxRating(from value: Int?) {
         guard let value, (1...5).contains(value) else { return }
         lastKnownStoreReviewMaxRating = value
+    }
+
+    /// Maps a transition on the new-order threshold to the analytics event
+    /// that best describes the user's intent: nil ↔ non-nil is a radio
+    /// switch between "All" and "High-value"; non-nil → non-nil is a
+    /// threshold edit. Same-value transitions and nil-to-nil are no-ops.
+    func trackStoreOrderMinAmountTransition(previous: Decimal?, current: Decimal?) {
+        switch (previous, current) {
+        case (.some, nil):
+            analytics.track(.notificationsDetailFilterOptionSelect(notificationType: .newOrder,
+                                                                    filterOption: .all))
+        case (nil, .some):
+            analytics.track(.notificationsDetailFilterOptionSelect(notificationType: .newOrder,
+                                                                    filterOption: .filtered))
+        case let (oldValue?, newValue?) where oldValue != newValue:
+            analytics.track(.notificationsDetailFilterValueChange(notificationType: .newOrder,
+                                                                   filterValue: NSDecimalNumber(decimal: newValue).floatValue))
+        default:
+            break
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -20,7 +20,8 @@ struct PushNotificationPreferencesViewModelTests {
 
     private func makeSUT(stores: MockStoresManager,
                          currencySettings: CurrencySettings = Self.testCurrencySettings,
-                         notificationCenter: UserNotificationsCenterAdapter = MockUserNotificationsCenterAdapter())
+                         notificationCenter: UserNotificationsCenterAdapter = MockUserNotificationsCenterAdapter(),
+                         analyticsProvider: MockAnalyticsProvider = MockAnalyticsProvider())
     -> PushNotificationPreferencesViewModel {
         // Use a fresh `NotificationCenter` so simulator-posted system
         // notifications don't queue work on the main actor and add contention
@@ -29,7 +30,8 @@ struct PushNotificationPreferencesViewModelTests {
                                              stores: stores,
                                              currencySettings: currencySettings,
                                              notificationCenter: notificationCenter,
-                                             appStateNotificationCenter: NotificationCenter())
+                                             appStateNotificationCenter: NotificationCenter(),
+                                             analytics: WooAnalytics(analyticsProvider: analyticsProvider))
     }
 
     private func makeStores() -> MockStoresManager {
@@ -80,6 +82,43 @@ struct PushNotificationPreferencesViewModelTests {
 
         // Then
         #expect(sut.loadState == .error)
+    }
+
+    @Test func test_load_when_remote_fails_then_notifications_settings_load_failed_is_tracked() async {
+        // Given
+        struct AnyError: Error {}
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.failure(AnyError()))
+            }
+        }
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: stores, analyticsProvider: analyticsProvider)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(analyticsProvider.receivedEvents.contains("notifications_settings_load_failed"))
+    }
+
+    @Test func test_load_when_remote_succeeds_then_notifications_settings_load_failed_is_not_tracked() async {
+        // Given
+        let stores = makeStores()
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .loadPushNotificationPreferences(_, onCompletion) = action {
+                onCompletion(.success(PushNotificationPreferences()))
+            }
+        }
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: stores, analyticsProvider: analyticsProvider)
+
+        // When
+        await sut.load()
+
+        // Then
+        #expect(!analyticsProvider.receivedEvents.contains("notifications_settings_load_failed"))
     }
 
     @Test func test_load_when_unsaved_edits_exist_then_response_does_not_stomp_displayed_state() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -1342,6 +1342,91 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_value_change"))
         #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_option_select"))
     }
+
+    // MARK: - Stock detail analytics
+
+    @Test func test_detailDidAppear_with_stockAlert_then_tracks_notifications_detail_view() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.detailDidAppear(notificationType: .stockAlert)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_view",
+                                            with: ["notification_type": "stock_alert"]))
+    }
+
+    @Test func test_setStoreStockEnabled_when_true_then_tracks_push_toggle_with_isEnabled_true() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreStockEnabled(true)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_push_toggle",
+                                            with: ["notification_type": "stock_alert",
+                                                   "is_enabled": true]))
+    }
+
+    @Test func test_setStoreStockEnabled_when_false_then_tracks_push_toggle_with_isEnabled_false() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreStockEnabled(false)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_push_toggle",
+                                            with: ["notification_type": "stock_alert",
+                                                   "is_enabled": false]))
+    }
+
+    @Test func test_setStoreStockLowStock_then_tracks_stock_option_toggle_with_lowStock() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreStockLowStock(true)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_stock_option_toggle",
+                                            with: ["option": "low_stock",
+                                                   "is_enabled": true]))
+    }
+
+    @Test func test_setStoreStockOutOfStock_then_tracks_stock_option_toggle_with_outOfStock() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreStockOutOfStock(true)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_stock_option_toggle",
+                                            with: ["option": "out_of_stock",
+                                                   "is_enabled": true]))
+    }
+
+    @Test func test_setStoreStockOnBackorder_then_tracks_stock_option_toggle_with_onBackorder() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreStockOnBackorder(false)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_stock_option_toggle",
+                                            with: ["option": "on_backorder",
+                                                   "is_enabled": false]))
+    }
 }
 
 /// Reference-typed box for capturing dispatched changes from a closure without

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -1238,6 +1238,110 @@ struct PushNotificationPreferencesViewModelTests {
         #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_value_change"))
         #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_option_select"))
     }
+
+    // MARK: - New-review detail analytics
+
+    @Test func test_detailDidAppear_with_newReview_then_tracks_notifications_detail_view() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.detailDidAppear(notificationType: .newReview)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_view",
+                                            with: ["notification_type": "new_review"]))
+    }
+
+    @Test func test_setStoreReviewEnabled_when_true_then_tracks_push_toggle_with_isEnabled_true() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreReviewEnabled(true)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_push_toggle",
+                                            with: ["notification_type": "new_review",
+                                                   "is_enabled": true]))
+    }
+
+    @Test func test_setStoreReviewEnabled_when_false_then_tracks_push_toggle_with_isEnabled_false() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreReviewEnabled(false)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_push_toggle",
+                                            with: ["notification_type": "new_review",
+                                                   "is_enabled": false]))
+    }
+
+    @Test func test_setStoreReviewMaxRating_from_nil_to_value_then_tracks_filter_option_filtered() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreReviewMaxRating(2)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_filter_option_select",
+                                            with: ["notification_type": "new_review",
+                                                   "filter_option": "filtered"]))
+    }
+
+    @Test func test_setStoreReviewMaxRating_from_value_to_nil_then_tracks_filter_option_all() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+        sut.setStoreReviewMaxRating(2)
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.setStoreReviewMaxRating(nil)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_filter_option_select",
+                                            with: ["notification_type": "new_review",
+                                                   "filter_option": "all"]))
+    }
+
+    @Test func test_setStoreReviewMaxRating_from_value_to_different_value_then_tracks_filter_value_change() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+        sut.setStoreReviewMaxRating(2)
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.setStoreReviewMaxRating(4)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_filter_value_change",
+                                            with: ["notification_type": "new_review",
+                                                   "filter_value": Float(4)]))
+    }
+
+    @Test func test_setStoreReviewMaxRating_with_same_value_then_does_not_track_filter_event() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+        sut.setStoreReviewMaxRating(2)
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.setStoreReviewMaxRating(2)
+
+        // Then
+        #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_value_change"))
+        #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_option_select"))
+    }
 }
 
 /// Reference-typed box for capturing dispatched changes from a closure without

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -331,9 +331,11 @@ struct PushNotificationPreferencesViewModelTests {
         // Given
         let stores = makeStores()
         let saveContinuation = SaveContinuationBox()
+        let (dispatched, dispatchedSignal) = AsyncStream<Void>.makeStream()
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
                 saveContinuation.deliver = { onCompletion(.success(changes)) }
+                dispatchedSignal.yield()
             }
         }
         let sut = makeSUT(stores: stores)
@@ -341,8 +343,13 @@ struct PushNotificationPreferencesViewModelTests {
 
         // When
         async let saveResult = sut.save()
-        // Yield until `save()` reaches its first await so `isSaving` has flipped.
-        await Task.yield()
+        // Wait deterministically until `save()` has dispatched: the mock
+        // closure runs synchronously inside the `withCheckedThrowingContinuation`
+        // body, so once we see the signal, `isSaving == true` is guaranteed.
+        // A bare `Task.yield()` is not enough — one cooperative slice can be
+        // too short to reach the continuation under load.
+        var iterator = dispatched.makeAsyncIterator()
+        _ = await iterator.next()
 
         // Then
         #expect(sut.isSaving == true)
@@ -360,16 +367,21 @@ struct PushNotificationPreferencesViewModelTests {
         let stores = makeStores()
         let saveContinuation = SaveContinuationBox()
         let dispatched = DispatchedChanges()
+        let (dispatchedStream, dispatchedSignal) = AsyncStream<Void>.makeStream()
         stores.whenReceivingAction(ofType: NotificationAction.self) { action in
             if case let .updatePushNotificationPreferences(_, changes, onCompletion) = action {
                 dispatched.append(changes)
                 saveContinuation.deliver = { onCompletion(.success(changes)) }
+                dispatchedSignal.yield()
             }
         }
         let sut = makeSUT(stores: stores)
         sut.setStoreOrderEnabled(true)
         async let firstSave = sut.save()
-        await Task.yield()
+        // Wait deterministically for the first save to dispatch — see the
+        // sibling test for the rationale.
+        var iterator = dispatchedStream.makeAsyncIterator()
+        _ = await iterator.next()
         #expect(sut.isSaving == true)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/PushNotificationPreferencesViewModelTests.swift
@@ -1134,6 +1134,110 @@ struct PushNotificationPreferencesViewModelTests {
         // Then
         #expect(sut.notificationsEnabled == false)
     }
+
+    // MARK: - New-order detail analytics
+
+    @Test func test_detailDidAppear_with_newOrder_then_tracks_notifications_detail_view() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.detailDidAppear(notificationType: .newOrder)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_view",
+                                            with: ["notification_type": "new_order"]))
+    }
+
+    @Test func test_setStoreOrderEnabled_when_true_then_tracks_push_toggle_with_isEnabled_true() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreOrderEnabled(true)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_push_toggle",
+                                            with: ["notification_type": "new_order",
+                                                   "is_enabled": true]))
+    }
+
+    @Test func test_setStoreOrderEnabled_when_false_then_tracks_push_toggle_with_isEnabled_false() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreOrderEnabled(false)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_push_toggle",
+                                            with: ["notification_type": "new_order",
+                                                   "is_enabled": false]))
+    }
+
+    @Test func test_setStoreOrderMinAmount_from_nil_to_value_then_tracks_filter_option_filtered() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+
+        // When
+        sut.setStoreOrderMinAmount(100)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_filter_option_select",
+                                            with: ["notification_type": "new_order",
+                                                   "filter_option": "filtered"]))
+    }
+
+    @Test func test_setStoreOrderMinAmount_from_value_to_nil_then_tracks_filter_option_all() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+        sut.setStoreOrderMinAmount(100)
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.setStoreOrderMinAmount(nil)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_filter_option_select",
+                                            with: ["notification_type": "new_order",
+                                                   "filter_option": "all"]))
+    }
+
+    @Test func test_setStoreOrderMinAmount_from_value_to_different_value_then_tracks_filter_value_change() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+        sut.setStoreOrderMinAmount(100)
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.setStoreOrderMinAmount(250)
+
+        // Then
+        #expect(analyticsProvider.received(event: "notifications_detail_filter_value_change",
+                                            with: ["notification_type": "new_order",
+                                                   "filter_value": Float(250)]))
+    }
+
+    @Test func test_setStoreOrderMinAmount_with_same_value_then_does_not_track_filter_event() async {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let sut = makeSUT(stores: makeStores(), analyticsProvider: analyticsProvider)
+        sut.setStoreOrderMinAmount(100)
+        analyticsProvider.clearEvents()
+
+        // When
+        sut.setStoreOrderMinAmount(100)
+
+        // Then
+        #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_value_change"))
+        #expect(!analyticsProvider.receivedEvents.contains("notifications_detail_filter_option_select"))
+    }
 }
 
 /// Reference-typed box for capturing dispatched changes from a closure without


### PR DESCRIPTION
## Description

Analytic events for the Smarter Notifications project. All events are defined in the EventHorizon scheme and shared with Android. 

Closes RSM-2710

## Test Steps
1. Sign in to a store with a few orders, reviews, and stock changes.
2. Navigate to Settings → Push Notifications. With Tracks debug logging enabled, confirm:
   - `notifications_settings_view` fires on appearance.
   - Forcing a load failure (toggle airplane mode and re-enter) fires `notifications_settings_load_failed`, and tapping Retry fires `notifications_settings_load_retry_tapped`.
3. Open the New orders detail screen and verify:
   - `notifications_detail_view` with `notification_type=new_order`.
   - Master toggle → `notifications_detail_push_toggle` with `notification_type=new_order`, `is_enabled` reflecting the new state.
   - Tapping "All new orders" / "Only high-value orders" → `notifications_detail_filter_option_select` with `filter_option=all` / `filtered`.
   - Editing the threshold and committing → `notifications_detail_filter_value_change` with the entered amount as `filter_value`.
   - Saving → `notifications_settings_update_started` → `_update_success`; forcing a failure (WireMock 500 on the update endpoint) → `_update_failed`.
   - Tapping back with unsaved changes → discard or cancel branches each fire `notifications_detail_dismiss_unsaved_changes_resolved` with the matching `outcome`.
4. Repeat on the New reviews screen, including tapping a star in the picker.
5. Repeat on the Stock screen: each sub-toggle fires `notifications_stock_option_toggle` with the corresponding `option` (`low_stock` / `out_of_stock` / `on_backorder`) and `is_enabled`.

## Screenshots
N/A — analytics-only changes, no UI delta.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.