### PR TITLE
Auto-translate App Store release_notes for 14 AI locales on each release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 - [**] Added support for 15 new app languages: Bulgarian, Czech, Danish, Finnish, Greek, Hindi, Hungarian, Malay, Norwegian Bokmål, Polish, Portuguese (Portugal), Romanian, Thai, Ukrainian, and Vietnamese.
+- [Internal] AI-translate App Store `release_notes.txt` into the 14 new ASC locales (cs, da, el, fi, hi, hu, ms, no [iOS nb], pl, pt-PT, ro, th, uk, vi) on each release via the WooAiTranslation engine. Haiku-first with Opus retry; failed locales fall back to English on the App Store.
 
 
 24.8

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,6 +10,9 @@ fastlane_require 'git'
 fastlane_require 'octokit'
 
 require_relative 'helpers/release_notes_pr_helper'
+# Canonical iOS → ASC mapping for the 14 AI-translated App Store listings.
+# Consumed by the `translate_release_notes_ai_locales` lane below.
+require_relative 'ai_translation/lib/woo_ai_translation/asc_locales'
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
@@ -700,6 +703,11 @@ platform :ios do
     # Don't check translation coverage in CI
     check_translation_progress_all unless is_ci
     download_localized_strings_and_metadata_from_glotpress
+    # AI-translate release_notes.txt for the 14 AI-only locales using the
+    # WooAiTranslation engine. Runs after GlotPress has populated
+    # `fastlane/metadata/default/release_notes.txt`; produces a separate
+    # commit so blame stays distinct from the GP-bot metadata commit.
+    translate_release_notes_ai_locales
     lint_localizations(fail_on_strings_not_in_base_language: false)
 
     UI.important('Pushing changes to remote')
@@ -1283,6 +1291,65 @@ platform :ios do
     git_commit(
       path: files_to_commit,
       message: 'Update metadata translations',
+      allow_nothing_to_commit: true
+    )
+  end
+
+  # Translates the App Store `release_notes.txt` into the 14 AI-only locales
+  # via the WooAiTranslation engine. The 16 GlotPress-curated locales are
+  # handled separately by `download_localized_metadata_from_glotpress`; this
+  # lane only writes to the 14 ASC folders enumerated in `AscLocales`.
+  #
+  # Per-locale failures (empty response, validator violation, length overflow)
+  # are soft: the locale is skipped, no file is written, and Apple's automatic
+  # English fallback supplies the release_notes for that locale. The lane
+  # fails the build only on infrastructure errors (missing source file, CLI
+  # error). A missing `ANTHROPIC_API_KEY` is treated as "skip all 14 locales"
+  # with a warning annotation — letting the rest of `download_release_translations`
+  # complete is preferable to blocking a release on a secret-management issue.
+  desc 'AI-translates App Store release_notes.txt into the 14 AI-only locales.'
+  lane :translate_release_notes_ai_locales do
+    if ENV.fetch('ANTHROPIC_API_KEY', '').strip.empty?
+      UI.important('ANTHROPIC_API_KEY not set — skipping AI release-notes translation. ' \
+                   'Apple will fall back to English for all 14 AI locales.')
+      if is_ci
+        buildkite_annotate(
+          style: 'warning',
+          context: 'ai-release-notes',
+          message: 'ANTHROPIC_API_KEY is not set on this agent — AI release-notes translation skipped. ' \
+                   'Apple will fall back to English release_notes for all 14 AI locales.'
+        )
+      end
+      next
+    end
+
+    source_path = File.join(FASTLANE_METADATA_FOLDER, 'default', 'release_notes.txt')
+    unless File.exist?(source_path)
+      fail_lane!(
+        context: 'ai-release-notes',
+        message: "Source release_notes not found at #{source_path}. " \
+                 '`download_localized_metadata_from_glotpress` must run first to populate it.'
+      )
+    end
+
+    cli = File.join(FASTLANE_DIR, 'ai_translation', 'bin', 'translate_release_notes.rb')
+    sh('ruby', cli, '--source', source_path, '--metadata-dir', FASTLANE_METADATA_FOLDER)
+
+    # Only stage the 14 AI locale files; the upstream GlotPress lane has its
+    # own commit for the 16 GP locale files.
+    ai_paths = WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES.values.map do |asc|
+      File.join(FASTLANE_METADATA_FOLDER, asc, 'release_notes.txt')
+    end
+    existing = ai_paths.select { |p| File.exist?(p) }
+    if existing.empty?
+      UI.important('No AI release-notes files were produced (all locales fell back to English).')
+      next
+    end
+
+    git_add(path: existing, shell_escape: false)
+    git_commit(
+      path: existing,
+      message: 'Update AI release notes translations',
       allow_nothing_to_commit: true
     )
   end

--- a/fastlane/ai_translation/.rubocop.yml
+++ b/fastlane/ai_translation/.rubocop.yml
@@ -77,6 +77,13 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
 
+Style/OneClassPerFile:
+  # Test files often bundle small helper stub classes (e.g.
+  # `ModelAwareStubClient` in release_notes_translator_test.rb) alongside the
+  # `*Test` class itself; splitting them into separate files harms locality.
+  Exclude:
+    - 'spec/**/*'
+
 Style/FormatStringToken:
   Exclude:
     - 'scripts/**/*'

--- a/fastlane/ai_translation/README.md
+++ b/fastlane/ai_translation/README.md
@@ -46,25 +46,28 @@ new ones); set it to scope a run.
 ```
 fastlane/ai_translation/
 ├── bin/
-│   └── translate_locale.rb       # CLI entry point
+│   ├── translate_locale.rb         # CLI: per-locale in-app .strings translation
+│   └── translate_release_notes.rb  # CLI: per-release ASC release_notes translation
 ├── lib/woo_ai_translation/
-│   ├── anthropic_client.rb       # Anthropic Messages API wrapper (+ StubClient)
-│   ├── byte_sizer.rb             # Script-aware batch sizing
-│   ├── constants.rb              # Version, model IDs, prompt version
-│   ├── ios_resources.rb          # .strings parser + writer
-│   ├── manifest.rb               # Source-only invalidation cache (per-locale JSON)
-│   ├── translator.rb             # Batched JSON-in/JSON-out translator with split-retry
-│   └── validator.rb              # Brand-safety + glossary enforcement
+│   ├── anthropic_client.rb         # Anthropic Messages API wrapper (+ StubClient)
+│   ├── asc_locales.rb              # iOS → ASC locale map for the 14 AI metadata locales
+│   ├── byte_sizer.rb               # Script-aware batch sizing
+│   ├── constants.rb                # Version, model IDs, prompt version
+│   ├── ios_resources.rb            # .strings parser + writer
+│   ├── manifest.rb                 # Source-only invalidation cache (per-locale JSON)
+│   ├── release_notes_translator.rb # Per-release release_notes orchestrator (Haiku → Opus)
+│   ├── translator.rb               # Batched JSON-in/JSON-out translator with split-retry
+│   └── validator.rb                # Brand-safety + glossary enforcement
 ├── glossary/
-│   ├── common.yml                # Brand names — never translate (hard validator)
-│   └── <locale>.yml × 31         # Per-locale UI term + noun mappings
+│   ├── common.yml                  # Brand names — never translate (hard validator)
+│   └── <locale>.yml × 31           # Per-locale UI term + noun mappings
 ├── style/
-│   ├── default.md                # Fallback style guide
-│   └── <locale>.md               # Per-locale register / quirks (when applicable)
-├── spec/                         # Minitest specs
-├── scripts/                      # One-off bootstrap utilities (assemble, gap-fill)
-├── Rakefile                      # Rake task wrappers
-└── translate-progress.json       # Audit checkpoint for the original bootstrap run
+│   ├── default.md                  # Fallback style guide
+│   └── <locale>.md                 # Per-locale register / quirks (when applicable)
+├── spec/                           # Minitest specs
+├── scripts/                        # One-off bootstrap utilities (assemble, gap-fill)
+├── Rakefile                        # Rake task wrappers
+└── translate-progress.json         # Audit checkpoint for the original bootstrap run
 ```
 
 ### Glossaries and brand-safety
@@ -179,6 +182,50 @@ This is the mode the CI step is designed to call on every PR that touches
 `en.lproj` (the CI wiring lands in a separate PR in this series). A typical
 PR adds 1–10 strings, so the incremental call costs cents and finishes in
 seconds.
+
+## App Store `release_notes.txt` (per release)
+
+A separate per-release workflow translates
+`fastlane/metadata/default/release_notes.txt` into the 14 AI-only ASC
+locales. It runs from the `translate_release_notes_ai_locales` Fastlane lane,
+which is wired into `download_release_translations` (Buildkite job
+`download-release-translations.yml`) right after GlotPress downloads the
+existing 16 locales' metadata.
+
+The locale list lives in `lib/woo_ai_translation/asc_locales.rb`. It is the
+in-app cutover list (15 codes) minus `bg` (Apple ASC unsupported), with `nb`
+mapping to ASC `no` (Apple has no Bokmål-specific listing).
+
+Per-locale flow:
+
+1. `ReleaseNotesTranslator` reads the EN source and synthesizes a single
+   Translator item with id `release_notes`.
+2. Attempts translation with Haiku (`DEFAULT_MODEL`). On failure (empty,
+   validator violation, or `> 4000` bytes) escalates to Opus.
+3. On success → writes `fastlane/metadata/<asc_locale>/release_notes.txt`.
+4. On final failure → skips writing. Apple's automatic English fallback
+   covers missing per-locale `release_notes.txt` files.
+
+The lane creates its own commit (`Update AI release notes translations`)
+separate from the GlotPress `Update metadata translations` commit so blame
+stays clean.
+
+Run the CLI directly (e.g. for a local dry-run):
+
+```bash
+ANTHROPIC_API_KEY=sk-... \
+  fastlane/ai_translation/bin/translate_release_notes.rb \
+  --source fastlane/metadata/default/release_notes.txt \
+  --metadata-dir fastlane/metadata
+```
+
+Or smoke-test with the deterministic stub (no API calls, no spend):
+
+```bash
+fastlane/ai_translation/bin/translate_release_notes.rb \
+  --source fastlane/metadata/default/release_notes.txt \
+  --metadata-dir /tmp/release-notes-smoke --offline
+```
 
 ## Adding a new locale
 

--- a/fastlane/ai_translation/bin/translate_release_notes.rb
+++ b/fastlane/ai_translation/bin/translate_release_notes.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Translate the English App Store `release_notes.txt` into the 14 AI locales
+# and write the result to each `fastlane/metadata/<asc_locale>/release_notes.txt`.
+# Invoked from the `translate_release_notes_ai_locales` Fastlane lane during the
+# release-translations Buildkite step.
+#
+# Per-locale failures (empty, validator violation, length overflow) are soft:
+# the locale is skipped and Apple's automatic English fallback handles it.
+# The script exits non-zero only on infrastructure errors (missing source,
+# missing API key on a non-offline run).
+#
+# Usage:
+#   bin/translate_release_notes.rb \
+#     --source fastlane/metadata/default/release_notes.txt \
+#     --metadata-dir fastlane/metadata
+#
+# Flags:
+#   --offline            Use the deterministic StubClient (no network, no spend).
+#   --model NAME         Override the default Haiku model used on the first attempt.
+
+require 'optparse'
+require 'fileutils'
+
+ROOT = File.expand_path('..', __dir__)
+$LOAD_PATH.unshift(File.join(ROOT, 'lib'))
+
+require 'woo_ai_translation/anthropic_client'
+require 'woo_ai_translation/asc_locales'
+require 'woo_ai_translation/constants'
+require 'woo_ai_translation/release_notes_translator'
+
+options = { offline: false, model: nil }
+OptionParser.new do |opts|
+  opts.banner = 'Usage: translate_release_notes.rb --source PATH --metadata-dir PATH [--offline] [--model NAME]'
+  opts.on('--source PATH', 'EN release_notes.txt path (required)') { |v| options[:source] = v }
+  opts.on('--metadata-dir PATH', 'fastlane/metadata root (required)') { |v| options[:metadata_dir] = v }
+  opts.on('--offline', 'Use deterministic StubClient (no API calls)') { options[:offline] = true }
+  opts.on('--model NAME', 'Override first-attempt model') { |v| options[:model] = v }
+end.parse!
+
+abort 'error: --source is required' unless options[:source]
+abort 'error: --metadata-dir is required' unless options[:metadata_dir]
+
+source_path = options[:source]
+abort "error: source file not found: #{source_path}" unless File.exist?(source_path)
+
+source_text = File.read(source_path).strip
+abort "error: source file is empty: #{source_path}" if source_text.empty?
+
+client =
+  if options[:offline]
+    WooAiTranslation::StubClient.new
+  else
+    c = WooAiTranslation::AnthropicClient.from_env
+    abort 'error: ANTHROPIC_API_KEY is not set (use --offline for a dry run)' unless c.available?
+    c
+  end
+
+glossary_dir = File.join(ROOT, 'glossary')
+style_dir = File.join(ROOT, 'style')
+
+orchestrator = WooAiTranslation::ReleaseNotesTranslator.new(
+  client: client,
+  glossary_dir: glossary_dir,
+  style_dir: style_dir,
+  logger: ->(msg) { warn msg }
+)
+
+# Allow CLI override of the first-attempt model. We can't easily thread it
+# through the orchestrator without bloating its API, so we monkey-patch the
+# constant for this process only. Acceptable since this is a single-purpose CLI.
+if options[:model]
+  WooAiTranslation.send(:remove_const, :DEFAULT_MODEL)
+  WooAiTranslation.const_set(:DEFAULT_MODEL, options[:model])
+end
+
+results = []
+WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES.each do |ios_locale, asc_locale|
+  result = orchestrator.translate(
+    source_text: source_text,
+    locale: ios_locale,
+    asc_locale: asc_locale
+  )
+  results << result
+
+  next unless result.status == :translated
+
+  target_dir = File.join(options[:metadata_dir], asc_locale)
+  FileUtils.mkdir_p(target_dir)
+  File.write(File.join(target_dir, 'release_notes.txt'), "#{result.translation.strip}\n")
+end
+
+# Plain-text summary. Buildkite log + Fastlane annotation both render fine.
+def row(cells)
+  widths = [7, 7, 10, 15]
+  padded = cells.each_with_index.map { |c, i| widths[i] ? c.to_s.ljust(widths[i]) : c.to_s }
+  padded.join('  ')
+end
+
+puts ''
+puts '=== AI release-notes translation summary ==='
+puts row(%w[iOS ASC Status Model Notes])
+puts row(%w[--- --- ------ ----- -----])
+results.each do |r|
+  status = r.status == :translated ? '✓ done' : '✗ skipped'
+  notes = r.status == :translated ? '' : r.skip_reason.to_s
+  puts row([r.locale, r.asc_locale, status, r.model, notes])
+end
+
+skipped = results.count { |r| r.status == :skipped }
+translated = results.size - skipped
+puts ''
+puts "Translated: #{translated}/#{results.size}  Skipped: #{skipped} (English fallback)"
+
+# Always exit zero: per-locale failures are not infrastructure failures.
+exit 0

--- a/fastlane/ai_translation/lib/woo_ai_translation/asc_locales.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/asc_locales.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module WooAiTranslation
+  # Mapping of iOS locale codes (matching `<locale>.lproj` folder names under
+  # `WooCommerce/Resources/`) to App Store Connect locale codes for the 14
+  # AI-translated locales.
+  #
+  # Two intentional asymmetries vs the 15-locale in-app list in
+  # `fastlane/ai_translation/Rakefile`:
+  #
+  #   - `bg` is excluded: Apple does not offer a Bulgarian App Store
+  #     listing. Bulgarian iOS users see the fully-translated app but the
+  #     English ASC listing. This matches the decision shipped with PR 5
+  #     ([#17271](https://github.com/woocommerce/woocommerce-ios/pull/17271)).
+  #
+  #   - `nb` (Norwegian Bokmål) maps to ASC `no`. Apple's App Store has only a
+  #     generic Norwegian listing, not a Bokmål-specific one. Acceptable lossy
+  #     mapping — Bokmål is the dominant written form.
+  #
+  # The remaining 16 ASC locales (ar-SA, de-DE, es-ES, fr-FR, he, id, it, ja,
+  # ko, nl-NL, pt-BR, ru, sv, tr, zh-Hans, zh-Hant) still receive their
+  # human-curated metadata from GlotPress; this list is the AI-only delta.
+  module AscLocales
+    # iOS locale code => ASC locale code.
+    AI_TRANSLATION_LOCALES = {
+      'cs' => 'cs',
+      'da' => 'da',
+      'el' => 'el',
+      'fi' => 'fi',
+      'hi' => 'hi',
+      'hu' => 'hu',
+      'ms' => 'ms',
+      'nb' => 'no',
+      'pl' => 'pl',
+      'pt-PT' => 'pt-PT',
+      'ro' => 'ro',
+      'th' => 'th',
+      'uk' => 'uk',
+      'vi' => 'vi'
+    }.freeze
+  end
+end

--- a/fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb
@@ -85,6 +85,23 @@ module WooAiTranslation
         translation: reason ? nil : raw,
         skip_reason: reason
       )
+    rescue AnthropicClient::Error, Net::OpenTimeout, Net::ReadTimeout => e
+      # `Translator#translate_slice` re-raises `AnthropicClient::Error` (and
+      # leaves network timeouts unhandled) when the batch has a single item —
+      # which is always our case for release_notes. Without this rescue, a
+      # transient Haiku failure (or an Opus-side parameter rejection)
+      # would kill the lane instead of flowing through the Haiku→Opus retry
+      # → English-fallback path. Surface the failure as a soft `:skipped`
+      # result so `translate` can try Opus, and so a final failure stays
+      # within the documented "ship English for the failed locale" contract.
+      Result.new(
+        locale: locale,
+        asc_locale: asc_locale,
+        model: model,
+        status: :skipped,
+        translation: nil,
+        skip_reason: "client error: #{e.class.name.split('::').last} (#{e.message})"
+      )
     end
 
     # Returns `nil` if `raw` is an acceptable translation, otherwise a short

--- a/fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'openssl'
+
 require_relative 'anthropic_client'
 require_relative 'constants'
 require_relative 'translator'
@@ -85,15 +87,21 @@ module WooAiTranslation
         translation: reason ? nil : raw,
         skip_reason: reason
       )
-    rescue AnthropicClient::Error, Net::OpenTimeout, Net::ReadTimeout => e
+    rescue AnthropicClient::Error,
+           Net::OpenTimeout, Net::ReadTimeout,
+           SystemCallError, SocketError, IOError,
+           OpenSSL::SSL::SSLError => e
       # `Translator#translate_slice` re-raises `AnthropicClient::Error` (and
       # leaves network timeouts unhandled) when the batch has a single item —
-      # which is always our case for release_notes. Without this rescue, a
-      # transient Haiku failure (or an Opus-side parameter rejection)
-      # would kill the lane instead of flowing through the Haiku→Opus retry
-      # → English-fallback path. Surface the failure as a soft `:skipped`
-      # result so `translate` can try Opus, and so a final failure stays
-      # within the documented "ship English for the failed locale" contract.
+      # which is always our case for release_notes. The underlying
+      # `Net::HTTP.request` in `AnthropicClient` can also raise socket-level
+      # exceptions (`Errno::ECONNRESET`, `SocketError`, `EOFError`,
+      # `OpenSSL::SSL::SSLError`) that `with_retries` does not catch. Without
+      # this broad rescue, any of those would kill the lane instead of
+      # flowing through the Haiku→Opus retry → English-fallback path.
+      # Surface the failure as a soft `:skipped` result so `translate` can
+      # try Opus, and so a final failure stays within the documented "ship
+      # English for the failed locale" contract.
       Result.new(
         locale: locale,
         asc_locale: asc_locale,

--- a/fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative 'anthropic_client'
+require_relative 'constants'
+require_relative 'translator'
+require_relative 'validator'
+
+module WooAiTranslation
+  # Orchestrates per-release App Store release-notes translation across the 14
+  # AI-translated locales. Re-uses the existing `Translator` + `Validator`
+  # plumbing with two release-notes-specific adaptations:
+  #
+  #   1. The source is a single plain-text blob, not a `.strings` document, so
+  #      we synthesize a single translation item (id `release_notes`).
+  #   2. Apple ASC caps release_notes at 4000 bytes. A locale whose translation
+  #      exceeds that is treated as a soft failure (skipped, English falls
+  #      back automatically) rather than a hard build failure — release_notes
+  #      copy is short enough that overflow is extremely unlikely in practice
+  #      and shipping English for one locale is preferable to blocking the
+  #      release.
+  #
+  # On a Haiku-tier failure (empty translation, validator violation, length
+  # overflow), we transparently retry with Opus per the engine's existing
+  # escalation pattern. If Opus also fails, we mark the locale `:skipped` and
+  # let Apple's automatic English fallback kick in. Callers receive a `Result`
+  # per locale so they can decide how to surface the outcome (Buildkite
+  # annotation, lane log, etc.).
+  class ReleaseNotesTranslator
+    # Apple's documented ASC release_notes byte limit. See `Fastfile`
+    # `download_localized_metadata_from_glotpress` lane target_files entry.
+    MAX_ASC_BYTES = 4000
+
+    # Plain-text item id we feed to the JSON-in/JSON-out Translator. Arbitrary
+    # but stable so a test can assert against it.
+    ITEM_ID = 'release_notes'
+
+    ITEM_CONTEXT = <<~CONTEXT.chomp
+      App Store release notes — a single short paragraph (typically 200-500 chars)
+      describing what changed in this release. Casual but professional tone for
+      merchants. Preserve any URLs, code-like tokens, and brand names verbatim.
+    CONTEXT
+
+    # Outcome of translating one locale.
+    # status: :translated | :skipped
+    # skip_reason: nil when translated; otherwise short human-readable string
+    Result = Struct.new(
+      :locale, :asc_locale, :status, :model, :translation, :skip_reason,
+      keyword_init: true
+    )
+
+    def initialize(client:, glossary_dir:, style_dir: nil, logger: nil)
+      @client = client
+      @translator = Translator.new(client: client, logger: logger)
+      @glossary_dir = glossary_dir
+      @style_dir = style_dir
+      @logger = logger
+    end
+
+    # Translate `source_text` into `locale`, returning a `Result`. Tries Haiku
+    # first; on failure (empty, validator violation, length overflow) retries
+    # with Opus. A second failure yields a `:skipped` result.
+    def translate(source_text:, locale:, asc_locale:)
+      first = attempt(source_text, locale, asc_locale, DEFAULT_MODEL)
+      return first if first.status == :translated
+
+      log("#{locale}: retrying with Opus — #{first.skip_reason}")
+      second = attempt(source_text, locale, asc_locale, ESCALATION_MODEL)
+      return second if second.status == :translated
+
+      log("#{locale}: skipped after Opus retry — #{second.skip_reason}")
+      second
+    end
+
+    private
+
+    def attempt(source_text, locale, asc_locale, model)
+      raw = call_translator(source_text, locale, model, load_style(locale))
+      reason = check_raw(raw, source_text, locale)
+
+      Result.new(
+        locale: locale,
+        asc_locale: asc_locale,
+        model: model,
+        status: reason ? :skipped : :translated,
+        translation: reason ? nil : raw,
+        skip_reason: reason
+      )
+    end
+
+    # Returns `nil` if `raw` is an acceptable translation, otherwise a short
+    # human-readable string describing the failure.
+    def check_raw(raw, source_text, locale)
+      return 'empty or missing translation' if raw.nil? || raw.strip.empty?
+      return "exceeds #{MAX_ASC_BYTES} bytes (got #{raw.bytesize})" if raw.bytesize > MAX_ASC_BYTES
+
+      violations = Validator.for_locale(locale: locale, base_dir: @glossary_dir)
+                            .validate(source: source_text, translation: raw)
+      return nil if violations.empty?
+
+      details = violations.map { |v| "#{v[:rule]}:#{v[:term]}" }.join(', ')
+      "validator failed (#{details})"
+    end
+
+    def call_translator(source_text, locale, model, style)
+      items = [{ id: ITEM_ID, source: source_text, context: ITEM_CONTEXT }]
+      out = @translator.translate(locale: locale, items: items, model: model, style: style)
+      out[ITEM_ID]
+    end
+
+    def load_style(locale)
+      return nil if @style_dir.nil?
+
+      path = File.join(@style_dir, "#{locale}.md")
+      File.exist?(path) ? File.read(path) : nil
+    end
+
+    def log(msg)
+      @logger&.call(msg)
+    end
+  end
+end

--- a/fastlane/ai_translation/spec/asc_locales_test.rb
+++ b/fastlane/ai_translation/spec/asc_locales_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/woo_ai_translation/asc_locales'
+
+class AscLocalesTest < Minitest::Test
+  def test_includes_all_14_expected_codes
+    # Given the 15 iOS-cutover locales minus bg (unsupported by ASC)
+    expected_ios = %w[cs da el fi hi hu ms nb pl pt-PT ro th uk vi].sort
+    actual_ios = WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES.keys.sort
+    assert_equal expected_ios, actual_ios
+  end
+
+  def test_ios_nb_maps_to_asc_no
+    # Apple's App Store has no Bokmål-specific listing — map to generic `no`.
+    assert_equal 'no', WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES['nb']
+  end
+
+  def test_bg_is_intentionally_absent
+    # Bulgarian is excluded: Apple ASC does not support it. Bulgarian users
+    # see the English ASC listing while the in-app strings remain translated.
+    refute WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES.key?('bg')
+  end
+
+  def test_most_codes_map_to_themselves
+    # Sanity check — only nb has a lossy mapping. Every other code is a 1:1.
+    one_to_one = WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES.reject { |ios, asc| ios == asc }
+    assert_equal({ 'nb' => 'no' }, one_to_one)
+  end
+
+  def test_mapping_is_frozen
+    assert WooAiTranslation::AscLocales::AI_TRANSLATION_LOCALES.frozen?
+  end
+end

--- a/fastlane/ai_translation/spec/release_notes_translator_test.rb
+++ b/fastlane/ai_translation/spec/release_notes_translator_test.rb
@@ -1,0 +1,201 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'json'
+require 'tmpdir'
+require 'fileutils'
+
+require_relative '../lib/woo_ai_translation/constants'
+require_relative '../lib/woo_ai_translation/release_notes_translator'
+
+# StubClient-style fake that lets a test program per-model behavior. The real
+# StubClient ignores the `model:` argument; here we branch on it so we can
+# exercise the Haiku → Opus escalation path deterministically.
+class ModelAwareStubClient
+  def initialize(transforms_by_model)
+    @transforms = transforms_by_model
+    @calls = []
+  end
+
+  attr_reader :calls
+
+  def available?
+    true
+  end
+
+  def complete(model:, system_blocks:, user_content:, max_tokens: 8192)
+    _ = [system_blocks, max_tokens] # unused in fake
+    @calls << model
+    locale = user_content[/locale:\s*([\w-]+)/, 1] || '??'
+    payload = JSON.parse(user_content[/\[.*\]/m] || '[]')
+    transform = @transforms.fetch(model) { ->(_loc, _src) { '' } }
+    out = payload.to_h { |item| [item['id'], transform.call(locale, item['source'])] }
+    JSON.generate(out)
+  end
+end
+
+class ReleaseNotesTranslatorTest < Minitest::Test
+  HAIKU = WooAiTranslation::DEFAULT_MODEL
+  OPUS = WooAiTranslation::ESCALATION_MODEL
+
+  def setup
+    @glossary_dir = Dir.mktmpdir
+    File.write(File.join(@glossary_dir, 'common.yml'), <<~YAML)
+      brands:
+        - WooCommerce
+    YAML
+    File.write(File.join(@glossary_dir, 'pl.yml'), <<~YAML)
+      ui_terms: {}
+      nouns: {}
+    YAML
+  end
+
+  def teardown
+    FileUtils.remove_entry(@glossary_dir) if @glossary_dir && File.exist?(@glossary_dir)
+  end
+
+  def make_translator(transforms)
+    WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(transforms),
+      glossary_dir: @glossary_dir
+    )
+  end
+
+  def test_translate_when_haiku_succeeds_then_returns_translated_with_haiku_model
+    # Given a Haiku response that passes validation
+    t = make_translator(HAIKU => ->(loc, src) { "[#{loc}] #{src}" })
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then the translation succeeds on first attempt with Haiku
+    assert_equal :translated, result.status
+    assert_equal HAIKU, result.model
+    assert_equal 'pl', result.locale
+    assert_equal 'pl', result.asc_locale
+    assert_equal '[pl] Welcome to WooCommerce', result.translation
+    assert_nil result.skip_reason
+  end
+
+  def test_translate_when_haiku_returns_empty_then_retries_with_opus_and_succeeds
+    # Given Haiku returns empty and Opus returns a valid translation
+    client_transforms = {
+      HAIKU => ->(_loc, _src) { '' },
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    stub = ModelAwareStubClient.new(client_transforms)
+    t = WooAiTranslation::ReleaseNotesTranslator.new(client: stub, glossary_dir: @glossary_dir)
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then the result is :translated via Opus, both models were called
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+    assert_equal [HAIKU, OPUS], stub.calls
+  end
+
+  def test_translate_when_haiku_drops_brand_then_retries_with_opus_and_succeeds
+    # Given Haiku returns a translation that drops "WooCommerce" (brand violation)
+    # and Opus returns one that preserves it
+    client_transforms = {
+      HAIKU => ->(loc, _src) { "[#{loc}] Witaj w sklepie" },
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    stub = ModelAwareStubClient.new(client_transforms)
+    t = WooAiTranslation::ReleaseNotesTranslator.new(client: stub, glossary_dir: @glossary_dir)
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get an Opus-tier success
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+    assert_includes result.translation, 'WooCommerce'
+  end
+
+  def test_translate_when_haiku_exceeds_max_bytes_then_retries_with_opus_and_succeeds
+    # Given Haiku returns a translation larger than MAX_ASC_BYTES (4000) and
+    # Opus returns a short one
+    long_payload = 'x' * (WooAiTranslation::ReleaseNotesTranslator::MAX_ASC_BYTES + 100)
+    client_transforms = {
+      HAIKU => ->(_loc, _src) { long_payload },
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(client_transforms),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Short source', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get an Opus-tier success
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+  end
+
+  def test_translate_when_both_models_drop_brand_then_returns_skipped
+    # Given both Haiku and Opus return translations that drop "WooCommerce"
+    drop = ->(loc, _src) { "[#{loc}] Witaj w sklepie" }
+    t = make_translator(HAIKU => drop, OPUS => drop)
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get a skipped result whose reason names the validator rule
+    assert_equal :skipped, result.status
+    assert_equal OPUS, result.model
+    assert_match(/validator/, result.skip_reason)
+    assert_match(/brand_safety/, result.skip_reason)
+    assert_nil result.translation
+  end
+
+  def test_translate_when_both_models_empty_then_returns_skipped_with_empty_reason
+    # Given both models return empty
+    empty = ->(_loc, _src) { '' }
+    t = make_translator(HAIKU => empty, OPUS => empty)
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get a skipped result citing the empty translation
+    assert_equal :skipped, result.status
+    assert_match(/empty/, result.skip_reason)
+  end
+
+  def test_translate_when_both_models_exceed_max_then_returns_skipped_with_size_reason
+    # Given both models return oversized output
+    huge = WooAiTranslation::ReleaseNotesTranslator::MAX_ASC_BYTES + 1
+    over = ->(_loc, _src) { 'x' * huge }
+    t = make_translator(HAIKU => over, OPUS => over)
+
+    # When we translate
+    result = t.translate(source_text: 'Short source', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get a skipped result citing the size overflow
+    assert_equal :skipped, result.status
+    assert_match(/exceeds/, result.skip_reason)
+    assert_match(/4000/, result.skip_reason)
+  end
+
+  def test_translate_when_style_file_present_then_no_crash_and_translation_succeeds
+    # Given a populated style directory
+    style_dir = Dir.mktmpdir
+    File.write(File.join(style_dir, 'pl.md'), '# Polish style notes')
+
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(HAIKU => ->(loc, src) { "[#{loc}] #{src}" }),
+      glossary_dir: @glossary_dir,
+      style_dir: style_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then the translation still succeeds (smoke test for the style path)
+    assert_equal :translated, result.status
+  ensure
+    FileUtils.remove_entry(style_dir) if style_dir && File.exist?(style_dir)
+  end
+end

--- a/fastlane/ai_translation/spec/release_notes_translator_test.rb
+++ b/fastlane/ai_translation/spec/release_notes_translator_test.rb
@@ -11,9 +11,13 @@ require_relative '../lib/woo_ai_translation/release_notes_translator'
 # StubClient-style fake that lets a test program per-model behavior. The real
 # StubClient ignores the `model:` argument; here we branch on it so we can
 # exercise the Haiku → Opus escalation path deterministically.
+#
+# Each value in `behaviors_by_model` can be either:
+#   - a Proc (locale, source) -> translation_string — for normal returns
+#   - an Exception instance — to simulate a client/API failure on that model
 class ModelAwareStubClient
-  def initialize(transforms_by_model)
-    @transforms = transforms_by_model
+  def initialize(behaviors_by_model)
+    @behaviors = behaviors_by_model
     @calls = []
   end
 
@@ -26,10 +30,12 @@ class ModelAwareStubClient
   def complete(model:, system_blocks:, user_content:, max_tokens: 8192)
     _ = [system_blocks, max_tokens] # unused in fake
     @calls << model
+    behavior = @behaviors.fetch(model) { ->(_loc, _src) { '' } }
+    raise behavior if behavior.is_a?(Exception)
+
     locale = user_content[/locale:\s*([\w-]+)/, 1] || '??'
     payload = JSON.parse(user_content[/\[.*\]/m] || '[]')
-    transform = @transforms.fetch(model) { ->(_loc, _src) { '' } }
-    out = payload.to_h { |item| [item['id'], transform.call(locale, item['source'])] }
+    out = payload.to_h { |item| [item['id'], behavior.call(locale, item['source'])] }
     JSON.generate(out)
   end
 end
@@ -177,6 +183,67 @@ class ReleaseNotesTranslatorTest < Minitest::Test
     assert_equal :skipped, result.status
     assert_match(/exceeds/, result.skip_reason)
     assert_match(/4000/, result.skip_reason)
+  end
+
+  def test_translate_when_haiku_raises_api_error_then_retries_with_opus_and_succeeds
+    # Given Haiku raises an AnthropicClient::Error (transient API failure)
+    # and Opus returns a valid translation
+    behaviors = {
+      HAIKU => WooAiTranslation::AnthropicClient::Error.new('simulated haiku failure'),
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    stub = ModelAwareStubClient.new(behaviors)
+    t = WooAiTranslation::ReleaseNotesTranslator.new(client: stub, glossary_dir: @glossary_dir)
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get an Opus-tier success — the rescue caught the error and
+    # let `translate` proceed to the escalation path.
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+    assert_equal [HAIKU, OPUS], stub.calls
+  end
+
+  def test_translate_when_both_models_raise_api_error_then_returns_skipped_with_client_error_reason
+    # Given both Haiku and Opus raise the same API error
+    behaviors = {
+      HAIKU => WooAiTranslation::AnthropicClient::Error.new('haiku unavailable'),
+      OPUS => WooAiTranslation::AnthropicClient::Error.new('opus also unavailable')
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(behaviors),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then per-locale failure is soft: we get a :skipped Result citing the
+    # client error, and the lane (caller) ships English for this locale.
+    assert_equal :skipped, result.status
+    assert_equal OPUS, result.model
+    assert_match(/client error/, result.skip_reason)
+    assert_match(/Error/, result.skip_reason)
+  end
+
+  def test_translate_when_haiku_raises_network_timeout_then_retries_with_opus
+    # Given Haiku raises a network timeout (covered by the same rescue)
+    behaviors = {
+      HAIKU => Net::ReadTimeout.new('haiku timed out'),
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(behaviors),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we get an Opus-tier success — network timeouts are recoverable too.
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
   end
 
   def test_translate_when_style_file_present_then_no_crash_and_translation_succeeds

--- a/fastlane/ai_translation/spec/release_notes_translator_test.rb
+++ b/fastlane/ai_translation/spec/release_notes_translator_test.rb
@@ -4,6 +4,8 @@ require 'minitest/autorun'
 require 'json'
 require 'tmpdir'
 require 'fileutils'
+require 'openssl'
+require 'socket'
 
 require_relative '../lib/woo_ai_translation/constants'
 require_relative '../lib/woo_ai_translation/release_notes_translator'
@@ -242,6 +244,84 @@ class ReleaseNotesTranslatorTest < Minitest::Test
     result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
 
     # Then we get an Opus-tier success — network timeouts are recoverable too.
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+  end
+
+  def test_translate_when_haiku_raises_econnreset_then_retries_with_opus
+    # Given Haiku raises Errno::ECONNRESET — a `SystemCallError` subclass that
+    # `Net::HTTP` propagates without retry. Verifies the rescue's
+    # `SystemCallError` arm.
+    behaviors = {
+      HAIKU => Errno::ECONNRESET.new('connection reset by peer'),
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(behaviors),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we recover via Opus
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+  end
+
+  def test_translate_when_haiku_raises_socket_error_then_retries_with_opus
+    # Given Haiku raises SocketError (DNS / connection setup failure).
+    behaviors = {
+      HAIKU => SocketError.new('getaddrinfo: nodename nor servname provided'),
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(behaviors),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we recover via Opus
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+  end
+
+  def test_translate_when_haiku_raises_eof_error_then_retries_with_opus
+    # Given Haiku raises EOFError (mid-stream connection close, an IOError).
+    behaviors = {
+      HAIKU => EOFError.new('end of file reached'),
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(behaviors),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we recover via Opus
+    assert_equal :translated, result.status
+    assert_equal OPUS, result.model
+  end
+
+  def test_translate_when_haiku_raises_ssl_error_then_retries_with_opus
+    # Given Haiku raises OpenSSL::SSL::SSLError (TLS handshake failure).
+    behaviors = {
+      HAIKU => OpenSSL::SSL::SSLError.new('SSL_connect returned=1'),
+      OPUS => ->(loc, src) { "[#{loc}] #{src}" }
+    }
+    t = WooAiTranslation::ReleaseNotesTranslator.new(
+      client: ModelAwareStubClient.new(behaviors),
+      glossary_dir: @glossary_dir
+    )
+
+    # When we translate
+    result = t.translate(source_text: 'Welcome to WooCommerce', locale: 'pl', asc_locale: 'pl')
+
+    # Then we recover via Opus
     assert_equal :translated, result.status
     assert_equal OPUS, result.model
   end


### PR DESCRIPTION
## Description

PR 6 in the AI translations stack. The previous PRs ([#17220](https://github.com/woocommerce/woocommerce-ios/pull/17220) cutover → [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221) engine → [#17222](https://github.com/woocommerce/woocommerce-ios/pull/17222) glossaries → [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250) CI ∥ [#17271](https://github.com/woocommerce/woocommerce-ios/pull/17271) metadata) ship the in-app translations and the one-shot ASC `description.txt` bootstrap. This PR closes the per-release loop by auto-translating `fastlane/metadata/default/release_notes.txt` into the 14 AI-only ASC locales on every release.

Without this PR, every release ships English `release_notes` to the 14 new App Store locales — a visible regression after [#17220](https://github.com/woocommerce/woocommerce-ios/pull/17220).

### Stack position

```
trunk
 └ ai-translations/cutover (#17220)
    └ ai-translations/engine (#17221)
       └ ai-translations/glossaries (#17222)
          ├ ai-translations/ci (#17250)
          ├ ai-translations/metadata (#17271)
          └ ai-translations/release-notes  ← this PR
```

Base: `ai-translations/glossaries`. Sibling of [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250) and [#17271](https://github.com/woocommerce/woocommerce-ios/pull/17271).

### What it does

- **New Fastlane lane** `translate_release_notes_ai_locales`. Wired into `download_release_translations` (which runs from `.buildkite/release-pipelines/download-release-translations.yml` during the App Store Submission step of the release scenario), called right after `download_localized_strings_and_metadata_from_glotpress`. Creates its own commit (`Update AI release notes translations`) so blame stays distinct from the GP-bot `Update metadata translations` commit.
- **Engine extension**: new `ReleaseNotesTranslator` orchestrator (`fastlane/ai_translation/lib/woo_ai_translation/release_notes_translator.rb`). Per locale: Haiku first, Opus on failure (empty translation, validator violation, length > 4000 bytes, or any client/network error). Re-uses the existing `Translator`, `Validator`, and `AnthropicClient` from [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221) without modifying them.
- **CLI** `bin/translate_release_notes.rb`. Drives one process across all 14 locales, prints a per-locale summary table to stdout (Buildkite log + Fastlane annotation render fine).
- **Locale map** `lib/woo_ai_translation/asc_locales.rb`. Single source of truth for the 14 iOS → ASC mappings: `bg` excluded (Apple ASC unsupported); `nb` → ASC `no` (Apple has no Bokmål-specific listing).

### Failure handling

Per-locale failures are **soft**: the locale is skipped, no file is written, and Apple's automatic English fallback covers it for that release. The lane fails only on infrastructure errors (missing source file, CLI exit code ≠ 0). Missing `ANTHROPIC_API_KEY` is treated as "skip all 14" with a warning annotation — preferable to blocking a release on a secret-management issue.

The orchestrator rescues a broad surface for soft handling: `AnthropicClient::Error`, `Net::OpenTimeout`, `Net::ReadTimeout`, `SystemCallError` (covers `Errno::ECONNRESET` etc.), `SocketError`, `IOError` (covers `EOFError`), and `OpenSSL::SSL::SSLError`. Catching all of these at the release-notes layer encodes a soft-fail contract that the in-app translation path explicitly does NOT want, which is why this rescue lives here and `anthropic_client.rb` is not modified.

### Notes

- Will trip Danger's "PR larger than 300 lines" soft warning. Same as [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221), [#17222](https://github.com/woocommerce/woocommerce-ios/pull/17222), and [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250). Pattern, not bug.
- Three rounds of Codex review; final verdict green. Two issues found and fixed during review: `AnthropicClient::Error` escaping the Opus retry path (round 1) and an incomplete socket-level rescue surface (round 2).
- 85/85 engine specs pass (5 asc_locales + 9 byte_sizer + 28 ios_resources + 10 manifest + 15 release_notes_translator + 18 validator).
- `RELEASE-NOTES.txt` entry added under 24.9 as `[Internal]`. If this PR misses the 24.9 train (likely, given [#17220](https://github.com/woocommerce/woocommerce-ios/pull/17220) is still in conflict with trunk), bump the entry to 24.10 at merge time.

## Test Steps

**1. Unit specs (offline, no network).** From the worktree root:

```bash
ruby -Ifastlane/ai_translation/lib fastlane/ai_translation/spec/asc_locales_test.rb
ruby -Ifastlane/ai_translation/lib fastlane/ai_translation/spec/release_notes_translator_test.rb
```

Expect 5 + 15 = 20 specs green. The release_notes spec covers happy path, Haiku → Opus escalation across six failure modes (empty, validator, length, API error, network timeout, socket-level errors).

**2. Offline CLI smoke.** Confirms the per-locale fan-out and the iOS `nb` → ASC `no` mapping:

```bash
mkdir -p /tmp/release-notes-smoke
cp fastlane/metadata/default/release_notes.txt /tmp/release-notes-smoke/
fastlane/ai_translation/bin/translate_release_notes.rb \
  --source /tmp/release-notes-smoke/release_notes.txt \
  --metadata-dir /tmp/release-notes-smoke \
  --offline
```

Expect 14 / 14 `✓ done` rows in the summary table. Verify the lossy mapping:

```bash
ls /tmp/release-notes-smoke/no/release_notes.txt  # iOS nb wrote to ASC no
ls /tmp/release-notes-smoke/nb/ 2>&1 | grep -q 'No such file' && echo "nb folder correctly absent"
```

**3. Live one-locale dry run** (optional, costs cents). Replace `pl` with any of the 14 codes. Requires `ANTHROPIC_API_KEY`:

```bash
mkdir -p /tmp/release-notes-live
cp fastlane/metadata/default/release_notes.txt /tmp/release-notes-live/
# Hack: temporarily reduce AI_TRANSLATION_LOCALES to one entry, or just run
# the full 14 — at ~14 short paragraphs total it's under 10 cents.
ANTHROPIC_API_KEY=sk-... fastlane/ai_translation/bin/translate_release_notes.rb \
  --source /tmp/release-notes-live/release_notes.txt \
  --metadata-dir /tmp/release-notes-live
```

Spot-check one of the output files (e.g. `/tmp/release-notes-live/pl/release_notes.txt`) for placeholder + brand-safety preservation.

**4. Real CI** (post-merge, naturally exercised by the release scenario): once this PR + its base PRs land on `trunk` and the next release cycle hits the "Create Build" step (App Store Submission phase, calls `download_release_translations`), the lane will produce 14 new per-locale `release_notes.txt` files alongside the 16 GP-translated ones, and a separate `Update AI release notes translations` commit on the release branch.

## Screenshots

N/A — pipeline change with no UI surface.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
