### PR TITLE
Label assistant telemetry completion stack as woo_mobile_ai

### DIFF
--- a/Modules/Sources/WooAIAssistant/Telemetry/AssistantTelemetryConstants.swift
+++ b/Modules/Sources/WooAIAssistant/Telemetry/AssistantTelemetryConstants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum AssistantTelemetryConstants {
-    public static let completionStack = "jetpack_ai_query"
+    public static let completionStack = "woo_mobile_ai"
     public static let promptVersion = "v1.0.0"
     public static let toolCatalogVersion = "v1.0.0"
 }

--- a/WooCommerce/WooCommerceTests/AIAssistant/Telemetry/WooAssistantTelemetryTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/Telemetry/WooAssistantTelemetryTrackerTests.swift
@@ -36,14 +36,14 @@ struct WooAssistantTelemetryTrackerTests {
         // When
         sut.track(.turnStarted(context: context,
                                isRetry: false,
-                               completionStack: "jetpack_ai_query",
+                               completionStack: "woo_mobile_ai",
                                promptVersion: "p1",
                                toolCatalogVersion: "t1"))
 
         // Then
         #expect(analyticsProvider.receivedEvents == ["ai_assistant_turn_started"])
         #expect(analyticsProvider.receivedProperties.last?["is_retry"] as? Bool == false)
-        #expect(analyticsProvider.receivedProperties.last?["completion_stack"] as? String == "jetpack_ai_query")
+        #expect(analyticsProvider.receivedProperties.last?["completion_stack"] as? String == "woo_mobile_ai")
         #expect(analyticsProvider.receivedProperties.last?["prompt_version"] as? String == "p1")
         #expect(analyticsProvider.receivedProperties.last?["tool_catalog_version"] as? String == "t1")
     }
@@ -141,7 +141,7 @@ struct WooAssistantTelemetryTrackerTests {
                                  durationMs: 999,
                                  errorKind: .network,
                                  isRetry: false,
-                                 completionStack: "jetpack_ai_query",
+                                 completionStack: "woo_mobile_ai",
                                  promptVersion: "p1",
                                  toolCatalogVersion: "t1"))
 


### PR DESCRIPTION
## Description

The AI Assistant telemetry `completion_stack` property still reports `jetpack_ai_query`, a stale leftover from RSM before the backend moved to the woo-mobile-ai WPCOM wrapper. This relabels it to `woo_mobile_ai` so dashboards attribute the traffic to the right stack.

## Test Steps

1. Open Woo app on the paid Dotcom / Jetpack account
2. Select the Woo mobile assistant at the top of the dashboard
3. Send a message
4. Confirm tracks log that the endpoint is woo_mobile_ai