### PR TITLE
Analytics: New bottom sheet for scheduled update setting

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
@@ -7,6 +7,7 @@ struct AnalyticsUpdateModeBottomSheet: View {
     @State private var viewModel: AnalyticsUpdateModeBottomSheetViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showingLearnMoreWebView = false
+    @State private var notice: Notice?
 
     init(viewModel: AnalyticsUpdateModeBottomSheetViewModel) {
         _viewModel = State(initialValue: viewModel)
@@ -25,6 +26,7 @@ struct AnalyticsUpdateModeBottomSheet: View {
         }
         .presentationDetents([.fraction(Layout.preferredDetentFraction), .large])
         .presentationDragIndicator(.visible)
+        .notice($notice)
         .sheet(isPresented: $showingLearnMoreWebView) {
             WebViewSheet(viewModel: Constants.learnMoreWebViewModel) {
                 showingLearnMoreWebView = false
@@ -71,18 +73,7 @@ struct AnalyticsUpdateModeBottomSheet: View {
         .padding(.top, Layout.descriptionToOptionsSpacing)
     }
 
-    @ViewBuilder
     private var footer: some View {
-        if viewModel.updateError != nil {
-            HStack(spacing: Layout.errorSpacing) {
-                Image(systemName: "exclamationmark.triangle")
-                    .foregroundStyle(Color(.error))
-                Text(Localization.updateError)
-                    .footnoteStyle(isError: true)
-            }
-            .padding(.top, Layout.errorTopSpacing)
-        }
-
         Text(Localization.footer)
             .font(.footnote)
             .foregroundStyle(.secondary)
@@ -91,8 +82,12 @@ struct AnalyticsUpdateModeBottomSheet: View {
 
     private func handleSelection(of mode: AnalyticsImportUpdateMode) {
         Task { @MainActor in
-            if await viewModel.handleSelection(mode) {
-                dismiss()
+            do {
+                if try await viewModel.handleSelection(mode) {
+                    dismiss()
+                }
+            } catch {
+                notice = Notice(title: Localization.updateErrorNotice, feedbackType: .error)
             }
         }
     }
@@ -166,8 +161,6 @@ extension AnalyticsUpdateModeBottomSheet {
         static let rowSpacing: CGFloat = 20
         static let rowTitleSubtitleSpacing: CGFloat = 3
         static let rowCheckmarkSpacing: CGFloat = 12
-        static let errorSpacing: CGFloat = 8
-        static let errorTopSpacing: CGFloat = 16
         static let preferredDetentFraction: CGFloat = 0.62
     }
 }
@@ -198,10 +191,10 @@ private enum Localization {
         value: "WooCommerce Analytics",
         comment: "Navigation title for the WooCommerce Analytics documentation web view."
     )
-    static let updateError = NSLocalizedString(
-        "analyticsUpdateModeBottomSheet.updateError",
-        value: "Couldn't update analytics updates. Please try again.",
-        comment: "Inline error shown when saving the analytics update mode setting fails."
+    static let updateErrorNotice = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.updateErrorNotice",
+        value: "Couldn't update the setting. Please try again.",
+        comment: "Notice shown when saving the analytics update mode setting fails."
     )
     static let scheduledTitle = NSLocalizedString(
         "analyticsUpdateModeBottomSheet.scheduledTitle",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+import enum Yosemite.AnalyticsImportUpdateMode
+
+/// Bottom sheet that explains and edits how WooCommerce Analytics imports update data.
+/// Backed by the `woocommerce_analytics_scheduled_import` site setting.
+struct AnalyticsUpdateModeBottomSheet: View {
+    @State private var viewModel: AnalyticsUpdateModeBottomSheetViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingLearnMoreWebView = false
+
+    init(viewModel: AnalyticsUpdateModeBottomSheetViewModel) {
+        _viewModel = State(initialValue: viewModel)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                header
+                typeSelector
+                footer
+            }
+            .padding(.horizontal, Layout.horizontalPadding)
+            .padding(.bottom, Layout.bottomPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .presentationDetents([.fraction(Layout.preferredDetentFraction), .large])
+        .presentationDragIndicator(.visible)
+        .sheet(isPresented: $showingLearnMoreWebView) {
+            WebViewSheet(viewModel: Constants.learnMoreWebViewModel) {
+                showingLearnMoreWebView = false
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(Localization.title)
+                .font(.title3.weight(.semibold))
+                .padding(.top, Layout.titleTopPadding)
+
+            Text(
+                AttributedString.withEmbeddedLink(
+                    mainContent: Localization.description,
+                    linkText: Localization.learnMore,
+                    link: Constants.learnMoreURL,
+                    font: .body,
+                    foregroundColor: Color(uiColor: .textSubtle)
+                )
+            )
+            .padding(.top, Layout.titleToDescriptionSpacing)
+            .environment(\.openURL, OpenURLAction { _ in
+                showingLearnMoreWebView = true
+                return .handled
+            })
+        }
+    }
+
+    private var typeSelector: some View {
+        VStack(alignment: .leading, spacing: Layout.rowSpacing) {
+            ForEach(AnalyticsImportUpdateMode.allCases, id: \.rawValue) { mode in
+                Button {
+                    handleSelection(of: mode)
+                } label: {
+                    row(for: mode)
+                }
+                .buttonStyle(.plain)
+                .disabled(viewModel.isUpdating)
+                .accessibilityIdentifier("dashboard-analytics-import-update-mode-\(mode.rawValue)")
+            }
+        }
+        .padding(.top, Layout.descriptionToOptionsSpacing)
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if viewModel.updateError != nil {
+            HStack(spacing: Layout.errorSpacing) {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(Color(.error))
+                Text(Localization.updateError)
+                    .footnoteStyle(isError: true)
+            }
+            .padding(.top, Layout.errorTopSpacing)
+        }
+
+        Text(Localization.footer)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(.top, Layout.optionsToFooterSpacing)
+    }
+
+    private func handleSelection(of mode: AnalyticsImportUpdateMode) {
+        Task { @MainActor in
+            if await viewModel.handleSelection(mode) {
+                dismiss()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(for mode: AnalyticsImportUpdateMode) -> some View {
+        let isSelected = viewModel.selectedMode == mode
+        let isUpdating = viewModel.updatingMode == mode
+        HStack(alignment: .top, spacing: Layout.rowCheckmarkSpacing) {
+            VStack(alignment: .leading, spacing: Layout.rowTitleSubtitleSpacing) {
+                Text(mode.localizedTitle)
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(.primary)
+                Text(mode.localizedDescription)
+                    .font(.subheadline.weight(.regular))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            trailingAccessory(isSelected: isSelected, isUpdating: isUpdating)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private func trailingAccessory(isSelected: Bool, isUpdating: Bool) -> some View {
+        if isUpdating {
+            ProgressView()
+                .progressViewStyle(.circular)
+        } else if isSelected {
+            Image(uiImage: .checkmarkStyledImage)
+        }
+    }
+}
+
+extension AnalyticsImportUpdateMode {
+    var localizedTitle: String {
+        switch self {
+        case .scheduled:
+            return Localization.scheduledTitle
+        case .immediate:
+            return Localization.immediateTitle
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .scheduled:
+            return Localization.scheduledDescription
+        case .immediate:
+            return Localization.immediateDescription
+        }
+    }
+}
+
+extension AnalyticsUpdateModeBottomSheet {
+    enum Constants {
+        static let learnMoreURL = "https://woocommerce.com/document/woocommerce-analytics/#section-24"
+        static let learnMoreWebViewModel = WebViewSheetViewModel(url: URL(string: learnMoreURL)!,
+                                                                 navigationTitle: Localization.learnMoreNavigationTitle,
+                                                                 authenticated: false)
+    }
+
+    enum Layout {
+        static let horizontalPadding: CGFloat = 16
+        static let titleTopPadding: CGFloat = 29
+        static let titleToDescriptionSpacing: CGFloat = 10
+        static let descriptionToOptionsSpacing: CGFloat = 24
+        static let optionsToFooterSpacing: CGFloat = 24
+        static let bottomPadding: CGFloat = 24
+        static let rowSpacing: CGFloat = 20
+        static let rowTitleSubtitleSpacing: CGFloat = 3
+        static let rowCheckmarkSpacing: CGFloat = 12
+        static let errorSpacing: CGFloat = 8
+        static let errorTopSpacing: CGFloat = 16
+        static let preferredDetentFraction: CGFloat = 0.62
+    }
+}
+
+private enum Localization {
+    static let title = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.title",
+        value: "Analytics updates",
+        comment: "Title of the bottom sheet that explains and lets the merchant choose how WooCommerce Analytics imports update data."
+    )
+    static let description = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.descriptionWithLearnMoreLink",
+        value: "Choose how WooCommerce processes analytics data updates. %1$@",
+        comment: "Description shown below the title of the analytics updates bottom sheet on the dashboard."
+    )
+    static let footer = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.footerWithoutLearnMoreLink",
+        value: "This is a store-wide setting, which also controls the \"Updates\" option in WooCommerce admin analytics settings.",
+        comment: "Clarification text shown below the analytics update options on the dashboard bottom sheet."
+    )
+    static let learnMore = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.learnMore",
+        value: "Learn more",
+        comment: "Link text in the analytics updates bottom sheet footer that opens WooCommerce Analytics documentation."
+    )
+    static let learnMoreNavigationTitle = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.learnMoreNavigationTitle",
+        value: "WooCommerce Analytics",
+        comment: "Navigation title for the WooCommerce Analytics documentation web view."
+    )
+    static let updateError = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.updateError",
+        value: "Couldn't update analytics updates. Please try again.",
+        comment: "Inline error shown when saving the analytics update mode setting fails."
+    )
+    static let scheduledTitle = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.scheduledTitle",
+        value: "Scheduled",
+        comment: "Analytics update option that imports analytics data on a schedule."
+    )
+    static let scheduledDescription = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.scheduledDescription",
+        value: "Automatically updates analytics data every 12 hours.\nRecommended for high order volume stores.",
+        comment: "Description of the Scheduled analytics update option."
+    )
+    static let immediateTitle = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.immediateTitle",
+        value: "Immediately",
+        comment: "Analytics update option that imports analytics data as soon as new data is available."
+    )
+    static let immediateDescription = NSLocalizedString(
+        "analyticsUpdateModeBottomSheet.immediateDescription",
+        value: "Updates analytics data as soon as new data becomes available.",
+        comment: "Description of the Immediately analytics update option."
+    )
+}
+
+#Preview("Default") {
+    Color.gray
+        .sheet(isPresented: .constant(true)) {
+            AnalyticsUpdateModeBottomSheet(
+                viewModel: AnalyticsUpdateModeBottomSheetViewModel(
+                    siteID: 123,
+                    selectedMode: .scheduled,
+                    onModeUpdated: { _ in }
+                )
+            )
+        }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
@@ -40,20 +40,9 @@ struct AnalyticsUpdateModeBottomSheet: View {
                 .font(.title3.weight(.semibold))
                 .padding(.top, Layout.titleTopPadding)
 
-            Text(
-                AttributedString.withEmbeddedLink(
-                    mainContent: Localization.description,
-                    linkText: Localization.learnMore,
-                    link: Constants.learnMoreURL,
-                    font: .body,
-                    foregroundColor: Color(uiColor: .textSubtle)
-                )
-            )
-            .padding(.top, Layout.titleToDescriptionSpacing)
-            .environment(\.openURL, OpenURLAction { _ in
-                showingLearnMoreWebView = true
-                return .handled
-            })
+            Text(Localization.description)
+                .bodyStyle()
+                .padding(.top, Layout.titleToDescriptionSpacing)
         }
     }
 
@@ -74,10 +63,20 @@ struct AnalyticsUpdateModeBottomSheet: View {
     }
 
     private var footer: some View {
-        Text(Localization.footer)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .padding(.top, Layout.optionsToFooterSpacing)
+        Text(
+            AttributedString.withEmbeddedLink(
+                mainContent: Localization.footer,
+                linkText: Localization.learnMore,
+                link: Constants.learnMoreURL,
+                font: .footnote,
+                foregroundColor: Color(.secondaryLabel)
+            )
+        )
+        .environment(\.openURL, OpenURLAction { _ in
+            showingLearnMoreWebView = true
+            return .handled
+        })
+        .padding(.top, Layout.optionsToFooterSpacing)
     }
 
     private func handleSelection(of mode: AnalyticsImportUpdateMode) {
@@ -172,14 +171,15 @@ private enum Localization {
         comment: "Title of the bottom sheet that explains and lets the merchant choose how WooCommerce Analytics imports update data."
     )
     static let description = NSLocalizedString(
-        "analyticsUpdateModeBottomSheet.descriptionWithLearnMoreLink",
-        value: "Choose how WooCommerce processes analytics data updates. %1$@",
+        "analyticsUpdateModeBottomSheet.description",
+        value: "Choose when analytics data is updated.",
         comment: "Description shown below the title of the analytics updates bottom sheet on the dashboard."
     )
     static let footer = NSLocalizedString(
-        "analyticsUpdateModeBottomSheet.footerWithoutLearnMoreLink",
-        value: "This is a store-wide setting, which also controls the \"Updates\" option in WooCommerce admin analytics settings.",
-        comment: "Clarification text shown below the analytics update options on the dashboard bottom sheet."
+        "analyticsUpdateModeBottomSheet.footerWithLearnMoreLink",
+        value: "This is a store-wide setting, which also controls the \"Updates\" option in WooCommerce admin analytics settings. %1$@.",
+        comment: "Clarification text shown below the analytics update options on the dashboard bottom sheet. " +
+        "The placeholder is a link for Learn more, please ensure to keep the trailing period."
     )
     static let learnMore = NSLocalizedString(
         "analyticsUpdateModeBottomSheet.learnMore",
@@ -203,7 +203,7 @@ private enum Localization {
     )
     static let scheduledDescription = NSLocalizedString(
         "analyticsUpdateModeBottomSheet.scheduledDescription",
-        value: "Automatically updates analytics data every 12 hours.\nRecommended for high order volume stores.",
+        value: "Updates automatically every 12 hours.\nRecommended for high order volume stores.",
         comment: "Description of the Scheduled analytics update option."
     )
     static let immediateTitle = NSLocalizedString(
@@ -213,7 +213,7 @@ private enum Localization {
     )
     static let immediateDescription = NSLocalizedString(
         "analyticsUpdateModeBottomSheet.immediateDescription",
-        value: "Updates analytics data as soon as new data becomes available.",
+        value: "Updates as soon as new data is available.",
         comment: "Description of the Immediately analytics update option."
     )
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModel.swift
@@ -1,0 +1,63 @@
+import Observation
+import Yosemite
+
+/// View model for `AnalyticsUpdateModeBottomSheet`.
+@MainActor
+@Observable
+final class AnalyticsUpdateModeBottomSheetViewModel {
+    private(set) var selectedMode: AnalyticsImportUpdateMode?
+    private(set) var updatingMode: AnalyticsImportUpdateMode?
+    private(set) var updateError: Error?
+
+    var isUpdating: Bool {
+        updatingMode != nil
+    }
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let onModeUpdated: @MainActor (AnalyticsImportUpdateMode) -> Void
+
+    init(siteID: Int64,
+         selectedMode: AnalyticsImportUpdateMode?,
+         stores: StoresManager = ServiceLocator.stores,
+         onModeUpdated: @escaping @MainActor (AnalyticsImportUpdateMode) -> Void) {
+        self.siteID = siteID
+        self.selectedMode = selectedMode
+        self.stores = stores
+        self.onModeUpdated = onModeUpdated
+    }
+
+    func handleSelection(_ mode: AnalyticsImportUpdateMode) async -> Bool {
+        if selectedMode == mode {
+            return true
+        }
+
+        guard updatingMode == nil else { return false }
+
+        updatingMode = mode
+        updateError = nil
+        defer { updatingMode = nil }
+
+        do {
+            try await updateAnalyticsImportUpdateMode(mode)
+            selectedMode = mode
+            onModeUpdated(mode)
+            return true
+        } catch {
+            DDLogError("Error updating analytics import update mode: \(error)")
+            updateError = error
+            return false
+        }
+    }
+}
+
+private extension AnalyticsUpdateModeBottomSheetViewModel {
+    func updateAnalyticsImportUpdateMode(_ mode: AnalyticsImportUpdateMode) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let action = SettingAction.updateAnalyticsImportUpdateMode(siteID: siteID, value: mode) { result in
+                continuation.resume(with: result)
+            }
+            stores.dispatch(action)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModel.swift
@@ -7,7 +7,6 @@ import Yosemite
 final class AnalyticsUpdateModeBottomSheetViewModel {
     private(set) var selectedMode: AnalyticsImportUpdateMode?
     private(set) var updatingMode: AnalyticsImportUpdateMode?
-    private(set) var updateError: Error?
 
     var isUpdating: Bool {
         updatingMode != nil
@@ -27,7 +26,7 @@ final class AnalyticsUpdateModeBottomSheetViewModel {
         self.onModeUpdated = onModeUpdated
     }
 
-    func handleSelection(_ mode: AnalyticsImportUpdateMode) async -> Bool {
+    func handleSelection(_ mode: AnalyticsImportUpdateMode) async throws -> Bool {
         if selectedMode == mode {
             return true
         }
@@ -35,7 +34,6 @@ final class AnalyticsUpdateModeBottomSheetViewModel {
         guard updatingMode == nil else { return false }
 
         updatingMode = mode
-        updateError = nil
         defer { updatingMode = nil }
 
         do {
@@ -45,8 +43,7 @@ final class AnalyticsUpdateModeBottomSheetViewModel {
             return true
         } catch {
             DDLogError("Error updating analytics import update mode: \(error)")
-            updateError = error
-            return false
+            throw error
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModelTests.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 final class AnalyticsUpdateModeBottomSheetViewModelTests: XCTestCase {
     @MainActor
-    func test_handleSelection_when_mode_matches_selected_mode_then_returns_true_without_saving() async {
+    func test_handleSelection_when_mode_matches_selected_mode_then_returns_true_without_saving() async throws {
         // Given
         var didUpdate = false
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -19,18 +19,17 @@ final class AnalyticsUpdateModeBottomSheetViewModelTests: XCTestCase {
                                                                 onModeUpdated: { _ in })
 
         // When
-        let shouldDismiss = await viewModel.handleSelection(.scheduled)
+        let shouldDismiss = try await viewModel.handleSelection(.scheduled)
 
         // Then
         XCTAssertTrue(shouldDismiss)
         XCTAssertFalse(didUpdate)
         XCTAssertEqual(viewModel.selectedMode, .scheduled)
         XCTAssertNil(viewModel.updatingMode)
-        XCTAssertNil(viewModel.updateError)
     }
 
     @MainActor
-    func test_handleSelection_when_update_succeeds_then_updates_selected_mode_and_notifies_dashboard() async {
+    func test_handleSelection_when_update_succeeds_then_updates_selected_mode_and_notifies_dashboard() async throws {
         // Given
         var updatedMode: AnalyticsImportUpdateMode?
         var notifiedMode: AnalyticsImportUpdateMode?
@@ -50,7 +49,7 @@ final class AnalyticsUpdateModeBottomSheetViewModelTests: XCTestCase {
         })
 
         // When
-        let shouldDismiss = await viewModel.handleSelection(.scheduled)
+        let shouldDismiss = try await viewModel.handleSelection(.scheduled)
 
         // Then
         XCTAssertTrue(shouldDismiss)
@@ -58,20 +57,19 @@ final class AnalyticsUpdateModeBottomSheetViewModelTests: XCTestCase {
         XCTAssertEqual(notifiedMode, .scheduled)
         XCTAssertEqual(viewModel.selectedMode, .scheduled)
         XCTAssertNil(viewModel.updatingMode)
-        XCTAssertNil(viewModel.updateError)
     }
 
     @MainActor
-    func test_handleSelection_when_update_fails_then_keeps_selected_mode_and_sets_error() async {
+    func test_handleSelection_when_update_fails_then_keeps_selected_mode_and_throws_error() async {
         // Given
-        let error = NSError(domain: "test", code: 1)
+        let expectedError = NSError(domain: "test", code: 1)
         var notifiedMode: AnalyticsImportUpdateMode?
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: SettingAction.self) { action in
             guard case let .updateAnalyticsImportUpdateMode(_, _, onCompletion) = action else {
                 return
             }
-            onCompletion(.failure(error))
+            onCompletion(.failure(expectedError))
         }
         let viewModel = AnalyticsUpdateModeBottomSheetViewModel(siteID: 123,
                                                                 selectedMode: .immediate,
@@ -81,13 +79,18 @@ final class AnalyticsUpdateModeBottomSheetViewModelTests: XCTestCase {
         })
 
         // When
-        let shouldDismiss = await viewModel.handleSelection(.scheduled)
+        do {
+            _ = try await viewModel.handleSelection(.scheduled)
+            XCTFail("Expected handleSelection to throw.")
+        } catch {
+            let error = error as NSError
+            XCTAssertEqual(error.domain, expectedError.domain)
+            XCTAssertEqual(error.code, expectedError.code)
+        }
 
         // Then
-        XCTAssertFalse(shouldDismiss)
         XCTAssertNil(notifiedMode)
         XCTAssertEqual(viewModel.selectedMode, .immediate)
         XCTAssertNil(viewModel.updatingMode)
-        XCTAssertNotNil(viewModel.updateError)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheetViewModelTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class AnalyticsUpdateModeBottomSheetViewModelTests: XCTestCase {
+    @MainActor
+    func test_handleSelection_when_mode_matches_selected_mode_then_returns_true_without_saving() async {
+        // Given
+        var didUpdate = false
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            if case .updateAnalyticsImportUpdateMode = action {
+                didUpdate = true
+            }
+        }
+        let viewModel = AnalyticsUpdateModeBottomSheetViewModel(siteID: 123,
+                                                                selectedMode: .scheduled,
+                                                                stores: stores,
+                                                                onModeUpdated: { _ in })
+
+        // When
+        let shouldDismiss = await viewModel.handleSelection(.scheduled)
+
+        // Then
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertFalse(didUpdate)
+        XCTAssertEqual(viewModel.selectedMode, .scheduled)
+        XCTAssertNil(viewModel.updatingMode)
+        XCTAssertNil(viewModel.updateError)
+    }
+
+    @MainActor
+    func test_handleSelection_when_update_succeeds_then_updates_selected_mode_and_notifies_dashboard() async {
+        // Given
+        var updatedMode: AnalyticsImportUpdateMode?
+        var notifiedMode: AnalyticsImportUpdateMode?
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            guard case let .updateAnalyticsImportUpdateMode(_, mode, onCompletion) = action else {
+                return
+            }
+            updatedMode = mode
+            onCompletion(.success(()))
+        }
+        let viewModel = AnalyticsUpdateModeBottomSheetViewModel(siteID: 123,
+                                                                selectedMode: .immediate,
+                                                                stores: stores,
+                                                                onModeUpdated: { mode in
+            notifiedMode = mode
+        })
+
+        // When
+        let shouldDismiss = await viewModel.handleSelection(.scheduled)
+
+        // Then
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(updatedMode, .scheduled)
+        XCTAssertEqual(notifiedMode, .scheduled)
+        XCTAssertEqual(viewModel.selectedMode, .scheduled)
+        XCTAssertNil(viewModel.updatingMode)
+        XCTAssertNil(viewModel.updateError)
+    }
+
+    @MainActor
+    func test_handleSelection_when_update_fails_then_keeps_selected_mode_and_sets_error() async {
+        // Given
+        let error = NSError(domain: "test", code: 1)
+        var notifiedMode: AnalyticsImportUpdateMode?
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            guard case let .updateAnalyticsImportUpdateMode(_, _, onCompletion) = action else {
+                return
+            }
+            onCompletion(.failure(error))
+        }
+        let viewModel = AnalyticsUpdateModeBottomSheetViewModel(siteID: 123,
+                                                                selectedMode: .immediate,
+                                                                stores: stores,
+                                                                onModeUpdated: { mode in
+            notifiedMode = mode
+        })
+
+        // When
+        let shouldDismiss = await viewModel.handleSelection(.scheduled)
+
+        // Then
+        XCTAssertFalse(shouldDismiss)
+        XCTAssertNil(notifiedMode)
+        XCTAssertEqual(viewModel.selectedMode, .immediate)
+        XCTAssertNil(viewModel.updatingMode)
+        XCTAssertNotNil(viewModel.updateError)
+    }
+}


### PR DESCRIPTION
Part of WOOMOB-3152

## Description
Adds the Analytics updates bottom sheet for the dashboard analytics update mode setting.

This PR only introduces the reusable sheet and its view model. The dashboard/card wiring is handled in a follow-up PR.

- Adds `AnalyticsUpdateModeBottomSheet` with Scheduled and Immediately options.
- Shows explanatory copy for the store-wide analytics update setting and a Learn more link to WooCommerce Analytics documentation.
- Saves selection changes with `SettingAction.updateAnalyticsImportUpdateMode`.
- Shows a loading indicator for the option currently being saved.
- Dismisses the sheet after a successful update and calls back with the updated mode.
- Shows an error notice when saving fails.
- Adds unit coverage for no-op selection, successful updates, and failed updates.

## Test Steps
1. Open `AnalyticsUpdateModeBottomSheet` in the SwiftUI preview.
2. Confirm the sheet displays the title, description, Learn more link, Scheduled option, Immediately option, and footer text.
3. Confirm the currently selected option shows the checkmark.
4. Tap Learn more and confirm the WooCommerce Analytics documentation web view opens.
5. Review `AnalyticsUpdateModeBottomSheetViewModelTests` to confirm:
   - selecting the already-selected mode does not dispatch an update;
   - selecting a different mode dispatches the setting update and calls the update callback;
   - a failed update preserves the selected mode and surfaces the failure.

Optional: You can also test #17300 to see the bottom sheet in action.

## Screenshots

<img width="294" height="591" alt="image" src="https://github.com/user-attachments/assets/d11fbec1-b1bc-40df-b0de-8d5d0379db28" />



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
