### PR TITLE
Harden POS refund submission safety

### DIFF
--- a/Modules/Sources/Networking/Remote/RefundsRemote.swift
+++ b/Modules/Sources/Networking/Remote/RefundsRemote.swift
@@ -115,7 +115,14 @@ public final class RefundsRemote: Remote {
                                          parameters: parameters,
                                          availableAsRESTRequest: true)
 
-            enqueue(request, mapper: mapper, completion: completion)
+            enqueue(request, mapper: mapper) { result in
+                switch result {
+                case .success(let refund):
+                    completion(refund, nil)
+                case .failure(let error):
+                    completion(nil, error)
+                }
+            }
         } catch {
             completion(nil, error)
             DDLogError("Unable to serialize data for refunds: \(error)")

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -62,6 +62,36 @@ enum RefundActionAvailability {
     case unavailable
 }
 
+enum POSRefundProcessingError: LocalizedError, Equatable {
+    case missingSelectedOrder
+    case missingRefundPreparation
+    case emptySelection
+    case refundAlreadyInProgress
+
+    var errorDescription: String? {
+        switch self {
+        case .missingSelectedOrder, .missingRefundPreparation:
+            return NSLocalizedString(
+                "pos.refund.processing.error.missingPreparation",
+                value: "The refund could not be prepared. Please try again.",
+                comment: "Error shown when POS tries to process a refund without prepared order refund data."
+            )
+        case .emptySelection:
+            return NSLocalizedString(
+                "pos.refund.processing.error.emptySelection",
+                value: "Select at least one item to refund.",
+                comment: "Error shown when POS tries to process a refund without selected refund items."
+            )
+        case .refundAlreadyInProgress:
+            return NSLocalizedString(
+                "pos.refund.processing.error.alreadyInProgress",
+                value: "A refund is already in progress. Please wait for it to finish.",
+                comment: "Error shown when POS tries to process a second refund while another refund is in progress."
+            )
+        }
+    }
+}
+
 @Observable final class POSOrderListController: POSSearchingOrderListControllerProtocol {
     var ordersViewState: POSOrderListState
     private var strategyPaginationTracker: [String: AsyncPaginationTracker] = [:]
@@ -76,6 +106,7 @@ enum RefundActionAvailability {
     private let refundsService: POSRefundsServiceProtocol
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
     private let featureFlags: POSFeatureFlagProviding
+    private var isProcessingRefund = false
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
              return existing
@@ -385,20 +416,26 @@ enum RefundActionAvailability {
 
     @MainActor
     func processRefund(reason: String?) async throws {
+        guard !isProcessingRefund else {
+            throw POSRefundProcessingError.refundAlreadyInProgress
+        }
+
+        isProcessingRefund = true
+        defer {
+            isProcessingRefund = false
+        }
+
         guard let order = selectedOrder else {
-            assertionFailure("processRefund called without selected order")
-            return
+            throw POSRefundProcessingError.missingSelectedOrder
         }
 
         guard case .loaded(let preparation) = selectedOrderRefundsState else {
-            assertionFailure("processRefund called without loaded refunds state")
-            return
+            throw POSRefundProcessingError.missingRefundPreparation
         }
 
         let selectedItems = refundSelectableItems.filter { $0.isSelected }
         guard !selectedItems.isEmpty else {
-            assertionFailure("processRefund called without selected items")
-            return
+            throw POSRefundProcessingError.emptySelection
         }
 
         try await refundSubmissionProcessor.submitRefund(

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundConfirmationView.swift
@@ -8,6 +8,8 @@ struct POSRefundConfirmationView: View {
     let onClose: () -> Void
     let onConfirm: () -> Void
     let onBack: (() -> Void)?
+    var shouldUseCardPresentCompletionStyle = false
+    var onPaymentCaptureErrorCancel: ((@escaping () -> Void) -> Void)?
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -82,6 +84,8 @@ private extension POSRefundConfirmationView {
             return .processing(.processing)
         case .displayingReaderMessage(let message):
             return .displayReaderMessage(.displayReaderMessage(message))
+        case .completed where shouldUseCardPresentCompletionStyle:
+            return .processing(.processing)
         case .idle, .loading, .onboarding, .preparingReader, .waitingForCard, .submitting, .retryableError, .nonRetryableError, .completed:
             return nil
         case .submittingCardPresent:
@@ -177,6 +181,8 @@ private extension POSRefundConfirmationView {
                                onClose: dismiss)
         case .submittingCardPresent:
             cardPresentMessageView(.processing(.processing))
+        case .completed where shouldUseCardPresentCompletionStyle:
+            cardPresentMessageView(.processing(.processing))
         case .idle, .loading, .submitting, .completed:
             loadingSection
         }
@@ -224,7 +230,7 @@ private extension POSRefundConfirmationView {
         case .paymentCaptureError(let cancelPayment):
             return .error(.init(error: POSRefundCardPresentPresentationError.unableToConfirmRefund,
                                 retryAction: nil,
-                                cancelAction: cancelAndReturnToConfirmation(cancelPayment)))
+                                cancelAction: paymentCaptureErrorCancelAction(cancelPayment)))
         case .paymentIntentCreationError(let error, let cancelPayment):
             return .error(.init(error: error,
                                 retryAction: nil,
@@ -245,6 +251,15 @@ private extension POSRefundConfirmationView {
             return retryAction
         case .dontRetry:
             return nil
+        }
+    }
+
+    func paymentCaptureErrorCancelAction(_ cancelPayment: @escaping () -> Void) -> () -> Void {
+        guard let onPaymentCaptureErrorCancel else {
+            return cancelAndReturnToConfirmation(cancelPayment)
+        }
+        return {
+            onPaymentCaptureErrorCancel(cancelPayment)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -60,6 +60,8 @@ private extension POSRefundErrorView {
                 Text(subtitle)
                     .font(.posBodyLargeRegular())
                     .foregroundColor(Color.posOnSurface)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .multilineTextAlignment(.center)
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -4,11 +4,26 @@ struct POSRefundErrorView: View {
     let title: String
     let subtitle: String
     let onRetry: (() -> Void)?
+    let cancelButtonTitle: String?
     let onCancel: () -> Void
     let onClose: () -> Void
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    init(title: String,
+         subtitle: String,
+         onRetry: (() -> Void)?,
+         cancelButtonTitle: String? = nil,
+         onCancel: @escaping () -> Void,
+         onClose: @escaping () -> Void) {
+        self.title = title
+        self.subtitle = subtitle
+        self.onRetry = onRetry
+        self.cancelButtonTitle = cancelButtonTitle
+        self.onCancel = onCancel
+        self.onClose = onClose
+    }
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -59,7 +74,7 @@ private extension POSRefundErrorView {
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
             }
 
-            Button(Localization.cancelButton, action: onCancel)
+            Button(cancelButtonTitle ?? Localization.cancelButton, action: onCancel)
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
         .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundErrorView.swift
@@ -9,7 +9,6 @@ struct POSRefundErrorView: View {
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var isViewLoaded: Bool = false
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -22,11 +21,6 @@ struct POSRefundErrorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
-        .onAppear {
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
-                isViewLoaded = true
-            }
-        }
     }
 }
 
@@ -41,22 +35,16 @@ private extension POSRefundErrorView {
     var contentView: some View {
         VStack(spacing: POSSpacing.xLarge) {
             POSErrorXMark()
-                .scaleEffect(isViewLoaded ? 1 : 0)
-                .opacity(isViewLoaded ? 1 : 0)
 
             VStack(spacing: POSSpacing.small) {
                 Text(title)
                     .font(.posHeadingBold)
                     .foregroundColor(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
 
                 Text(subtitle)
                     .font(.posBodyLargeRegular())
                     .foregroundColor(Color.posOnSurface)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
             }
             .multilineTextAlignment(.center)
         }
@@ -75,16 +63,6 @@ private extension POSRefundErrorView {
                 .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         }
         .posPhoneFullScreenButtonPadding(horizontalSizeClass: horizontalSizeClass)
-        .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
-        .opacity(isViewLoaded ? 1 : 0)
-    }
-}
-
-// MARK: - Constants
-
-private extension POSRefundErrorView {
-    enum Constants {
-        static let animationOffset: CGFloat = 100
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -97,6 +97,7 @@ struct POSRefundModalContentView: View {
     @State private var cardPresentOnboardingItem: POSRefundCardPresentOnboardingItem?
     @State private var currentRefundReason: String?
     @State private var reasonInputReviewData: POSRefundReviewData?
+    @State private var isDismissingAfterAmbiguousRefund = false
 
     var body: some View {
         ZStack {
@@ -205,7 +206,11 @@ struct POSRefundModalContentView: View {
                 submissionState: refundSubmissionModel.state,
                 onClose: {},
                 onConfirm: {},
-                onBack: { returnToRefundConfirmation(reviewData: reviewData) }
+                onBack: { returnToRefundConfirmation(reviewData: reviewData) },
+                shouldUseCardPresentCompletionStyle: orderListModel.ordersController.currentRefundRequiresCardPresentRefund,
+                onPaymentCaptureErrorCancel: { cancelPayment in
+                    handleAmbiguousCardPresentRefund(cancelPayment: cancelPayment)
+                }
             )
         case .success(let reviewData):
             POSRefundSuccessView(
@@ -339,8 +344,14 @@ struct POSRefundModalContentView: View {
             modalState = .success(reviewData)
             onRefundSuccess?()
         } catch POSRefundSubmissionError.canceledByUser {
+            guard !isDismissingAfterAmbiguousRefund else {
+                return
+            }
             returnToRefundConfirmation(reviewData: reviewData)
         } catch {
+            guard !isDismissingAfterAmbiguousRefund else {
+                return
+            }
             DDLogError("⛔️ Failed to process POS refund: \(error)")
             analytics.track(event: WooAnalyticsEvent.PointOfSale.refundProcessingFailed(error: error))
             onRefundFailure?(error)
@@ -379,6 +390,25 @@ struct POSRefundModalContentView: View {
             cardPresentOnboardingItem = nil
             refundSubmissionModel.reset()
             modalState = .confirmation(reviewData)
+        }
+    }
+
+    @MainActor
+    private func handleAmbiguousCardPresentRefund(cancelPayment: @escaping () -> Void) {
+        isDismissingAfterAmbiguousRefund = true
+        cardPresentAlertItem = nil
+        cardPresentOnboardingItem = nil
+        refundSubmissionModel.reset()
+        cancelPayment()
+        dismissRefundFlow()
+
+        Task { @MainActor in
+            do {
+                try await orderListModel.ordersController.updateOrder(orderID: order.id)
+            } catch {
+                DDLogError("⛔️ Failed to refresh POS order after ambiguous refund outcome: \(error)")
+            }
+            await orderListModel.ordersController.loadOrderRefunds()
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -221,12 +221,21 @@ struct POSRefundModalContentView: View {
                 onEmailReceipt: { isShowingEmailReceiptView = true }
             )
         case .error(let reviewData):
+            let isCardPresentRefundError = orderListModel.ordersController.currentRefundRequiresCardPresentRefund
+            let dismissError = {
+                if isCardPresentRefundError {
+                    dismissRefundFlowAndRefreshOrder()
+                } else {
+                    dismissRefundFlow()
+                }
+            }
             POSRefundErrorView(
-                title: errorStrings.createTitle,
-                subtitle: errorStrings.createSubtitle,
-                onRetry: { modalState = .confirmation(reviewData) },
-                onCancel: { dismissRefundFlow() },
-                onClose: { dismissRefundFlow() }
+                title: isCardPresentRefundError ? Localization.cardPresentCreateErrorTitle : errorStrings.createTitle,
+                subtitle: isCardPresentRefundError ? Localization.cardPresentCreateErrorSubtitle : errorStrings.createSubtitle,
+                onRetry: isCardPresentRefundError ? nil : { modalState = .confirmation(reviewData) },
+                cancelButtonTitle: isCardPresentRefundError ? Localization.backToOrderButton : nil,
+                onCancel: dismissError,
+                onClose: dismissError
             )
         }
     }
@@ -272,6 +281,12 @@ struct POSRefundModalContentView: View {
         } else {
             onDismiss()
         }
+    }
+
+    @MainActor
+    private func dismissRefundFlowAndRefreshOrder() {
+        dismissRefundFlow()
+        refreshOrderAfterPotentialCardPresentRefund()
     }
 
     private func updateCardPresentAlertItem() {
@@ -403,15 +418,18 @@ struct POSRefundModalContentView: View {
         cardPresentOnboardingItem = nil
         refundSubmissionModel.reset()
         cancelPayment()
-        dismissRefundFlow()
+        dismissRefundFlowAndRefreshOrder()
 
         // The submission task may still report cancellation/failure after dismissing; isDismissingAfterAmbiguousRefund
         // keeps that late callback from reopening the modal or tracking a normal refund failure.
+    }
+
+    private func refreshOrderAfterPotentialCardPresentRefund() {
         Task { @MainActor in
             do {
                 try await orderListModel.ordersController.updateOrder(orderID: order.id)
             } catch {
-                DDLogError("⛔️ Failed to refresh POS order after ambiguous refund outcome: \(error)")
+                DDLogError("⛔️ Failed to refresh POS order after card-present refund outcome: \(error)")
             }
             await orderListModel.ordersController.loadOrderRefunds()
         }
@@ -433,6 +451,30 @@ struct POSRefundModalContentView: View {
             return false
         }
         return true
+    }
+}
+
+// MARK: - Localization
+
+private extension POSRefundModalContentView {
+    enum Localization {
+        static let cardPresentCreateErrorTitle = NSLocalizedString(
+            "pos.refundModalContentView.cardPresentCreateError.title",
+            value: "Couldn't confirm refund",
+            comment: "Title shown when POS cannot confirm whether a card-present refund was recorded successfully."
+        )
+
+        static let cardPresentCreateErrorSubtitle = NSLocalizedString(
+            "pos.refundModalContentView.cardPresentCreateError.subtitle",
+            value: "Go back to the order and check it before trying again.",
+            comment: "Subtitle shown when POS cannot confirm whether a card-present refund was recorded successfully."
+        )
+
+        static let backToOrderButton = NSLocalizedString(
+            "pos.refundModalContentView.cardPresentCreateError.backToOrderButton",
+            value: "Back to order",
+            comment: "Button to leave the card-present refund error screen and return to the order."
+        )
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -395,6 +395,9 @@ struct POSRefundModalContentView: View {
 
     @MainActor
     private func handleAmbiguousCardPresentRefund(cancelPayment: @escaping () -> Void) {
+        // At this point the card-present refund may already have reached the gateway, but the app could not
+        // confirm the final result. Returning to confirmation would leave a live submit button that could create
+        // a duplicate refund, so exit the flow and refresh the order/refunds instead.
         isDismissingAfterAmbiguousRefund = true
         cardPresentAlertItem = nil
         cardPresentOnboardingItem = nil
@@ -402,6 +405,8 @@ struct POSRefundModalContentView: View {
         cancelPayment()
         dismissRefundFlow()
 
+        // The submission task may still report cancellation/failure after dismissing; isDismissingAfterAmbiguousRefund
+        // keeps that late callback from reopening the modal or tracking a normal refund failure.
         Task { @MainActor in
             do {
                 try await orderListModel.ordersController.updateOrder(orderID: order.id)

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundSuccessView.swift
@@ -9,7 +9,6 @@ struct POSRefundSuccessView: View {
 
     @Environment(\.posModalParentSize) private var parentSize
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var isViewLoaded: Bool = false
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -25,11 +24,6 @@ struct POSRefundSuccessView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.posSurfaceBright)
         .posRefundModalFrame(parentSize: parentSize, horizontalSizeClass: horizontalSizeClass)
-        .onAppear {
-            withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
-                isViewLoaded = true
-            }
-        }
     }
 }
 
@@ -39,29 +33,21 @@ private extension POSRefundSuccessView {
     var contentView: some View {
         VStack(spacing: POSSpacing.xLarge) {
             POSSuccessIcon()
-                .scaleEffect(isViewLoaded ? 1 : 0)
-                .opacity(isViewLoaded ? 1 : 0)
 
             VStack(spacing: POSSpacing.small) {
                 Text(Localization.title)
                     .font(.posHeadingBold)
                     .foregroundColor(Color.posOnSurface)
                     .accessibilityAddTraits(.isHeader)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
 
                 Text(String(format: Localization.messageFormat, formattedRefundTotal, paymentMethodDescription))
                     .font(.posBodyLargeRegular())
                     .foregroundColor(Color.posOnSurface)
-                    .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                    .opacity(isViewLoaded ? 1 : 0)
 
                 if let customerEmail, customerEmail.isNotEmpty {
                     Text(String(format: Localization.receiptSentFormat, customerEmail))
                         .font(.posBodyLargeRegular())
                         .foregroundColor(Color.posOnSurface)
-                        .offset(y: isViewLoaded ? 0 : Constants.animationOffset)
-                        .opacity(isViewLoaded ? 1 : 0)
                 }
             }
             .multilineTextAlignment(.center)
@@ -81,17 +67,6 @@ private extension POSRefundSuccessView {
         }
         .padding(.horizontal, POSPadding.large)
         .frame(maxWidth: POSRefundModalLayout.fullScreenCompletionActionMaxWidth)
-        .offset(y: isViewLoaded ? 0 : -Constants.animationOffset)
-        .opacity(isViewLoaded ? 1 : 0)
-    }
-}
-
-
-// MARK: - Constants
-
-private extension POSRefundSuccessView {
-    enum Constants {
-        static let animationOffset: CGFloat = 100
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Remote/RefundsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RefundsRemoteTests.swift
@@ -1,0 +1,88 @@
+import Alamofire
+import Combine
+import TestKit
+import XCTest
+@testable import Networking
+@testable import NetworkingCore
+
+final class RefundsRemoteTests: XCTestCase {
+    private let sampleSiteID: Int64 = 1234
+    private let sampleOrderID: Int64 = 560
+
+    func test_createRefund_returns_refund_on_success() async throws {
+        // Given
+        let network = MockNetwork()
+        let remote = RefundsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/refunds", filename: "refund-single")
+
+        // When
+        let refund = try await remote.createRefund(for: sampleSiteID, by: sampleOrderID, refund: sampleRefund())
+
+        // Then
+        XCTAssertEqual(refund.refundID, 562)
+    }
+
+    func test_createRefund_relays_network_error_when_response_data_is_present() async throws {
+        // Given
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500,
+                                                               response: Loader.contentsOf("refund-single"))
+        let network = RefundCreationNetwork(error: expectedError, responseData: Loader.contentsOf("refund-single"))
+        let remote = RefundsRemote(network: network)
+
+        // When / Then
+        await assertThrowsError({
+            _ = try await remote.createRefund(for: sampleSiteID, by: sampleOrderID, refund: sampleRefund())
+        }, errorAssert: { error in
+            (error as? NetworkError) == expectedError
+        })
+    }
+}
+
+private extension RefundsRemoteTests {
+    func sampleRefund() -> Refund {
+        Refund(refundID: 0,
+               orderID: sampleOrderID,
+               siteID: sampleSiteID,
+               dateCreated: Date(),
+               amount: "18",
+               reason: "",
+               refundedByUserID: 0,
+               isAutomated: nil,
+               createAutomated: true,
+               items: [],
+               shippingLines: nil)
+    }
+}
+
+private final class RefundCreationNetwork: Network {
+    let error: Error
+    let responseData: Data?
+    var session: URLSession { URLSession(configuration: .default) }
+
+    init(error: Error, responseData: Data?) {
+        self.error = error
+        self.responseData = responseData
+    }
+
+    func responseData(for request: URLRequestConvertible, completion: @escaping (Data?, Error?) -> Void) {
+        completion(responseData, error)
+    }
+
+    func responseData(for request: URLRequestConvertible, completion: @escaping (Result<Data, Error>) -> Void) {
+        completion(.failure(error))
+    }
+
+    func responseDataAndHeaders(for request: URLRequestConvertible) async throws -> (Data, ResponseHeaders?) {
+        throw error
+    }
+
+    func responseDataPublisher(for request: URLRequestConvertible) -> AnyPublisher<Result<Data, Error>, Never> {
+        Just(.failure(error)).eraseToAnyPublisher()
+    }
+
+    func uploadMultipartFormData(multipartFormData: @escaping (NetworkingCore.MultipartFormData) -> Void,
+                                 to request: URLRequestConvertible,
+                                 completion: @escaping (Data?, Error?) -> Void) {
+        completion(responseData, error)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -1257,6 +1257,93 @@ final class POSOrderListControllerTests {
     }
 
     @MainActor
+    @Test func processRefund_when_no_selected_order_then_throws_missingSelectedOrder() async throws {
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingSelectedOrder
+        })
+    }
+
+    @MainActor
+    @Test func processRefund_when_refund_is_not_prepared_then_throws_missingRefundPreparation() async throws {
+        // Given
+        sut.selectOrder(makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ]))
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .missingRefundPreparation
+        })
+    }
+
+    @MainActor
+    @Test func processRefund_when_no_items_are_selected_then_throws_emptySelection() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        sut.toggleAllRefundItemsSelection()
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .emptySelection
+        })
+    }
+
+    @MainActor
+    @Test func processRefund_when_refund_is_already_in_progress_then_throws_refundAlreadyInProgress() async throws {
+        // Given
+        featureFlags.isPointOfSaleRefundsi1Enabled = true
+        refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
+            refunds: [],
+            isFullyRefunded: false,
+            supportsAutomaticRefund: true
+        )
+
+        let order = makeOrder(lineItems: [
+            makePOSOrderItem(itemID: 1, quantity: 1, price: 10.00, formattedPrice: "$10.00")
+        ])
+        sut.selectOrder(order)
+        _ = await sut.startRefundFlow()
+        refundSubmissionProcessor.shouldSuspendSubmitRefund = true
+
+        var firstRefundTask: Task<Void, Error>?
+        await fireOnce { fire in
+            refundSubmissionProcessor.onSubmitRefundStarted = {
+                fire()
+            }
+            firstRefundTask = Task { @MainActor in
+                try await sut.processRefund(reason: .none)
+            }
+        }
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.processRefund(reason: .none)
+        }, throws: { error in
+            (error as? POSRefundProcessingError) == .refundAlreadyInProgress
+        })
+
+        refundSubmissionProcessor.resumeSubmitRefund()
+        try await firstRefundTask?.value
+    }
+
+    @MainActor
     @Test func processRefund_then_converts_items_with_correct_properties() async throws {
         // Given
         featureFlags.isPointOfSaleRefundsi1Enabled = true
@@ -1767,6 +1854,9 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
     nonisolated(unsafe) private let currencyFormatter: CurrencyFormatter
     private var refundResultsByOrderID: [Int64: POSRefundsResult] = [:]
     var requiresCardPresentRefund = false
+    var shouldSuspendSubmitRefund = false
+    var onSubmitRefundStarted: (() -> Void)?
+    private var submitRefundContinuation: CheckedContinuation<Void, Never>?
 
     nonisolated init(refundsService: MockPOSRefundsService,
                      currencyFormatter: CurrencyFormatter) {
@@ -1847,6 +1937,13 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
                       preparation: POSRefundPreparation,
                       selectedItems: [POSRefundSelectableItem],
                       reason: String?) async throws {
+        onSubmitRefundStarted?()
+        if shouldSuspendSubmitRefund {
+            await withCheckedContinuation { continuation in
+                submitRefundContinuation = continuation
+            }
+        }
+
         let refundableItems = selectedItems.map { item in
             POSRefundableItem(
                 itemID: item.itemID,
@@ -1864,5 +1961,11 @@ private final class MockPOSRefundSubmissionProcessor: POSRefundSubmissionProcess
             isAutomaticRefund: refundResultsByOrderID[preparation.orderID]?.supportsAutomaticRefund ?? true
         )
         stateModel.state = .completed
+    }
+
+    func resumeSubmitRefund() {
+        shouldSuspendSubmitRefund = false
+        submitRefundContinuation?.resume()
+        submitRefundContinuation = nil
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
+- [**] POS available for CA users, POS refund flow improved [https://github.com/woocommerce/woocommerce-ios/pull/17256]
 
 
 24.8

--- a/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/Card Present Payments/POSRefundSubmissionAdaptor.swift
@@ -112,6 +112,10 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
                       preparation: POSRefundPreparation,
                       selectedItems: [POSRefundSelectableItem],
                       reason: String?) async throws {
+        guard submissionUseCase == nil else {
+            throw POSRefundSubmissionAdaptorError.refundAlreadyInProgress
+        }
+
         guard let context = preparedContexts[preparation.orderID] else {
             throw POSRefundSubmissionAdaptorError.missingPreparedRefund
         }
@@ -190,7 +194,7 @@ final class POSRefundSubmissionAdaptor: POSRefundSubmissionProcessing {
             throw error
         }
 
-        stateModel.state = requiresCardPresentRefund ? .submittingCardPresent : .completed
+        stateModel.state = .completed
         removePreloadedRefund(for: preparation.orderID)
     }
 }
@@ -369,6 +373,7 @@ private extension Error {
 
 private enum POSRefundSubmissionAdaptorError: LocalizedError {
     case missingPreparedRefund
+    case refundAlreadyInProgress
 
     var errorDescription: String? {
         switch self {
@@ -377,6 +382,12 @@ private enum POSRefundSubmissionAdaptorError: LocalizedError {
                 "pos.refundSubmissionAdaptor.error.missingPreparedRefund",
                 value: "The refund could not be prepared. Please try again.",
                 comment: "Error shown when POS tries to submit a refund without prepared refund data."
+            )
+        case .refundAlreadyInProgress:
+            return NSLocalizedString(
+                "pos.refundSubmissionAdaptor.error.refundAlreadyInProgress",
+                value: "A refund is already in progress. Please wait for it to finish.",
+                comment: "Error shown when POS tries to submit a second refund while another refund is in progress."
             )
         }
     }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentRefundOrchestrator.swift
@@ -46,8 +46,8 @@ final class CardPresentRefundOrchestrator {
                 onWaitingForInput(inputMethods)
             case .displayMessage(let message):
                 onDisplayMessage(message)
-            case .removeCardRequested:
-                onProcessingMessage()
+            case .removeCardRequested(let message):
+                onDisplayMessage(message)
             case .cardInserted:
                 onCardInserted()
             case .cardDetailsCollected:

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -403,15 +403,20 @@ private extension RefundSubmissionUseCase {
 
             guard let self else { return }
 
-            if let refundData {
-                // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
-                self.retrieveUpdatedRefundData(refund: refundData)
-            }
             if let error {
                 DDLogError("Error creating refund: \(refund)\nWith Error: \(error)")
                 self.trackCreateRefundRequestFailed(error: error)
                 return onCompletion(.failure(error))
             }
+
+            guard let refundData else {
+                DDLogError("Error creating refund: \(refund)\nWith Error: missing created refund response")
+                self.trackCreateRefundRequestFailed(error: RefundSubmissionUseCaseSubmissionError.missingCreatedRefund)
+                return onCompletion(.failure(RefundSubmissionUseCaseSubmissionError.missingCreatedRefund))
+            }
+
+            // Workaround for https://github.com/woocommerce/woocommerce/issues/33389. This can be removed when the related API issue is fixed
+            self.retrieveUpdatedRefundData(refund: refundData)
             onCompletion(.success(()))
             self.trackCreateRefundRequestSuccess()
         }
@@ -517,6 +522,7 @@ enum RefundSubmissionUseCaseSubmissionError: Error, Equatable {
     case invalidRefundAmount
     case unknownPaymentGatewayAccount
     case canceledByUser
+    case missingCreatedRefund
 }
 
 private enum RefundSubmissionUseCaseDefinitions {

--- a/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockOrderDetailsPaymentAlerts.swift
@@ -12,6 +12,7 @@ final class MockOrderDetailsPaymentAlerts {
 
     var cardInsertedWasCalled = false
     var displayReaderMessageWasCalled = false
+    var spyDisplayReaderMessage: String?
     var processingPaymentWasCalled = false
     var error: Error?
     var retryFromError: (() -> Void)?
@@ -43,6 +44,7 @@ extension MockOrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
 
     func displayReaderMessage(message: String) {
         displayReaderMessageWasCalled = true
+        spyDisplayReaderMessage = message
     }
 
     func processingPayment(title: String) {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -109,7 +109,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertTrue(alerts.cardInsertedWasCalled)
     }
 
-    func test_submitRefund_with_removeCardRequested_reader_event_shows_processing_alert() {
+    func test_submitRefund_with_removeCardRequested_reader_event_shows_reader_message() {
         // Given
         let useCase = createUseCase(details: interacRefundDetails())
         mockCardPresentPaymentActions(returnCardReaderMessage: .removeCardRequested("Remove card"))
@@ -124,8 +124,8 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isSuccess)
-        XCTAssertTrue(alerts.processingPaymentWasCalled)
-        XCTAssertFalse(alerts.displayReaderMessageWasCalled)
+        XCTAssertTrue(alerts.displayReaderMessageWasCalled)
+        XCTAssertEqual(alerts.spyDisplayReaderMessage, "Remove card")
     }
 
     func test_submitRefund_with_non_interac_payment_method_does_not_call_showOnboardingIfRequired() throws {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -153,6 +153,31 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         XCTAssertFalse(onboardingPresenter.spyShowOnboardingWasCalled)
     }
 
+    func test_submitRefund_with_missing_server_side_refund_response_returns_failure() throws {
+        // Given
+        let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
+                                                   charge: .fake().copy(paymentMethodDetails: .cardPresent(
+                                                    details: .init(brand: .visa,
+                                                                   last4: "9969",
+                                                                   funding: .credit,
+                                                                   receipt: .init(accountType: .credit,
+                                                                                  applicationPreferredName: "Stripe Credit",
+                                                                                  dedicatedFileName: "A000000003101001")))),
+                                                   amount: "2.28",
+                                                   paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
+        mockServerSideRefund(refund: nil, error: nil)
+
+        // When
+        let result = waitFor { promise in
+            useCase.submitRefund(.fake(), showInProgressUI: {}) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .missingCreatedRefund)
+    }
+
     func test_submitRefund_with_interac_payment_method_calls_showOnboardingIfRequired() throws {
         // Given
         let useCase = createUseCase(details: .init(order: .fake().copy(total: "2.28"),
@@ -445,14 +470,23 @@ private extension RefundSubmissionUseCaseTests {
     }
 
     func mockServerSideRefund(result: Result<Void, Error>) {
+        let refund: Refund?
+        let error: Error?
+        switch result {
+        case .success:
+            refund = .fake()
+            error = nil
+        case .failure(let failure):
+            refund = nil
+            error = failure
+        }
+        mockServerSideRefund(refund: refund, error: error)
+    }
+
+    func mockServerSideRefund(refund: Refund?, error: Error?) {
         stores.whenReceivingAction(ofType: RefundAction.self) { action in
             if case let .createRefund(_, _, _, completion) = action {
-                switch result {
-                case .success:
-                    completion(.fake(), nil)
-                case .failure(let error):
-                    completion(nil, error)
-                }
+                completion(refund, error)
             }
         }
     }


### PR DESCRIPTION
Closes: RSM-645

## Description
Adds a small safety layer around the POS refund submission path. Invalid POS refund states now throw visible errors instead of silently returning, overlapping submissions are rejected, and ambiguous card-present refund outcomes dismiss back to the order and refresh refund data rather than reopening a tappable confirmation screen.

This also keeps card-present refund completion on the reader-style processing screen until the POS success screen takes over, and passes remove-card reader messages through the shared card-present refund flow.

## Test Steps
Verify a POS Interac refund still completes end to end, and that cancellation/ambiguous card-present failures do not return to a live confirmation CTA.

Targeted tests run locally:
`xcodebuild -project WooCommerce/WooCommerce.xcodeproj -scheme WooCommerce -destination platform=iOS\ Simulator,id=6E32D759-B6D7-43C1-A9C9-0FC44D85C8AC -derivedDataPath /private/tmp/woo-pos-refund-safety-dd -only-testing:PointOfSaleTests/POSOrderListControllerTests -only-testing:WooCommerceTests/RefundSubmissionUseCaseTests test -quiet`

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.