### PR TITLE
Push notifications: Hide Jetpack benefit banner for JCP site after registering for Woo PN

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -1052,7 +1052,7 @@ private extension DashboardViewModel {
 
     func updateSelfDrivenPushRegistrationStatus() async {
         let registeredSiteIDs = pushNotesManager.siteIDsRegisteredForWooPNs
-        isSelfDrivenPushNotificationRegistered = registeredSiteIDs.contains(siteID) && stores.isAuthenticatedWithoutWPCom
+        isSelfDrivenPushNotificationRegistered = registeredSiteIDs.contains(siteID)
         dismissedWPComConnectionSuggestion = userDefaults.hideWPComConnectionOnDashboard
 
         let isEligibleForSelfDrivenPN = await pushNotificationEligibilityChecker.checkEligibility()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1008,7 +1008,7 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_isSelfDrivenPushNotificationRegistered_returns_false_when_site_is_registered_and_wpcom_login() async {
+    func test_isSelfDrivenPushNotificationRegistered_returns_true_when_site_is_registered_and_wpcom_login() async {
         // Given
         mockReloadingData()
         stores.authenticate(credentials: SessionSettings.wpcomCredentials)
@@ -1027,7 +1027,7 @@ final class DashboardViewModelTests: XCTestCase {
         await viewModel.reloadAllData()
 
         // Then
-        XCTAssertFalse(viewModel.isSelfDrivenPushNotificationRegistered)
+        XCTAssertTrue(viewModel.isSelfDrivenPushNotificationRegistered)
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue with the Jetpack benefit banner being displayed for JCP sites after registering successfully for Woo PN.


## Test Steps
<!-- Describe how to test your changes. Include only what’s needed for the reviewer to validate the behavior.
For new features, outline the main user flow or goal rather than every tap or click — the reviewer should be able to complete the flow naturally.
If applicable, mention key devices, scenarios, or edge cases to verify. -->

Pre-requisite: set up a site that supports Woo PN and account connection for Jetpack but no full Jetpack plugin.
1. Log in to the site on the app.
2. Tap the WPCom connection banner to finish registering for Woo PN.
3. After registration succeeds, verify that you don't see the Jetpack benefit banner.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before | After 
--- | ---
<img width="320" alt="image" src="https://github.com/user-attachments/assets/89f581d0-e6c8-4702-b6b5-c7b0ed45c5cb" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/e198cdfd-5ea4-40de-9bed-5f19d1b5bdc8" />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
