### PR TITLE
Unify support entry point wording

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -222,7 +222,7 @@ struct ConnectivityTool: View {
     ///
     var onContactSupportTapped: (() -> ())?
 
-    /// Closure to be invoked when the "Chat with Support" button is tapped.
+    /// Closure to be invoked when the AI-backed "Contact Support" button is tapped.
     ///
     var onChatWithSupportTapped: (() -> ())?
 
@@ -263,7 +263,7 @@ struct ConnectivityTool: View {
             Divider().ignoresSafeArea()
 
             if showChatButton {
-                Button(Localization.chatWithSupport) {
+                Button(Localization.contactSupport) {
                     onChatWithSupportTapped?()
                 }
                 .buttonStyle(PrimaryButtonStyle())
@@ -288,11 +288,6 @@ private extension ConnectivityTool {
                                                 comment: "Subtitle on the connectivity tool screen")
         static let contactSupport = NSLocalizedString("Contact Support",
                                                       comment: "Contact support button in the connectivity tool screen")
-        static let chatWithSupport = NSLocalizedString(
-            "connectivityTool.chatWithSupport",
-            value: "Chat with Support",
-            comment: "Button to open AI chat support in the connectivity tool screen"
-        )
         static let title = NSLocalizedString(
             "connectivityTool.title",
             value: "Troubleshoot Connection",

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/PreLogin/PreLoginConnectivityToolView.swift
@@ -103,7 +103,7 @@ struct PreLoginConnectivityToolView: View {
     /// Closure invoked when the "Contact Support" button is tapped.
     var onContactSupportTapped: (() -> Void)?
 
-    /// Closure invoked when the "Chat with AI Support" button is tapped.
+    /// Closure invoked when the AI-backed "Contact Support" button is tapped.
     var onChatWithSupportTapped: (() -> Void)?
 
     var body: some View {
@@ -125,7 +125,7 @@ struct PreLoginConnectivityToolView: View {
             }
 
             if viewModel.showChatButton {
-                Button(Localization.chatWithSupport) {
+                Button(Localization.contactSupport) {
                     onChatWithSupportTapped?()
                 }
                 .buttonStyle(SecondaryButtonStyle())
@@ -249,11 +249,6 @@ private extension PreLoginConnectivityToolView {
             "preLoginConnectivityToolView.contactSupport",
             value: "Contact Support",
             comment: "Contact support button in the pre-login connectivity tool"
-        )
-        static let chatWithSupport = NSLocalizedString(
-            "preLoginConnectivityToolView.chatWithSupport",
-            value: "Chat with Support",
-            comment: "Chat with AI support button in the pre-login connectivity tool"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -238,8 +238,6 @@ private extension HelpAndSupportViewController {
             configureSiteCompatibility(cell: cell)
         case let cell as ValueOneTableViewCell where row == .featureFlags:
             configureFeatureFlags(cell: cell)
-        case let cell as ValueOneTableViewCell where row == .aiSupportChat:
-            configureAISupportChat(cell: cell)
         case let cell as ValueOneTableViewCell where row == .chatHistory:
             configureChatHistory(cell: cell)
         default:
@@ -263,7 +261,8 @@ private extension HelpAndSupportViewController {
         cell.selectionStyle = .default
         cell.textLabel?.text = NSLocalizedString("Contact Support", comment: "Contact Support title")
         cell.detailTextLabel?.text = NSLocalizedString(
-            "Reach our happiness engineers who can help answer tough questions",
+            "helpAndSupport.contactSupport.subtitle",
+            value: "Get help with app or store issues",
             comment: "Subtitle for Contact Support"
         )
     }
@@ -327,23 +326,6 @@ private extension HelpAndSupportViewController {
         cell.detailTextLabel?.text = "Toggle local feature flags"
     }
 
-    /// AI Support Chat cell
-    ///
-    func configureAISupportChat(cell: ValueOneTableViewCell) {
-        cell.accessoryType = .disclosureIndicator
-        cell.selectionStyle = .default
-        cell.textLabel?.text = NSLocalizedString(
-            "helpAndSupport.aiSupportChat.title",
-            value: "Chat with Support",
-            comment: "Title for the AI support chat row on the Help screen"
-        )
-        cell.detailTextLabel?.text = NSLocalizedString(
-            "helpAndSupport.aiSupportChat.subtitle",
-            value: "Get help from our AI assistant",
-            comment: "Subtitle for the AI support chat row on the Help screen"
-        )
-    }
-
     /// Chat History cell
     ///
     func configureChatHistory(cell: ValueOneTableViewCell) {
@@ -402,6 +384,11 @@ private extension HelpAndSupportViewController {
     /// Contact Support action
     ///
     func contactSupportWasPressed() {
+        guard !viewModel.shouldOpenAIChatFromContactSupport else {
+            aiSupportChatWasPressed()
+            return
+        }
+
         let viewController = SupportFormHostingController(viewModel: .init(sourceTag: sourceTag))
         viewController.show(from: self)
     }
@@ -620,8 +607,6 @@ extension HelpAndSupportViewController: UITableViewDelegate {
             siteCompatibilityWasPressed()
         case .featureFlags:
             featureFlagsWasPressed()
-        case .aiSupportChat:
-            aiSupportChatWasPressed()
         case .chatHistory:
             chatHistoryWasPressed()
         }
@@ -645,7 +630,6 @@ private struct Section {
 enum HelpAndSupportRow: CaseIterable {
     case helpCenter
     case contactSupport
-    case aiSupportChat
     case contactEmail
     case applicationLog
     case systemStatusReport
@@ -655,7 +639,7 @@ enum HelpAndSupportRow: CaseIterable {
 
     var type: UITableViewCell.Type {
         switch self {
-        case .helpCenter, .contactSupport, .aiSupportChat, .contactEmail, .applicationLog,
+        case .helpCenter, .contactSupport, .contactEmail, .applicationLog,
              .systemStatusReport, .siteCompatibility, .featureFlags, .chatHistory:
             return ValueOneTableViewCell.self
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -9,6 +9,10 @@ struct HelpAndSupportViewModel {
     private let developerFFPanelEnabled: Bool
     private let isAIChatEnabled: Bool
 
+    var shouldOpenAIChatFromContactSupport: Bool {
+        isAIChatEnabled
+    }
+
     init(isAuthenticated: Bool,
          isZendeskEnabled: Bool,
          isMacCatalyst: Bool,
@@ -32,18 +36,12 @@ struct HelpAndSupportViewModel {
             return [.helpCenter]
         }
 
-        var rows: [HelpAndSupportRow] = [.helpCenter, .contactEmail, .applicationLog]
-        if !isAIChatEnabled {
-            rows.insert(.contactSupport, at: 1)
-        }
+        var rows: [HelpAndSupportRow] = [.helpCenter, .contactSupport, .contactEmail, .applicationLog]
         if isAuthenticated {
             rows.append(.systemStatusReport)
         }
         if !isAuthenticated && hasLoginSiteURL {
             rows.append(.siteCompatibility)
-        }
-        if isAIChatEnabled {
-            rows.append(.aiSupportChat)
         }
         if isAuthenticated && isAIChatEnabled {
             rows.append(.chatHistory)

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -17,7 +17,6 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
         super.init(rootView: view)
 
         self.hidesBottomBarWhenPushed = true
-        self.title = Localization.title
 
         viewModel.onStartJetpackSetup = { [weak self] in
             self?.startJetpackSetup()
@@ -120,11 +119,6 @@ extension SupportChatHostingController {
 //
 private extension SupportChatHostingController {
     enum Localization {
-        static let title = NSLocalizedString(
-            "supportChatHostingController.title",
-            value: "Chat with Support",
-            comment: "Navigation title for the AI support chat screen"
-        )
         static let updateWooCommerce = NSLocalizedString(
             "supportChatHostingController.updateWooCommerce",
             value: "Update WooCommerce",

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatView.swift
@@ -10,7 +10,7 @@ struct SupportChatView: View {
     var body: some View {
         chatView
             .background(Color(.listBackground))
-            .navigationTitle(Localization.title)
+            .navigationTitle(Localization.contactSupport)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItemGroup(placement: .topBarTrailing) {
@@ -18,8 +18,8 @@ struct SupportChatView: View {
                         Button {
                             viewModel.contactHumanSupport(source: .toolbar)
                         } label: {
-                            Image(systemName: "person.fill.questionmark")
-                                .accessibilityLabel(Localization.toolbarContactSupport)
+                            Image(systemName: "headset")
+                                .accessibilityLabel(Localization.humanSupport)
                         }
                         .disabled(!viewModel.isContactHumanSupportButtonEnabled)
                         .onAppear {
@@ -60,7 +60,7 @@ struct SupportChatView: View {
                     set: { if !$0 { viewModel.dismissError() } }
                 ),
                 actions: {
-                    Button(Localization.contactSupport) {
+                    Button(Localization.humanSupport) {
                         viewModel.dismissError()
                         viewModel.contactHumanSupport(source: .errorDialog)
                     }
@@ -312,7 +312,7 @@ struct SupportChatView: View {
                 .foregroundColor(Color(.secondaryLabel))
                 .multilineTextAlignment(.center)
 
-            Button(Localization.contactSupport) {
+            Button(Localization.humanSupport) {
                 viewModel.contactHumanSupport(source: .banner)
             }
             .buttonStyle(SecondaryButtonStyle())
@@ -407,11 +407,6 @@ private extension SupportChatView {
 
 private extension SupportChatView {
     enum Localization {
-        static let title = NSLocalizedString(
-            "supportChatView.title",
-            value: "Chat with Support",
-            comment: "Navigation title for the AI support chat screen"
-        )
         static let placeholder = NSLocalizedString(
             "supportChatView.placeholder",
             value: "Type a message...",
@@ -447,9 +442,9 @@ private extension SupportChatView {
             value: "Contact Support",
             comment: "Button to contact human support from the chat"
         )
-        static let toolbarContactSupport = NSLocalizedString(
-            "supportChatView.toolbar.contactSupport",
-            value: "Contact Support",
+        static let humanSupport = NSLocalizedString(
+            "supportChatView.toolbar.humanSupport",
+            value: "Ask a happiness engineer",
             comment: "Trailing toolbar button on the AI support chat that lets the merchant escalate to human support"
         )
         static let toolbarMarkResolved = NSLocalizedString(

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -126,7 +126,7 @@ final class HelpAndSupportViewModelTests: XCTestCase {
         XCTAssertTrue(rows.isEmpty)
     }
 
-    func test_given_ai_chat_enabled_when_getting_rows_then_contact_support_is_hidden() {
+    func test_given_ai_chat_enabled_when_getting_rows_then_contact_support_and_chat_history_are_shown() {
         // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true,
                                                 isZendeskEnabled: true,
@@ -137,12 +137,11 @@ final class HelpAndSupportViewModelTests: XCTestCase {
         let rows = viewModel.getRows()
 
         // Then
-        XCTAssertFalse(rows.contains(.contactSupport))
-        XCTAssertTrue(rows.contains(.aiSupportChat))
-        XCTAssertTrue(rows.contains(.chatHistory))
+        XCTAssertEqual(rows, [.helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport, .chatHistory])
+        XCTAssertTrue(viewModel.shouldOpenAIChatFromContactSupport)
     }
 
-    func test_given_ai_chat_disabled_when_getting_rows_then_contact_support_is_shown() {
+    func test_given_ai_chat_disabled_when_getting_rows_then_contact_support_is_shown_without_chat_history() {
         // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true,
                                                 isZendeskEnabled: true,
@@ -154,7 +153,7 @@ final class HelpAndSupportViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(rows.contains(.contactSupport))
-        XCTAssertFalse(rows.contains(.aiSupportChat))
         XCTAssertFalse(rows.contains(.chatHistory))
+        XCTAssertFalse(viewModel.shouldOpenAIChatFromContactSupport)
     }
 }


### PR DESCRIPTION
## Description
Unifies support entry points around the existing `Contact Support` CTA.

- Keeps the Help screen's `Contact Support` row visible when AI support chat is enabled.
- Routes that row to AI support chat when the feature flag is on, and to the support form when it is off.
- Removes the separate `Chat with Support` row from Help and reuses existing `Contact Support` copy in support and connectivity entry points.
- Updates the Help row subtitle to a more generic app/store support message.

## Test Steps
1. Enable the AI support chat feature flag.
2. Open Help and confirm there is a single `Contact Support` row and no separate `Chat with Support` row.
3. Tap `Contact Support` and confirm it opens the support chat.
4. Open Troubleshoot connection and confirm that the CTA at the bottom says `Contact Support`. Tapping on it opens the support chat.
5. Disable the AI support chat feature flag.
6. Open Help, tap `Contact Support`, and confirm it opens the support form.

## Screenshots
Connectivity Tool | Chat screen | Help
--- | --- | ---
<img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 12 35 28" src="https://github.com/user-attachments/assets/ad657578-886c-460c-b482-e4a310c4950d" /> | <img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 12 35 45" src="https://github.com/user-attachments/assets/ec89ba04-4606-496a-be9c-f55fd8adff26" /> | <img width="320" alt="Simulator Screenshot - iPhone 17 - 2026-06-01 at 12 59 25" src="https://github.com/user-attachments/assets/e3803ead-0cf6-4b73-ae50-0f6ba8b3c0ef" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
