### PR TITLE
Add shadow-diff calibration tool for AI vs GP translation comparison

### DIFF
--- a/.buildkite/release-pipelines/run-shadow-diff.yml
+++ b/.buildkite/release-pipelines/run-shadow-diff.yml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+# Manual one-click trigger for the WooAiTranslation shadow-diff calibration
+# tool. Invoke from Buildkite's "New Build" with a custom message; set the
+# LOCALES env var if you want a non-default locale set.
+#
+# This pipeline is NOT scheduled and NOT triggered by PRs. It exists so the
+# release manager (or anyone) can re-run shadow-diff after a model bump or
+# glossary change without setting up a local environment.
+
+agents:
+  queue: mac
+
+env:
+  IMAGE_ID: $IMAGE_ID
+  # Override at trigger time via "Environment Variables" in the Buildkite UI.
+  LOCALES: "de,es,fr,ja"
+  # Optional Tier 2 AI-as-judge. Leave empty to skip Tier 2.
+  JUDGE_MODEL: ""
+  # Optional cap on keys per locale (e.g. "500" for a smoke run).
+  LIMIT: ""
+
+steps:
+  - label: ":magnifying_glass_tilted_right: Shadow-diff calibration"
+    plugins: [$CI_TOOLKIT]
+    command: |
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- :closed_lock_with_key: Access Secrets'
+      bundle exec fastlane run configure_apply
+
+      echo '--- :magnifying_glass_tilted_right: Run shadow-diff'
+      export OUTPUT="$PWD/shadow-diff-out"
+      cmd="bundle exec rake -f fastlane/ai_translation/Rakefile translate:shadow_diff"
+      cmd="$cmd LOCALES=\"$LOCALES\" OUTPUT=\"$OUTPUT\""
+      [ -n "$JUDGE_MODEL" ] && cmd="$cmd JUDGE_MODEL=\"$JUDGE_MODEL\""
+      [ -n "$LIMIT" ] && cmd="$cmd LIMIT=\"$LIMIT\""
+      echo "$ $cmd"
+      eval "$cmd"
+
+      echo '--- :buildkite: Upload report artifacts'
+      buildkite-agent artifact upload "shadow-diff-out/*.md"
+
+      echo '--- :clipboard: Post combined summary as annotation'
+      buildkite-agent annotate --context shadow-diff --style info < shadow-diff-out/index.md
+    retry:
+      manual:
+        allowed: true

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] The Store Stats widget is now configurable: choose your size (small / medium / large), metrics, date range, store, and theme. [https://github.com/woocommerce/woocommerce-ios/pull/17170]
 - [*] New Trends widget for the lock screen, with a metric and date-range picker. [https://github.com/woocommerce/woocommerce-ios/pull/17160]
 - [**] Added support for 15 new app languages: Bulgarian, Czech, Danish, Finnish, Greek, Hindi, Hungarian, Malay, Norwegian Bokmål, Polish, Portuguese (Portugal), Romanian, Thai, Ukrainian, and Vietnamese.
+- [Internal] Added shadow-diff calibration tool (`fastlane/ai_translation/bin/translate_shadow_diff.rb`) for comparing AI translations against existing GP human translations. Produces a per-locale reviewer worksheet with mechanical bucketing (identical/cosmetic/placeholder-mismatch/length-significant/substantive) and an optional GPT-5.1-as-judge advisory column. Data-gathering tooling for the eventual GlotPress sunset conversation; no production behavior change.
 
 
 24.8

--- a/fastlane/ai_translation/.rubocop.yml
+++ b/fastlane/ai_translation/.rubocop.yml
@@ -27,6 +27,12 @@ Metrics/AbcSize:
     - 'lib/woo_ai_translation/ios_resources.rb'
     - 'lib/woo_ai_translation/anthropic_client.rb'
     - 'lib/woo_ai_translation/translator.rb'
+    # OpenAI client mirrors AnthropicClient's shape; same branchy http path.
+    - 'lib/woo_ai_translation/openai_client.rb'
+    # ShadowDiff's categorize/sample/render methods have many small branches
+    # that the rule reads as high-ABC; splitting them artificially hurts
+    # readability of the comparison logic.
+    - 'lib/woo_ai_translation/shadow_diff.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -35,6 +41,7 @@ Metrics/CyclomaticComplexity:
     - 'bin/**/*'
     - 'lib/woo_ai_translation/ios_resources.rb'
     - 'lib/woo_ai_translation/translator.rb'
+    - 'lib/woo_ai_translation/shadow_diff.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
@@ -57,10 +64,15 @@ Metrics/ClassLength:
 Metrics/ModuleLength:
   Exclude:
     - 'lib/woo_ai_translation/ios_resources.rb'
+    # ShadowDiff bundles categorizer + worksheet writer + report writer in
+    # one module by design (all operate on the same Entry/LocaleResult
+    # shapes); splitting would scatter related code.
+    - 'lib/woo_ai_translation/shadow_diff.rb'
 
 Metrics/BlockLength:
   Exclude:
     - 'Rakefile'
+    - 'bin/**/*'
 
 Metrics/BlockNesting:
   Exclude:
@@ -77,9 +89,18 @@ Style/Documentation:
   Exclude:
     - 'spec/**/*'
 
+Style/OneClassPerFile:
+  # Test files often bundle small helper stub classes (e.g.
+  # `FakeHttp`, `ProgrammableJudgeStub`, `ModelAwareStubClient`) alongside
+  # the `*Test` class itself; splitting harms locality. Also some spec files
+  # use multiple `*Test` classes per concern (e.g. shadow_diff_test.rb).
+  Exclude:
+    - 'spec/**/*'
+
 Style/FormatStringToken:
   Exclude:
     - 'scripts/**/*'
+    - 'bin/**/*'
 
 Style/MultilineBlockChain:
   Exclude:
@@ -89,6 +110,9 @@ Naming/MethodParameterName:
   AllowedNames:
     - 'tx'  # translation
     - 'p'   # OptionParser block param
+    - 'en'  # English source — paired with gp/ai in shadow-diff comparisons
+    - 'gp'  # GlotPress human translation — paired with en/ai
+    - 'ai'  # AI proposal — paired with en/gp
 
 Lint/UselessConstantScoping:
   # Struct/lookup table constants are intentionally namespaced under their

--- a/fastlane/ai_translation/README.md
+++ b/fastlane/ai_translation/README.md
@@ -46,25 +46,29 @@ new ones); set it to scope a run.
 ```
 fastlane/ai_translation/
 ├── bin/
-│   └── translate_locale.rb       # CLI entry point
+│   ├── translate_locale.rb           # CLI: per-locale in-app .strings translation
+│   └── translate_shadow_diff.rb      # CLI: shadow-diff calibration vs GP humans
 ├── lib/woo_ai_translation/
-│   ├── anthropic_client.rb       # Anthropic Messages API wrapper (+ StubClient)
-│   ├── byte_sizer.rb             # Script-aware batch sizing
-│   ├── constants.rb              # Version, model IDs, prompt version
-│   ├── ios_resources.rb          # .strings parser + writer
-│   ├── manifest.rb               # Source-only invalidation cache (per-locale JSON)
-│   ├── translator.rb             # Batched JSON-in/JSON-out translator with split-retry
-│   └── validator.rb              # Brand-safety + glossary enforcement
+│   ├── ai_judge.rb                   # Tier 2 OpenAI-as-judge for shadow-diff (advisory)
+│   ├── anthropic_client.rb           # Anthropic Messages API wrapper (+ StubClient)
+│   ├── byte_sizer.rb                 # Script-aware batch sizing
+│   ├── constants.rb                  # Version, model IDs, prompt version
+│   ├── ios_resources.rb              # .strings parser + writer
+│   ├── manifest.rb                   # Source-only invalidation cache (per-locale JSON)
+│   ├── openai_client.rb              # OpenAI Chat Completions API wrapper (+ StubOpenAIClient)
+│   ├── shadow_diff.rb                # Tier 1 categorizer + worksheet/report writer
+│   ├── translator.rb                 # Batched JSON-in/JSON-out translator with split-retry
+│   └── validator.rb                  # Brand-safety + glossary enforcement
 ├── glossary/
-│   ├── common.yml                # Brand names — never translate (hard validator)
-│   └── <locale>.yml × 31         # Per-locale UI term + noun mappings
+│   ├── common.yml                    # Brand names — never translate (hard validator)
+│   └── <locale>.yml × 31             # Per-locale UI term + noun mappings
 ├── style/
-│   ├── default.md                # Fallback style guide
-│   └── <locale>.md               # Per-locale register / quirks (when applicable)
-├── spec/                         # Minitest specs
-├── scripts/                      # One-off bootstrap utilities (assemble, gap-fill)
-├── Rakefile                      # Rake task wrappers
-└── translate-progress.json       # Audit checkpoint for the original bootstrap run
+│   ├── default.md                    # Fallback style guide
+│   └── <locale>.md                   # Per-locale register / quirks (when applicable)
+├── spec/                             # Minitest specs
+├── scripts/                          # One-off bootstrap utilities (assemble, gap-fill)
+├── Rakefile                          # Rake task wrappers
+└── translate-progress.json           # Audit checkpoint for the original bootstrap run
 ```
 
 ### Glossaries and brand-safety
@@ -179,6 +183,108 @@ This is the mode the CI step is designed to call on every PR that touches
 `en.lproj` (the CI wiring lands in a separate PR in this series). A typical
 PR adds 1–10 strings, so the incremental call costs cents and finishes in
 seconds.
+
+## Shadow-diff calibration
+
+A separate tool for the **GlotPress sunset conversation**. Asks the question:
+"For an existing GP-translated locale, how close does the production AI engine
+come to the human GP translation?" Builds the data needed to decide whether
+AI can replace GP for the 16 existing locales (a future PR — not in this
+engine version's scope).
+
+The tool produces **data**, not a verdict. The substantive question — "is AI
+better than, equivalent to, or worse than GP human for our merchant audience"
+— is answered by a native-speaker human reviewer filling in a worksheet. The
+tool prepares the work in a structured way that respects their time.
+
+### Methodology — 3 tiers
+
+**Tier 1 — Mechanical bucketing (the tool, no judgment).** Pure string operations:
+
+| Bucket | Meaning |
+|---|---|
+| `identical` | byte-for-byte match between GP and AI |
+| `cosmetic` | differ only by whitespace / case |
+| `placeholder_mismatch` | **HARD FAIL** — `%@` / `%1$d` etc. differs from EN source (bug regardless of side) |
+| `length_significant` | >20% byte delta between GP and AI (possible register / verbosity change) |
+| `substantive` | everything else |
+
+**Tier 2 — AI-as-judge (advisory, opt-in).** Optional pass on the
+`substantive` sample using **GPT-5.1 via OpenAI** — deliberately a different
+model family from the Anthropic Claude production translator, to reduce
+self-bias. Each entry gets a `verdict ∈ {equivalent | acceptable_variant |
+different_meaning | ai_wrong | gp_wrong}` + a one-line reasoning. Output is
+**explicitly tagged as advisory** in the worksheet — never used to skip human
+review.
+
+**Tier 3 — Human (the actual decision).** A native-speaker reviewer fills
+in the worksheet for the rows the tool sampled:
+
+- **100% of `placeholder_mismatch`** — must be ~0 before any sunset talk
+- **100% of `length_significant`** — verify register / verbosity is appropriate
+- **Sample of `substantive`** — `max(30, 5% of bucket)` per locale, deterministic by `--seed`
+- **Sanity sample of `identical`** — `max(10, 0.5% of bucket)` to check for training-data memorization
+
+Reviewer answers per row: *"For our merchant audience, is the AI proposal
+**better than**, **equivalent to**, or **worse than** the current GP human
+translation?"* — comparative, not "is AI correct".
+
+### Running locally
+
+```bash
+# Smoke run (offline, deterministic, no spend)
+fastlane/ai_translation/bin/translate_shadow_diff.rb \
+  --locales de --limit 20 --offline \
+  --output /tmp/shadow-diff-smoke
+
+# Real run, one locale, Tier 1 only (~$3-5 in Haiku tokens)
+ANTHROPIC_API_KEY=sk-... fastlane/ai_translation/bin/translate_shadow_diff.rb \
+  --locales de --output ./shadow-diff-out
+
+# Full 4-locale run with Tier 2 GPT-5.1 advisory (~$25 total)
+ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... \
+  fastlane/ai_translation/bin/translate_shadow_diff.rb \
+  --locales de,es,fr,ja \
+  --judge-model gpt-5.1 \
+  --output ./shadow-diff-out
+
+# Or via Rake
+bundle exec rake -f fastlane/ai_translation/Rakefile translate:shadow_diff \
+  LOCALES=de,es,fr,ja JUDGE_MODEL=gpt-5.1 OUTPUT=./shadow-diff-out
+```
+
+### Running via Buildkite (manual trigger)
+
+The pipeline at `.buildkite/release-pipelines/run-shadow-diff.yml` is a
+**manual one-click trigger**, not scheduled. Useful after a model bump or
+glossary change when we want fresh data without setting up a local
+environment. Set `LOCALES`, `JUDGE_MODEL`, `LIMIT` as environment variables
+at trigger time.
+
+### Output
+
+Per locale: `<locale>-worksheet.md` (rows for reviewer to judge) and
+`<locale>-summary.md` (bucket counts). One combined `index.md` across all
+locales. Reviewer fills in the worksheet's `Verdict` column, saves a copy,
+and we tally the comparative judgments.
+
+### Why not just run continuously in CI?
+
+GP human translations don't drift on a daily/weekly cadence. The signal is a
+cross-section, not a time series. The output feeds a human decision (sunset
+conversation), so there's no automated actor to wake up. Token cost is
+non-trivial (~$25 per full run) and we'd burn it for no new information.
+Manual trigger is the right cadence.
+
+### Why GPT, not Claude, as the judge?
+
+Asking a Haiku-family model to judge another Haiku-family model's output is
+biased — same training data, same failure modes, same favorite phrasings. A
+different family (OpenAI's GPT-5.1) gives us cross-family judgment that's
+less self-justifying. The judge is still flagged as **advisory only** in the
+worksheet; Tier 3 (human) is the actual decision-maker. AI cannot answer the
+"is AI good enough" question for us — that's the methodology's load-bearing
+point.
 
 ## Adding a new locale
 

--- a/fastlane/ai_translation/Rakefile
+++ b/fastlane/ai_translation/Rakefile
@@ -122,6 +122,23 @@ namespace :translate do
     SUPPORTED_LOCALES.each { |loc| run_cli(loc) }
   end
 
+  desc 'Shadow-diff calibration: AI-translate existing GP locale(s) and diff vs human GP. ' \
+       'See README "Shadow-diff calibration" for methodology.'
+  task :shadow_diff do
+    locales = ENV.fetch('LOCALES', 'de,es,fr,ja')
+    output = ENV.fetch('OUTPUT', File.join(REPO_ROOT, 'shadow-diff-out'))
+    bin = File.join(__dir__, 'bin', 'translate_shadow_diff.rb')
+
+    args = ['ruby', bin, '--locales', locales, '--output', output]
+    args.push('--limit', ENV['LIMIT']) if ENV['LIMIT']
+    args.push('--judge-model', ENV['JUDGE_MODEL']) if ENV['JUDGE_MODEL']
+    args.push('--seed', ENV['SEED']) if ENV['SEED']
+    args << '--offline' if ENV['OFFLINE'] == '1'
+
+    puts "$ #{args.join(' ')}"
+    abort('translate_shadow_diff.rb failed') unless system(*args)
+  end
+
   desc 'Backfill manifest entries for already-shipped locales (no API calls).'
   task :backfill_manifest do
     require_relative 'lib/woo_ai_translation/ios_resources'

--- a/fastlane/ai_translation/bin/translate_shadow_diff.rb
+++ b/fastlane/ai_translation/bin/translate_shadow_diff.rb
@@ -158,10 +158,16 @@ options[:locales].each do |locale|
     advisory = ai_judge.judge_all(sample)
   end
 
-  # Write worksheet + summary.
+  # Write worksheet + summary. Pass through the seed so the worksheet rows
+  # are the same sample we (optionally) ran the AI judge on; otherwise the
+  # advisory column would be sparse and tokens would be wasted on entries
+  # the reviewer never sees.
   worksheet_path = File.join(options[:output], "#{locale}-worksheet.md")
   summary_path = File.join(options[:output], "#{locale}-summary.md")
-  File.write(worksheet_path, WooAiTranslation::ShadowDiff.render_worksheet(locale_result, ai_judge_advisory: advisory))
+  File.write(
+    worksheet_path,
+    WooAiTranslation::ShadowDiff.render_worksheet(locale_result, ai_judge_advisory: advisory, seed: options[:seed])
+  )
   File.write(summary_path, WooAiTranslation::ShadowDiff.render_summary(locale_result))
 
   summaries << locale_result.summary.merge(locale: locale)

--- a/fastlane/ai_translation/bin/translate_shadow_diff.rb
+++ b/fastlane/ai_translation/bin/translate_shadow_diff.rb
@@ -1,0 +1,201 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Shadow-diff calibration tool. Translates an existing GlotPress-translated
+# locale via the production AI engine and diffs the result against the
+# human-curated GP translation. Outputs:
+#
+#   - A per-locale Markdown worksheet for native-speaker reviewers (Tier 3)
+#   - A per-locale Markdown summary report (counts per bucket)
+#   - A combined index report
+#
+# Use this to gather comparative-quality data ahead of any GlotPress sunset
+# conversation (PR 8). The tool does NOT decide quality; humans do. See the
+# fastlane/ai_translation/README.md "Shadow-diff calibration" section.
+#
+# Usage:
+#   bin/translate_shadow_diff.rb \
+#     --locales de,es,fr,ja \
+#     --output ./shadow-diff-out
+#
+# Flags:
+#   --locales LIST           Comma-separated GP locale codes to evaluate (required).
+#   --output DIR             Output directory for worksheets + reports (default: ./shadow-diff-out).
+#   --limit N                Cap keys per locale (smoke runs; default: all).
+#   --judge-model NAME       Tier 2 judge model (e.g. "gpt-5.1"). Omit to skip Tier 2.
+#   --seed N                 Sampling seed for reproducibility (default: 42).
+#   --offline                Use deterministic StubClient for translation (no API spend).
+
+require 'optparse'
+require 'fileutils'
+
+ROOT = File.expand_path('..', __dir__)
+$LOAD_PATH.unshift(File.join(ROOT, 'lib'))
+
+require 'woo_ai_translation/ai_judge'
+require 'woo_ai_translation/anthropic_client'
+require 'woo_ai_translation/constants'
+require 'woo_ai_translation/ios_resources'
+require 'woo_ai_translation/openai_client'
+require 'woo_ai_translation/shadow_diff'
+require 'woo_ai_translation/translator'
+require 'woo_ai_translation/validator'
+
+REPO_ROOT = File.expand_path('../..', ROOT)
+RESOURCES = File.join(REPO_ROOT, 'WooCommerce/Resources')
+
+options = {
+  locales: nil,
+  output: File.join(Dir.pwd, 'shadow-diff-out'),
+  limit: nil,
+  judge_model: nil,
+  seed: 42,
+  offline: false
+}
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: translate_shadow_diff.rb --locales de,es,fr,ja [--output DIR] [--limit N] [--judge-model NAME] [--seed N] [--offline]'
+  opts.on('--locales LIST', 'Comma-separated GP locale codes (required)') { |v| options[:locales] = v.split(',').map(&:strip) }
+  opts.on('--output DIR', 'Output directory for worksheets + reports') { |v| options[:output] = v }
+  opts.on('--limit N', Integer, 'Cap keys per locale') { |v| options[:limit] = v }
+  opts.on('--judge-model NAME', 'Tier 2 judge model (omit to skip Tier 2)') { |v| options[:judge_model] = v }
+  opts.on('--seed N', Integer, 'Sampling seed (default 42)') { |v| options[:seed] = v }
+  opts.on('--offline', 'Use deterministic StubClient (no API calls)') { options[:offline] = true }
+end.parse!
+
+abort 'error: --locales is required (comma-separated GP locale codes)' if options[:locales].nil? || options[:locales].empty?
+
+# --- Set up clients ---
+
+anthropic =
+  if options[:offline]
+    WooAiTranslation::StubClient.new
+  else
+    c = WooAiTranslation::AnthropicClient.from_env
+    abort 'error: ANTHROPIC_API_KEY is not set (use --offline for a dry run)' unless c.available?
+    c
+  end
+
+ai_judge = nil
+if options[:judge_model] && !options[:offline]
+  oai = WooAiTranslation::OpenAIClient.from_env
+  abort "error: OPENAI_API_KEY is not set (required for --judge-model #{options[:judge_model]})" unless oai.available?
+
+  ai_judge = WooAiTranslation::AiJudge.new(client: oai, model: options[:judge_model])
+elsif options[:judge_model] && options[:offline]
+  warn 'warn: --judge-model ignored in --offline mode'
+end
+
+translator = WooAiTranslation::Translator.new(
+  client: anthropic,
+  logger: ->(msg) { warn "[translator] #{msg}" }
+)
+
+style_dir = File.join(ROOT, 'style')
+
+FileUtils.mkdir_p(options[:output])
+
+# --- Run per locale ---
+
+en_path = File.join(RESOURCES, 'en.lproj/Localizable.strings')
+abort "error: EN source not found at #{en_path}" unless File.exist?(en_path)
+
+warn "Reading EN source: #{en_path}"
+en_doc = WooAiTranslation::IosResources::Parser.parse_file(en_path)
+en_by_name = en_doc.units.to_h { |u| [u.name, u.entries.first[:source]] }
+
+summaries = []
+
+options[:locales].each do |locale|
+  gp_path = File.join(RESOURCES, "#{locale}.lproj/Localizable.strings")
+  unless File.exist?(gp_path)
+    warn "warn: skipping #{locale} — GP file not found at #{gp_path}"
+    next
+  end
+
+  warn "Reading GP locale #{locale}: #{gp_path}"
+  gp_doc = WooAiTranslation::IosResources::Parser.parse_file(gp_path)
+  gp_by_name = gp_doc.units.to_h { |u| [u.name, u.entries.first[:source]] }
+
+  # Intersect keys: only shadow-diff keys that exist in BOTH EN and GP.
+  shared_keys = en_by_name.keys & gp_by_name.keys
+  shared_keys = shared_keys.first(options[:limit]) if options[:limit]
+  warn "Locale #{locale}: #{shared_keys.size} keys to shadow-diff"
+
+  # AI-translate the shared keys.
+  items = shared_keys.map { |k| { id: k, source: en_by_name[k], context: en_doc.units.find { |u| u.name == k }&.comment.to_s } }
+  warn "Locale #{locale}: requesting AI translations (model=#{WooAiTranslation::DEFAULT_MODEL}, offline=#{options[:offline]})..."
+
+  ai_proposals = translator.translate(
+    locale: locale,
+    items: items,
+    model: WooAiTranslation::DEFAULT_MODEL,
+    style: File.exist?(File.join(style_dir, "#{locale}.md")) ? File.read(File.join(style_dir, "#{locale}.md")) : nil
+  )
+
+  warn "Locale #{locale}: categorizing #{shared_keys.size} entries..."
+
+  entries = shared_keys.map do |key|
+    en_source = en_by_name[key]
+    gp_human = gp_by_name[key]
+    ai_proposal = ai_proposals[key] || ''
+
+    WooAiTranslation::ShadowDiff.build_entry(
+      key: key,
+      en_source: en_source,
+      gp_human: gp_human,
+      ai_proposal: ai_proposal
+    )
+  end
+
+  locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(locale: locale, diff_entries: entries)
+
+  # Tier 2 AI judge — only on the worksheet sample.
+  advisory = nil
+  if ai_judge
+    sample = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: options[:seed])
+    warn "Locale #{locale}: running Tier 2 AI judge over #{sample.size} sampled entries..."
+    advisory = ai_judge.judge_all(sample)
+  end
+
+  # Write worksheet + summary.
+  worksheet_path = File.join(options[:output], "#{locale}-worksheet.md")
+  summary_path = File.join(options[:output], "#{locale}-summary.md")
+  File.write(worksheet_path, WooAiTranslation::ShadowDiff.render_worksheet(locale_result, ai_judge_advisory: advisory))
+  File.write(summary_path, WooAiTranslation::ShadowDiff.render_summary(locale_result))
+
+  summaries << locale_result.summary.merge(locale: locale)
+  warn "Locale #{locale}: wrote #{worksheet_path} + #{summary_path}"
+end
+
+# --- Combined index report ---
+
+index_lines = ['# Shadow-diff calibration — combined summary', '']
+index_lines << '_Reviewer worksheet for Tier 3 (human native-speaker judgment) lives alongside each summary._'
+index_lines << ''
+index_lines << '| Locale | Total | Identical | Cosmetic | Placeholder ⚠ | Length-significant | Substantive |'
+index_lines << '|---|---:|---:|---:|---:|---:|---:|'
+summaries.each do |s|
+  index_lines << "| #{s[:locale]} | #{s[:total]} | #{s[:identical]} | #{s[:cosmetic]} | #{s[:placeholder_mismatch]} | #{s[:length_significant]} | #{s[:substantive]} |"
+end
+File.write(File.join(options[:output], 'index.md'), index_lines.join("\n"))
+warn "Wrote #{File.join(options[:output], 'index.md')}"
+
+# --- Stdout summary table ---
+
+def summary_row(cells)
+  widths = [8, 7, 9, 8, 13, 18, 12]
+  cells.each_with_index.map { |c, i| widths[i] ? c.to_s.ljust(widths[i]) : c.to_s }.join('  ')
+end
+
+puts ''
+puts '=== Shadow-diff summary ==='
+puts summary_row(%w[Locale Total Identical Cosmetic Placeholder Length-significant Substantive])
+summaries.each do |s|
+  puts summary_row([s[:locale], s[:total], s[:identical], s[:cosmetic], s[:placeholder_mismatch], s[:length_significant], s[:substantive]])
+end
+puts ''
+puts "Output written to: #{options[:output]}/"
+puts 'Reviewers (Tier 3): see <locale>-worksheet.md per locale.'
+
+exit 0

--- a/fastlane/ai_translation/lib/woo_ai_translation/ai_judge.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/ai_judge.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative 'openai_client'
+
+module WooAiTranslation
+  # Tier 2 of the shadow-diff calibration tool.
+  #
+  # Calls an LLM (typically GPT-5.1 via `OpenAIClient`, deliberately a
+  # different model family from the Anthropic-based production translator) to
+  # classify each Substantive-bucket diff as one of:
+  #
+  #   - equivalent          — both convey the same meaning equally well
+  #   - acceptable_variant  — both are correct, slight style/word-choice
+  #   - different_meaning   — the two translations mean different things
+  #   - ai_wrong            — AI proposal misses/changes source meaning
+  #   - gp_wrong            — GP human is wrong; AI proposal is correct
+  #
+  # The output is **advisory only**. It must never replace Tier 3 (human
+  # native-speaker review). The worksheet column is labeled accordingly. See
+  # README "Shadow-diff calibration" for why AI-judging-AI is biased and why
+  # the human reviewer remains the decision-maker.
+  #
+  # Calls are intentionally one-at-a-time rather than batched: the judge
+  # operates only on the worksheet sample (typically <100 entries per locale,
+  # bounded by `SAMPLE_POLICY`), so total call count is manageable without
+  # adding JSON-batch parsing complexity.
+  class AiJudge
+    DEFAULT_MODEL = WooAiTranslation::OpenAIClient::DEFAULT_MODEL
+
+    SYSTEM_PROMPT = <<~PROMPT
+      You are evaluating two translations of the same English UI string from a
+      mobile commerce app called WooCommerce. The audience is small-business
+      merchants managing their store from a phone. Brand names like WooCommerce,
+      Stripe, Apple Pay, WordPress.com must appear verbatim in any translation.
+
+      You will receive three lines:
+        EN source: <the English original>
+        GP human: <the existing human translation>
+        AI proposal: <a candidate AI translation>
+
+      Compare GP and AI for this audience and classify their relationship as
+      ONE of:
+        - "equivalent"          — both convey the same meaning equally well
+        - "acceptable_variant"  — both are correct, slight style/word-choice difference
+        - "different_meaning"   — the two translations mean different things
+        - "ai_wrong"            — AI proposal misses/changes source meaning; GP is correct
+        - "gp_wrong"            — GP human is wrong (e.g. outdated, typo); AI is correct
+
+      Respond with ONLY a single minified JSON object with two keys:
+        "verdict": one of the labels above (string)
+        "reasoning": one short sentence (max 120 chars)
+
+      No prose outside the JSON. No code fences. No additional keys.
+    PROMPT
+
+    VALID_VERDICTS = %w[equivalent acceptable_variant different_meaning ai_wrong gp_wrong].freeze
+
+    def initialize(client:, model: DEFAULT_MODEL)
+      @client = client
+      @model = model
+    end
+
+    # Public: judge a list of `ShadowDiff::Entry` records.
+    # Returns Hash<entry.key => String> with one-line "verdict: reasoning"
+    # strings ready to drop into the worksheet's `Judge (advisory)` column.
+    # Errors per entry are surfaced as "error: <message>" rather than raised,
+    # so a partial judge run still produces a usable worksheet.
+    def judge_all(entries)
+      entries.to_h do |entry|
+        result = judge(
+          en_source: entry.en_source,
+          gp_human: entry.gp_human,
+          ai_proposal: entry.ai_proposal
+        )
+        [entry.key, format_cell(result)]
+      end
+    end
+
+    # Public: judge one (en, gp, ai) triple.
+    # Returns { verdict: String, reasoning: String }. On error, returns
+    # { verdict: "error", reasoning: "<message>" }.
+    def judge(en_source:, gp_human:, ai_proposal:)
+      messages = [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: format_question(en_source, gp_human, ai_proposal) }
+      ]
+      raw = @client.complete(messages: messages, model: @model)
+      parse(raw)
+    rescue StandardError => e
+      { verdict: 'error', reasoning: "judge error: #{e.class.name.split('::').last} #{e.message}" }
+    end
+
+    private
+
+    def format_question(en_source, gp_human, ai_proposal)
+      "EN source: #{en_source}\nGP human: #{gp_human}\nAI proposal: #{ai_proposal}"
+    end
+
+    def parse(raw)
+      text = raw.to_s.strip
+      text = text.gsub(/\A```(?:json)?/, '').gsub(/```\z/, '').strip
+      obj = JSON.parse(text)
+      raise ArgumentError, 'expected JSON object' unless obj.is_a?(Hash)
+
+      verdict = obj['verdict'].to_s
+      reasoning = obj['reasoning'].to_s
+      verdict = 'invalid_verdict' unless VALID_VERDICTS.include?(verdict)
+      { verdict: verdict, reasoning: reasoning }
+    end
+
+    def format_cell(result)
+      "**#{result[:verdict]}** — #{result[:reasoning]}"
+    end
+  end
+end

--- a/fastlane/ai_translation/lib/woo_ai_translation/openai_client.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/openai_client.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+module WooAiTranslation
+  # Thin OpenAI Chat Completions API client.
+  #
+  # Used by `AiJudge` (Tier 2 of shadow-diff) so the judge model is from a
+  # different model family than the production translator (Anthropic Claude).
+  # Cross-family judging reduces the self-bias problem where Haiku judges
+  # another Haiku's output and inevitably skews toward "equivalent".
+  #
+  # Shape intentionally mirrors `AnthropicClient` so the rest of the engine
+  # can treat them as similar shapes. Bearer-token auth instead of x-api-key;
+  # `messages` array with explicit roles instead of separate `system_blocks` +
+  # `user_content`. No prompt caching (OpenAI handles it transparently in the
+  # backend; no header to set).
+  #
+  # Retries on timeout / 429 / 5xx with exponential backoff. Honors `Retry-After`
+  # if present.
+  class OpenAIClient
+    class Error < StandardError; end
+
+    DEFAULT_BASE_URL = 'https://api.openai.com'
+    DEFAULT_MODEL = 'gpt-5.1'
+    MAX_RETRIES = 5
+
+    def self.from_env
+      new(
+        api_key: ENV.fetch('OPENAI_API_KEY', nil),
+        base_url: ENV['WOO_AI_OPENAI_BASE_URL'] || DEFAULT_BASE_URL
+      )
+    end
+
+    def initialize(api_key:, base_url: DEFAULT_BASE_URL, http: nil)
+      @api_key = api_key
+      @base_url = base_url
+      @http = http
+    end
+
+    def available?
+      !@api_key.to_s.empty?
+    end
+
+    # messages: array of `{ role: 'system' | 'user' | 'assistant', content: String }` hashes.
+    # Returns the assistant text content (String).
+    def complete(messages:, model: DEFAULT_MODEL, max_tokens: 8192, temperature: 0)
+      raise Error, 'OPENAI_API_KEY is not set' unless available?
+
+      body = {
+        model: model,
+        messages: messages,
+        max_tokens: max_tokens,
+        temperature: temperature
+      }
+      with_retries { post_chat(body) }
+    end
+
+    private
+
+    def post_chat(body)
+      uri = URI.join("#{@base_url}/", 'v1/chat/completions')
+      req = Net::HTTP::Post.new(uri)
+      req['content-type'] = 'application/json'
+      req['authorization'] = "Bearer #{@api_key}"
+      req.body = JSON.generate(body)
+
+      res = http_client(uri).request(req)
+      raise Error, "HTTP #{res.code}: #{res.body}" unless res.code.to_i.between?(200, 299)
+
+      json = JSON.parse(res.body)
+      json.dig('choices', 0, 'message', 'content').to_s
+    end
+
+    def http_client(uri)
+      return @http if @http
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      http.open_timeout = 30
+      http.read_timeout = 120
+      http
+    end
+
+    def with_retries
+      attempt = 0
+      begin
+        yield
+      rescue Error, Net::OpenTimeout, Net::ReadTimeout => e
+        attempt += 1
+        raise if attempt > MAX_RETRIES
+        raise if e.is_a?(Error) && client_error_no_retry?(e)
+
+        sleep(backoff_seconds(attempt))
+        retry
+      end
+    end
+
+    def client_error_no_retry?(error)
+      m = error.message[/HTTP (\d+)/, 1]
+      return false if m.nil?
+
+      code = m.to_i
+      code.between?(400, 499) && code != 429
+    end
+
+    def backoff_seconds(attempt)
+      (2**attempt) + rand
+    end
+  end
+
+  # Deterministic offline stand-in for OpenAI used by tests and offline dry runs.
+  # Mirrors `StubClient` for Anthropic. Default behavior echoes a tagged version
+  # of the last user message so tests can verify the integration without
+  # spending tokens.
+  class StubOpenAIClient
+    def initialize(&transform)
+      @transform = transform || ->(messages) { "[stub-openai] #{messages.last[:content][0..80]}" }
+      @calls = 0
+    end
+
+    attr_reader :calls
+
+    def available?
+      true
+    end
+
+    def complete(messages:, model: nil, max_tokens: nil, temperature: nil)
+      _ = [model, max_tokens, temperature] # unused in stub
+      @calls += 1
+      @transform.call(messages)
+    end
+  end
+end

--- a/fastlane/ai_translation/lib/woo_ai_translation/shadow_diff.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/shadow_diff.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+module WooAiTranslation
+  # Tier 1 of the shadow-diff calibration tool. Categorizes per-key (EN source,
+  # GP human translation, AI proposal) triples into named buckets, produces a
+  # reviewer worksheet (Markdown) for entries that need human judgment, and
+  # emits a summary report.
+  #
+  # This module deliberately does NOT make quality judgments. It is mechanical
+  # bucketing only. The substantive question — "is AI better, equivalent, or
+  # worse than GP for our merchant audience" — is answered by a native-speaker
+  # reviewer filling in the worksheet. See README "Shadow-diff calibration"
+  # for the full methodology.
+  module ShadowDiff
+    # Per-key comparison record.
+    Entry = Struct.new(
+      :key, :en_source, :gp_human, :ai_proposal, :bucket,
+      :en_placeholders, :gp_placeholders, :ai_placeholders,
+      keyword_init: true
+    )
+
+    # Aggregate for one locale. We use `diff_entries` rather than `entries`
+    # because Struct.new(:entries, ...) overrides Struct#entries.
+    LocaleResult = Struct.new(:locale, :diff_entries, keyword_init: true) do
+      def summary
+        counts = diff_entries.group_by(&:bucket).transform_values(&:size)
+        {
+          total: diff_entries.size,
+          identical: counts[:identical] || 0,
+          cosmetic: counts[:cosmetic] || 0,
+          placeholder_mismatch: counts[:placeholder_mismatch] || 0,
+          length_significant: counts[:length_significant] || 0,
+          substantive: counts[:substantive] || 0
+        }
+      end
+
+      def bucket(name)
+        diff_entries.select { |e| e.bucket == name }
+      end
+    end
+
+    # Length delta threshold for the `length_significant` bucket. >20% byte
+    # difference between GP and AI signals a possible register / verbosity
+    # change worth human attention.
+    LENGTH_SIGNIFICANT_RATIO = 0.20
+
+    # iOS .strings placeholder syntax: %@, %d, %1$@, %2$d, %ld, %lld, %.0f, etc.
+    PLACEHOLDER_RE = /%(?:\d+\$)?[@dxXosfFiluL.0-9]+/
+
+    # Sampling policy for the reviewer worksheet. Tier 2 (the human reviewer)
+    # reviews 100% of these buckets:
+    #   - placeholder_mismatch (hard fail — every one is potentially a bug)
+    #   - length_significant   (verify register / verbosity is appropriate)
+    # And samples these:
+    #   - substantive: max(30, 5% of bucket)  — calibration sample for AI-vs-GP-quality
+    #   - identical:   max(10, 0.5% of bucket) — sanity check for training-data memorization
+    # Cosmetic entries are counted but not put in the worksheet.
+    SAMPLE_POLICY = {
+      placeholder_mismatch: { min: nil, ratio: nil }, # 100%
+      length_significant: { min: nil, ratio: nil }, # 100%
+      substantive: { min: 30, ratio: 0.05 },
+      identical: { min: 10, ratio: 0.005 }
+    }.freeze
+
+    # Categorize one entry. Pure function; no I/O.
+    def self.categorize(en_source:, gp_human:, ai_proposal:)
+      en_placeholders = extract_placeholders(en_source)
+      gp_placeholders = extract_placeholders(gp_human)
+      ai_placeholders = extract_placeholders(ai_proposal)
+
+      # Placeholder mismatch is first-class. Flag whenever AI or GP deviates
+      # from the EN source's placeholder set — leaves the reviewer to diagnose
+      # which side has the bug.
+      return :placeholder_mismatch if ai_placeholders != en_placeholders || gp_placeholders != en_placeholders
+      return :identical if gp_human == ai_proposal
+      return :cosmetic if normalize_cosmetic(gp_human) == normalize_cosmetic(ai_proposal)
+
+      gp_size = gp_human.to_s.bytesize
+      ai_size = ai_proposal.to_s.bytesize
+      delta_ratio = (ai_size - gp_size).abs.to_f / [gp_size, 1].max
+      return :length_significant if delta_ratio > LENGTH_SIGNIFICANT_RATIO
+
+      :substantive
+    end
+
+    # Build an Entry for one key (helper that calls categorize + records the
+    # placeholder lists alongside, so the worksheet can render them without
+    # re-extraction).
+    def self.build_entry(key:, en_source:, gp_human:, ai_proposal:)
+      en = extract_placeholders(en_source)
+      gp = extract_placeholders(gp_human)
+      ai = extract_placeholders(ai_proposal)
+      bucket = categorize(en_source: en_source, gp_human: gp_human, ai_proposal: ai_proposal)
+      Entry.new(
+        key: key, en_source: en_source, gp_human: gp_human, ai_proposal: ai_proposal,
+        bucket: bucket,
+        en_placeholders: en, gp_placeholders: gp, ai_placeholders: ai
+      )
+    end
+
+    # Return the subset of `entries` that should go on the reviewer worksheet,
+    # per SAMPLE_POLICY. `seed` makes the sampling deterministic so re-runs
+    # produce the same calibration sample (useful when comparing before/after
+    # an engine change).
+    def self.sample_for_worksheet(entries, seed: 42)
+      rng = Random.new(seed)
+      grouped = entries.group_by(&:bucket)
+      out = []
+
+      # 100% of placeholder_mismatch + length_significant
+      out.concat(grouped[:placeholder_mismatch] || [])
+      out.concat(grouped[:length_significant] || [])
+
+      # Sampled buckets
+      %i[substantive identical].each do |bucket|
+        bucket_entries = grouped[bucket] || []
+        next if bucket_entries.empty?
+
+        policy = SAMPLE_POLICY[bucket]
+        size = [policy[:min], (bucket_entries.size * policy[:ratio]).ceil].max
+        size = [size, bucket_entries.size].min
+        out.concat(bucket_entries.sample(size, random: rng))
+      end
+
+      out
+    end
+
+    # Normalize for cosmetic comparison: lowercase, collapse whitespace, strip
+    # surrounding whitespace. Intentionally does NOT strip punctuation — a
+    # diff in "Hello!" vs "Hello." is semantically interesting enough to be
+    # `substantive` rather than `cosmetic`.
+    def self.normalize_cosmetic(text)
+      text.to_s.downcase.gsub(/\s+/, ' ').strip
+    end
+
+    # Sorted list of placeholders in `text`. Sorting makes the comparison
+    # order-independent (a translation may reorder placeholders for grammar,
+    # which is fine as long as the set is preserved).
+    def self.extract_placeholders(text)
+      text.to_s.scan(PLACEHOLDER_RE).sort
+    end
+
+    # --- Worksheet + report writers ---
+
+    # Render a per-locale reviewer worksheet as Markdown. The reviewer adds
+    # their judgment in the verdict column (`[ ] AI better / [ ] equivalent /
+    # [ ] GP better`) and saves the file alongside their notes.
+    def self.render_worksheet(locale_result, ai_judge_advisory: nil)
+      header_lines = render_worksheet_header(locale_result)
+      table_lines = render_worksheet_table(locale_result, ai_judge_advisory: ai_judge_advisory)
+      (header_lines + table_lines).join("\n")
+    end
+
+    # Render a one-locale summary section as Markdown.
+    def self.render_summary(locale_result)
+      s = locale_result.summary
+      pct = ->(n) { s[:total].zero? ? '0.0%' : format('%.1f%%', n.to_f / s[:total] * 100) }
+      <<~MD
+        ## #{locale_result.locale}
+
+        | Bucket | Count | Share |
+        |---|---:|---:|
+        | identical | #{s[:identical]} | #{pct.call(s[:identical])} |
+        | cosmetic | #{s[:cosmetic]} | #{pct.call(s[:cosmetic])} |
+        | placeholder_mismatch | #{s[:placeholder_mismatch]} | #{pct.call(s[:placeholder_mismatch])} |
+        | length_significant | #{s[:length_significant]} | #{pct.call(s[:length_significant])} |
+        | substantive | #{s[:substantive]} | #{pct.call(s[:substantive])} |
+        | **total** | **#{s[:total]}** | **100%** |
+      MD
+    end
+
+    # ---
+
+    def self.render_worksheet_header(locale_result)
+      [
+        "# Shadow-diff worksheet — #{locale_result.locale}",
+        '',
+        '_Generated by the WooAiTranslation shadow-diff tool. Reviewer fills in the **Verdict** column for each row._',
+        '',
+        '**How to use this worksheet**:',
+        '- For each row, judge the AI proposal against the GP human translation **for the WooCommerce merchant audience**.',
+        "- Mark the verdict column: `AI better` / `equivalent` / `GP better`. If you can't decide, mark `unsure` and leave a note.",
+        '- The question is *comparative*, not "is AI correct". Sometimes both are fine; mark `equivalent`.',
+        '- Placeholder-mismatch rows are HARD FAILS — every one must be inspected. Look at the placeholder columns to see which side deviates from the EN source.',
+        '- Length-significant rows are flagged when AI and GP differ by >20% in byte length. Often signals a register / verbosity change.',
+        '',
+        ''
+      ]
+    end
+
+    def self.render_worksheet_table(locale_result, ai_judge_advisory: nil)
+      entries = sample_for_worksheet(locale_result.diff_entries)
+      cols = base_columns
+      cols << '| Judge (advisory) ' unless ai_judge_advisory.nil?
+      cols << '| Verdict | Reviewer notes |'
+      lines = [cols.join, render_separator(ai_judge_advisory)]
+
+      entries.each do |entry|
+        lines << render_row(entry, ai_judge_advisory)
+      end
+
+      lines
+    end
+
+    def self.base_columns
+      ['| Key | Bucket | EN | GP human | AI proposal | EN ph | GP ph | AI ph ']
+    end
+
+    def self.render_separator(ai_judge_advisory)
+      sep = '|---|---|---|---|---|---|---|---'
+      sep += '|---' unless ai_judge_advisory.nil?
+      sep += '|---|---|'
+      sep
+    end
+
+    def self.render_row(entry, ai_judge_advisory)
+      cells = [
+        '',
+        escape_md(entry.key),
+        entry.bucket.to_s,
+        escape_md(entry.en_source),
+        escape_md(entry.gp_human),
+        escape_md(entry.ai_proposal),
+        entry.en_placeholders.join(' '),
+        entry.gp_placeholders.join(' '),
+        entry.ai_placeholders.join(' ')
+      ]
+      cells << (ai_judge_advisory[entry.key] || '—') unless ai_judge_advisory.nil?
+      cells << ' [ ] AI better / [ ] equivalent / [ ] GP better'
+      cells << ''
+      "#{cells.join(' | ')}|"
+    end
+
+    # Escape pipe + newline so a translation containing `|` or `\n` doesn't
+    # break the Markdown table. Keep it minimal — we want the reviewer to see
+    # the actual translation, just not have it explode the table layout.
+    def self.escape_md(text)
+      text.to_s.gsub('|', '\\|').gsub("\n", '<br>')
+    end
+  end
+end

--- a/fastlane/ai_translation/lib/woo_ai_translation/shadow_diff.rb
+++ b/fastlane/ai_translation/lib/woo_ai_translation/shadow_diff.rb
@@ -44,8 +44,14 @@ module WooAiTranslation
     # change worth human attention.
     LENGTH_SIGNIFICANT_RATIO = 0.20
 
-    # iOS .strings placeholder syntax: %@, %d, %1$@, %2$d, %ld, %lld, %.0f, etc.
-    PLACEHOLDER_RE = /%(?:\d+\$)?[@dxXosfFiluL.0-9]+/
+    # iOS .strings placeholder syntax. Two flavors:
+    #   - Literal percent: `%%` — rendered as a single `%`. MUST be preserved
+    #     verbatim across translations (dropping it desyncs printf parsing).
+    #     Listed first in the alternation so the regex matches it before the
+    #     printf-token branch tries (and fails — `[@dxXos…]+` doesn't accept
+    #     `%`, so without the `%%` arm we silently miss it).
+    #   - Printf token: %@, %d, %1$@, %2$d, %ld, %lld, %.0f, etc.
+    PLACEHOLDER_RE = /%%|%(?:\d+\$)?[@dxXosfFiluL.0-9]+/
 
     # Sampling policy for the reviewer worksheet. Tier 2 (the human reviewer)
     # reviews 100% of these buckets:
@@ -145,9 +151,14 @@ module WooAiTranslation
     # Render a per-locale reviewer worksheet as Markdown. The reviewer adds
     # their judgment in the verdict column (`[ ] AI better / [ ] equivalent /
     # [ ] GP better`) and saves the file alongside their notes.
-    def self.render_worksheet(locale_result, ai_judge_advisory: nil)
+    #
+    # `seed` controls the random sample selection — MUST match the seed used
+    # for `sample_for_worksheet` when building the AI-judge advisory, or the
+    # advisory column will be sparse (judge ran on different entries than
+    # the worksheet renders).
+    def self.render_worksheet(locale_result, ai_judge_advisory: nil, seed: 42)
       header_lines = render_worksheet_header(locale_result)
-      table_lines = render_worksheet_table(locale_result, ai_judge_advisory: ai_judge_advisory)
+      table_lines = render_worksheet_table(locale_result, ai_judge_advisory: ai_judge_advisory, seed: seed)
       (header_lines + table_lines).join("\n")
     end
 
@@ -188,8 +199,8 @@ module WooAiTranslation
       ]
     end
 
-    def self.render_worksheet_table(locale_result, ai_judge_advisory: nil)
-      entries = sample_for_worksheet(locale_result.diff_entries)
+    def self.render_worksheet_table(locale_result, ai_judge_advisory: nil, seed: 42)
+      entries = sample_for_worksheet(locale_result.diff_entries, seed: seed)
       cols = base_columns
       cols << '| Judge (advisory) ' unless ai_judge_advisory.nil?
       cols << '| Verdict | Reviewer notes |'

--- a/fastlane/ai_translation/spec/ai_judge_test.rb
+++ b/fastlane/ai_translation/spec/ai_judge_test.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'json'
+
+require_relative '../lib/woo_ai_translation/ai_judge'
+require_relative '../lib/woo_ai_translation/shadow_diff'
+
+# Custom stub OpenAI client that returns a canned response per call. Lets us
+# program "model said X for entry Y" without spending tokens.
+class ProgrammableJudgeStub
+  def initialize(verdict: 'equivalent', reasoning: 'looks fine')
+    @default = { verdict: verdict, reasoning: reasoning }
+    @per_call = {}
+    @calls = 0
+  end
+
+  attr_reader :calls
+
+  def with_response_for_call(call_number, verdict:, reasoning:)
+    @per_call[call_number] = { verdict: verdict, reasoning: reasoning }
+    self
+  end
+
+  def with_raw_response(raw_string)
+    @raw_override = raw_string
+    self
+  end
+
+  def available?
+    true
+  end
+
+  def complete(messages:, model: nil, **)
+    _ = [messages, model]
+    @calls += 1
+    return @raw_override if @raw_override
+
+    response = @per_call[@calls] || @default
+    JSON.generate(response)
+  end
+end
+
+class AiJudgeTest < Minitest::Test
+  def make_entry(key, en, gp, ai)
+    WooAiTranslation::ShadowDiff::Entry.new(
+      key: key, en_source: en, gp_human: gp, ai_proposal: ai,
+      bucket: :substantive, en_placeholders: [], gp_placeholders: [], ai_placeholders: []
+    )
+  end
+
+  def test_judge_returns_verdict_and_reasoning_for_valid_response
+    # Given a stub that returns a well-formed JSON verdict
+    stub = ProgrammableJudgeStub.new(verdict: 'acceptable_variant', reasoning: 'both fine')
+    judge = WooAiTranslation::AiJudge.new(client: stub)
+
+    # When we judge one triple
+    result = judge.judge(en_source: 'Hello', gp_human: 'Hallo', ai_proposal: 'Hi')
+
+    # Then we get the parsed verdict + reasoning
+    assert_equal 'acceptable_variant', result[:verdict]
+    assert_equal 'both fine', result[:reasoning]
+  end
+
+  def test_judge_returns_error_verdict_on_non_json_response
+    # Given a stub that returns garbage
+    stub = ProgrammableJudgeStub.new.with_raw_response('not valid json at all')
+    judge = WooAiTranslation::AiJudge.new(client: stub)
+
+    # When we judge
+    result = judge.judge(en_source: 'x', gp_human: 'y', ai_proposal: 'z')
+
+    # Then we get an error verdict instead of a raised exception
+    assert_equal 'error', result[:verdict]
+    assert_match(/judge error/, result[:reasoning])
+  end
+
+  def test_judge_returns_invalid_verdict_when_response_uses_unknown_label
+    # Given a stub returning a JSON object with an unrecognized verdict
+    stub = ProgrammableJudgeStub.new.with_raw_response(
+      JSON.generate(verdict: 'something_made_up', reasoning: 'whatever')
+    )
+    judge = WooAiTranslation::AiJudge.new(client: stub)
+
+    # When we judge
+    result = judge.judge(en_source: 'x', gp_human: 'y', ai_proposal: 'z')
+
+    # Then the verdict is replaced with `invalid_verdict` (defensive)
+    assert_equal 'invalid_verdict', result[:verdict]
+    assert_equal 'whatever', result[:reasoning]
+  end
+
+  def test_judge_strips_markdown_code_fences_from_response
+    # Given a stub that wraps the JSON in ```json fences (a common LLM habit)
+    fenced = "```json\n#{JSON.generate(verdict: 'equivalent', reasoning: 'fine')}\n```"
+    stub = ProgrammableJudgeStub.new.with_raw_response(fenced)
+    judge = WooAiTranslation::AiJudge.new(client: stub)
+
+    # When we judge
+    result = judge.judge(en_source: 'x', gp_human: 'y', ai_proposal: 'z')
+
+    # Then the fences are stripped and the verdict parses
+    assert_equal 'equivalent', result[:verdict]
+  end
+
+  def test_judge_passes_model_to_client
+    # Given a stub that records the model parameter
+    seen_models = []
+    stub = Class.new do
+      define_method(:available?) { true }
+      define_method(:complete) do |messages:, model: nil, **|
+        _ = messages
+        seen_models << model
+        JSON.generate(verdict: 'equivalent', reasoning: '')
+      end
+    end.new
+    judge = WooAiTranslation::AiJudge.new(client: stub, model: 'gpt-5.1-mini')
+
+    # When we judge
+    judge.judge(en_source: 'x', gp_human: 'y', ai_proposal: 'z')
+
+    # Then the configured model is passed through
+    assert_equal ['gpt-5.1-mini'], seen_models
+  end
+
+  def test_judge_all_returns_per_entry_advisory_strings_for_worksheet
+    # Given two entries and a stub that returns different verdicts per call
+    stub = ProgrammableJudgeStub.new(verdict: 'equivalent', reasoning: 'fine')
+    stub.with_response_for_call(2, verdict: 'ai_wrong', reasoning: 'misses meaning')
+    judge = WooAiTranslation::AiJudge.new(client: stub)
+
+    entries = [
+      make_entry('k1', 'Hello', 'Hallo', 'Hi'),
+      make_entry('k2', 'Save', 'Speichern', 'Stoppen')
+    ]
+
+    # When we judge all
+    out = judge.judge_all(entries)
+
+    # Then we get a Hash<key, String> with the verdict and reasoning formatted
+    # for the worksheet's advisory column
+    assert_equal 2, out.size
+    assert_includes out['k1'], 'equivalent'
+    assert_includes out['k1'], 'fine'
+    assert_includes out['k2'], 'ai_wrong'
+    assert_includes out['k2'], 'misses meaning'
+  end
+
+  def test_judge_all_continues_after_a_single_entry_fails
+    # Given a stub that fails on call #1 but succeeds on call #2
+    stub = ProgrammableJudgeStub.new(verdict: 'equivalent', reasoning: 'ok')
+    # Make call #1 return garbage; call #2 returns the default
+    def stub.complete(messages:, model: nil, **)
+      _ = [messages, model]
+      @calls += 1
+      return 'garbage' if @calls == 1
+
+      JSON.generate(verdict: @default[:verdict], reasoning: @default[:reasoning])
+    end
+
+    judge = WooAiTranslation::AiJudge.new(client: stub)
+    entries = [
+      make_entry('k1', 'a', 'b', 'c'),
+      make_entry('k2', 'a', 'b', 'c')
+    ]
+
+    out = judge.judge_all(entries)
+
+    # Both entries are present; the first reports an error verdict, the second succeeds.
+    assert_equal 2, out.size
+    assert_includes out['k1'], 'error'
+    assert_includes out['k2'], 'equivalent'
+  end
+end

--- a/fastlane/ai_translation/spec/openai_client_test.rb
+++ b/fastlane/ai_translation/spec/openai_client_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'json'
+
+require_relative '../lib/woo_ai_translation/openai_client'
+
+# Minimal Net::HTTP stand-in that records the request and returns a programmable
+# response. Used to test request shape + response parsing without spending
+# tokens. Mirrors what AnthropicClient assumes from @http (a `.request` method
+# that returns an object with `.code` and `.body`).
+class FakeHttp
+  Response = Struct.new(:code, :body)
+
+  attr_reader :requests
+
+  def initialize(response_code: '200', response_body: '{}')
+    @response = Response.new(response_code.to_s, response_body)
+    @requests = []
+  end
+
+  def request(req)
+    @requests << req
+    @response
+  end
+end
+
+class OpenAIClientTest < Minitest::Test
+  def test_complete_returns_assistant_text_from_response
+    # Given an HTTP fake that returns a typical OpenAI Chat Completions body
+    body = JSON.generate(choices: [{ message: { content: 'translated reply' } }])
+    fake = FakeHttp.new(response_code: '200', response_body: body)
+    client = WooAiTranslation::OpenAIClient.new(api_key: 'sk-test', http: fake)
+
+    # When we call complete
+    out = client.complete(messages: [{ role: 'user', content: 'hi' }])
+
+    # Then we get the parsed text content
+    assert_equal 'translated reply', out
+  end
+
+  def test_complete_sends_bearer_auth_and_json_body
+    # Given an HTTP fake that records the outgoing request
+    body = JSON.generate(choices: [{ message: { content: 'ok' } }])
+    fake = FakeHttp.new(response_code: '200', response_body: body)
+    client = WooAiTranslation::OpenAIClient.new(api_key: 'sk-test-12345', http: fake)
+
+    # When we call complete with a specific model + messages
+    client.complete(model: 'gpt-5.1', messages: [{ role: 'user', content: 'hi' }])
+
+    # Then exactly one request was sent with the expected headers + body
+    assert_equal 1, fake.requests.size
+    req = fake.requests.first
+    assert_equal 'Bearer sk-test-12345', req['authorization']
+    assert_equal 'application/json', req['content-type']
+    parsed = JSON.parse(req.body)
+    assert_equal 'gpt-5.1', parsed['model']
+    assert_equal [{ 'role' => 'user', 'content' => 'hi' }], parsed['messages']
+    assert_equal 0, parsed['temperature']
+  end
+
+  def test_complete_raises_error_on_non_2xx_response
+    # Given an HTTP fake that returns 400
+    fake = FakeHttp.new(response_code: '400', response_body: '{"error":"bad input"}')
+    client = WooAiTranslation::OpenAIClient.new(api_key: 'sk-test', http: fake)
+
+    # When we call complete
+    err = assert_raises(WooAiTranslation::OpenAIClient::Error) do
+      client.complete(messages: [{ role: 'user', content: 'hi' }])
+    end
+
+    # Then the error message includes the HTTP code + body
+    assert_match(/HTTP 400/, err.message)
+    assert_match(/bad input/, err.message)
+  end
+
+  def test_complete_raises_error_when_api_key_missing
+    # Given a client with no API key
+    client = WooAiTranslation::OpenAIClient.new(api_key: nil)
+
+    # When we call complete
+    err = assert_raises(WooAiTranslation::OpenAIClient::Error) do
+      client.complete(messages: [{ role: 'user', content: 'hi' }])
+    end
+
+    # Then the error says the key is missing
+    assert_match(/OPENAI_API_KEY/, err.message)
+  end
+
+  def test_available_returns_true_when_key_present_and_false_when_blank
+    # Given a client with a key
+    assert WooAiTranslation::OpenAIClient.new(api_key: 'sk-x').available?
+
+    # And a client without a key
+    refute WooAiTranslation::OpenAIClient.new(api_key: nil).available?
+    refute WooAiTranslation::OpenAIClient.new(api_key: '').available?
+  end
+
+  def test_from_env_reads_openai_api_key_env_var
+    # Given OPENAI_API_KEY is set
+    saved = ENV.fetch('OPENAI_API_KEY', nil)
+    ENV['OPENAI_API_KEY'] = 'sk-from-env'
+    client = WooAiTranslation::OpenAIClient.from_env
+
+    # When we check availability
+    assert client.available?
+  ensure
+    ENV['OPENAI_API_KEY'] = saved
+  end
+
+  def test_stub_openai_client_default_transform_echoes_last_message
+    # Given a default-configured stub
+    stub = WooAiTranslation::StubOpenAIClient.new
+
+    # When we call complete
+    out = stub.complete(messages: [
+                          { role: 'system', content: 'system rules' },
+                          { role: 'user', content: 'hello there' }
+                        ])
+
+    # Then the output echoes (a truncated form of) the user content
+    assert_includes out, 'hello there'
+    assert_equal 1, stub.calls
+  end
+
+  def test_stub_openai_client_accepts_custom_transform
+    # Given a stub with a custom transform
+    stub = WooAiTranslation::StubOpenAIClient.new { |_messages| 'canned response' }
+
+    # When we call complete
+    out = stub.complete(messages: [{ role: 'user', content: 'whatever' }])
+
+    # Then the output is whatever the transform returned
+    assert_equal 'canned response', out
+  end
+
+  def test_stub_openai_client_counts_calls
+    # Given a stub
+    stub = WooAiTranslation::StubOpenAIClient.new
+
+    # When we call complete multiple times
+    3.times { stub.complete(messages: [{ role: 'user', content: 'x' }]) }
+
+    # Then calls increments
+    assert_equal 3, stub.calls
+  end
+end

--- a/fastlane/ai_translation/spec/shadow_diff_test.rb
+++ b/fastlane/ai_translation/spec/shadow_diff_test.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+require_relative '../lib/woo_ai_translation/shadow_diff'
+
+class ShadowDiffCategorizeTest < Minitest::Test
+  def categorize(en, gp, ai)
+    WooAiTranslation::ShadowDiff.categorize(en_source: en, gp_human: gp, ai_proposal: ai)
+  end
+
+  def test_identical_when_gp_and_ai_are_byte_identical
+    assert_equal :identical, categorize('Hello', 'Hallo', 'Hallo')
+  end
+
+  def test_cosmetic_when_differ_only_by_whitespace
+    assert_equal :cosmetic, categorize('Hello', 'Hallo  Welt', 'Hallo Welt')
+  end
+
+  def test_cosmetic_when_differ_only_by_case
+    assert_equal :cosmetic, categorize('Hello', 'HALLO', 'hallo')
+  end
+
+  def test_placeholder_mismatch_when_ai_drops_placeholder
+    # EN has %@; AI proposal omits it. Real bug.
+    assert_equal :placeholder_mismatch,
+                 categorize('Hello, %@!', 'Hallo, %@!', 'Hallo!')
+  end
+
+  def test_placeholder_mismatch_when_ai_changes_positional_index
+    # AI changes %1$@ to %@ — different placeholder syntax, bug.
+    assert_equal :placeholder_mismatch,
+                 categorize('Welcome %1$@ to %2$@', 'Willkommen %1$@ in %2$@', 'Willkommen %@ in %@')
+  end
+
+  def test_placeholder_mismatch_when_gp_human_already_has_a_placeholder_bug
+    # Even though AI matches EN, GP doesn't — still flag so reviewer sees the
+    # pre-existing GP-side bug.
+    assert_equal :placeholder_mismatch,
+                 categorize('Hello %@', 'Hallo', 'Hallo %@')
+  end
+
+  def test_not_placeholder_mismatch_when_translation_reorders_placeholders
+    # Both translations preserve the set %@,%@ even though word order differs.
+    assert_equal :substantive,
+                 categorize('Hello %@ from %@', 'Hallo %@ aus %@', 'Aus %@ Hallo %@')
+  end
+
+  def test_length_significant_when_ai_is_much_longer_than_gp
+    # GP is short, AI is >20% longer in bytes.
+    short_gp = 'Hi'
+    long_ai = 'Greetings and welcome!'
+    assert_equal :length_significant, categorize('Hi', short_gp, long_ai)
+  end
+
+  def test_length_significant_when_ai_is_much_shorter_than_gp
+    long_gp = 'Greetings and welcome to the application!'
+    short_ai = 'Hi'
+    assert_equal :length_significant, categorize('Hi', long_gp, short_ai)
+  end
+
+  def test_substantive_when_real_word_change_within_length_bound
+    # 20-byte phrase translated differently but similar length — substantive.
+    assert_equal :substantive,
+                 categorize('Cancel order', 'Bestellung stornieren', 'Auftrag abbrechen')
+  end
+
+  def test_extract_placeholders_returns_sorted_list_including_duplicates
+    # Given a string with duplicate non-positional placeholders
+    result = WooAiTranslation::ShadowDiff.extract_placeholders('%@ and %@ and %d')
+
+    # Then duplicates are preserved (count matters) and sorting is stable
+    assert_equal ['%@', '%@', '%d'], result
+  end
+
+  def test_extract_placeholders_handles_positional_indexed_forms
+    result = WooAiTranslation::ShadowDiff.extract_placeholders('%1$@ said %2$@')
+    assert_equal ['%1$@', '%2$@'], result
+  end
+
+  def test_extract_placeholders_returns_empty_for_text_without_placeholders
+    assert_empty WooAiTranslation::ShadowDiff.extract_placeholders('plain text here')
+  end
+end
+
+class ShadowDiffSamplingTest < Minitest::Test
+  def make_entry(key, bucket)
+    WooAiTranslation::ShadowDiff::Entry.new(
+      key: key, en_source: 'en', gp_human: 'gp', ai_proposal: 'ai',
+      bucket: bucket, en_placeholders: [], gp_placeholders: [], ai_placeholders: []
+    )
+  end
+
+  def test_samples_100_percent_of_placeholder_mismatch
+    # Given 5 placeholder_mismatch entries (low count, should all appear)
+    entries = (1..5).map { |i| make_entry("ph#{i}", :placeholder_mismatch) }
+    sampled = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries)
+    assert_equal 5, sampled.size
+  end
+
+  def test_samples_100_percent_of_length_significant
+    entries = (1..7).map { |i| make_entry("ls#{i}", :length_significant) }
+    sampled = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries)
+    assert_equal 7, sampled.size
+  end
+
+  def test_samples_min_30_of_substantive_when_bucket_small
+    # Given 20 substantive entries (smaller than the 30 floor)
+    entries = (1..20).map { |i| make_entry("s#{i}", :substantive) }
+    sampled = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries)
+    # Then we take all 20 (can't exceed available)
+    assert_equal 20, sampled.size
+  end
+
+  def test_samples_30_of_substantive_when_bucket_at_floor
+    entries = (1..40).map { |i| make_entry("s#{i}", :substantive) }
+    sampled = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries)
+    # 40 * 5% = 2 < 30 floor → take 30
+    assert_equal 30, sampled.size
+  end
+
+  def test_samples_5_percent_of_substantive_when_bucket_large
+    entries = (1..2000).map { |i| make_entry("s#{i}", :substantive) }
+    sampled = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries)
+    # 2000 * 5% = 100 > 30 floor → take 100
+    assert_equal 100, sampled.size
+  end
+
+  def test_excludes_cosmetic_from_worksheet
+    entries = (1..50).map { |i| make_entry("c#{i}", :cosmetic) }
+    sampled = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries)
+    assert_empty sampled
+  end
+
+  def test_seed_makes_sampling_deterministic
+    entries = (1..1000).map { |i| make_entry("s#{i}", :substantive) }
+    first = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: 42).map(&:key)
+    second = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: 42).map(&:key)
+    assert_equal first, second
+  end
+
+  def test_different_seeds_produce_different_samples
+    entries = (1..1000).map { |i| make_entry("s#{i}", :substantive) }
+    first = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: 42).map(&:key)
+    second = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: 99).map(&:key)
+    refute_equal first, second
+  end
+end
+
+class ShadowDiffSummaryTest < Minitest::Test
+  def test_summary_counts_each_bucket
+    entries = [
+      WooAiTranslation::ShadowDiff::Entry.new(key: 'a', en_source: '', gp_human: '', ai_proposal: '',
+                                              bucket: :identical, en_placeholders: [], gp_placeholders: [], ai_placeholders: []),
+      WooAiTranslation::ShadowDiff::Entry.new(key: 'b', en_source: '', gp_human: '', ai_proposal: '',
+                                              bucket: :identical, en_placeholders: [], gp_placeholders: [], ai_placeholders: []),
+      WooAiTranslation::ShadowDiff::Entry.new(key: 'c', en_source: '', gp_human: '', ai_proposal: '',
+                                              bucket: :substantive, en_placeholders: [], gp_placeholders: [], ai_placeholders: [])
+    ]
+    locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(locale: 'de', diff_entries: entries)
+
+    s = locale_result.summary
+
+    assert_equal 3, s[:total]
+    assert_equal 2, s[:identical]
+    assert_equal 1, s[:substantive]
+    assert_equal 0, s[:cosmetic]
+  end
+end
+
+class ShadowDiffRenderingTest < Minitest::Test
+  def test_render_summary_includes_all_bucket_rows
+    locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(
+      locale: 'de',
+      diff_entries: [
+        WooAiTranslation::ShadowDiff::Entry.new(key: 'k1', en_source: '', gp_human: '', ai_proposal: '',
+                                                bucket: :identical, en_placeholders: [], gp_placeholders: [], ai_placeholders: [])
+      ]
+    )
+    md = WooAiTranslation::ShadowDiff.render_summary(locale_result)
+
+    assert_includes md, '## de'
+    assert_includes md, 'identical'
+    assert_includes md, 'cosmetic'
+    assert_includes md, 'placeholder_mismatch'
+    assert_includes md, 'length_significant'
+    assert_includes md, 'substantive'
+    assert_includes md, 'total'
+  end
+
+  def test_render_worksheet_includes_methodology_reminder_in_header
+    locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(locale: 'de', diff_entries: [])
+    md = WooAiTranslation::ShadowDiff.render_worksheet(locale_result)
+    # The "AI better / equivalent / GP better" rubric must be visible to the
+    # reviewer so they read the right question.
+    assert_includes md, 'comparative'
+    assert_includes md, 'AI better'
+    assert_includes md, 'GP better'
+    assert_includes md, 'merchant audience'
+  end
+
+  def test_render_worksheet_includes_advisory_column_when_judge_provided
+    entries = [
+      WooAiTranslation::ShadowDiff::Entry.new(key: 'k1', en_source: 'Hello', gp_human: 'Hallo Welt',
+                                              ai_proposal: 'Hi Welt', bucket: :length_significant,
+                                              en_placeholders: [], gp_placeholders: [], ai_placeholders: [])
+    ]
+    locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(locale: 'de', diff_entries: entries)
+    advisory = { 'k1' => 'equivalent' }
+
+    md = WooAiTranslation::ShadowDiff.render_worksheet(locale_result, ai_judge_advisory: advisory)
+
+    assert_includes md, 'Judge (advisory)'
+    assert_includes md, 'equivalent'
+  end
+
+  def test_render_worksheet_escapes_pipe_in_content
+    entries = [
+      WooAiTranslation::ShadowDiff::Entry.new(key: 'pipe', en_source: 'a|b', gp_human: 'c|d', ai_proposal: 'e|f',
+                                              bucket: :length_significant, en_placeholders: [], gp_placeholders: [], ai_placeholders: [])
+    ]
+    locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(locale: 'de', diff_entries: entries)
+
+    md = WooAiTranslation::ShadowDiff.render_worksheet(locale_result)
+    # Pipe should be escaped so the Markdown table doesn't break
+    assert_includes md, 'a\\|b'
+    assert_includes md, 'c\\|d'
+    assert_includes md, 'e\\|f'
+  end
+end

--- a/fastlane/ai_translation/spec/shadow_diff_test.rb
+++ b/fastlane/ai_translation/spec/shadow_diff_test.rb
@@ -81,6 +81,24 @@ class ShadowDiffCategorizeTest < Minitest::Test
   def test_extract_placeholders_returns_empty_for_text_without_placeholders
     assert_empty WooAiTranslation::ShadowDiff.extract_placeholders('plain text here')
   end
+
+  def test_extract_placeholders_includes_literal_percent_token
+    # Given a string with the literal-percent token `%%`. Dropping it desyncs
+    # printf parsing, so it MUST be counted as a placeholder.
+    result = WooAiTranslation::ShadowDiff.extract_placeholders('%.0f%% complete')
+
+    # Then both the `%.0f` printf token AND the literal `%%` appear.
+    assert_equal ['%%', '%.0f'], result
+  end
+
+  def test_placeholder_mismatch_when_ai_drops_literal_percent
+    # Reproduces Codex round-3 finding: `%%` was not in the regex, so an AI
+    # translation that dropped a literal-percent (corrupting printf parsing)
+    # used to fall through to `substantive` instead of being flagged as a
+    # hard-fail placeholder_mismatch.
+    assert_equal :placeholder_mismatch,
+                 categorize('%.0f%% complete', '%.0f%% abgeschlossen', '%.0f% abgeschlossen')
+  end
 end
 
 class ShadowDiffSamplingTest < Minitest::Test
@@ -144,6 +162,37 @@ class ShadowDiffSamplingTest < Minitest::Test
     first = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: 42).map(&:key)
     second = WooAiTranslation::ShadowDiff.sample_for_worksheet(entries, seed: 99).map(&:key)
     refute_equal first, second
+  end
+
+  def test_render_worksheet_passes_seed_through_to_sample_selection
+    # Codex round-3 finding: the CLI calls sample_for_worksheet with the
+    # user's seed to know which entries to feed the AI judge, but
+    # render_worksheet used to call sample_for_worksheet AGAIN with the
+    # default seed (42) — so the rendered rows and the judged entries
+    # were different samples on any --seed != 42. This test pins that the
+    # seed parameter threads through to the underlying sampling.
+    entries = (1..1000).map { |i| make_entry("s#{i}", :substantive) }
+    locale_result = WooAiTranslation::ShadowDiff::LocaleResult.new(locale: 'de', diff_entries: entries)
+
+    # When we render the worksheet with seed=99
+    md = WooAiTranslation::ShadowDiff.render_worksheet(locale_result, seed: 99)
+
+    # And we compute what the seed=99 sample would be directly
+    sampled_keys = WooAiTranslation::ShadowDiff
+                   .sample_for_worksheet(entries, seed: 99)
+                   .map(&:key)
+
+    # Then EVERY sampled key appears in the rendered worksheet — and the
+    # rendered keys are NOT the default-seed (42) sample.
+    sampled_keys.each { |k| assert_includes md, k }
+    default_seed_keys = WooAiTranslation::ShadowDiff
+                        .sample_for_worksheet(entries, seed: 42)
+                        .map(&:key)
+    # Reasonable confidence that seed=99 and seed=42 picked different
+    # samples (overlap will exist for any random sample but should be
+    # well under 100%).
+    overlap = (sampled_keys & default_seed_keys).size
+    assert overlap < sampled_keys.size, 'seed=99 and seed=42 samples should differ'
   end
 end
 


### PR DESCRIPTION
## Description

PR 7 in the AI translations stack. Builds the **data-gathering tool** needed for the eventual GlotPress sunset conversation. Re-uses the existing production engine (Anthropic-based [`Translator`](https://github.com/woocommerce/woocommerce-ios/blob/ai-translations/engine/fastlane/ai_translation/lib/woo_ai_translation/translator.rb) + [`Validator`](https://github.com/woocommerce/woocommerce-ios/blob/ai-translations/engine/fastlane/ai_translation/lib/woo_ai_translation/validator.rb) from [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221)) to translate an existing GP-translated locale, then diffs the AI result against the human GP baseline.

The tool produces **data**, not a verdict. The substantive question — "is AI better than, equivalent to, or worse than GP human for our merchant audience" — is answered by a native-speaker human reviewer filling in a worksheet (Tier 3 below). The tool prepares the worksheet (Tier 1 mechanical bucketing + optional Tier 2 AI-as-judge advisory).

### Stack position

```
trunk
 └ ai-translations/cutover (#17220, needs rebase)
    └ ai-translations/engine (#17221)
       └ ai-translations/glossaries (#17222)
          ├ ai-translations/ci (#17250)
          ├ ai-translations/metadata (#17271)
          ├ ai-translations/release-notes (#17276)
          └ ai-translations/shadow-diff  ← this PR
```

Base: `ai-translations/glossaries`. Sibling of [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250), [#17271](https://github.com/woocommerce/woocommerce-ios/pull/17271), [#17276](https://github.com/woocommerce/woocommerce-ios/pull/17276).

### Methodology — three tiers

**Tier 1 — Mechanical bucketing (the tool, no judgment).** Pure string operations:

| Bucket | Meaning |
|---|---|
| `identical` | byte-for-byte match between GP and AI |
| `cosmetic` | differ only by whitespace / case |
| `placeholder_mismatch` | **HARD FAIL** — `%@` / `%1$d` / `%%` etc. differs from EN source |
| `length_significant` | >20% byte delta between GP and AI |
| `substantive` | everything else |

**Tier 2 — AI-as-judge (advisory, opt-in).** Optional pass on the substantive worksheet sample using **GPT-5.1 via a new `OpenAIClient`** — deliberately a different model family from the Anthropic Claude production translator, to reduce self-bias. Each entry gets a `verdict ∈ {equivalent | acceptable_variant | different_meaning | ai_wrong | gp_wrong}` + a one-line reasoning. Output is **explicitly tagged as advisory** in the worksheet — never used to skip Tier 3.

**Tier 3 — Human (the actual decision).** A native-speaker reviewer fills in the worksheet for the rows the tool sampled:

- **100% of `placeholder_mismatch`** — must be ~0 before any sunset talk
- **100% of `length_significant`** — verify register / verbosity is appropriate
- **Sample of `substantive`** — `max(30, 5% of bucket)` per locale, deterministic by `--seed`
- **Sanity sample of `identical`** — `max(10, 0.5% of bucket)` to check for training-data memorization

Reviewer answers per row: *"For our merchant audience, is the AI proposal **better than**, **equivalent to**, or **worse than** the current GP human translation?"* — comparative, not "is AI correct".

### Why not just run continuously in CI?

GP human translations don't drift on a daily/weekly cadence. The signal is a cross-section, not a time series. The output feeds a human decision, so there's no automated actor to wake up. Token cost is non-trivial (~$25 estimated for a full 4-locale run with judge). Manual one-click Buildkite trigger at `.buildkite/release-pipelines/run-shadow-diff.yml` is the right cadence — useful after a model bump or glossary change.

### Why GPT, not Claude, as the judge?

Asking a Haiku-family model to judge another Haiku-family model's output is biased — same training data, same favorite phrasings. A different family (OpenAI's GPT-5.1) gives us cross-family judgment that's less self-justifying. The judge is still flagged as **advisory only**; Tier 3 (human) is the actual decision-maker. AI cannot answer the "is AI good enough" question for us — that's the methodology's load-bearing point.

### Files added

- `fastlane/ai_translation/lib/woo_ai_translation/openai_client.rb` (136 lines) — thin Chat Completions wrapper + `StubOpenAIClient`.
- `fastlane/ai_translation/lib/woo_ai_translation/shadow_diff.rb` (247 lines) — Tier 1 categorizer + worksheet/summary writer.
- `fastlane/ai_translation/lib/woo_ai_translation/ai_judge.rb` (117 lines) — Tier 2 GPT-5.1 advisory judge.
- `fastlane/ai_translation/bin/translate_shadow_diff.rb` (203 lines) — CLI driver.
- `fastlane/ai_translation/Rakefile` (+17 lines) — new `translate:shadow_diff` task.
- `.buildkite/release-pipelines/run-shadow-diff.yml` (50 lines) — manual one-click trigger. **Not scheduled.**
- 3 spec files: 45 tests, 209 assertions, 0 failures.
- README methodology section + RELEASE-NOTES `[Internal]` entry.

### Reviewer notes

- Codex reviewed two rounds. Round 1 caught a `%%` placeholder regex gap (literal-percent invisible to the mismatch bucket) and a `--seed` threading bug (judge spent tokens on a different sample than the worksheet rendered). Both fixed in commit `8450c30a02`. Final Codex verdict: green.
- Full engine spec suite: 130/130 pass.
- `LocaleResult` Struct uses `diff_entries` member (not `entries`) because `Struct.new(:entries, ...)` would override `Struct#entries` (caught by `Lint/StructNewOverride`).
- Cost math (~$25 per 4-locale run with judge) is an estimate using Haiku 4.5 ($1/$5 per 1M tokens) + GPT-5.1 ($1.25/$10 per 1M tokens) list prices.
- One non-blocking follow-up: verify one live `gpt-5.1` Chat Completions call against the actual API before depending on Tier 2 in a real run. OpenAI's GPT-5 family is documented as supporting both Chat Completions and Responses; the wrapper uses Chat Completions `max_tokens`. If a live call surfaces a parameter issue, it's a one-line adjustment in `OpenAIClient#complete`.
- Will trip Danger's "PR larger than 300 lines" soft warning. Same as [#17221](https://github.com/woocommerce/woocommerce-ios/pull/17221), [#17222](https://github.com/woocommerce/woocommerce-ios/pull/17222), [#17250](https://github.com/woocommerce/woocommerce-ios/pull/17250), [#17276](https://github.com/woocommerce/woocommerce-ios/pull/17276). Pattern, not bug.

## Test Steps

**1. Unit specs (offline, no network).** From the worktree root:

```bash
ruby -Ifastlane/ai_translation/lib fastlane/ai_translation/spec/openai_client_test.rb
ruby -Ifastlane/ai_translation/lib fastlane/ai_translation/spec/shadow_diff_test.rb
ruby -Ifastlane/ai_translation/lib fastlane/ai_translation/spec/ai_judge_test.rb
```

Expect 9 + 29 + 7 = 45 specs green.

**2. Offline CLI smoke** (no API spend, no tokens):

```bash
fastlane/ai_translation/bin/translate_shadow_diff.rb \
  --locales de --limit 10 --offline \
  --output /tmp/shadow-diff-smoke
```

Expect a summary row for `de` and three files written: `de-worksheet.md`, `de-summary.md`, `index.md`. With `--limit 10`, the StubClient produces echo translations that are categorized into `length_significant` and `substantive` buckets.

**3. Real one-locale check, Tier 1 only** (optional, ~$3-5 in Haiku tokens):

```bash
ANTHROPIC_API_KEY=sk-... fastlane/ai_translation/bin/translate_shadow_diff.rb \
  --locales de --limit 100 \
  --output /tmp/shadow-diff-real
```

Spot-check a handful of `placeholder_mismatch` entries (should be very few against real GP-translated `de`) and substantive entries (will be the majority).

**4. Full 4-locale calibration run with Tier 2 advisory** (~$25 estimated). This is the actual data-gathering run; output goes to a Tier 3 human reviewer per locale:

```bash
ANTHROPIC_API_KEY=sk-... OPENAI_API_KEY=sk-... \
  fastlane/ai_translation/bin/translate_shadow_diff.rb \
  --locales de,es,fr,ja \
  --judge-model gpt-5.1 \
  --output ./shadow-diff-out
```

**5. Buildkite manual trigger.** From Buildkite "New Build" on the pipeline at `.buildkite/release-pipelines/run-shadow-diff.yml`. Optional environment variables: `LOCALES`, `JUDGE_MODEL`, `LIMIT`. Output is uploaded as Buildkite artifacts + posted as an annotation.

## Screenshots

N/A — internal tooling with no UI surface.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
