### PR TITLE
Disable custom amounts in debug builds

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -98,7 +98,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .pointOfSaleRoles:
             return buildConfig == .localDeveloper
         case .pointOfSaleCustomAmounts:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return false
         case .pointOfSalePhonePrototype:
             // Behind the flag for now — gates and UI follow in stacked PRs. Default to
             // localDeveloper only so alpha builds aren't affected until we're ready.


### PR DESCRIPTION
## Description

Discussed with @toupper , we'll turn this one off temporarily so does not intercept with testing the multiple additions to POS and Phone POS during RSM while we stabilize the rest. 

We'll restore it when needed.

## Test Steps
- Run POS
- Custom amounts should not appear as an option