### PR TITLE
[Woo POS][Phone] Fix dismissing payments selection flow mid-way breaks navigation selection

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -531,6 +531,7 @@ extension POSPaymentModel {
         analytics.track(event: .PointOfSale.paymentsOnboardingDismissed(onboardingState: onboardingViewContainer.configuration.state))
         cardPresentPaymentOnboardingViewContainer = nil
         onOnboardingCancellation?()
+        cancelConnectCardReaderTask()
     }
 
     func trackCardPaymentsOnboardingShown() {


### PR DESCRIPTION
Closes WOOMOB-3129

## Description

This PR addresses not being able to setup payment card reader selection from POS Settings if we happen to dismiss the setup once. After dismissing, clicking the button for card reader config stopped working.

This happened because during connection the service publishes `.showOnboarding(factory, onCancel)` which makes the onboarding modal appears, but if we dismiss the view, while `cancelCardPaymentsOnboarding()` fires and triggers `onOnboardingCancellation()`, the initial connectReader(...) is still awaiting, the Task never completes and never throws.

We see the `pos_card_reader_connection_tapped` event tracked as happens before the guard, but no modal or flow starts.

After testing further, the issue does not happen only in phones but iPads too.

## Test Steps
1. In iPad or phone, navigate to POS Settings > Hardware > Card Readers > Connect Card Reader. 
2. Start the setup, then dismiss the view by pressing X while connecting
3. Attempting to setup for a second and subsequent times should work normally

https://github.com/user-attachments/assets/d8ed7743-2882-4878-ad50-fdf694ff3e7b