### PR TITLE
RSM-3812: Show store-wide low-stock threshold in Stock notification settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/EditLowStockThresholdWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/EditLowStockThresholdWebViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// `WPAdminWebViewModel` subclass that fires `onDisappear` when the
+/// authenticated webview goes away, so the caller can refresh the cached
+/// store-wide low-stock threshold.
+///
+final class EditLowStockThresholdWebViewModel: WPAdminWebViewModel {
+    private let onDisappearHandler: () -> Void
+
+    init(title: String, initialURL: URL, onDisappear: @escaping () -> Void) {
+        self.onDisappearHandler = onDisappear
+        super.init(title: title, initialURL: initialURL)
+    }
+
+    override func handleDisappear() {
+        onDisappearHandler()
+        super.handleDisappear()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
@@ -95,28 +95,20 @@ struct NewStockNotificationPreferencesDetailView: View {
 
     private func thresholdValueText(_ value: Int) -> some View {
         let valueString = NumberFormatter.localizedString(from: NSNumber(value: value), number: .none)
-        let prefix = String.localizedStringWithFormat(Localization.thresholdValuePrefixFormat, valueString)
-        var attributed = AttributedString(prefix)
+        let content = String.localizedStringWithFormat(
+            Localization.thresholdValueWithLinkFormat,
+            valueString,
+            Localization.editStoreWideThresholdLink)
+        var attributed = AttributedString.withEmbeddedLinks(
+            content: content,
+            links: [Localization.editStoreWideThresholdLink: Self.editLinkScheme],
+            font: .caption2,
+            foregroundColor: Color(.secondaryLabel))
         if let range = attributed.range(of: valueString) {
             attributed[range].font = .caption2.bold()
         }
-        var link = AttributedString(Localization.editStoreWideThresholdLink)
-        link.link = URL(string: Self.editLinkScheme)
-        return (Text(attributed + AttributedString(" ") + link)
-                + Text(" ")
-                + Text(Image(systemName: Self.externalLinkSymbol)).foregroundColor(.accentColor))
-            .font(.caption2)
-            .foregroundStyle(Color(.secondaryLabel))
-            .environment(\.openURL, OpenURLAction { [detailViewModel] url in
-                if url.absoluteString == Self.editLinkScheme {
-                    detailViewModel.onTapEditStoreWideThreshold?()
-                    return .handled
-                }
-                return .systemAction
-            })
-            // Override the auto-generated label so VoiceOver doesn't announce
-            // the SF Symbol's name ("arrow up right") at the end of the sentence.
-            .accessibilityLabel(prefix + " " + Localization.editStoreWideThresholdLink)
+        return Text(attributed)
+            .environment(\.openURL, handleEditStoreWideThresholdTap)
     }
 
     private var thresholdLoadingText: some View {
@@ -128,27 +120,29 @@ struct NewStockNotificationPreferencesDetailView: View {
     }
 
     private var thresholdUnavailableText: some View {
-        let prefixString = Localization.thresholdUnavailablePrefix
-        let prefix = AttributedString(prefixString)
-        var link = AttributedString(Localization.viewStoreWideThresholdLink)
-        link.link = URL(string: Self.editLinkScheme)
-        let suffix = AttributedString(" " + Localization.thresholdUnavailableSuffix)
-        return (Text(prefix + AttributedString(" ") + link)
-                + Text(" ")
-                + Text(Image(systemName: Self.externalLinkSymbol)).foregroundColor(.accentColor)
-                + Text(suffix))
-            .font(.caption2)
-            .foregroundStyle(Color(.secondaryLabel))
-            .environment(\.openURL, OpenURLAction { [detailViewModel] url in
-                if url.absoluteString == Self.editLinkScheme {
-                    detailViewModel.onTapEditStoreWideThreshold?()
-                    return .handled
-                }
-                return .systemAction
-            })
-            // Override the auto-generated label so VoiceOver doesn't announce
-            // the SF Symbol's name ("arrow up right") between the link and suffix.
-            .accessibilityLabel(prefixString + " " + Localization.viewStoreWideThresholdLink + " " + Localization.thresholdUnavailableSuffix)
+        let content = String.localizedStringWithFormat(
+            Localization.thresholdUnavailableSentenceFormat,
+            Localization.viewStoreWideThresholdLink)
+        let attributed = AttributedString.withEmbeddedLinks(
+            content: content,
+            links: [Localization.viewStoreWideThresholdLink: Self.editLinkScheme],
+            font: .caption2,
+            foregroundColor: Color(.secondaryLabel))
+        return Text(attributed)
+            .environment(\.openURL, handleEditStoreWideThresholdTap)
+    }
+
+    /// Routes the in-text "edit/view store-wide threshold" link's tap to the
+    /// hosting controller via `onTapEditStoreWideThreshold`. Defined once so
+    /// both the loaded and unavailable variants share the routing logic.
+    private var handleEditStoreWideThresholdTap: OpenURLAction {
+        OpenURLAction { [detailViewModel] url in
+            if url.absoluteString == Self.editLinkScheme {
+                detailViewModel.onTapEditStoreWideThreshold?()
+                return .handled
+            }
+            return .systemAction
+        }
     }
 
     private func toggleRow(title: String,
@@ -165,7 +159,6 @@ struct NewStockNotificationPreferencesDetailView: View {
 
 private extension NewStockNotificationPreferencesDetailView {
     static let editLinkScheme = "woo-internal://edit-store-wide-threshold"
-    static let externalLinkSymbol = "arrow.up.right"
     static let loadingPlaceholderValue = 8
 
     enum Layout {
@@ -205,21 +198,18 @@ private extension NewStockNotificationPreferencesDetailView {
             value: "When a product variant reaches its low stock threshold.",
             comment: "Subtitle of the low-stock toggle row."
         )
-        static let thresholdValuePrefixFormat = NSLocalizedString(
-            "newStockNotificationPreferencesDetailView.lowStock.thresholdSentenceFormat",
-            value: "Products can use their own threshold or the store-wide threshold of\u{00A0}%1$@.",
-            comment: "Sentence shown under the Low stock toggle. %1$@ is the store-wide low stock threshold value, e.g. 5. "
-                + "The non-breaking space (\\u00A0) before the placeholder keeps the word 'of' and the value on the same line."
+        static let thresholdValueWithLinkFormat = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.thresholdValueWithLinkFormat",
+            value: "Products can use their own threshold or the store-wide threshold of\u{00A0}%1$@. %2$@",
+            comment: "Sentence shown under the Low stock toggle. %1$@ is the store-wide low stock threshold value, e.g. 5; "
+                + "%2$@ is the tappable 'Edit store-wide threshold' link text. "
+                + "The non-breaking space (\\u00A0) before %1$@ keeps the word 'of' and the value on the same line."
         )
-        static let thresholdUnavailablePrefix = NSLocalizedString(
-            "newStockNotificationPreferencesDetailView.lowStock.thresholdUnavailablePrefix",
-            value: "Products can use their own threshold or the store-wide threshold.",
-            comment: "Sentence shown under the Low stock toggle when the store-wide threshold value is unavailable."
-        )
-        static let thresholdUnavailableSuffix = NSLocalizedString(
-            "newStockNotificationPreferencesDetailView.lowStock.thresholdUnavailableSuffix",
-            value: "to see the current value.",
-            comment: "Sentence fragment shown after the 'View store-wide threshold' link when the store-wide threshold value is unavailable."
+        static let thresholdUnavailableSentenceFormat = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.thresholdUnavailableSentenceFormat",
+            value: "Products can use their own threshold or the store-wide threshold. %1$@ to see the current value.",
+            comment: "Sentence shown under the Low stock toggle when the store-wide threshold value is unavailable. "
+                + "%1$@ is the tappable 'View store-wide threshold' link text."
         )
         static let editStoreWideThresholdLink = NSLocalizedString(
             "newStockNotificationPreferencesDetailView.lowStock.editStoreWideThresholdLink",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
@@ -8,9 +8,12 @@ import SwiftUI
 struct NewStockNotificationPreferencesDetailView: View {
 
     @Bindable private var viewModel: PushNotificationPreferencesViewModel
+    @Bindable private var detailViewModel: NewStockNotificationPreferencesDetailViewModel
 
-    init(viewModel: PushNotificationPreferencesViewModel) {
+    init(viewModel: PushNotificationPreferencesViewModel,
+         detailViewModel: NewStockNotificationPreferencesDetailViewModel) {
         self.viewModel = viewModel
+        self.detailViewModel = detailViewModel
     }
 
     var body: some View {
@@ -31,6 +34,7 @@ struct NewStockNotificationPreferencesDetailView: View {
         .onAppear {
             viewModel.detailDidAppear(notificationType: .stockAlert)
         }
+        .task { await detailViewModel.onAppear() }
     }
 
     private var masterToggleSection: some View {
@@ -48,10 +52,7 @@ struct NewStockNotificationPreferencesDetailView: View {
 
     private var customizationSection: some View {
         Section {
-            toggleRow(title: Localization.lowStockTitle,
-                      subtitle: Localization.lowStockSubtitle,
-                      isOn: Binding(get: { viewModel.isStoreStockLowStock },
-                                    set: { viewModel.setStoreStockLowStock($0) }))
+            lowStockRow
             toggleRow(title: Localization.outOfStockTitle,
                       subtitle: Localization.outOfStockSubtitle,
                       isOn: Binding(get: { viewModel.isStoreStockOutOfStock },
@@ -67,6 +68,89 @@ struct NewStockNotificationPreferencesDetailView: View {
         .opacity(viewModel.isStoreStockEnabled ? 1.0 : Layout.disabledOpacity)
     }
 
+    private var lowStockRow: some View {
+        VStack(alignment: .leading, spacing: Layout.titleDetailSpacing) {
+            Toggle(Localization.lowStockTitle,
+                   isOn: Binding(get: { viewModel.isStoreStockLowStock },
+                                 set: { viewModel.setStoreStockLowStock($0) }))
+            Text(Localization.lowStockSubtitle)
+                .foregroundStyle(Color(.secondaryLabel))
+                .captionStyle()
+            thresholdLine
+                .padding(.top, Layout.thresholdTopSpacing)
+        }
+    }
+
+    @ViewBuilder
+    private var thresholdLine: some View {
+        switch detailViewModel.lowStockThresholdState {
+        case .loading:
+            thresholdLoadingText
+        case .value(let number?):
+            thresholdValueText(number)
+        case .value(nil):
+            thresholdUnavailableText
+        }
+    }
+
+    private func thresholdValueText(_ value: Int) -> some View {
+        let valueString = NumberFormatter.localizedString(from: NSNumber(value: value), number: .none)
+        let prefix = String.localizedStringWithFormat(Localization.thresholdValuePrefixFormat, valueString)
+        var attributed = AttributedString(prefix)
+        if let range = attributed.range(of: valueString) {
+            attributed[range].font = .caption2.bold()
+        }
+        var link = AttributedString(Localization.editStoreWideThresholdLink)
+        link.link = URL(string: Self.editLinkScheme)
+        return (Text(attributed + AttributedString(" ") + link)
+                + Text(" ")
+                + Text(Image(systemName: Self.externalLinkSymbol)).foregroundColor(.accentColor))
+            .font(.caption2)
+            .foregroundStyle(Color(.secondaryLabel))
+            .environment(\.openURL, OpenURLAction { [detailViewModel] url in
+                if url.absoluteString == Self.editLinkScheme {
+                    detailViewModel.onTapEditStoreWideThreshold?()
+                    return .handled
+                }
+                return .systemAction
+            })
+            // Override the auto-generated label so VoiceOver doesn't announce
+            // the SF Symbol's name ("arrow up right") at the end of the sentence.
+            .accessibilityLabel(prefix + " " + Localization.editStoreWideThresholdLink)
+    }
+
+    private var thresholdLoadingText: some View {
+        // Render the value-known layout with a placeholder number so the row's
+        // vertical space stays stable, and shimmer to signal loading.
+        thresholdValueText(Self.loadingPlaceholderValue)
+            .redacted(reason: .placeholder)
+            .shimmering()
+    }
+
+    private var thresholdUnavailableText: some View {
+        let prefixString = Localization.thresholdUnavailablePrefix
+        let prefix = AttributedString(prefixString)
+        var link = AttributedString(Localization.viewStoreWideThresholdLink)
+        link.link = URL(string: Self.editLinkScheme)
+        let suffix = AttributedString(" " + Localization.thresholdUnavailableSuffix)
+        return (Text(prefix + AttributedString(" ") + link)
+                + Text(" ")
+                + Text(Image(systemName: Self.externalLinkSymbol)).foregroundColor(.accentColor)
+                + Text(suffix))
+            .font(.caption2)
+            .foregroundStyle(Color(.secondaryLabel))
+            .environment(\.openURL, OpenURLAction { [detailViewModel] url in
+                if url.absoluteString == Self.editLinkScheme {
+                    detailViewModel.onTapEditStoreWideThreshold?()
+                    return .handled
+                }
+                return .systemAction
+            })
+            // Override the auto-generated label so VoiceOver doesn't announce
+            // the SF Symbol's name ("arrow up right") between the link and suffix.
+            .accessibilityLabel(prefixString + " " + Localization.viewStoreWideThresholdLink + " " + Localization.thresholdUnavailableSuffix)
+    }
+
     private func toggleRow(title: String,
                            subtitle: String,
                            isOn: Binding<Bool>) -> some View {
@@ -80,8 +164,13 @@ struct NewStockNotificationPreferencesDetailView: View {
 }
 
 private extension NewStockNotificationPreferencesDetailView {
+    static let editLinkScheme = "woo-internal://edit-store-wide-threshold"
+    static let externalLinkSymbol = "arrow.up.right"
+    static let loadingPlaceholderValue = 8
+
     enum Layout {
         static let titleDetailSpacing: CGFloat = 4
+        static let thresholdTopSpacing: CGFloat = 6
         static let disabledOpacity: Double = 0.5
     }
 
@@ -115,6 +204,32 @@ private extension NewStockNotificationPreferencesDetailView {
             "newStockNotificationPreferencesDetailView.lowStock.subtitle",
             value: "When a product variant reaches its low stock threshold.",
             comment: "Subtitle of the low-stock toggle row."
+        )
+        static let thresholdValuePrefixFormat = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.thresholdSentenceFormat",
+            value: "Products can use their own threshold or the store-wide threshold of\u{00A0}%1$@.",
+            comment: "Sentence shown under the Low stock toggle. %1$@ is the store-wide low stock threshold value, e.g. 5. "
+                + "The non-breaking space (\\u00A0) before the placeholder keeps the word 'of' and the value on the same line."
+        )
+        static let thresholdUnavailablePrefix = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.thresholdUnavailablePrefix",
+            value: "Products can use their own threshold or the store-wide threshold.",
+            comment: "Sentence shown under the Low stock toggle when the store-wide threshold value is unavailable."
+        )
+        static let thresholdUnavailableSuffix = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.thresholdUnavailableSuffix",
+            value: "to see the current value.",
+            comment: "Sentence fragment shown after the 'View store-wide threshold' link when the store-wide threshold value is unavailable."
+        )
+        static let editStoreWideThresholdLink = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.editStoreWideThresholdLink",
+            value: "Edit store-wide threshold",
+            comment: "Tappable link that opens wp-admin to edit the store-wide low stock threshold."
+        )
+        static let viewStoreWideThresholdLink = NSLocalizedString(
+            "newStockNotificationPreferencesDetailView.lowStock.viewStoreWideThresholdLink",
+            value: "View store-wide threshold",
+            comment: "Tappable link that opens wp-admin to view the store-wide low stock threshold when its value is unavailable."
         )
         static let outOfStockTitle = NSLocalizedString(
             "newStockNotificationPreferencesDetailView.outOfStock.title",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailView.swift
@@ -101,7 +101,7 @@ struct NewStockNotificationPreferencesDetailView: View {
             Localization.editStoreWideThresholdLink)
         var attributed = AttributedString.withEmbeddedLinks(
             content: content,
-            links: [Localization.editStoreWideThresholdLink: Self.editLinkScheme],
+            links: [Localization.editStoreWideThresholdLink: Constants.editLinkScheme],
             font: .caption2,
             foregroundColor: Color(.secondaryLabel))
         if let range = attributed.range(of: valueString) {
@@ -114,7 +114,7 @@ struct NewStockNotificationPreferencesDetailView: View {
     private var thresholdLoadingText: some View {
         // Render the value-known layout with a placeholder number so the row's
         // vertical space stays stable, and shimmer to signal loading.
-        thresholdValueText(Self.loadingPlaceholderValue)
+        thresholdValueText(Constants.loadingPlaceholderValue)
             .redacted(reason: .placeholder)
             .shimmering()
     }
@@ -125,7 +125,7 @@ struct NewStockNotificationPreferencesDetailView: View {
             Localization.viewStoreWideThresholdLink)
         let attributed = AttributedString.withEmbeddedLinks(
             content: content,
-            links: [Localization.viewStoreWideThresholdLink: Self.editLinkScheme],
+            links: [Localization.viewStoreWideThresholdLink: Constants.editLinkScheme],
             font: .caption2,
             foregroundColor: Color(.secondaryLabel))
         return Text(attributed)
@@ -137,7 +137,7 @@ struct NewStockNotificationPreferencesDetailView: View {
     /// both the loaded and unavailable variants share the routing logic.
     private var handleEditStoreWideThresholdTap: OpenURLAction {
         OpenURLAction { [detailViewModel] url in
-            if url.absoluteString == Self.editLinkScheme {
+            if url.absoluteString == Constants.editLinkScheme {
                 detailViewModel.onTapEditStoreWideThreshold?()
                 return .handled
             }
@@ -158,8 +158,17 @@ struct NewStockNotificationPreferencesDetailView: View {
 }
 
 private extension NewStockNotificationPreferencesDetailView {
-    static let editLinkScheme = "woo-internal://edit-store-wide-threshold"
-    static let loadingPlaceholderValue = 8
+    enum Constants {
+        /// Internal URL scheme used to route in-text link taps through
+        /// `OpenURLAction` — the actual wp-admin URL is constructed and
+        /// presented by the hosting controller.
+        static let editLinkScheme = "woo-internal://edit-store-wide-threshold"
+
+        /// Placeholder threshold value rendered behind the shimmer while the
+        /// real value is loading. Only its width matters; the redacted
+        /// modifier obscures the content.
+        static let loadingPlaceholderValue = 8
+    }
 
     enum Layout {
         static let titleDetailSpacing: CGFloat = 4

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailViewModel.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Observation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// State of the store-wide low-stock threshold row.
+///
+enum LowStockThresholdState: Equatable {
+    /// First load, nothing cached yet.
+    case loading
+    /// Loaded; `.value(nil)` means the setting is absent, non-integer, or the
+    /// sync failed without delivering data.
+    case value(Int?)
+}
+
+/// View model for `NewStockNotificationPreferencesDetailView`. Owns screen-local
+/// state that isn't part of the shared `PushNotificationPreferencesViewModel`,
+/// starting with the store-wide low-stock threshold row.
+///
+@MainActor
+@Observable
+final class NewStockNotificationPreferencesDetailViewModel {
+
+    // MARK: - Low stock threshold
+
+    private(set) var lowStockThresholdState: LowStockThresholdState = .loading
+
+    var onTapEditStoreWideThreshold: (() -> Void)?
+
+    /// `nil` when no admin URL was supplied at construction time.
+    var editStoreWideThresholdURL: URL? {
+        guard let siteAdminURL else { return nil }
+        return siteAdminURL
+            .appendingPathComponent("admin.php")
+            .appending(queryItems: [
+                URLQueryItem(name: "page", value: "wc-settings"),
+                URLQueryItem(name: "tab", value: "products"),
+                URLQueryItem(name: "section", value: "inventory")
+            ])
+    }
+
+    // MARK: - Dependencies
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let siteAdminURL: URL?
+    @ObservationIgnored
+    private let lowStockThresholdResultsController: ResultsController<StorageSiteSetting>
+
+    init(siteID: Int64,
+         siteAdminURL: URL?,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+        self.siteID = siteID
+        self.siteAdminURL = siteAdminURL
+        self.stores = stores
+        let predicate = NSPredicate(format: "siteID == %ld AND settingID == %@",
+                                    siteID, Self.lowStockAmountKey)
+        let sortDescriptor = NSSortDescriptor(keyPath: \StorageSiteSetting.settingID, ascending: true)
+        self.lowStockThresholdResultsController = ResultsController<StorageSiteSetting>(
+            storageManager: storageManager,
+            matching: predicate,
+            sortedBy: [sortDescriptor])
+        configureLowStockThresholdResultsController()
+    }
+
+    /// Screen `.task` hook. Triggers any refresh work owned by this VM.
+    func onAppear() async {
+        await refreshLowStockThreshold()
+    }
+
+    /// Drives `synchronizeProductSiteSettings`. The new value flows in via the
+    /// `ResultsController`. Errors are logged silently — when sync fails or
+    /// returns no data, the row falls back to the cached value, or to
+    /// `.value(nil)` (which renders the inline "view store-wide threshold"
+    /// fallback copy) if nothing is cached.
+    func refreshLowStockThreshold() async {
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                stores.dispatch(SettingAction.synchronizeProductSiteSettings(siteID: siteID) { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                })
+            }
+        } catch {
+            DDLogError("⛔️ Error syncing product site settings for siteID=\(siteID): \(error)")
+        }
+        // Whether the sync succeeded, returned no data, or threw, resolve
+        // `.loading` to whatever's in storage (which may still be nil).
+        if case .loading = lowStockThresholdState {
+            lowStockThresholdState = .value(readCachedLowStockThreshold())
+        }
+    }
+}
+
+private extension NewStockNotificationPreferencesDetailViewModel {
+    static let lowStockAmountKey = "woocommerce_notify_low_stock_amount"
+
+    func configureLowStockThresholdResultsController() {
+        lowStockThresholdResultsController.onDidChangeContent = { [weak self] in
+            self?.applyLowStockThresholdStorageValue()
+        }
+        // `StorageManagerDidResetStorage` can be posted from a background
+        // thread, so hop to main before mutating @Observable state.
+        lowStockThresholdResultsController.onDidResetContent = { [weak self] in
+            DispatchQueue.main.async { self?.applyLowStockThresholdStorageValue() }
+        }
+        do {
+            try lowStockThresholdResultsController.performFetch()
+        } catch {
+            DDLogError("⛔️ Error fetching cached low stock threshold for siteID=\(siteID): \(error)")
+        }
+        applyLowStockThresholdStorageValue()
+    }
+
+    /// Reflects the latest storage value into `lowStockThresholdState`.
+    func applyLowStockThresholdStorageValue() {
+        let hasStoredRow = !lowStockThresholdResultsController.fetchedObjects.isEmpty
+        switch lowStockThresholdState {
+        case .loading where !hasStoredRow:
+            // No row in storage yet — wait for the network sync to resolve.
+            // (A row that exists but holds a non-Int value still transitions
+            // out of loading; `readCachedLowStockThreshold` returns nil and the
+            // row renders the "value unavailable" fallback.)
+            return
+        default:
+            lowStockThresholdState = .value(readCachedLowStockThreshold())
+        }
+    }
+
+    func readCachedLowStockThreshold() -> Int? {
+        guard let raw = lowStockThresholdResultsController.fetchedObjects.first?.value else { return nil }
+        return Int(raw)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesDetailViewModel.swift
@@ -100,13 +100,14 @@ private extension NewStockNotificationPreferencesDetailViewModel {
     static let lowStockAmountKey = "woocommerce_notify_low_stock_amount"
 
     func configureLowStockThresholdResultsController() {
+        // The view-model is `@MainActor`-isolated; hop explicitly from these
+        // non-isolated `ResultsController` callbacks so the actor isolation
+        // matches without relying on `viewContext` being on main.
         lowStockThresholdResultsController.onDidChangeContent = { [weak self] in
-            self?.applyLowStockThresholdStorageValue()
+            Task { @MainActor in self?.applyLowStockThresholdStorageValue() }
         }
-        // `StorageManagerDidResetStorage` can be posted from a background
-        // thread, so hop to main before mutating @Observable state.
         lowStockThresholdResultsController.onDidResetContent = { [weak self] in
-            DispatchQueue.main.async { self?.applyLowStockThresholdStorageValue() }
+            Task { @MainActor in self?.applyLowStockThresholdStorageValue() }
         }
         do {
             try lowStockThresholdResultsController.performFetch()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/NewStockNotificationPreferencesHostingController.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Yosemite
 
 /// Hosts `NewStockNotificationPreferencesDetailView`. Navigation chrome
 /// (Save, back button, discard alert, saving spinner) is inherited from
@@ -7,14 +8,50 @@ import SwiftUI
 final class NewStockNotificationPreferencesHostingController:
     NotificationDetailHostingController<NewStockNotificationPreferencesDetailView> {
 
-    init(viewModel: PushNotificationPreferencesViewModel) {
+    private let detailViewModel: NewStockNotificationPreferencesDetailViewModel
+
+    init(viewModel: PushNotificationPreferencesViewModel,
+         siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores) {
+        let detailViewModel = NewStockNotificationPreferencesDetailViewModel(
+            siteID: siteID,
+            siteAdminURL: stores.sessionManager.defaultSite?.adminURLWithFallback(),
+            stores: stores)
+        self.detailViewModel = detailViewModel
         super.init(viewModel: viewModel,
-                   rootView: NewStockNotificationPreferencesDetailView(viewModel: viewModel),
+                   rootView: NewStockNotificationPreferencesDetailView(
+                       viewModel: viewModel,
+                       detailViewModel: detailViewModel),
                    notificationType: .stockAlert,
                    onDiscard: { [weak viewModel] in viewModel?.discardStoreStockEdits() })
+        detailViewModel.onTapEditStoreWideThreshold = { [weak self] in
+            self?.presentEditStoreWideThreshold()
+        }
     }
 
     dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func presentEditStoreWideThreshold() {
+        guard let url = detailViewModel.editStoreWideThresholdURL else { return }
+        let webModel = EditLowStockThresholdWebViewModel(
+            title: Localization.editThresholdWebTitle,
+            initialURL: url,
+            onDisappear: { [weak detailViewModel] in
+                Task { @MainActor in await detailViewModel?.refreshLowStockThreshold() }
+            })
+        let vc = AuthenticatedWebViewController(viewModel: webModel)
+        navigationController?.pushViewController(vc, animated: true)
+    }
+}
+
+private extension NewStockNotificationPreferencesHostingController {
+    enum Localization {
+        static let editThresholdWebTitle = NSLocalizedString(
+            "newStockNotificationPreferencesHostingController.editThreshold.webTitle",
+            value: "Low stock threshold",
+            comment: "Title of the authenticated webview shown when the merchant taps 'Edit store-wide threshold' under the Low stock toggle."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/NotificationSettings/PushNotificationPreferencesHostingController.swift
@@ -3,10 +3,14 @@ import Yosemite
 
 final class PushNotificationPreferencesHostingController: UIHostingController<PushNotificationPreferencesView> {
     private let viewModel: PushNotificationPreferencesViewModel
+    private let siteID: Int64
+    private let stores: StoresManager
 
     init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
         let viewModel = PushNotificationPreferencesViewModel(siteID: siteID, stores: stores)
         self.viewModel = viewModel
+        self.siteID = siteID
+        self.stores = stores
         super.init(rootView: PushNotificationPreferencesView(viewModel: viewModel))
         // Set after `super.init` so the closures can capture `self` weakly.
         rootView.onNewOrderTapped = { [weak self] in
@@ -35,7 +39,9 @@ final class PushNotificationPreferencesHostingController: UIHostingController<Pu
     }
 
     private func showNewStockDetail() {
-        let detail = NewStockNotificationPreferencesHostingController(viewModel: viewModel)
+        let detail = NewStockNotificationPreferencesHostingController(viewModel: viewModel,
+                                                                     siteID: siteID,
+                                                                     stores: stores)
         navigationController?.pushViewController(detail, animated: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/NewStockNotificationPreferencesDetailViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/NewStockNotificationPreferencesDetailViewModelTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Testing
+import Yosemite
+import YosemiteTestHelpers
+import protocol Storage.StorageManagerType
+@testable import WooCommerce
+
+@MainActor
+@Suite(.timeLimit(.minutes(5)))
+struct NewStockNotificationPreferencesDetailViewModelTests {
+
+    private static let siteID: Int64 = 123
+    private static let lowStockSettingID = "woocommerce_notify_low_stock_amount"
+
+    // MARK: - Low stock threshold: initial state
+
+    @Test func test_initial_lowStockThresholdState_when_cached_value_present_then_publishes_value() async {
+        // Given
+        let storageManager = MockStorageManager()
+        await insertLowStock(value: "5", into: storageManager)
+
+        // When
+        let sut = makeSUT(storageManager: storageManager)
+
+        // Then
+        #expect(sut.lowStockThresholdState == .value(5))
+    }
+
+    @Test func test_initial_lowStockThresholdState_when_no_cached_value_then_is_loading() {
+        // Given / When
+        let sut = makeSUT(storageManager: MockStorageManager())
+
+        // Then
+        #expect(sut.lowStockThresholdState == .loading)
+    }
+
+    @Test func test_initial_lowStockThresholdState_when_setting_value_is_not_int_then_is_value_nil() async {
+        // Given
+        let storageManager = MockStorageManager()
+        await insertLowStock(value: "abc", into: storageManager)
+
+        // When
+        let sut = makeSUT(storageManager: storageManager)
+
+        // Then
+        #expect(sut.lowStockThresholdState == .value(nil))
+    }
+
+    // MARK: - Low stock threshold: refresh
+
+    @Test func test_refreshLowStockThreshold_when_sync_succeeds_with_no_cache_then_state_is_value_nil() async {
+        // Given
+        let stores = makeStores()
+        stubSyncProductSettings(stores, result: nil)
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.refreshLowStockThreshold()
+
+        // Then
+        #expect(sut.lowStockThresholdState == .value(nil))
+    }
+
+    @Test func test_refreshLowStockThreshold_when_sync_fails_with_cached_value_then_state_falls_back_to_cache() async {
+        // Given
+        let storageManager = MockStorageManager()
+        await insertLowStock(value: "7", into: storageManager)
+        let stores = makeStores()
+        stubSyncProductSettings(stores, result: SyncError.network)
+        let sut = makeSUT(stores: stores, storageManager: storageManager)
+
+        // When
+        await sut.refreshLowStockThreshold()
+
+        // Then
+        #expect(sut.lowStockThresholdState == .value(7))
+    }
+
+    @Test func test_refreshLowStockThreshold_when_sync_fails_with_no_cache_then_state_is_value_nil() async {
+        // Given
+        let stores = makeStores()
+        stubSyncProductSettings(stores, result: SyncError.network)
+        let sut = makeSUT(stores: stores)
+
+        // When
+        await sut.refreshLowStockThreshold()
+
+        // Then
+        #expect(sut.lowStockThresholdState == .value(nil))
+    }
+
+    // MARK: - Low stock threshold: predicate tightness + reactive updates
+
+    @Test func test_storage_write_to_another_settingID_does_not_change_lowStockThresholdState() async {
+        // Given
+        let storageManager = MockStorageManager()
+        let sut = makeSUT(storageManager: storageManager)
+        #expect(sut.lowStockThresholdState == .loading)
+
+        // When — write an unrelated setting.
+        await insert(settingID: "woocommerce_currency", value: "USD", into: storageManager)
+
+        // Then
+        #expect(sut.lowStockThresholdState == .loading)
+    }
+
+    @Test func test_storage_update_to_low_stock_setting_after_load_propagates_to_state() async {
+        // Given
+        let storageManager = MockStorageManager()
+        await insertLowStock(value: "3", into: storageManager)
+        let sut = makeSUT(storageManager: storageManager)
+        #expect(sut.lowStockThresholdState == .value(3))
+
+        // When — webview edit results in the store-wide value being updated.
+        await insertLowStock(value: "12", into: storageManager)
+
+        // Then
+        #expect(sut.lowStockThresholdState == .value(12))
+    }
+
+    // MARK: - editStoreWideThresholdURL
+
+    @Test func test_editStoreWideThresholdURL_when_admin_url_present_then_returns_inventory_wp_admin_url() {
+        // Given
+        let sut = makeSUT(siteAdminURL: URL(string: "https://example.test/wp-admin/"))
+
+        // When / Then
+        #expect(sut.editStoreWideThresholdURL?.absoluteString ==
+                "https://example.test/wp-admin/admin.php?page=wc-settings&tab=products&section=inventory")
+    }
+
+    @Test func test_editStoreWideThresholdURL_when_no_admin_url_then_is_nil() {
+        // Given
+        let sut = makeSUT(siteAdminURL: nil)
+
+        // When / Then
+        #expect(sut.editStoreWideThresholdURL == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private extension NewStockNotificationPreferencesDetailViewModelTests {
+    enum SyncError: Error { case network }
+
+    func makeStores() -> MockStoresManager {
+        MockStoresManager(sessionManager: .testingInstance)
+    }
+
+    func makeSUT(stores: MockStoresManager? = nil,
+                 storageManager: MockStorageManager = MockStorageManager(),
+                 siteAdminURL: URL? = URL(string: "https://example.test/wp-admin/"))
+    -> NewStockNotificationPreferencesDetailViewModel {
+        NewStockNotificationPreferencesDetailViewModel(
+            siteID: Self.siteID,
+            siteAdminURL: siteAdminURL,
+            stores: stores ?? makeStores(),
+            storageManager: storageManager)
+    }
+
+    func stubSyncProductSettings(_ stores: MockStoresManager, result error: Error?) {
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            if case let .synchronizeProductSiteSettings(_, onCompletion) = action {
+                onCompletion(error)
+            }
+        }
+    }
+
+    func insertLowStock(value: String, into storageManager: MockStorageManager) async {
+        await insert(settingID: Self.lowStockSettingID, value: value, into: storageManager)
+    }
+
+    func insert(settingID: String, value: String, into storageManager: MockStorageManager) async {
+        let setting = SiteSetting.fake().copy(siteID: Self.siteID,
+                                              settingID: settingID,
+                                              value: value,
+                                              settingGroupKey: SiteSettingGroup.product.rawValue)
+        await withCheckedContinuation { continuation in
+            storageManager.performAndSave({ [storageManager] _ in
+                if let existing = storageManager.viewStorage
+                    .loadSiteSetting(siteID: Self.siteID, settingID: settingID) {
+                    storageManager.viewStorage.deleteObject(existing)
+                }
+                storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+            }, completion: {
+                continuation.resume()
+            }, on: .main)
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a store-wide low-stock threshold row beneath the **Low stock** toggle in Settings → Notifications → Stock, mirroring Android. Merchants see the cached threshold value inline, can tap a link to edit it in an authenticated `wp-admin → Products → Inventory` webview, and the row reflects the new value automatically on return.

Implementation notes:

- **Reactive value**: a new `NewStockNotificationPreferencesDetailViewModel` (`@Observable`, screen-scoped, sits alongside the shared `PushNotificationPreferencesViewModel`) observes `StorageSiteSetting` via `ResultsController` filtered on the `woocommerce_notify_low_stock_amount` key. `SettingAction.synchronizeProductSiteSettings` only drives loading state — the value propagates from storage automatically, so the post-webview refresh path needs no manual re-read.
- **Failure handling**: matches the convention in `PushNotificationPreferencesViewModel.load()` and `ProductDetailPreviewViewModel`'s sync — `DDLogError` and silently fall back to the cached value, or to an inline "View store-wide threshold ↗" link when nothing is cached.
- **Webview dismissal**: a tiny `EditLowStockThresholdWebViewModel` subclass of `WPAdminWebViewModel` exposes an `onDisappear` hook that fires `refreshLowStockThreshold()` (mirrors the existing `ProductDetailWebCoordinator.AdminWebViewModel` pattern).
- **Loading**: shimmering placeholder of the value-known layout so the row's vertical space stays stable.
- **Link affordance**: inline `arrow.up.right` SF Symbol in accent color, signalling external navigation.

Linear: RSM-3812.

## Test Steps

1. Open Settings → Notifications → **Stock** detail screen.
2. With **Enable stock notifications** off — confirm the threshold row inherits the dimmed/disabled treatment from the rest of the customization section.
3. With **Enable stock notifications** on and a cached value already in storage (i.e. you've visited this screen before with internet), confirm the value renders inline immediately: "Products can use their own threshold or the store-wide threshold of **{N}**. **Edit store-wide threshold** ↗".
4. Cold-launch on a fresh install (or `xcrun simctl uninstall booted ...` first) — confirm the row shows a shimmering placeholder briefly, then resolves to the value (or to the "View store-wide threshold ↗ to see the current value." fallback if the setting is absent / non-integer / offline with no cache).
5. Tap **Edit store-wide threshold** ↗ → confirm an authenticated webview opens at `wp-admin → Products → Inventory`. Change the threshold there, save, back out → confirm the row reflects the new value.
6. Repeat with airplane mode on — confirm the row keeps the last cached value (no error banner), and the link still opens the webview.
7. Confirm none of the other Stock toggles (Out of stock, On backorder) regressed.

## Screenshots

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-25 at 15 23 07" src="https://github.com/user-attachments/assets/db135796-27a4-4cf5-a14f-7a3d92d20325" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.