### PR TITLE
[Woo POS][Phones] Adapt header so search bar has the correct size in phone POS

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Search/POSSearchView.swift
@@ -62,6 +62,7 @@ struct POSSearchField: View {
                 handleSearchTermChange(newValue)
             }
         }
+        .frame(maxWidth: .infinity)
         .onChange(of: keyboardObserver.isKeyboardVisible) { _, isVisible in
             guard isVisible == false else { return }
             analytics.track(.pointOfSaleKeyboardDismissedInSearch)

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -95,7 +95,9 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
             HStack(alignment: hStackAlignment, spacing: Constants.horizontalSpacing) {
                 leadingContent
 
-                itemsContent
+                if shouldShowItemsContent {
+                    itemsContent
+                }
 
                 if items.isNotEmpty {
                     Spacer(minLength: 0)
@@ -183,6 +185,10 @@ struct POSPageHeaderView<LeadingContent: View, TrailingContent: View, BottomCont
     }
 
     private var shouldHaveLeadingPaddingForItems: Bool {
+        items.isNotEmpty || showsBackButton
+    }
+
+    private var shouldShowItemsContent: Bool {
         items.isNotEmpty || showsBackButton
     }
 


### PR DESCRIPTION
Closes WOOMOB-3131

## Description

Fixes the phone POS search bar width.

The POS header kept rendering an empty header-items area while search mode placed `POSSearchField` in the trailing slot, so the search field stayed at intrinsic width on phones. This skips empty header item content and lets the POS search field expand to the available header width.

## Test Steps
1. Phone: Verify the search bar fills the available header width both in POS products and coupons.
2. Phone: Switch to POS Order and verify search renders correctly.
3. Tablet: Verify tablet POS header/search layout still looks unchanged.

## Screenshots
| - | -  |
|--------|--------|
| <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-05-28 at 14 46 21" src="https://github.com/user-attachments/assets/2a22ac41-d7e4-4edf-a466-88e0d577cd96" /> | <img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-05-28 at 14 47 19" src="https://github.com/user-attachments/assets/33029e75-e27e-4d9c-8322-dcedca8b3848" /> | 


| - | - |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-28 at 14 49 39" src="https://github.com/user-attachments/assets/f1d50a76-09cb-455e-9cf0-0b7de3025a2f" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-05-28 at 14 49 53" src="https://github.com/user-attachments/assets/bd7e0caf-4abf-410a-8752-568fe057bb64" />  |  

