### PR TITLE
Enable smarter notifications flag and make it remotely controllable

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -128,7 +128,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .arParcelFitting:
             return true
         case .smarterNotifications:
-            return !buildConfig.isProduction
+            return true
         default:
             return true
         }

--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -40,6 +40,7 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
     case pointOfSaleMarkOrderAsPaid
     case wooAIAssistant
     case arParcelFitting
+    case smarterNotifications
 
     init?(rawValue: String) {
         switch rawValue {
@@ -69,6 +70,8 @@ public enum RemoteFeatureFlag: CaseIterable, Hashable, Decodable {
             self = .wooAIAssistant
         case "woo_ar_parcel_fitting":
             self = .arParcelFitting
+        case "smarter_notifications":
+            self = .smarterNotifications
         default:
             return nil
         }

--- a/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
@@ -84,6 +84,17 @@ final class FeatureFlagRemoteTests: XCTestCase {
         XCTAssertEqual(flag, .inPersonPaymentsAustraliaWooPayments)
     }
 
+    func test_rawValue_when_smarter_notifications_then_maps_to_smarterNotifications_case() {
+        // Given
+        let key = "smarter_notifications"
+
+        // When
+        let flag = RemoteFeatureFlag(rawValue: key)
+
+        // Then
+        XCTAssertEqual(flag, .smarterNotifications)
+    }
+
     func test_rawValue_when_unknown_key_then_returns_nil() {
         // Given
         let key = "definitely_not_a_known_flag"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -108,6 +108,7 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking
 
     private var isSelfDrivenPNEligible = false
+    private var isSmarterNotificationsEnabled = false
     private var subscriptions: Set<AnyCancellable> = []
 
     /// Reference to the Zendesk shared instance
@@ -175,7 +176,28 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private func checkPushNotificationEligibility() {
         Task { @MainActor in
             isSelfDrivenPNEligible = await pushNotificationEligibilityChecker.checkEligibility()
+            isSmarterNotificationsEnabled = await checkSmarterNotificationsEligibility()
             reloadSettings()
+        }
+    }
+
+    /// Resolves whether smarter (AI-powered) push notifications are enabled, letting the remote
+    /// feature flag override the local default.
+    @MainActor
+    private func checkSmarterNotificationsEligibility() async -> Bool {
+        let localDefault = featureFlagService.isFeatureFlagEnabled(.smarterNotifications)
+        guard stores.isAuthenticated else {
+            return localDefault
+        }
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(
+                .smarterNotifications,
+                defaultValue: localDefault,
+                useCache: true,
+                completion: { value in
+                    continuation.resume(returning: value)
+                })
+            )
         }
     }
 
@@ -329,7 +351,7 @@ private extension SettingsViewModel {
                 return pushNotesManager.siteIDsRegisteredForWooPNs.contains(siteID)
             }()
             let showPushNotificationPreferences = isRegisteredForWooDrivenPushes
-                && featureFlagService.isFeatureFlagEnabled(.smarterNotifications)
+                && isSmarterNotificationsEnabled
             if showPushNotificationPreferences {
                 rows = [.pushNotificationPreferences, .privacy]
             } else if notificationAvailable && !isSelfDrivenPushNotificationsRegistered {

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -45,7 +45,24 @@ final class MockStoresManager: DefaultStoresManager {
         } else {
             if let callback = receivedActionCallbacks[String(describing: type(of: action))] {
                 callback(action)
+            } else {
+                resolveDefaultIfNeeded(action)
             }
+        }
+    }
+
+    /// Provides a sensible default response for actions whose completion must always be called to
+    /// avoid leaking suspended continuations when a test does not register an explicit callback.
+    ///
+    private func resolveDefaultIfNeeded(_ action: Action) {
+        switch action {
+        case let action as FeatureFlagAction:
+            // Mirror `FeatureFlagStore`: with no remote override configured, resolve to the local default.
+            if case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion) = action {
+                completion(defaultValue)
+            }
+        default:
+            break
         }
     }
 
@@ -86,5 +103,16 @@ extension MockStoresManager {
         }
         let key = String(describing: actionType)
         receivedActionCallbacks[key] = wrappingCallback
+    }
+
+    /// Resolves `FeatureFlagAction.isRemoteFeatureFlagEnabled` by returning the given fixed value,
+    /// regardless of the local `defaultValue` — mimicking a remote override.
+    ///
+    func resolveRemoteFeatureFlag(returning value: Bool) {
+        whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            if case let .isRemoteFeatureFlagEnabled(_, _, _, completion) = action {
+                completion(value)
+            }
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -336,6 +336,27 @@ final class SettingsViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_sections_contains_pushNotificationPreferences_row_when_local_flag_is_off_but_remote_flag_is_on() async {
+        // Given
+        let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: testSite))
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [123], hasStoredSiteIDsRegisteredForWooPNs: true)
+        let featureFlagService = MockFeatureFlagService(smarterNotifications: false)
+        stores.resolveRemoteFeatureFlag(returning: true)
+        let viewModel = SettingsViewModel(stores: stores,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults,
+                                          pushNotesManager: pushNotesManager)
+
+        // When
+        viewModel.onViewDidLoad()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.pushNotificationPreferences) })
+    }
+
+    @MainActor
     func test_sections_does_not_contain_pushNotificationPreferences_row_when_site_is_not_registered() async {
         // Given
         let testSite = Site.fake().copy(siteID: 123, isJetpackThePluginInstalled: true, isJetpackConnected: true)


### PR DESCRIPTION
## Description
Enables the `smarterNotifications` feature flag (AI-powered push notifications) and makes it controllable from the server, so the rollout can be toggled remotely without an app update.

Two changes:
1. **Local flag forced on** — `DefaultFeatureFlagService` now returns `true` for `.smarterNotifications` in all build configurations (was `!buildConfig.isProduction`). This becomes the *default value* / fallback.
2. **Remotely controllable** — added a `smarterNotifications` case to `RemoteFeatureFlag` mapped to the server key `smarter_notifications`. `SettingsViewModel` now resolves the flag via `FeatureFlagAction.isRemoteFeatureFlagEnabled(.smarterNotifications, defaultValue: <local flag>)`, mirroring the existing `selfDrivenPushNotificationsM1` pattern.

**Resolution logic** (`FeatureFlagStore`): debug override → cache → remote value → local default. When the backend has not published the `smarter_notifications` key (or the fetch fails), the local default (`true`) applies. Once the backend defines the key, the remote value wins and can force the flag off or keep it on.

This is gated behind a feature flag.

## Test Steps
1. On a build where the backend does **not** return `smarter_notifications`: go to **Settings**, confirm the "push notification preferences" row appears for a store registered for Woo-driven push notifications (local default `true`).
2. In a debug build, open the **Override Feature Flags** screen → the new `smarterNotifications` remote flag appears. Toggle it off and confirm the Settings row disappears; toggle on and confirm it returns.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.