### PR TITLE
POS Roles: PIN entry numpad

### DIFF
--- a/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
+++ b/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
@@ -16,6 +16,12 @@ struct POSPINEntryViewHelper {
         pin.count == length
     }
 
+    func acceptingDigit(_ digit: Character, currentPIN: String, length: Int) -> (pin: String, shouldSubmit: Bool) {
+        let basePIN = isComplete(currentPIN, length: length) ? "" : currentPIN
+        let newPIN = appending(digit, to: basePIN, length: length)
+        return (newPIN, isComplete(newPIN, length: length))
+    }
+
     func isInputEnabled(for state: POSPINEntryState) -> Bool {
         switch state {
         case .idle, .error:

--- a/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
+++ b/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct POSPINEntryViewHelper {
+    func appending(_ digit: Character, to pin: String, length: Int) -> String {
+        guard pin.count < length else {
+            return pin
+        }
+        return pin + String(digit)
+    }
+
+    func removingLastDigit(from pin: String) -> String {
+        String(pin.dropLast())
+    }
+
+    func isComplete(_ pin: String, length: Int) -> Bool {
+        pin.count == length
+    }
+
+    func isInputEnabled(for state: POSPINEntryState) -> Bool {
+        switch state {
+        case .idle, .error:
+            return true
+        case .lockout, .loading:
+            return false
+        }
+    }
+
+    func remainingLockoutSeconds(until date: Date, now: Date = Date()) -> Int {
+        max(0, Int(date.timeIntervalSince(now).rounded(.up)))
+    }
+
+    func lockoutMessage(remainingSeconds: Int) -> String {
+        String.localizedStringWithFormat(Localization.lockoutFormat, remainingSeconds)
+    }
+}
+
+private extension POSPINEntryViewHelper {
+    enum Localization {
+        static let lockoutFormat = NSLocalizedString(
+            "pos.pinEntry.lockout.countdown",
+            value: "Too many attempts. Try again in %1$d seconds.",
+            comment: "Lock-out message on the POS PIN numpad. %1$d is the seconds remaining."
+        )
+    }
+}

--- a/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
+++ b/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
@@ -38,8 +38,8 @@ private extension POSPINEntryViewHelper {
     enum Localization {
         static let lockoutFormat = NSLocalizedString(
             "pos.pinEntry.lockout.countdown",
-            value: "Too many attempts. Try again in %1$d seconds.",
-            comment: "Lock-out message on the POS PIN numpad. %1$d is the seconds remaining."
+            value: "Too many attempts. Try again in %1$ds.",
+            comment: "Lock-out message on the POS PIN numpad. %1$d is the seconds remaining; 's' abbreviates seconds (localize if needed)."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
+++ b/Modules/Sources/PointOfSale/Roles/ViewHelpers/POSPINEntryViewHelper.swift
@@ -30,16 +30,25 @@ struct POSPINEntryViewHelper {
     }
 
     func lockoutMessage(remainingSeconds: Int) -> String {
-        String.localizedStringWithFormat(Localization.lockoutFormat, remainingSeconds)
+        let duration = Self.durationFormatter.string(from: TimeInterval(max(0, remainingSeconds))) ?? ""
+        return String.localizedStringWithFormat(Localization.lockoutFormat, duration)
     }
+
+    private static let durationFormatter: DateComponentsFormatter = {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.hour, .minute, .second]
+        formatter.unitsStyle = .abbreviated
+        formatter.zeroFormattingBehavior = .dropLeading
+        return formatter
+    }()
 }
 
 private extension POSPINEntryViewHelper {
     enum Localization {
         static let lockoutFormat = NSLocalizedString(
             "pos.pinEntry.lockout.countdown",
-            value: "Too many attempts. Try again in %1$ds.",
-            comment: "Lock-out message on the POS PIN numpad. %1$d is the seconds remaining; 's' abbreviates seconds (localize if needed)."
+            value: "Too many attempts. Try again in %1$@.",
+            comment: "Lock-out message on the POS PIN numpad. %1$@ is a localized duration such as 30s or 1m 30s."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryState.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum POSPINEntryState: Equatable {
+    case idle
+    case error(message: String)
+    case lockout(until: Date)
+    case loading
+}

--- a/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryView.swift
@@ -1,0 +1,317 @@
+import SwiftUI
+
+struct POSPINEntryView: View {
+    private let state: POSPINEntryState
+    private let pinLength: Int
+    private let maxContentWidth: CGFloat?
+    private let onComplete: (String) -> Void
+
+    @State private var enteredPIN = ""
+    @State private var shakeAmount: CGFloat = 0
+    @State private var loadingWave = false
+
+    private let helper = POSPINEntryViewHelper()
+    private let haptics = POSPINHapticFeedback()
+
+    init(state: POSPINEntryState,
+         pinLength: Int = 4,
+         maxContentWidth: CGFloat? = nil,
+         onComplete: @escaping (String) -> Void) {
+        self.state = state
+        self.pinLength = pinLength
+        self.maxContentWidth = maxContentWidth
+        self.onComplete = onComplete
+    }
+
+    var body: some View {
+        VStack(spacing: POSSpacing.xLarge) {
+            VStack(spacing: POSSpacing.medium) {
+                dotsRow
+                messageArea
+            }
+            numpad
+        }
+        .frame(maxWidth: maxContentWidth ?? .infinity, maxHeight: .infinity)
+        .onAppear { handleStateChange(state) }
+        .onChange(of: state) { _, newState in
+            handleStateChange(newState)
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSPINEntryView {
+    var isInputEnabled: Bool {
+        helper.isInputEnabled(for: state)
+    }
+
+    var isLoading: Bool {
+        if case .loading = state {
+            return true
+        }
+        return false
+    }
+
+    var dotsRow: some View {
+        HStack(spacing: POSSpacing.medium) {
+            ForEach(0..<pinLength, id: \.self) { index in
+                dot(filled: isLoading || index < enteredPIN.count, index: index)
+            }
+        }
+        .modifier(ShakeEffect(animatableData: shakeAmount))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Localization.dotsAccessibilityLabel)
+        .accessibilityValue(Localization.dotsAccessibilityValue(entered: enteredPIN.count, total: pinLength))
+    }
+
+    func dot(filled: Bool, index: Int) -> some View {
+        Circle()
+            .fill(filled ? Color.posPrimary : Color.clear)
+            .overlay(
+                Circle().strokeBorder(filled ? Color.posPrimary : Color.posOutline,
+                                      lineWidth: Constants.dotBorderWidth)
+            )
+            .frame(width: Constants.dotSize, height: Constants.dotSize)
+            .offset(y: isLoading ? (loadingWave ? -Constants.waveHeight : Constants.waveHeight) : 0)
+            .animation(waveAnimation(for: index), value: loadingWave)
+    }
+
+    func waveAnimation(for index: Int) -> Animation? {
+        guard isLoading else {
+            return .default
+        }
+        return .easeInOut(duration: Constants.waveDuration)
+            .repeatForever(autoreverses: true)
+            .delay(Double(index) * Constants.waveStagger)
+    }
+
+    @ViewBuilder
+    var messageArea: some View {
+        Group {
+            switch state {
+            case .idle, .loading:
+                Color.clear
+            case .error(let message):
+                statusMessage(message)
+            case .lockout(let until):
+                lockoutCountdown(until: until)
+            }
+        }
+        .frame(minHeight: Constants.messageAreaHeight)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    func statusMessage(_ text: String) -> some View {
+        Text(text)
+            .font(.posBodyMediumRegular())
+            .foregroundColor(.posError)
+            .multilineTextAlignment(.center)
+    }
+
+    func lockoutCountdown(until date: Date) -> some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            statusMessage(helper.lockoutMessage(remainingSeconds: helper.remainingLockoutSeconds(until: date, now: context.date)))
+        }
+    }
+
+    var numpad: some View {
+        VStack(spacing: POSSpacing.medium) {
+            ForEach(Constants.rows, id: \.self) { row in
+                HStack(spacing: POSSpacing.medium) {
+                    ForEach(row, id: \.self) { key in
+                        keyButton(for: key)
+                    }
+                }
+            }
+        }
+        .opacity(isInputEnabled ? 1 : Constants.disabledOpacity)
+        .animation(.default, value: isInputEnabled)
+    }
+
+    @ViewBuilder
+    func keyButton(for key: String) -> some View {
+        switch key {
+        case Constants.emptyKey:
+            Color.clear.frame(width: Constants.keySize, height: Constants.keySize)
+        case Constants.deleteKey:
+            keyContainer(action: handleDelete) {
+                Image(systemName: "delete.backward")
+                    .font(.posHeadingBold)
+                    .foregroundColor(.posOnSurface)
+            }
+            .accessibilityLabel(Localization.deleteAccessibilityLabel)
+            .disabled(!isInputEnabled || enteredPIN.isEmpty)
+        default:
+            keyContainer(action: { handleDigit(key) }) {
+                Text(key)
+                    .font(.posHeadingBold)
+                    .foregroundColor(.posOnSurface)
+            }
+            .disabled(!isInputEnabled)
+        }
+    }
+
+    func keyContainer<Label: View>(action: @escaping () -> Void, @ViewBuilder label: () -> Label) -> some View {
+        Button(action: action) {
+            label()
+                .frame(width: Constants.keySize, height: Constants.keySize)
+                .background(Color.posSurface)
+                .cornerRadius(POSCornerRadiusStyle.medium.value)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Input handling
+
+private extension POSPINEntryView {
+    func handleDigit(_ key: String) {
+        guard isInputEnabled, let digit = key.first else {
+            return
+        }
+        var pin = helper.isComplete(enteredPIN, length: pinLength) ? "" : enteredPIN
+        pin = helper.appending(digit, to: pin, length: pinLength)
+        enteredPIN = pin
+        haptics.digitEntered()
+        if helper.isComplete(pin, length: pinLength) {
+            onComplete(pin)
+        }
+    }
+
+    func handleDelete() {
+        guard isInputEnabled else {
+            return
+        }
+        enteredPIN = helper.removingLastDigit(from: enteredPIN)
+    }
+
+    // Parent drives state per attempt (e.g. via .loading) so a repeated failure re-animates, and exits .lockout once the deadline passes.
+    func handleStateChange(_ newState: POSPINEntryState) {
+        switch newState {
+        case .error:
+            enteredPIN = ""
+            haptics.attemptFailed()
+            withAnimation(.linear(duration: Constants.shakeDuration)) {
+                shakeAmount += 1
+            }
+        case .idle:
+            enteredPIN = ""
+        case .loading:
+            loadingWave.toggle()
+        case .lockout:
+            break
+        }
+    }
+}
+
+// MARK: - Shake
+
+private struct ShakeEffect: GeometryEffect {
+    var animatableData: CGFloat
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        let translation = Constants.shakeTravel * sin(animatableData * .pi * Constants.shakeCount)
+        return ProjectionTransform(CGAffineTransform(translationX: translation, y: 0))
+    }
+
+    private enum Constants {
+        static let shakeTravel: CGFloat = 8
+        static let shakeCount: CGFloat = 3
+    }
+}
+
+// MARK: - Constants
+
+private extension POSPINEntryView {
+    enum Constants {
+        static let dotSize: CGFloat = 22
+        static let dotBorderWidth: CGFloat = 2
+        static let keySize: CGFloat = 72
+        static let messageAreaHeight: CGFloat = 40
+        static let disabledOpacity: Double = 0.4
+        static let shakeDuration: TimeInterval = 0.4
+        static let waveHeight: CGFloat = 6
+        static let waveDuration: TimeInterval = 0.5
+        static let waveStagger: TimeInterval = 0.1
+        static let emptyKey = ""
+        static let deleteKey = "delete"
+        static let rows: [[String]] = [
+            ["1", "2", "3"],
+            ["4", "5", "6"],
+            ["7", "8", "9"],
+            [emptyKey, "0", deleteKey]
+        ]
+    }
+}
+
+// MARK: - Localization
+
+private extension POSPINEntryView {
+    enum Localization {
+        static let deleteAccessibilityLabel = NSLocalizedString(
+            "pos.pinEntry.delete.accessibilityLabel",
+            value: "Delete",
+            comment: "Accessibility label for the delete key on the POS PIN numpad"
+        )
+        static let dotsAccessibilityLabel = NSLocalizedString(
+            "pos.pinEntry.dots.accessibilityLabel",
+            value: "PIN entry",
+            comment: "Accessibility label for the PIN dots on the POS PIN numpad"
+        )
+        static let dotsAccessibilityValueFormat = NSLocalizedString(
+            "pos.pinEntry.dots.accessibilityValue",
+            value: "%1$d of %2$d digits entered",
+            comment: "Accessibility value for the PIN dots. %1$d is the entered count, %2$d the total."
+        )
+        static func dotsAccessibilityValue(entered: Int, total: Int) -> String {
+            String.localizedStringWithFormat(dotsAccessibilityValueFormat, entered, total)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Idle") {
+    POSPINEntryView(state: .idle, onComplete: { _ in })
+        .padding()
+        .background(Color.posSurfaceContainerLow)
+}
+
+#Preview("Error") {
+    POSPINEntryView(state: .error(message: "Incorrect PIN. Try again."), onComplete: { _ in })
+        .padding()
+        .background(Color.posSurfaceContainerLow)
+}
+
+#Preview("Lockout") {
+    POSPINEntryView(state: .lockout(until: Date().addingTimeInterval(30)), onComplete: { _ in })
+        .padding()
+        .background(Color.posSurfaceContainerLow)
+}
+
+#Preview("Loading") {
+    POSPINEntryView(state: .loading, onComplete: { _ in })
+        .padding()
+        .background(Color.posSurfaceContainerLow)
+}
+
+#Preview("Modal width") {
+    POSPINEntryView(state: .idle, maxContentWidth: 320, onComplete: { _ in })
+        .padding()
+        .background(Color.posSurfaceContainerLow)
+}
+
+#Preview("Interactive (wrong PIN)") {
+    @Previewable @State var state: POSPINEntryState = .idle
+    POSPINEntryView(state: state, onComplete: { _ in
+        state = .loading
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            state = .error(message: "Incorrect PIN. Try again.")
+        }
+    })
+    .padding()
+    .background(Color.posSurfaceContainerLow)
+}
+#endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryView.swift
@@ -167,12 +167,11 @@ private extension POSPINEntryView {
         guard isInputEnabled, let digit = key.first else {
             return
         }
-        var pin = helper.isComplete(enteredPIN, length: pinLength) ? "" : enteredPIN
-        pin = helper.appending(digit, to: pin, length: pinLength)
-        enteredPIN = pin
+        let result = helper.acceptingDigit(digit, currentPIN: enteredPIN, length: pinLength)
+        enteredPIN = result.pin
         haptics.digitEntered()
-        if helper.isComplete(pin, length: pinLength) {
-            onComplete(pin)
+        if result.shouldSubmit {
+            onComplete(result.pin)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSPINEntryView.swift
@@ -3,23 +3,19 @@ import SwiftUI
 struct POSPINEntryView: View {
     private let state: POSPINEntryState
     private let pinLength: Int
-    private let maxContentWidth: CGFloat?
     private let onComplete: (String) -> Void
 
     @State private var enteredPIN = ""
     @State private var shakeAmount: CGFloat = 0
-    @State private var loadingWave = false
 
     private let helper = POSPINEntryViewHelper()
     private let haptics = POSPINHapticFeedback()
 
     init(state: POSPINEntryState,
          pinLength: Int = 4,
-         maxContentWidth: CGFloat? = nil,
          onComplete: @escaping (String) -> Void) {
         self.state = state
         self.pinLength = pinLength
-        self.maxContentWidth = maxContentWidth
         self.onComplete = onComplete
     }
 
@@ -31,7 +27,7 @@ struct POSPINEntryView: View {
             }
             numpad
         }
-        .frame(maxWidth: maxContentWidth ?? .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear { handleStateChange(state) }
         .onChange(of: state) { _, newState in
             handleStateChange(newState)
@@ -54,18 +50,21 @@ private extension POSPINEntryView {
     }
 
     var dotsRow: some View {
-        HStack(spacing: POSSpacing.medium) {
-            ForEach(0..<pinLength, id: \.self) { index in
-                dot(filled: isLoading || index < enteredPIN.count, index: index)
+        TimelineView(.animation(paused: !isLoading)) { context in
+            HStack(spacing: POSSpacing.medium) {
+                ForEach(0..<pinLength, id: \.self) { index in
+                    dot(filled: isLoading || index < enteredPIN.count,
+                        yOffset: waveOffset(index: index, date: context.date))
+                }
             }
+            .modifier(ShakeEffect(animatableData: shakeAmount))
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Localization.dotsAccessibilityLabel)
+            .accessibilityValue(Localization.dotsAccessibilityValue(entered: enteredPIN.count, total: pinLength))
         }
-        .modifier(ShakeEffect(animatableData: shakeAmount))
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Localization.dotsAccessibilityLabel)
-        .accessibilityValue(Localization.dotsAccessibilityValue(entered: enteredPIN.count, total: pinLength))
     }
 
-    func dot(filled: Bool, index: Int) -> some View {
+    func dot(filled: Bool, yOffset: CGFloat) -> some View {
         Circle()
             .fill(filled ? Color.posPrimary : Color.clear)
             .overlay(
@@ -73,17 +72,15 @@ private extension POSPINEntryView {
                                       lineWidth: Constants.dotBorderWidth)
             )
             .frame(width: Constants.dotSize, height: Constants.dotSize)
-            .offset(y: isLoading ? (loadingWave ? -Constants.waveHeight : Constants.waveHeight) : 0)
-            .animation(waveAnimation(for: index), value: loadingWave)
+            .offset(y: yOffset)
     }
 
-    func waveAnimation(for index: Int) -> Animation? {
+    func waveOffset(index: Int, date: Date) -> CGFloat {
         guard isLoading else {
-            return .default
+            return 0
         }
-        return .easeInOut(duration: Constants.waveDuration)
-            .repeatForever(autoreverses: true)
-            .delay(Double(index) * Constants.waveStagger)
+        let time = date.timeIntervalSinceReferenceDate
+        return sin(time * Constants.waveSpeed + Double(index) * Constants.wavePhase) * Constants.waveHeight
     }
 
     @ViewBuilder
@@ -197,9 +194,7 @@ private extension POSPINEntryView {
             }
         case .idle:
             enteredPIN = ""
-        case .loading:
-            loadingWave.toggle()
-        case .lockout:
+        case .loading, .lockout:
             break
         }
     }
@@ -232,8 +227,8 @@ private extension POSPINEntryView {
         static let disabledOpacity: Double = 0.4
         static let shakeDuration: TimeInterval = 0.4
         static let waveHeight: CGFloat = 6
-        static let waveDuration: TimeInterval = 0.5
-        static let waveStagger: TimeInterval = 0.1
+        static let waveSpeed: Double = 5.0
+        static let wavePhase: Double = 0.7
         static let emptyKey = ""
         static let deleteKey = "delete"
         static let rows: [[String]] = [
@@ -297,11 +292,6 @@ private extension POSPINEntryView {
         .background(Color.posSurfaceContainerLow)
 }
 
-#Preview("Modal width") {
-    POSPINEntryView(state: .idle, maxContentWidth: 320, onComplete: { _ in })
-        .padding()
-        .background(Color.posSurfaceContainerLow)
-}
 
 #Preview("Interactive (wrong PIN)") {
     @Previewable @State var state: POSPINEntryState = .idle

--- a/Modules/Sources/PointOfSale/Roles/Views/POSPINHapticFeedback.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSPINHapticFeedback.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+struct POSPINHapticFeedback {
+    func digitEntered() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    func attemptFailed() {
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/POSPINEntryViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSPINEntryViewHelperTests.swift
@@ -1,0 +1,131 @@
+import Testing
+import Foundation
+@testable import PointOfSale
+
+struct POSPINEntryViewHelperTests {
+    private let helper = POSPINEntryViewHelper()
+
+    @Test func test_appending_when_below_length_then_adds_digit() {
+        // Given
+        let pin = "12"
+
+        // When
+        let result = helper.appending("3", to: pin, length: 4)
+
+        // Then
+        #expect(result == "123")
+    }
+
+    @Test func test_appending_when_at_length_then_does_not_exceed() {
+        // Given
+        let pin = "1234"
+
+        // When
+        let result = helper.appending("5", to: pin, length: 4)
+
+        // Then
+        #expect(result == "1234")
+    }
+
+    @Test func test_removingLastDigit_when_pin_has_digits_then_drops_last() {
+        // Given
+        let pin = "123"
+
+        // When
+        let result = helper.removingLastDigit(from: pin)
+
+        // Then
+        #expect(result == "12")
+    }
+
+    @Test func test_removingLastDigit_when_empty_then_returns_empty() {
+        // Given
+        let pin = ""
+
+        // When
+        let result = helper.removingLastDigit(from: pin)
+
+        // Then
+        #expect(result.isEmpty)
+    }
+
+    @Test func test_isComplete_when_below_length_then_false() {
+        // Given
+        let pin = "12"
+
+        // When
+        let complete = helper.isComplete(pin, length: 4)
+
+        // Then
+        #expect(complete == false)
+    }
+
+    @Test func test_isComplete_when_at_length_then_true() {
+        // Given
+        let pin = "1234"
+
+        // When
+        let complete = helper.isComplete(pin, length: 4)
+
+        // Then
+        #expect(complete == true)
+    }
+
+    @Test func test_isComplete_when_above_length_then_false() {
+        // Given
+        let pin = "12345"
+
+        // When
+        let complete = helper.isComplete(pin, length: 4)
+
+        // Then
+        #expect(complete == false)
+    }
+
+    @Test func test_isInputEnabled_when_idle_or_error_then_true() {
+        // Given / When / Then
+        #expect(helper.isInputEnabled(for: .idle) == true)
+        #expect(helper.isInputEnabled(for: .error(message: "Incorrect PIN")) == true)
+    }
+
+    @Test func test_isInputEnabled_when_lockout_or_loading_then_false() {
+        // Given / When / Then
+        #expect(helper.isInputEnabled(for: .lockout(until: Date())) == false)
+        #expect(helper.isInputEnabled(for: .loading) == false)
+    }
+
+    @Test func test_remainingLockoutSeconds_when_future_then_returns_positive() {
+        // Given
+        let now = Date(timeIntervalSinceReferenceDate: 0)
+        let until = now.addingTimeInterval(30)
+
+        // When
+        let seconds = helper.remainingLockoutSeconds(until: until, now: now)
+
+        // Then
+        #expect(seconds == 30)
+    }
+
+    @Test func test_remainingLockoutSeconds_when_past_then_clamps_to_zero() {
+        // Given
+        let now = Date(timeIntervalSinceReferenceDate: 0)
+        let until = now.addingTimeInterval(-5)
+
+        // When
+        let seconds = helper.remainingLockoutSeconds(until: until, now: now)
+
+        // Then
+        #expect(seconds == 0)
+    }
+
+    @Test func test_lockoutMessage_when_given_seconds_then_includes_count() {
+        // Given
+        let seconds = 30
+
+        // When
+        let message = helper.lockoutMessage(remainingSeconds: seconds)
+
+        // Then
+        #expect(message.contains("30"))
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/POSPINEntryViewHelperTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSPINEntryViewHelperTests.swift
@@ -82,6 +82,42 @@ struct POSPINEntryViewHelperTests {
         #expect(complete == false)
     }
 
+    @Test func test_acceptingDigit_when_below_length_then_appends_without_submitting() {
+        // Given
+        let pin = "12"
+
+        // When
+        let result = helper.acceptingDigit("3", currentPIN: pin, length: 4)
+
+        // Then
+        #expect(result.pin == "123")
+        #expect(result.shouldSubmit == false)
+    }
+
+    @Test func test_acceptingDigit_when_completing_then_submits() {
+        // Given
+        let pin = "123"
+
+        // When
+        let result = helper.acceptingDigit("4", currentPIN: pin, length: 4)
+
+        // Then
+        #expect(result.pin == "1234")
+        #expect(result.shouldSubmit == true)
+    }
+
+    @Test func test_acceptingDigit_when_currentPIN_is_complete_then_starts_fresh_attempt() {
+        // Given
+        let pin = "1234"
+
+        // When
+        let result = helper.acceptingDigit("5", currentPIN: pin, length: 4)
+
+        // Then
+        #expect(result.pin == "5")
+        #expect(result.shouldSubmit == false)
+    }
+
     @Test func test_isInputEnabled_when_idle_or_error_then_true() {
         // Given / When / Then
         #expect(helper.isInputEnabled(for: .idle) == true)


### PR DESCRIPTION
WOOMOB-3138

## Description
Adds a reusable SwiftUI PIN-entry numpad for Point of Sale - `POSPINEntryView` plus a stateless `POSPINEntryViewHelper` - behind the `pointOfSaleRoles` feature flag (off in production). It's the first visible piece of the POS Roles & Permissions work; follow-up PRs will wrap it as the lock screen and the manager-override modal.

The numpad is intentionally numpad-only: masked dots, the digit/delete grid, an inline status message, fixed-length auto-submit, a `TimelineView`-driven loading wave, a timer-free shake on error, a live lockout countdown, and light haptics. Title/subtitle, Cancel, and "Forgot PIN?" live in the wrappers so the same component is reused in both contexts. All entry logic lives in the stateless helper, which is unit-tested.

Builds on #17257 (the roles foundations). Everything is `internal` to the PointOfSale module and nothing is wired into the app yet.

### Follow-ups
Later PRs will wrap this numpad as the lock screen ("Enter your PIN" + "Forgot PIN?") and the manager-override modal, and wire it to the access session. Two constraints to carry into those:
- Keys use the grey `posSurface` fill, so a wrapper's background must be the white `posSurfaceContainerLow` (not `posSurface`) or the keys blend in.
- The wrapper should change `state` on each attempt (e.g. via `.loading`) so a repeated identical error re-animates.

## Test Steps
Foundational, not-yet-wired component (no in-app flow yet):
1. Open `WooCommerce.xcworkspace`, select the **PointOfSale** scheme + an iPad simulator.
2. Open `POSPINEntryView.swift` and run the canvas previews: Idle, Error, Lockout, Loading, and Interactive (wrong PIN) - type 4 digits, see the loading wave, then the shake, cleared dots, and error message.

## Screenshots

https://github.com/user-attachments/assets/978e43e4-f7cc-4468-af77-562edf3e5c9c

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.