### PR TITLE
POS Roles: lock screen view and access overlay

### DIFF
--- a/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
@@ -12,16 +12,8 @@ final class POSLockScreenModel {
         session.isLocked
     }
 
-    var hasAnyPINs: Bool {
-        session.hasAnyPINs
-    }
-
     init(session: POSAccessSession) {
         self.session = session
-    }
-
-    func refreshPINStatus() async {
-        await session.refreshPINStatus()
     }
 
     func signIn(withPIN pin: String) async {

--- a/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
@@ -6,20 +6,22 @@ import Observation
 final class POSLockScreenModel {
     private let session: POSAccessSession
 
-    private(set) var isLocked: Bool
-    private(set) var hasAnyPINs: Bool
     var pinEntryState: POSPINEntryState = .idle
+
+    var isLocked: Bool {
+        session.isLocked
+    }
+
+    var hasAnyPINs: Bool {
+        session.hasAnyPINs
+    }
 
     init(session: POSAccessSession) {
         self.session = session
-        self.isLocked = session.isLocked
-        self.hasAnyPINs = session.hasAnyPINs
-        observeSessionState()
     }
 
     func refreshPINStatus() async {
         await session.refreshPINStatus()
-        syncSessionState()
     }
 
     func signIn(withPIN pin: String) async {
@@ -31,29 +33,10 @@ final class POSLockScreenModel {
         } catch {
             pinEntryState = .error(message: message(for: error))
         }
-
-        syncSessionState()
-    }
-
-    func syncSessionState() {
-        isLocked = session.isLocked
-        hasAnyPINs = session.hasAnyPINs
     }
 }
 
 private extension POSLockScreenModel {
-    func observeSessionState() {
-        withObservationTracking {
-            _ = session.isLocked
-            _ = session.hasAnyPINs
-        } onChange: { [weak self] in
-            Task { @MainActor in
-                self?.syncSessionState()
-                self?.observeSessionState()
-            }
-        }
-    }
-
     func message(for error: POSAuthError) -> String {
         switch error {
         case .invalidPIN:

--- a/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Observation
+
+@Observable
+@MainActor
+final class POSLockScreenModel {
+    private let session: POSAccessSession
+
+    private(set) var isLocked: Bool
+    private(set) var hasAnyPINs: Bool
+    var pinEntryState: POSPINEntryState = .idle
+
+    init(session: POSAccessSession) {
+        self.session = session
+        self.isLocked = session.isLocked
+        self.hasAnyPINs = session.hasAnyPINs
+        observeSessionState()
+    }
+
+    func refreshPINStatus() async {
+        await session.refreshPINStatus()
+        syncSessionState()
+    }
+
+    func signIn(withPIN pin: String) async {
+        pinEntryState = .loading
+
+        do {
+            try await session.signIn(withPIN: pin)
+            pinEntryState = .idle
+        } catch {
+            pinEntryState = .error(message: message(for: error))
+        }
+
+        syncSessionState()
+    }
+
+    func syncSessionState() {
+        isLocked = session.isLocked
+        hasAnyPINs = session.hasAnyPINs
+    }
+}
+
+private extension POSLockScreenModel {
+    func observeSessionState() {
+        withObservationTracking {
+            _ = session.isLocked
+            _ = session.hasAnyPINs
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.syncSessionState()
+                self?.observeSessionState()
+            }
+        }
+    }
+
+    func message(for error: POSAuthError) -> String {
+        switch error {
+        case .invalidPIN:
+            Localization.invalidPIN
+        case .unknown:
+            Localization.unknownError
+        }
+    }
+
+    enum Localization {
+        static let invalidPIN = NSLocalizedString(
+            "pos.lockScreen.invalidPIN",
+            value: "Incorrect PIN. Try again.",
+            comment: "Error shown on the POS lock screen when the entered PIN is invalid."
+        )
+        static let unknownError = NSLocalizedString(
+            "pos.lockScreen.unknownError",
+            value: "Something went wrong. Try again.",
+            comment: "Error shown on the POS lock screen when unlocking fails for an unknown reason."
+        )
+    }
+}

--- a/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
@@ -6,7 +6,7 @@ import Observation
 final class POSLockScreenModel {
     private let session: POSAccessSession
 
-    var pinEntryState: POSPINEntryState = .idle
+    private(set) var pinEntryState: POSPINEntryState = .idle
 
     var isLocked: Bool {
         session.isLocked
@@ -15,6 +15,13 @@ final class POSLockScreenModel {
     init(session: POSAccessSession) {
         self.session = session
     }
+
+    #if DEBUG
+    convenience init(session: POSAccessSession, initialPinEntryState: POSPINEntryState) {
+        self.init(session: session)
+        self.pinEntryState = initialPinEntryState
+    }
+    #endif
 
     func signIn(withPIN pin: String) async {
         pinEntryState = .loading

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -9,7 +9,6 @@ final class MockPOSAccessSession: POSAccessSession {
     var isLocked: Bool
     var hasAnyPINs: Bool
     var signInResult: Result<POSOperator, POSAuthError>
-    var refreshedPINStatus: Bool
     var signInPINs: [String] = []
     var onSignIn: (() -> Void)?
 
@@ -18,13 +17,11 @@ final class MockPOSAccessSession: POSAccessSession {
          hasAnyPINs: Bool = true,
          signInResult: Result<POSOperator, POSAuthError> = .success(
             POSOperator(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
-         ),
-         refreshedPINStatus: Bool = true) {
+         )) {
         self.currentOperator = currentOperator
         self.isLocked = isLocked
         self.hasAnyPINs = hasAnyPINs
         self.signInResult = signInResult
-        self.refreshedPINStatus = refreshedPINStatus
     }
 
     func allows(_ capability: POSCapability) -> Bool {
@@ -50,9 +47,7 @@ final class MockPOSAccessSession: POSAccessSession {
         isLocked = true
     }
 
-    func refreshPINStatus() async {
-        hasAnyPINs = refreshedPINStatus
-    }
+    func refreshPINStatus() async {}
 }
 
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -1,0 +1,75 @@
+#if DEBUG
+
+import Observation
+
+@Observable
+@MainActor
+final class MockPOSAccessSession: POSAccessSession {
+    var currentOperator: POSOperator?
+    var isLocked: Bool
+    var hasAnyPINs: Bool
+    var signInResult: Result<POSOperator, POSAuthError>
+    var managerApprovalResult: Result<Void, POSAuthError>
+    var refreshedPINStatus: Bool
+    var signInPINs: [String] = []
+    var managerApprovalPINs: [String] = []
+    var approvedCapabilities: [POSCapability] = []
+    var onSignIn: (() -> Void)?
+    var onRefreshPINStatus: (() -> Void)?
+
+    init(currentOperator: POSOperator? = nil,
+         isLocked: Bool = false,
+         hasAnyPINs: Bool = true,
+         signInResult: Result<POSOperator, POSAuthError> = .success(
+            POSOperator(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
+         ),
+         managerApprovalResult: Result<Void, POSAuthError> = .success(()),
+         refreshedPINStatus: Bool = true) {
+        self.currentOperator = currentOperator
+        self.isLocked = isLocked
+        self.hasAnyPINs = hasAnyPINs
+        self.signInResult = signInResult
+        self.managerApprovalResult = managerApprovalResult
+        self.refreshedPINStatus = refreshedPINStatus
+    }
+
+    func allows(_ capability: POSCapability) -> Bool {
+        currentOperator?.hasCapability(capability) == true
+    }
+
+    func signIn(withPIN pin: String) async throws(POSAuthError) {
+        signInPINs.append(pin)
+        onSignIn?()
+
+        switch signInResult {
+        case .success(let signedInOperator):
+            currentOperator = signedInOperator
+            isLocked = false
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func requestManagerApproval(withPIN pin: String, for capability: POSCapability) async throws(POSAuthError) {
+        managerApprovalPINs.append(pin)
+        approvedCapabilities.append(capability)
+
+        switch managerApprovalResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func lock() {
+        isLocked = true
+    }
+
+    func refreshPINStatus() async {
+        hasAnyPINs = refreshedPINStatus
+        onRefreshPINStatus?()
+    }
+}
+
+#endif

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -9,13 +9,9 @@ final class MockPOSAccessSession: POSAccessSession {
     var isLocked: Bool
     var hasAnyPINs: Bool
     var signInResult: Result<POSOperator, POSAuthError>
-    var managerApprovalResult: Result<Void, POSAuthError>
     var refreshedPINStatus: Bool
     var signInPINs: [String] = []
-    var managerApprovalPINs: [String] = []
-    var approvedCapabilities: [POSCapability] = []
     var onSignIn: (() -> Void)?
-    var onRefreshPINStatus: (() -> Void)?
 
     init(currentOperator: POSOperator? = nil,
          isLocked: Bool = false,
@@ -23,13 +19,11 @@ final class MockPOSAccessSession: POSAccessSession {
          signInResult: Result<POSOperator, POSAuthError> = .success(
             POSOperator(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
          ),
-         managerApprovalResult: Result<Void, POSAuthError> = .success(()),
          refreshedPINStatus: Bool = true) {
         self.currentOperator = currentOperator
         self.isLocked = isLocked
         self.hasAnyPINs = hasAnyPINs
         self.signInResult = signInResult
-        self.managerApprovalResult = managerApprovalResult
         self.refreshedPINStatus = refreshedPINStatus
     }
 
@@ -50,17 +44,7 @@ final class MockPOSAccessSession: POSAccessSession {
         }
     }
 
-    func requestManagerApproval(withPIN pin: String, for capability: POSCapability) async throws(POSAuthError) {
-        managerApprovalPINs.append(pin)
-        approvedCapabilities.append(capability)
-
-        switch managerApprovalResult {
-        case .success:
-            return
-        case .failure(let error):
-            throw error
-        }
-    }
+    func requestManagerApproval(withPIN pin: String, for capability: POSCapability) async throws(POSAuthError) {}
 
     func lock() {
         isLocked = true
@@ -68,7 +52,6 @@ final class MockPOSAccessSession: POSAccessSession {
 
     func refreshPINStatus() async {
         hasAnyPINs = refreshedPINStatus
-        onRefreshPINStatus?()
     }
 }
 

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -5,27 +5,27 @@ import Observation
 @Observable
 @MainActor
 final class MockPOSAccessSession: POSAccessSession {
-    var currentOperator: POSOperator?
+    var currentStaff: POSStaff?
     var isLocked: Bool
     var hasAnyPINs: Bool
-    var signInResult: Result<POSOperator, POSAuthError>
+    var signInResult: Result<POSStaff, POSAuthError>
     var signInPINs: [String] = []
     var onSignIn: (() -> Void)?
 
-    init(currentOperator: POSOperator? = nil,
+    init(currentStaff: POSStaff? = nil,
          isLocked: Bool = false,
          hasAnyPINs: Bool = true,
-         signInResult: Result<POSOperator, POSAuthError> = .success(
-            POSOperator(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
+         signInResult: Result<POSStaff, POSAuthError> = .success(
+            POSStaff(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
          )) {
-        self.currentOperator = currentOperator
+        self.currentStaff = currentStaff
         self.isLocked = isLocked
         self.hasAnyPINs = hasAnyPINs
         self.signInResult = signInResult
     }
 
     func allows(_ capability: POSCapability) -> Bool {
-        currentOperator?.hasCapability(capability) == true
+        currentStaff?.hasCapability(capability) == true
     }
 
     func signIn(withPIN pin: String) async throws(POSAuthError) {
@@ -33,8 +33,8 @@ final class MockPOSAccessSession: POSAccessSession {
         onSignIn?()
 
         switch signInResult {
-        case .success(let signedInOperator):
-            currentOperator = signedInOperator
+        case .success(let signedInStaff):
+            currentStaff = signedInStaff
             isLocked = false
         case .failure(let error):
             throw error

--- a/Modules/Sources/PointOfSale/Roles/Providers/UnrestrictedPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/UnrestrictedPOSAccessSession.swift
@@ -1,5 +1,7 @@
 @MainActor
 final class UnrestrictedPOSAccessSession: POSAccessSession {
+    nonisolated init() {}
+
     var currentStaff: POSStaff? { nil }
     var isLocked: Bool { false }
     var hasAnyPINs: Bool { false }

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenOverlay.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenOverlay.swift
@@ -44,13 +44,13 @@ private enum POSLockScreenOverlayConstants {
 }
 
 #if DEBUG
-#Preview("Interactive unlock") {
-    POSLockScreenOverlay(session: MockPOSAccessSession(isLocked: true)) {
-        Text("Unlocked POS content")
-            .font(.posHeadingBold)
-            .foregroundStyle(Color.posOnSurface)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.posSurface)
+#Preview("Modifier over dashboard") {
+    NavigationStack {
+        PointOfSaleDashboardView()
+            .environment(POSPreviewHelpers.makePreviewAggregateModel())
+            .environmentObject(POSModalManager())
+            .posLockScreenOverlay()
     }
+    .environment(\.posAccessSession, MockPOSAccessSession(isLocked: true))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenOverlay.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenOverlay.swift
@@ -44,38 +44,8 @@ private enum POSLockScreenOverlayConstants {
 }
 
 #if DEBUG
-#Preview("Overlay locked") {
-    POSLockScreenOverlay(
-        session: MockPOSAccessSession(
-            currentOperator: nil,
-            isLocked: true,
-            hasAnyPINs: true
-        )
-    ) {
-        Color.posSurface
-    }
-}
-
-#Preview("Overlay unlocked") {
-    POSLockScreenOverlay(
-        session: MockPOSAccessSession(
-            currentOperator: POSOperator(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue))),
-            isLocked: false,
-            hasAnyPINs: true
-        )
-    ) {
-        Color.posSurface
-    }
-}
-
 #Preview("Interactive unlock") {
-    POSLockScreenOverlay(
-        session: MockPOSAccessSession(
-            currentOperator: nil,
-            isLocked: true,
-            hasAnyPINs: true
-        )
-    ) {
+    POSLockScreenOverlay(session: MockPOSAccessSession(isLocked: true)) {
         Text("Unlocked POS content")
             .font(.posHeadingBold)
             .foregroundStyle(Color.posOnSurface)

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenOverlay.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenOverlay.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+struct POSLockScreenOverlay<Content: View>: View {
+    private let content: Content
+    @State private var model: POSLockScreenModel
+
+    init(session: POSAccessSession, @ViewBuilder content: () -> Content) {
+        self.content = content()
+        self._model = State(initialValue: POSLockScreenModel(session: session))
+    }
+
+    var body: some View {
+        content
+            .disabled(model.isLocked)
+            .accessibilityHidden(model.isLocked)
+            .overlay {
+                if model.isLocked {
+                    POSLockScreenView(model: model)
+                        .transition(.opacity)
+                }
+            }
+            .animation(.easeInOut(duration: POSLockScreenOverlayConstants.animationDuration), value: model.isLocked)
+    }
+}
+
+private struct POSLockScreenOverlayModifier: ViewModifier {
+    @Environment(\.posAccessSession) private var session
+
+    func body(content: Content) -> some View {
+        POSLockScreenOverlay(session: session) {
+            content
+        }
+    }
+}
+
+extension View {
+    func posLockScreenOverlay() -> some View {
+        modifier(POSLockScreenOverlayModifier())
+    }
+}
+
+private enum POSLockScreenOverlayConstants {
+    static let animationDuration: TimeInterval = 0.2
+}
+
+#if DEBUG
+#Preview("Overlay locked") {
+    POSLockScreenOverlay(
+        session: MockPOSAccessSession(
+            currentOperator: nil,
+            isLocked: true,
+            hasAnyPINs: true
+        )
+    ) {
+        Color.posSurface
+    }
+}
+
+#Preview("Overlay unlocked") {
+    POSLockScreenOverlay(
+        session: MockPOSAccessSession(
+            currentOperator: POSOperator(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue))),
+            isLocked: false,
+            hasAnyPINs: true
+        )
+    ) {
+        Color.posSurface
+    }
+}
+
+#Preview("Interactive unlock") {
+    POSLockScreenOverlay(
+        session: MockPOSAccessSession(
+            currentOperator: nil,
+            isLocked: true,
+            hasAnyPINs: true
+        )
+    ) {
+        Text("Unlocked POS content")
+            .font(.posHeadingBold)
+            .foregroundStyle(Color.posOnSurface)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.posSurface)
+    }
+}
+#endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
@@ -65,8 +65,10 @@ private extension POSLockScreenView {
 }
 
 #Preview("Invalid PIN") {
-    let model = POSLockScreenModel(session: MockPOSAccessSession(isLocked: true, signInResult: .failure(.invalidPIN)))
-    model.pinEntryState = .error(message: "Incorrect PIN. Try again.")
+    let model = POSLockScreenModel(
+        session: MockPOSAccessSession(isLocked: true, signInResult: .failure(.invalidPIN)),
+        initialPinEntryState: .error(message: "Incorrect PIN. Try again.")
+    )
     return POSLockScreenView(model: model)
 }
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+struct POSLockScreenView: View {
+    @State private var model: POSLockScreenModel
+
+    init(session: POSAccessSession) {
+        self._model = State(initialValue: POSLockScreenModel(session: session))
+    }
+
+    init(model: POSLockScreenModel) {
+        self._model = State(initialValue: model)
+    }
+
+    var body: some View {
+        ZStack {
+            Color.posSurfaceContainerLow
+                .ignoresSafeArea()
+
+            VStack(spacing: POSSpacing.xxLarge) {
+                header
+
+                if model.hasAnyPINs {
+                    POSPINEntryView(state: model.pinEntryState) { pin in
+                        Task {
+                            await model.signIn(withPIN: pin)
+                        }
+                    }
+                    .frame(height: Constants.pinEntryHeight)
+                } else {
+                    noPINsMessage
+                }
+            }
+            .frame(maxWidth: Constants.contentWidth)
+            .padding(POSPadding.xxLarge)
+        }
+        .task {
+            await model.refreshPINStatus()
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSLockScreenView {
+    var header: some View {
+        VStack(spacing: POSSpacing.medium) {
+            Image(systemName: "lock.fill")
+                .font(.posHeadingBold)
+                .foregroundColor(.posPrimary)
+                .accessibilityHidden(true)
+
+            VStack(spacing: POSSpacing.xSmall) {
+                Text(Localization.title)
+                    .font(.posHeadingBold)
+                    .foregroundStyle(Color.posOnSurface)
+                    .multilineTextAlignment(.center)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(Localization.subtitle)
+                    .font(.posBodyLargeRegular())
+                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    var noPINsMessage: some View {
+        VStack(spacing: POSSpacing.small) {
+            Text(Localization.noPINsTitle)
+                .font(.posBodyLargeBold)
+                .foregroundStyle(Color.posOnSurface)
+                .multilineTextAlignment(.center)
+
+            Text(Localization.noPINsMessage)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(Color.posOnSurfaceVariantHighest)
+                .multilineTextAlignment(.center)
+        }
+        .padding(POSPadding.large)
+        .background(Color.posSurface)
+        .cornerRadius(POSCornerRadiusStyle.medium.value)
+    }
+}
+
+// MARK: - Constants
+
+private extension POSLockScreenView {
+    enum Constants {
+        static let contentWidth: CGFloat = 420
+        static let pinEntryHeight: CGFloat = 430
+    }
+}
+
+// MARK: - Localization
+
+private extension POSLockScreenView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pos.lockScreen.title",
+            value: "Enter staff PIN",
+            comment: "Title shown on the POS lock screen."
+        )
+        static let subtitle = NSLocalizedString(
+            "pos.lockScreen.subtitle",
+            value: "Unlock POS to continue.",
+            comment: "Subtitle shown on the POS lock screen."
+        )
+        static let noPINsTitle = NSLocalizedString(
+            "pos.lockScreen.noPINs.title",
+            value: "Staff PINs are not set up",
+            comment: "Title shown on the POS lock screen when no staff PINs are available."
+        )
+        static let noPINsMessage = NSLocalizedString(
+            "pos.lockScreen.noPINs.message",
+            value: "Ask a store manager to set up staff PINs before locking POS.",
+            comment: "Message shown on the POS lock screen when no staff PINs are available."
+        )
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Locked") {
+    POSLockScreenView(
+        session: MockPOSAccessSession(
+            currentOperator: nil,
+            isLocked: true,
+            hasAnyPINs: true
+        )
+    )
+}
+
+#Preview("Invalid PIN") {
+    let session = MockPOSAccessSession(
+        currentOperator: nil,
+        isLocked: true,
+        hasAnyPINs: true,
+        signInResult: .failure(.invalidPIN)
+    )
+    let model = POSLockScreenModel(session: session)
+    model.pinEntryState = .error(message: "Incorrect PIN. Try again.")
+
+    return POSLockScreenView(model: model)
+}
+
+#Preview("No PINs") {
+    POSLockScreenView(
+        session: MockPOSAccessSession(
+            currentOperator: nil,
+            isLocked: true,
+            hasAnyPINs: false
+        )
+    )
+}
+#endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
@@ -122,35 +122,16 @@ private extension POSLockScreenView {
 
 #if DEBUG
 #Preview("Locked") {
-    POSLockScreenView(
-        session: MockPOSAccessSession(
-            currentOperator: nil,
-            isLocked: true,
-            hasAnyPINs: true
-        )
-    )
+    POSLockScreenView(session: MockPOSAccessSession(isLocked: true))
 }
 
 #Preview("Invalid PIN") {
-    let session = MockPOSAccessSession(
-        currentOperator: nil,
-        isLocked: true,
-        hasAnyPINs: true,
-        signInResult: .failure(.invalidPIN)
-    )
-    let model = POSLockScreenModel(session: session)
+    let model = POSLockScreenModel(session: MockPOSAccessSession(isLocked: true, signInResult: .failure(.invalidPIN)))
     model.pinEntryState = .error(message: "Incorrect PIN. Try again.")
-
     return POSLockScreenView(model: model)
 }
 
 #Preview("No PINs") {
-    POSLockScreenView(
-        session: MockPOSAccessSession(
-            currentOperator: nil,
-            isLocked: true,
-            hasAnyPINs: false
-        )
-    )
+    POSLockScreenView(session: MockPOSAccessSession(isLocked: true, hasAnyPINs: false, refreshedPINStatus: false))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
@@ -19,22 +19,15 @@ struct POSLockScreenView: View {
             VStack(spacing: POSSpacing.xxLarge) {
                 header
 
-                if model.hasAnyPINs {
-                    POSPINEntryView(state: model.pinEntryState) { pin in
-                        Task {
-                            await model.signIn(withPIN: pin)
-                        }
+                POSPINEntryView(state: model.pinEntryState) { pin in
+                    Task {
+                        await model.signIn(withPIN: pin)
                     }
-                    .frame(height: Constants.pinEntryHeight)
-                } else {
-                    noPINsMessage
                 }
+                .frame(height: Constants.pinEntryHeight)
             }
             .frame(maxWidth: Constants.contentWidth)
             .padding(POSPadding.xxLarge)
-        }
-        .task {
-            await model.refreshPINStatus()
         }
     }
 }
@@ -58,36 +51,10 @@ private extension POSLockScreenView {
 
                 Text(Localization.subtitle)
                     .font(.posBodyLargeRegular())
-                    .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                    .multilineTextAlignment(.center)
-            }
-        }
-    }
-
-    var noPINsMessage: some View {
-        VStack(spacing: POSSpacing.small) {
-            Text(Localization.noPINsTitle)
-                .font(.posBodyLargeBold)
-                .foregroundStyle(Color.posOnSurface)
-                .multilineTextAlignment(.center)
-
-            Text(Localization.noPINsMessage)
-                .font(.posBodyMediumRegular())
                 .foregroundStyle(Color.posOnSurfaceVariantHighest)
                 .multilineTextAlignment(.center)
+            }
         }
-        .padding(POSPadding.large)
-        .background(Color.posSurface)
-        .cornerRadius(POSCornerRadiusStyle.medium.value)
-    }
-}
-
-// MARK: - Constants
-
-private extension POSLockScreenView {
-    enum Constants {
-        static let contentWidth: CGFloat = 420
-        static let pinEntryHeight: CGFloat = 430
     }
 }
 
@@ -105,16 +72,15 @@ private extension POSLockScreenView {
             value: "Unlock POS to continue.",
             comment: "Subtitle shown on the POS lock screen."
         )
-        static let noPINsTitle = NSLocalizedString(
-            "pos.lockScreen.noPINs.title",
-            value: "Staff PINs are not set up",
-            comment: "Title shown on the POS lock screen when no staff PINs are available."
-        )
-        static let noPINsMessage = NSLocalizedString(
-            "pos.lockScreen.noPINs.message",
-            value: "Ask a store manager to set up staff PINs before locking POS.",
-            comment: "Message shown on the POS lock screen when no staff PINs are available."
-        )
+    }
+}
+
+// MARK: - Constants
+
+private extension POSLockScreenView {
+    enum Constants {
+        static let contentWidth: CGFloat = 420
+        static let pinEntryHeight: CGFloat = 430
     }
 }
 
@@ -129,9 +95,5 @@ private extension POSLockScreenView {
     let model = POSLockScreenModel(session: MockPOSAccessSession(isLocked: true, signInResult: .failure(.invalidPIN)))
     model.pinEntryState = .error(message: "Incorrect PIN. Try again.")
     return POSLockScreenView(model: model)
-}
-
-#Preview("No PINs") {
-    POSLockScreenView(session: MockPOSAccessSession(isLocked: true, hasAnyPINs: false, refreshedPINStatus: false))
 }
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSLockScreenView.swift
@@ -17,7 +17,11 @@ struct POSLockScreenView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: POSSpacing.xxLarge) {
-                header
+                Text(Localization.title)
+                    .font(.posHeadingBold)
+                    .foregroundStyle(Color.posOnSurface)
+                    .multilineTextAlignment(.center)
+                    .accessibilityAddTraits(.isHeader)
 
                 POSPINEntryView(state: model.pinEntryState) { pin in
                     Task {
@@ -32,45 +36,14 @@ struct POSLockScreenView: View {
     }
 }
 
-// MARK: - Subviews
-
-private extension POSLockScreenView {
-    var header: some View {
-        VStack(spacing: POSSpacing.medium) {
-            Image(systemName: "lock.fill")
-                .font(.posHeadingBold)
-                .foregroundColor(.posPrimary)
-                .accessibilityHidden(true)
-
-            VStack(spacing: POSSpacing.xSmall) {
-                Text(Localization.title)
-                    .font(.posHeadingBold)
-                    .foregroundStyle(Color.posOnSurface)
-                    .multilineTextAlignment(.center)
-                    .accessibilityAddTraits(.isHeader)
-
-                Text(Localization.subtitle)
-                    .font(.posBodyLargeRegular())
-                .foregroundStyle(Color.posOnSurfaceVariantHighest)
-                .multilineTextAlignment(.center)
-            }
-        }
-    }
-}
-
 // MARK: - Localization
 
 private extension POSLockScreenView {
     enum Localization {
         static let title = NSLocalizedString(
-            "pos.lockScreen.title",
-            value: "Enter staff PIN",
+            "pos.lockScreen.enterYourPIN.title",
+            value: "Enter your PIN",
             comment: "Title shown on the POS lock screen."
-        )
-        static let subtitle = NSLocalizedString(
-            "pos.lockScreen.subtitle",
-            value: "Unlock POS to continue.",
-            comment: "Subtitle shown on the POS lock screen."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSEnvironmentKeys.swift
@@ -58,6 +58,10 @@ struct POSSearchTextFieldUnfocusedBorderColorKey: EnvironmentKey {
     static let defaultValue: Color = .posSurfaceBright
 }
 
+struct POSAccessSessionKey: EnvironmentKey {
+    static let defaultValue: POSAccessSession = UnrestrictedPOSAccessSession()
+}
+
 extension EnvironmentValues {
     var posAnalytics: POSAnalyticsProviding {
         get { self[POSAnalyticsKey.self] }
@@ -97,6 +101,11 @@ extension EnvironmentValues {
     var posSearchTextFieldUnfocusedBorderColor: Color {
         get { self[POSSearchTextFieldUnfocusedBorderColorKey.self] }
         set { self[POSSearchTextFieldUnfocusedBorderColorKey.self] = newValue }
+    }
+
+    var posAccessSession: POSAccessSession {
+        get { self[POSAccessSessionKey.self] }
+        set { self[POSAccessSessionKey.self] = newValue }
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
@@ -58,11 +58,11 @@ struct POSLockScreenModelTests {
 
     @Test func test_signIn_when_pin_is_valid_then_unlocks_and_resets_pin_state() async {
         // Given
-        let signedInOperator = makeOperator()
+        let signedInStaff = makeStaff()
         let session = MockPOSAccessSession(
-            currentOperator: nil,
+            currentStaff: nil,
             isLocked: true,
-            signInResult: .success(signedInOperator)
+            signInResult: .success(signedInStaff)
         )
         let sut = POSLockScreenModel(session: session)
 
@@ -72,7 +72,7 @@ struct POSLockScreenModelTests {
         // Then
         #expect(sut.isLocked == false)
         #expect(sut.pinEntryState == .idle)
-        #expect(session.currentOperator == signedInOperator)
+        #expect(session.currentStaff == signedInStaff)
     }
 
     @Test func test_signIn_when_pin_is_invalid_then_shows_invalid_pin_error() async {
@@ -101,8 +101,8 @@ struct POSLockScreenModelTests {
         #expect(sut.pinEntryState == .error(message: "Something went wrong. Try again."))
     }
 
-    private func makeOperator() -> POSOperator {
-        POSOperator(
+    private func makeStaff() -> POSStaff {
+        POSStaff(
             displayName: "Maya",
             role: "Manager",
             capabilities: Set(POSCapability.allCases.map(\.rawValue))

--- a/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
@@ -7,33 +7,19 @@ import Observation
 struct POSLockScreenModelTests {
     @Test func test_init_when_session_is_locked_then_copies_session_state() {
         // Given
-        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true)
+        let session = MockPOSAccessSession(isLocked: true)
 
         // When
         let sut = POSLockScreenModel(session: session)
 
         // Then
         #expect(sut.isLocked == true)
-        #expect(sut.hasAnyPINs == true)
         #expect(sut.pinEntryState == .idle)
-    }
-
-    @Test func test_refreshPINStatus_when_session_status_changes_then_updates_pin_availability() async {
-        // Given
-        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true, refreshedPINStatus: false)
-        let sut = POSLockScreenModel(session: session)
-
-        // When
-        await sut.refreshPINStatus()
-
-        // Then
-        #expect(sut.hasAnyPINs == false)
-        #expect(sut.isLocked == true)
     }
 
     @Test func test_sessionState_when_session_locks_then_model_updates() async {
         // Given
-        let session = MockPOSAccessSession(isLocked: false, hasAnyPINs: true)
+        let session = MockPOSAccessSession(isLocked: false)
         let sut = POSLockScreenModel(session: session)
 
         await withCheckedContinuation { continuation in
@@ -57,7 +43,7 @@ struct POSLockScreenModelTests {
 
     @Test func test_signIn_when_started_then_sets_loading_state() async {
         // Given
-        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true)
+        let session = MockPOSAccessSession(isLocked: true)
         let sut = POSLockScreenModel(session: session)
         session.onSignIn = {
             #expect(sut.pinEntryState == .loading)
@@ -76,7 +62,6 @@ struct POSLockScreenModelTests {
         let session = MockPOSAccessSession(
             currentOperator: nil,
             isLocked: true,
-            hasAnyPINs: true,
             signInResult: .success(signedInOperator)
         )
         let sut = POSLockScreenModel(session: session)
@@ -92,7 +77,7 @@ struct POSLockScreenModelTests {
 
     @Test func test_signIn_when_pin_is_invalid_then_shows_invalid_pin_error() async {
         // Given
-        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true, signInResult: .failure(.invalidPIN))
+        let session = MockPOSAccessSession(isLocked: true, signInResult: .failure(.invalidPIN))
         let sut = POSLockScreenModel(session: session)
 
         // When
@@ -105,7 +90,7 @@ struct POSLockScreenModelTests {
 
     @Test func test_signIn_when_error_is_unknown_then_shows_generic_error() async {
         // Given
-        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true, signInResult: .failure(.unknown))
+        let session = MockPOSAccessSession(isLocked: true, signInResult: .failure(.unknown))
         let sut = POSLockScreenModel(session: session)
 
         // When

--- a/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Observation
+@testable import PointOfSale
+
+@MainActor
+@Suite(.timeLimit(.minutes(5)))
+struct POSLockScreenModelTests {
+    @Test func test_init_when_session_is_locked_then_copies_session_state() {
+        // Given
+        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true)
+
+        // When
+        let sut = POSLockScreenModel(session: session)
+
+        // Then
+        #expect(sut.isLocked == true)
+        #expect(sut.hasAnyPINs == true)
+        #expect(sut.pinEntryState == .idle)
+    }
+
+    @Test func test_refreshPINStatus_when_session_status_changes_then_updates_pin_availability() async {
+        // Given
+        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true, refreshedPINStatus: false)
+        let sut = POSLockScreenModel(session: session)
+
+        // When
+        await sut.refreshPINStatus()
+
+        // Then
+        #expect(sut.hasAnyPINs == false)
+        #expect(sut.isLocked == true)
+    }
+
+    @Test func test_sessionState_when_session_locks_then_model_updates() async {
+        // Given
+        let session = MockPOSAccessSession(isLocked: false, hasAnyPINs: true)
+        let sut = POSLockScreenModel(session: session)
+
+        await withCheckedContinuation { continuation in
+            withObservationTracking {
+                _ = sut.isLocked
+            } onChange: {
+                Task { @MainActor in
+                    if sut.isLocked {
+                        continuation.resume()
+                    }
+                }
+            }
+
+            // When
+            session.lock()
+        }
+
+        // Then
+        #expect(sut.isLocked == true)
+    }
+
+    @Test func test_signIn_when_started_then_sets_loading_state() async {
+        // Given
+        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true)
+        let sut = POSLockScreenModel(session: session)
+        session.onSignIn = {
+            #expect(sut.pinEntryState == .loading)
+        }
+
+        // When
+        await sut.signIn(withPIN: "1234")
+
+        // Then
+        #expect(session.signInPINs == ["1234"])
+    }
+
+    @Test func test_signIn_when_pin_is_valid_then_unlocks_and_resets_pin_state() async {
+        // Given
+        let signedInOperator = makeOperator()
+        let session = MockPOSAccessSession(
+            currentOperator: nil,
+            isLocked: true,
+            hasAnyPINs: true,
+            signInResult: .success(signedInOperator)
+        )
+        let sut = POSLockScreenModel(session: session)
+
+        // When
+        await sut.signIn(withPIN: "1234")
+
+        // Then
+        #expect(sut.isLocked == false)
+        #expect(sut.pinEntryState == .idle)
+        #expect(session.currentOperator == signedInOperator)
+    }
+
+    @Test func test_signIn_when_pin_is_invalid_then_shows_invalid_pin_error() async {
+        // Given
+        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true, signInResult: .failure(.invalidPIN))
+        let sut = POSLockScreenModel(session: session)
+
+        // When
+        await sut.signIn(withPIN: "9999")
+
+        // Then
+        #expect(sut.isLocked == true)
+        #expect(sut.pinEntryState == .error(message: "Incorrect PIN. Try again."))
+    }
+
+    @Test func test_signIn_when_error_is_unknown_then_shows_generic_error() async {
+        // Given
+        let session = MockPOSAccessSession(isLocked: true, hasAnyPINs: true, signInResult: .failure(.unknown))
+        let sut = POSLockScreenModel(session: session)
+
+        // When
+        await sut.signIn(withPIN: "1234")
+
+        // Then
+        #expect(sut.isLocked == true)
+        #expect(sut.pinEntryState == .error(message: "Something went wrong. Try again."))
+    }
+
+    private func makeOperator() -> POSOperator {
+        POSOperator(
+            displayName: "Maya",
+            role: "Manager",
+            capabilities: Set(POSCapability.allCases.map(\.rawValue))
+        )
+    }
+}


### PR DESCRIPTION
WOOMOB-3139

## Description
This adds the POS lock screen model and SwiftUI view backed by the POS access session. It also adds a reusable lock-screen overlay modifier so a follow-up PR can wrap the POS root once the production access session is injected; this PR only introduces the wrapper and previews, and does not wire it into the live POS entry flow.

## Test Steps
1. Open the `POSLockScreenView` previews and confirm the lock screen shows the minimal `Enter your PIN` header with the shared PIN entry component.
2. Use the invalid PIN preview to confirm the inline error state appears

## Videos & Screenshots

https://github.com/user-attachments/assets/53544e98-9957-4366-bffd-8d68ec7501ec

<img width="350" alt="image" src="https://github.com/user-attachments/assets/87eaa292-58bd-404a-815b-cba668a87ad7" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
