### PR TITLE
Fix downloadable file native reorder path

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -461,10 +461,7 @@ extension ProductDownloadListViewController: UITableViewDataSource, UITableViewD
     }
 
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        if let item = viewModel.item(at: sourceIndexPath.row) {
-            viewModel.remove(at: destinationIndexPath.row)
-            viewModel.insert(item, at: destinationIndexPath.row)
-        }
+        viewModel.move(from: sourceIndexPath.row, to: destinationIndexPath.row)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewModel.swift
@@ -18,6 +18,7 @@ protocol ProductDownloadListViewModelOutput {
     func insert(_ newElement: ProductDownloadDragAndDrop, at index: Int)
     func append(_ newElement: ProductDownloadDragAndDrop)
     func update(at index: Int, element: ProductDownloadDragAndDrop)
+    func move(from sourceIndex: Int, to destinationIndex: Int)
     func count() -> Int
 }
 
@@ -87,6 +88,14 @@ final class ProductDownloadListViewModel: ProductDownloadListViewModelOutput {
 
     func update(at index: Int, element: ProductDownloadDragAndDrop) {
         downloadableFiles[index] = element
+    }
+
+    func move(from sourceIndex: Int, to destinationIndex: Int) {
+        guard let item = remove(at: sourceIndex) else {
+            return
+        }
+
+        insert(item, at: destinationIndex)
     }
 
     func count() -> Int {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Downloadable Files/ProductDownloadListViewModelTests.swift
@@ -124,6 +124,32 @@ final class ProductDownloadListViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasUnsavedChanges())
     }
 
+    func test_move_when_moving_first_file_to_end_then_reorders_without_duplicates() {
+        // Arrange
+        let product = Fakes.ProductFactory.productWithDownloadableFiles()
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadListViewModel(product: model)
+
+        // Act
+        viewModel.move(from: 0, to: 2)
+
+        // Assert
+        XCTAssertEqual(viewModel.downloadableFiles.map { $0.downloadableFile.name }, ["Song #2", "Song #3", "Song #1"])
+    }
+
+    func test_move_when_moving_last_file_to_start_then_reorders_without_duplicates() {
+        // Arrange
+        let product = Fakes.ProductFactory.productWithDownloadableFiles()
+        let model = EditableProductModel(product: product)
+        let viewModel = ProductDownloadListViewModel(product: model)
+
+        // Act
+        viewModel.move(from: 2, to: 0)
+
+        // Assert
+        XCTAssertEqual(viewModel.downloadableFiles.map { $0.downloadableFile.name }, ["Song #3", "Song #1", "Song #2"])
+    }
+
     func test_insert_when_reinserting_removed_file_at_original_end_index_then_does_not_crash() throws {
         // Given
         let product = Fakes.ProductFactory.productWithDownloadableFiles()


### PR DESCRIPTION
## Description
An AI search found a theoretical bug in reordering downloadable files.

A unit test showed it could happen in `tableView(_:moveRowAt:to:)`: moving file 0 to position 2 produced a duplicate ordering (`[Song #1, Song #2, Song #1]`) because the code removed the destination row before inserting the source item.

I've not been able to reproduce by hand.

## Test Steps
Unit tests only, but you can check manually reordering downloadable files in edit product details.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.