### PR TITLE
Analytics: Integrate scheduled import setting

### DIFF
--- a/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteSettingsRemote.swift
@@ -5,6 +5,8 @@ public protocol SiteSettingsRemoteProtocol {
     func setFeature(for siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool
     func loadAnalyticsOrderDateType(for siteID: Int64) async throws -> SiteSetting
     func updateAnalyticsOrderDateType(for siteID: Int64, value: String) async throws -> SiteSetting
+    func loadAnalyticsScheduledImport(for siteID: Int64) async throws -> SiteSetting
+    func updateAnalyticsScheduledImport(for siteID: Int64, value: String) async throws -> SiteSetting
 }
 
 /// Features that can be enabled/disabled in core, under WC Settings > Advanced > Features.
@@ -219,6 +221,45 @@ public class SiteSettingsRemote: Remote {
         let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: .custom(Constants.analyticsSettingsGroup))
         return try await enqueue(request, mapper: mapper)
     }
+
+    /// Retrieves the current value of the WooCommerce Analytics scheduled-import setting.
+    ///
+    /// - Parameter siteID: Site for which we'll fetch the setting.
+    /// - Returns: The setting payload as returned by the wc-admin settings endpoint.
+    /// - Throws: An error if the request fails or the response cannot be parsed.
+    ///
+    public func loadAnalyticsScheduledImport(for siteID: Int64) async throws -> SiteSetting {
+        let path = Constants.siteSettingsPath + Constants.analyticsSettingsGroup + "/" + Constants.analyticsScheduledImportSettingID
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: .custom(Constants.analyticsSettingsGroup))
+        return try await enqueue(request, mapper: mapper)
+    }
+
+    /// Updates the WooCommerce Analytics scheduled-import setting.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll update the setting.
+    ///   - value: New value for the setting (`yes` for scheduled updates, `no` for immediate updates).
+    /// - Returns: The setting payload as returned by the wc-admin settings endpoint.
+    /// - Throws: An error if the request fails or the response cannot be parsed.
+    ///
+    public func updateAnalyticsScheduledImport(for siteID: Int64, value: String) async throws -> SiteSetting {
+        let parameters: [String: Any] = [Constants.valueParameter: value]
+        let path = Constants.siteSettingsPath + Constants.analyticsSettingsGroup + "/" + Constants.analyticsScheduledImportSettingID
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .put,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = SiteSettingMapper(siteID: siteID, settingsGroup: .custom(Constants.analyticsSettingsGroup))
+        return try await enqueue(request, mapper: mapper)
+    }
 }
 
 extension SiteSettingsRemote: SiteSettingsRemoteProtocol {}
@@ -243,6 +284,7 @@ private extension SiteSettingsRemote {
         static let pointOfSaleSettingsGroup: String = "point-of-sale"
         static let analyticsSettingsGroup: String = "wc_admin"
         static let analyticsOrderDateTypeSettingID: String = "woocommerce_date_type"
+        static let analyticsScheduledImportSettingID: String = "woocommerce_analytics_scheduled_import"
         static let valueParameter: String = "value"
         static let featureEnabledValue: String = "yes"
         static let featureDisabledValue: String = "no"

--- a/Modules/Sources/Yosemite/Actions/SettingAction.swift
+++ b/Modules/Sources/Yosemite/Actions/SettingAction.swift
@@ -56,4 +56,12 @@ public enum SettingAction: Action {
     /// Updates the WooCommerce Analytics order date-type setting (`woocommerce_date_type`).
     ///
     case updateAnalyticsOrderDateType(siteID: Int64, value: AnalyticsOrderDateType, onCompletion: (Result<Void, Error>) -> Void)
+
+    /// Retrieves the WooCommerce Analytics scheduled-import setting (`woocommerce_analytics_scheduled_import`).
+    ///
+    case retrieveAnalyticsImportUpdateMode(siteID: Int64, onCompletion: (Result<AnalyticsImportUpdateMode, Error>) -> Void)
+
+    /// Updates the WooCommerce Analytics scheduled-import setting (`woocommerce_analytics_scheduled_import`).
+    ///
+    case updateAnalyticsImportUpdateMode(siteID: Int64, value: AnalyticsImportUpdateMode, onCompletion: (Result<Void, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Enums/AnalyticsImportUpdateMode+Cache.swift
+++ b/Modules/Sources/Yosemite/Model/Enums/AnalyticsImportUpdateMode+Cache.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Storage
+
+public extension AnalyticsImportUpdateMode {
+    /// Reads the cached analytics import update mode for the given site from local storage.
+    /// Returns `nil` when no value has been persisted yet for this site, or when the stored value
+    /// can't be mapped to a known mode.
+    static func cachedValue(siteID: Int64, storageManager: StorageManagerType) -> AnalyticsImportUpdateMode? {
+        guard let value = storageManager.viewStorage.loadSiteSetting(siteID: siteID, settingID: cachedSettingID)?.value else {
+            return nil
+        }
+        return AnalyticsImportUpdateMode(backendValue: value)
+    }
+
+    /// Mirrors `SiteSettingsRemote.Constants.analyticsScheduledImportSettingID`. Kept in
+    /// sync manually because the Networking constant is private to that file.
+    private static var cachedSettingID: String { "woocommerce_analytics_scheduled_import" }
+}

--- a/Modules/Sources/Yosemite/Model/Enums/AnalyticsImportUpdateMode.swift
+++ b/Modules/Sources/Yosemite/Model/Enums/AnalyticsImportUpdateMode.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// How WooCommerce Analytics imports new data.
+///
+/// Backed by the `woocommerce_analytics_scheduled_import` site setting.
+public enum AnalyticsImportUpdateMode: String, CaseIterable, Sendable {
+    /// Automatically update analytics data every 12 hours.
+    case scheduled = "yes"
+    /// Update analytics data as soon as new data becomes available.
+    case immediate = "no"
+
+    public init?(backendValue: String) {
+        switch backendValue {
+        case Self.scheduled.rawValue:
+            self = .scheduled
+        case Self.immediate.rawValue, "":
+            self = .immediate
+        default:
+            return nil
+        }
+    }
+}

--- a/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/ActionHandlers/MockSettingActionHandler.swift
@@ -41,6 +41,10 @@ struct MockSettingActionHandler: MockActionHandler {
             onCompletion(.success(.paid))
         case .updateAnalyticsOrderDateType(_, _, let onCompletion):
             onCompletion(.success(()))
+        case .retrieveAnalyticsImportUpdateMode(_, let onCompletion):
+            onCompletion(.success(.immediate))
+        case .updateAnalyticsImportUpdateMode(_, _, let onCompletion):
+            onCompletion(.success(()))
         default: unimplementedAction(action: action)
         }
     }

--- a/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
+++ b/Modules/Sources/Yosemite/Stores/Helpers/SettingStoreMethods.swift
@@ -19,6 +19,8 @@ internal protocol SettingStoreMethodsProtocol {
     func isFeatureEnabled(siteID: Int64, feature: SiteSettingsFeature) async throws -> Bool
     func retrieveAnalyticsOrderDateType(siteID: Int64) async throws -> AnalyticsOrderDateType
     func updateAnalyticsOrderDateType(siteID: Int64, value: AnalyticsOrderDateType) async throws
+    func retrieveAnalyticsImportUpdateMode(siteID: Int64) async throws -> AnalyticsImportUpdateMode
+    func updateAnalyticsImportUpdateMode(siteID: Int64, value: AnalyticsImportUpdateMode) async throws
 }
 
 internal class SettingStoreMethods: SettingStoreMethodsProtocol {
@@ -192,6 +194,24 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
         _ = try await parseAndCacheAnalyticsOrderDateType(setting, siteID: siteID)
     }
 
+    /// Retrieves the WooCommerce Analytics scheduled-import setting (`woocommerce_analytics_scheduled_import`).
+    ///
+    /// Throws `SettingError.parseError` if the response value cannot be mapped to a known mode.
+    ///
+    func retrieveAnalyticsImportUpdateMode(siteID: Int64) async throws -> AnalyticsImportUpdateMode {
+        let setting = try await siteSettingsRemote.loadAnalyticsScheduledImport(for: siteID)
+        return try await parseAndCacheAnalyticsImportUpdateMode(setting, siteID: siteID)
+    }
+
+    /// Updates the WooCommerce Analytics scheduled-import setting (`woocommerce_analytics_scheduled_import`).
+    ///
+    /// Throws `SettingError.parseError` if the response value cannot be mapped to a known mode.
+    ///
+    func updateAnalyticsImportUpdateMode(siteID: Int64, value: AnalyticsImportUpdateMode) async throws {
+        let setting = try await siteSettingsRemote.updateAnalyticsScheduledImport(for: siteID, value: value.rawValue)
+        _ = try await parseAndCacheAnalyticsImportUpdateMode(setting, siteID: siteID)
+    }
+
     /// Parses the response value into `AnalyticsOrderDateType` and, only on success, caches the SiteSetting locally.
     /// Throws `SettingError.parseError` (without writing to cache) when the value can't be mapped to a known case.
     private func parseAndCacheAnalyticsOrderDateType(_ setting: Networking.SiteSetting, siteID: Int64) async throws -> AnalyticsOrderDateType {
@@ -200,6 +220,16 @@ internal class SettingStoreMethods: SettingStoreMethodsProtocol {
         }
         await upsertSingleStoredSetting(siteID: siteID, readOnlySiteSetting: setting)
         return dateType
+    }
+
+    /// Parses the response value into `AnalyticsImportUpdateMode` and, only on success, caches the SiteSetting locally.
+    /// Treats an empty value, which is what the networking model emits for a `null` setting value, as `.immediate`.
+    private func parseAndCacheAnalyticsImportUpdateMode(_ setting: Networking.SiteSetting, siteID: Int64) async throws -> AnalyticsImportUpdateMode {
+        guard let mode = AnalyticsImportUpdateMode(backendValue: setting.value) else {
+            throw SettingError.parseError
+        }
+        await upsertSingleStoredSetting(siteID: siteID, readOnlySiteSetting: setting.copy(value: mode.rawValue))
+        return mode
     }
 }
 

--- a/Modules/Sources/Yosemite/Stores/SettingStore.swift
+++ b/Modules/Sources/Yosemite/Stores/SettingStore.swift
@@ -84,6 +84,24 @@ public class SettingStore: Store {
                     onCompletion(.failure(error))
                 }
             }
+        case let .retrieveAnalyticsImportUpdateMode(siteID, onCompletion):
+            Task { @MainActor in
+                do {
+                    let mode = try await methods.retrieveAnalyticsImportUpdateMode(siteID: siteID)
+                    onCompletion(.success(mode))
+                } catch {
+                    onCompletion(.failure(error))
+                }
+            }
+        case let .updateAnalyticsImportUpdateMode(siteID, value, onCompletion):
+            Task { @MainActor in
+                do {
+                    try await methods.updateAnalyticsImportUpdateMode(siteID: siteID, value: value)
+                    onCompletion(.success(()))
+                } catch {
+                    onCompletion(.failure(error))
+                }
+            }
         }
     }
 }

--- a/Modules/Tests/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/SiteSettingsRemoteTests.swift
@@ -338,4 +338,84 @@ final class SiteSettingsRemoteTests: XCTestCase {
             XCTAssertEqual(error as? NetworkError, .unacceptableStatusCode(statusCode: 500))
         }
     }
+
+    // MARK: - `loadAnalyticsScheduledImport`
+
+    func test_loadAnalyticsScheduledImport_returns_parsed_setting() async throws {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-yes")
+
+        // When
+        let setting = try await remote.loadAnalyticsScheduledImport(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(setting.settingID, "woocommerce_analytics_scheduled_import")
+        XCTAssertEqual(setting.value, "yes")
+        XCTAssertEqual(setting.settingGroupKey, "wc_admin")
+    }
+
+    func test_loadAnalyticsScheduledImport_when_value_is_null_then_returns_empty_value() async throws {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-null")
+
+        // When
+        let setting = try await remote.loadAnalyticsScheduledImport(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(setting.settingID, "woocommerce_analytics_scheduled_import")
+        XCTAssertEqual(setting.value, "")
+    }
+
+    func test_loadAnalyticsScheduledImport_throws_error_when_network_fails() async {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                              error: error)
+
+        // When/Then
+        do {
+            _ = try await remote.loadAnalyticsScheduledImport(for: sampleSiteID)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? NetworkError, .unacceptableStatusCode(statusCode: 500))
+        }
+    }
+
+    // MARK: - `updateAnalyticsScheduledImport`
+
+    func test_updateAnalyticsScheduledImport_returns_parsed_setting() async throws {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-no")
+
+        // When
+        let setting = try await remote.updateAnalyticsScheduledImport(for: sampleSiteID, value: "no")
+
+        // Then
+        XCTAssertEqual(setting.settingID, "woocommerce_analytics_scheduled_import")
+        XCTAssertEqual(setting.value, "no")
+        XCTAssertEqual(setting.settingGroupKey, "wc_admin")
+    }
+
+    func test_updateAnalyticsScheduledImport_throws_error_when_network_fails() async {
+        // Given
+        let remote = SiteSettingsRemote(network: network)
+        let error = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                              error: error)
+
+        // When/Then
+        do {
+            _ = try await remote.updateAnalyticsScheduledImport(for: sampleSiteID, value: "yes")
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual(error as? NetworkError, .unacceptableStatusCode(statusCode: 500))
+        }
+    }
 }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-no.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-no.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "id": "woocommerce_analytics_scheduled_import",
+        "label": "Updates",
+        "description": "Choose how analytics imports are processed.",
+        "type": "select",
+        "default": "yes",
+        "options": {
+            "yes": "Scheduled",
+            "no": "Immediately"
+        },
+        "value": "no",
+        "group_id": "wc_admin"
+    }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-null.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-null.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "id": "woocommerce_analytics_scheduled_import",
+        "label": "Updates",
+        "description": "Choose how analytics imports are processed.",
+        "type": "select",
+        "default": "yes",
+        "options": {
+            "yes": "Scheduled",
+            "no": "Immediately"
+        },
+        "value": null,
+        "group_id": "wc_admin"
+    }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-parse-error.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-parse-error.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "id": "woocommerce_analytics_scheduled_import",
+        "label": "Updates",
+        "description": "Choose how analytics imports are processed.",
+        "type": "select",
+        "default": "yes",
+        "options": {
+            "yes": "Scheduled",
+            "no": "Immediately"
+        },
+        "value": "unexpected",
+        "group_id": "wc_admin"
+    }
+}

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-yes.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/setting-analytics-scheduled-import-yes.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "id": "woocommerce_analytics_scheduled_import",
+        "label": "Updates",
+        "description": "Choose how analytics imports are processed.",
+        "type": "select",
+        "default": "yes",
+        "options": {
+            "yes": "Scheduled",
+            "no": "Immediately"
+        },
+        "value": "yes",
+        "group_id": "wc_admin"
+    }
+}

--- a/Modules/Tests/YosemiteTests/Mocks/MockSettingStoreMethods.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSettingStoreMethods.swift
@@ -21,6 +21,11 @@ final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
     var updateAnalyticsOrderDateTypeResult: Result<Void, Error> = .success(())
     var updateAnalyticsOrderDateTypeReceivedSiteID: Int64?
     var updateAnalyticsOrderDateTypeReceivedValue: AnalyticsOrderDateType?
+    var retrieveAnalyticsImportUpdateModeResult: Result<AnalyticsImportUpdateMode, Error> = .success(.immediate)
+    var retrieveAnalyticsImportUpdateModeReceivedSiteID: Int64?
+    var updateAnalyticsImportUpdateModeResult: Result<Void, Error> = .success(())
+    var updateAnalyticsImportUpdateModeReceivedSiteID: Int64?
+    var updateAnalyticsImportUpdateModeReceivedValue: AnalyticsImportUpdateMode?
 
     func synchronizeGeneralSiteSettings(siteID: Int64,
                                       onCompletion: @escaping (Error?) -> Void) {
@@ -107,6 +112,27 @@ final class MockSettingStoreMethods: SettingStoreMethodsProtocol {
         updateAnalyticsOrderDateTypeReceivedSiteID = siteID
         updateAnalyticsOrderDateTypeReceivedValue = value
         switch updateAnalyticsOrderDateTypeResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func retrieveAnalyticsImportUpdateMode(siteID: Int64) async throws -> AnalyticsImportUpdateMode {
+        retrieveAnalyticsImportUpdateModeReceivedSiteID = siteID
+        switch retrieveAnalyticsImportUpdateModeResult {
+        case .success(let mode):
+            return mode
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func updateAnalyticsImportUpdateMode(siteID: Int64, value: AnalyticsImportUpdateMode) async throws {
+        updateAnalyticsImportUpdateModeReceivedSiteID = siteID
+        updateAnalyticsImportUpdateModeReceivedValue = value
+        switch updateAnalyticsImportUpdateModeResult {
         case .success:
             return
         case .failure(let error):

--- a/Modules/Tests/YosemiteTests/Mocks/MockSiteSettingsRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/MockSiteSettingsRemote.swift
@@ -12,6 +12,11 @@ final class MockSiteSettingsRemote: SiteSettingsRemoteProtocol {
     var updateAnalyticsOrderDateTypeResult: Result<SiteSetting, Error> = .success(SiteSetting.fake())
     var spyUpdateAnalyticsOrderDateTypeSiteID: Int64?
     var spyUpdateAnalyticsOrderDateTypeValue: String?
+    var loadAnalyticsScheduledImportResult: Result<SiteSetting, Error> = .success(SiteSetting.fake())
+    var spyLoadAnalyticsScheduledImportSiteID: Int64?
+    var updateAnalyticsScheduledImportResult: Result<SiteSetting, Error> = .success(SiteSetting.fake())
+    var spyUpdateAnalyticsScheduledImportSiteID: Int64?
+    var spyUpdateAnalyticsScheduledImportValue: String?
 
     func setFeature(for siteID: Int64, feature: SiteSettingsFeature, enabled: Bool) async throws -> Bool {
         setFeatureCalled = true
@@ -41,6 +46,27 @@ final class MockSiteSettingsRemote: SiteSettingsRemoteProtocol {
         spyUpdateAnalyticsOrderDateTypeSiteID = siteID
         spyUpdateAnalyticsOrderDateTypeValue = value
         switch updateAnalyticsOrderDateTypeResult {
+        case .success(let setting):
+            return setting
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func loadAnalyticsScheduledImport(for siteID: Int64) async throws -> SiteSetting {
+        spyLoadAnalyticsScheduledImportSiteID = siteID
+        switch loadAnalyticsScheduledImportResult {
+        case .success(let setting):
+            return setting
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func updateAnalyticsScheduledImport(for siteID: Int64, value: String) async throws -> SiteSetting {
+        spyUpdateAnalyticsScheduledImportSiteID = siteID
+        spyUpdateAnalyticsScheduledImportValue = value
+        switch updateAnalyticsScheduledImportResult {
         case .success(let setting):
             return setting
         case .failure(let error):

--- a/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/SettingStoreTests.swift
@@ -1081,6 +1081,107 @@ final class SettingStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(result.isFailure)
     }
+
+    // MARK: - SettingAction.retrieveAnalyticsImportUpdateMode
+
+    func test_retrieveAnalyticsImportUpdateMode_returns_scheduled_value() throws {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-yes")
+
+        // When
+        let result: Result<AnalyticsImportUpdateMode, Error> = waitFor { promise in
+            let action = SettingAction.retrieveAnalyticsImportUpdateMode(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let mode = try XCTUnwrap(result.get())
+        XCTAssertEqual(mode, .scheduled)
+    }
+
+    func test_retrieveAnalyticsImportUpdateMode_when_value_is_null_then_returns_immediate_value_and_caches_no() throws {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-null")
+
+        // When
+        let result: Result<AnalyticsImportUpdateMode, Error> = waitFor { promise in
+            let action = SettingAction.retrieveAnalyticsImportUpdateMode(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        let mode = try XCTUnwrap(result.get())
+        XCTAssertEqual(mode, .immediate)
+        XCTAssertEqual(viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: "woocommerce_analytics_scheduled_import")?.value, "no")
+    }
+
+    func test_retrieveAnalyticsImportUpdateMode_returns_parse_error_and_skips_cache_when_value_is_unknown() {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-parse-error")
+
+        // When
+        let result: Result<AnalyticsImportUpdateMode, Error> = waitFor { promise in
+            let action = SettingAction.retrieveAnalyticsImportUpdateMode(siteID: self.sampleSiteID) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        guard case let .failure(error) = result else {
+            return XCTFail("Expected failure")
+        }
+        XCTAssertEqual(error as? SettingError, .parseError)
+        XCTAssertNil(viewStorage.loadSiteSetting(siteID: sampleSiteID, settingID: "woocommerce_analytics_scheduled_import"))
+    }
+
+    // MARK: - SettingAction.updateAnalyticsImportUpdateMode
+
+    func test_updateAnalyticsImportUpdateMode_returns_success_when_response_parses() throws {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import",
+                                 filename: "setting-analytics-scheduled-import-no")
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = SettingAction.updateAnalyticsImportUpdateMode(siteID: self.sampleSiteID, value: .immediate) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+    }
+
+    func test_updateAnalyticsImportUpdateMode_returns_failure_when_network_fails() {
+        // Given
+        let store = SettingStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 500)
+        network.simulateError(requestUrlSuffix: "settings/wc_admin/woocommerce_analytics_scheduled_import", error: expectedError)
+
+        // When
+        let result: Result<Void, Error> = waitFor { promise in
+            let action = SettingAction.updateAnalyticsImportUpdateMode(siteID: self.sampleSiteID, value: .scheduled) { result in
+                promise(result)
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
 }
 
 


### PR DESCRIPTION
Part of WOOMOB-3152

## Description
Adds support for reading and updating the WooCommerce Analytics scheduled import setting (`woocommerce_analytics_scheduled_import`) through the Networking remote and Yosemite SettingAction flow.

Introduces `AnalyticsImportUpdateMode` to map backend `yes`/`no` values, normalizes `null`/empty responses to immediate mode, and caches the parsed setting for later use.

## Test Steps
Just CI passing is sufficient.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.