### PR TITLE
Analytics: Show scheduled update setting on dashboard

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/AnalyticsUpdateModeBottomSheet.swift
@@ -145,9 +145,11 @@ extension AnalyticsImportUpdateMode {
 extension AnalyticsUpdateModeBottomSheet {
     enum Constants {
         static let learnMoreURL = "https://woocommerce.com/document/woocommerce-analytics/#section-24"
-        static let learnMoreWebViewModel = WebViewSheetViewModel(url: URL(string: learnMoreURL)!,
-                                                                 navigationTitle: Localization.learnMoreNavigationTitle,
-                                                                 authenticated: false)
+        static let learnMoreWebViewModel = WebViewSheetViewModel(
+            url: URL(string: learnMoreURL)!,
+            navigationTitle: Localization.learnMoreNavigationTitle,
+            authenticated: false
+        )
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -202,6 +202,11 @@ struct DashboardView: View {
         .sheet(isPresented: $viewModel.showingTapToPayAwarenessMoment) {
             TapToPayAwarenessMomentView()
         }
+        .sheet(isPresented: $viewModel.showingAnalyticsImportUpdateModeInfo) {
+            AnalyticsUpdateModeBottomSheet(
+                viewModel: viewModel.makeAnalyticsUpdateModeBottomSheetViewModel()
+            )
+        }
         .onAppear {
             Task {
                 await viewModel.onViewAppear()
@@ -238,11 +243,15 @@ private extension DashboardView {
                             onCustomRangeRedactedViewTap?()
                         }, onViewAllAnalytics: { siteID, siteTimeZone, timeRange in
                             onViewAllAnalytics?(siteID, siteTimeZone, timeRange)
+                        }, onAnalyticsImportUpdateModeInfoTapped: {
+                            viewModel.showAnalyticsImportUpdateModeInfo()
                         })
                     case .topPerformers:
                         TopPerformersDashboardView(viewModel: viewModel.topPerformersViewModel,
                                                    onViewAllAnalytics: { siteID, siteTimeZone, timeRange in
                             onViewAllAnalytics?(siteID, siteTimeZone, timeRange)
+                        }, onAnalyticsImportUpdateModeInfoTapped: {
+                            viewModel.showAnalyticsImportUpdateModeInfo()
                         })
                     case .inbox:
                         InboxDashboardCard(viewModel: viewModel.inboxViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -80,6 +80,7 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var dismissedWPComConnectionSuggestion = false
 
+    @Published private(set) var analyticsImportUpdateMode: AnalyticsImportUpdateMode?
     @Published private var hasOrders = false
 
     @Published private(set) var isEligibleForInbox = false
@@ -89,6 +90,8 @@ final class DashboardViewModel: ObservableObject {
     @Published private(set) var isEligibleForStoreSetup = false
 
     @Published var showingCustomization = false
+
+    @Published var showingAnalyticsImportUpdateModeInfo = false
 
     @Published private(set) var showNewCardsNotice = false
 
@@ -221,6 +224,7 @@ final class DashboardViewModel: ObservableObject {
         self.pushNotificationEligibilityChecker = pushNotificationEligibilityChecker
 
         configureTapToPayAwarnessMomentPresentation()
+        seedAnalyticsImportUpdateModeFromCache()
 
         self.inAppFeedbackCardViewModel.onFeedbackGiven = { [weak self] feedback in
             self?.showingInAppFeedbackSurvey = feedback == .didntLike
@@ -415,6 +419,19 @@ final class DashboardViewModel: ObservableObject {
             await reloadAllData(forceCardsRefresh: true)
         }
     }
+
+    func showAnalyticsImportUpdateModeInfo() {
+        showingAnalyticsImportUpdateModeInfo = true
+    }
+
+    func makeAnalyticsUpdateModeBottomSheetViewModel() -> AnalyticsUpdateModeBottomSheetViewModel {
+        AnalyticsUpdateModeBottomSheetViewModel(siteID: siteID,
+                                                selectedMode: analyticsImportUpdateMode,
+                                                stores: stores,
+                                                onModeUpdated: { [weak self] mode in
+            self?.applyAnalyticsImportUpdateMode(mode)
+        })
+    }
 }
 
 // MARK: Dashboard card persistence
@@ -476,9 +493,12 @@ private extension DashboardViewModel {
         }
 
         // Phase 2: Card availability checks and announcements.
-        // These toggle card visibility and load banners — not needed for initial render.
+        // These toggle card visibility, load banners, and sync analytics card settings - not needed for initial render.
         // Deferred to reduce the concurrent request count in the initial burst.
         await withTaskGroup(of: Void.self) { group in
+            group.addTask { [weak self] in
+                await self?.loadAnalyticsImportUpdateMode()
+            }
             group.addTask { [weak self] in
                 guard let self else { return }
                 await self.syncAnnouncements(for: self.siteID)
@@ -872,6 +892,34 @@ private extension DashboardViewModel {
         productStockCardViewModel.onDismiss = showCustomizationScreen
         lastOrdersCardViewModel.onDismiss = showCustomizationScreen
         googleAdsDashboardCardViewModel.onDismiss = showCustomizationScreen
+    }
+
+    func seedAnalyticsImportUpdateModeFromCache() {
+        guard let cached = AnalyticsImportUpdateMode.cachedValue(siteID: siteID, storageManager: storageManager) else {
+            return
+        }
+        applyAnalyticsImportUpdateMode(cached)
+    }
+
+    @MainActor
+    func loadAnalyticsImportUpdateMode() async {
+        do {
+            let mode: AnalyticsImportUpdateMode = try await withCheckedThrowingContinuation { continuation in
+                let action = SettingAction.retrieveAnalyticsImportUpdateMode(siteID: siteID) { result in
+                    continuation.resume(with: result)
+                }
+                stores.dispatch(action)
+            }
+            applyAnalyticsImportUpdateMode(mode)
+        } catch {
+            DDLogWarn("Could not fetch analytics import update mode: \(error)")
+        }
+    }
+
+    func applyAnalyticsImportUpdateMode(_ mode: AnalyticsImportUpdateMode) {
+        analyticsImportUpdateMode = mode
+        storePerformanceViewModel.setAnalyticsImportUpdateMode(mode)
+        topPerformersViewModel.setAnalyticsImportUpdateMode(mode)
     }
 
     func generateDefaultCards(canShowOnboarding: Bool,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -21,13 +21,16 @@ struct StorePerformanceView: View {
     private let onViewAllAnalytics: (_ siteID: Int64,
                                      _ timeZone: TimeZone,
                                      _ timeRange: StatsTimeRangeV4) -> Void
+    private let onAnalyticsImportUpdateModeInfoTapped: () -> Void
 
     init(viewModel: StorePerformanceViewModel,
          onCustomRangeRedactedViewTap: @escaping () -> Void,
-         onViewAllAnalytics: @escaping (Int64, TimeZone, StatsTimeRangeV4) -> Void) {
+         onViewAllAnalytics: @escaping (Int64, TimeZone, StatsTimeRangeV4) -> Void,
+         onAnalyticsImportUpdateModeInfoTapped: @escaping () -> Void) {
         self.viewModel = viewModel
         self.onCustomRangeRedactedViewTap = onCustomRangeRedactedViewTap
         self.onViewAllAnalytics = onViewAllAnalytics
+        self.onAnalyticsImportUpdateModeInfoTapped = onAnalyticsImportUpdateModeInfoTapped
     }
 
     var body: some View {
@@ -238,9 +241,26 @@ private extension StorePerformanceView {
     }
 
     var timestampView: some View {
-        Text(Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
-            .footnoteStyle()
-            .frame(maxWidth: .infinity, alignment: .center)
+        HStack(alignment: .center, spacing: Layout.timestampInfoSpacing) {
+            Text(viewModel.shouldShowScheduledAnalyticsImportInfo ?
+                 Localization.scheduledUpdatesDelayText :
+                 Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
+                .footnoteStyle()
+
+            if viewModel.shouldShowAnalyticsImportUpdateModeInfoButton {
+                Button {
+                    viewModel.trackAnalyticsImportUpdateModeInfoTapped()
+                    onAnalyticsImportUpdateModeInfoTapped()
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.footnote)
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Localization.scheduledUpdatesInfoAccessibilityLabel)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     func statsItemView(title: String, value: String, redactMode: RedactMode) -> some View {
@@ -390,6 +410,7 @@ private extension StorePerformanceView {
         static let emptyViewSpacing: CGFloat = 24
         static let orderTypeChevronSpacing: CGFloat = 4
         static let orderTypeLabelMinScale: CGFloat = 0.7
+        static let timestampInfoSpacing: CGFloat = 4
     }
 
     enum Localization {
@@ -437,6 +458,11 @@ private extension StorePerformanceView {
             let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the performance card was last updated")
             return String.localizedStringWithFormat(format, time)
         }
+        static let scheduledUpdatesDelayText = NSLocalizedString(
+            "storePerformanceView.scheduledUpdatesDelayText",
+            value: "Stats may be up to 12 hours delayed",
+            comment: "Text shown on the Performance card instead of the last updated timestamp when analytics updates are scheduled."
+        )
         static let unavailableAnalytics = NSLocalizedString(
             "storePerformanceView.unavailableAnalyticsView.title",
             value: "Unable to display your store's performance",
@@ -462,6 +488,11 @@ private extension StorePerformanceView {
             value: "Revenue type",
             comment: "Accessibility label for the segmented control that switches between Gross, Net, and Total revenue on the Performance card."
         )
+        static let scheduledUpdatesInfoAccessibilityLabel = NSLocalizedString(
+            "storePerformanceView.scheduledUpdatesInfoAccessibilityLabel",
+            value: "Analytics update details",
+            comment: "Accessibility label for the info button next to the Performance card's last updated timestamp."
+        )
     }
 }
 
@@ -469,5 +500,6 @@ private extension StorePerformanceView {
     StorePerformanceView(viewModel: StorePerformanceViewModel(siteID: 123,
                                                               usageTracksEventEmitter: .init()),
                          onCustomRangeRedactedViewTap: {},
-                         onViewAllAnalytics: { _, _, _ in })
+                         onViewAllAnalytics: { _, _, _ in },
+                         onAnalyticsImportUpdateModeInfoTapped: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -56,6 +56,10 @@ final class StorePerformanceViewModel: ObservableObject {
     /// merchant initiates a new selection.
     @Published var orderTypeUpdateError: Error?
 
+    /// Currently applied analytics import update mode. `nil` until the value is loaded or seeded
+    /// from cache, so the scheduled-update info affordance only appears after a known `yes` value.
+    @Published private(set) var analyticsImportUpdateMode: AnalyticsImportUpdateMode?
+
     /// Tracks whether the merchant has manually picked an order type during this session.
     /// Prevents a late-arriving initial `loadOrderType` from clobbering a user selection.
     private var hasUserSelectedOrderType = false
@@ -287,6 +291,10 @@ final class StorePerformanceViewModel: ObservableObject {
         analytics.track(event: .Dashboard.performanceCardOrderDateTypeSelectorTapped())
     }
 
+    func trackAnalyticsImportUpdateModeInfoTapped() {
+        trackInteraction()
+    }
+
     /// Switches the displayed revenue metric and persists the choice for next launch. No-op if the
     /// metric matches the current selection. Switching invalidates the highlighted chart point so the
     /// merchant sees the totals for the new metric in the header instead of a stale data point.
@@ -352,6 +360,10 @@ final class StorePerformanceViewModel: ObservableObject {
             analytics.track(event: .Dashboard.performanceCardOrderDateTypeUpdateFailed(error: error))
         }
     }
+
+    func setAnalyticsImportUpdateMode(_ mode: AnalyticsImportUpdateMode) {
+        analyticsImportUpdateMode = mode
+    }
 }
 
 // MARK: - Data for `StorePerformanceView`
@@ -405,6 +417,14 @@ extension StorePerformanceViewModel {
             return false
         }
         return chartViewModel.hasRevenue
+    }
+
+    var shouldShowScheduledAnalyticsImportInfo: Bool {
+        analyticsImportUpdateMode == .scheduled
+    }
+
+    var shouldShowAnalyticsImportUpdateModeInfoButton: Bool {
+        analyticsImportUpdateMode != nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -12,11 +12,14 @@ struct TopPerformersDashboardView: View {
     private let onViewAllAnalytics: (_ siteID: Int64,
                                      _ timeZone: TimeZone,
                                      _ timeRange: StatsTimeRangeV4) -> Void
+    private let onAnalyticsImportUpdateModeInfoTapped: () -> Void
 
     init(viewModel: TopPerformersDashboardViewModel,
-         onViewAllAnalytics: @escaping (Int64, TimeZone, StatsTimeRangeV4) -> Void) {
+         onViewAllAnalytics: @escaping (Int64, TimeZone, StatsTimeRangeV4) -> Void,
+         onAnalyticsImportUpdateModeInfoTapped: @escaping () -> Void) {
         self.viewModel = viewModel
         self.onViewAllAnalytics = onViewAllAnalytics
+        self.onAnalyticsImportUpdateModeInfoTapped = onAnalyticsImportUpdateModeInfoTapped
     }
 
     var body: some View {
@@ -174,9 +177,26 @@ private extension TopPerformersDashboardView {
     }
 
     var timestampView: some View {
-        Text(Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
-            .footnoteStyle()
-            .frame(maxWidth: .infinity, alignment: .center)
+        HStack(alignment: .center, spacing: Layout.timestampInfoSpacing) {
+            Text(viewModel.shouldShowScheduledAnalyticsImportInfo ?
+                 Localization.scheduledUpdatesDelayText :
+                 Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
+                .footnoteStyle()
+
+            if viewModel.shouldShowAnalyticsImportUpdateModeInfoButton {
+                Button {
+                    viewModel.trackAnalyticsImportUpdateModeInfoTapped()
+                    onAnalyticsImportUpdateModeInfoTapped()
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.footnote)
+                        .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Localization.scheduledUpdatesInfoAccessibilityLabel)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     func productDetailView(for item: TopEarnerStatsItem) -> UIViewController {
@@ -192,6 +212,7 @@ private extension TopPerformersDashboardView {
         static let padding: CGFloat = 16
         static let cornerSize = CGSize(width: 8.0, height: 8.0)
         static let hideIconVerticalPadding: CGFloat = 8
+        static let timestampInfoSpacing: CGFloat = 4
     }
 
     enum Localization {
@@ -214,15 +235,26 @@ private extension TopPerformersDashboardView {
             let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the top performers card was last updated")
             return String.localizedStringWithFormat(format, time)
         }
+        static let scheduledUpdatesDelayText = NSLocalizedString(
+            "topPerformersDashboardView.scheduledUpdatesDelayText",
+            value: "Stats may be up to 12 hours delayed",
+            comment: "Text shown on the Top Performers card instead of the last updated timestamp when analytics updates are scheduled."
+        )
         static let unavailableAnalytics = NSLocalizedString(
             "topPerformersDashboardView.unavailableAnalyticsView.title",
             value: "Unable to display your store's top performers",
             comment: "Title when the Top Performers card is disabled because the analytics feature is unavailable"
+        )
+        static let scheduledUpdatesInfoAccessibilityLabel = NSLocalizedString(
+            "topPerformersDashboardView.scheduledUpdatesInfoAccessibilityLabel",
+            value: "Analytics update details",
+            comment: "Accessibility label for the info button next to the Top Performers card's last updated timestamp."
         )
     }
 }
 
 #Preview {
     TopPerformersDashboardView(viewModel: .init(siteID: 123, usageTracksEventEmitter: .init()),
-                               onViewAllAnalytics: { _, _, _ in })
+                               onViewAllAnalytics: { _, _, _ in },
+                               onAnalyticsImportUpdateModeInfoTapped: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -19,6 +19,7 @@ final class TopPerformersDashboardViewModel: ObservableObject {
     @Published var selectedItem: TopEarnerStatsItem?
     @Published private(set) var syncingError: Error?
     @Published private(set) var analyticsEnabled = true
+    @Published private(set) var analyticsImportUpdateMode: AnalyticsImportUpdateMode?
 
     let siteID: Int64
     let siteTimezone: TimeZone
@@ -166,6 +167,14 @@ final class TopPerformersDashboardViewModel: ObservableObject {
         /// tracks `used_analytics`
         usageTracksEventEmitter.interacted()
     }
+
+    func trackAnalyticsImportUpdateModeInfoTapped() {
+        trackInteraction()
+    }
+
+    func setAnalyticsImportUpdateMode(_ mode: AnalyticsImportUpdateMode) {
+        analyticsImportUpdateMode = mode
+    }
 }
 
 // MARK: - Data for `TopPerformersDashboardView`
@@ -197,6 +206,14 @@ extension TopPerformersDashboardViewModel {
             return nil
         }
         return Localization.addCustomRange
+    }
+
+    var shouldShowScheduledAnalyticsImportInfo: Bool {
+        analyticsImportUpdateMode == .scheduled
+    }
+
+    var shouldShowAnalyticsImportUpdateModeInfoButton: Bool {
+        analyticsImportUpdateMode != nil
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -270,7 +270,7 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_analytics_import_update_mode_sheet_view_model_when_save_succeeds_then_updates_dashboard_and_analytics_cards() async {
+    func test_analytics_import_update_mode_sheet_view_model_when_save_succeeds_then_updates_dashboard_and_analytics_cards() async throws {
         // Given
         var updatedMode: AnalyticsImportUpdateMode?
         mockReloadingData(analyticsImportUpdateModeResult: .success(.immediate),
@@ -286,7 +286,7 @@ final class DashboardViewModelTests: XCTestCase {
 
         // When
         let sheetViewModel = viewModel.makeAnalyticsUpdateModeBottomSheetViewModel()
-        let shouldDismiss = await sheetViewModel.handleSelection(.scheduled)
+        let shouldDismiss = try await sheetViewModel.handleSelection(.scheduled)
 
         // Then
         XCTAssertTrue(shouldDismiss)
@@ -295,7 +295,6 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.analyticsImportUpdateMode, .scheduled)
         XCTAssertEqual(viewModel.storePerformanceViewModel.analyticsImportUpdateMode, .scheduled)
         XCTAssertEqual(viewModel.topPerformersViewModel.analyticsImportUpdateMode, .scheduled)
-        XCTAssertNil(sheetViewModel.updateError)
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -114,6 +114,20 @@ final class DashboardViewModelTests: XCTestCase {
                 break
             }
         }
+
+        // SettingAction - dispatched by analytics card view models during init and dashboard data loading
+        storesManager.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveAnalyticsOrderDateType(_, onCompletion):
+                onCompletion(.success(.paid))
+            case let .retrieveAnalyticsImportUpdateMode(_, onCompletion):
+                onCompletion(.success(.immediate))
+            case let .updateAnalyticsImportUpdateMode(_, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
     }
 
     @MainActor
@@ -212,6 +226,76 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.announcementViewModel?.title, "Higher priority JITM")
+    }
+
+    @MainActor
+    func test_reloadAllData_when_analytics_import_update_mode_loads_then_updates_analytics_cards() async {
+        // Given
+        mockReloadingData(analyticsImportUpdateModeResult: .success(.scheduled))
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertEqual(viewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertEqual(viewModel.storePerformanceViewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertEqual(viewModel.topPerformersViewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertTrue(viewModel.storePerformanceViewModel.shouldShowScheduledAnalyticsImportInfo)
+        XCTAssertTrue(viewModel.topPerformersViewModel.shouldShowScheduledAnalyticsImportInfo)
+    }
+
+    @MainActor
+    func test_reloadAllData_when_store_has_no_orders_then_still_loads_analytics_import_update_mode() async {
+        // Given
+        mockReloadingData(storeHasOrders: false,
+                          analyticsImportUpdateModeResult: .success(.scheduled))
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertEqual(viewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertEqual(viewModel.storePerformanceViewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertEqual(viewModel.topPerformersViewModel.analyticsImportUpdateMode, .scheduled)
+    }
+
+    @MainActor
+    func test_analytics_import_update_mode_sheet_view_model_when_save_succeeds_then_updates_dashboard_and_analytics_cards() async {
+        // Given
+        var updatedMode: AnalyticsImportUpdateMode?
+        mockReloadingData(analyticsImportUpdateModeResult: .success(.immediate),
+                          onAnalyticsImportUpdateModeUpdate: { mode in
+            updatedMode = mode
+        })
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+        await viewModel.reloadAllData()
+
+        // When
+        let sheetViewModel = viewModel.makeAnalyticsUpdateModeBottomSheetViewModel()
+        let shouldDismiss = await sheetViewModel.handleSelection(.scheduled)
+
+        // Then
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(updatedMode, .scheduled)
+        XCTAssertEqual(sheetViewModel.selectedMode, .scheduled)
+        XCTAssertEqual(viewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertEqual(viewModel.storePerformanceViewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertEqual(viewModel.topPerformersViewModel.analyticsImportUpdateMode, .scheduled)
+        XCTAssertNil(sheetViewModel.updateError)
     }
 
     @MainActor
@@ -1389,7 +1473,9 @@ private extension DashboardViewModelTests {
                            existingProducts: [Product] = [],
                            existingBlazeCampaigns: [BlazeCampaignListItem] = [],
                            storedDashboardCards: [DashboardCard] = [],
-                           shouldShowInAppFeedback: Bool = false) {
+                           shouldShowInAppFeedback: Bool = false,
+                           analyticsImportUpdateModeResult: Result<AnalyticsImportUpdateMode, Error> = .success(.immediate),
+                           onAnalyticsImportUpdateModeUpdate: ((AnalyticsImportUpdateMode) -> Void)? = nil) {
         stores.whenReceivingAction(ofType: JustInTimeMessageAction.self) { action in
             switch action {
             case let .loadMessage(_, _, _, completion):
@@ -1478,6 +1564,20 @@ private extension DashboardViewModelTests {
                 onCompletion(.success(.fake()))
             case let .fetchAdsCampaigns(_, onCompletion):
                 onCompletion(.success([]))
+            default:
+                break
+            }
+        }
+
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .retrieveAnalyticsOrderDateType(_, onCompletion):
+                onCompletion(.success(.paid))
+            case let .retrieveAnalyticsImportUpdateMode(_, onCompletion):
+                onCompletion(analyticsImportUpdateModeResult)
+            case let .updateAnalyticsImportUpdateMode(_, value, onCompletion):
+                onAnalyticsImportUpdateModeUpdate?(value)
+                onCompletion(.success(()))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -364,6 +364,27 @@ final class StorePerformanceViewModelTests: XCTestCase {
         XCTAssertEqual(properties?["type"], "performance")
     }
 
+    @MainActor
+    func test_shouldShowAnalyticsImportUpdateModeInfoButton_when_setting_has_not_loaded_then_returns_false() {
+        // Given
+        let viewModel = StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init())
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowAnalyticsImportUpdateModeInfoButton)
+    }
+
+    @MainActor
+    func test_shouldShowAnalyticsImportUpdateModeInfoButton_when_setting_has_loaded_then_returns_true() {
+        // Given
+        let viewModel = StorePerformanceViewModel(siteID: 123, usageTracksEventEmitter: .init())
+
+        // When
+        viewModel.setAnalyticsImportUpdateMode(.immediate)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowAnalyticsImportUpdateModeInfoButton)
+    }
+
     // MARK: - Order type bottom sheet
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModelTests.swift
@@ -147,6 +147,27 @@ final class TopPerformersDashboardViewModelTests: XCTestCase {
         let properties = analyticsProvider.receivedProperties[index] as? [String: AnyHashable]
         XCTAssertEqual(properties?["type"], "top_performers")
     }
+
+    @MainActor
+    func test_shouldShowAnalyticsImportUpdateModeInfoButton_when_setting_has_not_loaded_then_returns_false() {
+        // Given
+        let viewModel = TopPerformersDashboardViewModel(siteID: 123, usageTracksEventEmitter: .init())
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowAnalyticsImportUpdateModeInfoButton)
+    }
+
+    @MainActor
+    func test_shouldShowAnalyticsImportUpdateModeInfoButton_when_setting_has_loaded_then_returns_true() {
+        // Given
+        let viewModel = TopPerformersDashboardViewModel(siteID: 123, usageTracksEventEmitter: .init())
+
+        // When
+        viewModel.setAnalyticsImportUpdateMode(.immediate)
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowAnalyticsImportUpdateModeInfoButton)
+    }
 }
 
 private extension TopPerformersDashboardViewModelTests {


### PR DESCRIPTION
Part of WOOMOB-3152

## Description
Updates the dashboard cards to use the Analytics import update mode setting introduced by the base branch.

- Loads the Analytics import update mode from `DashboardViewModel` during the second dashboard essential-data batch, alongside other non-initial dashboard requests.
- Propagates the loaded setting to the Performance and Top Performers cards.
- Shows the info button on those cards only after the setting has loaded.
- Replaces the “Last Updated” timestamp with “Stats may be up to 12 hours delayed” on both cards when the store uses scheduled analytics updates.
- Routes info-button taps back through the dashboard so `DashboardView` presents the Analytics updates bottom sheet.
- Keeps dashboard and card state in sync after the setting is changed from the bottom sheet.
- Adds unit coverage for dashboard loading and the card visibility/wording state.

## Test Steps
1. Open the dashboard for a store with Performance and Top Performers cards available.
2. Confirm the Performance and Top Performers cards do not show the analytics update info button before the setting has loaded.
3. With Analytics updates set to `Scheduled`, confirm both cards show `Stats may be up to 12 hours delayed` with the info button.
4. Tap the info button on either card and confirm the Analytics updates bottom sheet is presented.
5. Change the setting to `Immediately` from the bottom sheet.
6. Confirm both cards update back to the regular `Last Updated` timestamp while still showing the info button.
7. Pull to refresh the dashboard and confirm the setting is loaded again and reflected by both cards.

## Screenshots

https://github.com/user-attachments/assets/732eb49d-7f49-4ba9-9ef9-7c1cba8bf8ec




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
