### PR TITLE
Relax system status report decoding

### DIFF
--- a/Modules/Sources/Networking/Model/SystemStatusDetails/SystemStatusReport+Database.swift
+++ b/Modules/Sources/Networking/Model/SystemStatusDetails/SystemStatusReport+Database.swift
@@ -34,8 +34,8 @@ public extension SystemStatusReport {
     /// Subtype for details about a database table.
     ///
     struct DatabaseTable: Decodable {
-        public let data: String
-        public let index: String
-        public let engine: String
+        public let data: String?
+        public let index: String?
+        public let engine: String?
     }
 }

--- a/Modules/Sources/Networking/Model/SystemStatusDetails/SystemStatusReport+Database.swift
+++ b/Modules/Sources/Networking/Model/SystemStatusDetails/SystemStatusReport+Database.swift
@@ -37,5 +37,27 @@ public extension SystemStatusReport {
         public let data: String?
         public let index: String?
         public let engine: String?
+
+        public var formattedString: String {
+            let formattedData: String = {
+                if let data {
+                    "Data: \(data)MB"
+                } else {
+                    "Data: null"
+                }
+            }()
+
+            let formattedIndex: String = {
+                if let index {
+                    "Index: \(index)MB"
+                } else {
+                    "Index: null"
+                }
+            }()
+
+            let formattedEngine = "Engine: \(engine ?? "null")"
+
+            return [formattedData, formattedIndex, formattedEngine].joined(separator: " + ")
+        }
     }
 }

--- a/Modules/Sources/Networking/Model/SystemStatusReport.swift
+++ b/Modules/Sources/Networking/Model/SystemStatusReport.swift
@@ -47,18 +47,18 @@ public struct SystemStatusReport: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let activePlugins = try container.decode([SystemPlugin].self, forKey: .activePlugins)
         let inactivePlugins = try container.decode([SystemPlugin].self, forKey: .inactivePlugins)
-        let environment = try container.decodeIfPresent(Environment.self, forKey: .environment)
-        let database = try container.decodeIfPresent(Database.self, forKey: .database)
+        let environment = try? container.decodeIfPresent(Environment.self, forKey: .environment)
+        let database = try? container.decodeIfPresent(Database.self, forKey: .database)
 
         let dropinMustUsePlugins = try? container.nestedContainer(keyedBy: DropinMustUserPluginsCodingKeys.self, forKey: .dropinMustUsePlugins)
-        let dropinPlugins = try dropinMustUsePlugins?.decodeIfPresent([DropinMustUsePlugin].self, forKey: .dropins) ?? []
-        let mustUsePlugins = try dropinMustUsePlugins?.decodeIfPresent([DropinMustUsePlugin].self, forKey: .mustUsePlugins) ?? []
+        let dropinPlugins = (try? dropinMustUsePlugins?.decodeIfPresent([DropinMustUsePlugin].self, forKey: .dropins)) ?? []
+        let mustUsePlugins = (try? dropinMustUsePlugins?.decodeIfPresent([DropinMustUsePlugin].self, forKey: .mustUsePlugins)) ?? []
 
-        let theme = try container.decodeIfPresent(Theme.self, forKey: .theme)
-        let settings = try container.decodeIfPresent(Settings.self, forKey: .settings)
-        let pages = try container.decodeIfPresent([Page].self, forKey: .pages) ?? []
-        let postTypeCounts = try container.decodeIfPresent([PostTypeCount].self, forKey: .postTypeCounts) ?? []
-        let security = try container.decodeIfPresent(Security.self, forKey: .security)
+        let theme = try? container.decodeIfPresent(Theme.self, forKey: .theme)
+        let settings = try? container.decodeIfPresent(Settings.self, forKey: .settings)
+        let pages = (try? container.decodeIfPresent([Page].self, forKey: .pages)) ?? []
+        let postTypeCounts = (try? container.decodeIfPresent([PostTypeCount].self, forKey: .postTypeCounts)) ?? []
+        let security = try? container.decodeIfPresent(Security.self, forKey: .security)
 
         self.init(
             activePlugins: activePlugins,

--- a/Modules/Tests/NetworkingTests/Mapper/SystemStatusReportMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/SystemStatusReportMapperTests.swift
@@ -206,6 +206,22 @@ final class SystemStatusReportMapperTests: XCTestCase {
         XCTAssertEqual(tableWithStringValues?.index, "12.75")
         XCTAssertEqual(tableWithStringValues?.engine, "InnoDB")
     }
+
+    func test_database_table_formattedString_when_values_are_nil_then_displays_null() {
+        // Given
+        let table = SystemStatusReport.DatabaseTable(data: nil, index: nil, engine: nil)
+
+        // Then
+        XCTAssertEqual(table.formattedString, "Data: null + Index: null + Engine: null")
+    }
+
+    func test_database_table_formattedString_when_values_are_present_then_displays_values_with_units() {
+        // Given
+        let table = SystemStatusReport.DatabaseTable(data: "8.52", index: "12.75", engine: "InnoDB")
+
+        // Then
+        XCTAssertEqual(table.formattedString, "Data: 8.52MB + Index: 12.75MB + Engine: InnoDB")
+    }
 }
 
 private extension SystemStatusReportMapperTests {

--- a/Modules/Tests/NetworkingTests/Mapper/SystemStatusReportMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/SystemStatusReportMapperTests.swift
@@ -159,6 +159,53 @@ final class SystemStatusReportMapperTests: XCTestCase {
         XCTAssertEqual(report.pages.count, 5)
         XCTAssertEqual(report.postTypeCounts.count, 3)
     }
+
+    func test_system_status_report_fields_are_properly_parsed_when_database_table_has_null_values() throws {
+        // Given
+        let response = Data("""
+        {
+            "active_plugins": [],
+            "inactive_plugins": [],
+            "database": {
+                "wc_database_version": "10.7.0",
+                "database_prefix": "wp_",
+                "database_tables": {
+                    "woocommerce": {},
+                    "other": {
+                        "wp_wsm_uniqueVisitors": {
+                            "data": null,
+                            "index": null,
+                            "engine": null
+                        },
+                        "wp_actionscheduler_actions": {
+                            "data": "8.52",
+                            "index": "12.75",
+                            "engine": "InnoDB"
+                        }
+                    }
+                },
+                "database_size": {
+                    "data": 150.56,
+                    "index": 114.66
+                }
+            }
+        }
+        """.utf8)
+
+        // When
+        let report = try SystemStatusReportMapper(siteID: dummySiteID).map(response: response)
+
+        // Then
+        let tableWithNullValues = report.database?.databaseTables.other["wp_wsm_uniqueVisitors"]
+        XCTAssertNil(tableWithNullValues?.data)
+        XCTAssertNil(tableWithNullValues?.index)
+        XCTAssertNil(tableWithNullValues?.engine)
+
+        let tableWithStringValues = report.database?.databaseTables.other["wp_actionscheduler_actions"]
+        XCTAssertEqual(tableWithStringValues?.data, "8.52")
+        XCTAssertEqual(tableWithStringValues?.index, "12.75")
+        XCTAssertEqual(tableWithStringValues?.engine, "InnoDB")
+    }
 }
 
 private extension SystemStatusReportMapperTests {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 24.9
 -----
+- [*] Fixed Connectivity Tool failures when system status reports include database tables with missing metadata [https://github.com/woocommerce/woocommerce-ios/pull/17275]
 - [*] Shipping Labels: Updated validation for US territories and domestic-mail customs descriptions [https://github.com/woocommerce/woocommerce-ios/pull/17255]
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
@@ -94,11 +94,11 @@ extension SystemStatusReportViewModel {
             ])
 
             for (tableName, content) in database.databaseTables.woocommerce {
-                lines.append("\(tableName): Data: \(content.data)MB + Index: \(content.index)MB + Engine \(content.engine)")
+                lines.append("\(tableName): \(content.formattedString)")
             }
 
             for (tableName, content) in database.databaseTables.other {
-                lines.append("\(tableName): Data: \(content.data)MB + Index: \(content.index)MB + Engine \(content.engine)")
+                lines.append("\(tableName): \(content.formattedString)")
             }
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/SystemStatusReportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/SystemStatusReportViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import Networking
 @testable import Yosemite
 @testable import WooCommerce
 
@@ -27,5 +28,38 @@ final class SystemStatusReportViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(fetchedSiteID, testSiteID)
         XCTAssertTrue(viewModel.errorFetchingReport)
+    }
+
+    func test_formatReport_when_database_table_has_nil_values_then_displays_null_values() {
+        // Given
+        let report = SystemStatusReport(
+            activePlugins: [],
+            inactivePlugins: [],
+            environment: nil,
+            database: .init(
+                wcDatabaseVersion: "10.7.0",
+                databasePrefix: "wp_",
+                databaseTables: .init(
+                    woocommerce: [:],
+                    other: [
+                        "wp_wsm_uniqueVisitors": .init(data: nil, index: nil, engine: nil)
+                    ]
+                ),
+                databaseSize: .init(data: 150.56, index: 114.66)
+            ),
+            dropinPlugins: [],
+            mustUsePlugins: [],
+            theme: nil,
+            settings: nil,
+            pages: [],
+            postTypeCounts: [],
+            security: nil
+        )
+
+        // When
+        let formattedReport = SystemStatusReportViewModel.formatReport(with: report)
+
+        // Then
+        XCTAssertTrue(formattedReport.contains("wp_wsm_uniqueVisitors: Data: null + Index: null + Engine: null"))
     }
 }


### PR DESCRIPTION
## Description
Closes WOOMOB-3104

The system status endpoint can return database table metadata with `null` values when orphaned plugin-created MySQL views remain on a store. Those `null` values caused the system status report decode to fail, which made the troubleshooting Connectivity Tool report a site connection failure.

This updates database table metadata decoding to accept missing values for `data`, `index`, and `engine`, and keeps the broader system status report resilient when optional report sections fail to decode. It also adds a mapper regression test for the null table metadata case.

Also updated the decoding of SSR to allow failures for other optional fields.

## Test Steps

Confirm `SystemStatusReportMapperTests` passes, including `test_system_status_report_fields_are_properly_parsed_when_database_table_has_null_values`.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.