### PR TITLE
Mitigate crash due failed to initialize GRDBManager

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/GRDBManagerProvider.swift
+++ b/WooCommerce/Classes/ServiceLocator/GRDBManagerProvider.swift
@@ -1,0 +1,11 @@
+import protocol Storage.GRDBManagerProtocol
+
+protocol GRDBManagerProviding {
+    var initializedGRDBManager: GRDBManagerProtocol? { get }
+}
+
+struct ServiceLocatorGRDBManagerProvider: GRDBManagerProviding {
+    var initializedGRDBManager: GRDBManagerProtocol? {
+        ServiceLocator.initializedGRDBManager
+    }
+}

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -565,7 +565,6 @@ extension ServiceLocator {
 
         _productImageUploader = mock
     }
-
 }
 
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -91,6 +91,7 @@ final class ServiceLocator {
     /// GRDB Manager for local catalog persistence
     ///
     private static var _grdbManager: GRDBManagerProtocol?
+    private static let grdbManagerLock = NSLock()
 
     /// Cocoalumberjack DDLog
     ///
@@ -264,25 +265,43 @@ final class ServiceLocator {
     /// - Returns: An instance of GRDBManagerProtocol
     /// - Throws: Fatal error if GRDBManager initialization fails
     static var grdbManager: GRDBManagerProtocol {
-        guard let grdbManager = _grdbManager else {
-            do {
-                guard let documentsPath = FileManager.default.urls(
-                    for: .documentDirectory,
-                    in: .userDomainMask).first else {
-                    fatalError("Failed to get the path to the documents directory.")
+        withGRDBManagerLock {
+            guard let grdbManager = _grdbManager else {
+                do {
+                    guard let documentsPath = FileManager.default.urls(
+                        for: .documentDirectory,
+                        in: .userDomainMask).first else {
+                        fatalError("Failed to get the path to the documents directory.")
+                    }
+
+                    let databasePath = documentsPath.appendingPathComponent(WooConstants.localSQLiteDatabaseName).path
+                    let manager = try GRDBManager(databasePath: databasePath)
+                    DDLogInfo("Started GRDBManager with database path: \(databasePath)")
+                    _grdbManager = manager
+                    return manager
+                } catch {
+                    fatalError("Failed to initialize GRDBManager: \(error)")
                 }
-
-                let databasePath = documentsPath.appendingPathComponent(WooConstants.localSQLiteDatabaseName).path
-                let manager = try GRDBManager(databasePath: databasePath)
-                DDLogInfo("Started GRDBManager with database path: \(databasePath)")
-                _grdbManager = manager
-                return manager
-            } catch {
-                fatalError("Failed to initialize GRDBManager: \(error)")
             }
-        }
 
-        return grdbManager
+            return grdbManager
+        }
+    }
+
+    /// The already initialized GRDB manager, if any.
+    /// This intentionally does not create the database.
+    static var initializedGRDBManager: GRDBManagerProtocol? {
+        withGRDBManagerLock {
+            _grdbManager
+        }
+    }
+
+    private static func withGRDBManagerLock<T>(_ block: () -> T) -> T {
+        grdbManagerLock.lock()
+        defer {
+            grdbManagerLock.unlock()
+        }
+        return block()
     }
 
     /// Provides the access point to the FileLogger.
@@ -548,12 +567,14 @@ extension ServiceLocator {
     }
 
     /// periphery:ignore - for use in future tests.
-    static func setGRDBManager(_ testInstance: GRDBManagerProtocol) {
+    static func setGRDBManager(_ testInstance: GRDBManagerProtocol?) {
         guard isRunningTests() else {
             return
         }
 
-        _grdbManager = testInstance
+        withGRDBManagerLock {
+            _grdbManager = testInstance
+        }
     }
 }
 

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -566,16 +566,6 @@ extension ServiceLocator {
         _productImageUploader = mock
     }
 
-    /// periphery:ignore - for use in future tests.
-    static func setGRDBManager(_ testInstance: GRDBManagerProtocol?) {
-        guard isRunningTests() else {
-            return
-        }
-
-        withGRDBManagerLock {
-            _grdbManager = testInstance
-        }
-    }
 }
 
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -296,12 +296,9 @@ class DefaultStoresManager: StoresManager {
             dispatch(resetAction)
         }
 
-        // Stop any ongoing catalog sync tasks before resetting session
-        if let siteID = sessionManager.defaultStoreID {
-            Task {
-                await posCatalogSyncCoordinator?.stopOngoingSyncs(for: siteID)
-            }
-        }
+        let siteIDForSync = sessionManager.defaultStoreID
+        let syncCoordinator = posCatalogSyncCoordinator
+        let grdbManager = ServiceLocator.initializedGRDBManager
 
         sessionManager.deleteApplicationPassword(locally: true)
         sessionManager.reset()
@@ -311,13 +308,18 @@ class DefaultStoresManager: StoresManager {
         ZendeskProvider.shared.reset()
         ServiceLocator.storageManager.reset()
 
-        // Reset GRDB on a background thread to avoid blocking logout
-        // when there's a large catalog to delete
-        Task.detached(priority: .userInitiated) {
-            do {
-                try ServiceLocator.grdbManager.reset()
-            } catch {
-                DDLogError("Could not reset GRDB database: \(error)")
+        // Reset GRDB on a background thread to avoid blocking logout when there's a large catalog to delete.
+        // Capture the authenticated-session dependencies before resetting state so cleanup is not lost.
+        if let grdbManager {
+            Task.detached(priority: .userInitiated) {
+                if let siteID = siteIDForSync {
+                    await syncCoordinator?.stopOngoingSyncs(for: siteID)
+                }
+                do {
+                    try grdbManager.reset()
+                } catch {
+                    DDLogError("Could not reset GRDB database: \(error)")
+                }
             }
         }
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -304,6 +304,13 @@ class DefaultStoresManager: StoresManager {
         let syncCoordinator = posCatalogSyncCoordinator
         let grdbManager = grdbManagerProvider.initializedGRDBManager
 
+        // Stop any ongoing catalog sync tasks before resetting session.
+        if let siteID = siteIDForSync {
+            Task {
+                await syncCoordinator?.stopOngoingSyncs(for: siteID)
+            }
+        }
+
         sessionManager.deleteApplicationPassword(locally: true)
         sessionManager.reset()
         state = DeauthenticatedState()
@@ -313,12 +320,8 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.storageManager.reset()
 
         // Reset GRDB on a background thread to avoid blocking logout when there's a large catalog to delete.
-        // Capture the authenticated-session dependencies before resetting state so cleanup is not lost.
         if let grdbManager {
             Task.detached(priority: .userInitiated) {
-                if let siteID = siteIDForSync {
-                    await syncCoordinator?.stopOngoingSyncs(for: siteID)
-                }
                 do {
                     try grdbManager.reset()
                 } catch {

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -42,6 +42,8 @@ class DefaultStoresManager: StoresManager {
     ///
     private let cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache
 
+    private let grdbManagerProvider: GRDBManagerProviding
+
     /// Tracks site IDs that are eligible for app password support to prevent duplicate analytics events
     ///
     private var trackedEligibleSites: Set<Int64> = []
@@ -155,12 +157,14 @@ class DefaultStoresManager: StoresManager {
     init(sessionManager: SessionManagerProtocol,
          notificationCenter: NotificationCenter = .default,
          defaults: UserDefaults = .standard,
-         cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache = .shared) {
+         cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache = .shared,
+         grdbManagerProvider: GRDBManagerProviding = ServiceLocatorGRDBManagerProvider()) {
         _sessionManager = sessionManager
         self.state = AuthenticatedState(sessionManager: sessionManager) ?? DeauthenticatedState()
         self.notificationCenter = notificationCenter
         self.defaults = defaults
         self.cardPresentPaymentOnboardingStateCache = cardPresentPaymentOnboardingStateCache
+        self.grdbManagerProvider = grdbManagerProvider
 
         isLoggedIn = isAuthenticated
         if isLoggedIn, case .some(.wpcom) = sessionManager.defaultCredentials {
@@ -298,7 +302,7 @@ class DefaultStoresManager: StoresManager {
 
         let siteIDForSync = sessionManager.defaultStoreID
         let syncCoordinator = posCatalogSyncCoordinator
-        let grdbManager = ServiceLocator.initializedGRDBManager
+        let grdbManager = grdbManagerProvider.initializedGRDBManager
 
         sessionManager.deleteApplicationPassword(locally: true)
         sessionManager.reset()

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -2,6 +2,7 @@ import Codegen
 import Combine
 import XCTest
 import Networking
+import Storage
 @testable import WooCommerce
 import Yosemite
 
@@ -179,6 +180,51 @@ final class StoresManagerTests: XCTestCase {
         // Assert - verify deauthentication completed successfully
         XCTAssertFalse(manager.isAuthenticated, "Manager should be deauthenticated")
         XCTAssertNil(sessionManager.defaultStoreID, "Default store ID should be cleared after deauthentication")
+    }
+
+    @MainActor
+    func test_deauthenticate_does_not_initialize_grdb_manager_when_it_was_not_initialized() async {
+        // Arrange
+        let sessionManager = SessionManager.testingInstance
+        let manager = DefaultStoresManager(sessionManager: sessionManager,
+                                           notificationCenter: MockNotificationCenter.testingInstance)
+        manager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        manager.updateDefaultStore(storeID: 123)
+        ServiceLocator.setGRDBManager(nil)
+        defer {
+            ServiceLocator.setGRDBManager(nil)
+        }
+
+        // Action
+        manager.deauthenticate()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Assert
+        XCTAssertNil(ServiceLocator.initializedGRDBManager)
+    }
+
+    @MainActor
+    func test_deauthenticate_resets_existing_grdb_manager() async {
+        // Arrange
+        let sessionManager = SessionManager.testingInstance
+        let manager = DefaultStoresManager(sessionManager: sessionManager,
+                                           notificationCenter: MockNotificationCenter.testingInstance)
+        manager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        manager.updateDefaultStore(storeID: 123)
+
+        let resetExpectation = expectation(description: "GRDB reset is called")
+        ServiceLocator.setGRDBManager(MockGRDBManager {
+            resetExpectation.fulfill()
+        })
+        defer {
+            ServiceLocator.setGRDBManager(nil)
+        }
+
+        // Action
+        manager.deauthenticate()
+
+        // Assert
+        await fulfillment(of: [resetExpectation], timeout: 1)
     }
 
     /// Verifies that `authenticate(username: authToken:)` persists the Credentials in the Keychain Storage.
@@ -512,6 +558,22 @@ final class MockAuthenticationManager: AuthenticationManager {
     override func authenticationUI() -> UIViewController {
         authenticationUIInvoked = true
         return UIViewController()
+    }
+}
+
+private final class MockGRDBManager: GRDBManagerProtocol {
+    private let onReset: () -> Void
+
+    var databaseConnection: GRDBDatabaseConnection {
+        fatalError("MockGRDBManager.databaseConnection should not be accessed by these tests.")
+    }
+
+    init(onReset: @escaping () -> Void) {
+        self.onReset = onReset
+    }
+
+    func reset() throws {
+        onReset()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -183,42 +183,37 @@ final class StoresManagerTests: XCTestCase {
     }
 
     @MainActor
-    func test_deauthenticate_does_not_initialize_grdb_manager_when_it_was_not_initialized() async {
+    func test_deauthenticate_does_not_reset_grdb_manager_when_it_was_not_initialized() {
         // Arrange
         let sessionManager = SessionManager.testingInstance
+        let grdbManagerProvider = MockGRDBManagerProvider(grdbManager: nil)
         let manager = DefaultStoresManager(sessionManager: sessionManager,
-                                           notificationCenter: MockNotificationCenter.testingInstance)
+                                           notificationCenter: MockNotificationCenter.testingInstance,
+                                           grdbManagerProvider: grdbManagerProvider)
         manager.authenticate(credentials: SessionSettings.wpcomCredentials)
         manager.updateDefaultStore(storeID: 123)
-        ServiceLocator.setGRDBManager(nil)
-        defer {
-            ServiceLocator.setGRDBManager(nil)
-        }
 
         // Action
         manager.deauthenticate()
-        try? await Task.sleep(nanoseconds: 100_000_000)
 
         // Assert
-        XCTAssertNil(ServiceLocator.initializedGRDBManager)
+        XCTAssertEqual(grdbManagerProvider.initializedGRDBManagerReadCount, 1)
     }
 
     @MainActor
     func test_deauthenticate_resets_existing_grdb_manager() async {
         // Arrange
         let sessionManager = SessionManager.testingInstance
+        let resetExpectation = expectation(description: "GRDB reset is called")
+        let grdbManager = MockGRDBManager {
+            resetExpectation.fulfill()
+        }
+        let grdbManagerProvider = MockGRDBManagerProvider(grdbManager: grdbManager)
         let manager = DefaultStoresManager(sessionManager: sessionManager,
-                                           notificationCenter: MockNotificationCenter.testingInstance)
+                                           notificationCenter: MockNotificationCenter.testingInstance,
+                                           grdbManagerProvider: grdbManagerProvider)
         manager.authenticate(credentials: SessionSettings.wpcomCredentials)
         manager.updateDefaultStore(storeID: 123)
-
-        let resetExpectation = expectation(description: "GRDB reset is called")
-        ServiceLocator.setGRDBManager(MockGRDBManager {
-            resetExpectation.fulfill()
-        })
-        defer {
-            ServiceLocator.setGRDBManager(nil)
-        }
 
         // Action
         manager.deauthenticate()
@@ -558,6 +553,20 @@ final class MockAuthenticationManager: AuthenticationManager {
     override func authenticationUI() -> UIViewController {
         authenticationUIInvoked = true
         return UIViewController()
+    }
+}
+
+private final class MockGRDBManagerProvider: GRDBManagerProviding {
+    private let grdbManager: GRDBManagerProtocol?
+    private(set) var initializedGRDBManagerReadCount = 0
+
+    init(grdbManager: GRDBManagerProtocol?) {
+        self.grdbManager = grdbManager
+    }
+
+    var initializedGRDBManager: GRDBManagerProtocol? {
+        initializedGRDBManagerReadCount += 1
+        return grdbManager
     }
 }
 


### PR DESCRIPTION
Continuation of WOOMOB-3133, first PR on https://github.com/woocommerce/woocommerce-ios/pull/17264

## Description

See https://a8c.sentry.io/issues/7491981428/?project=1458804

Mitigates what seems to be a deauthentication crash (I wasn't able to reproduce) where logout could lazily initialize `GRDBManager` and fatal if SQLite reported the database as locked while creating the GRDB migrations table.

Before this change, `DefaultStoresManager.deauthenticate()` always called `ServiceLocator.grdbManager.reset()`. If GRDB had not been initialized yet, this entered the lazy getter, attempted to create `GRDBManager`, and could crash with:

```Failed to initialize GRDBManager: SQLite error 5: database is locked - while executing CREATE TABLE IF NOT EXISTS grdb_migrations...``` 

The problem I saw reproducing this is that GRDB seems to init much earlier in the lifecycle, even re-installing the app fresh we do not even need to access POS, or enter any specific flow that trigger POS/local catalog setup. In any case this PR changes deauthentication to only reset GRDB when a manager is already initialized. It also serializes access to the lazy GRDB manager to avoid same-process races during first initialization.

Both claude and codex seem to agree independently that most likely this is a logout/deauthentication race involving POS local catalog cleanup plus store actions being dispatched after the app has moved to DeauthenticatedState.

## Changes
- Add a locked, non-creating `ServiceLocator.initializedGRDBManager` accessor.
- Guard `_grdbManager` reads/writes with `NSLock`.
- Update `deauthenticate()` to use an existing GRDB manager instead of forcing lazy initialization.
- Add tests for both deauth paths:
  - GRDB is not initialized, so deauth skips reset.
  - GRDB is initialized, so deauth still resets it.

## Test Steps
- CI should pass
-  Mostly regression checks, for example:
  - Launch the app with an existing authenticated session and confirm the dashboard and POS loads normally.
  - Open POS/local catalog entry point, then log out and confirm logout completes.
  - Log in again after logout and confirm the selected store loads normally.
  - Repeat logout after opening POS to confirm the existing GRDB reset path does not block logout or crash.

## Screenshots
N/A
