### PR TITLE
[Woo POS][Phone] Always display button for selecting payment method

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
@@ -3,8 +3,21 @@ import SwiftUI
 /// Displays the WooPayments onboarding UI based on the state.
 struct PointOfSaleCardPresentPaymentOnboardingView: View {
     @ObservedObject var viewModel: PointOfSaleCardPresentPaymentOnboardingViewModel
+    @Environment(\.posLayoutScale) private var layoutScale
+    @Environment(\.posModalParentSize) private var parentSize
 
     var body: some View {
+        if isPOSPhoneLayout {
+            content
+                .padding(PointOfSaleReaderConnectionModalLayout.contentPadding)
+                .frame(width: parentSize.width, height: parentSize.height)
+        } else {
+            content
+                .posModalSizing()
+        }
+    }
+
+    private var content: some View {
         VStack(spacing: Constants.verticalSpacing) {
             AnyView(viewModel.onboardingViewContainer.view)
                 // Hides the navigation bar title `navigationTitle` in `CardPresentPaymentsOnboardingView`.
@@ -13,7 +26,10 @@ struct PointOfSaleCardPresentPaymentOnboardingView: View {
         .posModalCloseButton(action: viewModel.cancelOnboarding,
                              accessibilityLabel: Localization.cancelOnboarding)
         .safariSheet(url: $viewModel.onboardingURL)
-        .posModalSizing()
+    }
+
+    private var isPOSPhoneLayout: Bool {
+        layoutScale == .phone && UIDevice.current.userInterfaceIdiom == .phone
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Payments Onboarding/PointOfSaleCardPresentPaymentOnboardingView.swift
@@ -3,21 +3,8 @@ import SwiftUI
 /// Displays the WooPayments onboarding UI based on the state.
 struct PointOfSaleCardPresentPaymentOnboardingView: View {
     @ObservedObject var viewModel: PointOfSaleCardPresentPaymentOnboardingViewModel
-    @Environment(\.posLayoutScale) private var layoutScale
-    @Environment(\.posModalParentSize) private var parentSize
 
     var body: some View {
-        if isPOSPhoneLayout {
-            content
-                .padding(PointOfSaleReaderConnectionModalLayout.contentPadding)
-                .frame(width: parentSize.width, height: parentSize.height)
-        } else {
-            content
-                .posModalSizing()
-        }
-    }
-
-    private var content: some View {
         VStack(spacing: Constants.verticalSpacing) {
             AnyView(viewModel.onboardingViewContainer.view)
                 // Hides the navigation bar title `navigationTitle` in `CardPresentPaymentsOnboardingView`.
@@ -26,10 +13,7 @@ struct PointOfSaleCardPresentPaymentOnboardingView: View {
         .posModalCloseButton(action: viewModel.cancelOnboarding,
                              accessibilityLabel: Localization.cancelOnboarding)
         .safariSheet(url: $viewModel.onboardingURL)
-    }
-
-    private var isPOSPhoneLayout: Bool {
-        layoutScale == .phone && UIDevice.current.userInterfaceIdiom == .phone
+        .posModalSizing(fullScreenWhenCompact: true)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalSizing.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSModalSizing.swift
@@ -2,14 +2,17 @@ import SwiftUI
 
 extension View {
     /// Sets the frame size and applies a padding to a modal in POS.
-    func posModalSizing() -> some View {
-        self.modifier(POSModalSizing())
+    func posModalSizing(fullScreenWhenCompact: Bool = false) -> some View {
+        self.modifier(POSModalSizing(fullScreenWhenCompact: fullScreenWhenCompact))
     }
 }
 
 struct POSModalSizing: ViewModifier {
     @Environment(\.sizeCategory) private var sizeCategory
     @Environment(\.posModalParentSize) private var parentSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+    let fullScreenWhenCompact: Bool
 
     func body(content: Content) -> some View {
         content
@@ -20,6 +23,9 @@ struct POSModalSizing: ViewModifier {
 
 private extension POSModalSizing {
     var frameWidth: CGFloat {
+        if shouldUseFullScreenFrame {
+            return parentSize.width
+        }
         return min(preferredFrameWidth, maxAvailableFrameWidth)
     }
 
@@ -47,6 +53,9 @@ private extension POSModalSizing {
     }
 
     var frameHeight: CGFloat {
+        if shouldUseFullScreenFrame {
+            return parentSize.height
+        }
         return min(preferredFrameHeight, maxAvailableFrameHeight)
     }
 
@@ -83,5 +92,9 @@ private extension POSModalSizing {
             .connectedScenes
             .compactMap { ($0 as? UIWindowScene)?.keyWindow }
             .last
+    }
+
+    var shouldUseFullScreenFrame: Bool {
+        fullScreenWhenCompact && horizontalSizeClass == .compact
     }
 }


### PR DESCRIPTION
Closes WOOMOB-3128

## Description
The button to confirm payment method selection on phone POS settings is hidden outside the view, despite being scrollable, it cannot be seen in first instance, which may cause confusion to the merchant on how to proceed.

## Test Steps

Returning `nil` from `CardPresentPaymentsOnboardingUseCase. storedPreferredPlugin` allows to test repeteadly as does not store the payment preference:

```
    var storedPreferredPlugin: CardPresentPaymentsPlugin? {
        return nil
```

iPad (no regression)

<img width="2266" height="1488" alt="Simulator Screenshot - iPad mini (A17 Pro) - US store - 2026-06-04 at 16 09 34" src="https://github.com/user-attachments/assets/72bd3077-4566-4ad2-951e-b6bd3c574194" />

iPhone (confirm button shows) 

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-06-04 at 15 59 49" src="https://github.com/user-attachments/assets/cebe71f4-bac6-4603-af89-2bdc24d4bdea" />

