### PR TITLE
Enable feature flag for self-driven PN

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -110,7 +110,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             // alpha and beta keep showing only Cash + Card reader for now.
             return buildConfig == .localDeveloper
         case .selfDrivenPushToken:
-            return false
+            return true
         case .clientSideDashboardBanner:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .ageRangeRequirementsCompliance:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-ios/pull/17218]
+- [***] Push notifications are now available without the requirement of full Jetpack plugin [https://github.com/woocommerce/woocommerce-ios/pull/17254]
 - [Internal] Phone POS Tap to Pay on iPhone: hero CTA stays tappable during silent pre-connect, Apple-compliant "Tap to Pay on iPhone" wording, Bluetooth as a one-shot opt-in from the Other payment methods sheet. Feature-flagged. [https://github.com/woocommerce/woocommerce-ios/pull/17152]
 
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 - [**] Contact support now includes troubleshooting and AI help [https://github.com/woocommerce/woocommerce-ios/pull/17218]
-- [***] Push notifications are now available without the requirement of full Jetpack plugin [https://github.com/woocommerce/woocommerce-ios/pull/17254]
+- [Internal] Enabled local flag for self-driven push notifications [https://github.com/woocommerce/woocommerce-ios/pull/17254]
 - [Internal] Phone POS Tap to Pay on iPhone: hero CTA stays tappable during silent pre-connect, Apple-compliant "Tap to Pay on iPhone" wording, Bluetooth as a one-shot opt-in from the Other payment methods sheet. Feature-flagged. [https://github.com/woocommerce/woocommerce-ios/pull/17152]
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables the feature flag for self-driven PN to enable the feature in 24.9 following the plan in pe5sF9-5o2-p2.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

1. Follow the guide in paaHJt-9VE-p2 to set up a JN site for self-driven PN.
2. Log in the the site on the app using site credentials.
3. If testing on debug build, go to Menu > Settings > Debug enable > Enable the remote flag `selfDrivenPushNotificationsM1`.
4. Confirm that there's a banner to enable PN on the dashboard.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="320" alt="image" src="https://github.com/user-attachments/assets/80f21b9f-bb62-430f-990f-2b61511afd20" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.