### PR TITLE
Fix duplicated product overwriting the original product's images

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.0
 -----
-
+- [*] Fixed duplicating a product overwriting the original product's images; the duplicate now opens after copying. [https://github.com/woocommerce/woocommerce-ios/pull/17291]
 
 24.9
 -----

--- a/WooCommerce/Classes/Routing/ProductDetail/Coordinator/ProductDetailNativeCoordinator.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/Coordinator/ProductDetailNativeCoordinator.swift
@@ -9,10 +9,12 @@ class ProductDetailNativeCoordinator {
         product: Product,
         presentationStyle: ProductDetailNavigator.Presentation,
         isReadOnly: Bool,
-        onDelete: (() -> Void)? = nil) -> UIViewController {
+        onDelete: (() -> Void)? = nil,
+        onDuplicate: ((Product) -> Void)? = nil) -> UIViewController {
             return ProductDetailsFactory.productDetails(product: product,
                                                         presentationStyle: presentationStyle.asProductFormPresentationStyle,
                                                         forceReadOnly: isReadOnly,
-                                                        onDeleteCompletion: onDelete ?? {})
+                                                        onDeleteCompletion: onDelete ?? {},
+                                                        onDuplicateCompletion: onDuplicate)
         }
 }

--- a/WooCommerce/Classes/Routing/ProductDetail/ProductDetailNavigator.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/ProductDetailNavigator.swift
@@ -39,12 +39,15 @@ final class ProductDetailNavigator {
     ///   - presentationStyle: How to present **native** detail (ignored for web).
     ///   - isReadOnly: Whether the native screen should be read-only.
     ///   - onDelete: Optional callback invoked after a successful product delete.
+    ///   - onDuplicate: Optional callback invoked with the new duplicate after a successful product duplication,
+    ///     letting the caller decide how to open it (native flow only).
     /// - Returns: A ready-to-present view controller (native or web).
     func makeDestination(product: Product,
                          presentationStyle: Presentation = .push,
                          isReadOnly: Bool,
                          onDismissWeb: (() -> Void)? = nil,
-                         onDelete: (() -> Void)? = nil) -> UIViewController {
+                         onDelete: (() -> Void)? = nil,
+                         onDuplicate: ((Product) -> Void)? = nil) -> UIViewController {
 
         let viewController: UIViewController
         if shouldOpenInWeb(product: product) {
@@ -57,7 +60,8 @@ final class ProductDetailNavigator {
             viewController = coordinator.viewController(product: product,
                                                         presentationStyle: presentationStyle,
                                                         isReadOnly: isReadOnly,
-                                                        onDelete: onDelete)
+                                                        onDelete: onDelete,
+                                                        onDuplicate: onDuplicate)
         }
 
         return viewController

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -95,6 +95,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     private let onDeleteCompletion: () -> Void
 
+    /// Called with the newly created duplicate after a successful product duplication, letting the presenter decide
+    /// how to open it. When `nil`, the form falls back to confirming the copy in place (the legacy behavior).
+    private let onDuplicateCompletion: ((Product) -> Void)?
+
     private let userDefaults: UserDefaults
 
     init(viewModel: ViewModel,
@@ -106,7 +110,8 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
          presentationStyle: ProductFormPresentationStyle,
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          userDefaults: UserDefaults = .standard,
-         onDeleteCompletion: @escaping () -> Void = {}) {
+         onDeleteCompletion: @escaping () -> Void = {},
+         onDuplicateCompletion: ((Product) -> Void)? = nil) {
         self.viewModel = viewModel
         self.isAIContent = isAIContent
         self.eventLogger = eventLogger
@@ -118,6 +123,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         self.userDefaults = userDefaults
         self.productImageUploader = productImageUploader
         self.onDeleteCompletion = onDeleteCompletion
+        self.onDuplicateCompletion = onDuplicateCompletion
         self.aiEligibilityChecker = .init(site: ServiceLocator.stores.sessionManager.defaultSite)
         self.subscriptionProductsEligibilityChecker = WooSubscriptionProductsEligibilityChecker(siteID: viewModel.productModel.siteID, storage: storageManager)
         self.tableViewModel = DefaultProductFormTableViewModel(product: viewModel.productModel,
@@ -1171,10 +1177,19 @@ private extension ProductFormViewController {
                 self?.navigationController?.dismiss(animated: true) {
                     self?.displayError(error: error, title: Localization.duplicateProductError)
                 }
-            case .success:
-                // Dismisses the in-progress UI, then presents the confirmation alert.
+            case .success(let duplicatedProduct):
+                // Dismisses the in-progress UI, then either hands the duplicate to the presenter to open (matching
+                // Android) or, when no handler is provided, confirms the copy in place (the legacy behavior).
                 self?.navigationController?.dismiss(animated: true) {
-                    self?.presentProductConfirmationSaveAlert(type: .copied)
+                    guard let self else {
+                        return
+                    }
+                    if let onDuplicateCompletion = self.onDuplicateCompletion,
+                       let product = (duplicatedProduct as? EditableProductModel)?.product {
+                        onDuplicateCompletion(product)
+                    } else {
+                        self.presentProductConfirmationSaveAlert(type: .copied)
+                    }
                 }
             }
         })

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -628,6 +628,9 @@ private extension ProductFormViewController {
     /// Configure navigation bar with the title
     ///
     func configureNavigationBar(title: String = "") {
+        // In collapsed split-view replacements, the surrounding navigation controller might not receive
+        // `willShow`, so the form needs to own its large-title preference.
+        navigationItem.largeTitleDisplayMode = .never
         updateNavigationBar()
         updateBackButtonTitle()
         updateNavigationBarTitle()
@@ -1187,6 +1190,9 @@ private extension ProductFormViewController {
                     if let onDuplicateCompletion = self.onDuplicateCompletion,
                        let product = (duplicatedProduct as? EditableProductModel)?.product {
                         onDuplicateCompletion(product)
+                        ServiceLocator.noticePresenter.enqueue(
+                            notice: .init(title: ProductSavedAlertType.copied.alertTitle)
+                        )
                     } else {
                         self.presentProductConfirmationSaveAlert(type: .copied)
                     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -633,8 +633,9 @@ extension ProductFormViewModel {
             case .failure(let error):
                 onCompletion(.failure(error))
             case .success(let data):
-                self.resetProduct(data.product)
-                self.resetPassword(data.password)
+                // Do not reset this form's baseline to the duplicate. This form still represents the original
+                // product; rebinding `originalProduct`/`originalPassword` to the duplicate corrupts change
+                // tracking and can leak the duplicate's images into the original via the shared image action handler.
                 onCompletion(.success(data.product))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -10,18 +10,21 @@ struct ProductDetailsFactory {
     ///   - currencySettings: site currency settings.
     ///   - forceReadOnly: force the product detail to be presented in read only mode
     ///   - onDeleteCompletion: called when the product deletion completes in the product form.
+    ///   - onDuplicateCompletion: called with the new duplicate when a product duplication completes in the product form.
     static func productDetails(product: Product,
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings = ServiceLocator.currencySettings,
                                forceReadOnly: Bool,
                                productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
-                               onDeleteCompletion: @escaping () -> Void = {}) -> UIViewController {
+                               onDeleteCompletion: @escaping () -> Void = {},
+                               onDuplicateCompletion: ((Product) -> Void)? = nil) -> UIViewController {
         let vc = productDetails(product: product,
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
                                 isEditProductsEnabled: forceReadOnly ? false: true,
                                 productImageUploader: productImageUploader,
-                                onDeleteCompletion: onDeleteCompletion)
+                                onDeleteCompletion: onDeleteCompletion,
+                                onDuplicateCompletion: onDuplicateCompletion)
         return vc
     }
 }
@@ -32,7 +35,8 @@ private extension ProductDetailsFactory {
                                currencySettings: CurrencySettings,
                                isEditProductsEnabled: Bool,
                                productImageUploader: ProductImageUploaderProtocol,
-                               onDeleteCompletion: @escaping () -> Void) -> UIViewController {
+                               onDeleteCompletion: @escaping () -> Void,
+                               onDuplicateCompletion: ((Product) -> Void)? = nil) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
         let productImageActionHandler = productImageUploader
@@ -48,7 +52,8 @@ private extension ProductDetailsFactory {
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
                                        presentationStyle: presentationStyle,
-                                       onDeleteCompletion: onDeleteCompletion)
+                                       onDeleteCompletion: onDeleteCompletion,
+                                       onDuplicateCompletion: onDuplicateCompletion)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -130,6 +130,11 @@ private extension ProductsSplitViewCoordinator {
             },
             onDelete: { [weak self] in
                 self?.onSecondaryProductFormDeletion()
+            },
+            onDuplicate: { [weak self] duplicate in
+                // Opens the duplicate by replacing the secondary stack (not pushing), keeping the single-product-form
+                // invariant and matching Android, where the copy opens and Back returns to the product list.
+                self?.showProductForm(product: duplicate)
             })
 
         showSecondaryView(contentType: .productForm(product: product),

--- a/WooCommerce/WooCommerceTests/Mocks/MockProductDetailCoordinator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockProductDetailCoordinator.swift
@@ -12,7 +12,8 @@ class MockProductDetailNativeCoordinator: ProductDetailNativeCoordinator {
     override func viewController(product: Product,
                         presentationStyle: ProductDetailNavigator.Presentation,
                         isReadOnly: Bool,
-                        onDelete: (() -> Void)?) -> UIViewController {
+                        onDelete: (() -> Void)?,
+                        onDuplicate: ((Product) -> Void)?) -> UIViewController {
         UIViewController()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/ProductFormViewModel+SaveTests.swift
@@ -263,6 +263,39 @@ final class ProductFormViewModel_SaveTests: XCTestCase {
         // Then
         XCTAssertEqual(savedProduct?.status, .published)
     }
+
+    // MARK: `duplicateProduct`
+
+    func test_duplicateProduct_does_not_change_original_form_baseline() throws {
+        // Given
+        let originalProduct = Product.fake().copy(productID: 123,
+                                                  name: "Original",
+                                                  statusKey: ProductStatus.published.rawValue)
+        let productImagesUploader = MockProductImageUploader()
+        let viewModel = createViewModel(product: originalProduct, formType: .edit, productImagesUploader: productImagesUploader)
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            if case let ProductAction.addProduct(productToSave, onCompletion) = action {
+                // Simulate the server returning the duplicate with a new ID and copied name.
+                onCompletion(.success(productToSave.copy(productID: 456, name: "Original Copy")))
+            }
+        }
+
+        // When
+        var duplicatedProduct: EditableProductModel?
+        waitForExpectation { expectation in
+            viewModel.duplicateProduct { result in
+                duplicatedProduct = try? result.get()
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        // The completion returns the duplicate...
+        XCTAssertEqual(duplicatedProduct?.productID, 456)
+        // ...but this form still represents the original product, so its baseline must be untouched.
+        XCTAssertEqual(viewModel.originalProductModel, EditableProductModel(product: originalProduct))
+        XCTAssertFalse(viewModel.hasUnsavedChanges())
+    }
 }
 
 private extension ProductFormViewModel_SaveTests {


### PR DESCRIPTION
## Description

Fixes WOOMOB-2615 — duplicating a product could overwrite the original product's images.

**Root cause.** On a successful duplication, `ProductFormViewModel.duplicateProduct` called `resetProduct`/`resetPassword`, rebinding *this* form's baseline (`originalProduct`/`originalPassword`) to the newly created duplicate. The form still represents the original product, so this corrupted change tracking and — because the image action handler is shared per session — leaked the duplicate's images back into the original.

**Fix.** Stop resetting the baseline on duplication. The form keeps representing the original product; the duplicate is handed to the completion handler only.

**Bonus parity with Android.** Previously iOS showed a "Product copied" toast and stayed on the original. Android opens the new copy after duplicating. This PR matches that: an optional `onDuplicate` callback is threaded through the product-detail navigator chain (`ProductDetailNavigator` → `ProductDetailNativeCoordinator` → `ProductDetailsFactory` → `ProductFormViewController`), mirroring the existing `onDelete` plumbing. The products split-view coordinator implements it by **replacing** the secondary navigation stack (via its existing `showProductForm`), not by pushing — so it preserves the coordinator's documented "only one product form in the secondary stack" invariant and behaves correctly on both form factors:

- **iPhone**: the copy opens and Back returns to the product list.
- **iPad**: the copy replaces the detail pane (just like selecting a different product); the sidebar is untouched. The new draft appears in the list automatically via the existing `ResultsController` (CoreData), with no manual refetch.

Every other entry point (deep-link loader, AI assistant, legacy non-split push, add-product flow) passes `nil` for `onDuplicate` and therefore keeps the prior in-place "Product copied" confirmation — no behavior change.

**Tests.** Adds `test_duplicateProduct_does_not_change_original_form_baseline`, which verifies the completion returns the duplicate while the form's `originalProductModel` baseline stays bound to the original (the regression guard). `MockProductDetailNativeCoordinator`'s `viewController(...)` override is updated to match the new `onDuplicate:` parameter.


## Test Steps

1. On a store with at least one product, open a product for editing.
2. Tap the more menu (•••) → **Duplicate**.
3. Verify the duplicate opens as a new draft.
4. Add or change one or more images on the Duplicate product, save.
5. Go back to the original product and confirm its images are **unchanged** (the bug was the original picking up the duplicate's images).
6. **iPhone**: after duplicating, tap Back — you should land on the product list.
7. **iPad**: after duplicating, the detail pane shows the copy and the left sidebar does **not** jump/refetch; the new draft appears in the list.
8. Duplicate a product that opens in the admin web view (e.g. a bookable product) and confirm no regression.

## Reproduction & Fix Demo

### ⚠️ Note on reproduction
The bug triggers when adding images from the **phone gallery** or **site media library** — not from the camera, which appears to use a different code path.

---

### Before the fix (two bugs)

**Bug 1 — No discard prompt on unsaved duplicate**

1. Duplicate a product.
2. Add an image to the duplicate (from phone gallery or site media library).
3. Tap the back button.
4. **Expected:** A "Discard changes?" prompt appears.
5. **Actual:** No prompt — navigates back silently, as if nothing changed.

**Bug 2 — Duplicate's images overwrite the original product**

This happens in two scenarios:

*Scenario A (unsaved duplicate):*
1. Duplicate a product and add an image to the duplicate.
2. Tap back (no discard prompt, per Bug 1).
3. Open the **original** product.
4. **Expected:** Original product opens normally with its own images.
5. **Actual:** Original product opens in edit mode, showing the image you just added to the duplicate.


https://github.com/user-attachments/assets/3bef3e51-0aba-4b85-9828-9ddc2dd3cf8b



*Scenario B (saved duplicate):*
1. Delete the previous duplicate, then duplicate the product again.
2. Add an image to the duplicate and **save/publish** it.
3. Go back and open the **original** product.
4. **Expected:** Original product is unaffected.
5. **Actual:** Same as Scenario A — original product shows the duplicate's image.


https://github.com/user-attachments/assets/f820d442-ce61-4eb3-99e1-9d957e17917e


---

### After the fix

**Bug 1 fixed:** Duplicate a product, make any changes, tap back → "Discard changes?" prompt appears correctly.

**Bug 2 fixed:** Whether you discard or save the duplicate, going back and opening the original product shows its own images, completely unaffected by the duplicate.


https://github.com/user-attachments/assets/233fa77b-aa9f-4164-ab80-cf3d7c7bb982



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.