### PR TITLE
Decode push notification preferences data envelope

### DIFF
--- a/Modules/Sources/Networking/Remote/PushNotificationPreferencesRemote.swift
+++ b/Modules/Sources/Networking/Remote/PushNotificationPreferencesRemote.swift
@@ -35,7 +35,8 @@ public final class PushNotificationPreferencesRemote: Remote, PushNotificationPr
                                      siteID: siteID,
                                      path: Paths.preferences,
                                      availableAsRESTRequest: true)
-        return try await enqueue(request)
+        let mapper = SingleItemMapper<PushNotificationPreferences>(siteID: siteID)
+        return try await enqueue(request, mapper: mapper)
     }
 
     public func updatePreferences(siteID: Int64,
@@ -47,7 +48,8 @@ public final class PushNotificationPreferencesRemote: Remote, PushNotificationPr
                                      path: Paths.preferences,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        return try await enqueue(request)
+        let mapper = SingleItemMapper<PushNotificationPreferences>(siteID: siteID)
+        return try await enqueue(request, mapper: mapper)
     }
 }
 

--- a/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/PushNotificationPreferencesRemoteTests.swift
@@ -139,6 +139,28 @@ struct PushNotificationPreferencesRemoteTests {
         #expect(preferences.storeStock?.onBackorder == false)
     }
 
+    @Test func loadPreferences_when_response_has_data_envelope_then_decodes_preferences() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences-data-envelope")
+
+        // When
+        let preferences = try await remote.loadPreferences(siteID: sampleSiteID)
+
+        // Then
+        #expect(preferences.storeOrder?.enabled == true)
+        #expect(preferences.storeOrder?.minAmount == nil)
+
+        #expect(preferences.storeReview?.enabled == true)
+        #expect(preferences.storeReview?.maxRating == nil)
+
+        #expect(preferences.storeStock?.enabled == true)
+        #expect(preferences.storeStock?.lowStock == true)
+        #expect(preferences.storeStock?.outOfStock == true)
+        #expect(preferences.storeStock?.onBackorder == true)
+    }
+
     @Test func loadPreferences_when_unknown_top_level_key_present_then_known_fields_still_decode() async throws {
         // Given
         let remote = PushNotificationPreferencesRemote(network: network)
@@ -193,5 +215,24 @@ struct PushNotificationPreferencesRemoteTests {
         #expect(preferences.storeOrder?.enabled == true)
         #expect(preferences.storeReview?.maxRating == 5)
         #expect(preferences.storeStock?.onBackorder == false)
+    }
+
+    @Test func updatePreferences_when_response_has_data_envelope_then_returns_decoded_preferences() async throws {
+        // Given
+        let remote = PushNotificationPreferencesRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "wc-push-notifications/preferences",
+                                 filename: "push-notification-preferences-data-envelope")
+        let changes = PushNotificationPreferences(storeStock: .init(onBackorder: true))
+
+        // When
+        let preferences = try await remote.updatePreferences(siteID: sampleSiteID, changes: changes)
+
+        // Then
+        #expect(preferences.storeOrder?.enabled == true)
+        #expect(preferences.storeOrder?.minAmount == nil)
+        #expect(preferences.storeReview?.enabled == true)
+        #expect(preferences.storeReview?.maxRating == nil)
+        #expect(preferences.storeStock?.enabled == true)
+        #expect(preferences.storeStock?.onBackorder == true)
     }
 }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/push-notification-preferences-data-envelope.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/push-notification-preferences-data-envelope.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "store_order": {
+      "enabled": true,
+      "min_amount": null
+    },
+    "store_review": {
+      "enabled": true,
+      "max_rating": null
+    },
+    "store_stock": {
+      "enabled": true,
+      "low_stock": true,
+      "out_of_stock": true,
+      "on_backorder": true
+    }
+  }
+}


### PR DESCRIPTION
## Description
When using WordPress.com, requests that use Jetpack Tunnel will be wrapped in a top-level `data` envelope. The push notification preferences endpoint was decoding that response directly, which silently produced empty optional preference groups and made the notification preference rows appear Off.

This updates the push notification preferences remote to decode load and update responses through `SingleItemMapper`, matching the shared Networking envelope handling, and adds fixture coverage for the envelope shape.

## Test Steps
Automated verification:

```bash
xcodebuild -workspace WooCommerce.xcworkspace -scheme Networking -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:"NetworkingTests/PushNotificationPreferencesRemoteTests"
```

Manual verification:

1. Sign in using WordPress.com.
2. Select a WooCommerce store that satisfies the Woo-driven push notification conditions:
   - WooCommerce is active and on a version that supports Woo-driven push notifications, and the app feature flag is enabled.
   - The `smarterNotifications` feature flag is enabled.
3. Make sure the preferences request uses the WordPress.com/Jetpack Tunnel path.
4. Go to Settings > Push Notifications.
5. Confirm `New orders`, `New reviews`, and `Stock` show the saved server preferences instead of all showing `Off`.
6. Open one preference detail screen, change a setting, save, and confirm the saved value is reflected when returning to the Push Notifications screen.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.