### PR TITLE
Surface Other payment methods on POS checkout row

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentButtonsRow.swift
@@ -60,6 +60,8 @@ struct POSCheckoutPaymentButtonsRow: View {
             return Localization.cardReader
         case .cashPayment:
             return Localization.cashPayment
+        case .otherPaymentMethods:
+            return Localization.otherPaymentMethods
         }
     }
 
@@ -71,6 +73,8 @@ struct POSCheckoutPaymentButtonsRow: View {
             return "pos-card-reader-button"
         case .cashPayment:
             return "pos-cash-payment-button"
+        case .otherPaymentMethods:
+            return "pos-other-payment-methods-button"
         }
     }
 }
@@ -92,6 +96,12 @@ private extension POSCheckoutPaymentButtonsRow {
             "pos.checkout.paymentMethod.cashPayment",
             value: "Cash payment",
             comment: "Title for the cash-payment button in the POS checkout payment-method row."
+        )
+        static let otherPaymentMethods = NSLocalizedString(
+            "pos.checkout.paymentMethod.otherPaymentMethods",
+            value: "Other payment methods",
+            comment: "Title for the button that opens the Other Payment Methods sheet (Scan to Pay, " +
+                "Mark order as paid) in the POS checkout payment-method row."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentMethod.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSCheckoutPaymentMethod.swift
@@ -15,4 +15,10 @@ enum POSCheckoutPaymentMethod: Hashable {
     case cardReader
     /// Manually entered cash payment.
     case cashPayment
+    /// Opens the "Other payment methods" sheet exposing Scan-to-Pay and Mark-as-Paid
+    /// (whichever are feature-flag-on). Appended to the row whenever at least one
+    /// secondary method is enabled, so the merchant can always reach those flows from
+    /// the iPad-no-TTP card path where neither the TTP-companion strip nor a
+    /// promoted-no-card layout applies.
+    case otherPaymentMethods
 }

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -671,6 +671,15 @@ private extension TotalsView {
             methods.append(.cardReader)
         }
         methods.append(.cashPayment)
+        // Surface the Other-payment-methods sheet as a row slot whenever there's anything
+        // to put inside it. Without this, iPad merchants in non-TTP card-supported countries
+        // (FR, DE, IE, NL, AT, BE, FI, IT, LU, PT, ES, SG, NZ, AU, PR) have no way to reach
+        // Scan-to-Pay / Mark-as-Paid — `useCashAndOtherMethodsBottomStrip` is TTP-tied and
+        // there's no other entry point in `POSCheckoutPaymentButtonsRow`.
+        if featureFlags.isFeatureFlagEnabled(.pointOfSaleScanToPay)
+            || featureFlags.isFeatureFlagEnabled(.pointOfSaleMarkOrderAsPaid) {
+            methods.append(.otherPaymentMethods)
+        }
         return methods
     }
 
@@ -682,6 +691,8 @@ private extension TotalsView {
             paymentModel.connectCardReader()
         case .cashPayment:
             paymentModel.startCashPayment()
+        case .otherPaymentMethods:
+            handleOtherPaymentMethodsTapped()
         }
     }
 


### PR DESCRIPTION
## Description

iPad merchants in non-TTP card-supported countries (**FR, DE, IE, NL, AT, BE, FI, IT, LU, PT, ES, SG, NZ, AU, PR**) currently have no entry point to Scan-to-Pay or Mark-as-Paid from the POS checkout screen.

Why: those entry points live in two places today, and neither covers this scenario.

- `useCashAndOtherMethodsBottomStrip` is TTP-tied (only fires on phone with TTP, or on TTP-eligible iPads with a BT reader connected), so the "Other payment methods" affordance never reaches non-TTP iPads.
- `POSCheckoutPaymentButtonsRow` (the fallback for everyone else) only exposes `.tapToPay` / `.cardReader` / `.cashPayment` — no path to the sheet.

Result: an EU iPad merchant ends up with `[Card reader] [Cash payment]` in the bottom of TotalsView with no way to reach Scan-to-Pay or Mark-as-Paid even when those flags are on.

**The fix.** Adds an `.otherPaymentMethods` case to `POSCheckoutPaymentMethod` and appends it to the methods list in `TotalsView.checkoutPaymentMethods` whenever either `pointOfSaleScanToPay` or `pointOfSaleMarkOrderAsPaid` is enabled. Selecting the slot calls the existing `handleOtherPaymentMethodsTapped()` which presents `POSOtherPaymentMethodsSheet` — the sheet already gates its own contents by the same two flags, so this hook just extends the entry-point coverage without changing any downstream behaviour.

The slot is omitted when both secondary flags are off, so we don't expose an empty sheet.

## Test Steps

1. Run on **iPad simulator**, sign in to a store in a non-TTP card-supported country (**FR, DE, IE, NL, AT, BE, FI, IT, LU, PT, ES, SG, NZ, AU, PR**). If you don't have one handy, change your existing store's country in WP admin → WooCommerce → Settings → General → Country/State to e.g. France, save, kill the app, relaunch.
2. Open POS → add an item → Checkout.
3. With `pointOfSaleScanToPay` and `pointOfSaleMarkOrderAsPaid` enabled (defaults to ON for `localDeveloper` + `alpha` builds), expect the bottom row:
   - `[Card reader (filled-primary)]`
   - `[Cash payment]`
   - **`[Other payment methods]` ← new**
4. Tap **Other payment methods** → existing `POSOtherPaymentMethodsSheet` appears with Scan to Pay + Mark order as paid rows. Tap each → existing flows still work.

### Regression scenarios (all should be unchanged)

- **iPad US/GB** (TTP-eligible) → `[Cash] [Other payment methods]` strip (`useCashAndOtherMethodsBottomStrip`) renders as before. The row never appears in that path, so `.otherPaymentMethods` doesn't double up.
- **iPad EU/SG/NZ/AU/PR with both secondary flags OFF** → row reverts to `[Card reader] [Cash]`. No `.otherPaymentMethods` slot (nothing to put in the sheet).
- **Phone with TTP** → TTP hero + `cashAndOtherMethodsBottomStrip`, unchanged.
- **Phone non-TTP** → row falls through, gets `.otherPaymentMethods` only if a secondary flag is on. Same logic as iPad, no special-casing.

### Tests

- `xcodebuild test -scheme PointOfSale` — 644 tests pass.
- `xcodebuild build-for-testing -scheme XcodeTarget_WooCommerceTests` — TEST BUILD SUCCEEDED.

## Screenshots

N/A — single new outlined button rendered at the bottom of an existing row. Tapping it opens the existing sheet, which is unchanged.

---

- [x] No release notes — surfaces a feature-flagged path that is still off in alpha/beta; no user-facing wording change at this stage.