### PR TITLE
Mitigate crash due Swift continuation `checkEligibility()` miss-use

### DIFF
--- a/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationEligibilityCheck.swift
@@ -21,6 +21,8 @@ final class WooPushNotificationEligibilityCheck: WooPushNotificationEligibilityC
 
     @MainActor
     func checkEligibility() async -> Bool {
+        guard stores.isAuthenticated else { return false }
+
         let defaultM1Value = featureFlagService.isFeatureFlagEnabled(.selfDrivenPushToken)
 
         return await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/POS/POSNotificationScheduler.swift
+++ b/WooCommerce/Classes/POS/POSNotificationScheduler.swift
@@ -60,6 +60,8 @@ final class POSNotificationScheduler: POSNotificationScheduling {
     }
 
     func scheduleLocalNotificationIfEligible(for merchantType: POSNotificationScheduler.MerchantType) async {
+        guard stores.isAuthenticated else { return }
+
         let isScheduled = await isNotificationAlreadyScheduled(for: merchantType)
         guard !isScheduled else { return }
         guard isCountryEligible() else { return }

--- a/WooCommerce/Classes/POS/POSNotificationScheduler.swift
+++ b/WooCommerce/Classes/POS/POSNotificationScheduler.swift
@@ -101,32 +101,32 @@ final class POSNotificationScheduler: POSNotificationScheduling {
     }
 
     private func checkIfScheduled(for merchantType: MerchantType) async -> Bool {
-        await withCheckedContinuation { continuation in
+        await MainActor.run {
+            var isScheduled = false
             let action: AppSettingsAction
             switch merchantType {
             case .potentialMerchant:
-                action = AppSettingsAction.getPOSSurveyPotentialMerchantNotificationScheduled { isScheduled in
-                    continuation.resume(returning: isScheduled)
+                action = AppSettingsAction.getPOSSurveyPotentialMerchantNotificationScheduled { scheduled in
+                    isScheduled = scheduled
                 }
             case .currentMerchant:
-                action = AppSettingsAction.getPOSSurveyCurrentMerchantNotificationScheduled { isScheduled in
-                    continuation.resume(returning: isScheduled)
+                action = AppSettingsAction.getPOSSurveyCurrentMerchantNotificationScheduled { scheduled in
+                    isScheduled = scheduled
                 }
             }
-            Task { @MainActor in
-                stores.dispatch(action)
-            }
+            stores.dispatch(action)
+            return isScheduled
         }
     }
 
     private func hasOpenedPOSAtLeastOnce() async -> Bool {
-        await withCheckedContinuation { continuation in
+        await MainActor.run {
+            var hasOpenedPOS = false
             let action = AppSettingsAction.getHasPOSBeenOpenedAtLeastOnce { hasOpened in
-                continuation.resume(returning: hasOpened)
+                hasOpenedPOS = hasOpened
             }
-            Task { @MainActor in
-                stores.dispatch(action)
-            }
+            stores.dispatch(action)
+            return hasOpenedPOS
         }
     }
 
@@ -148,21 +148,15 @@ final class POSNotificationScheduler: POSNotificationScheduling {
 
         await pushNotificationsManager.requestLocalNotification(notification, trigger: trigger)
 
-        await withCheckedContinuation { continuation in
+        await MainActor.run {
             let action: AppSettingsAction
             switch merchantType {
             case .potentialMerchant:
-                action = AppSettingsAction.setPOSSurveyPotentialMerchantNotificationScheduled { _ in
-                    continuation.resume()
-                }
+                action = AppSettingsAction.setPOSSurveyPotentialMerchantNotificationScheduled { _ in }
             case .currentMerchant:
-                action = AppSettingsAction.setPOSSurveyCurrentMerchantNotificationScheduled { _ in
-                    continuation.resume()
-                }
+                action = AppSettingsAction.setPOSSurveyCurrentMerchantNotificationScheduled { _ in }
             }
-            Task { @MainActor in
-                stores.dispatch(action)
-            }
+            stores.dispatch(action)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
@@ -9,7 +9,7 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        storesManager = MockStoresManager(sessionManager: .testingInstance)
+        storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
         featureFlagService = MockFeatureFlagService()
     }
 
@@ -119,6 +119,22 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
 
         // Then
         XCTAssertEqual(capturedUseCache, true)
+    }
+
+    func test_checkEligibility_when_stores_are_not_authenticated_returns_false_without_dispatching_action() async {
+        // Given
+        storesManager = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
+        let checker = WooPushNotificationEligibilityCheck(
+            featureFlagService: featureFlagService,
+            stores: storesManager
+        )
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertTrue(storesManager.receivedActions.isEmpty)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/POSNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSNotificationSchedulerTests.swift
@@ -12,7 +12,7 @@ struct POSNotificationSchedulerTests {
     init() async throws {
         mockFeatureFlagService = MockFeatureFlagService()
         mockPushNotesManager = MockPushNotificationsManager()
-        mockStores = MockStoresManager(sessionManager: .makeForTesting())
+        mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
     }
 
     @Test func scheduleLocalNotificationIfEligible_when_country_is_US_then_notification_is_scheduled() async throws {
@@ -75,6 +75,44 @@ struct POSNotificationSchedulerTests {
 
         // When
         await scheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+
+        // Then
+        #expect(mockPushNotesManager.requestedLocalNotifications.isEmpty)
+    }
+
+    @Test func scheduleLocalNotificationIfEligible_when_stores_are_not_authenticated_then_no_notification_scheduled() async throws {
+        // Given
+        let siteSettings = sampleSiteSettings(countryCode: "US")
+        let mockStores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
+
+        let scheduler = POSNotificationScheduler(
+            stores: mockStores,
+            siteSettings: siteSettings,
+            featureFlagService: mockFeatureFlagService,
+            pushNotificationsManager: mockPushNotesManager
+        )
+
+        // When
+        await scheduler.scheduleLocalNotificationIfEligible(for: .potentialMerchant)
+
+        // Then
+        #expect(mockPushNotesManager.requestedLocalNotifications.isEmpty)
+        #expect(mockStores.receivedActions.isEmpty)
+    }
+
+    @Test func scheduleLocalNotificationIfEligible_when_store_action_is_not_handled_then_uses_safe_defaults() async throws {
+        // Given
+        let siteSettings = sampleSiteSettings(countryCode: "US")
+
+        let scheduler = POSNotificationScheduler(
+            stores: mockStores,
+            siteSettings: siteSettings,
+            featureFlagService: mockFeatureFlagService,
+            pushNotificationsManager: mockPushNotesManager
+        )
+
+        // When
+        await scheduler.scheduleLocalNotificationIfEligible(for: .currentMerchant)
 
         // Then
         #expect(mockPushNotesManager.requestedLocalNotifications.isEmpty)


### PR DESCRIPTION
Part of WOOMOB-3133

## Description
This is a 2-PR mitigation fix. This PR only addresses the first part, which is the continuation misuse:

```
EXC_BREAKPOINT: SWIFT TASK CONTINUATION MISUSE: checkEligibility() leaked its continuation without resuming it
```

GRDB/deauthentication cleanup is intentionally left out for separate follow-up work, as can be tested independently.

## Changes

Since `AuthenticatedState` registers `FeatureFlagStore` and `AppSettingsStore`, but `DeauthenticatedState` does not, if these actions are dispatched after logout the dispatcher can drop them without calling their completion handlers, which can leak checked continuations. We update the following:

  - Skips self-driven push eligibility checks when stores are no longer authenticated.
  - Skips POS local notification scheduling when stores are no longer authenticated.
  - Removes unnecessary checked continuations from `POSNotificationScheduler` for synchronous `AppSettingsAction` dispatches.

## Test Steps
I wasn't able to replicate the crash, but the changes are pretty much defensive, and added additional regression tests to:

- `WooPushNotificationEligibilityCheckTests`
- `POSNotificationSchedulerTests`

## Screenshots
N/A
