### PR TITLE
Exclude .claude/worktrees from SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,8 @@
 swiftlint_version: 0.63.2
 
 excluded:
+  # Local agent worktrees contain full repo copies (incl. vendored sub-configs); never lint them
+  - .claude/worktrees
   - build
   - BuildTools/.build
   - DerivedData


### PR DESCRIPTION
## Description
Adds `.claude/worktrees` to the SwiftLint `excluded` list.

Local agent worktrees hold full copies of the repository (including vendored sub-configs), so SwiftLint scanning them produces noise and false failures. This is a tooling-only, developer-local change — it has no effect on the app.

Split out of #17295 (POS Custom Amounts) so the tooling change can be reviewed and land independently of the feature work.

## Test Steps
1. Create an agent worktree under `.claude/worktrees/...` (or just create that directory with a copy of some Swift files).
2. Run SwiftLint via the BuildTools plugin.
3. Confirm files under `.claude/worktrees` are not linted (no violations reported for them).

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. _(Tooling-only, developer-local — no user-facing release note.)_