### PR TITLE
Speculative crash fixes

### DIFF
--- a/Modules/Sources/NetworkingCore/Model/Stats/MIContainer.swift
+++ b/Modules/Sources/NetworkingCore/Model/Stats/MIContainer.swift
@@ -34,7 +34,8 @@ public struct MIContainer {
     let fieldNames: [String]
 
     func fetchStringValue<T: RawRepresentable>(for field: T) -> String where T.RawValue == String {
-        guard let index = fieldNames.firstIndex(of: field.rawValue) else {
+        guard let index = fieldNames.firstIndex(of: field.rawValue),
+              data.indices.contains(index) else {
             return ""
         }
 
@@ -52,14 +53,16 @@ public struct MIContainer {
 
     func fetchIntValue<T: RawRepresentable>(for field: T) -> Int where T.RawValue == String {
         guard let index = fieldNames.firstIndex(of: field.rawValue),
-            let returnValue = self.data[index] as? Int else {
+              data.indices.contains(index),
+              let returnValue = self.data[index] as? Int else {
                 return 0
         }
         return returnValue
     }
 
     func fetchDoubleValue<T: RawRepresentable>(for field: T) -> Double where T.RawValue == String {
-        guard let index = fieldNames.firstIndex(of: field.rawValue) else {
+        guard let index = fieldNames.firstIndex(of: field.rawValue),
+              data.indices.contains(index) else {
             return 0
         }
 

--- a/Modules/Tests/NetworkingTests/Mapper/SiteVisitStatsMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/SiteVisitStatsMapperTests.swift
@@ -103,6 +103,33 @@ class SiteVisitStatsMapperTests: XCTestCase {
         XCTAssertEqual(sampleItem2.visitors, 144)
         XCTAssertEqual(sampleItem2.views, 288)
     }
+
+    func test_map_when_data_row_has_fewer_values_than_fields_then_does_not_crash() throws {
+        // Given
+        let response = """
+        {
+            "date": "2018-08-06",
+            "unit": "day",
+            "fields": [
+                "period",
+                "views",
+                "visitors"
+            ],
+            "data": [
+                [
+                    "2018-08-06",
+                    4
+                ]
+            ]
+        }
+        """.data(using: .utf8)!
+
+        // When
+        _ = try SiteVisitStatsMapper(siteID: sampleSiteID).map(response: response)
+
+        // Then
+        XCTAssertTrue(true)
+    }
 }
 
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 25.0
 -----
 - [*] Fixed duplicating a product overwriting the original product's images; the duplicate now opens after copying. [https://github.com/woocommerce/woocommerce-ios/pull/17291]
+- [*] Fixed several crash-risk code paths in Shipping, Downloadable files, and POS payments [https://github.com/woocommerce/woocommerce-ios/pull/17307]
 
 24.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 25.0
 -----
 - [*] Fixed duplicating a product overwriting the original product's images; the duplicate now opens after copying. [https://github.com/woocommerce/woocommerce-ios/pull/17291]
-- [*] Fixed several crash-risk code paths in Shipping, Downloadable files, and POS payments [https://github.com/woocommerce/woocommerce-ios/pull/17307]
+- [*] Fixed several crash-risk code paths in Shipping Labels, Stats, and Downloadable files [https://github.com/woocommerce/woocommerce-ios/pull/17307]
 
 24.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -501,7 +501,12 @@ extension ShippingLabelFormViewController {
     func displayCustomsFormListVC(customsForms: [ShippingLabelCustomsForm]) {
         guard let countryCode = viewModel.destinationAddress?.country,
               let country = viewModel.countries.first(where: { $0.code == countryCode }) else {
-            fatalError("⛔️ Destination country is not found")
+            let notice = Notice(title: Localization.noticeUnableToFetchCountries, feedbackType: .error, actionTitle: Localization.noticeRetryAction) {
+                [weak self] in
+                self?.viewModel.fetchCountries()
+            }
+            noticePresenter.enqueue(notice: notice)
+            return
         }
         let hostingVC = ShippingCustomsFormListHostingController(order: viewModel.order,
                                                                  customsForms: viewModel.customsForms,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -423,7 +423,7 @@ private extension ShippingLabelFormViewController {
 
 // MARK: - Actions
 //
-private extension ShippingLabelFormViewController {
+extension ShippingLabelFormViewController {
     func displayEditAddressFormVC(address: ShippingLabelAddress?, email: String?, validationError: ShippingLabelAddressValidationError?, type: ShipType) {
         guard viewModel.countries.isNotEmpty else {
             let notice = Notice(title: Localization.noticeUnableToFetchCountries, feedbackType: .error, actionTitle: Localization.noticeRetryAction) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -423,7 +423,7 @@ private extension ShippingLabelFormViewController {
 
 // MARK: - Actions
 //
-extension ShippingLabelFormViewController {
+private extension ShippingLabelFormViewController {
     func displayEditAddressFormVC(address: ShippingLabelAddress?, email: String?, validationError: ShippingLabelAddressValidationError?, type: ShipType) {
         guard viewModel.countries.isNotEmpty else {
             let notice = Notice(title: Localization.noticeUnableToFetchCountries, feedbackType: .error, actionTitle: Localization.noticeRetryAction) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -342,12 +342,16 @@ final class WooShippingAddPackageViewModel: ObservableObject {
                     starredCarriersPackages.insert(carrierID)
                 }
                 // second: undo removing from custom saved
-                if let customPackagesIndex {
-                    customSavedPackages.insert(packageToRemove, at: customPackagesIndex)
+                if let customPackagesIndex,
+                   customSavedPackages.contains(where: { $0.id == packageToRemove.id }) == false {
+                    let insertionIndex = min(customPackagesIndex, customSavedPackages.count)
+                    customSavedPackages.insert(packageToRemove, at: insertionIndex)
                 }
                 // third: undo removing from predefined saved
-                if let predefinedPackagesIndex {
-                    predefinedSavedPackages.insert(packageToRemove, at: predefinedPackagesIndex)
+                if let predefinedPackagesIndex,
+                   predefinedSavedPackages.contains(where: { $0.id == packageToRemove.id }) == false {
+                    let insertionIndex = min(predefinedPackagesIndex, predefinedSavedPackages.count)
+                    predefinedSavedPackages.insert(packageToRemove, at: insertionIndex)
                 }
 
                 notice = Notice(title: Localization.removingPackageFailure,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Split Shipments/WooShippingSplitShipmentsViewModel.swift
@@ -160,30 +160,38 @@ final class WooShippingSplitShipmentsViewModel: ObservableObject {
     }
 
     func didPurchaseLabel(for shipmentIndex: Int, label: ShippingLabel) {
-        let currentShipment = shipments[shipmentIndex]
+        guard let shipmentArrayIndex = shipments.firstIndex(where: { $0.index == shipmentIndex }) else {
+            return
+        }
+
+        let currentShipment = shipments[shipmentArrayIndex]
         let updatedContents = currentShipment.contents.map {
             CollapsibleShipmentItemCardViewModel(item: $0.packageItem, isSelectable: false, currency: order.currency)
         }
-        shipments[shipmentIndex] = Shipment(index: shipmentIndex,
-                                            contents: updatedContents,
-                                            purchasedLabel: label,
-                                            currency: order.currency,
-                                            currencySettings: currencySettings,
-                                            shippingSettingsService: shippingSettingsService)
+        shipments[shipmentArrayIndex] = Shipment(index: currentShipment.index,
+                                                 contents: updatedContents,
+                                                 purchasedLabel: label,
+                                                 currency: order.currency,
+                                                 currencySettings: currencySettings,
+                                                 shippingSettingsService: shippingSettingsService)
         shipmentsSavedInRemote = shipments
     }
 
     func didRequestRefund(for shipmentIndex: Int) {
-        let currentShipment = shipments[shipmentIndex]
+        guard let shipmentArrayIndex = shipments.firstIndex(where: { $0.index == shipmentIndex }) else {
+            return
+        }
+
+        let currentShipment = shipments[shipmentArrayIndex]
         let updatedContents = currentShipment.contents.map {
             CollapsibleShipmentItemCardViewModel(item: $0.packageItem, isSelectable: true, currency: order.currency)
         }
-        shipments[shipmentIndex] = Shipment(index: shipmentIndex,
-                                            contents: updatedContents,
-                                            purchasedLabel: nil,
-                                            currency: order.currency,
-                                            currencySettings: currencySettings,
-                                            shippingSettingsService: shippingSettingsService)
+        shipments[shipmentArrayIndex] = Shipment(index: currentShipment.index,
+                                                 contents: updatedContents,
+                                                 purchasedLabel: nil,
+                                                 currency: order.currency,
+                                                 currencySettings: currencySettings,
+                                                 shippingSettingsService: shippingSettingsService)
         shipmentsSavedInRemote = shipments
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -102,7 +102,9 @@ struct WooShippingCreateLabelsView: View {
                 }
             }
             .sheet(isPresented: $showingCustomsForm) {
-                WooShippingCustomsForm(viewModel: viewModel.currentShipmentDetailsViewModel.customsFormViewModel)
+                if let currentShipmentDetailsViewModel = viewModel.currentShipmentDetailsViewModel {
+                    WooShippingCustomsForm(viewModel: currentShipmentDetailsViewModel.customsFormViewModel)
+                }
             }
             .notice($viewModel.labelPurchaseErrorNotice, autoDismiss: false)
             .notice($viewModel.hazmatNotice)
@@ -207,8 +209,10 @@ private extension WooShippingCreateLabelsView {
                         showingSplitShipments = true
                     })
                 }
-                WooShippingShipmentDetailsView(viewModel: viewModel.currentShipmentDetailsViewModel)
-                    .disabled(viewModel.isPurchasingLabel)
+                if let currentShipmentDetailsViewModel = viewModel.currentShipmentDetailsViewModel {
+                    WooShippingShipmentDetailsView(viewModel: currentShipmentDetailsViewModel)
+                        .disabled(viewModel.isPurchasingLabel)
+                }
             }
             .padding(Layout.contentSpacing)
         }
@@ -340,13 +344,13 @@ private extension WooShippingCreateLabelsView {
                             viewModel.editDestinationAddress()
                         }
                     })
-                } else if let itnMissingNoticeLabel = viewModel.currentShipmentDetailsViewModel.itnMissingNoticeLabel {
+                } else if let itnMissingNoticeLabel = viewModel.currentShipmentDetailsViewModel?.itnMissingNoticeLabel {
                     // Verification notice for missing ITN in customs form
                     verificationNotice(with: itnMissingNoticeLabel,
                                        isVerified: false,
                                        onDismiss: {
                         withAnimation {
-                            viewModel.currentShipmentDetailsViewModel.itnMissingNoticeLabel = nil
+                            viewModel.currentShipmentDetailsViewModel?.itnMissingNoticeLabel = nil
                         }
                     },
                                        onTap: {
@@ -371,14 +375,14 @@ private extension WooShippingCreateLabelsView {
                         }
                         .tint(Color(.primary))
                     }
-                    if shouldShowPurchaseButton || viewModel.currentShipmentDetailsViewModel.selectedPackage != nil {
+                    if shouldShowPurchaseButton || viewModel.currentShipmentDetailsViewModel?.selectedPackage != nil {
                         purchaseButton
                     }
                 }
             }
             else {
                 HStack(spacing: Layout.bottomSheetSpacing) {
-                    if viewModel.currentShipmentDetailsViewModel.selectedPackage != nil || isShipmentDetailsExpanded {
+                    if viewModel.currentShipmentDetailsViewModel?.selectedPackage != nil || isShipmentDetailsExpanded {
                         Toggle(isOn: $viewModel.markOrderComplete) {
                             Text(Localization.BottomSheet.markComplete)
                                 .font(.subheadline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -42,17 +42,20 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private(set) var orderItems: WooShippingItemsViewModel
 
     var canViewLabel: Bool {
-        currentShipmentDetailsViewModel.canViewLabel
+        currentShipmentDetailsViewModel?.canViewLabel ?? false
     }
 
     var postPurchase: WooShippingPostPurchaseViewModel? {
-        currentShipmentDetailsViewModel.postPurchase
+        currentShipmentDetailsViewModel?.postPurchase
     }
 
     @Published private(set) var shipments: [Shipment] {
         didSet {
             updateSelectedShipmentIndex(previousShipments: oldValue)
             updateShipmentDetailsViewModels()
+            if shipments.isEmpty {
+                state = .missingRequiredData
+            }
         }
     }
 
@@ -65,8 +68,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         }
     }
 
-    var currentShipment: Shipment {
-        shipments[boundedSelectedShipmentIndex(for: shipments.count)]
+    var currentShipment: Shipment? {
+        shipments[safe: boundedSelectedShipmentIndex(for: shipments.count)]
     }
 
     var hasUnfulfilledShipments: Bool {
@@ -84,8 +87,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     private(set) var shipmentDetailViewModels: [WooShippingShipmentDetailsViewModel] = []
 
-    var currentShipmentDetailsViewModel: WooShippingShipmentDetailsViewModel {
-        shipmentDetailViewModels[boundedSelectedShipmentIndex(for: shipmentDetailViewModels.count)]
+    var currentShipmentDetailsViewModel: WooShippingShipmentDetailsViewModel? {
+        shipmentDetailViewModels[safe: boundedSelectedShipmentIndex(for: shipmentDetailViewModels.count)]
     }
 
     /// View model for a list of origin addresses to ship from.
@@ -107,7 +110,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Address to ship from (store address), formatted for display and split into separate lines to allow additional formatting.
     var originAddressLines: [String]? {
-        if let shippingLabel = currentShipmentDetailsViewModel.shippingLabel {
+        if let shippingLabel = currentShipmentDetailsViewModel?.shippingLabel {
             shippingLabel.originAddress.formattedPostalAddress?.components(separatedBy: "\n")
         } else {
             originAddress.components(separatedBy: ", ")
@@ -119,7 +122,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     var destinationAddressLines: [String]? {
-        if let shippingLabel = currentShipmentDetailsViewModel.shippingLabel {
+        if let shippingLabel = currentShipmentDetailsViewModel?.shippingLabel {
             shippingLabel.destinationAddress.formattedPostalAddress?.components(separatedBy: "\n")
         } else {
             (destinationAddress?.formattedPostalAddress)?.components(separatedBy: ", ")
@@ -154,7 +157,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// Total cost of the shipping label, formatted for display.
     var totalCost: String? {
-        currentShipmentDetailsViewModel.totalCost
+        currentShipmentDetailsViewModel?.totalCost
     }
 
     private var isMissingStoreSettings: Bool {
@@ -166,7 +169,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     /// If the purchase button should be enabled.
     var isPurchaseButtonEnabled: Bool {
-        currentShipmentDetailsViewModel.isPurchaseButtonEnabled
+        currentShipmentDetailsViewModel?.isPurchaseButtonEnabled ?? false
     }
 
     /// If the label purchase is in progress.
@@ -350,7 +353,8 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             }
         }
 
-        if isMissingStoreSettings ||
+        if shipments.isEmpty ||
+            isMissingStoreSettings ||
             (originAddress.isEmpty && hasUnfulfilledShipments) {
             state = .missingRequiredData
         } else {
@@ -373,6 +377,10 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     /// Purchases a shipping label with the provided label details and settings.
     @MainActor
     func purchaseLabel(shouldRefreshPackageAndRate: Bool) async {
+        guard let currentShipmentDetailsViewModel else {
+            return
+        }
+
         guard paymentMethod != nil else {
             showingPaymentMethods = true
             return
@@ -600,21 +608,37 @@ private extension WooShippingCreateLabelsViewModel {
     }
 
     func observeHAZMATNotices() {
+        guard let currentShipmentDetailsViewModel else {
+            hazmatNotice = nil
+            return
+        }
         currentShipmentDetailsViewModel.$hazmatNotice
             .assign(to: &$hazmatNotice)
     }
 
     func observeSelectedPackage() {
+        guard let currentShipmentDetailsViewModel else {
+            selectedPackage = nil
+            return
+        }
         currentShipmentDetailsViewModel.$selectedPackage
             .assign(to: &$selectedPackage)
     }
 
     func observeSelectedRates() {
+        guard let currentShipmentDetailsViewModel else {
+            selectedRate = nil
+            return
+        }
         currentShipmentDetailsViewModel.$selectedRate
             .assign(to: &$selectedRate)
     }
 
     func observeShippingRates() {
+        guard let currentShipmentDetailsViewModel else {
+            shippingRates = []
+            return
+        }
         currentShipmentDetailsViewModel.$shippingRates
             .assign(to: &$shippingRates)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -53,9 +53,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         didSet {
             updateSelectedShipmentIndex(previousShipments: oldValue)
             updateShipmentDetailsViewModels()
-            if shipments.isEmpty {
-                state = .missingRequiredData
-            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -644,27 +644,33 @@ extension WooShippingCreateLabelsViewModel {
     }
 
     func handleLabelPurchaseSuccess(newLabel: ShippingLabel, in shipment: Shipment) {
-        let index = shipment.index
-        shipments[index] = Shipment(index: index,
-                                    contents: shipment.contents,
-                                    purchasedLabel: newLabel,
-                                    currency: order.currency,
-                                    currencySettings: currencySettings,
-                                    shippingSettingsService: shippingSettingsService)
-        splitShipmentsViewModel.didPurchaseLabel(for: index, label: newLabel)
+        guard let shipmentArrayIndex = shipments.firstIndex(where: { $0.index == shipment.index }) else {
+            return
+        }
+
+        shipments[shipmentArrayIndex] = Shipment(index: shipment.index,
+                                                 contents: shipment.contents,
+                                                 purchasedLabel: newLabel,
+                                                 currency: order.currency,
+                                                 currencySettings: currencySettings,
+                                                 shippingSettingsService: shippingSettingsService)
+        splitShipmentsViewModel.didPurchaseLabel(for: shipment.index, label: newLabel)
         onLabelPurchase?(markOrderComplete)
     }
 
     func handleLabelRefundRequested(labelID: Int64,
                                     in shipment: Shipment) {
-        let shipmentIndex = shipment.index
-        shipments[shipmentIndex] = Shipment(index: shipmentIndex,
-                                            contents: shipment.contents,
-                                            purchasedLabel: nil,
-                                            currency: order.currency,
-                                            currencySettings: currencySettings,
-                                            shippingSettingsService: shippingSettingsService)
-        splitShipmentsViewModel.didRequestRefund(for: shipmentIndex)
+        guard let shipmentArrayIndex = shipments.firstIndex(where: { $0.index == shipment.index }) else {
+            return
+        }
+
+        shipments[shipmentArrayIndex] = Shipment(index: shipment.index,
+                                                 contents: shipment.contents,
+                                                 purchasedLabel: nil,
+                                                 currency: order.currency,
+                                                 currencySettings: currencySettings,
+                                                 shippingSettingsService: shippingSettingsService)
+        splitShipmentsViewModel.didRequestRefund(for: shipment.index)
         refundNotice = Notice(message: Localization.refundNotice)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -566,7 +566,7 @@ extension WooShippingCreateLabelsViewModel {
 }
 
 // MARK: Utils
-extension WooShippingCreateLabelsViewModel {
+private extension WooShippingCreateLabelsViewModel {
 
     func boundedSelectedShipmentIndex(for count: Int) -> Int {
         boundedShipmentIndex(selectedShipmentIndex, count: count)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -51,6 +51,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     @Published private(set) var shipments: [Shipment] {
         didSet {
+            updateSelectedShipmentIndex(previousShipments: oldValue)
             updateShipmentDetailsViewModels()
         }
     }
@@ -65,7 +66,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     }
 
     var currentShipment: Shipment {
-        shipments[selectedShipmentIndex]
+        shipments[boundedSelectedShipmentIndex(for: shipments.count)]
     }
 
     var hasUnfulfilledShipments: Bool {
@@ -84,7 +85,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     private(set) var shipmentDetailViewModels: [WooShippingShipmentDetailsViewModel] = []
 
     var currentShipmentDetailsViewModel: WooShippingShipmentDetailsViewModel {
-        shipmentDetailViewModels[selectedShipmentIndex]
+        shipmentDetailViewModels[boundedSelectedShipmentIndex(for: shipmentDetailViewModels.count)]
     }
 
     /// View model for a list of origin addresses to ship from.
@@ -313,7 +314,7 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
             // Otherwise, compare the purchased labels with the initial selected label.
             switch preselection {
             case .shipment(let index):
-                self.selectedShipmentIndex = index
+                self.selectedShipmentIndex = self.boundedShipmentIndex(index, count: shipments.count)
             case .shippingLabel(let label):
                 if let matchingIndex = shipments.firstIndex(where: { $0.purchasedLabel?.shippingLabelID == label.shippingLabelID }) {
                     self.selectedShipmentIndex = matchingIndex
@@ -567,6 +568,37 @@ extension WooShippingCreateLabelsViewModel {
 // MARK: Utils
 private extension WooShippingCreateLabelsViewModel {
 
+    func boundedSelectedShipmentIndex(for count: Int) -> Int {
+        boundedShipmentIndex(selectedShipmentIndex, count: count)
+    }
+
+    func boundedShipmentIndex(_ index: Int, count: Int) -> Int {
+        min(max(index, 0), max(count - 1, 0))
+    }
+
+    func ensureValidSelectedShipmentIndex() {
+        let boundedIndex = boundedSelectedShipmentIndex(for: shipments.count)
+        if selectedShipmentIndex != boundedIndex {
+            selectedShipmentIndex = boundedIndex
+        }
+    }
+
+    func updateSelectedShipmentIndex(previousShipments: [Shipment]) {
+        guard let previouslySelectedShipment = previousShipments[safe: selectedShipmentIndex] else {
+            ensureValidSelectedShipmentIndex()
+            return
+        }
+
+        if let updatedIndex = shipments.firstIndex(where: { $0.index == previouslySelectedShipment.index }) {
+            guard selectedShipmentIndex != updatedIndex else {
+                return
+            }
+            selectedShipmentIndex = updatedIndex
+        } else {
+            ensureValidSelectedShipmentIndex()
+        }
+    }
+
     func observeHAZMATNotices() {
         currentShipmentDetailsViewModel.$hazmatNotice
             .assign(to: &$hazmatNotice)
@@ -707,7 +739,7 @@ private extension WooShippingCreateLabelsViewModel {
             .delay(for: initialNoticeDelay, scheduler: RunLoop.current)
             .combineLatest($shipments, $selectedShipmentIndex)
             .map { _, shipments, selectedIndex in
-                shipments[selectedIndex].isPurchased == false
+                shipments[safe: selectedIndex]?.isPurchased == false
             }
             .assign(to: &$shouldShowNotices)
     }
@@ -727,7 +759,7 @@ private extension WooShippingCreateLabelsViewModel {
         $paymentMethod
             .combineLatest($shipments, $selectedShipmentIndex)
             .map { paymentMethod, shipments, selectedIndex -> WooShippingPaymentMethodLine? in
-                if shipments[selectedIndex].isPurchased {
+                if shipments[safe: selectedIndex]?.isPurchased == true {
                     return nil
                 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -566,7 +566,7 @@ extension WooShippingCreateLabelsViewModel {
 }
 
 // MARK: Utils
-private extension WooShippingCreateLabelsViewModel {
+extension WooShippingCreateLabelsViewModel {
 
     func boundedSelectedShipmentIndex(for count: Int) -> Int {
         boundedShipmentIndex(selectedShipmentIndex, count: count)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
@@ -77,7 +77,8 @@ final class ProductDownloadListViewModel: ProductDownloadListViewModelOutput {
     }
 
     func insert(_ newElement: ProductDownloadDragAndDrop, at index: Int) {
-        downloadableFiles.insert(newElement, at: index)
+        let insertionIndex = min(max(index, 0), downloadableFiles.count)
+        downloadableFiles.insert(newElement, at: insertionIndex)
     }
 
     func append(_ newElement: ProductDownloadDragAndDrop) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
@@ -124,6 +124,21 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func test_insert_when_reinserting_removed_file_at_original_end_index_then_does_not_crash() throws {
+        // Given
+        let product = Fakes.ProductFactory.productWithDownloadableFiles()
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadListViewModel(product: model)
+        let originalEndIndex = viewModel.count()
+        let removedFile = try XCTUnwrap(viewModel.remove(at: 0))
+
+        // When
+        viewModel.insert(removedFile, at: originalEndIndex)
+
+        // Then
+        XCTAssertTrue(true)
+    }
+
     func test_viewModel_has_unsaved_changes_after_updating_with_the_original_values() {
         // Arrange
         let product = Fakes.ProductFactory.productWithDownloadableFiles()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -77,19 +77,6 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(shippingLabelFormViewModel.originAddress?.phone, expectedPhoneNumber)
     }
 
-    func test_displayCustomsFormListVC_when_destination_country_is_not_loaded_then_does_not_crash() {
-        // Given
-        let destinationAddress = Address.fake().copy(country: "ZZ")
-        let order = Order.fake().copy(shippingAddress: destinationAddress)
-        let viewController = ShippingLabelFormViewController(order: order)
-
-        // When
-        viewController.displayCustomsFormListVC(customsForms: [])
-
-        // Then
-        XCTAssertTrue(true)
-    }
-
     func test_handleOriginAddressValueChanges_returns_updated_ShippingLabelAddress() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Create Shipping Label/ShippingLabelFormViewModelTests.swift
@@ -77,6 +77,19 @@ final class ShippingLabelFormViewModelTests: XCTestCase {
         XCTAssertEqual(shippingLabelFormViewModel.originAddress?.phone, expectedPhoneNumber)
     }
 
+    func test_displayCustomsFormListVC_when_destination_country_is_not_loaded_then_does_not_crash() {
+        // Given
+        let destinationAddress = Address.fake().copy(country: "ZZ")
+        let order = Order.fake().copy(shippingAddress: destinationAddress)
+        let viewController = ShippingLabelFormViewController(order: order)
+
+        // When
+        viewController.displayCustomsFormListVC(customsForms: [])
+
+        // Then
+        XCTAssertTrue(true)
+    }
+
     func test_handleOriginAddressValueChanges_returns_updated_ShippingLabelAddress() {
         // Given
         let shippingLabelFormViewModel = ShippingLabelFormViewModel(order: MockOrders().makeOrder(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/Split shipments/WooShippingSplitShipmentsViewModelTests.swift
@@ -882,6 +882,26 @@ final class WooShippingSplitShipmentsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.shipments[1].purchasedLabel)
     }
 
+    func test_didPurchaseLabel_when_remote_shipment_index_is_not_array_offset_then_does_not_crash() throws {
+        // Given index 7 with only one shipment
+        let items = [sampleItem(id: 1, weight: 5, value: 10, quantity: 2)]
+        let remoteShipments = [
+            WooShippingShipment.fake().copy(index: "7", items: [.init(id: 1, subItems: ["sub-1", "sub-2"])])
+        ]
+        let viewModel = WooShippingSplitShipmentsViewModel(order: sampleOrder,
+                                                           remoteShipments: remoteShipments,
+                                                           items: items,
+                                                           currencySettings: currencySettings,
+                                                           shippingSettingsService: shippingSettingsService)
+        let shipmentIndex = try XCTUnwrap(viewModel.shipments.first?.index)
+
+        // When
+        viewModel.didPurchaseLabel(for: shipmentIndex, label: .fake())
+
+        // Then
+        XCTAssertTrue(true)
+    }
+
     // MARK: - `enableDoneButton`
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingAddPackageViewModelTests.swift
@@ -305,6 +305,44 @@ final class WooShippingAddPackageViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.notice?.feedbackType, .error)
     }
 
+    func test_remove_saved_package_when_later_failure_reinserts_after_another_deletion_then_does_not_crash() throws {
+        // Given
+        let siteID: Int64 = 1
+        let customPackages: [WooShippingCustomPackage] = [
+            .fake().copy(id: "Custom1"),
+            .fake().copy(id: "Custom2")
+        ]
+        let packages = WooShippingPackagesResponse(siteID: siteID,
+                                                   customPackages: customPackages,
+                                                   savedPredefinedPackages: [],
+                                                   allPredefinedOptions: [])
+        let storageManager = MockStorageManager()
+        storageManager.insertSamplePackages(readOnlyPackages: packages)
+
+        let mockStores = MockStoresManager(sessionManager: .testingInstance)
+        var deleteCompletions: [String: (Result<WooShippingCreatePackageResponse, Error>) -> Void] = [:]
+        mockStores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case let .deletePackage(_, packageID, _, completion):
+                deleteCompletions[packageID] = completion
+            default:
+                XCTFail("Received unexpected action: \(action)")
+            }
+        }
+
+        let viewModel = WooShippingAddPackageViewModel(siteID: siteID, stores: mockStores, storage: storageManager)
+        let firstPackage = try XCTUnwrap(viewModel.customSavedPackages.first)
+        let secondPackage = try XCTUnwrap(viewModel.customSavedPackages[safe: 1])
+
+        // When
+        viewModel.removeSavedPackage(secondPackage)
+        viewModel.removeSavedPackage(firstPackage)
+        try XCTUnwrap(deleteCompletions[secondPackage.id])(.failure(NSError(domain: "Test", code: 400)))
+
+        // Then
+        XCTAssertTrue(true)
+    }
+
     func test_it_fetches_and_transforms_packages_from_storage() throws {
         // Given
         let siteID: Int64 = 1

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -619,29 +619,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentShipment.index, 1)
     }
 
-    func test_handleLabelPurchaseSuccess_when_remote_shipment_index_is_not_array_offset_then_does_not_crash() {
-        // Given
-        let order = Order.fake().copy(siteID: siteID, orderID: orderID)
-        let currencySettings = CurrencySettings()
-        let shippingSettingsService = MockShippingSettingsService()
-        let viewModel = WooShippingCreateLabelsViewModel(order: order,
-                                                         currencySettings: currencySettings,
-                                                         shippingSettingsService: shippingSettingsService,
-                                                         storageManager: storageManager)
-        let shipment = Shipment(index: 7,
-                                contents: [],
-                                currency: order.currency,
-                                currencySettings: currencySettings,
-                                shippingSettingsService: shippingSettingsService)
-        viewModel.updateShipments([shipment])
-
-        // When
-        viewModel.handleLabelPurchaseSuccess(newLabel: ShippingLabel.fake(), in: shipment)
-
-        // Then
-        XCTAssertTrue(true)
-    }
-
     func test_destinationPhoneNumberNoticeLabel_is_missing_when_phone_is_empty() {
         // Given
         let labelDestinationAddress = ShippingLabelAddress.fake().copy(phone: "", country: "US")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -548,6 +548,39 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
     }
 
+    func test_currentShipment_when_selected_index_points_past_reloaded_shipments_then_does_not_crash() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        setupInitialDataLoadingMocks(for: stores)
+
+        let order = Order.fake().copy(siteID: siteID, orderID: orderID)
+        let shipments = [
+            WooShippingShipment.fake().copy(siteID: siteID, orderID: orderID, index: "0", items: [WooShippingShipmentItem.fake()]),
+            WooShippingShipment.fake().copy(siteID: siteID, orderID: orderID, index: "1", items: [WooShippingShipmentItem.fake()])
+        ]
+        insert(shipments: shipments, order: order)
+
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        waitUntil {
+            viewModel.shipments.count == 2
+        }
+        viewModel.selectedShipmentIndex = 1
+
+        let storedShipmentToDelete = try XCTUnwrap(storage.allObjects(ofType: StorageWooShippingShipment.self,
+                                                                      matching: NSPredicate(format: "index == %@", "1"),
+                                                                      sortedBy: nil).first)
+
+        // When
+        storage.deleteObject(storedShipmentToDelete)
+        storage.saveIfNeeded()
+        _ = viewModel.currentShipment
+
+        // Then
+        XCTAssertTrue(true)
+    }
+
     func test_destinationPhoneNumberNoticeLabel_is_missing_when_phone_is_empty() {
         // Given
         let labelDestinationAddress = ShippingLabelAddress.fake().copy(phone: "", country: "US")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -581,6 +581,44 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertTrue(true)
     }
 
+    func test_currentShipment_when_earlier_shipment_is_removed_then_preserves_selected_shipment() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        setupInitialDataLoadingMocks(for: stores)
+
+        let order = Order.fake().copy(siteID: siteID, orderID: orderID)
+        let shipments = [
+            WooShippingShipment.fake().copy(siteID: siteID, orderID: orderID, index: "0", items: [WooShippingShipmentItem.fake()]),
+            WooShippingShipment.fake().copy(siteID: siteID, orderID: orderID, index: "1", items: [WooShippingShipmentItem.fake()]),
+            WooShippingShipment.fake().copy(siteID: siteID, orderID: orderID, index: "2", items: [WooShippingShipmentItem.fake()])
+        ]
+        insert(shipments: shipments, order: order)
+
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        waitUntil {
+            viewModel.shipments.count == 3
+        }
+        viewModel.selectedShipmentIndex = 1
+        XCTAssertEqual(viewModel.currentShipment.index, 1)
+
+        let storedShipmentToDelete = try XCTUnwrap(storage.allObjects(ofType: StorageWooShippingShipment.self,
+                                                                      matching: NSPredicate(format: "index == %@", "0"),
+                                                                      sortedBy: nil).first)
+
+        // When
+        storage.deleteObject(storedShipmentToDelete)
+        storage.saveIfNeeded()
+
+        // Then
+        waitUntil {
+            viewModel.shipments.count == 2
+        }
+        XCTAssertEqual(viewModel.selectedShipmentIndex, 0)
+        XCTAssertEqual(viewModel.currentShipment.index, 1)
+    }
+
     func test_destinationPhoneNumberNoticeLabel_is_missing_when_phone_is_empty() {
         // Given
         let labelDestinationAddress = ShippingLabelAddress.fake().copy(phone: "", country: "US")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -534,13 +534,14 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
     }
 
-    func test_hazmatNotice_is_updated_after_setting_new_hazmat_category() {
+    func test_hazmatNotice_is_updated_after_setting_new_hazmat_category() throws {
         // Given
         let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake())
         XCTAssertNil(viewModel.hazmatNotice)
+        let currentShipmentDetailsViewModel = try XCTUnwrap(viewModel.currentShipmentDetailsViewModel)
 
         // When
-        viewModel.currentShipmentDetailsViewModel.hazmatCategory = .class1
+        currentShipmentDetailsViewModel.hazmatCategory = .class1
 
         // Then
         waitUntil {
@@ -581,6 +582,32 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertTrue(true)
     }
 
+    func test_currentShipment_when_shipments_are_empty_then_does_not_crash() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        setupInitialDataLoadingMocks(for: stores)
+
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        waitUntil {
+            viewModel.state != .loading
+        }
+
+        // When
+        viewModel.updateShipments([])
+        _ = viewModel.currentShipment
+        _ = viewModel.currentShipmentDetailsViewModel
+
+        // Then
+        XCTAssertNil(viewModel.currentShipment)
+        XCTAssertNil(viewModel.currentShipmentDetailsViewModel)
+        XCTAssertFalse(viewModel.canViewLabel)
+        XCTAssertFalse(viewModel.isPurchaseButtonEnabled)
+        XCTAssertNil(viewModel.totalCost)
+        XCTAssertEqual(viewModel.state, .missingRequiredData)
+    }
+
     func test_currentShipment_when_earlier_shipment_is_removed_then_preserves_selected_shipment() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -601,7 +628,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             viewModel.shipments.count == 3
         }
         viewModel.selectedShipmentIndex = 1
-        XCTAssertEqual(viewModel.currentShipment.index, 1)
+        XCTAssertEqual(viewModel.currentShipment?.index, 1)
 
         let storedShipmentToDelete = try XCTUnwrap(storage.allObjects(ofType: StorageWooShippingShipment.self,
                                                                       matching: NSPredicate(format: "index == %@", "0"),
@@ -616,7 +643,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             viewModel.shipments.count == 2
         }
         XCTAssertEqual(viewModel.selectedShipmentIndex, 0)
-        XCTAssertEqual(viewModel.currentShipment.index, 1)
+        XCTAssertEqual(viewModel.currentShipment?.index, 1)
     }
 
     func test_destinationPhoneNumberNoticeLabel_is_missing_when_phone_is_empty() {
@@ -739,7 +766,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             viewModel.state == .ready
         }
         await until {
-            viewModel.currentShipmentDetailsViewModel.shippingService != nil
+            viewModel.currentShipmentDetailsViewModel?.shippingService != nil
         }
         viewModel.didUpdateAccountSettings(accountSettings)
 
@@ -771,8 +798,12 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             saturdayDeliveryRate: nil,
             additionalHandlingRate: nil
         )
-        viewModel.currentShipmentDetailsViewModel.selectPackage(package)
-        viewModel.currentShipmentDetailsViewModel.shippingService?.onSelectRate?(selectedRate)
+        guard let currentShipmentDetailsViewModel = viewModel.currentShipmentDetailsViewModel else {
+            XCTFail("Expected a current shipment details view model")
+            return
+        }
+        currentShipmentDetailsViewModel.selectPackage(package)
+        currentShipmentDetailsViewModel.shippingService?.onSelectRate?(selectedRate)
 
         // When
         await viewModel.purchaseLabel(shouldRefreshPackageAndRate: false)
@@ -888,14 +919,15 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(viewModel.currentShipment.purchasedLabel?.shippingLabelID, shippingLabel.shippingLabelID)
+        XCTAssertEqual(viewModel.currentShipment?.purchasedLabel?.shippingLabelID, shippingLabel.shippingLabelID)
         XCTAssertEqual(viewModel.originAddressLines?.first, labelOriginAddress.address1)
 
         // When
         viewModel.selectedShipmentIndex = 1
 
         // Then
-        XCTAssertNil(viewModel.currentShipment.purchasedLabel)
+        XCTAssertEqual(viewModel.currentShipment?.index, 1)
+        XCTAssertNil(viewModel.currentShipment?.purchasedLabel)
         XCTAssertEqual(viewModel.originAddressLines?.first, originAddress.address1)
     }
 
@@ -936,14 +968,15 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(viewModel.currentShipment.purchasedLabel?.shippingLabelID, shippingLabel.shippingLabelID)
+        XCTAssertEqual(viewModel.currentShipment?.purchasedLabel?.shippingLabelID, shippingLabel.shippingLabelID)
         XCTAssertEqual(viewModel.destinationAddressLines?.first, labelDestinationAddress.address1)
 
         // When
         viewModel.selectedShipmentIndex = 1
 
         // Then
-        XCTAssertNil(viewModel.currentShipment.purchasedLabel)
+        XCTAssertEqual(viewModel.currentShipment?.index, 1)
+        XCTAssertNil(viewModel.currentShipment?.purchasedLabel)
         XCTAssertEqual(viewModel.destinationAddressLines?.first, destinationAddress.address1)
     }
 
@@ -1947,7 +1980,7 @@ private extension WooShippingCreateLabelsViewModelTests {
 
         let viewModel = WooShippingCreateLabelsViewModel(order: order, stores: stores, storageManager: storageManager)
         await until { viewModel.state == .ready }
-        await until { viewModel.currentShipmentDetailsViewModel.shippingService != nil }
+        await until { viewModel.currentShipmentDetailsViewModel?.shippingService != nil }
         viewModel.didUpdateAccountSettings(accountSettings)
 
         let package = WooShippingPackageData(id: "box", name: "Box", length: "10", width: "10", height: "5",
@@ -1958,8 +1991,12 @@ private extension WooShippingCreateLabelsViewModelTests {
             signatureRate: nil, adultSignatureRate: nil, carbonNeutralRate: nil,
             saturdayDeliveryRate: nil, additionalHandlingRate: nil
         )
-        viewModel.currentShipmentDetailsViewModel.selectPackage(package)
-        viewModel.currentShipmentDetailsViewModel.shippingService?.onSelectRate?(selectedRate)
+        guard let currentShipmentDetailsViewModel = viewModel.currentShipmentDetailsViewModel else {
+            XCTFail("Expected a current shipment details view model")
+            return viewModel
+        }
+        currentShipmentDetailsViewModel.selectPackage(package)
+        currentShipmentDetailsViewModel.shippingService?.onSelectRate?(selectedRate)
 
         return viewModel
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -619,6 +619,29 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentShipment.index, 1)
     }
 
+    func test_handleLabelPurchaseSuccess_when_remote_shipment_index_is_not_array_offset_then_does_not_crash() {
+        // Given
+        let order = Order.fake().copy(siteID: siteID, orderID: orderID)
+        let currencySettings = CurrencySettings()
+        let shippingSettingsService = MockShippingSettingsService()
+        let viewModel = WooShippingCreateLabelsViewModel(order: order,
+                                                         currencySettings: currencySettings,
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         storageManager: storageManager)
+        let shipment = Shipment(index: 7,
+                                contents: [],
+                                currency: order.currency,
+                                currencySettings: currencySettings,
+                                shippingSettingsService: shippingSettingsService)
+        viewModel.updateShipments([shipment])
+
+        // When
+        viewModel.handleLabelPurchaseSuccess(newLabel: ShippingLabel.fake(), in: shipment)
+
+        // Then
+        XCTAssertTrue(true)
+    }
+
     func test_destinationPhoneNumberNoticeLabel_is_missing_when_phone_is_empty() {
         // Given
         let labelDestinationAddress = ShippingLabelAddress.fake().copy(phone: "", country: "US")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -593,6 +593,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         waitUntil {
             viewModel.state != .loading
         }
+        let previousState = viewModel.state
 
         // When
         viewModel.updateShipments([])
@@ -605,7 +606,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.canViewLabel)
         XCTAssertFalse(viewModel.isPurchaseButtonEnabled)
         XCTAssertNil(viewModel.totalCost)
-        XCTAssertEqual(viewModel.state, .missingRequiredData)
+        XCTAssertEqual(viewModel.state, previousState)
     }
 
     func test_currentShipment_when_earlier_shipment_is_removed_then_preserves_selected_shipment() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR is the result of having an agent hunt for potential crashing bugs. 

I couldn't reproduce any of the crashes it found, but they're detailed at the end of the PR. Instead, I had it write unit tests which cause the crash, then fix the issues.

### Important: How to review this PR
This PR is best reviewed two commits at a time – you'll find the tests added in the first, and then the fix in the second. It'll be really difficult to follow as a single view on `Files changed`.

## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Use a store with WooShipping enabled, saved packages, a valid payment method, and at least one order with 3+ items.

I wasn't able to reproduce any of the crashes manually, these test steps cover the areas which could be affected by the fixes – we don't want to add regressions.

### 1. Analytics Stats Mapper

Area: Dashboard / Analytics Hub

1. Open the Dashboard.
2. Open Analytics Hub / analytics cards.
3. Switch date ranges: today, week, month, year.
4. Pull to refresh.

### 2. Downloadable Product Files

Area: Product editor > Downloadable files

1. Open a downloadable product with files.
2. Reorder files, especially moving an item to the end of the list.
3. Delete a file.
4. Add a new file.
5. Edit an existing file.
6. Save the product.
7. Reopen the product and confirm file order, names, and URLs.

### 3. WooShipping Saved Package Removal

Area: WooShipping create label > package selection > saved packages

1. Start creating a label.
2. Open package selection.
3. Use a store with multiple custom and saved predefined packages (you can add some quickly with the star button and custom tab)
4. Remove a saved package.
5. Remove another package immediately after.
6. If possible, force the delete API to fail for one removal.

### 4. WooShipping Split Shipments

Area: WooShipping create label > split shipments

1. Start a label for an order with 3+ items.
2. Open split shipments.
3. Move items between shipments.
4. Create a new shipment.
5. Return to label creation.
6. Switch between shipment tabs.

### 5. WooShipping Purchase / Refund Shipment Update

Area: WooShipping post-purchase and refund flow

1. Use a multi-shipment order.
2. Select a non-first shipment.
3. Configure package/rate and purchase a label.
4. Confirm only that shipment shows purchased state
5. Request a refund for that label.
6. Confirm only that shipment returns to unpurchased state.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
