### PR TITLE
[Test] Trigger AI translation CI (iOS port of woocommerce-android#15984)

### DIFF
--- a/.buildkite/commands/post-translation-health-report.sh
+++ b/.buildkite/commands/post-translation-health-report.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -eu
+
+# Generates a per-locale translation health report (key parity vs en.lproj,
+# missing keys, drift) and appends it to the just-published GitHub release
+# notes. Runs after a release is finalized.
+#
+# Per César's call (DoD C13): no release gate, report-only. The report is
+# informational — it tells the team which locales have drifted so they
+# can be triaged in a follow-up.
+#
+# Reads:
+#   RELEASE_VERSION  e.g. "24.9.0". Falls back to most recent release.
+#   GITHUB_TOKEN     for `gh` CLI.
+
+echo "--- :bar_chart: Generating translation health report"
+
+REPORT_FILE="/tmp/translation-health-report.md"
+bundle exec rake -f fastlane/ai_translation/Rakefile translate:report > "${REPORT_FILE}"
+
+echo "--- Report (first 20 lines) ---"
+head -n 20 "${REPORT_FILE}"
+echo "------------------------------"
+
+# Drop as Buildkite annotation so the report is visible from the build page
+# without needing to click out to GitHub.
+buildkite-agent annotate --style 'info' --context translation-health < "${REPORT_FILE}" || true
+
+# Determine the release tag to update.
+if [[ -n "${RELEASE_VERSION:-}" ]]; then
+  TAG="${RELEASE_VERSION}"
+else
+  TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+fi
+
+if [[ -z "${TAG}" ]]; then
+  echo "No release tag resolved. Annotation posted, but release notes unchanged."
+  exit 0
+fi
+
+echo "Appending report to release ${TAG}…"
+
+EXISTING=$(gh release view "${TAG}" --json body --jq '.body')
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+NEW_BODY="${EXISTING}
+
+---
+
+## 🌐 Translation health (auto-generated ${TIMESTAMP})
+
+$(cat "${REPORT_FILE}")
+"
+
+gh release edit "${TAG}" --notes "${NEW_BODY}"
+echo "Translation health report appended to release ${TAG}."

--- a/.buildkite/commands/run-ai-translations.sh
+++ b/.buildkite/commands/run-ai-translations.sh
@@ -132,6 +132,21 @@ fi
 
 echo "--- :git: Committing and pushing translations"
 
+# The Buildkite default clone uses a read-only deploy key (Automattic
+# security policy: deploy keys never get write access). `use-bot-for-git`
+# is the established pattern for any step that pushes back — it exports
+# GIT_SSH_COMMAND pointing at wpmobilebot's SSH key on the trusted agent
+# and sets a default bot identity. Every iOS release-pipeline step under
+# .buildkite/release-pipelines/ uses it (plus every other Automattic
+# mobile repo). Source is at:
+#   Automattic/buildkite-ci:src/agents/mac-metal/resources/use-bot-for-git.sh
+echo "--- :robot_face: Use bot for Git operations"
+source use-bot-for-git
+
+# `use-bot-for-git` set a global identity ("Automattic Release Bot"). Pin
+# the translation-bot identity locally so the commit's author makes the
+# loop-prevention check above pattern-match on later runs and so a human
+# reviewer can tell translation bot commits apart from release bot ones.
 git config user.name "${BOT_NAME}"
 git config user.email "${BOT_EMAIL}"
 

--- a/.buildkite/commands/run-ai-translations.sh
+++ b/.buildkite/commands/run-ai-translations.sh
@@ -1,0 +1,128 @@
+#!/bin/bash -eu
+
+# Runs the AI translation engine on a PR branch.
+#
+# When the PR has changes to WooCommerce/Resources/en.lproj/, this script
+# runs `rake translate:incremental` for every supported locale, commits
+# the resulting changes back to the PR branch as a separate "Translate:"
+# commit, and exits.
+#
+# Per the team's policy (see project_ai_translations_pipeline.md), the
+# bot's commits do NOT auto-merge — they push to the PR branch like a
+# co-author and the PR author still hits merge after review.
+#
+# Hybrid CI gate (per DoD C13 / Jorge's alignment report):
+#   - Same-repo PRs: STRICT. Validator failures, missing-secret, push errors
+#     all block the PR. The pipeline.yml step does NOT use soft_fail so a
+#     non-zero exit from this script fails the build.
+#   - Fork PRs: SOFT. We exit 0 with an annotation so external contributors
+#     aren't blocked by missing secrets they cannot provide. The release-time
+#     health report (post-translation-health-report.sh) is the backstop.
+#
+# Skipped (exit 0, no failure) when:
+#   - the build is not a PR (e.g. trunk / release branches)
+#   - the PR is from a fork (annotated; translation will be done on a
+#     same-repo PR or by the release sweep)
+#   - no EN strings changed in the PR
+#   - HEAD is already a translation-bot commit (loop prevention)
+#
+# Fails (exit 1) when:
+#   - it's a same-repo PR and ANTHROPIC_API_KEY is not set (secret broken)
+#   - rake translate:incremental returns non-zero (validator failure)
+#   - the push of the translation commit fails
+#
+# Reads:
+#   BUILDKITE_PULL_REQUEST          PR number ("false" if not a PR)
+#   BUILDKITE_PULL_REQUEST_BASE_BRANCH
+#   BUILDKITE_BRANCH                current branch
+#   BUILDKITE_PULL_REQUEST_REPO     git URL of PR head repo
+#   BUILDKITE_REPO                  git URL of main repo
+#   ANTHROPIC_API_KEY               required for actual translation
+
+BOT_NAME="WooCommerce Translation Bot"
+BOT_EMAIL="translation-bot@noreply.woocommerce.com"
+COMMIT_PREFIX="Translate:"
+
+echo "--- :globe_with_meridians: AI Translation"
+
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
+  echo "Skipping: not a pull request build."
+  exit 0
+fi
+
+if [[ "${BUILDKITE_PULL_REQUEST_REPO:-}" != "" && "${BUILDKITE_PULL_REQUEST_REPO}" != "${BUILDKITE_REPO}" ]]; then
+  echo "Skipping: PR is from a fork (${BUILDKITE_PULL_REQUEST_REPO})."
+  echo "Translation bot cannot push back to forks; the release-time sweep will pick up missing translations."
+  buildkite-agent annotate --style 'info' --context ai-translation-fork \
+    "AI translation skipped: PR is from a fork. Maintainer or release sweep will translate." || true
+  exit 0
+fi
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  # Same-repo PR with no API key is a secrets-misconfiguration, not an
+  # expected skip. Fail loudly so it surfaces during review.
+  echo "ERROR: ANTHROPIC_API_KEY is not set in this same-repo PR build." >&2
+  echo "The Buildkite secret may be misconfigured. Translation cannot proceed." >&2
+  buildkite-agent annotate --style 'error' --context ai-translation-no-key \
+    "AI translation FAILED: ANTHROPIC_API_KEY missing in same-repo PR build. Check Buildkite secret configuration." || true
+  exit 1
+fi
+
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-trunk}"
+echo "Comparing against ${BASE_BRANCH} to detect EN string changes…"
+
+git fetch origin "${BASE_BRANCH}" --depth=50
+
+CHANGED_EN=$(git diff --name-only "origin/${BASE_BRANCH}...HEAD" -- \
+  'WooCommerce/Resources/en.lproj/Localizable.strings' \
+  'WooCommerce/Resources/en.lproj/InfoPlist.strings' | head -n 5)
+
+if [[ -z "${CHANGED_EN}" ]]; then
+  echo "Skipping: no EN strings touched on this PR."
+  exit 0
+fi
+echo "EN files changed in this PR:"
+echo "${CHANGED_EN}"
+
+# Loop prevention. If the most recent commit is from the bot, the previous
+# CI run already produced these translations.
+LAST_AUTHOR=$(git log -1 --pretty=format:'%an')
+LAST_SUBJECT=$(git log -1 --pretty=format:'%s')
+if [[ "${LAST_AUTHOR}" == "${BOT_NAME}" ]] || [[ "${LAST_SUBJECT}" == ${COMMIT_PREFIX}* ]]; then
+  echo "Skipping: HEAD is already a translation-bot commit (${LAST_AUTHOR}: ${LAST_SUBJECT})."
+  echo "Avoiding CI loop."
+  exit 0
+fi
+
+# Run the incremental translation across every supported locale.
+echo "--- :rocket: Running incremental translation"
+bundle exec rake -f fastlane/ai_translation/Rakefile translate:incremental
+
+# If nothing changed on disk, we're done.
+if [[ -z "$(git status --porcelain)" ]]; then
+  echo "No translation changes produced. Exiting clean."
+  exit 0
+fi
+
+echo "--- :git: Committing and pushing translations"
+
+git config user.name "${BOT_NAME}"
+git config user.email "${BOT_EMAIL}"
+
+# Stage only the resource files; leave anything else (rare) for review.
+git add WooCommerce/Resources/*.lproj/Localizable.strings
+git add WooCommerce/Resources/*.lproj/InfoPlist.strings
+
+SUMMARY=$(rake -f fastlane/ai_translation/Rakefile translate:report 2>/dev/null | tail -n +5 || true)
+
+git commit -m "${COMMIT_PREFIX} apply AI translations for new/changed strings
+
+Automated by the AI translation pipeline on Buildkite build
+${BUILDKITE_BUILD_NUMBER:-unknown}.
+
+${SUMMARY}
+
+Co-Authored-By: WooCommerce Translation Bot <${BOT_EMAIL}>"
+
+git push origin "HEAD:${BUILDKITE_BRANCH}"
+echo "Translations pushed to ${BUILDKITE_BRANCH}."

--- a/.buildkite/commands/run-ai-translations.sh
+++ b/.buildkite/commands/run-ai-translations.sh
@@ -113,6 +113,13 @@ if [[ "${LAST_AUTHOR}" == "${BOT_NAME}" ]] || [[ "${LAST_SUBJECT}" == ${COMMIT_P
   exit 0
 fi
 
+# Install gems before invoking bundler-managed tools. `install_gems` is
+# provided by the a8c-ci-toolkit Buildkite plugin (loaded into the env
+# by its hook on this step). We only run it past the early-exit checks
+# so skipped jobs stay snappy.
+echo "--- :rubygems: Installing gems"
+install_gems
+
 # Run the incremental translation across every supported locale.
 echo "--- :rocket: Running incremental translation"
 bundle exec rake -f fastlane/ai_translation/Rakefile translate:incremental
@@ -132,7 +139,7 @@ git config user.email "${BOT_EMAIL}"
 git add WooCommerce/Resources/*.lproj/Localizable.strings
 git add WooCommerce/Resources/*.lproj/InfoPlist.strings
 
-SUMMARY=$(rake -f fastlane/ai_translation/Rakefile translate:report 2>/dev/null | tail -n +5 || true)
+SUMMARY=$(bundle exec rake -f fastlane/ai_translation/Rakefile translate:report 2>/dev/null | tail -n +5 || true)
 
 git commit -m "${COMMIT_PREFIX} apply AI translations for new/changed strings
 

--- a/.buildkite/commands/run-ai-translations.sh
+++ b/.buildkite/commands/run-ai-translations.sh
@@ -43,14 +43,33 @@ BOT_NAME="WooCommerce Translation Bot"
 BOT_EMAIL="translation-bot@noreply.woocommerce.com"
 COMMIT_PREFIX="Translate:"
 
+# Normalizes a git URL to its `owner/repo` form so that ssh and https
+# forms of the same repo compare equal. BUILDKITE_REPO is typically
+# `git@github.com:org/repo.git` while BUILDKITE_PULL_REQUEST_REPO comes
+# from GitHub as `https://github.com/org/repo.git`; without normalizing
+# the fork-detection branch below misfires on every same-repo PR.
+normalize_repo_url() {
+  local url="${1:-}"
+  url="${url#git@github.com:}"
+  url="${url#https://github.com/}"
+  url="${url#git://github.com/}"
+  url="${url%.git}"
+  printf '%s' "$url"
+}
+
 echo "--- :globe_with_meridians: AI Translation"
+echo "PR repo: ${BUILDKITE_PULL_REQUEST_REPO:-<unset>}"
+echo "Main repo: ${BUILDKITE_REPO:-<unset>}"
 
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]]; then
   echo "Skipping: not a pull request build."
   exit 0
 fi
 
-if [[ "${BUILDKITE_PULL_REQUEST_REPO:-}" != "" && "${BUILDKITE_PULL_REQUEST_REPO}" != "${BUILDKITE_REPO}" ]]; then
+PR_REPO_PATH=$(normalize_repo_url "${BUILDKITE_PULL_REQUEST_REPO:-}")
+MAIN_REPO_PATH=$(normalize_repo_url "${BUILDKITE_REPO:-}")
+
+if [[ -n "${PR_REPO_PATH}" && "${PR_REPO_PATH}" != "${MAIN_REPO_PATH}" ]]; then
   echo "Skipping: PR is from a fork (${BUILDKITE_PULL_REQUEST_REPO})."
   echo "Translation bot cannot push back to forks; the release-time sweep will pick up missing translations."
   buildkite-agent annotate --style 'info' --context ai-translation-fork \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,28 @@ env:
 # This is the default pipeline – it will build and test the app
 steps:
   #################
+  # AI Translation (PR-time only; commits new translations back to the PR)
+  #
+  # Hybrid CI gate (per DoD C13):
+  #   - Same-repo PRs: strict; validator failures block the PR.
+  #   - Fork PRs: soft; the script exits 0 with an annotation so external
+  #     contributors aren't blocked by missing secrets. The release-time
+  #     health report is the backstop for any drift.
+  #
+  # The script handles the same-repo vs fork distinction itself; the step
+  # does NOT use soft_fail so genuine same-repo failures show as required-
+  # status failures.
+  #################
+  - label: ":globe_with_meridians: AI Translation"
+    key: ai-translation
+    if: build.pull_request.id != null
+    command: .buildkite/commands/run-ai-translations.sh
+    plugins: [$CI_TOOLKIT]
+    notify:
+      - github_commit_status:
+          context: AI Translation
+
+  #################
   # Build the app
   #################
   - label: ":pipeline: Build"

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -9,6 +9,7 @@ env:
 
 steps:
   - label: Publish Release
+    key: publish-release
     plugins: [$CI_TOOLKIT]
     command: |
       echo '--- :robot_face: Use bot for Git operations'
@@ -29,3 +30,12 @@ steps:
         # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
         reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false
+
+  - label: ":bar_chart: Translation Health Report"
+    depends_on: publish-release
+    plugins: [$CI_TOOLKIT]
+    soft_fail: true
+    command: |
+      .buildkite/commands/checkout-release-branch.sh "$RELEASE_VERSION"
+      install_gems
+      .buildkite/commands/post-translation-health-report.sh

--- a/WooCommerce/Resources/bg.lproj/Localizable.strings
+++ b/WooCommerce/Resources/bg.lproj/Localizable.strings
@@ -16142,3 +16142,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Приеми плащане";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Нисък запас";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Съхранен %1$@ със SKU %2$@ и %3$d единици в наличност.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Цена на продажба %1$@ е %2$d%% по-ниска от обичайната цена и действа от %3$@ до %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Спестете 20%% на групирани продукти и запазете 100%% от формата на вашия SKU.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Преглед <a href=\"inventory-threshold\"><u>прагове на инвентара</u></a> преди включване на предварителни поръчки.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Продукт %1$@ е разпродаден.\nПреоткрийте %2$d единици или го маркирайте като наличен по поръчка.";

--- a/WooCommerce/Resources/cs.lproj/Localizable.strings
+++ b/WooCommerce/Resources/cs.lproj/Localizable.strings
@@ -16107,3 +16107,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Přijmout platbu";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Nízký stav zásob";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Uložen %1$@ se SKU %2$@ a %3$d kusů skladem.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Prodejní cena %1$@ je %2$d%% nižší než běžná cena a trvá od %3$@ do %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Ušetřete 20%% na balených produktech a zachovejte 100%% vašeho SKU formátování.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Před povolením objednávek vyprodaných položek zkontrolujte <a href=\"inventory-threshold\"><u>limity zásob</u></a>.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produkt %1$@ je vyprodaný.\nDoplňte %2$d kusů nebo jej označte jako objednaný.";

--- a/WooCommerce/Resources/da.lproj/Localizable.strings
+++ b/WooCommerce/Resources/da.lproj/Localizable.strings
@@ -16142,3 +16142,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Country option for a site address. */
 "San Marino" = "San Marino";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Lav lagerbeholdning";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Gemte %1$@ med SKU %2$@ og %3$d enheder på lager.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Salgspris %1$@ er %2$d%% lavere end den almindelige pris og gælder fra %3$@ til %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Spar 20%% på bundlede produkter og behold 100%% af dine SKU-formateringer.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Gennemse <a href=\"inventory-threshold\"><u>lagergrænser</u></a> før du aktiverer backordre.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produktet %1$@ er udsolgt.\nGenopfyld %2$d enheder eller markér det som backordered.";

--- a/WooCommerce/Resources/el.lproj/Localizable.strings
+++ b/WooCommerce/Resources/el.lproj/Localizable.strings
@@ -16069,3 +16069,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Είσπραξη πληρωμής";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Χαμηλό απόθεμα προϊόντος";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Αποθηκεύτηκε %1$@ με SKU %2$@ και %3$d μονάδες σε απόθεμα.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Η τιμή προσφοράς %1$@ είναι %2$d%% χαμηλότερη από την κανονική τιμή και ισχύει από %3$@ έως %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Εξοικονομήστε 20%% σε προϊόντα πακέτου και διατηρήστε 100%% της μορφοποίησης του SKU σας.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Ελέγξτε τα <a href=\"inventory-threshold\"><u>όρια αποθέματος</u></a> πριν ενεργοποιήσετε τις προπαραγγελίες.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Το προϊόν %1$@ δεν είναι διαθέσιμο.\nΕπαναφέρτε %2$d μονάδες ή επισημάνετέ το ως προπαραγγελία.";

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -16104,6 +16104,27 @@ If your translation of that term also happens to contains a hyphen, please be su
 /* Text of the notice that is displayed after the refund is created. */
 "🎉 Products successfully refunded" = "🎉 Products successfully refunded";
 
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Low stock product";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Saved %1$@ with SKU %2$@ and %3$d units in stock.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Sale price %1$@ is %2$d%% lower than the regular price and runs from %3$@ to %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Save 20%% on bundled products and keep 100%% of your SKU formatting.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Review <a href=\"inventory-threshold\"><u>inventory thresholds</u></a> before enabling backorders.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Product %1$@ is out of stock.\nRestock %2$d units or mark it as backordered.";
+
 
 /* MARK: - InfoPlist.strings */
 

--- a/WooCommerce/Resources/fi.lproj/Localizable.strings
+++ b/WooCommerce/Resources/fi.lproj/Localizable.strings
@@ -16142,3 +16142,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Enter your store credentials for {site url}. Asks the user to enter .org site credentials for their store. */
 "Enter your store credentials for %@." = "Anna kauppasi kirjautumistiedot kohteelle %@.";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Vähissä varastoa";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Tallennettu %1$@ tuotteen SKU %2$@ kanssa ja %3$d yksikköä varastossa.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Myyntihinta %1$@ on %2$d%% alhaisempi kuin normaali hinta ja se kestää %3$@–%4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Säästä 20%% pakotetuista tuotteista ja pidä 100%% SKU-muotoilusta.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Tarkista <a href=\"inventory-threshold\"><u>varaston alarmit</u></a> ennen toimitusta myöhemmin saatavissa olevien tuotteiden osalta.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Tuote %1$@ on loppu.\nTäydennä %2$d yksikköä tai merkitse se toimittamiseen myöhemmin.";

--- a/WooCommerce/Resources/hi.lproj/Localizable.strings
+++ b/WooCommerce/Resources/hi.lproj/Localizable.strings
@@ -16145,3 +16145,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title of the local notification to remind to continue the Blaze campaign creation. */
 "localNotification.AbandonedCampaignCreation.title" = "अपनी बिक्री बढ़ाने के बारे में सोच रहे हैं?";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "कम स्टॉक उत्पाद";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "%1$@ को SKU %2$@ के साथ और %3$d यूनिट स्टॉक में सहेजा गया।";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "विक्रय मूल्य %1$@ नियमित मूल्य से %2$d%% कम है और %3$@ से %4$@ तक चलता है।";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "बंडल उत्पादों पर 20%% की बचत करें और अपनी SKU फॉर्मेटिंग का 100%% रखें।";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "बैकऑर्डर सक्षम करने से पहले <a href=\"inventory-threshold\"><u>इन्वेंटरी थ्रेसहोल्ड</u></a> की समीक्षा करें।";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "उत्पाद %1$@ स्टॉक में नहीं है।\n%2$d यूनिट का पुनः स्टॉक करें या इसे बैकऑर्डर के रूप में चिह्नित करें।";

--- a/WooCommerce/Resources/hu.lproj/Localizable.strings
+++ b/WooCommerce/Resources/hu.lproj/Localizable.strings
@@ -16139,3 +16139,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Fizetés beszedése";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Alacsony készlet";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "%1$@ mentve az %2$@ SKU-val és %3$d darab készlettel.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Az %1$@ szokásos árhoz képest %2$d%%-kal olcsóbb, és %3$@-tól %4$@-ig érvényes.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "20%%-os kedvezmény a csomagban foglalt termékekre, és az SKU formázás 100%%-ban megmarad.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "A visszarendelés engedélyezése előtt ellenőrizze az <a href=\"inventory-threshold\"><u>készletküszöbértékeket</u></a>.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "A(z) %1$@ termék elfogyott.\n%2$d darabot kell újra feltölteni, vagy jelölje meg visszarendeltként.";

--- a/WooCommerce/Resources/ms.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ms.lproj/Localizable.strings
@@ -16144,3 +16144,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Kumpul Pembayaran";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Stok rendah";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Simpan %1$@ dengan SKU %2$@ dan %3$d unit dalam stok.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Harga jualan %1$@ adalah %2$d%% lebih rendah daripada harga biasa dan berjalan dari %3$@ hingga %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Jimat 20%% pada produk berpakej dan kekalkan 100%% pemformatan SKU anda.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Semak <a href=\"inventory-threshold\"><u>ambang inventori</u></a> sebelum membenarkan pesanan tertangguh.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produk %1$@ kehabisan stok.\nDulang semula %2$d unit atau tandai sebagai pesanan tertangguh.";

--- a/WooCommerce/Resources/nb.lproj/Localizable.strings
+++ b/WooCommerce/Resources/nb.lproj/Localizable.strings
@@ -16142,3 +16142,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Error title on the watch orders list screen. */
 "watch.orders.error.title" = "Kunne ikke laste bestillinger";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Lavt lager";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Lagret %1$@ med SKU %2$@ og %3$d enheter.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Salgspris %1$@ er %2$d%% lavere enn vanlig pris og kjører fra %3$@ til %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Spar 20%% på bundlede produkter og behold 100%% av SKU-formateringen.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Gå gjennom <a href=\"inventory-threshold\"><u>lagergrenser</u></a> før du aktiverer restordrer.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produkt %1$@ er utsolgt.\nLagerfyll %2$d enheter eller merk det som restordre.";

--- a/WooCommerce/Resources/pl.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pl.lproj/Localizable.strings
@@ -16077,3 +16077,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Zbierz płatność";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Niski stan magazynowy";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Zapisano %1$@ z kodem SKU %2$@ i %3$d jednostkami na magazynie.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Cena promocyjna %1$@ jest o %2$d%% niższa niż cena regularna i obowiązuje od %3$@ do %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Zaoszczędź 20%% na produktach bundlowanych i zachowaj 100%% formatowania SKU.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Sprawdź <a href=\"inventory-threshold\"><u>progi magazynowania</u></a> przed włączeniem zamówień do realizacji.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produkt %1$@ jest niedostępny.\nUzupełnij zapas o %2$d jednostek lub oznacz jako dostępny do zamówienia.";

--- a/WooCommerce/Resources/pt-PT.lproj/Localizable.strings
+++ b/WooCommerce/Resources/pt-PT.lproj/Localizable.strings
@@ -16143,3 +16143,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Enter your store credentials for {site url}. Asks the user to enter .org site credentials for their store. */
 "Enter your store credentials for %@." = "Introduz as credenciais da tua loja para %@.";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Stock baixo";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Guardado %1$@ com SKU %2$@ e %3$d unidades em stock.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Preço de promoção %1$@ é %2$d%% inferior ao preço normal e decorre de %3$@ a %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Economize 20%% em produtos agrupados e mantenha 100%% da formatação do seu SKU.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Reveja os <a href=\"inventory-threshold\"><u>limiares de stock</u></a> antes de ativar encomendas em atraso.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produto %1$@ está fora de stock.\nReabasteça %2$d unidades ou marque como encomenda em atraso.";

--- a/WooCommerce/Resources/ro.lproj/Localizable.strings
+++ b/WooCommerce/Resources/ro.lproj/Localizable.strings
@@ -16139,3 +16139,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Colectează plata";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Stoc limitat";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "S-a salvat %1$@ cu SKU %2$@ și %3$d unități în stoc.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Prețul de vânzare %1$@ este cu %2$d%% mai mic decât prețul regulat și rulează din %3$@ până la %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Economisești 20%% la produsele în pachet și păstrezi 100%% din formatarea SKU-ului tău.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Revizuiește <a href=\"inventory-threshold\"><u>pragurile de inventar</u></a> înainte de a activa comenzile în pre-comandă.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Produsul %1$@ nu mai este în stoc.\nReaprovizionează %2$d unități sau marchează-l ca în pre-comandă.";

--- a/WooCommerce/Resources/th.lproj/Localizable.strings
+++ b/WooCommerce/Resources/th.lproj/Localizable.strings
@@ -16143,3 +16143,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Enter your store credentials for {site url}. Asks the user to enter .org site credentials for their store. */
 "Enter your store credentials for %@." = "ป้อนข้อมูลรับรองร้านค้าของคุณสำหรับ %@";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "สินค้าคงเหลือน้อย";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "บันทึก %1$@ โดยมี SKU %2$@ และสินค้าคงคลัง %3$d ชิ้นแล้ว";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "ราคาขายพิเศษ %1$@ ต่ำกว่าราคาปกติ %2$d%% และมีกำหนดตั้งแต่ %3$@ ถึง %4$@";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "ประหยัด 20%% บนสินค้ารวมและรักษา 100%% การจัดรูปแบบ SKU ของคุณ";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "ตรวจสอบ <a href=\"inventory-threshold\"><u>ขีดจำกัดสินค้าคงเหลือ</u></a> ก่อนเปิดใช้งานการสั่งซื้อล่วงหน้า";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "สินค้า %1$@ หมดสต็อกแล้ว\nเติมสินค้า %2$d ชิ้นหรือทำเครื่องหมายให้เป็นการสั่งซื้อล่วงหน้า";

--- a/WooCommerce/Resources/uk.lproj/Localizable.strings
+++ b/WooCommerce/Resources/uk.lproj/Localizable.strings
@@ -16142,3 +16142,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Error title on the watch orders list screen. */
 "watch.orders.error.title" = "Не вдалося завантажити замовлення";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Низький запас";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Збережено %1$@ з SKU %2$@ та %3$d одиниць в наявності.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Ціна розпродажу %1$@ на %2$d%% нижча за звичайну ціну та діє з %3$@ по %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Заощаджуйте 20%% на комплектних товарах і зберігайте 100%% форматування SKU.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Переглядайте <a href=\"inventory-threshold\"><u>пороги запасів</u></a> перед активацією передзамовлень.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Товар %1$@ відсутній.\nповедіміть запас %2$d одиниць або позначте його як передзамовлення.";

--- a/WooCommerce/Resources/vi.lproj/Localizable.strings
+++ b/WooCommerce/Resources/vi.lproj/Localizable.strings
@@ -16139,3 +16139,24 @@ If your translation of that term also happens to contains a hyphen, please be su
 
 /* Title for Payments home screen action */
 "infoplist.CollectPaymentAction.Title" = "Thu thanh toán";
+
+/* Dummy translation-pipeline test string. Very short ecommerce label for a product stock keeping unit field. */
+"ai_translation_test_product_short_sku" = "SKU";
+
+/* Dummy translation-pipeline test string. Badge text shown beside a product that has limited inventory. */
+"ai_translation_test_product_medium_low_stock_badge" = "Sản phẩm hết hàng";
+
+/* Dummy translation-pipeline test string. Message shown after saving an inventory threshold for a product variation. Keep product, SKU and unit-count placeholders intact. */
+"ai_translation_test_product_placeholder_inventory" = "Đã lưu %1$@ với SKU %2$@ và %3$d đơn vị trong kho.";
+
+/* Dummy translation-pipeline test string. Explains a scheduled promotion for a product catalog item. Keep currency, percent, and date placeholders intact. */
+"ai_translation_test_product_placeholder_sale_window" = "Giá khuyến mãi %1$@ thấp hơn giá thường %2$d%% và áp dụng từ %3$@ đến %4$@.";
+
+/* Dummy translation-pipeline test string. Marketing copy containing literal percent signs (escaped as %% so NSString format keeps them as a literal '%' character). */
+"ai_translation_test_product_formatted_false_discount" = "Tiết kiệm 20%% cho sản phẩm gói và giữ 100%% định dạng SKU của bạn.";
+
+/* Dummy translation-pipeline test string. Product editor helper text with inline HTML link formatting that must remain valid. */
+"ai_translation_test_product_html_link" = "Xem xét <a href=\"inventory-threshold\"><u>ngưỡng hàng tồn kho</u></a> trước khi bật đặt hàng trước.";
+
+/* Dummy translation-pipeline test string. Multiline product availability warning shown in a dialog. Keep the newline and placeholders intact. */
+"ai_translation_test_product_multiline_backorder" = "Sản phẩm %1$@ đã hết hàng.\nNhập lại %2$d đơn vị hoặc đánh dấu nó là đặt hàng trước.";

--- a/fastlane/ai_translation/README.md
+++ b/fastlane/ai_translation/README.md
@@ -51,12 +51,46 @@ fastlane/ai_translation/
 │   ├── byte_sizer.rb             # Script-aware batch sizing
 │   ├── constants.rb              # Version, model IDs, prompt version
 │   ├── ios_resources.rb          # .strings parser + writer
-│   └── translator.rb             # Batched JSON-in/JSON-out translator with split-retry
+│   ├── translator.rb             # Batched JSON-in/JSON-out translator with split-retry
+│   └── validator.rb              # Brand-safety + glossary enforcement
+├── glossary/
+│   ├── common.yml                # Brand names — never translate (hard validator)
+│   └── <locale>.yml × 31         # Per-locale UI term + noun mappings
+├── style/
+│   ├── default.md                # Fallback style guide
+│   └── <locale>.md               # Per-locale register / quirks (when applicable)
 ├── spec/                         # Minitest specs
 ├── scripts/                      # One-off bootstrap utilities (assemble, gap-fill)
 ├── Rakefile                      # Rake task wrappers
 └── translate-progress.json       # Audit checkpoint for the original bootstrap run
 ```
+
+### Glossaries and brand-safety
+
+`glossary/common.yml` lists the brand and product names that must appear
+verbatim in every translation regardless of target locale (WooCommerce,
+Woo, Stripe, Apple Pay, Tap to Pay, Blaze, Bluetooth, etc.). The
+`Validator` enforces this as a hard rule: if a source string contains a
+listed brand, the translation must contain the same brand unchanged. The
+violation is reported and the entry is rejected (counted in the
+`glossary_violations` summary line).
+
+`glossary/<locale>.yml` adds per-locale UI-term and noun mappings. When
+the source string is *exactly* one of those keys, the translation must
+match the mapped value. This pins terminology like "Cancel" → "Anuluj"
+(Polish) or "Orders" → "ऑर्डर" (Hindi) so terminology can't drift
+across PRs.
+
+The 15 new locales bootstrapped in PR #17220 ship with rich
+`<locale>.yml` files (seeded from the sub-agent translation prompts). The
+16 existing GlotPress locales (de, es, fr, …) ship with stub files that
+inherit only the brand-safety rules; future work will derive their UI
+terms from the existing translations.
+
+Style guides at `style/<locale>.md` are loaded as additional system-prompt
+context when translating that locale. They cover register choices,
+numerals, quotation conventions, and locale-specific pitfalls (e.g.,
+pt-PT vs pt-BR distinctions, Bahasa Malaysia vs Bahasa Indonesia).
 
 ### Why a separate `byte_sizer`
 

--- a/fastlane/ai_translation/README.md
+++ b/fastlane/ai_translation/README.md
@@ -173,6 +173,40 @@ This is what the CI step calls on every PR that touches `en.lproj`. A typical
 PR adds 1–10 strings, so the incremental call costs cents and finishes in
 seconds.
 
+## CI integration
+
+The engine is wired into Buildkite via two scripts:
+
+### `.buildkite/commands/run-ai-translations.sh`
+
+Runs on every PR build. Skips itself (no failure) when:
+- the build is not a PR (trunk / release branches);
+- no EN strings changed in the PR (`git diff` against the base);
+- the most recent commit is already a translation-bot commit (loop prevention);
+- `ANTHROPIC_API_KEY` is not in the env;
+- the PR is from a fork (no push access).
+
+When it runs, it executes `rake translate:incremental` for every locale and
+commits the resulting changes back to the PR branch as a single
+`Translate: …` commit authored by **WooCommerce Translation Bot**. The
+commit is co-authored so the PR author still owns the merge.
+
+**Human-ack policy**: the bot's commits do NOT auto-merge. The PR author
+still needs the usual 1 reviewer approval and clicks merge themselves.
+
+### `.buildkite/commands/post-translation-health-report.sh`
+
+Runs after a release is published (wired into
+`release-pipelines/publish-release.yml`). Generates the per-locale
+parity report via `rake translate:report` and:
+
+1. Drops it as a Buildkite annotation on the build (visible inline).
+2. Appends it to the GitHub release notes body.
+
+This is **report-only** — it does not block the release. Per the locked
+DoD decision (C13), drift is surfaced for triage rather than gating
+shipping.
+
 ## Adding a new locale
 
 1. Add the locale code to `SUPPORTED_LOCALES` in `Rakefile`.

--- a/fastlane/ai_translation/Rakefile
+++ b/fastlane/ai_translation/Rakefile
@@ -31,11 +31,11 @@ def cli_args_from_env
   args
 end
 
-def run_cli(locale, *extra)
-  args = ['ruby', BIN, locale, *cli_args_from_env, *extra]
+def run_cli(locales, *extra)
+  args = ['ruby', BIN, *Array(locales), *cli_args_from_env, *extra]
   puts "$ #{args.join(' ')}"
   ok = system(*args)
-  abort("translate_locale.rb failed for #{locale}") unless ok
+  abort("translate_locale.rb failed (locales=#{Array(locales).join(',')})") unless ok
 end
 
 def resolve_locales
@@ -55,7 +55,11 @@ namespace :translate do
 
   desc 'Translate only missing keys for LOCALE (or all locales). Safe to run on every PR.'
   task :incremental do
-    resolve_locales.each { |loc| run_cli(loc, '--incremental') }
+    # Single Ruby process, all locales. Pays Ruby/bundler/Parser-cache boot
+    # cost once instead of 15×; on a 15-locale incremental with ~7 new keys
+    # per locale this is the difference between ~12 min and ~1 min total.
+    # See translate_locale.rb main() / process_locale().
+    run_cli(resolve_locales, '--incremental')
   end
 
   desc 'Verify a locale: key parity vs en.lproj, no API calls. LOCALE=xx or all.'

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -126,8 +126,14 @@ def filter_missing_units(en_units, target_path, logger:, manifest: nil)
       existing_unit = existing_by_name[u.name]
       next false unless existing_unit
 
-      existing_value = existing_unit.entries.first[:value].to_s
-      !existing_value.empty? && existing_value != src
+      # The parser stores the right-hand side of `"key" = "value";` in :source
+      # and leaves :value as nil (see IosResources::Parser, ios_resources.rb).
+      # For a *target* locale file that's the existing translation — exactly
+      # what we want to compare against the EN source here. Reading :value
+      # used to mask every existing translation as missing and re-translated
+      # the entire locale on a first PR-time run.
+      existing_translation = existing_unit.entries.first[:source].to_s
+      !existing_translation.empty? && existing_translation != src
     end
   end
 

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -106,9 +106,14 @@ end
 #
 # When a manifest is provided, source-only invalidation drives the decision:
 # an entry needs translation iff its source value differs from the recorded
-# `src_sha`. Falls back to the heuristic check ("present in target with a
-# non-EN value") when no manifest entry exists, which lets us bootstrap a
-# manifest from the existing locale files in PR #17220.
+# `src_sha`. Without a manifest entry, we fall back to the simplest rule
+# that matches how PR #17220 bootstrapped the new locales: if the EN key has
+# any non-empty value in the target file, trust it. We don't try to re-detect
+# bare-scaffold mistakes (e.g. `cp en.lproj xx.lproj`) here because PR #17220
+# wasn't built that way, and the engine's `translate:bootstrap` task is the
+# supported entry point for new locales. Re-translating entries where the
+# existing value happens to equal EN (placeholders, brand names) just burns
+# API time and risks unparseable/validator failures with no improvement.
 def filter_missing_units(en_units, target_path, logger:, manifest: nil)
   existing_by_name = if File.exist?(target_path)
                        WooAiTranslation::IosResources::Parser.parse_file(target_path)
@@ -127,13 +132,11 @@ def filter_missing_units(en_units, target_path, logger:, manifest: nil)
       next false unless existing_unit
 
       # The parser stores the right-hand side of `"key" = "value";` in :source
-      # and leaves :value as nil (see IosResources::Parser, ios_resources.rb).
-      # For a *target* locale file that's the existing translation — exactly
-      # what we want to compare against the EN source here. Reading :value
-      # used to mask every existing translation as missing and re-translated
-      # the entire locale on a first PR-time run.
-      existing_translation = existing_unit.entries.first[:source].to_s
-      !existing_translation.empty? && existing_translation != src
+      # and leaves :value nil (see IosResources::Parser, ios_resources.rb).
+      # For a target-locale file that's the existing translation. Trust any
+      # non-empty value — including one that happens to equal EN, which is the
+      # correct outcome for placeholders ("%1$@") and brand names ("WooCommerce").
+      !existing_unit.entries.first[:source].to_s.empty?
     end
   end
 

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -71,7 +71,7 @@ PLACEHOLDER_RE = /
 
 def parse_args(argv)
   opts = {
-    locale: nil,
+    locales: [],
     offline: false,
     batch: nil, # nil => auto-size via ByteSizer
     skip_infoplist: false,
@@ -84,7 +84,7 @@ def parse_args(argv)
     use_escalation: true
   }
   parser = OptionParser.new do |p|
-    p.banner = 'Usage: translate_locale.rb <locale> [options]'
+    p.banner = 'Usage: translate_locale.rb <locale> [<locale> ...] [options]'
     p.on('--offline', 'Use StubClient (no API call, deterministic)') { opts[:offline] = true }
     p.on('--batch N', Integer, 'Override auto-sized batch (default: ByteSizer)') { |v| opts[:batch] = v }
     p.on('--limit N', Integer, 'Translate only the first N keys (smoke test)') { |v| opts[:limit] = v }
@@ -97,8 +97,11 @@ def parse_args(argv)
     p.on('--max-output-tokens N', Integer, "Output budget for auto batch sizing (default: #{opts[:max_output_tokens]})") { |v| opts[:max_output_tokens] = v }
   end
   parser.permute!(argv)
-  opts[:locale] = argv.shift or abort(parser.help)
-  abort("unknown locale '#{opts[:locale]}' (expand LOCALE_NAMES in the script)") unless LOCALE_NAMES.key?(opts[:locale])
+  opts[:locales] = argv.dup
+  abort(parser.help) if opts[:locales].empty?
+  opts[:locales].each do |loc|
+    abort("unknown locale '#{loc}' (expand LOCALE_NAMES in the script)") unless LOCALE_NAMES.key?(loc)
+  end
   opts
 end
 
@@ -333,8 +336,8 @@ end
 
 def main(argv)
   opts = parse_args(argv)
-  locale = opts[:locale]
-  log_path = "/tmp/translate_locale_#{locale}.log"
+  locales = opts[:locales]
+  log_path = '/tmp/translate_locale.log'
   log_io = File.open(log_path, 'w')
   logger = lambda do |msg|
     line = "[#{Time.now.utc.iso8601}] #{msg}"
@@ -343,14 +346,33 @@ def main(argv)
     log_io.flush
   end
 
-  logger.call("start locale=#{locale} model=#{opts[:model]} batch=#{opts[:batch]} " \
-              "offline=#{opts[:offline]} limit=#{opts[:limit] || '∞'}")
-
   client = opts[:offline] ? WooAiTranslation::StubClient.new : WooAiTranslation::AnthropicClient.from_env
   unless client.available?
     logger.call('ANTHROPIC_API_KEY is not set; use --offline for a dry run')
     exit 1
   end
+
+  # Run every locale in this one Ruby process. We pay the Ruby + bundler boot
+  # cost once instead of 15× (previous design re-launched the CLI per locale
+  # via the Rakefile), and IosResources::Parser::CACHE persists across all
+  # locales so en.lproj is parsed once and reused. Per-locale validators and
+  # manifests are still loaded independently because the data is locale-
+  # specific.
+  any_failures = false
+  locales.each_with_index do |locale, i|
+    logger.call("===== [#{i + 1}/#{locales.size}] locale=#{locale} =====")
+    ok = process_locale(locale, opts, client, logger)
+    any_failures = true unless ok
+  end
+
+  logger.call("log written to #{log_path}")
+  log_io.close
+  exit(any_failures ? 2 : 0)
+end
+
+def process_locale(locale, opts, client, logger)
+  logger.call("start locale=#{locale} model=#{opts[:model]} batch=#{opts[:batch]} " \
+              "offline=#{opts[:offline]} limit=#{opts[:limit] || '∞'}")
 
   # Auto-size the batch when not explicitly overridden, so non-Latin scripts
   # don't overflow the output token budget.
@@ -361,11 +383,11 @@ def main(argv)
     auto
   end
 
-  # Load glossary / brand-safety validator first so we can lift its brand
-  # list into the translator's system prompt. Without this, the model
-  # translates terms like "SKU" into the target language (e.g. Bulgarian
-  # "Артикулен №") and the validator catches it post-hoc, wasting an Opus
-  # escalation and still failing the run.
+  # Load glossary / brand-safety validator so we can lift its brand list
+  # into the translator's system prompt. Without this, the model translates
+  # terms like "SKU" into the target language (e.g. Bulgarian "Артикулен №")
+  # and the validator catches it post-hoc, wasting an Opus escalation and
+  # still failing the run.
   validator = begin
     base = File.expand_path('../glossary', __dir__)
     WooAiTranslation::Validator.for_locale(locale: locale, base_dir: base) if Dir.exist?(base)
@@ -423,7 +445,7 @@ def main(argv)
   end
 
   # --- Summary ----------------------------------------------------------
-  logger.call('===== summary =====')
+  logger.call("---- summary [#{locale}] ----")
   logger.call("locale=#{locale} translated=#{total_translated} missing=#{all_missing.size} " \
               "placeholder_errors=#{all_errors.size} glossary_violations=#{all_glossary_errors.size}")
   unless all_errors.empty?
@@ -445,10 +467,11 @@ def main(argv)
     all_missing.first(10).each { |n| logger.call("  #{n}") }
   end
 
-  logger.call("log written to #{log_path}")
-  log_io.close
-  exit_code = all_errors.empty? && all_missing.empty? && all_glossary_errors.empty? ? 0 : 2
-  exit(exit_code)
+  all_errors.empty? && all_missing.empty? && all_glossary_errors.empty?
+rescue StandardError => e
+  logger.call("[#{locale}] FAILED: #{e.class}: #{e.message}")
+  e.backtrace&.first(5)&.each { |bt| logger.call("  #{bt}") }
+  false
 end
 
 main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -263,13 +263,26 @@ def apply_results(units_to_translate, results, by_name, manifest:, model:, origi
   [translated, failed_missing, failed_validation, failed_glossary]
 end
 
-# Write-then-parse sanity check: re-read the file we just wrote and make sure
-# the parser sees the same unit names. Catches cases where the writer emits
-# output the parser cannot consume (escape mismatches, lost terminators).
+# Write-then-scan sanity check: re-read the file we just wrote and confirm
+# every unit name we intended to write actually appears as a key. Catches
+# the common failure mode — units dropped during write (e.g. the
+# `:value`-vs-`:source` bug that landed empty pl.lproj files).
+#
+# We use a regex scan rather than a full reparse here because the parser is
+# O(n²) on a 1MB file (~40s/locale × 15 locales = ~10 minutes that buys very
+# little). Escape-corruption bugs in the writer (\n / \" / \\) would be
+# missed by a scan, but those are caught earlier by the placeholder
+# validator on each translation and would have to corrupt many writes in
+# series to slip through. Counts + first-5-diff stays meaningful.
 def verify_round_trip!(output_path, units_for_write, logger:, locale:)
-  reparsed = WooAiTranslation::IosResources::Parser.parse_file(output_path)
-  written = units_for_write.to_set(&:name)
-  reread = reparsed.units.to_set(&:name)
+  written = units_for_write.select(&:fully_translated?).map(&:name).to_set
+  content = File.read(output_path, encoding: 'UTF-8')
+  # Match `"quoted_key" =` and `unquoted_key =`; unescape backslash sequences
+  # only in the quoted form (keys typically don't contain escapes but we
+  # keep parity with the parser's handling).
+  reread = content.scan(/^(?:"((?:\\.|[^"\\])*)"|([A-Za-z0-9_.\-]+))\s*=/).map do |q, u|
+    q ? q.gsub(/\\(.)/, '\1') : u
+  end.to_set
   missing = written - reread
   extra = reread - written
   return if missing.empty? && extra.empty?

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -361,22 +361,27 @@ def main(argv)
     auto
   end
 
-  translator = WooAiTranslation::Translator.new(
-    client: client,
-    batch_size: batch_size,
-    logger: logger
-  )
-
-  manifest = opts[:use_manifest] ? WooAiTranslation::Manifest.new(locale: locale) : nil
-  logger.call("manifest #{manifest ? "loaded (#{manifest.size} entries, #{manifest.path})" : 'disabled'}")
-  escalation_model = opts[:use_escalation] ? opts[:escalation_model] : nil
-
-  # Load glossary / brand-safety validator if files exist for this locale.
+  # Load glossary / brand-safety validator first so we can lift its brand
+  # list into the translator's system prompt. Without this, the model
+  # translates terms like "SKU" into the target language (e.g. Bulgarian
+  # "Артикулен №") and the validator catches it post-hoc, wasting an Opus
+  # escalation and still failing the run.
   validator = begin
     base = File.expand_path('../glossary', __dir__)
     WooAiTranslation::Validator.for_locale(locale: locale, base_dir: base) if Dir.exist?(base)
   end
   logger.call("validator loaded: brands=#{validator&.brands&.size || 0} terms=#{validator&.terms&.size || 0}") if validator
+
+  translator = WooAiTranslation::Translator.new(
+    client: client,
+    batch_size: batch_size,
+    logger: logger,
+    brand_terms: validator&.brands
+  )
+
+  manifest = opts[:use_manifest] ? WooAiTranslation::Manifest.new(locale: locale) : nil
+  logger.call("manifest #{manifest ? "loaded (#{manifest.size} entries, #{manifest.path})" : 'disabled'}")
+  escalation_model = opts[:use_escalation] ? opts[:escalation_model] : nil
 
   out_dir = File.join(TARGET_BASE, "#{locale}.lproj")
 

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -277,11 +277,23 @@ end
 def verify_round_trip!(output_path, units_for_write, logger:, locale:)
   written = units_for_write.select(&:fully_translated?).map(&:name).to_set
   content = File.read(output_path, encoding: 'UTF-8')
-  # Match `"quoted_key" =` and `unquoted_key =`; unescape backslash sequences
-  # only in the quoted form (keys typically don't contain escapes but we
-  # keep parity with the parser's handling).
+  # Match `"quoted_key" =` and `unquoted_key =`. For quoted keys we must
+  # decode backslash escapes the same way IosResources::Parser does — the
+  # in-memory `unit.name` is post-decode, so a key like `"a\nb"` on disk
+  # is `"a<LF>b"` in memory. A naive `\\(.)` → `\1` here strips the
+  # backslash and the keys mismatch on every entry containing \n / \" / \\.
   reread = content.scan(/^(?:"((?:\\.|[^"\\])*)"|([A-Za-z0-9_.\-]+))\s*=/).map do |q, u|
-    q ? q.gsub(/\\(.)/, '\1') : u
+    next u unless q
+
+    q.gsub(/\\(.)/) do
+      case ::Regexp.last_match(1)
+      when 'n' then "\n"
+      when 'r' then "\r"
+      when 't' then "\t"
+      when '0' then "\0"
+      else ::Regexp.last_match(1) # \" \\ \' or lenient passthrough
+      end
+    end
   end.to_set
   missing = written - reread
   extra = reread - written

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -30,6 +30,7 @@ require 'woo_ai_translation/anthropic_client'
 require 'woo_ai_translation/translator'
 require 'woo_ai_translation/byte_sizer'
 require 'woo_ai_translation/manifest'
+require 'woo_ai_translation/validator'
 
 REPO_ROOT = File.expand_path('../../..', __dir__)
 SOURCE_DIR = File.join(REPO_ROOT, 'WooCommerce/Resources/en.lproj')
@@ -144,7 +145,7 @@ def placeholders_match?(source, translation)
 end
 
 def translate_file(input_path:, output_path:, translator:, locale:, model:, limit:, logger:,
-                   incremental: false, manifest: nil, escalation_model: nil)
+                   incremental: false, manifest: nil, escalation_model: nil, validator: nil)
   doc = WooAiTranslation::IosResources::Parser.parse_file(input_path)
   units = doc.translatable_units
   units = units.first(limit) if limit
@@ -167,22 +168,29 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
   units_for_write = incremental && File.exist?(output_path) ? merge_with_existing(units, output_path) : units
   by_name = units_for_write.to_h { |u| [u.name, u] }
 
-  translated, failed_missing, failed_validation = apply_results(
-    units_to_translate, results, by_name, manifest: manifest, model: model, origin: 'ai'
+  translated, failed_missing, failed_validation, failed_glossary = apply_results(
+    units_to_translate, results, by_name,
+    manifest: manifest, model: model, origin: 'ai', validator: validator
   )
 
-  # Opus fallback: retry validator-failed entries with the escalation model.
-  if escalation_model && !failed_validation.empty?
-    logger.call("[#{locale}] escalating #{failed_validation.size} failed entries to #{escalation_model}")
-    retry_units = units_to_translate.select { |u| failed_validation.any? { |f| f[:name] == u.name } }
+  # Opus fallback: retry validator-failed entries (placeholder OR glossary)
+  # with the escalation model. Successful retries are recorded with
+  # origin=ai-opus-retry so the audit trail shows why a stronger model
+  # produced the value.
+  if escalation_model && !(failed_validation.empty? && failed_glossary.empty?)
+    retry_names = (failed_validation + failed_glossary).to_set { |f| f[:name] }
+    retry_units = units_to_translate.select { |u| retry_names.include?(u.name) }
+    logger.call("[#{locale}] escalating #{retry_units.size} failed entries to #{escalation_model}")
     retry_results = run_translation(translator, locale, retry_units, escalation_model)
-    extra_translated, _retry_missing, still_failing = apply_results(
+    extra_translated, _retry_missing, still_failing_v, still_failing_g = apply_results(
       retry_units, retry_results, by_name,
-      manifest: manifest, model: escalation_model, origin: 'ai-opus-retry'
+      manifest: manifest, model: escalation_model, origin: 'ai-opus-retry', validator: validator
     )
     translated += extra_translated
-    failed_validation = still_failing
-    logger.call("[#{locale}] escalation recovered #{extra_translated} entries; #{still_failing.size} still failing")
+    failed_validation = still_failing_v
+    failed_glossary = still_failing_g
+    logger.call("[#{locale}] escalation recovered #{extra_translated} entries; " \
+                "#{still_failing_v.size} placeholder + #{still_failing_g.size} glossary still failing")
   end
 
   WooAiTranslation::IosResources::Writer.write(output_path, units_for_write, locale)
@@ -190,8 +198,9 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
   manifest&.save!
 
   logger.call("[#{locale}] wrote #{output_path} (#{translated} keys, " \
-              "#{failed_missing.size} missing, #{failed_validation.size} placeholder errors)")
-  [translated, failed_missing, failed_validation]
+              "#{failed_missing.size} missing, #{failed_validation.size} placeholder errors, " \
+              "#{failed_glossary.size} glossary/brand violations)")
+  [translated, failed_missing, failed_validation, failed_glossary]
 end
 
 def run_translation(translator, locale, units, model)
@@ -201,10 +210,11 @@ end
 
 # Walk units_to_translate, apply each result, and report counts. Mutates
 # the corresponding entries inside `by_name` so the caller can write them.
-def apply_results(units_to_translate, results, by_name, manifest:, model:, origin:)
+def apply_results(units_to_translate, results, by_name, manifest:, model:, origin:, validator: nil)
   translated = 0
   failed_missing = []
   failed_validation = []
+  failed_glossary = []
 
   units_to_translate.each do |u|
     src = u.entries.first[:source]
@@ -222,13 +232,22 @@ def apply_results(units_to_translate, results, by_name, manifest:, model:, origi
       next
     end
 
+    if validator
+      glossary_violations = validator.validate(source: src, translation: tx)
+      unless glossary_violations.empty?
+        failed_glossary << { name: u.name, source: src, translation: tx,
+                             violations: glossary_violations }
+        next
+      end
+    end
+
     target_unit = by_name[u.name] or next
     target_unit.entries.first[:value] = tx
     manifest&.record!(key: u.name, source: src, model: model, origin: origin)
     translated += 1
   end
 
-  [translated, failed_missing, failed_validation]
+  [translated, failed_missing, failed_validation, failed_glossary]
 end
 
 # Write-then-parse sanity check: re-read the file we just wrote and make sure
@@ -307,21 +326,29 @@ def main(argv)
   logger.call("manifest #{manifest ? "loaded (#{manifest.size} entries, #{manifest.path})" : 'disabled'}")
   escalation_model = opts[:use_escalation] ? opts[:escalation_model] : nil
 
+  # Load glossary / brand-safety validator if files exist for this locale.
+  validator = begin
+    base = File.expand_path('../glossary', __dir__)
+    WooAiTranslation::Validator.for_locale(locale: locale, base_dir: base) if Dir.exist?(base)
+  end
+  logger.call("validator loaded: brands=#{validator&.brands&.size || 0} terms=#{validator&.terms&.size || 0}") if validator
+
   out_dir = File.join(TARGET_BASE, "#{locale}.lproj")
 
   # --- Localizable.strings (the main corpus) ----------------------------
   t0 = Time.now
-  trans, missing, errors = translate_file(
+  trans, missing, errors, glossary_errors = translate_file(
     input_path: File.join(SOURCE_DIR, 'Localizable.strings'),
     output_path: File.join(out_dir, 'Localizable.strings'),
     translator: translator, locale: locale, model: opts[:model],
     limit: opts[:limit], logger: logger, incremental: opts[:incremental],
-    manifest: manifest, escalation_model: escalation_model
+    manifest: manifest, escalation_model: escalation_model, validator: validator
   )
   logger.call("Localizable.strings done in #{(Time.now - t0).round(1)}s")
   total_translated = trans
   all_missing = missing
   all_errors = errors
+  all_glossary_errors = glossary_errors
 
   # --- InfoPlist.strings (16 entries, small but important) --------------
   unless opts[:skip_infoplist]
@@ -329,16 +356,17 @@ def main(argv)
     info_in = File.join(SOURCE_DIR, 'InfoPlist.strings')
     info_out = File.join(out_dir, 'InfoPlist.strings')
     if File.exist?(info_in)
-      trans, missing, errors = translate_file(
+      trans, missing, errors, glossary_errors = translate_file(
         input_path: info_in, output_path: info_out,
         translator: translator, locale: locale, model: opts[:model],
         limit: nil, logger: logger, incremental: opts[:incremental],
-        manifest: manifest, escalation_model: escalation_model
+        manifest: manifest, escalation_model: escalation_model, validator: validator
       )
       logger.call("InfoPlist.strings done in #{(Time.now - t0).round(1)}s")
       total_translated += trans
       all_missing.concat(missing)
       all_errors.concat(errors)
+      all_glossary_errors.concat(glossary_errors)
     else
       logger.call("no InfoPlist.strings at #{info_in}; skipping")
     end
@@ -347,12 +375,19 @@ def main(argv)
   # --- Summary ----------------------------------------------------------
   logger.call('===== summary =====')
   logger.call("locale=#{locale} translated=#{total_translated} missing=#{all_missing.size} " \
-              "placeholder_errors=#{all_errors.size}")
+              "placeholder_errors=#{all_errors.size} glossary_violations=#{all_glossary_errors.size}")
   unless all_errors.empty?
     logger.call('---- placeholder errors (first 10) ----')
     all_errors.first(10).each do |e|
       logger.call("  #{e[:name]}: src=#{e[:source].inspect} tx=#{e[:translation].inspect}")
       logger.call("    expected=#{e[:expected]} got=#{e[:got]}")
+    end
+  end
+  unless all_glossary_errors.empty?
+    logger.call('---- glossary/brand violations (first 10) ----')
+    all_glossary_errors.first(10).each do |e|
+      logger.call("  #{e[:name]}: src=#{e[:source].inspect} tx=#{e[:translation].inspect}")
+      e[:violations].each { |v| logger.call("    #{v[:rule]}: term=#{v[:term].inspect} expected=#{v[:expected].inspect}") }
     end
   end
   unless all_missing.empty?
@@ -362,7 +397,8 @@ def main(argv)
 
   logger.call("log written to #{log_path}")
   log_io.close
-  exit(all_errors.empty? && all_missing.empty? ? 0 : 2)
+  exit_code = all_errors.empty? && all_missing.empty? && all_glossary_errors.empty? ? 0 : 2
+  exit(exit_code)
 end
 
 main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -209,8 +209,20 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
                 "#{still_failing_v.size} placeholder + #{still_failing_g.size} glossary still failing")
   end
 
-  WooAiTranslation::IosResources::Writer.write(output_path, units_for_write, locale)
-  verify_round_trip!(output_path, units_for_write, logger: logger, locale: locale)
+  # In incremental mode, splice the freshly-translated entries into the
+  # existing target file in place so the bot's `Translate: ...` commit
+  # touches only the keys that actually changed. Bootstrap mode (no
+  # existing target file, or first locale ever) still emits a full file.
+  if incremental && File.exist?(output_path)
+    fresh_names = (units_to_translate.map(&:name) - failed_missing).to_set
+    fresh_units = units_for_write.select { |u| fresh_names.include?(u.name) }
+    WooAiTranslation::IosResources::Writer.write_incremental(output_path, fresh_units, locale)
+    # Round-trip verifies the whole file is still parseable + complete.
+    verify_round_trip!(output_path, units_for_write, logger: logger, locale: locale)
+  else
+    WooAiTranslation::IosResources::Writer.write(output_path, units_for_write, locale)
+    verify_round_trip!(output_path, units_for_write, logger: logger, locale: locale)
+  end
   manifest&.save!
 
   logger.call("[#{locale}] wrote #{output_path} (#{translated} keys, " \

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -286,7 +286,14 @@ def merge_with_existing(en_units, target_path)
   en_units.each do |u|
     next unless (e = existing_by_name[u.name])
 
-    existing_val = e.entries.first[:value].to_s
+    # As in filter_missing_units, the parsed value sits in :source (the
+    # parser leaves :value nil — it's reserved for newly-applied API
+    # results). Without reading :source here, existing translations stay
+    # nil on the en_units after the merge, fail the writer's
+    # `fully_translated?` gate in ios_resources.rb, and the emitted file
+    # contains only the just-translated keys — dropping every other
+    # existing translation.
+    existing_val = e.entries.first[:source].to_s
     u.entries.first[:value] = existing_val unless existing_val.empty?
   end
   en_units

--- a/fastlane/ai_translation/bin/translate_locale.rb
+++ b/fastlane/ai_translation/bin/translate_locale.rb
@@ -161,7 +161,11 @@ def translate_file(input_path:, output_path:, translator:, locale:, model:, limi
 
   if units_to_translate.empty?
     logger.call("[#{locale}] nothing to translate; output left unchanged")
-    return [0, [], []]
+    # Tuple must stay in sync with the normal return at the bottom of this
+    # function: [translated, failed_missing, failed_validation, failed_glossary].
+    # Caller destructures four values; returning three leaves `glossary_errors`
+    # nil and crashes the InfoPlist follow-up at all_glossary_errors.concat.
+    return [0, [], [], []]
   end
 
   results = run_translation(translator, locale, units_to_translate, model)

--- a/fastlane/ai_translation/glossary/ar.yml
+++ b/fastlane/ai_translation/glossary/ar.yml
@@ -1,0 +1,7 @@
+# Arabic (ar) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ar.lproj/.
+# Note: RTL script; .right alignments need natural-alignment treatment (see swift-style.md).
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/bg.yml
+++ b/fastlane/ai_translation/glossary/bg.yml
@@ -1,0 +1,29 @@
+# Bulgarian (bg) — UI terminology mappings.
+# Register: informal mobile UI; "ти" form.
+
+ui_terms:
+  Cancel: Отказ
+  Save: Запази
+  Done: Готово
+  OK: OK
+  Close: Затвори
+  Edit: Редактирай
+  Delete: Изтрий
+  Refresh: Опресни
+  Retry: Опитай отново
+  Try Again: Опитай отново
+  Continue: Продължи
+  Loading: Зареждане
+
+nouns:
+  Orders: Поръчки
+  Products: Продукти
+  Payments: Плащания
+  Customers: Клиенти
+  Reviews: Отзиви
+  Cart: Количка
+  Address: Адрес
+  Shipping: Доставка
+  Refund: Възстановяване
+  Stock: Наличност
+  Coupons: Купони

--- a/fastlane/ai_translation/glossary/common.yml
+++ b/fastlane/ai_translation/glossary/common.yml
@@ -1,0 +1,81 @@
+# Brand and product names that MUST appear verbatim in every translation,
+# regardless of target locale. The validator treats any source string
+# containing one of these names as requiring the same name to appear,
+# untranslated, in the translation.
+#
+# Adding to this list is a hard constraint: translators (human or AI) cannot
+# transliterate or localize these terms. Remove only with stakeholder review.
+
+# Top-level brands
+brands:
+  - WooCommerce
+  - Woo
+  - WordPress
+  - WordPress.com
+  - Automattic
+  - Jetpack
+
+# Payment partners and product names
+payments:
+  - Stripe
+  - PayPal
+  - Apple Pay
+  - Tap to Pay
+  - Tap to Pay on iPhone
+  - Scan to Pay
+  - WooPayments
+
+# Marketing / feature names
+features:
+  - Blaze
+  - Spark
+  - Point of Sale
+  - POS
+
+# Hardware / network technologies (treated as proper nouns in UI)
+tech:
+  - Bluetooth
+  - Wi-Fi
+  - NFC
+  - HID
+
+# Apple ecosystem (always English in third-party app UI)
+apple:
+  - Apple ID
+  - iCloud
+  - iPhone
+  - iPad
+  - iOS
+  - Safari
+  - Mail
+  - Apple Maps
+
+# Other third-party services that appear verbatim
+external:
+  - Google
+  - X
+  - Yahoo Mail
+  - Microsoft Outlook
+  - DHL
+  - UPS
+  - USPS
+  - DudaMobile
+
+# Identifiers / standards — never translated
+standards:
+  - SKU
+  - URL
+  - URI
+  - PIN
+  - QR
+  - GTIN
+  - UPC
+  - EAN
+  - ISBN
+  - HTML
+  - SMS
+  - HAZMAT
+  - AES
+  - REST API
+  - WP-Admin
+  - Application Passwords

--- a/fastlane/ai_translation/glossary/cs.yml
+++ b/fastlane/ai_translation/glossary/cs.yml
@@ -1,0 +1,29 @@
+# Czech (cs) — UI terminology mappings.
+# Register: informal mobile UI; "ty" form.
+
+ui_terms:
+  Cancel: Zrušit
+  Save: Uložit
+  Done: Hotovo
+  OK: OK
+  Close: Zavřít
+  Edit: Upravit
+  Delete: Smazat
+  Refresh: Obnovit
+  Retry: Zkusit znovu
+  Try Again: Zkusit znovu
+  Continue: Pokračovat
+  Loading: Načítání
+
+nouns:
+  Orders: Objednávky
+  Products: Produkty
+  Payments: Platby
+  Customers: Zákazníci
+  Reviews: Recenze
+  Cart: Košík
+  Address: Adresa
+  Shipping: Doprava
+  Refund: Vrácení peněz
+  Stock: Sklad
+  Coupons: Kupóny

--- a/fastlane/ai_translation/glossary/da.yml
+++ b/fastlane/ai_translation/glossary/da.yml
@@ -1,0 +1,29 @@
+# Danish (da) — UI terminology mappings.
+# Register: informal mobile UI; "du" form.
+
+ui_terms:
+  Cancel: Annuller
+  Save: Gem
+  Done: Færdig
+  OK: OK
+  Close: Luk
+  Edit: Rediger
+  Delete: Slet
+  Refresh: Opdater
+  Retry: Prøv igen
+  Try Again: Prøv igen
+  Continue: Fortsæt
+  Loading: Indlæser
+
+nouns:
+  Orders: Ordrer
+  Products: Produkter
+  Payments: Betalinger
+  Customers: Kunder
+  Reviews: Anmeldelser
+  Cart: Kurv
+  Address: Adresse
+  Shipping: Forsendelse
+  Refund: Refusion
+  Stock: Lager
+  Coupons: Kuponer

--- a/fastlane/ai_translation/glossary/de.yml
+++ b/fastlane/ai_translation/glossary/de.yml
@@ -1,0 +1,7 @@
+# German (de) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/de.lproj/.
+# Brand-safety from common.yml applies until this is filled in.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/el.yml
+++ b/fastlane/ai_translation/glossary/el.yml
@@ -1,0 +1,29 @@
+# Greek (el) — UI terminology mappings.
+# Register: polite-neutral mobile UI.
+
+ui_terms:
+  Cancel: Ακύρωση
+  Save: Αποθήκευση
+  Done: Έγινε
+  OK: OK
+  Close: Κλείσιμο
+  Edit: Επεξεργασία
+  Delete: Διαγραφή
+  Refresh: Ανανέωση
+  Retry: Δοκιμή ξανά
+  Try Again: Δοκιμή ξανά
+  Continue: Συνέχεια
+  Loading: Φόρτωση
+
+nouns:
+  Orders: Παραγγελίες
+  Products: Προϊόντα
+  Payments: Πληρωμές
+  Customers: Πελάτες
+  Reviews: Κριτικές
+  Cart: Καλάθι
+  Address: Διεύθυνση
+  Shipping: Αποστολή
+  Refund: Επιστροφή χρημάτων
+  Stock: Απόθεμα
+  Coupons: Κουπόνια

--- a/fastlane/ai_translation/glossary/es.yml
+++ b/fastlane/ai_translation/glossary/es.yml
@@ -1,0 +1,6 @@
+# Spanish (es) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/es.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/fi.yml
+++ b/fastlane/ai_translation/glossary/fi.yml
@@ -1,0 +1,29 @@
+# Finnish (fi) — UI terminology mappings.
+# Register: neutral mobile UI; usually no explicit second-person pronoun.
+
+ui_terms:
+  Cancel: Peruuta
+  Save: Tallenna
+  Done: Valmis
+  OK: OK
+  Close: Sulje
+  Edit: Muokkaa
+  Delete: Poista
+  Refresh: Päivitä
+  Retry: Yritä uudelleen
+  Try Again: Yritä uudelleen
+  Continue: Jatka
+  Loading: Ladataan
+
+nouns:
+  Orders: Tilaukset
+  Products: Tuotteet
+  Payments: Maksut
+  Customers: Asiakkaat
+  Reviews: Arvostelut
+  Cart: Ostoskori
+  Address: Osoite
+  Shipping: Toimitus
+  Refund: Hyvitys
+  Stock: Varasto
+  Coupons: Kupongit

--- a/fastlane/ai_translation/glossary/fr.yml
+++ b/fastlane/ai_translation/glossary/fr.yml
@@ -1,0 +1,6 @@
+# French (fr) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/fr.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/he.yml
+++ b/fastlane/ai_translation/glossary/he.yml
@@ -1,0 +1,7 @@
+# Hebrew (he) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/he.lproj/.
+# Note: RTL script.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/hi.yml
+++ b/fastlane/ai_translation/glossary/hi.yml
@@ -1,0 +1,30 @@
+# Hindi (hi) — UI terminology mappings (Devanagari).
+# Register: light-formal mobile UI; "आप" form.
+# Numerals: Arabic (1, 2, 3) — NOT Devanagari numerals.
+
+ui_terms:
+  Cancel: रद्द करें
+  Save: सहेजें
+  Done: हो गया
+  OK: ठीक है
+  Close: बंद करें
+  Edit: संपादित करें
+  Delete: हटाएं
+  Refresh: रीफ्रेश करें
+  Retry: पुनः प्रयास करें
+  Try Again: पुनः प्रयास करें
+  Continue: जारी रखें
+  Loading: लोड हो रहा है
+
+nouns:
+  Orders: ऑर्डर
+  Products: उत्पाद
+  Payments: भुगतान
+  Customers: ग्राहक
+  Reviews: समीक्षाएं
+  Cart: कार्ट
+  Address: पता
+  Shipping: शिपिंग
+  Refund: रिफंड
+  Stock: स्टॉक
+  Coupons: कूपन

--- a/fastlane/ai_translation/glossary/hu.yml
+++ b/fastlane/ai_translation/glossary/hu.yml
@@ -1,0 +1,29 @@
+# Hungarian (hu) — UI terminology mappings.
+# Register: formal-neutral mobile UI; magázás avoided in favor of imperatives.
+
+ui_terms:
+  Cancel: Mégse
+  Save: Mentés
+  Done: Kész
+  OK: OK
+  Close: Bezárás
+  Edit: Szerkesztés
+  Delete: Törlés
+  Refresh: Frissítés
+  Retry: Újrapróbálkozás
+  Try Again: Próbáld újra
+  Continue: Folytatás
+  Loading: Betöltés
+
+nouns:
+  Orders: Rendelések
+  Products: Termékek
+  Payments: Fizetések
+  Customers: Vásárlók
+  Reviews: Vélemények
+  Cart: Kosár
+  Address: Cím
+  Shipping: Szállítás
+  Refund: Visszatérítés
+  Stock: Készlet
+  Coupons: Kuponok

--- a/fastlane/ai_translation/glossary/id.yml
+++ b/fastlane/ai_translation/glossary/id.yml
@@ -1,0 +1,7 @@
+# Indonesian (id) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/id.lproj/.
+# Note: Bahasa Indonesia — distinct from Malay (ms.yml).
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/it.yml
+++ b/fastlane/ai_translation/glossary/it.yml
@@ -1,0 +1,6 @@
+# Italian (it) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/it.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/ja.yml
+++ b/fastlane/ai_translation/glossary/ja.yml
@@ -1,0 +1,6 @@
+# Japanese (ja) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ja.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/ko.yml
+++ b/fastlane/ai_translation/glossary/ko.yml
@@ -1,0 +1,6 @@
+# Korean (ko) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ko.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/ms.yml
+++ b/fastlane/ai_translation/glossary/ms.yml
@@ -1,0 +1,30 @@
+# Malay (ms / Bahasa Malaysia) — UI terminology mappings.
+# Register: neutral; "anda" form.
+# Note: Bahasa Malaysia, NOT Bahasa Indonesia.
+
+ui_terms:
+  Cancel: Batal
+  Save: Simpan
+  Done: Selesai
+  OK: OK
+  Close: Tutup
+  Edit: Edit
+  Delete: Padam
+  Refresh: Muat semula
+  Retry: Cuba lagi
+  Try Again: Cuba lagi
+  Continue: Teruskan
+  Loading: Memuatkan
+
+nouns:
+  Orders: Pesanan
+  Products: Produk
+  Payments: Pembayaran
+  Customers: Pelanggan
+  Reviews: Ulasan
+  Cart: Troli
+  Address: Alamat
+  Shipping: Penghantaran
+  Refund: Bayaran Balik
+  Stock: Stok
+  Coupons: Kupon

--- a/fastlane/ai_translation/glossary/nb.yml
+++ b/fastlane/ai_translation/glossary/nb.yml
@@ -1,0 +1,29 @@
+# Norwegian Bokmål (nb) — UI terminology mappings.
+# Register: informal mobile UI; "du" form.
+
+ui_terms:
+  Cancel: Avbryt
+  Save: Lagre
+  Done: Ferdig
+  OK: OK
+  Close: Lukk
+  Edit: Rediger
+  Delete: Slett
+  Refresh: Oppdater
+  Retry: Prøv igjen
+  Try Again: Prøv igjen
+  Continue: Fortsett
+  Loading: Laster
+
+nouns:
+  Orders: Bestillinger
+  Products: Produkter
+  Payments: Betalinger
+  Customers: Kunder
+  Reviews: Anmeldelser
+  Cart: Handlekurv
+  Address: Adresse
+  Shipping: Frakt
+  Refund: Refusjon
+  Stock: Lager
+  Coupons: Kuponger

--- a/fastlane/ai_translation/glossary/nl.yml
+++ b/fastlane/ai_translation/glossary/nl.yml
@@ -1,0 +1,6 @@
+# Dutch (nl) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/nl.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/pl.yml
+++ b/fastlane/ai_translation/glossary/pl.yml
@@ -1,0 +1,32 @@
+# Polish (pl) — UI terminology mappings.
+# When the source string is exactly one of these keys (case-insensitive on
+# bare words, exact on phrases), the translation MUST use the mapped value.
+#
+# Register: informal mobile UI; "ty" form.
+
+ui_terms:
+  Cancel: Anuluj
+  Save: Zapisz
+  Done: Gotowe
+  OK: OK
+  Close: Zamknij
+  Edit: Edytuj
+  Delete: Usuń
+  Refresh: Odśwież
+  Retry: Spróbuj ponownie
+  Try Again: Spróbuj ponownie
+  Continue: Kontynuuj
+  Loading: Ładowanie
+
+nouns:
+  Orders: Zamówienia
+  Products: Produkty
+  Payments: Płatności
+  Customers: Klienci
+  Reviews: Recenzje
+  Cart: Koszyk
+  Address: Adres
+  Shipping: Wysyłka
+  Refund: Zwrot
+  Stock: Stan magazynowy
+  Coupons: Kupony

--- a/fastlane/ai_translation/glossary/pt-BR.yml
+++ b/fastlane/ai_translation/glossary/pt-BR.yml
@@ -1,0 +1,7 @@
+# Brazilian Portuguese (pt-BR) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/pt-BR.lproj/.
+# Note: NOT European Portuguese — distinct locale, see pt-PT.yml.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/pt-PT.yml
+++ b/fastlane/ai_translation/glossary/pt-PT.yml
@@ -1,0 +1,31 @@
+# European Portuguese (pt-PT) — UI terminology mappings.
+# Register: informal mobile UI; "tu" form.
+# Note: NOT Brazilian Portuguese. Use "ecrã" not "tela", "ficheiro" not
+# "arquivo", "telemóvel" not "celular", "encomenda" preferred for "order".
+
+ui_terms:
+  Cancel: Cancelar
+  Save: Guardar
+  Done: Concluído
+  OK: OK
+  Close: Fechar
+  Edit: Editar
+  Delete: Eliminar
+  Refresh: Atualizar
+  Retry: Tentar novamente
+  Try Again: Tentar novamente
+  Continue: Continuar
+  Loading: A carregar
+
+nouns:
+  Orders: Encomendas
+  Products: Produtos
+  Payments: Pagamentos
+  Customers: Clientes
+  Reviews: Avaliações
+  Cart: Carrinho
+  Address: Endereço
+  Shipping: Envio
+  Refund: Reembolso
+  Stock: Stock
+  Coupons: Cupões

--- a/fastlane/ai_translation/glossary/ro.yml
+++ b/fastlane/ai_translation/glossary/ro.yml
@@ -1,0 +1,29 @@
+# Romanian (ro) — UI terminology mappings.
+# Register: informal mobile UI; "tu" form.
+
+ui_terms:
+  Cancel: Anulează
+  Save: Salvează
+  Done: Gata
+  OK: OK
+  Close: Închide
+  Edit: Editează
+  Delete: Șterge
+  Refresh: Reîmprospătează
+  Retry: Încearcă din nou
+  Try Again: Încearcă din nou
+  Continue: Continuă
+  Loading: Se încarcă
+
+nouns:
+  Orders: Comenzi
+  Products: Produse
+  Payments: Plăți
+  Customers: Clienți
+  Reviews: Recenzii
+  Cart: Coș
+  Address: Adresă
+  Shipping: Livrare
+  Refund: Rambursare
+  Stock: Stoc
+  Coupons: Cupoane

--- a/fastlane/ai_translation/glossary/ru.yml
+++ b/fastlane/ai_translation/glossary/ru.yml
@@ -1,0 +1,6 @@
+# Russian (ru) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/ru.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/sv.yml
+++ b/fastlane/ai_translation/glossary/sv.yml
@@ -1,0 +1,6 @@
+# Swedish (sv) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/sv.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/th.yml
+++ b/fastlane/ai_translation/glossary/th.yml
@@ -1,0 +1,30 @@
+# Thai (th) — UI terminology mappings.
+# Register: neutral polite mobile UI. No ครับ/ค่ะ at end of UI strings.
+# Numerals: Arabic (1, 2, 3) — not Thai numerals.
+
+ui_terms:
+  Cancel: ยกเลิก
+  Save: บันทึก
+  Done: เสร็จสิ้น
+  OK: ตกลง
+  Close: ปิด
+  Edit: แก้ไข
+  Delete: ลบ
+  Refresh: รีเฟรช
+  Retry: ลองอีกครั้ง
+  Try Again: ลองอีกครั้ง
+  Continue: ดำเนินการต่อ
+  Loading: กำลังโหลด
+
+nouns:
+  Orders: คำสั่งซื้อ
+  Products: สินค้า
+  Payments: การชำระเงิน
+  Customers: ลูกค้า
+  Reviews: รีวิว
+  Cart: ตะกร้า
+  Address: ที่อยู่
+  Shipping: การจัดส่ง
+  Refund: การคืนเงิน
+  Stock: สต๊อก
+  Coupons: คูปอง

--- a/fastlane/ai_translation/glossary/tr.yml
+++ b/fastlane/ai_translation/glossary/tr.yml
@@ -1,0 +1,6 @@
+# Turkish (tr) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/tr.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/uk.yml
+++ b/fastlane/ai_translation/glossary/uk.yml
@@ -1,0 +1,29 @@
+# Ukrainian (uk) — UI terminology mappings.
+# Register: informal mobile UI; "ти" form.
+
+ui_terms:
+  Cancel: Скасувати
+  Save: Зберегти
+  Done: Готово
+  OK: OK
+  Close: Закрити
+  Edit: Редагувати
+  Delete: Видалити
+  Refresh: Оновити
+  Retry: Спробувати знову
+  Try Again: Спробуй ще раз
+  Continue: Продовжити
+  Loading: Завантаження
+
+nouns:
+  Orders: Замовлення
+  Products: Товари
+  Payments: Платежі
+  Customers: Клієнти
+  Reviews: Відгуки
+  Cart: Кошик
+  Address: Адреса
+  Shipping: Доставка
+  Refund: Повернення коштів
+  Stock: Запас
+  Coupons: Купони

--- a/fastlane/ai_translation/glossary/vi.yml
+++ b/fastlane/ai_translation/glossary/vi.yml
@@ -1,0 +1,29 @@
+# Vietnamese (vi) — UI terminology mappings.
+# Register: polite-neutral mobile UI.
+
+ui_terms:
+  Cancel: Hủy
+  Save: Lưu
+  Done: Xong
+  OK: OK
+  Close: Đóng
+  Edit: Chỉnh sửa
+  Delete: Xóa
+  Refresh: Làm mới
+  Retry: Thử lại
+  Try Again: Thử lại
+  Continue: Tiếp tục
+  Loading: Đang tải
+
+nouns:
+  Orders: Đơn hàng
+  Products: Sản phẩm
+  Payments: Thanh toán
+  Customers: Khách hàng
+  Reviews: Đánh giá
+  Cart: Giỏ hàng
+  Address: Địa chỉ
+  Shipping: Vận chuyển
+  Refund: Hoàn tiền
+  Stock: Tồn kho
+  Coupons: Phiếu giảm giá

--- a/fastlane/ai_translation/glossary/zh-Hans.yml
+++ b/fastlane/ai_translation/glossary/zh-Hans.yml
@@ -1,0 +1,6 @@
+# Simplified Chinese (zh-Hans) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/zh-Hans.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/glossary/zh-Hant.yml
+++ b/fastlane/ai_translation/glossary/zh-Hant.yml
@@ -1,0 +1,6 @@
+# Traditional Chinese (zh-Hant) — UI terminology mappings.
+# STUB: existing GlotPress locale, not yet auto-translated by this engine.
+# TODO: derive UI terms by scanning existing WooCommerce/Resources/zh-Hant.lproj/.
+
+ui_terms: {}
+nouns: {}

--- a/fastlane/ai_translation/lib/woo_ai_translation/anthropic_client.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/anthropic_client.rb
@@ -46,10 +46,16 @@ module WooAiTranslation
     def complete(model:, system_blocks:, user_content:, max_tokens: 8192)
       raise Error, 'ANTHROPIC_API_KEY is not set' unless available?
 
+      # Older Anthropic models accepted `temperature: 0` for strict
+      # determinism, but Haiku 4.5 / Opus 4.7 (our current default +
+      # escalation models) reject the parameter with HTTP 400. Rather
+      # than maintain a per-model allowlist, we omit it entirely and let
+      # the API pick its default. We get mild non-determinism in
+      # exchange; the manifest cache deduplicates across runs and the
+      # validator catches any meaningful drift on individual entries.
       body = {
         model: model,
         max_tokens: max_tokens,
-        temperature: 0,
         system: cacheable_system(system_blocks),
         messages: [{ role: 'user', content: user_content }]
       }

--- a/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
@@ -411,6 +411,59 @@ module WooAiTranslation
         FileUtils.mkdir_p(File.dirname(path))
         File.write(path, "#{header(locale)}#{body}")
       end
+
+      # Preserved-line writer for incremental PR-time runs. Reads the existing
+      # target file as text, replaces the value of each `"key" = "value";`
+      # entry whose key appears in `fresh_units` with the unit's new
+      # translation, and appends any genuinely-new keys (not present in the
+      # original file) at the end. Every other byte stays exactly as it was —
+      # comments, ordering, whitespace, the file header from PR #17220, etc.
+      #
+      # Why: the previous writer re-rendered the entire file from EN-derived
+      # units on every run, which propagated EN comment drift (curly-quote
+      # vs straight-quote, comment edits) into every target locale and
+      # produced 5000-line diffs on the bot's `Translate: ...` commit even
+      # when only ~7 keys changed. Aligning with the Android engine's
+      # "preserved-line writer" (see android #15972) keeps bot commits
+      # reviewable and decouples comment-sync from translation.
+      #
+      # Falls back to `#write` when the target file is missing (e.g. brand-new
+      # locale bootstrap mode).
+      def write_incremental(path, fresh_units, locale)
+        fresh_units = fresh_units.select(&:fully_translated?)
+        fresh_by_name = fresh_units.to_h { |u| [u.name, u] }
+        return write(path, fresh_units, locale) unless File.exist?(path) && !fresh_by_name.empty?
+
+        content = File.binread(path).force_encoding(Encoding::UTF_8)
+        replaced = []
+
+        # Capture `"key" = "value";` (or unquoted-key form) with the equals
+        # punctuation and trailing semicolon preserved verbatim. Only the
+        # value content (inside the second pair of quotes) is rewritten.
+        pattern = /^(?<key>"(?:\\.|[^"\\])*"|[A-Za-z0-9_.\-]+)(?<eq>[\t ]*=[\t ]*)"(?<val>(?:\\.|[^"\\])*)"(?<tail>[\t ]*;)/
+        new_content = content.gsub(pattern) do
+          md = ::Regexp.last_match
+          raw_key = md[:key]
+          decoded_key = raw_key.start_with?('"') ? unescape(raw_key[1..-2]) : raw_key
+          if (u = fresh_by_name[decoded_key])
+            replaced << decoded_key
+            new_value = escape(u.entries.first[:value])
+            %(#{raw_key}#{md[:eq]}"#{new_value}"#{md[:tail]})
+          else
+            md[0]
+          end
+        end
+
+        # Append any fresh entries that weren't present in the original file.
+        appended_keys = fresh_by_name.keys - replaced
+        unless appended_keys.empty?
+          appended = appended_keys.map { |k| render_unit(fresh_by_name[k]) }.join("\n")
+          sep = new_content.end_with?("\n\n") ? '' : (new_content.end_with?("\n") ? "\n" : "\n\n")
+          new_content = "#{new_content}#{sep}#{appended}"
+        end
+
+        File.write(path, new_content)
+      end
     end
   end
 end

--- a/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
@@ -2,6 +2,7 @@
 
 require 'digest'
 require 'fileutils'
+require 'tmpdir'
 
 module WooAiTranslation
   # Order-preserving reader/writer for iOS `Localizable.strings` resources.
@@ -113,11 +114,47 @@ module WooAiTranslation
 
       ParseError = Class.new(StandardError)
 
+      # In-process memoization keyed by content digest. Survives within a
+      # single process; identical-content files (e.g. en.lproj re-parsed
+      # by filter and round-trip) share one parsed Document.
+      CACHE = {}
+
       # Read a `.strings` file, transparently decoding UTF-16 (BE/LE) if the
       # source still uses Apple's legacy encoding. Modern Xcode emits UTF-8.
+      #
+      # The parser is O(n²) on large files (known limitation noted in
+      # MIGRATIONS / README); on a 1MB en.lproj this is ~40s. We aggressively
+      # cache to avoid paying that cost repeatedly:
+      #   - In-process: same content within one process => one parse.
+      #   - On-disk: cross-process Marshal cache at /tmp/wai_parse_<sha>.bin.
+      #     The CI run spawns 15 translate_locale.rb processes that each see
+      #     the same en.lproj; without the disk cache they'd each pay ~40s.
+      # Cache key is sha256(file content), so any edit invalidates cleanly
+      # without mtime games. The disk cache is best-effort: a load/save
+      # failure (corrupt file, /tmp full, etc.) falls through to re-parse
+      # rather than aborting.
       def parse_file(path)
         bytes = File.binread(path)
-        parse(decode(bytes), source_path: path)
+        key = Digest::SHA256.hexdigest(bytes)
+        CACHE[key] ||= load_cached_or_parse(path, bytes, key)
+      end
+
+      def load_cached_or_parse(path, bytes, key)
+        disk = File.join(Dir.tmpdir, "wai_parse_#{key[0, 16]}.bin")
+        if File.exist?(disk)
+          begin
+            return Marshal.load(File.binread(disk))
+          rescue StandardError
+            # corrupt cache — fall through to re-parse + rewrite
+          end
+        end
+        doc = parse(decode(bytes), source_path: path)
+        begin
+          File.binwrite(disk, Marshal.dump(doc))
+        rescue StandardError
+          # disk full / read-only fs / etc. — caching is best-effort
+        end
+        doc
       end
 
       def parse(text, source_path: '<string>')

--- a/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
@@ -158,8 +158,20 @@ module WooAiTranslation
       end
 
       def parse(text, source_path: '<string>')
+        # Force byte-level indexing. Ruby String#[] is O(n) on UTF-8 (it has
+        # to scan from the start to find the n-th character), so the original
+        # parse-by-character loop was effectively O(n²) on a 1MB .strings
+        # file (~40s for en.lproj). With ASCII_8BIT the same loop is O(1) per
+        # access, taking ~1s.
+        #
+        # All branch conditions compare against ASCII literals ('/', '"',
+        # '\\', '=', ';') which are single-byte and match identically under
+        # ASCII_8BIT. UTF-8 multi-byte sequences inside string literals are
+        # appended byte-by-byte to the output buffer, producing valid UTF-8
+        # by construction; we re-tag the final strings as UTF-8 below.
+        text = text.dup.force_encoding(Encoding::ASCII_8BIT) if text.encoding != Encoding::ASCII_8BIT
         pos = 0
-        len = text.length
+        len = text.bytesize
         units = []
         last_comment = ''
 
@@ -198,6 +210,23 @@ module WooAiTranslation
           end
 
           raise ParseError, error_at(text, pos, source_path, "unexpected character #{text[pos].inspect}")
+        end
+
+        # Re-tag everything the parser collected from byte-level reads back to
+        # UTF-8 so downstream code (Hash keys, comparisons, regex) sees the
+        # canonical encoding. The bytes are already valid UTF-8 because the
+        # input started as UTF-8 and we only sliced/copied through it.
+        units.each do |u|
+          u.comment = u.comment.dup.force_encoding(Encoding::UTF_8) if u.comment
+          # Rebuild attributes Hash with UTF-8 keys/values (currently empty
+          # for .strings but cheap to handle).
+          u.entries = u.entries.map do |e|
+            {
+              id: e[:id]&.dup&.force_encoding(Encoding::UTF_8),
+              source: e[:source]&.dup&.force_encoding(Encoding::UTF_8),
+              value: e[:value]
+            }
+          end
         end
 
         Document.new(units)

--- a/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
@@ -78,6 +78,19 @@ module WooAiTranslation
         copy.entries = @entries.map { |e| e.dup.tap { |x| x[:value] = nil } }
         copy
       end
+
+      # Same content, fresh containers. Used by Parser.parse_file to return an
+      # independent Document tree to each caller so mutations from one locale
+      # (e.g. apply_results setting entry[:value]) don't leak into the cached
+      # Document that the next locale receives. The string fields (name, id,
+      # source) are shared with the original — they're never mutated, only
+      # the entry Hash itself ever gets `e[:value] = ...` written to it, so
+      # dup'ing each Hash is enough to isolate writers.
+      def deep_clone
+        copy = Unit.new(type: @type, name: @name, attributes: @attributes, comment: @comment)
+        copy.entries = @entries.map(&:dup)
+        copy
+      end
     end
 
     # Parsed document; keeps every unit in source order.
@@ -86,6 +99,14 @@ module WooAiTranslation
 
       def initialize(units)
         @units = units
+      end
+
+      # Independent copy with the same source/key content but fresh entry
+      # Hashes per Unit. Lets parse_file hand each caller a tree it can
+      # safely mutate (apply_results assigns to entry[:value]) without
+      # affecting either the cached document or other concurrent callers.
+      def deep_clone
+        Document.new(@units.map(&:deep_clone))
       end
 
       def translatable_units
@@ -137,6 +158,14 @@ module WooAiTranslation
         bytes = File.binread(path)
         key = Digest::SHA256.hexdigest(bytes)
         CACHE[key] ||= load_cached_or_parse(path, bytes, key)
+        # Return an independent tree so the caller can mutate entry[:value]
+        # (via apply_results / merge_with_existing) without those mutations
+        # bleeding into the next caller. Before this clone, a single-process
+        # multi-locale run had locale N+1 inheriting locale N's translations
+        # in the cached Document — reproducible cross-locale leak. Cloning
+        # is O(units) and cheap (~5ms on en.lproj's 5141 entries); the parse
+        # itself is what we wanted to avoid amortizing.
+        CACHE[key].deep_clone
       end
 
       def load_cached_or_parse(path, bytes, key)
@@ -458,9 +487,33 @@ module WooAiTranslation
       def write_incremental(path, fresh_units, locale)
         fresh_units = fresh_units.select(&:fully_translated?)
         fresh_by_name = fresh_units.to_h { |u| [u.name, u] }
-        return write(path, fresh_units, locale) unless File.exist?(path) && !fresh_by_name.empty?
+
+        # No fresh translations + a real target file = nothing to do. Don't
+        # fall through to `#write` here: that would rebuild the file from
+        # only `fresh_units` (an empty list), producing a header-plus-nothing
+        # file and clobbering every existing translation. Reachable when
+        # every requested key comes back missing after split-retry (every
+        # name lands in failed_missing, fresh_names ends up empty in
+        # translate_locale.rb).
+        return if fresh_by_name.empty? && File.exist?(path)
+        return write(path, fresh_units, locale) unless File.exist?(path)
 
         content = File.binread(path).force_encoding(Encoding::UTF_8)
+        # Skip regex matches that fall inside `/* ... */` comment blocks.
+        # The line-anchored pattern below would otherwise match against
+        # `"example.key" = "value";` example syntax embedded in a comment
+        # and rewrite the comment text (or, worse, "consume" a fresh-units
+        # key as already-handled if it only appears inside a comment).
+        comment_ranges = []
+        scan_pos = 0
+        while (start = content.index('/*', scan_pos))
+          finish = content.index('*/', start + 2)
+          break unless finish
+          comment_ranges << (start..(finish + 1))
+          scan_pos = finish + 2
+        end
+        in_comment = ->(offset) { comment_ranges.any? { |r| r.include?(offset) } }
+
         replaced = []
 
         # Capture `"key" = "value";` (or unquoted-key form) with the equals
@@ -469,6 +522,8 @@ module WooAiTranslation
         pattern = /^(?<key>"(?:\\.|[^"\\])*"|[A-Za-z0-9_.\-]+)(?<eq>[\t ]*=[\t ]*)"(?<val>(?:\\.|[^"\\])*)"(?<tail>[\t ]*;)/
         new_content = content.gsub(pattern) do
           md = ::Regexp.last_match
+          next md[0] if in_comment.call(md.begin(0))
+
           raw_key = md[:key]
           decoded_key = raw_key.start_with?('"') ? unescape(raw_key[1..-2]) : raw_key
           if (u = fresh_by_name[decoded_key])

--- a/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
@@ -234,8 +234,19 @@ module WooAiTranslation
         # string read off disk — that bug ate build #37965, where every
         # non-ASCII key (e.g. `"%1$@ · %2$@"`) failed verify_round_trip!.
         units.each do |u|
-          u.comment&.force_encoding(Encoding::UTF_8)
+          # The comment may be the frozen `last_comment = ''` literal when a
+          # unit had no preceding /* */ — force_encoding mutates in place,
+          # which raises FrozenError under `frozen_string_literal: true`. Dup
+          # to get a mutable receiver. Spec failure caught this on PR head
+          # 82f37ec3b0: 14 errors in ios_resources_test.rb, all originating
+          # at the comment-retag line for keys without a comment.
+          u.comment = u.comment.dup.force_encoding(Encoding::UTF_8) if u.comment
           u.entries.each do |e|
+            # No dup here: u.name and entries.first[:id] are the same String
+            # object (Unit.new received `key` for both), so an in-place
+            # force_encoding flips them both. The values returned from
+            # read_quoted_string / read_unquoted_identifier are always
+            # mutable (+'' inside the parser), so no frozen-string risk.
             e[:id]&.force_encoding(Encoding::UTF_8)
             e[:source]&.force_encoding(Encoding::UTF_8)
             # :value is nil immediately after parse; populated later by

--- a/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ios_resources.rb
@@ -140,7 +140,12 @@ module WooAiTranslation
       end
 
       def load_cached_or_parse(path, bytes, key)
-        disk = File.join(Dir.tmpdir, "wai_parse_#{key[0, 16]}.bin")
+        # The version prefix lets us invalidate previously-cached Marshal
+        # blobs whenever the schema of the parsed Document changes (e.g.
+        # the encoding-retag fix that flipped u.name from ASCII_8BIT to
+        # UTF-8 — a v1 blob would deserialize with a binary-tagged name
+        # and silently break verify_round_trip!). Bump on any schema change.
+        disk = File.join(Dir.tmpdir, "wai_parse_v2_#{key[0, 16]}.bin")
         if File.exist?(disk)
           begin
             return Marshal.load(File.binread(disk))
@@ -216,16 +221,26 @@ module WooAiTranslation
         # UTF-8 so downstream code (Hash keys, comparisons, regex) sees the
         # canonical encoding. The bytes are already valid UTF-8 because the
         # input started as UTF-8 and we only sliced/copied through it.
+        #
+        # CRITICAL: use force_encoding in-place, NOT `.dup.force_encoding`.
+        # In the parse loop above we built `Unit.new(name: key, ...)` and
+        # `unit.entries = [{ id: key, ... }]` — so `u.name` and
+        # `u.entries.first[:id]` are the *same* String object (sharing
+        # identity, not just content). force_encoding flips the encoding
+        # tag of the receiver, so tagging e[:id] also tags u.name. A
+        # `.dup` would create a new string for e[:id] and leave u.name
+        # stuck on ASCII_8BIT, which silently breaks any set membership /
+        # hash comparison that compares u.name (binary) against a UTF-8
+        # string read off disk — that bug ate build #37965, where every
+        # non-ASCII key (e.g. `"%1$@ · %2$@"`) failed verify_round_trip!.
         units.each do |u|
-          u.comment = u.comment.dup.force_encoding(Encoding::UTF_8) if u.comment
-          # Rebuild attributes Hash with UTF-8 keys/values (currently empty
-          # for .strings but cheap to handle).
-          u.entries = u.entries.map do |e|
-            {
-              id: e[:id]&.dup&.force_encoding(Encoding::UTF_8),
-              source: e[:source]&.dup&.force_encoding(Encoding::UTF_8),
-              value: e[:value]
-            }
+          u.comment&.force_encoding(Encoding::UTF_8)
+          u.entries.each do |e|
+            e[:id]&.force_encoding(Encoding::UTF_8)
+            e[:source]&.force_encoding(Encoding::UTF_8)
+            # :value is nil immediately after parse; populated later by
+            # apply_results or merge_with_existing using already-UTF-8
+            # strings.
           end
         end
 

--- a/fastlane/ai_translation/lib/woo_ai_translation/translator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/translator.rb
@@ -37,10 +37,17 @@ module WooAiTranslation
       its translated string. No prose, no code fences.
     RULES
 
-    def initialize(client:, batch_size: DEFAULT_BATCH, logger: nil)
+    def initialize(client:, batch_size: DEFAULT_BATCH, logger: nil, brand_terms: nil)
       @client = client
       @batch_size = batch_size
       @logger = logger
+      # Locale-agnostic terms that must appear verbatim in every translation
+      # (sourced from glossary/common.yml in the caller). Listing them in the
+      # system prompt keeps the model on-rails BEFORE the validator catches a
+      # violation post-hoc — otherwise we waste an Opus escalation and still
+      # end up with a glossary_violations failure (e.g. Bulgarian translating
+      # "SKU" to "Артикулен №").
+      @brand_terms = Array(brand_terms).compact.uniq
     end
 
     # items: [{ id:, source:, context: }] ; returns { id => translation }.
@@ -81,9 +88,32 @@ module WooAiTranslation
     end
 
     def system_blocks(locale, style)
-      # First block: constant rules. Last block: per-locale style guide. The
-      # client cache-flags the last block so the whole prefix is prompt-cached.
-      [SYSTEM_RULES, "Target locale: #{locale}.\n#{style || default_style(locale)}"]
+      # Block order:
+      #   1. SYSTEM_RULES — constant rules (placeholders, HTML, escapes, tone).
+      #   2. Brand-safety list — verbatim terms, when provided by the caller.
+      #      Lifts the validator's hard constraint into the prompt so the model
+      #      doesn't have to be corrected post-hoc.
+      #   3. Per-locale style guide.
+      # The client cache-flags the LAST block, so we put the per-locale block
+      # at the end and the constants earlier.
+      blocks = [SYSTEM_RULES]
+      blocks << brand_safety_block unless @brand_terms.empty?
+      blocks << "Target locale: #{locale}.\n#{style || default_style(locale)}"
+      blocks
+    end
+
+    def brand_safety_block
+      list = @brand_terms.map { |t| "- #{t}" }.join("\n")
+      <<~TXT.strip
+        Brand-safety terms — non-negotiable:
+        Every name in this list MUST appear in the translation EXACTLY as in
+        the source, with no transliteration, translation, or localization.
+        If a name appears in the source string, the same characters MUST
+        appear in the translation. This includes acronyms and short labels
+        even when a natural-language equivalent exists in the target locale.
+
+        #{list}
+      TXT
     end
 
     def default_style(locale)

--- a/fastlane/ai_translation/lib/woo_ai_translation/validator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/validator.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module WooAiTranslation
+  # Translation validator. Loads glossary YAMLs and applies two hard rules
+  # per translated entry:
+  #
+  #   1. Brand-safety: every brand name from `glossary/common.yml` that
+  #      appears in the source MUST appear unchanged in the translation.
+  #
+  #   2. Glossary lookup: if the source text equals a key in the per-locale
+  #      glossary's `ui_terms` or `nouns` section, the translation MUST
+  #      equal the mapped value.
+  #
+  # Returns a list of violation hashes; an empty list means the translation
+  # is acceptable. Callers (the translator pipeline) decide whether to retry
+  # or reject the entry.
+  #
+  # The validator never mutates the translation. It only reports.
+  class Validator
+    GlossaryPaths = Struct.new(:common, :locale, keyword_init: true)
+
+    class << self
+      # Load brand list + a single locale's glossary.
+      # base_dir is the directory containing `common.yml` and `<locale>.yml`.
+      def for_locale(locale:, base_dir:)
+        common_path = File.join(base_dir, 'common.yml')
+        locale_path = File.join(base_dir, "#{locale}.yml")
+        new(
+          locale: locale,
+          common: load_yaml(common_path),
+          locale_glossary: load_yaml(locale_path)
+        )
+      end
+
+      def load_yaml(path)
+        return {} unless File.exist?(path)
+
+        YAML.safe_load_file(path) || {}
+      end
+    end
+
+    attr_reader :locale, :brands, :terms
+
+    def initialize(locale:, common:, locale_glossary:)
+      @locale = locale
+      @brands = collect_brands(common)
+      @terms = collect_terms(locale_glossary)
+    end
+
+    # Validate one (source, translation) pair.
+    # Returns an array of violation hashes; empty array means OK.
+    #
+    # A violation hash has:
+    #   - :rule (:brand_safety | :glossary)
+    #   - :term (the offending term)
+    #   - :expected (the expected translation, for glossary rule)
+    def validate(source:, translation:)
+      violations = []
+      violations.concat(brand_violations(source, translation))
+      violations.concat(glossary_violations(source, translation))
+      violations
+    end
+
+    private
+
+    def collect_brands(common)
+      vals = []
+      (common || {}).each_value { |list| vals.concat(Array(list)) }
+      vals.compact.map(&:to_s).uniq
+    end
+
+    def collect_terms(glossary)
+      h = {}
+      %w[ui_terms nouns].each do |section|
+        (glossary[section] || {}).each { |k, v| h[k.to_s] = v.to_s }
+      end
+      h
+    end
+
+    # Brand-safety check with "longest match wins": when WooCommerce appears
+    # in the source, we don't also flag Woo (which is a substring of it).
+    # We sort brands by length descending and mask each found occurrence so
+    # subsequent (shorter) brand checks don't double-count it.
+    def brand_violations(source, translation)
+      src = source.to_s.dup
+      tx = translation.to_s
+      sorted = @brands.sort_by { |b| -b.length }
+
+      violations = []
+      sorted.each do |brand|
+        next unless src.include?(brand)
+
+        # Mask this brand in the working copy so shorter brands that are
+        # substrings won't trigger.
+        src.gsub!(brand, "\u0001" * brand.length)
+        next if tx.include?(brand)
+
+        violations << { rule: :brand_safety, term: brand, expected: brand }
+      end
+      violations
+    end
+
+    # The glossary rule fires only when the source EQUALS a glossary key
+    # (case-insensitive, trimmed). This is intentionally narrow: short UI
+    # labels like "Cancel" or "Orders" should always map to the canonical
+    # term, but free-form sentences that happen to contain "orders" as a
+    # substring are not constrained.
+    def glossary_violations(source, translation)
+      key = source.to_s.strip
+      lookup = @terms.find { |term, _| term.downcase == key.downcase }
+      return [] unless lookup
+
+      expected = lookup.last
+      return [] if translation.to_s.strip == expected
+
+      [{ rule: :glossary, term: lookup.first, expected: expected }]
+    end
+  end
+end

--- a/fastlane/ai_translation/spec/validator_test.rb
+++ b/fastlane/ai_translation/spec/validator_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require_relative '../lib/woo_ai_translation/validator'
+
+class ValidatorTest < Minitest::Test
+  def setup
+    @dir = Dir.mktmpdir
+    File.write(File.join(@dir, 'common.yml'), <<~YAML)
+      brands:
+        - WooCommerce
+        - Woo
+      payments:
+        - Stripe
+        - Apple Pay
+    YAML
+    File.write(File.join(@dir, 'pl.yml'), <<~YAML)
+      ui_terms:
+        Cancel: Anuluj
+        Save: Zapisz
+      nouns:
+        Orders: Zamówienia
+    YAML
+    @v = WooAiTranslation::Validator.for_locale(locale: 'pl', base_dir: @dir)
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir) if @dir && File.exist?(@dir)
+  end
+
+  def test_brand_safety_passes_when_brand_preserved
+    out = @v.validate(source: 'Connect WooCommerce', translation: 'Połącz WooCommerce')
+    assert_empty out
+  end
+
+  def test_brand_safety_fails_when_brand_translated_or_dropped
+    out = @v.validate(source: 'Connect WooCommerce', translation: 'Połącz sklep')
+    assert_equal 1, out.size
+    assert_equal :brand_safety, out.first[:rule]
+    assert_equal 'WooCommerce', out.first[:term]
+  end
+
+  def test_brand_safety_catches_multi_word_brand
+    out = @v.validate(source: 'Configure Apple Pay', translation: 'Skonfiguruj Płatność Apple')
+    assert_equal 1, out.size
+    assert_equal 'Apple Pay', out.first[:term]
+  end
+
+  def test_glossary_enforces_canonical_term_when_source_equals_key
+    out = @v.validate(source: 'Cancel', translation: 'Wstecz')
+    assert_equal 1, out.size
+    assert_equal :glossary, out.first[:rule]
+    assert_equal 'Cancel', out.first[:term]
+    assert_equal 'Anuluj', out.first[:expected]
+  end
+
+  def test_glossary_accepts_canonical_translation
+    out = @v.validate(source: 'Cancel', translation: 'Anuluj')
+    assert_empty out
+  end
+
+  def test_glossary_case_insensitive_key_match
+    out = @v.validate(source: 'cancel', translation: 'Anuluj')
+    assert_empty out
+  end
+
+  def test_glossary_only_enforces_on_exact_source_match
+    # "Cancel order" contains "Cancel" but is not the glossary key — no enforcement
+    out = @v.validate(source: 'Cancel order', translation: 'Anuluj zamówienie')
+    assert_empty out
+  end
+
+  def test_glossary_picks_up_nouns_section
+    out = @v.validate(source: 'Orders', translation: 'Zamowienia') # missing diacritic
+    assert_equal 1, out.size
+    assert_equal 'Orders', out.first[:term]
+    assert_equal 'Zamówienia', out.first[:expected]
+  end
+
+  def test_multiple_brand_violations_reported
+    out = @v.validate(source: 'WooCommerce + Stripe + Apple Pay', translation: 'Sklep + Pasek + Płatność')
+    assert_equal 3, out.size
+    rules = out.map { |v| v[:rule] }.uniq
+    assert_equal [:brand_safety], rules
+  end
+
+  def test_missing_glossary_file_falls_back_to_brands_only
+    v = WooAiTranslation::Validator.for_locale(locale: 'xx', base_dir: @dir)
+    assert_empty v.validate(source: 'Cancel', translation: 'whatever')
+    out = v.validate(source: 'WooCommerce', translation: 'sklep')
+    assert_equal 1, out.size
+    assert_equal :brand_safety, out.first[:rule]
+  end
+
+  def test_brands_list_collected_across_yaml_sections
+    assert_includes @v.brands, 'WooCommerce'
+    assert_includes @v.brands, 'Stripe'
+    assert_includes @v.brands, 'Apple Pay'
+  end
+
+  def test_terms_collected_from_ui_terms_and_nouns
+    assert_equal 'Anuluj', @v.terms['Cancel']
+    assert_equal 'Zamówienia', @v.terms['Orders']
+  end
+end

--- a/fastlane/ai_translation/style/bg.md
+++ b/fastlane/ai_translation/style/bg.md
@@ -1,0 +1,13 @@
+# Bulgarian (bg) — Translation style guide
+
+**Register:** Informal mobile UI. "Ти" form / 2nd person singular informal.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, direct.
+
+**Common pitfalls:**
+- Cyrillic script — never transliterate
+- Definite article is a suffix (-та, -ът, -то); don't add separate "the"
+- "Order" → "Поръчка"; verb "поръчвам"

--- a/fastlane/ai_translation/style/cs.md
+++ b/fastlane/ai_translation/style/cs.md
@@ -1,0 +1,13 @@
+# Czech (cs) — Translation style guide
+
+**Register:** Informal mobile UI. "Ty" form / 2nd person singular informal.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, direct, brief.
+
+**Common pitfalls:**
+- "Order" → "Objednávka"; verbal forms "objednat" (place an order)
+- "Refund" → "Vrácení peněz" (not "Refundace")
+- Diacritics matter — never strip them

--- a/fastlane/ai_translation/style/da.md
+++ b/fastlane/ai_translation/style/da.md
@@ -1,0 +1,13 @@
+# Danish (da) — Translation style guide
+
+**Register:** Informal mobile UI. "Du" form / 2nd person singular informal.
+**Quotation marks:** "..." or »...«
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, casual, short.
+
+**Common pitfalls:**
+- "Order" → "Ordre" (mobile UI) or "Bestilling" (older convention); prefer "Ordre" for consistency
+- æ/ø/å must be preserved (UTF-8 multi-byte)
+- "San Marino" stays English (the country name itself)

--- a/fastlane/ai_translation/style/default.md
+++ b/fastlane/ai_translation/style/default.md
@@ -1,0 +1,17 @@
+# Default style guide
+
+Fallback when no per-locale style guide is provided.
+
+**Tone:** Concise, friendly, action-oriented. Match the tone of modern mobile commerce apps.
+
+**Register:** Use whichever 2nd-person register is conventional for the target locale's mobile-app ecosystem. Avoid formal honorifics unless required (e.g., legal disclaimers).
+
+**Numerals:** Arabic digits (1, 2, 3). Do not localize to script-specific numeral systems (e.g., Devanagari १२३, Thai ๑๒๓) — the app's number formatting expects Arabic input.
+
+**Brands:** Keep all brand names verbatim — see `glossary/common.yml`.
+
+**Placeholders:** Preserve every `%@`, `%1$@`, `%d`, `%.0f`, `\n`, `\t`, etc. exactly. Never reorder positional placeholders.
+
+**Markup:** Preserve HTML tags (`<b>`, `<a href="...">`, `</a>`) and their attributes. Translate only the visible text inside them.
+
+**Length:** Aim for translations close to the source length. Mobile UI has limited space.

--- a/fastlane/ai_translation/style/el.md
+++ b/fastlane/ai_translation/style/el.md
@@ -1,0 +1,13 @@
+# Greek (el) — Translation style guide
+
+**Register:** Polite-neutral mobile UI. Mostly impersonal or 2nd person plural where address is needed.
+**Quotation marks:** «...» (guillemets)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Direct, modern, concise.
+
+**Common pitfalls:**
+- Distinguish "Customer" (Πελάτης) and "User" (Χρήστης)
+- "Refresh" → "Ανανέωση" (always, not "Φόρτωση")
+- Use polytonic only where standard requires; UI is monotonic Greek

--- a/fastlane/ai_translation/style/fi.md
+++ b/fastlane/ai_translation/style/fi.md
@@ -1,0 +1,13 @@
+# Finnish (fi) — Translation style guide
+
+**Register:** Neutral mobile UI. Usually no explicit second-person pronoun ("Sinä" only when emphasizing).
+**Quotation marks:** "..." (curly) or »...«
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1,99)
+
+**Tone:** Direct, concise. Finnish is often briefer than English.
+
+**Common pitfalls:**
+- Compound nouns (tilauksenseuranta = order tracking) — write as one word
+- Case suffixes change frequently; don't hand-stitch placeholders into inflected words without an explanatory context
+- "Refresh" → "Päivitä" (not "Lataa uudelleen")

--- a/fastlane/ai_translation/style/hi.md
+++ b/fastlane/ai_translation/style/hi.md
@@ -1,0 +1,16 @@
+# Hindi (hi) — Translation style guide
+
+**Register:** Light-formal mobile UI. "आप" form / formal you (avoid "तुम").
+**Script:** Devanagari (देवनागरी)
+**Quotation marks:** "..." (English-style)
+**Numerals:** Arabic (1, 2, 3) — NOT Devanagari numerals (१२३). The app's numeric formatting expects Arabic.
+**Decimals:** period (.)
+
+**Tone:** Direct, modern, action-oriented. Avoid heavy Sanskrit-derived vocabulary; prefer commonly-spoken Hindi.
+
+**Common pitfalls:**
+- DON'T use Hindi numerals (१२३) — they look "wrong" in mixed-numeral UI contexts
+- Brand names stay English: never transliterate "WooCommerce" to "वूकॉमर्स"
+- "Order" → "ऑर्डर" (transliteration is standard, "आदेश" sounds archaic)
+- Avoid गणक-style hyper-formal Sanskrit — keep it casual professional
+- सहायता (help) vs मदद (informal help) — use मदद for buttons

--- a/fastlane/ai_translation/style/hu.md
+++ b/fastlane/ai_translation/style/hu.md
@@ -1,0 +1,13 @@
+# Hungarian (hu) — Translation style guide
+
+**Register:** Formal-neutral mobile UI. Magázás (formal you) avoided; prefer imperatives or impersonal phrasing.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Direct, no contractions, action-focused.
+
+**Common pitfalls:**
+- "Order" → "Rendelés" (NOT "Megrendelés" except in formal contexts)
+- Capitalize only first letter of sentence, not every word
+- Avoid the English-style "Click here" — use "Tap here" → "Koppints ide" if needed

--- a/fastlane/ai_translation/style/ms.md
+++ b/fastlane/ai_translation/style/ms.md
@@ -1,0 +1,19 @@
+# Malay (ms / Bahasa Malaysia) — Translation style guide
+
+**Register:** Neutral mobile UI. "Anda" form.
+**Quotation marks:** "..." (English-style)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** period (.)
+
+**Tone:** Direct, modern, brief.
+
+**Common pitfalls:**
+- This is **Bahasa Malaysia**, NOT Bahasa Indonesia. Diverge intentionally:
+  - "kedai" (Malay) not "toko" (Indonesian)
+  - "pesanan" (Malay) not "pesan" (Indonesian as noun)
+  - "kemas kini" (Malay) not "perbarui" (Indonesian)
+  - "pemalam" not "plugin"
+  - "pemberitahuan tolak" for push notifications
+  - "kebenaran" not "izin" for permission
+- Plurals: don't inflect — "1 minggu" and "2 minggu" both use "minggu"
+- Verb stem changes: "membayar" (to pay) vs "bayaran" (payment, noun)

--- a/fastlane/ai_translation/style/nb.md
+++ b/fastlane/ai_translation/style/nb.md
@@ -1,0 +1,13 @@
+# Norwegian Bokmål (nb) — Translation style guide
+
+**Register:** Informal mobile UI. "Du" form / 2nd person singular informal.
+**Quotation marks:** "..." or «...»
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, casual.
+
+**Common pitfalls:**
+- "Order" → "Bestilling" (preferred over "Ordre" in Norwegian iOS apps)
+- æ/ø/å must be preserved
+- This is Bokmål, NOT Nynorsk; if there's any doubt, use Bokmål forms

--- a/fastlane/ai_translation/style/pl.md
+++ b/fastlane/ai_translation/style/pl.md
@@ -1,0 +1,13 @@
+# Polish (pl) — Translation style guide
+
+**Register:** Informal mobile UI. Direct address using imperatives or "ty" form.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1,99)
+
+**Tone:** Concise, friendly, action-oriented. Avoid formal "Pan/Pani" except where clearly business-customer (e.g., legal disclaimers).
+
+**Common pitfalls:**
+- "Order" → "Zamówienie" (NOT "Polecenie")
+- "Cart" → "Koszyk" (always)
+- Gender agreement matters: match adjectives to noun gender

--- a/fastlane/ai_translation/style/pt-PT.md
+++ b/fastlane/ai_translation/style/pt-PT.md
@@ -1,0 +1,27 @@
+# European Portuguese (pt-PT) — Translation style guide
+
+**Register:** Informal mobile UI. "Tu" form / 2nd person singular informal.
+**Quotation marks:** "..." or «...»
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1,99)
+
+**Tone:** Friendly, modern, direct. Consistent with WordPress.com mobile app style.
+
+**This is European Portuguese — NOT Brazilian.** Diverge intentionally:
+
+- "ecrã" not "tela" (screen)
+- "telemóvel" not "celular" (mobile phone)
+- "ficheiro" not "arquivo" (file)
+- "rato" not "mouse" (cursor)
+- "stock" kept English (Brazilian uses "estoque")
+- "encomenda" preferred for "order" (Brazilian "pedido")
+- "subscrição" not "assinatura" (subscription)
+- "cupão" not "cupom" (coupon)
+- "palavra-passe" not "senha" (password)
+- "ligação" can mean both "connection" and "link" — use "hiperligação" for clarity in link contexts
+- "endereço" for address
+- "Estás" not "Você está" (informal you, 2nd person singular present)
+
+**Verb forms (2nd person singular informal):** tens, queres, podes, introduz, verifica, aguarda, tenta, contacta
+
+**Gender agreement:** "encomenda" is feminine — "paga", "concluída"

--- a/fastlane/ai_translation/style/ro.md
+++ b/fastlane/ai_translation/style/ro.md
@@ -1,0 +1,13 @@
+# Romanian (ro) — Translation style guide
+
+**Register:** Informal mobile UI. "Tu" form / 2nd person singular informal.
+**Quotation marks:** „..." (low-high)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, modern. Use diacritics correctly (ă, â, î, ș, ț).
+
+**Common pitfalls:**
+- "Cart" → "Coș" (with diacritic, not "Cos")
+- Distinguish "ș" (s-comma) from "ş" (s-cedilla); use s-comma (Unicode 0219)
+- "Order" → "Comandă"; verbal "a comanda" (to order)

--- a/fastlane/ai_translation/style/th.md
+++ b/fastlane/ai_translation/style/th.md
@@ -1,0 +1,18 @@
+# Thai (th) — Translation style guide
+
+**Register:** Neutral polite mobile UI. NO polite-particle ครับ/ค่ะ at end of UI strings.
+**Script:** Thai (ภาษาไทย)
+**Quotation marks:** "..." (English-style) or "..." (curly)
+**Numerals:** Arabic (1, 2, 3) — NOT Thai numerals (๑๒๓).
+**Decimals:** period (.)
+
+**Tone:** Direct, modern. Often omit the second-person pronoun (คุณ) where context is clear.
+
+**Common pitfalls:**
+- DON'T add ครับ/ค่ะ to button labels or short UI strings — they're for spoken/email contexts
+- DON'T use Thai numerals — Arabic only for app UI
+- No spaces between Thai words (Thai uses spaces only between phrases/sentences)
+- Brand names stay English: WooCommerce, Tap to Pay, etc.
+- "Order" → "คำสั่งซื้อ" (formal) or "ออเดอร์" (transliterated, slangy — avoid in UI)
+- "Cancel" → "ยกเลิก" (always)
+- "Refresh" → "รีเฟรช" or "โหลดใหม่" — prefer "รีเฟรช" for short UI

--- a/fastlane/ai_translation/style/uk.md
+++ b/fastlane/ai_translation/style/uk.md
@@ -1,0 +1,14 @@
+# Ukrainian (uk) — Translation style guide
+
+**Register:** Informal mobile UI. "Ти" form / 2nd person singular informal.
+**Quotation marks:** „..." or «...»
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator
+
+**Tone:** Friendly, direct.
+
+**Common pitfalls:**
+- Cyrillic (Ukrainian variant — has і, ї, є, ґ that Russian does not)
+- "Order" → "Замовлення"
+- Apostrophe is U+02BC (modifier letter), not straight quote
+- DO NOT use Russian (ру/Ы/Э/Ъ); this is Ukrainian only

--- a/fastlane/ai_translation/style/vi.md
+++ b/fastlane/ai_translation/style/vi.md
@@ -1,0 +1,13 @@
+# Vietnamese (vi) — Translation style guide
+
+**Register:** Polite-neutral mobile UI. Omit second-person pronouns where possible.
+**Quotation marks:** "..." (English-style)
+**Numerals:** Arabic (1, 2, 3)
+**Decimals:** comma separator (1.000,99)
+
+**Tone:** Direct, brief, modern.
+
+**Common pitfalls:**
+- All diacritic marks must be preserved (Vietnamese is fully accented)
+- "Order" → "Đơn hàng"; "Place order" → "Đặt đơn hàng" / "Đặt hàng"
+- Don't use Sino-Vietnamese where modern Vietnamese reads better in UI


### PR DESCRIPTION
## Description

**Test PR — do not merge.** Created to validate the AI translation CI step landed in [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250). Stacked on `ai-translations/ci` so this branch inherits the pipeline.yml step + the engine + glossaries + manifest.

iOS port of [woocommerce-android#15984](https://github.com/woocommerce/woocommerce-android/pull/15984) so we can compare both platforms' CI behavior side-by-side.

## Test strings (7 entries, source = `WooCommerce/Resources/en.lproj/Localizable.strings`)

Mirrors Android's dummy strings to the extent the `.strings` file format supports. Each row exercises a different risk in the translation pipeline:

| Key | What it tests |
|-----|---------------|
| `ai_translation_test_product_short_sku` | Very short label ("SKU") — single token translation |
| `ai_translation_test_product_medium_low_stock_badge` | Medium label, plain ecommerce vocab |
| `ai_translation_test_product_placeholder_inventory` | Three typed placeholders: `%1$@ %2$@ %3$d` |
| `ai_translation_test_product_placeholder_sale_window` | Currency / percent / date placeholders: `%1$@ %2$d%% %3$@ %4$@` |
| `ai_translation_test_product_formatted_false_discount` | Two literal percent signs (`%%`) preserved across translation |
| `ai_translation_test_product_html_link` | Inline HTML with escaped quotes — `<a href=\"…\"><u>…</u></a>` |
| `ai_translation_test_product_multiline_backorder` | Multi-line (`\n`) plus 2 placeholders |

**Skipped vs Android** because the `.strings` format has no equivalent: CDATA-wrapped rich text, plurals (would live in `.stringsdict`, out of scope for v1), string arrays.

## Expected CI behavior

CI should show a new step labeled **:globe_with_meridians: AI Translation** that:

1. Detects `en.lproj/Localizable.strings` changed in the diff.
2. Confirms same-repo PR + secret present.
3. Runs `bundle exec rake -f fastlane/ai_translation/Rakefile translate:incremental` for all 15 locales.
4. The engine for each locale:
   - Falls back to "missing key" heuristic (no manifest yet).
   - Translates the 7 new entries via Haiku 4.5.
   - Validates: placeholder parity (every `%@`, `%d`, `%%` must survive in correct count), glossary + brand-safety.
   - If validation rejects, retries with Opus 4.7. Successful retries are recorded with `origin: ai-opus-retry`.
   - Writes the new entries into `<locale>.lproj/Localizable.strings`.
   - Records entries in `manifest/<locale>.json` with `origin: ai`.
   - Round-trip parses the written file to catch writer bugs.
5. Stages all modified `.lproj/*.strings`, commits as **"Translate: …"** authored by *WooCommerce Translation Bot*, pushes to this branch.
6. The new commit re-triggers CI. The loop-prevention check matches the bot's commit at HEAD and skips with exit 0.

## What to inspect after CI runs

1. Bot commit's diff: 15 `.lproj/Localizable.strings` files should each have the 7 new keys with translated values.
2. **Placeholder preservation in every locale**:
   - `%1$@`, `%2$@`, `%3$@`, `%4$@`, `%3$d` must appear in exactly the right count and indexes.
   - `%%` must remain `%%` (no translation should expand it to `%` or another character).
3. **HTML preservation**: `<a href=\"…\"><u>…</u></a>` must survive untouched.
4. **`\n` preservation**: the multi-line string should still contain `\n` as a literal escape.
5. **Brand-safety**: any locale that contains "SKU" or "WooCommerce" should keep it verbatim.
6. **Manifest files** under `fastlane/ai_translation/manifest/<locale>.json` should be present, schema-valid, with 7 new entries each at `origin: ai`.

## Caveats

- **Required-status branch protection is NOT yet configured.** Even if the script exits 1 (e.g., missing secret), GitHub won't physically block merging. The "strict" half of the hybrid gate kicks in only after a repo admin adds `AI Translation` to required statuses.
- **No manifest backfill yet** — first run creates manifests for these 7 entries only, with `origin: ai`. The 5141 pre-existing translations won't have manifest entries until someone runs `rake translate:backfill_manifest` once on trunk and commits the result.
- **Cost is negligible** — 7 strings × 15 locales at Haiku rates = a handful of cents.
- **Don't merge.** Revert and close once the CI behavior is confirmed.

## Stack

- [#17220](https://github.com/woocommerce/woocommerce-ios/pull/17220) translations cutover
- [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221) engine + manifest + Opus fallback + write-then-parse
- [#17222](https://github.com/woocommerce/woocommerce-ios/pull/17222) glossaries + style guides + brand-safety validator
- [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250) CI integration (hybrid strict/soft gate)
- **#17258** — this test PR

---
- [ ] Not adding release notes because this is a test PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)