### PR TITLE
Prevent POS checkout with mismatched orders

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleOrderController.swift
@@ -276,6 +276,9 @@ private extension PointOfSaleOrderController {
             }
             return .missingProducts(missingProductInfo)
         }
+        else if case .orderDoesNotMatchCart = error as? POSOrderService.POSOrderServiceError {
+            return .orderDoesNotMatchCart
+        }
         else if let couponsError = CouponsError(underlyingError: error) {
             return .invalidCoupon(couponsError.message)
         } else {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleOrderState.swift
@@ -12,6 +12,7 @@ enum PointOfSaleOrderState: Equatable {
         case other(String)
         case invalidCoupon(String)
         case missingProducts([MissingProductInfo])
+        case orderDoesNotMatchCart
 
         struct MissingProductInfo: Equatable {
             let productID: Int64
@@ -27,6 +28,8 @@ enum PointOfSaleOrderState: Equatable {
                 return lhsCoupon == rhsCoupon
             case (.missingProducts(let lhsProducts), .missingProducts(let rhsProducts)):
                 return lhsProducts == rhsProducts
+            case (.orderDoesNotMatchCart, .orderDoesNotMatchCart):
+                return true
             default:
                 return false
             }

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
@@ -9,7 +9,7 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
     init(message: String, retryHandler: @escaping () -> Void) {
         self.title = Localization.title
         self.message = message
-        self.actionTitle = Localization.actionTitle
+        self.actionTitle = Localization.retryActionTitle
         self.action = retryHandler
     }
 
@@ -65,7 +65,7 @@ private extension PointOfSaleOrderSyncErrorMessageView {
             comment: "Title of the error when failing to synchronize order and calculate order totals"
         )
 
-        static let actionTitle = NSLocalizedString(
+        static let retryActionTitle = NSLocalizedString(
             "pointOfSale.orderSync.error.tryAgain",
             value: "Try again",
             comment: "Button title to retry synchronizing order and calculating order totals"

--- a/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
@@ -1,8 +1,24 @@
 import SwiftUI
 
 struct PointOfSaleOrderSyncErrorMessageView: View {
+    let title: String
     let message: String
-    let retryHandler: () -> Void
+    let actionTitle: String
+    let action: () -> Void
+
+    init(message: String, retryHandler: @escaping () -> Void) {
+        self.title = Localization.title
+        self.message = message
+        self.actionTitle = Localization.actionTitle
+        self.action = retryHandler
+    }
+
+    init(title: String, message: String, actionTitle: String, action: @escaping () -> Void) {
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.action = action
+    }
 
     var body: some View {
         HStack(alignment: .center) {
@@ -12,7 +28,7 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
                 POSErrorExclamationMark(size: .large)
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.imageAndTextSpacing)
                 VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text(Localization.title)
+                    Text(title)
                         .foregroundStyle(Color.posOnSurface)
                         .font(.posHeadingBold)
 
@@ -22,7 +38,7 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
                         .padding([.leading, .trailing])
                 }
                 Spacer().frame(height: PointOfSaleCardPresentPaymentLayout.textAndButtonSpacing)
-                Button(Localization.actionTitle, action: retryHandler)
+                Button(actionTitle, action: action)
                     .buttonStyle(POSFilledButtonStyle(size: .normal))
                     .padding([.leading, .trailing], Constants.buttonSidePadding)
                     .padding([.bottom], Constants.buttonBottomPadding)

--- a/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/TotalsView.swift
@@ -121,6 +121,15 @@ struct TotalsView: View {
                 PointOfSaleOrderSyncErrorMessageView(message: message, retryHandler: handler)
                     .transition(.opacity)
 
+            case .error(.orderDoesNotMatchCart, _):
+                PointOfSaleOrderSyncErrorMessageView(
+                    title: Localization.orderMismatchTitle,
+                    message: Localization.orderMismatchMessage,
+                    actionTitle: Localization.orderMismatchActionTitle,
+                    action: posModel.addMoreToCart
+                )
+                    .transition(.opacity)
+
             case .error(.invalidCoupon(let message), let handler):
                 PointOfSaleOrderSyncCouponsErrorMessageView(message: message, retryHandler: handler)
                     .transition(.opacity)
@@ -417,6 +426,18 @@ private extension TotalsView {
             value: "Other payment methods",
             comment: "Title for the Other payment methods button shown alongside the Tap to Pay hero on phone POS checkout. "
                 + "Tapping it opens a sheet with non-TTP options (currently Card reader).")
+        static let orderMismatchTitle = NSLocalizedString(
+            "pos.totalsView.orderMismatch.error.title",
+            value: "Couldn't check out",
+            comment: "Title shown when the POS order created by the server does not match the cart contents.")
+        static let orderMismatchMessage = NSLocalizedString(
+            "pos.totalsView.orderMismatch.error.message",
+            value: "There was a problem creating this order, the items don't match your selection. Check the cart contents and try again.",
+            comment: "Message shown when the POS order created by the server does not match the cart contents.")
+        static let orderMismatchActionTitle = NSLocalizedString(
+            "pos.totalsView.orderMismatch.error.editOrder",
+            value: "Edit order",
+            comment: "Button to return to item selection when the POS order created by the server does not match the cart contents.")
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -42,8 +42,10 @@ public extension POSCart {
         return CartOrderComparison(
             missingItems: itemsComparison.missingItems,
             quantityMismatches: itemsComparison.quantityMismatches,
+            extraItemsCount: itemsComparison.extraItemsCount,
             couponsMatch: couponsMatch,
-            customAmountsMatch: customAmountsMatch
+            customAmountsMatch: customAmountsMatch,
+            extraCustomAmountsCount: customAmounts.extraActiveFeesCount(order: order)
         )
     }
 }
@@ -54,14 +56,23 @@ public struct CartOrderComparison {
     public let missingItems: [MissingCartItem]
     /// Items where the quantity in the order doesn't match the cart
     public let quantityMismatches: [QuantityMismatch]
+    /// Number of product/variation groups found in the order but not in the cart
+    public let extraItemsCount: Int
     /// Whether the coupons in the cart match the order
     public let couponsMatch: Bool
     /// Whether the custom amounts in the cart match the order's active fee lines
     public let customAmountsMatch: Bool
+    /// Number of active fee lines found in the order but not in the cart
+    public let extraCustomAmountsCount: Int
 
     /// Returns true if there are any discrepancies between cart and order
     public var hasDiscrepancies: Bool {
         return !missingItems.isEmpty || !quantityMismatches.isEmpty || !couponsMatch || !customAmountsMatch
+    }
+
+    /// Returns true when the order has remote-added lines that are not present in the cart.
+    public var hasRemoteAdditions: Bool {
+        return extraItemsCount > 0 || extraCustomAmountsCount > 0
     }
 
     /// Represents an item that was expected in the cart but is missing from the order
@@ -94,6 +105,10 @@ extension [POSCartItem] {
             return self.isEmpty
         }
 
+        guard !self.isEmpty else {
+            return order.items.isEmpty
+        }
+
         let consolidatedCartItems = self.reduce(into: [POSCartItem]()) { partialResult, nextItem in
             if let matchingIndex = partialResult.firstIndex(where: { $0.item.isEqual(to: nextItem.item) }) {
                 let itemToUpdate = partialResult[matchingIndex]
@@ -110,10 +125,6 @@ extension [POSCartItem] {
             } else {
                 partialResult.append(nextItem)
             }
-        }
-
-        guard consolidatedCartItems.count == consolidatedOrderItems.count else {
-            return false
         }
 
         for cartItem in consolidatedCartItems {
@@ -139,7 +150,7 @@ extension [POSCartItem] {
                     name: cartItem.item.name
                 )
             }
-            return ItemsComparison(missingItems: missingItems, quantityMismatches: [])
+            return ItemsComparison(missingItems: missingItems, quantityMismatches: [], extraItemsCount: 0)
         }
 
         // Group cart items by product/variation ID to consolidate duplicates
@@ -159,9 +170,10 @@ extension [POSCartItem] {
         }
 
         // Group order items by product/variation ID
-        let orderQuantities = Dictionary(grouping: order.items, by: { (item: OrderItem) -> String in
+        let orderItemsByProductKey = Dictionary(grouping: order.items, by: { (item: OrderItem) -> String in
             item.variationID != 0 ? "variation_\(item.variationID)" : "product_\(item.productID)"
-        }).mapValues { items in
+        })
+        let orderQuantities = orderItemsByProductKey.mapValues { items in
             items.reduce(Decimal(0)) { $0 + $1.quantity }
         }
 
@@ -199,7 +211,9 @@ extension [POSCartItem] {
             }
         }
 
-        return ItemsComparison(missingItems: missingItems, quantityMismatches: quantityMismatches)
+        let extraItemsCount = orderItemsByProductKey.keys.filter { cartQuantities[$0] == nil }.count
+
+        return ItemsComparison(missingItems: missingItems, quantityMismatches: quantityMismatches, extraItemsCount: extraItemsCount)
     }
 
     private func extractProductIDs(from item: POSOrderableItem) -> (productID: Int64, variationID: Int64)? {
@@ -217,6 +231,7 @@ extension [POSCartItem] {
     struct ItemsComparison {
         let missingItems: [CartOrderComparison.MissingCartItem]
         let quantityMismatches: [CartOrderComparison.QuantityMismatch]
+        let extraItemsCount: Int
     }
 
     func createGroupedOrderSyncProductInputs() -> [OrderSyncProductInput.ProductType: OrderSyncProductInput] {

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -67,12 +67,12 @@ public struct CartOrderComparison {
 
     /// Returns true if there are any discrepancies between cart and order
     public var hasDiscrepancies: Bool {
-        return !missingItems.isEmpty || !quantityMismatches.isEmpty || !couponsMatch || !customAmountsMatch
+        return !missingItems.isEmpty || !quantityMismatches.isEmpty || extraItemsCount > 0 || !couponsMatch || !customAmountsMatch
     }
 
-    /// Returns true when the order has remote-added lines that are not present in the cart.
+    /// Returns true when the order has allowed remote-added fee lines that are not present in the cart.
     public var hasRemoteAdditions: Bool {
-        return extraItemsCount > 0 || extraCustomAmountsCount > 0
+        return extraCustomAmountsCount > 0
     }
 
     /// Represents an item that was expected in the cart but is missing from the order
@@ -134,6 +134,15 @@ extension [POSCartItem] {
                 return false
             }
         }
+
+        for orderItem in consolidatedOrderItems {
+            guard consolidatedCartItems.contains(where: { cartItem in
+                cartItem.item.matches(orderItem: orderItem) && cartItem.quantity == orderItem.quantity
+            }) else {
+                return false
+            }
+        }
+
         return true
     }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCart.swift
@@ -37,15 +37,15 @@ public extension POSCart {
     func compareWithOrder(_ order: Order?) -> CartOrderComparison {
         let itemsComparison = items.compareWithOrder(order)
         let couponsMatch = coupons.matches(order: order)
-        let customAmountsMatch = customAmounts.matches(order: order)
+        let customAmountComparison = customAmounts.comparison(with: order)
 
         return CartOrderComparison(
             missingItems: itemsComparison.missingItems,
             quantityMismatches: itemsComparison.quantityMismatches,
             extraItemsCount: itemsComparison.extraItemsCount,
             couponsMatch: couponsMatch,
-            customAmountsMatch: customAmountsMatch,
-            extraCustomAmountsCount: customAmounts.extraActiveFeesCount(order: order)
+            customAmountsMatch: customAmountComparison.matches,
+            extraCustomAmountsCount: customAmountComparison.extraFeesCount
         )
     }
 }
@@ -62,7 +62,10 @@ public struct CartOrderComparison {
     public let couponsMatch: Bool
     /// Whether the custom amounts in the cart match the order's active fee lines
     public let customAmountsMatch: Bool
-    /// Number of active fee lines found in the order but not in the cart
+    /// Number of active fee lines found in the order but not in the cart.
+    ///
+    /// Remote-added fee lines are allowed so stores can add charges from snippets or plugins. They are tracked for logging,
+    /// but do not count as cart-order discrepancies.
     public let extraCustomAmountsCount: Int
 
     /// Returns true if there are any discrepancies between cart and order

--- a/Modules/Sources/Yosemite/Tools/POS/POSCustomAmount.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCustomAmount.swift
@@ -29,27 +29,34 @@ extension [POSCustomAmount] {
     /// intent (e.g. a tax-exempt customer or store-level tax-class override). Treating
     /// a divergence on `isTaxable` as a mismatch would force a redundant resync every
     /// time the merchant places a taxable custom amount on a non-taxable order.
+    /// Remote-added fees are allowed so server plugins can add their own charges.
     func matches(order: Order?) -> Bool {
-        let activeOrderFees = order?.fees.filter { !$0.isDeleted } ?? []
-        guard self.count == activeOrderFees.count else {
-            return false
-        }
-
-        let cartSummaries = self
-            .map { CustomAmountSummary(name: $0.name, amount: $0.amount) }
-            .sorted()
-        let orderSummaries = activeOrderFees
-            .map { CustomAmountSummary(name: $0.name ?? "", amount: $0.total) }
-            .sorted()
-        return cartSummaries == orderSummaries
+        return comparison(with: order).matches
     }
 
-    private struct CustomAmountSummary: Hashable, Comparable {
+    func extraActiveFeesCount(order: Order?) -> Int {
+        return comparison(with: order).extraFeesCount
+    }
+
+    private func comparison(with order: Order?) -> (matches: Bool, extraFeesCount: Int) {
+        let activeOrderFees = order?.fees.filter { !$0.isDeleted } ?? []
+        let cartSummaries = self
+            .map { CustomAmountSummary(name: $0.name, amount: $0.amount) }
+        var unmatchedOrderSummaries = activeOrderFees
+            .map { CustomAmountSummary(name: $0.name ?? "", amount: $0.total) }
+
+        for cartSummary in cartSummaries {
+            guard let matchingIndex = unmatchedOrderSummaries.firstIndex(of: cartSummary) else {
+                return (matches: false, extraFeesCount: unmatchedOrderSummaries.count)
+            }
+            unmatchedOrderSummaries.remove(at: matchingIndex)
+        }
+
+        return (matches: true, extraFeesCount: unmatchedOrderSummaries.count)
+    }
+
+    private struct CustomAmountSummary: Hashable {
         let name: String
         let amount: String
-
-        static func < (lhs: Self, rhs: Self) -> Bool {
-            (lhs.name, lhs.amount) < (rhs.name, rhs.amount)
-        }
     }
 }

--- a/Modules/Sources/Yosemite/Tools/POS/POSCustomAmount.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCustomAmount.swift
@@ -38,7 +38,7 @@ extension [POSCustomAmount] {
         return comparison(with: order).extraFeesCount
     }
 
-    private func comparison(with order: Order?) -> (matches: Bool, extraFeesCount: Int) {
+    func comparison(with order: Order?) -> (matches: Bool, extraFeesCount: Int) {
         let activeOrderFees = order?.fees.filter { !$0.isDeleted } ?? []
         let cartSummaries = self
             .map { CustomAmountSummary(name: $0.name, amount: $0.amount) }

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -95,12 +95,15 @@ public final class POSOrderService: POSOrderServiceProtocol {
             DDLogWarn("""
                 ⚠️ Order created but cart-order mismatch detected. \
                 Missing items: \(comparison.missingItems.count), \
-                Quantity mismatches: \(comparison.quantityMismatches.count)
+                Quantity mismatches: \(comparison.quantityMismatches.count), \
+                Coupons match: \(comparison.couponsMatch), \
+                Custom amounts match: \(comparison.customAmountsMatch)
                 """)
 
             if !comparison.missingItems.isEmpty {
                 throw POSOrderServiceError.missingProductsInOrder(comparison.missingItems)
             }
+            throw POSOrderServiceError.orderDoesNotMatchCart
         }
 
         return createdOrder
@@ -223,9 +226,23 @@ private extension POSCustomAmount {
 }
 
 public extension POSOrderService {
-    enum POSOrderServiceError: Error {
+    enum POSOrderServiceError: Error, LocalizedError {
         case updateOrderFailed
         case missingProductsInOrder([CartOrderComparison.MissingCartItem])
+        case orderDoesNotMatchCart
+
+        public var errorDescription: String? {
+            switch self {
+            case .orderDoesNotMatchCart:
+                return NSLocalizedString(
+                    "pointOfSale.orderController.orderDoesNotMatchCart",
+                    value: "We couldn't sync the cart exactly. Review the cart and try checking out again.",
+                    comment: "Error displayed in Point of Sale checkout when the created order does not match the cart contents."
+                )
+            default:
+                return nil
+            }
+        }
     }
 }
 

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -96,14 +96,24 @@ public final class POSOrderService: POSOrderServiceProtocol {
                 ⚠️ Order created but cart-order mismatch detected. \
                 Missing items: \(comparison.missingItems.count), \
                 Quantity mismatches: \(comparison.quantityMismatches.count), \
+                Extra items: \(comparison.extraItemsCount), \
                 Coupons match: \(comparison.couponsMatch), \
-                Custom amounts match: \(comparison.customAmountsMatch)
+                Custom amounts match: \(comparison.customAmountsMatch), \
+                Extra custom amounts: \(comparison.extraCustomAmountsCount)
                 """)
 
             if !comparison.missingItems.isEmpty {
                 throw POSOrderServiceError.missingProductsInOrder(comparison.missingItems)
             }
             throw POSOrderServiceError.orderDoesNotMatchCart
+        }
+
+        if comparison.hasRemoteAdditions {
+            DDLogInfo("""
+                ℹ️ POS order contains remote-added lines. \
+                Extra product groups: \(comparison.extraItemsCount), \
+                Extra fee lines: \(comparison.extraCustomAmountsCount)
+                """)
         }
 
         return createdOrder
@@ -235,8 +245,8 @@ public extension POSOrderService {
             switch self {
             case .orderDoesNotMatchCart:
                 return NSLocalizedString(
-                    "pointOfSale.orderController.orderDoesNotMatchCart",
-                    value: "We couldn't sync the cart exactly. Review the cart and try checking out again.",
+                    "pointOfSale.orderController.orderDoesNotMatchCart2",
+                    value: "There was a problem creating this order, the items don't match your selection. Check the cart contents and try again.",
                     comment: "Error displayed in Point of Sale checkout when the created order does not match the cart contents."
                 )
             default:

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -110,8 +110,7 @@ public final class POSOrderService: POSOrderServiceProtocol {
 
         if comparison.hasRemoteAdditions {
             DDLogInfo("""
-                ℹ️ POS order contains remote-added lines. \
-                Extra product groups: \(comparison.extraItemsCount), \
+                ℹ️ POS order contains remote-added fee lines. \
                 Extra fee lines: \(comparison.extraCustomAmountsCount)
                 """)
         }

--- a/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSOrderService.swift
@@ -238,6 +238,7 @@ public extension POSOrderService {
     enum POSOrderServiceError: Error, LocalizedError {
         case updateOrderFailed
         case missingProductsInOrder([CartOrderComparison.MissingCartItem])
+        /// The localized description is shown in POS checkout when the created order does not match the cart contents.
         case orderDoesNotMatchCart
 
         public var errorDescription: String? {

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleOrderControllerTests.swift
@@ -8,6 +8,7 @@ import struct Yosemite.OrderItem
 import struct Yosemite.OrderCouponLine
 import struct Yosemite.SystemPlugin
 import enum Yosemite.OrderAction
+import class Yosemite.POSOrderService
 import protocol Yosemite.PluginsServiceProtocol
 import class WooFoundation.CurrencySettings
 import protocol WooFoundation.Analytics
@@ -192,6 +193,44 @@ struct PointOfSaleOrderControllerTests {
             .idle,
             .syncing,
             .error(.other(MockPOSOrderServiceError.noOrderToReturn.localizedDescription), {})
+        ])
+    }
+
+    @Test func syncOrder_when_order_does_not_match_cart_then_sets_orderDoesNotMatchCart_error() async throws {
+        // Given
+        let sut = PointOfSaleOrderController(orderService: mockOrderService,
+                                             receiptSender: mockReceiptSender,
+                                             currencySettingsProvider: MockCurrencySettingsProvider(),
+                                             analytics: MockPOSAnalytics())
+        mockOrderService.errorToReturn = POSOrderService.POSOrderServiceError.orderDoesNotMatchCart
+
+        var orderStates: [PointOfSaleInternalOrderState] = [sut.orderState]
+        var orderStateAppendTask: Task<Void, Never>? = nil
+        await confirmation(expectedCount: 2) { confirmation in
+            @Sendable func observeOrderState() {
+                withObservationTracking {
+                    _ = sut.orderState
+                } onChange: {
+                    orderStateAppendTask = Task { @MainActor in
+                        orderStates.append(sut.orderState)
+                    }
+                    confirmation()
+                    observeOrderState()
+                }
+            }
+            observeOrderState()
+
+            // When
+            await sut.syncOrder(for: Cart(purchasableItems: [makeItem()]), retryHandler: {})
+        }
+
+        await orderStateAppendTask?.value
+
+        // Then
+        #expect(orderStates == [
+            .idle,
+            .syncing,
+            .error(.orderDoesNotMatchCart, {})
         ])
     }
 

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
@@ -20,6 +20,14 @@ struct POSCartItemTests {
         #expect([POSCartItem]().matches(order: order) == true)
     }
 
+    @Test func empty_cart_does_not_match_order_with_items() async throws {
+        // Given
+        let order = Order.fake().copy(items: [OrderItem.fake().copy(productID: 3, quantity: 1)])
+
+        // When, Then
+        #expect([POSCartItem]().matches(order: order) == false)
+    }
+
     @Test func cart_with_item_does_not_match_nil_order() async throws {
         // Given
         let sut = [makeCartItem(quantity: 1, matching: [])]
@@ -90,7 +98,7 @@ struct POSCartItemTests {
         #expect(sut.matches(order: order) == true)
     }
 
-    @Test func cart_with_item_matching_order_item_does_not_match_order_with_additional_non_matching_item() async throws {
+    @Test func cart_with_item_matching_order_item_matches_order_with_additional_non_matching_item() async throws {
         // Given
         let orderItem = OrderItem.fake().copy(productID: 3, quantity: 2)
         let orderItem2 = OrderItem.fake().copy(productID: 6, quantity: 1)
@@ -98,7 +106,7 @@ struct POSCartItemTests {
         let sut = [makeCartItem(quantity: 2, matcher: { $0.productID == 3 })]
 
         // When, Then
-        #expect(sut.matches(order: order) == false)
+        #expect(sut.matches(order: order) == true)
     }
 
     private func makeCartItem(

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCartItemTests.swift
@@ -98,15 +98,15 @@ struct POSCartItemTests {
         #expect(sut.matches(order: order) == true)
     }
 
-    @Test func cart_with_item_matching_order_item_matches_order_with_additional_non_matching_item() async throws {
+    @Test func cart_with_item_matching_order_item_does_not_match_order_with_additional_non_matching_item() async throws {
         // Given
         let orderItem = OrderItem.fake().copy(productID: 3, quantity: 2)
         let orderItem2 = OrderItem.fake().copy(productID: 6, quantity: 1)
         let order = Order.fake().copy(items: [orderItem, orderItem2])
-        let sut = [makeCartItem(quantity: 2, matcher: { $0.productID == 3 })]
+        let sut = [makeCartItem(quantity: 2, matching: [orderItem])]
 
         // When, Then
-        #expect(sut.matches(order: order) == true)
+        #expect(sut.matches(order: order) == false)
     }
 
     private func makeCartItem(

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSCustomAmountTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSCustomAmountTests.swift
@@ -21,6 +21,15 @@ struct POSCustomAmountTests {
         #expect([POSCustomAmount]().matches(order: order) == true)
     }
 
+    @Test func empty_cart_matches_order_with_remote_added_fee() async throws {
+        // Given
+        let fee = OrderFeeLine.fake().copy(name: "Plugin fee", total: "2.50")
+        let order = Order.fake().copy(fees: [fee])
+
+        // When, Then
+        #expect([POSCustomAmount]().matches(order: order) == true)
+    }
+
     @Test func cart_with_custom_amount_does_not_match_order_with_no_fees() async throws {
         // Given
         let order = Order.fake()
@@ -60,7 +69,7 @@ struct POSCustomAmountTests {
         #expect(sut.matches(order: order) == false)
     }
 
-    @Test func cart_with_custom_amount_does_not_match_order_with_extra_fee() async throws {
+    @Test func cart_with_custom_amount_matches_order_with_extra_remote_added_fee() async throws {
         // Given
         let fee1 = OrderFeeLine.fake().copy(name: "Tip", total: "5.00")
         let fee2 = OrderFeeLine.fake().copy(name: "Delivery", total: "2.50")
@@ -68,7 +77,7 @@ struct POSCustomAmountTests {
         let sut = [POSCustomAmount(name: "Tip", amount: "5.00", isTaxable: false)]
 
         // When, Then
-        #expect(sut.matches(order: order) == false)
+        #expect(sut.matches(order: order) == true)
     }
 
     @Test func cart_with_multiple_custom_amounts_matches_order_with_all_fees() async throws {

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -195,7 +195,7 @@ struct POSOrderServiceTests {
     }
 
     @Test
-    func syncOrder_when_returned_order_has_extra_product_not_in_cart_then_succeeds() async throws {
+    func syncOrder_when_returned_order_has_extra_product_not_in_cart_then_throws() async throws {
         // Given
         let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
         let orderWithExtraProduct = OrderFactory.newOrder(currency: .USD)
@@ -209,11 +209,14 @@ struct POSOrderServiceTests {
             )
         mockOrdersRemote.createPOSOrderResult = .success(orderWithExtraProduct)
 
-        // When
-        let syncedOrder = try await sut.syncOrder(cart: cart, currency: .USD)
+        let comparison = cart.compareWithOrder(orderWithExtraProduct)
+        #expect(comparison.extraItemsCount == 1)
+        #expect(comparison.hasDiscrepancies == true)
 
-        // Then
-        #expect(syncedOrder.items.count == 2)
+        // When / Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: isOrderMismatchError)
     }
 
     @Test

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -147,9 +147,7 @@ struct POSOrderServiceTests {
         // When / Then
         await #expect(performing: {
             try await sut.syncOrder(cart: cart, currency: .USD)
-        }, throws: { _ in
-            true
-        })
+        }, throws: isOrderMismatchError)
     }
 
     @Test
@@ -174,9 +172,7 @@ struct POSOrderServiceTests {
         // When / Then
         await #expect(performing: {
             try await sut.syncOrder(cart: cart, currency: .USD)
-        }, throws: { _ in
-            true
-        })
+        }, throws: isOrderMismatchError)
     }
 
     @Test
@@ -194,9 +190,7 @@ struct POSOrderServiceTests {
         // When / Then
         await #expect(performing: {
             try await sut.syncOrder(cart: cart, currency: .USD)
-        }, throws: { _ in
-            true
-        })
+        }, throws: isOrderMismatchError)
     }
 
     @Test
@@ -218,9 +212,7 @@ struct POSOrderServiceTests {
         // When / Then
         await #expect(performing: {
             try await sut.syncOrder(cart: cart, currency: .USD)
-        }, throws: { _ in
-            true
-        })
+        }, throws: isOrderMismatchError)
     }
 
     @Test
@@ -674,3 +666,10 @@ private func makePOSCartItem(
             quantity: quantity
         )
     }
+
+private func isOrderMismatchError(_ error: Error) -> Bool {
+    if case .orderDoesNotMatchCart = error as? POSOrderService.POSOrderServiceError {
+        return true
+    }
+    return false
+}

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -128,13 +128,8 @@ struct POSOrderServiceTests {
         #expect(delivery.taxStatus == .none)
     }
 
-    /// Locks in the documented behaviour for cart↔server fee mismatches: unlike a
-    /// missing line item (which throws), a custom amount discrepancy is recorded as
-    /// `customAmountsMatch == false` and only logged. The merchant-facing UX would
-    /// otherwise force a redundant resync each time the server's tax decision diverges
-    /// from the cart's intent (covered by `cart_matches_order_regardless_of_tax_status`).
     @Test
-    func syncOrder_when_returned_order_fees_dont_match_cart_then_does_not_throw() async throws {
+    func syncOrder_when_returned_order_fees_dont_match_cart_then_throws() async throws {
         // Given - cart has one fee, server returns the same order shape but with no fees
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
@@ -149,13 +144,16 @@ struct POSOrderServiceTests {
             )
         mockOrdersRemote.createPOSOrderResult = .success(orderWithMatchingItemsButNoFees)
 
-        // When / Then - returns the order without throwing despite the fee discrepancy
-        let result = try await sut.syncOrder(cart: cart, currency: .USD)
-        #expect(result.fees.isEmpty)
+        // When / Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { _ in
+            true
+        })
     }
 
     @Test
-    func syncOrder_when_returned_order_has_more_fees_than_cart_then_does_not_throw() async throws {
+    func syncOrder_when_returned_order_has_more_fees_than_cart_then_throws() async throws {
         // Given - cart has one fee, server echoes back two
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
@@ -173,9 +171,56 @@ struct POSOrderServiceTests {
             )
         mockOrdersRemote.createPOSOrderResult = .success(orderWithExtraFee)
 
-        // When / Then - returns the order without throwing despite the count mismatch
-        let result = try await sut.syncOrder(cart: cart, currency: .USD)
-        #expect(result.fees.count == 2)
+        // When / Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { _ in
+            true
+        })
+    }
+
+    @Test
+    func syncOrder_when_returned_order_has_lower_product_quantity_than_cart_then_throws() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 2)])
+        let orderWithLowerProductQuantity = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [OrderItem.fake().copy(productID: 100, quantity: 1)]
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(orderWithLowerProductQuantity)
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { _ in
+            true
+        })
+    }
+
+    @Test
+    func syncOrder_when_returned_order_omits_cart_coupon_then_throws() async throws {
+        // Given
+        let cart = POSCart(
+            items: [makePOSCartItem(productID: 100, quantity: 1)],
+            coupons: [.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "SAVE10")]
+        )
+        let orderWithMatchingItemsButNoCoupons = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [OrderItem.fake().copy(productID: 100, quantity: 1)],
+                coupons: []
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(orderWithMatchingItemsButNoCoupons)
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: { _ in
+            true
+        })
     }
 
     @Test

--- a/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/POS/POSOrderServiceTests.swift
@@ -151,8 +151,8 @@ struct POSOrderServiceTests {
     }
 
     @Test
-    func syncOrder_when_returned_order_has_more_fees_than_cart_then_throws() async throws {
-        // Given - cart has one fee, server echoes back two
+    func syncOrder_when_returned_order_has_more_fees_than_cart_then_succeeds() async throws {
+        // Given - cart has one fee, server echoes back that fee plus a remote-added fee
         let cart = POSCart(
             items: [makePOSCartItem(productID: 100, quantity: 1)],
             customAmounts: [POSCustomAmount(name: "Service fee", amount: "10.00", isTaxable: true)]
@@ -169,10 +169,11 @@ struct POSOrderServiceTests {
             )
         mockOrdersRemote.createPOSOrderResult = .success(orderWithExtraFee)
 
-        // When / Then
-        await #expect(performing: {
-            try await sut.syncOrder(cart: cart, currency: .USD)
-        }, throws: isOrderMismatchError)
+        // When
+        let syncedOrder = try await sut.syncOrder(cart: cart, currency: .USD)
+
+        // Then
+        #expect(syncedOrder.fees.count == 2)
     }
 
     @Test
@@ -194,6 +195,28 @@ struct POSOrderServiceTests {
     }
 
     @Test
+    func syncOrder_when_returned_order_has_extra_product_not_in_cart_then_succeeds() async throws {
+        // Given
+        let cart = POSCart(items: [makePOSCartItem(productID: 100, quantity: 1)])
+        let orderWithExtraProduct = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [
+                    OrderItem.fake().copy(productID: 100, quantity: 1),
+                    OrderItem.fake().copy(productID: 200, quantity: 1)
+                ]
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(orderWithExtraProduct)
+
+        // When
+        let syncedOrder = try await sut.syncOrder(cart: cart, currency: .USD)
+
+        // Then
+        #expect(syncedOrder.items.count == 2)
+    }
+
+    @Test
     func syncOrder_when_returned_order_omits_cart_coupon_then_throws() async throws {
         // Given
         let cart = POSCart(
@@ -208,6 +231,31 @@ struct POSOrderServiceTests {
                 coupons: []
             )
         mockOrdersRemote.createPOSOrderResult = .success(orderWithMatchingItemsButNoCoupons)
+
+        // When / Then
+        await #expect(performing: {
+            try await sut.syncOrder(cart: cart, currency: .USD)
+        }, throws: isOrderMismatchError)
+    }
+
+    @Test
+    func syncOrder_when_returned_order_has_extra_product_and_omits_cart_coupon_then_throws() async throws {
+        // Given
+        let cart = POSCart(
+            items: [makePOSCartItem(productID: 100, quantity: 1)],
+            coupons: [.init(id: POSItemIdentifier(underlyingType: .coupon, itemID: 1), code: "SAVE10")]
+        )
+        let orderWithExtraProductButNoCoupons = OrderFactory.newOrder(currency: .USD)
+            .copy(
+                siteID: 123,
+                status: .autoDraft,
+                items: [
+                    OrderItem.fake().copy(productID: 100, quantity: 1),
+                    OrderItem.fake().copy(productID: 200, quantity: 1)
+                ],
+                coupons: []
+            )
+        mockOrdersRemote.createPOSOrderResult = .success(orderWithExtraProductButNoCoupons)
 
         // When / Then
         await #expect(performing: {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.0
 -----
+- [*] POS: Prevent checkout when the server-created order does not match the cart. [https://github.com/woocommerce/woocommerce-ios/pull/17314]
 - [*] Fixed duplicating a product overwriting the original product's images; the duplicate now opens after copying. [https://github.com/woocommerce/woocommerce-ios/pull/17291]
 
 24.9


### PR DESCRIPTION
## Description

An AI search of our code found a potential bug – if a POS order was returned with different items, we would still check out as normal. This could lead to a merchant under or overcharging the shopper without realising.

This PR blocks checkout in these cases. It's quite theoretical, and there's other error handling for things like a product having been removed (0 qty or missing line item) or a coupon having expired.

Because it's unlikely to happen, I've not added a button to resolve the cart to match what came back in the order, it's difficult to know what the consequences are for that.

## Test Steps

1. Open POS and add items to a cart
2. Use Proxyman or Charles to proxy the POST Order API route for your site
3. Tap `Check out`
4. In your proxy tool, edit the response to the `orders POST`, modify the line items. You could remove an item, change the quantity, or add an item
5. Observe that when you send the response, an error is shown.
6. Confirm that tapping `Edit order` returns to item selection, and the next time you try (without editing the response) the order continues as normal.

## Screenshots

### Before

https://github.com/user-attachments/assets/268796ef-114a-4865-96af-12961eea61ab

### After

https://github.com/user-attachments/assets/78c96513-0c07-4bb1-ac10-b8b96ec83c11

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
