### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/Modules/Sources/Hardware/CardReader/StripeCardReader/ReaderDisplayMessage+Localization.swift
+++ b/Modules/Sources/Hardware/CardReader/StripeCardReader/ReaderDisplayMessage+Localization.swift
@@ -23,7 +23,7 @@ extension ReaderDisplayMessage {
         case .cardRemovedTooEarly:
             return Localization.cardRemovedTooEarly
         @unknown default:
-            DDLogWarn("Unlocalized IPP ReaderDisplayMessage recieved")
+            DDLogWarn("Unlocalized IPP ReaderDisplayMessage received")
             return Terminal.stringFromReaderDisplayMessage(self)
         }
     }

--- a/Modules/Sources/Networking/Model/Product/ProductReview.swift
+++ b/Modules/Sources/Networking/Model/Product/ProductReview.swift
@@ -107,7 +107,7 @@ private extension ProductReview {
         /// The URL of the "96" key in the JSON.
         ///
         /// We are ignoring all avatars except the one marked as 96
-        /// to avoid adding an unecessary intermediate object
+        /// to avoid adding an unnecessary intermediate object
         let url96: String?
 
         enum CodingKeys: String, CodingKey {

--- a/Modules/Sources/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/Packages/ShippingLabelCustomsForm.swift
@@ -61,7 +61,7 @@ public struct ShippingLabelCustomsForm: Hashable, Equatable, GeneratedFakeable, 
         self.items = items
     }
 
-    /// Convenient intializer
+    /// Convenient initializer
     ///
     public init(packageID: String, packageName: String, items: [Item]) {
         self.init(packageID: packageID,

--- a/Modules/Sources/Networking/Model/ShippingLabel/WooShippingShipmentIDFormatter.swift
+++ b/Modules/Sources/Networking/Model/ShippingLabel/WooShippingShipmentIDFormatter.swift
@@ -3,7 +3,7 @@ import Foundation
 enum WooShippingShipmentIDFormatter {
     /// Turns numeric shipment ID into formatted as `shipment_<id>`
     /// - Parameter shipmentID: numeric shipment id
-    /// - Returns: formated id string
+    /// - Returns: formatted id string
     static func formattedShipmentID(_ shipmentID: String) -> String {
         return isArgumentIDValid(shipmentID) ?
         Values.shipmentIDPrefix + shipmentID :

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -5,7 +5,7 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
     let title = Localization.title
     let imageName = PointOfSaleAssets.readerConnectionError.imageName
     let settingsAdminUrl: URL
-    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // An unchanging, pseudo-random ID helps us correctly compare two copies which may have different closures.
     // This relies on the closures being immutable
     let id = UUID()
 

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -4,7 +4,7 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel: Identifi
     let readerIDs: [String]
     let connect: (String) -> Void
     let cancelSearch: () -> Void
-    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // An unchanging, pseudo-random ID helps us correctly compare two copies which may have different closures.
     // This relies on the closures being immutable
     let id = UUID()
 

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
@@ -8,7 +8,7 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel
     let progressSubtitle: String = Localization.messageOptional
     let cancelButtonTitle: String
     let cancelReaderUpdate: (() -> Void)?
-    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // An unchanging, pseudo-random ID helps us correctly compare two copies which may have different closures.
     // This relies on the closures being immutable
     let id = UUID()
 

--- a/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
@@ -8,7 +8,7 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel
     let progressSubtitle: String = Localization.messageRequired
     let cancelButtonTitle: String
     let cancelReaderUpdate: (() -> Void)?
-    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // An unchanging, pseudo-random ID helps us correctly compare two copies which may have different closures.
     // This relies on the closures being immutable
     let id = UUID()
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -160,7 +160,7 @@ extension View {
     /// - Parameters:
     ///   - isPresented: Binding to control when the modal is shown.
     ///   - content: Content to show – note this will not update in response to changes outside the scope of the view builder
-    /// - Returns: a modified view which can show the modal content specifed, when applicable.
+    /// - Returns: a modified view which can show the modal content specified, when applicable.
     func posModal<ModalContent: View>(isPresented: Binding<Bool>,
                                       onDismiss: (() -> Void)? = nil,
                                       @ViewBuilder content: @escaping () -> ModalContent) -> some View {
@@ -180,7 +180,7 @@ extension View {
     /// - Parameters:
     ///   - item: Binding to control when the modal is shown. When non-nil, the item is used to build the content.
     ///   - content: Content to show
-    /// - Returns: a modified view which can show the modal content specifed, when applicable.
+    /// - Returns: a modified view which can show the modal content specified, when applicable.
     func posModal<Item: Identifiable & Equatable, ModalContent: View>(
         item: Binding<Item?>,
         onDismiss: (() -> Void)? = nil,

--- a/Modules/Sources/WPMediaPicker/include/WPMediaCollectionDataSource.h
+++ b/Modules/Sources/WPMediaPicker/include/WPMediaCollectionDataSource.h
@@ -333,12 +333,12 @@ typedef int32_t WPMediaRequestID;
 /**
  *  Sets the sorting order the assets are show based on creationDate
  *
- *  @param ascending the order wich assets are retrieved, based on the creationDate. The default value is YES
+ *  @param ascending the order which assets are retrieved, based on the creationDate. The default value is YES
  */
 - (void)setAscendingOrdering:(BOOL)ascending;
 
 /**
- *  The sorting order on wich the assets are returned
+ *  The sorting order on which the assets are returned
  *
  *  @return if the assets are return in ascending order
  */

--- a/Modules/Sources/WooFoundationCore/CurrencyFormatter.swift
+++ b/Modules/Sources/WooFoundationCore/CurrencyFormatter.swift
@@ -120,7 +120,7 @@ public class CurrencyFormatter {
         let space = "\u{00a0}" // unicode equivalent of &nbsp;
         let negative = isNegative ? "-" : ""
 
-        // Remove all occurences of the minus sign from the string amount.
+        // Remove all occurrences of the minus sign from the string amount.
         // We want to position the minus sign manually.
         let amount = amount.replacingOccurrences(of: "-", with: "")
 

--- a/Modules/Sources/WordPressUI/Extensions/UIView+Animations.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIView+Animations.swift
@@ -155,7 +155,7 @@ extension UIView {
     /// Coordinates an animation block alongside a keyboard's notification animation event.
     /// - Parameters:
     ///     - notification: A notficiation from a keyboard change event (keyboardWillShowNotification, keyboardWillHideNotification, etc)
-    ///     - animations: The animation block to be preformed. The block will provide the rects from keyboardFrameBeginUserInfoKey and keyboardFrameEndUserInfoKey to the animation block.
+    ///     - animations: The animation block to be performed. The block will provide the rects from keyboardFrameBeginUserInfoKey and keyboardFrameEndUserInfoKey to the animation block.
     ///
     public static func animate(withKeyboard notification: Notification, _ animations: @escaping (CGRect, CGRect) -> Void ) {
         guard let userInfo = notification.userInfo else { return }

--- a/Modules/Sources/Yosemite/Model/SystemInformation.swift
+++ b/Modules/Sources/Yosemite/Model/SystemInformation.swift
@@ -1,7 +1,7 @@
 import Networking
 import Codegen
 
-/// Store sytem information entity.
+/// Store system information entity.
 ///
 public struct SystemInformation: GeneratedFakeable, GeneratedCopiable {
     /// Store UUID

--- a/Modules/Tests/YosemiteTests/Stores/JustInTimeMessageStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/JustInTimeMessageStoreTests.swift
@@ -102,7 +102,7 @@ final class JustInTimeMessageStoreTests: XCTestCase {
         XCTAssert(result.isFailure)
         guard case .failure(let error) = result,
             let error = error as? DotcomError else {
-            return XCTFail("Expected error not recieved")
+            return XCTFail("Expected error not received")
         }
         assertEqual(DotcomError.noRestRoute(), error)
     }

--- a/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
@@ -591,7 +591,7 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(storageOrder?.toReadOnly(), remoteOrder)
     }
 
-    /// Verifies that `upsertStoredOrder` doesnt mark a Pre Existant order as "Search Results" (since it's been already
+    /// Verifies that `upsertStoredOrder` doesn't mark a Pre Existant order as "Search Results" (since it's been already
     /// retrieved for "Regular Scroll" display).
     ///
     func testUpsertStoredOrderDoesntMarkPreExistantOrdersAsSearchResults() {

--- a/Modules/Tests/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -53,7 +53,7 @@ final class ResultsControllerTests: XCTestCase {
     }
 
 
-    /// Verifies that ResultsController does pick up pre-existant entities, right after performFetch runs.
+    /// Verifies that ResultsController does pick up pre-existent entities, right after performFetch runs.
     ///
     func testResultsControllerPicksUpEntitiesAvailablePriorToInstantiation() {
         storageManager.insertSampleAccount()
@@ -261,7 +261,7 @@ final class ResultsControllerTests: XCTestCase {
     }
 
 
-    /// Verifies that `objectIndex(from indexPath:)` returns a plain Integer that can be used to retrive the target Object
+    /// Verifies that `objectIndex(from indexPath:)` returns a plain Integer that can be used to retrieve the target Object
     /// from the `fetchedObjects` collection.
     ///
     func testObjectIndexFromIndexPathReturnsAPlainIndexThatLetsYouMapTheProperObject() {

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -312,7 +312,7 @@ private extension WooAnalytics {
         return [PropertyKeys.propertyKeyTimeInApp: timeInApp.description]
     }
 
-    /// Builds the necesary properties for the `application_opened` event.
+    /// Builds the necessary properties for the `application_opened` event.
     ///
     func applicationOpenedProperties(_ configurationResult: Result<[WidgetInfo], Error>) -> [String: String] {
         guard let installedWidgets = try? configurationResult.get() else {

--- a/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
+++ b/WooCommerce/Classes/Authentication/WebAuth/WebKitViewController.swift
@@ -149,7 +149,7 @@ class WebKitViewController: UIViewController {
         stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         stackView.topAnchor.constraint(equalTo: safeArea.topAnchor).isActive = true
 
-        // this constraint saved as a varible so it can be deactivated when the toolbar is hidden, to prevent unintended pinning to the safe area
+        // this constraint saved as a variable so it can be deactivated when the toolbar is hidden, to prevent unintended pinning to the safe area
         let stackViewBottom = stackView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)
         stackViewBottomAnchor = stackViewBottom
         NSLayoutConstraint.activate([stackViewBottom])

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase+Woo.swift
@@ -3,10 +3,10 @@ import Yosemite
 
 extension MarkOrderAsReadUseCase {
     /// Async method that marks the order note as read if it is the notification for the last order.
-    /// We do it in a way that first we syncronize notification to get the remote `Note`
+    /// We do it in a way that first we synchronize notification to get the remote `Note`
     /// and then we compare local `orderID` with the one from remote `Note`.
     /// If they match we mark it as read.
-    /// Returns syncronized note if marking was successful and error if some error happened
+    /// Returns synchronized note if marking was successful and error if some error happened
     @MainActor
     static func markOrderNoteAsReadIfNeeded(stores: StoresManager, noteID: Int64, orderID: Int) async -> Result<Note, Error> {
         let syncronizedNoteResult: Result<Note, Error> = await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
@@ -11,10 +11,10 @@ struct MarkOrderAsReadUseCase {
     }
 
     /// Async method that marks the order note as read if it is the notification for the last order.
-    /// We do it in a way that first we syncronize notification to get the remote `Note`
+    /// We do it in a way that first we synchronize notification to get the remote `Note`
     /// and then we compare local `orderID` with the one from remote `Note`.
     /// If they match we mark it as read.
-    /// Returns syncronized note id if marking was successful and error if some error happened
+    /// Returns synchronized note id if marking was successful and error if some error happened
     static func markOrderNoteAsReadIfNeeded(network: Network, noteID: Int64, orderID: Int) async -> Result<Int64, Error> {
         let notesRemote = NotificationsRemote(network: network)
 

--- a/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
+++ b/WooCommerce/Classes/Model/ShippingLabelAddress+Woo.swift
@@ -20,7 +20,7 @@ extension ShippingLabelAddress {
         return output.joined(separator: "\n")
     }
 
-    /// Returns the Postal Address, formated and ready for display.
+    /// Returns the Postal Address, formatted and ready for display.
     ///
     var formattedPostalAddress: String? {
         return postalAddress.formatted(as: .mailingAddress)

--- a/WooCommerce/Classes/Styles/Style.swift
+++ b/WooCommerce/Classes/Styles/Style.swift
@@ -19,7 +19,7 @@ final class StyleManager {
     }
 
     static var chartLabelFont: UIFont {
-        // Dashboard chart needs from a slighly smaller maximum font to be able to fit it when using the biggest accessibility font.
+        // Dashboard chart needs from a slightly smaller maximum font to be able to fit it when using the biggest accessibility font.
         return .font(forStyle: .caption2, weight: .regular, maxFontSize: 20.0)
     }
 

--- a/WooCommerce/Classes/Tools/AppLocalizedString.swift
+++ b/WooCommerce/Classes/Tools/AppLocalizedString.swift
@@ -24,7 +24,7 @@ typealias LocalizedString = String
 /// from App Extensions and Widgets, in order to reference strings whose localization live in the app bundle's `.strings` file
 /// (rather than the AppExtension's own bundle).
 ///
-/// In order to avoid duplicating our strings accross targets, and make our localization process & tooling easier, we keep all
+/// In order to avoid duplicating our strings across targets, and make our localization process & tooling easier, we keep all
 /// localized `.strings` in the app's bundle (and don't have a `.strings` file in the App Extension targets themselves);
 /// then we make those App Extensions & Widgets reference the strings from the `Localizable.strings` files
 /// hosted in the app bundle itself – which is when this helper method is helpful.

--- a/WooCommerce/Classes/Tools/ShippingValueLocalizer/DefaultShippingValueLocalizer.swift
+++ b/WooCommerce/Classes/Tools/ShippingValueLocalizer/DefaultShippingValueLocalizer.swift
@@ -59,7 +59,7 @@ private extension DefaultShippingValueLocalizer {
     ///     - from: The current `Locale` of the input string.
     ///     - to: The `Locale` to be used for localizing the input string.
     ///
-    /// - Returns: The input string localized to the target locale. Returns `nil` if the localization is unsucessful.
+    /// - Returns: The input string localized to the target locale. Returns `nil` if the localization is unsuccessful.
     ///
     func localizedString(using string: String,
                                 from sourceLocale: Locale,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -24,13 +24,13 @@ protocol CardPresentPaymentsModalViewModelContent {
     /// The title in the bottom section of the modal. Right below the image
     var bottomTitle: String? { get }
 
-    /// The attributed title in the bottom section of the modal. Prefered over bottomTitle if defined
+    /// The attributed title in the bottom section of the modal. Preferred over bottomTitle if defined
     var bottomAttributedTitle: NSAttributedString? { get }
 
     /// The subtitle in the bottom section of the modal. Right below the image
     var bottomSubtitle: String? { get }
 
-    /// The attributed title in the bottom section of the modal. Prefered over bottomTitle if defined
+    /// The attributed title in the bottom section of the modal. Preferred over bottomTitle if defined
     var bottomAttributedSubtitle: NSAttributedString? { get }
 
     /// The accessibilityLabel to be provided to VoiceOver

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -54,13 +54,13 @@ struct AddOnCrossreferenceUseCase {
         return components.dropLast().joined(separator: splitToken)
     }
 
-    /// Returns whether if the provided add-on name matches any of the stored product add-ons
+    /// Returns whether the provided add-on name matches any of the stored product add-ons
     ///
     private func addOnNameExistsInProductAddOns(_ name: String) -> Bool {
         product.addOns.contains { $0.name == name }
     }
 
-    /// Returns whether if the provided add-on name matches any of the stored global add-ons
+    /// Returns whether the provided add-on name matches any of the stored global add-ons
     ///
     private func addOnNameExistsInGlobalAddOns(_ name: String) -> Bool {
         let globalAddOns = addOnGroups.flatMap { $0.addOns }

--- a/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/AddOns/AddOnCrossreferenceUseCase.swift
@@ -54,13 +54,13 @@ struct AddOnCrossreferenceUseCase {
         return components.dropLast().joined(separator: splitToken)
     }
 
-    /// Returns wether if the provided add-on name matches any of the stored product add-ons
+    /// Returns whether if the provided add-on name matches any of the stored product add-ons
     ///
     private func addOnNameExistsInProductAddOns(_ name: String) -> Bool {
         product.addOns.contains { $0.name == name }
     }
 
-    /// Returns wether if the provided add-on name matches any of the stored global add-ons
+    /// Returns whether if the provided add-on name matches any of the stored global add-ons
     ///
     private func addOnNameExistsInGlobalAddOns(_ name: String) -> Bool {
         let globalAddOns = addOnGroups.flatMap { $0.addOns }

--- a/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ProductDetailsCellViewModel.swift
@@ -35,7 +35,7 @@ struct ProductDetailsCellViewModel {
 
     let addOns: AddOnsViewModel
 
-    /// Wether the item has add-ons associated to it.
+    /// Whether the item has add-ons associated to it.
     ///
     let hasAddOns: Bool
 

--- a/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/ShippingProvidersViewModel.swift
@@ -3,7 +3,7 @@ import UIKit
 import Yosemite
 
 /// Encapsulates the logic necessary to render a list of shipment tracking providers
-/// The list of providers has to be ordered alphabetically (ascending), wiht two exceptions:
+/// The list of providers has to be ordered alphabetically (ascending), with two exceptions:
 /// - A section to add Custom Providers
 /// - The providers corresponding to the store country should be shown first
 final class ShippingProvidersViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingIPPUsersRefresher.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingIPPUsersRefresher.swift
@@ -11,7 +11,7 @@ class CardPresentPaymentsOnboardingIPPUsersRefresher {
     private var cancellables: Set<AnyCancellable> = []
 
     /// These are separate from other cancellables (if we add any) because they get cancelled whenever
-    /// we recieve an onboarding state, other than `.loading`.
+    /// we receive an onboarding state, other than `.loading`.
     /// This is unlikely to be what we want for other subscriptions.
     private var onboardingStateObservations: Set<AnyCancellable> = []
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewViewModel.swift
@@ -164,7 +164,7 @@ private extension WooPaymentsPayoutsCurrencyOverviewViewModel {
             comment: "String used when there's no date available for a payout type on the WooPayments Payouts View.")
         static let estimatedDateString = NSLocalizedString(
             "Est. %1$@",
-            comment: "String indicating that a payout date is an estimate. Shown on when WooPayments Payouts View. " +
+            comment: "String indicating that a payout date is an estimate. Shown on the WooPayments Payouts View. " +
             "%1$@ will be replaced with a locale-appropriate date string.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsPayoutsCurrencyOverviewViewModel.swift
@@ -164,7 +164,7 @@ private extension WooPaymentsPayoutsCurrencyOverviewViewModel {
             comment: "String used when there's no date available for a payout type on the WooPayments Payouts View.")
         static let estimatedDateString = NSLocalizedString(
             "Est. %1$@",
-            comment: "String indicating that a payout date is an estimate. Shown on whe WooPayments Payouts View. " +
+            comment: "String indicating that a payout date is an estimate. Shown on when WooPayments Payouts View. " +
             "%1$@ will be replaced with a locale-appropriate date string.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -325,7 +325,7 @@ final class PaymentMethodsViewModel: ObservableObject {
         trackCollectIntention(method: .scanToPay, cardReaderType: .none)
     }
 
-    /// Perform the necesary tasks after a link is shared.
+    /// Perform the necessary tasks after a link is shared.
     ///
     func performLinkSharedTasks() {
         presentNoticeSubject.send(.created)

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewModel.swift
@@ -145,7 +145,7 @@ final class ProductCategoryListViewModel {
         self.onReloadNeeded = onReloadNeeded
     }
 
-    /// The invokation of this method will trigger a reload of the list without performing any new fetch,
+    /// The invocation of this method will trigger a reload of the list without performing any new fetch,
     /// neither local or remote.
     ///
     func reloadData() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/BottomSheetProductType.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/BottomSheetListSelector/BottomSheetProductType.swift
@@ -90,7 +90,7 @@ public enum BottomSheetProductType: Hashable, Identifiable {
             return NSLocalizedString(
                 "bottomSheetProductType.variable.title",
                 value: "Variable product",
-                comment: "Action sheet option when the user wants to change the Product type to varible product")
+                comment: "Action sheet option when the user wants to change the Product type to variable product")
         case .grouped:
             return NSLocalizedString(
                 "bottomSheetProductType.grouped.title",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/EditProductCategoryListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Categories/EditProductCategoryListViewModel.swift
@@ -43,7 +43,7 @@ final class EditProductCategoryListViewModel {
         onCompletionCallback(baseProductCategoryListViewModel.selectedCategories)
     }
 
-    /// Informs of wether there are still changes that were not commited
+    /// Informs of whether there are still changes that were not committed
     ///
     func hasUnsavedChanges() -> Bool {
         return product.categories.sorted() != baseProductCategoryListViewModel.selectedCategories.sorted()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/UnitInputViewModel+BulkUpdatePrice.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Bulk Edit Price/UnitInputViewModel+BulkUpdatePrice.swift
@@ -11,7 +11,7 @@ extension UnitInputViewModel {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         let currencyCode = currencySettings.currencyCode
         let unit = currencySettings.symbol(from: currencyCode)
-        /// Depending on the currency settings we might have different decimal seperator or number of digits
+        /// Depending on the currency settings we might have different decimal separator or number of digits
         let formattedPlaceholder = currencyFormatter.localize(Decimal.zero,
                                                               decimalSeparator: currencySettings.decimalSeparator,
                                                               fractionDigits: currencySettings.fractionDigits,

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterType+Products.swift
@@ -8,7 +8,7 @@ struct PromotableProductType: Equatable {
     ///
     let productType: ProductType
 
-    /// Wether the product is available in the store
+    /// Whether the product is available in the store
     ///
     let isAvailable: Bool
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/TopProductsFromCachedOrdersProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/TopProductsFromCachedOrdersProvider.swift
@@ -38,7 +38,7 @@ final class TopProductsFromCachedOrdersProvider: ProductSelectorTopProductsProvi
 
 private extension TopProductsFromCachedOrdersProvider {
     func retrievePopularProductsIds(from siteID: Int64) -> [Int64] {
-        // Get product ids sorted by occurence
+        // Get product ids sorted by occurrence
         let completedOrdersItems = retrieveCompletedOrders(from: siteID).flatMap { $0.items }
         let productIDCountDictionary = completedOrdersItems.reduce(into: [:]) { counts, orderItem in counts[orderItem.productID, default: 0] += 1 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationGenerator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationGenerator.swift
@@ -34,7 +34,7 @@ struct ProductVariationGenerator {
         return buildVariations(from: uniqueCombinations, for: product)
     }
 
-    /// Generates all posible combination for a product attributes.
+    /// Generates all possible combination for a product attributes.
     ///
     private static func getCombinations(from product: Product) -> [Combination] {
         // Iterates through attributes while receiving the previous combinations list.

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationGenerator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationGenerator.swift
@@ -34,7 +34,7 @@ struct ProductVariationGenerator {
         return buildVariations(from: uniqueCombinations, for: product)
     }
 
-    /// Generates all possible combination for a product attributes.
+    /// Generates all possible combinations for a product attributes.
     ///
     private static func getCombinations(from product: Product) -> [Combination] {
         // Iterates through attributes while receiving the previous combinations list.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/BordersView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/BordersView.swift
@@ -94,7 +94,7 @@ class BordersView: UIView {
         }
     }
 
-    /// Overriden Frame Property!
+    /// Overridden Frame Property!
     ///
     override var frame: CGRect {
         didSet {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -293,7 +293,7 @@ struct TopTabView<Content: View>: View {
     }
 
     private func calculateOffset(index: Int) -> CGFloat {
-        // Takes all preceeding tab widths, and adds appropriate spacing to each side to get the overall offset
+        // Takes all preceding tab widths, and adds appropriate spacing to each side to get the overall offset
         return tabWidths.prefix(index).reduce(0, +) + CGFloat(index) * (tabPadding * 2)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewControllersFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewControllersFactory.swift
@@ -11,7 +11,7 @@ protocol SurveyViewControllersFactoryProtocol {
     func makeSurveyViewController(survey: SurveyViewController.Source,
                                   onCompletion: @escaping () -> Void) -> SurveyViewControllerOutputs
 
-    /// Creates a `ViewController` that conforms to`SurveySubmittedViewControllerOutputs` by providing the necesary actions
+    /// Creates a `ViewController` that conforms to`SurveySubmittedViewControllerOutputs` by providing the necessary actions
     ///
     func makeSurveySubmittedViewController(onContactUsAction: @escaping () -> Void,
                                            onBackToStoreAction: @escaping () -> Void) -> SurveySubmittedViewControllerOutputs

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -147,7 +147,7 @@ extension CrashLogging {
     /// Causes the Crash Logging System to refresh its knowledge about the current state of the system.
     ///
     /// This is required in situations like login / logout, when the system otherwise might not
-    /// know a change has occured.
+    /// know a change has occurred.
     ///
     /// Calling this method in these situations prevents
     public func setNeedsDataRefresh() {

--- a/WooCommerce/WordPressAuthenticator/Services/WordPressComAccountService.swift
+++ b/WooCommerce/WordPressAuthenticator/Services/WordPressComAccountService.swift
@@ -4,7 +4,7 @@ import Foundation
 //
 public class WordPressComAccountService {
 
-    /// Makes the intializer public for external access.
+    /// Makes the initializer public for external access.
     public init() {}
 
     /// Indicates if a WordPress.com account is "PasswordLess": This kind of account must be authenticated via a Magic Link.

--- a/WooCommerce/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
+++ b/WooCommerce/WordPressAuthenticator/UI/SiteInfoHeaderView.swift
@@ -71,7 +71,7 @@ class SiteInfoHeaderView: UIView {
         }
     }
 
-    // MARK: - Overriden Methods
+    // MARK: - Overridden Methods
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressAPIError.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressAPIError.swift
@@ -5,13 +5,13 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
         NSLocalizedString(
             "wordpress-api.error.unknown",
             value: "Something went wrong, please try again later.",
-            comment: "Error message that describes an unknown error had occured"
+            comment: "Error message that describes an unknown error had occurred"
         )
     }
 
     /// Can't encode the request arguments into a valid HTTP request. This is a programming error.
     case requestEncodingFailure(underlyingError: Error)
-    /// Error occured in the HTTP connection.
+    /// Error occurred in the HTTP connection.
     case connection(URLError)
     /// The API call returned an error result. For example, an OAuth endpoint may return an 'incorrect username or password' error, an upload media endpoint may return an 'unsupported media type' error.
     case endpointError(EndpointError)
@@ -19,7 +19,7 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     case unacceptableStatusCode(response: HTTPURLResponse, body: Data)
     /// The API call returned an HTTP response that WordPressKit can't parse. Receiving this error could be an indicator that there is an error response that's not handled properly by WordPressKit.
     case unparsableResponse(response: HTTPURLResponse?, body: Data?, underlyingError: Error)
-    /// Other error occured.
+    /// Other error occurred.
     case unknown(underlyingError: Error)
 
     static func unparsableResponse(response: HTTPURLResponse?, body: Data?) -> Self {

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCApi.swift
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/CoreAPI/WordPressOrgXMLRPCApi.swift
@@ -315,7 +315,7 @@ extension WordPressOrgXMLRPCApiError: LocalizedError {
         case .responseSerializationFailed:
             return NSLocalizedString("The serialization of the response failed.", comment: "A failure reason for when the response couldn't be serialized.")
         case .unknown:
-            return NSLocalizedString("An unknown error occurred.", comment: "A failure reason for when the error that occured wasn't able to be determined.")
+            return NSLocalizedString("An unknown error occurred.", comment: "A failure reason for when the error that occurred wasn't able to be determined.")
         }
     }
 }

--- a/WooCommerce/WordPressAuthenticator/WordPressKit/Services/AccountServiceRemoteREST.m
+++ b/WooCommerce/WordPressAuthenticator/WordPressKit/Services/AccountServiceRemoteREST.m
@@ -96,7 +96,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
         NSParameterAssert([key isKindOfClass:[NSNumber class]]);
         NSParameterAssert([obj isKindOfClass:[NSNumber class]]);
         /*
-         Blog IDs are pased as strings because JSON dictionaries can't take
+         Blog IDs are passed as strings because JSON dictionaries can't take
          non-string keys. If you try, you get a NSInvalidArgumentException
          */
         NSString *blogID = [key stringValue];

--- a/WooCommerce/WordPressAuthenticatorTests/GoogleSignIn/CodeVerifierTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/GoogleSignIn/CodeVerifierTests.swift
@@ -11,7 +11,7 @@ class CodeVerifierTests: XCTestCase {
     }
 
     func testGeneratedCodeVerifierHasLength43() throws {
-        // 43 is the recommended lenght. See https://www.rfc-editor.org/rfc/rfc7636#section-4.1
+        // 43 is the recommended length. See https://www.rfc-editor.org/rfc/rfc7636#section-4.1
         XCTAssertEqual(try ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier().rawValue.count, 43)
         XCTAssertEqual(try ProofKeyForCodeExchange.CodeVerifier.makeRandomCodeVerifier().rawValue.count, 43)
     }
@@ -34,7 +34,7 @@ class CodeVerifierTests: XCTestCase {
     // MARK: –
 
     func testCodeVerifierInitFailsWithValueShorterThan43() {
-        // 43 is the minimmum lenght from the spec
+        // 43 is the minimum length from the spec
         XCTAssertNil(ProofKeyForCodeExchange.CodeVerifier(value: ""))
         XCTAssertNil(ProofKeyForCodeExchange.CodeVerifier(value: "a".repeated(42)))
         XCTAssertEqual(ProofKeyForCodeExchange.CodeVerifier(value: "a".repeated(43))?.rawValue.count, 43)

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
@@ -332,7 +332,7 @@ class WordPressComRestApiTests: XCTestCase {
             expect.fulfill()
             }, failure: { _, _ in
                 expect.fulfill()
-                XCTFail("This call should successful")
+                XCTFail("This call should succeed")
             }
         )
         self.waitForExpectations(timeout: 5, handler: nil)

--- a/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
+++ b/WooCommerce/WordPressAuthenticatorTests/WordPressKit/CoreAPITests/WordPressComRestApiTests.swift
@@ -332,7 +332,7 @@ class WordPressComRestApiTests: XCTestCase {
             expect.fulfill()
             }, failure: { _, _ in
                 expect.fulfill()
-                XCTFail("This call should succesful")
+                XCTFail("This call should successful")
             }
         )
         self.waitForExpectations(timeout: 5, handler: nil)

--- a/docs/choosing-between-structs-and-classes.md
+++ b/docs/choosing-between-structs-and-classes.md
@@ -15,6 +15,6 @@ But consider using `class` instead if:
 When using classes, these should be marked as `final` by default so their behavior cannot be altered by subclassing and/or overriding. There's a few reasons for that:
 
 - It favors composition over inheritance
-- The class could be missused or abused when subclassed or overriden, which could be problematic if the class is doing anything important. By making it `final` we disallow this at compiler time, and enforce that the class has to be used as it was written.
+- The class could be missused or abused when subclassed or overridden, which could be problematic if the class is doing anything important. By making it `final` we disallow this at compiler time, and enforce that the class has to be used as it was written.
 - Marking a class as `final` tells the Swift compiler that the class methods should be called directly rather than looking them up in a method table (static vs dynamic dispatch), which [reduces function call overhead and increases performance](https://developer.apple.com/swift/blog/?id=27)
 - If inheritance is necessary later on, it can always be allowed, but the `final` modifier will create a reminder of its necessity and refactoring

--- a/docs/choosing-between-structs-and-classes.md
+++ b/docs/choosing-between-structs-and-classes.md
@@ -15,6 +15,6 @@ But consider using `class` instead if:
 When using classes, these should be marked as `final` by default so their behavior cannot be altered by subclassing and/or overriding. There's a few reasons for that:
 
 - It favors composition over inheritance
-- The class could be missused or abused when subclassed or overridden, which could be problematic if the class is doing anything important. By making it `final` we disallow this at compiler time, and enforce that the class has to be used as it was written.
+- The class could be misused or abused when subclassed or overridden, which could be problematic if the class is doing anything important. By making it `final` we disallow this at compiler time, and enforce that the class has to be used as it was written.
 - Marking a class as `final` tells the Swift compiler that the class methods should be called directly rather than looking them up in a method table (static vs dynamic dispatch), which [reduces function call overhead and increases performance](https://developer.apple.com/swift/blog/?id=27)
 - If inheritance is necessary later on, it can always be allowed, but the `final` modifier will create a reminder of its necessity and refactoring


### PR DESCRIPTION
## Description

Mechanical typo fixes in code comments, doc-comments, and one developer doc.
No behavior changes; no user-facing strings touched.

Each commit fixes typos in a single file so the diff can be reviewed file-by-file.

## Test Steps

- Skim the diff; verify each replacement is the obvious correction.
- CI should be green.

---
- [x] No user-facing changes — release notes not needed.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*