### PR TITLE
Skip malformed POS orders in order list

### DIFF
--- a/Modules/Sources/NetworkingCore/Mapper/ListMapper.swift
+++ b/Modules/Sources/NetworkingCore/Mapper/ListMapper.swift
@@ -1,17 +1,21 @@
 import Foundation
 
-/// ListMapper: Maps generic WooCommerce REST API Lists
+/// ListMapper: Maps generic WooCommerce REST API lists.
 ///
-struct ListMapper<Output: Decodable>: Mapper {
+public struct ListMapper<Output: Decodable>: Mapper {
     /// Site Identifier associated to the items that will be parsed.
     ///
     /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned by our endpoints.
     ///
     let siteID: Int64
 
-    /// (Attempts) to convert a dictionary into [Output].
+    public init(siteID: Int64) {
+        self.siteID = siteID
+    }
+
+    /// Attempts to convert a dictionary into `[Output]`.
     ///
-    func map(response: Data) throws -> [Output] {
+    public func map(response: Data) throws -> [Output] {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
         decoder.userInfo = [
@@ -28,7 +32,7 @@ struct ListMapper<Output: Decodable>: Mapper {
 
 /// ListEnvelope Disposable Entity:
 /// Our list endpoints return the items in the `data` key.
-/// This entity allows us to do parse all the things with JSONDecoder.
+/// This entity allows us to parse all the things with JSONDecoder.
 ///
 private struct ListEnvelope<Output: Decodable>: Decodable {
     let items: [Output]

--- a/Modules/Sources/NetworkingCore/Mapper/POSOrderListMapper.swift
+++ b/Modules/Sources/NetworkingCore/Mapper/POSOrderListMapper.swift
@@ -1,49 +1,6 @@
-import Foundation
-
-/// Mapper: POS OrderList
-///
 /// POS order history can show a partial page when a single order payload is malformed.
 /// The regular `OrderListMapper` stays strict for the rest of the app.
-struct POSOrderListMapper: Mapper {
-    /// Site Identifier associated to the orders that will be parsed.
-    ///
-    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
-    ///
-    let siteID: Int64
-
-    /// Attempts to convert a dictionary into `[Order]`, skipping individual malformed orders.
-    ///
-    func map(response: Data) throws -> [Order] {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
-        decoder.userInfo = [
-            .siteID: siteID
-        ]
-
-        return try decoder.decode(POSOrderListResponse.self, from: response).orders
-    }
-}
-
-private struct POSOrderListResponse: Decodable {
-    let orders: [Order]
-
-    init(from decoder: Decoder) throws {
-        if let keyedContainer = try? decoder.container(keyedBy: CodingKeys.self),
-           keyedContainer.contains(.data) {
-            orders = try keyedContainer.decode([LossyPOSOrder].self, forKey: .data).compactMap(\.order)
-            return
-        }
-
-        let container = try decoder.singleValueContainer()
-        orders = try container.decode([LossyPOSOrder].self).compactMap(\.order)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case data
-    }
-}
-
-private struct LossyPOSOrder: Decodable {
+struct LossyPOSOrder: Decodable {
     let order: Order?
 
     init(from decoder: Decoder) throws {

--- a/Modules/Sources/NetworkingCore/Mapper/POSOrderListMapper.swift
+++ b/Modules/Sources/NetworkingCore/Mapper/POSOrderListMapper.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Mapper: POS OrderList
+///
+/// POS order history can show a partial page when a single order payload is malformed.
+/// The regular `OrderListMapper` stays strict for the rest of the app.
+struct POSOrderListMapper: Mapper {
+    /// Site Identifier associated to the orders that will be parsed.
+    ///
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in any of the Order Endpoints.
+    ///
+    let siteID: Int64
+
+    /// Attempts to convert a dictionary into `[Order]`, skipping individual malformed orders.
+    ///
+    func map(response: Data) throws -> [Order] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(DateFormatter.Defaults.dateTimeFormatter)
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(POSOrderListEnvelope.self, from: response).orders
+        } else {
+            return try decoder.decode(LossyPOSOrderList.self, from: response).orders
+        }
+    }
+}
+
+private struct POSOrderListEnvelope: Decodable {
+    let orders: [Order]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        orders = try container.decode(LossyPOSOrderList.self, forKey: .orders).orders
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case orders = "data"
+    }
+}
+
+private struct LossyPOSOrderList: Decodable {
+    let orders: [Order]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let wrappers = try container.decode([LossyPOSOrder].self)
+        orders = wrappers.compactMap(\.order)
+    }
+}
+
+private struct LossyPOSOrder: Decodable {
+    let order: Order?
+
+    init(from decoder: Decoder) throws {
+        do {
+            order = try Order(from: decoder)
+        } catch {
+            order = nil
+            let siteID = decoder.userInfo[.siteID] as? Int64
+            let descriptor = (try? SkippedOrderDescriptor(from: decoder))?.description ?? "unknown order"
+            DDLogError("POSOrderListMapper: Skipping malformed POS order for siteID \(siteID ?? 0), \(descriptor): \(error)")
+        }
+    }
+}
+
+private struct SkippedOrderDescriptor: Decodable {
+    let orderID: Int64?
+    let number: String?
+
+    var description: String {
+        switch (orderID, number) {
+        case let (orderID?, number?):
+            return "orderID \(orderID), number \(number)"
+        case let (orderID?, nil):
+            return "orderID \(orderID)"
+        case let (nil, number?):
+            return "number \(number)"
+        case (nil, nil):
+            return "unknown order"
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        orderID = try container.decodeIfPresent(Int64.self, forKey: .orderID)
+        number = try container.decodeIfPresent(String.self, forKey: .number)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case orderID = "id"
+        case number
+    }
+}

--- a/Modules/Sources/NetworkingCore/Mapper/POSOrderListMapper.swift
+++ b/Modules/Sources/NetworkingCore/Mapper/POSOrderListMapper.swift
@@ -20,34 +20,26 @@ struct POSOrderListMapper: Mapper {
             .siteID: siteID
         ]
 
-        if hasDataEnvelope(in: response) {
-            return try decoder.decode(POSOrderListEnvelope.self, from: response).orders
-        } else {
-            return try decoder.decode(LossyPOSOrderList.self, from: response).orders
-        }
+        return try decoder.decode(POSOrderListResponse.self, from: response).orders
     }
 }
 
-private struct POSOrderListEnvelope: Decodable {
+private struct POSOrderListResponse: Decodable {
     let orders: [Order]
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        orders = try container.decode(LossyPOSOrderList.self, forKey: .orders).orders
+        if let keyedContainer = try? decoder.container(keyedBy: CodingKeys.self),
+           keyedContainer.contains(.data) {
+            orders = try keyedContainer.decode([LossyPOSOrder].self, forKey: .data).compactMap(\.order)
+            return
+        }
+
+        let container = try decoder.singleValueContainer()
+        orders = try container.decode([LossyPOSOrder].self).compactMap(\.order)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case orders = "data"
-    }
-}
-
-private struct LossyPOSOrderList: Decodable {
-    let orders: [Order]
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let wrappers = try container.decode([LossyPOSOrder].self)
-        orders = wrappers.compactMap(\.order)
+        case data
     }
 }
 

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -544,8 +544,9 @@ extension OrdersRemote: POSOrdersRemoteProtocol {
                                    path: path,
                                    parameters: parameters,
                                    availableAsRESTRequest: true)
-        let mapper = POSOrderListMapper(siteID: siteID)
-        let (orders, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+        let mapper = ListMapper<LossyPOSOrder>(siteID: siteID)
+        let (lossyOrders, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+        let orders = lossyOrders.compactMap(\.order)
         return createPagedItems(items: orders, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
     }
 
@@ -566,8 +567,9 @@ extension OrdersRemote: POSOrdersRemoteProtocol {
                                    path: path,
                                    parameters: parameters,
                                    availableAsRESTRequest: true)
-        let mapper = POSOrderListMapper(siteID: siteID)
-        let (orders, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+        let mapper = ListMapper<LossyPOSOrder>(siteID: siteID)
+        let (lossyOrders, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
+        let orders = lossyOrders.compactMap(\.order)
         return createPagedItems(items: orders, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
     }
 }
@@ -690,8 +692,9 @@ public extension OrdersRemote {
                                      path: path,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = POSOrderListMapper(siteID: siteID)
-        return try await enqueue(request, mapper: mapper)
+        let mapper = ListMapper<LossyPOSOrder>(siteID: siteID)
+        let lossyOrders = try await enqueue(request, mapper: mapper)
+        return lossyOrders.compactMap(\.order)
     }
 }
 

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -544,7 +544,7 @@ extension OrdersRemote: POSOrdersRemoteProtocol {
                                    path: path,
                                    parameters: parameters,
                                    availableAsRESTRequest: true)
-        let mapper = OrderListMapper(siteID: siteID)
+        let mapper = POSOrderListMapper(siteID: siteID)
         let (orders, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
         return createPagedItems(items: orders, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
     }
@@ -566,7 +566,7 @@ extension OrdersRemote: POSOrdersRemoteProtocol {
                                    path: path,
                                    parameters: parameters,
                                    availableAsRESTRequest: true)
-        let mapper = OrderListMapper(siteID: siteID)
+        let mapper = POSOrderListMapper(siteID: siteID)
         let (orders, responseHeaders) = try await enqueueWithResponseHeaders(request, mapper: mapper)
         return createPagedItems(items: orders, responseHeaders: responseHeaders, currentPageNumber: pageNumber)
     }
@@ -690,7 +690,7 @@ public extension OrdersRemote {
                                      path: path,
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
-        let mapper = OrderListMapper(siteID: siteID)
+        let mapper = POSOrderListMapper(siteID: siteID)
         return try await enqueue(request, mapper: mapper)
     }
 }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
@@ -99,7 +99,7 @@ struct PointOfSaleErrorState: Equatable {
             errorType: .ordersLoadError,
             title: Constants.failedToLoadOrdersTitle,
             subtitle: subtitle(for: error),
-            buttonText: Constants.retryButtonTitle)
+            buttonText: Constants.ordersTryAgainButtonTitle)
     }
 
     static func errorOnLoadingOrdersNextPage(error: Error? = nil) -> Self {
@@ -107,7 +107,7 @@ struct PointOfSaleErrorState: Equatable {
             errorType: .ordersNextPageError,
             title: Constants.failedToLoadOrdersNextPageTitle,
             subtitle: subtitle(for: error),
-            buttonText: Constants.retryButtonTitle)
+            buttonText: Constants.ordersTryAgainButtonTitle)
     }
 
     static func errorOnInitalCatalogSync(error: Error? = nil) -> Self {
@@ -228,6 +228,11 @@ struct PointOfSaleErrorState: Equatable {
             value: "Unable to load more orders",
             comment: "Text appearing on the order list screen when there's an error loading a page of orders after " +
             "the first. Shown inline with the previously loaded orders above."
+        )
+        static let ordersTryAgainButtonTitle = NSLocalizedString(
+            "pos.orderList.tryAgainButtonTitle",
+            value: "Try again",
+            comment: "Button text to retry loading orders in Point of Sale."
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -99,11 +99,11 @@ struct POSOrderListView: View {
                     }
                 }
             case (.error(let errorState), true):
-                POSListErrorView(error: errorState) {
+                POSListErrorView(error: errorState, onAction: {
                     Task { @MainActor in
                         await orderListModel.ordersController.loadOrders()
                     }
-                }
+                })
             default:
                 listView
             }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -106,11 +106,11 @@ struct POSOrdersView: View {
         ZStack {
             VStack {
                 Spacer()
-                POSListErrorView(error: error) {
+                POSListErrorView(error: error, onAction: {
                     Task { @MainActor in
                         await orderListModel.ordersController.loadOrders()
                     }
-                }
+                })
                 Spacer()
             }
 

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderListService.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderListService.swift
@@ -32,8 +32,7 @@ public final class POSOrderListService: POSOrderListServiceProtocol {
                 return .init(items: [], hasMorePages: false, totalItems: 0)
             }
 
-            // Convert Order objects to POSOrder objects
-            let posOrders = try pagedOrders.items.map { try mapper.map(order: $0) }
+            let posOrders = mapOrdersSkippingFailures(pagedOrders.items)
 
             return .init(items: posOrders,
                         hasMorePages: pagedOrders.hasMorePages,
@@ -58,8 +57,7 @@ public final class POSOrderListService: POSOrderListServiceProtocol {
                 return .init(items: [], hasMorePages: false, totalItems: 0)
             }
 
-            // Convert Order objects to POSOrder objects
-            let posOrders = try pagedOrders.items.map { try mapper.map(order: $0) }
+            let posOrders = mapOrdersSkippingFailures(pagedOrders.items)
 
             return .init(items: posOrders,
                         hasMorePages: pagedOrders.hasMorePages,
@@ -74,11 +72,33 @@ public final class POSOrderListService: POSOrderListServiceProtocol {
     public func loadOrder(orderID: Int64) async throws -> POSOrder {
         do {
             let order = try await ordersRemote.loadPOSOrder(siteID: siteID, orderID: orderID)
-            return try mapper.map(order: order)
+            do {
+                return try mapper.map(order: order)
+            } catch {
+                logMappingFailure(order: order, error: error)
+                throw error
+            }
         } catch AFError.explicitlyCancelled {
             throw POSOrderListServiceError.requestCancelled
         } catch {
             throw POSOrderListServiceError.requestFailed
         }
+    }
+}
+
+private extension POSOrderListService {
+    func mapOrdersSkippingFailures(_ orders: [Order]) -> [POSOrder] {
+        orders.compactMap { order in
+            do {
+                return try mapper.map(order: order)
+            } catch {
+                logMappingFailure(order: order, error: error)
+                return nil
+            }
+        }
+    }
+
+    func logMappingFailure(order: Order, error: Error) {
+        DDLogError("⛔️ POSOrderListService: Failed to map POS order for siteID \(siteID), orderID \(order.orderID): \(error)")
     }
 }

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -6,6 +6,12 @@ import struct NetworkingCore.OrderItem
 import struct NetworkingCore.OrderItemAttribute
 import struct NetworkingCore.OrderRefundCondensed
 
+enum POSOrderItemMappingError: Error {
+    case invalidTaxValue(orderID: Int64, itemID: Int64, value: String)
+    case priceFormattingFailed(orderID: Int64, itemID: Int64, price: NSDecimalNumber, currency: String)
+    case totalFormattingFailed(orderID: Int64, itemID: Int64, total: String, currency: String)
+}
+
 struct POSOrderMapper {
     private let currencyFormatter: CurrencyFormatter
 
@@ -16,7 +22,7 @@ struct POSOrderMapper {
     func map(order: NetworkingCore.Order) throws -> POSOrder {
         let customerEmail = order.billingAddress?.email
 
-        let posLineItems = order.items.map { map(orderItem: $0, currency: order.currency) }
+        let posLineItems = try order.items.map { try map(orderItem: $0, orderID: order.orderID, currency: order.currency) }
 
         let posCustomAmounts = order.fees
             .filter { !$0.isDeleted }
@@ -67,18 +73,25 @@ struct POSOrderMapper {
         )
     }
 
-    private func map(orderItem: NetworkingCore.OrderItem, currency: String) -> POSOrderItem {
-        let price = decimal(from: orderItem.price) ?? .zero
-        let total = Decimal(string: orderItem.total) ?? price * orderItem.quantity
-        let totalTax = Decimal(string: orderItem.totalTax) ?? .zero
-        let formattedPrice = decimal(from: orderItem.price).flatMap { currencyFormatter.formatAmount($0, with: currency) } ?? ""
-        let formattedTotal = currencyFormatter.formatAmount(orderItem.total, with: currency) ?? currencyFormatter.formatAmount(total, with: currency) ?? ""
+    private func map(orderItem: NetworkingCore.OrderItem, orderID: Int64, currency: String) throws -> POSOrderItem {
+        guard let totalTax = Decimal(string: orderItem.totalTax) else {
+            throw POSOrderItemMappingError.invalidTaxValue(orderID: orderID, itemID: orderItem.itemID, value: orderItem.totalTax)
+        }
+        guard orderItem.price != NSDecimalNumber.notANumber,
+              let formattedPrice = currencyFormatter.formatAmount(orderItem.price, with: currency) else {
+            throw POSOrderItemMappingError.priceFormattingFailed(orderID: orderID, itemID: orderItem.itemID, price: orderItem.price, currency: currency)
+        }
+        guard let formattedTotal = currencyFormatter.formatAmount(orderItem.total, with: currency) else {
+            throw POSOrderItemMappingError.totalFormattingFailed(orderID: orderID, itemID: orderItem.itemID, total: orderItem.total, currency: currency)
+        }
+
+        let total = Decimal(string: orderItem.total) ?? (orderItem.price as Decimal) * orderItem.quantity
 
         return POSOrderItem(
             itemID: orderItem.itemID,
             name: orderItem.name,
             quantity: orderItem.quantity,
-            price: price,
+            price: orderItem.price as Decimal,
             total: total,
             totalTax: totalTax,
             formattedPrice: formattedPrice,
@@ -112,13 +125,6 @@ struct POSOrderMapper {
             formattedTotal: currencyFormatter.formatAmount(orderRefund.total, with: currency) ?? "",
             reason: orderRefund.reason
         )
-    }
-
-    private func decimal(from amount: NSDecimalNumber) -> Decimal? {
-        guard amount != NSDecimalNumber.notANumber else {
-            return nil
-        }
-        return amount as Decimal
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -6,12 +6,6 @@ import struct NetworkingCore.OrderItem
 import struct NetworkingCore.OrderItemAttribute
 import struct NetworkingCore.OrderRefundCondensed
 
-enum POSOrderItemMappingError: Error {
-    case invalidTaxValue(itemID: Int64, value: String)
-    case priceFormattingFailed(itemID: Int64, price: NSDecimalNumber, currency: String)
-    case totalFormattingFailed(itemID: Int64, total: String, currency: String)
-}
-
 struct POSOrderMapper {
     private let currencyFormatter: CurrencyFormatter
 
@@ -22,7 +16,7 @@ struct POSOrderMapper {
     func map(order: NetworkingCore.Order) throws -> POSOrder {
         let customerEmail = order.billingAddress?.email
 
-        let posLineItems = try order.items.map { try map(orderItem: $0, currency: order.currency) }
+        let posLineItems = order.items.map { map(orderItem: $0, currency: order.currency) }
 
         let posCustomAmounts = order.fees
             .filter { !$0.isDeleted }
@@ -73,24 +67,18 @@ struct POSOrderMapper {
         )
     }
 
-    private func map(orderItem: NetworkingCore.OrderItem, currency: String) throws -> POSOrderItem {
-        guard let totalTax = Decimal(string: orderItem.totalTax) else {
-            throw POSOrderItemMappingError.invalidTaxValue(itemID: orderItem.itemID, value: orderItem.totalTax)
-        }
-        guard let formattedPrice = currencyFormatter.formatAmount(orderItem.price, with: currency) else {
-            throw POSOrderItemMappingError.priceFormattingFailed(itemID: orderItem.itemID, price: orderItem.price, currency: currency)
-        }
-        guard let formattedTotal = currencyFormatter.formatAmount(orderItem.total, with: currency) else {
-            throw POSOrderItemMappingError.totalFormattingFailed(itemID: orderItem.itemID, total: orderItem.total, currency: currency)
-        }
-
-        let total = Decimal(string: orderItem.total) ?? (orderItem.price as Decimal) * orderItem.quantity
+    private func map(orderItem: NetworkingCore.OrderItem, currency: String) -> POSOrderItem {
+        let price = decimal(from: orderItem.price) ?? .zero
+        let total = Decimal(string: orderItem.total) ?? price * orderItem.quantity
+        let totalTax = Decimal(string: orderItem.totalTax) ?? .zero
+        let formattedPrice = decimal(from: orderItem.price).flatMap { currencyFormatter.formatAmount($0, with: currency) } ?? ""
+        let formattedTotal = currencyFormatter.formatAmount(orderItem.total, with: currency) ?? currencyFormatter.formatAmount(total, with: currency) ?? ""
 
         return POSOrderItem(
             itemID: orderItem.itemID,
             name: orderItem.name,
             quantity: orderItem.quantity,
-            price: orderItem.price as Decimal,
+            price: price,
             total: total,
             totalTax: totalTax,
             formattedPrice: formattedPrice,
@@ -124,6 +112,13 @@ struct POSOrderMapper {
             formattedTotal: currencyFormatter.formatAmount(orderRefund.total, with: currency) ?? "",
             reason: orderRefund.reason
         )
+    }
+
+    private func decimal(from amount: NSDecimalNumber) -> Decimal? {
+        guard amount != NSDecimalNumber.notANumber else {
+            return nil
+        }
+        return amount as Decimal
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/OrderList/POSOrderMapper.swift
@@ -12,6 +12,11 @@ enum POSOrderItemMappingError: Error {
     case totalFormattingFailed(orderID: Int64, itemID: Int64, total: String, currency: String)
 }
 
+enum POSOrderMappingError: Error {
+    case totalFormattingFailed(orderID: Int64, total: String, currency: String)
+    case totalTaxFormattingFailed(orderID: Int64, totalTax: String, currency: String)
+}
+
 struct POSOrderMapper {
     private let currencyFormatter: CurrencyFormatter
 
@@ -29,6 +34,10 @@ struct POSOrderMapper {
             .map { map(fee: $0, currency: order.currency) }
 
         let posRefunds = order.refunds.map { map(orderRefund: $0, currency: order.currency) }
+
+        let formattedTotal = try mapFormattedTotal(order: order)
+        let formattedTotalTax = try mapFormattedTotalTax(order: order)
+        let formattedPaymentTotal = mapFormattedPaymentTotal(order: order, formattedTotal: formattedTotal)
 
         let formattedDiscountTotal: String? = {
             guard let discountTotalValue = Double(order.discountTotal), discountTotalValue > 0 else {
@@ -55,7 +64,7 @@ struct POSOrderMapper {
             number: order.number,
             dateCreated: order.dateCreated,
             status: order.status,
-            formattedTotal: currencyFormatter.formatAmount(order.total, with: order.currency) ?? "",
+            formattedTotal: formattedTotal,
             formattedSubtotal: order.subtotalValue(currencyFormatter: currencyFormatter),
             customerEmail: customerEmail,
             paymentMethodID: order.paymentMethodID,
@@ -64,13 +73,34 @@ struct POSOrderMapper {
             customAmounts: posCustomAmounts,
             refunds: posRefunds,
             formattedDiscountTotal: formattedDiscountTotal,
-            formattedTotalTax: currencyFormatter.formatAmount(order.totalTax, with: order.currency) ?? "",
-            formattedPaymentTotal: order.paymentTotal(currencyFormatter: currencyFormatter),
+            formattedTotalTax: formattedTotalTax,
+            formattedPaymentTotal: formattedPaymentTotal,
             formattedNetAmount: formattedNetAmount,
             datePaid: order.datePaid,
             paymentStatusMetadata: order.paymentStatusMetadata,
             lineItemQuantitiesByProductOrVariationID: lineItemQuantitiesByProductOrVariationID
         )
+    }
+
+    private func mapFormattedTotal(order: NetworkingCore.Order) throws -> String {
+        guard let formattedTotal = currencyFormatter.formatAmount(order.total, with: order.currency) else {
+            throw POSOrderMappingError.totalFormattingFailed(orderID: order.orderID, total: order.total, currency: order.currency)
+        }
+        return formattedTotal
+    }
+
+    private func mapFormattedTotalTax(order: NetworkingCore.Order) throws -> String {
+        guard let formattedTotalTax = currencyFormatter.formatAmount(order.totalTax, with: order.currency) else {
+            throw POSOrderMappingError.totalTaxFormattingFailed(orderID: order.orderID, totalTax: order.totalTax, currency: order.currency)
+        }
+        return formattedTotalTax
+    }
+
+    private func mapFormattedPaymentTotal(order: NetworkingCore.Order, formattedTotal: String) -> String {
+        guard order.datePaid != nil else {
+            return currencyFormatter.formatAmount("0.00", with: order.currency) ?? ""
+        }
+        return formattedTotal
     }
 
     private func map(orderItem: NetworkingCore.OrderItem, orderID: Int64, currency: String) throws -> POSOrderItem {

--- a/Modules/Tests/NetworkingTests/Mapper/POSOrderListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/POSOrderListMapperTests.swift
@@ -10,7 +10,7 @@ final class POSOrderListMapperTests: XCTestCase {
             malformedOrder.removeValue(forKey: "total")
         }
 
-        let orders = try POSOrderListMapper(siteID: dummySiteID).map(response: response)
+        let orders = try mapPOSOrders(response: response)
 
         XCTAssertEqual(orders.map(\.orderID), [964])
     }
@@ -31,7 +31,7 @@ final class POSOrderListMapperTests: XCTestCase {
             malformedOrder["line_items"] = lineItems
         }
 
-        let orders = try POSOrderListMapper(siteID: dummySiteID).map(response: response)
+        let orders = try mapPOSOrders(response: response)
 
         XCTAssertEqual(orders.map(\.orderID), [964])
     }
@@ -41,7 +41,7 @@ final class POSOrderListMapperTests: XCTestCase {
             malformedOrder.removeValue(forKey: "total")
         }
 
-        let orders = try POSOrderListMapper(siteID: dummySiteID).map(response: response)
+        let orders = try mapPOSOrders(response: response)
 
         XCTAssertEqual(orders.map(\.orderID), [964])
     }
@@ -74,5 +74,11 @@ private extension POSOrderListMapperTests {
         let orders = [malformedOrder, validOrder]
         let payload: Any = hasDataEnvelope ? ["data": orders] : orders
         return try JSONSerialization.data(withJSONObject: payload)
+    }
+
+    func mapPOSOrders(response: Data) throws -> [Order] {
+        return try ListMapper<LossyPOSOrder>(siteID: dummySiteID)
+            .map(response: response)
+            .compactMap(\.order)
     }
 }

--- a/Modules/Tests/NetworkingTests/Mapper/POSOrderListMapperTests.swift
+++ b/Modules/Tests/NetworkingTests/Mapper/POSOrderListMapperTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Networking
+@testable import NetworkingCore
+
+final class POSOrderListMapperTests: XCTestCase {
+    private let dummySiteID: Int64 = 242424
+
+    func test_map_skips_order_with_missing_required_top_level_field_and_keeps_valid_orders() throws {
+        let response = try makeOrdersResponse { malformedOrder in
+            malformedOrder.removeValue(forKey: "total")
+        }
+
+        let orders = try POSOrderListMapper(siteID: dummySiteID).map(response: response)
+
+        XCTAssertEqual(orders.map(\.orderID), [964])
+    }
+
+    func test_map_skips_order_with_nested_decoding_failure_and_keeps_valid_orders() throws {
+        let response = try makeOrdersResponse { malformedOrder in
+            guard var lineItems = malformedOrder["line_items"] as? [[String: Any]],
+                  var firstLineItem = lineItems.first else {
+                return
+            }
+            firstLineItem["taxes"] = [
+                [
+                    "id": 1,
+                    "subtotal": "1.00"
+                ]
+            ]
+            lineItems[0] = firstLineItem
+            malformedOrder["line_items"] = lineItems
+        }
+
+        let orders = try POSOrderListMapper(siteID: dummySiteID).map(response: response)
+
+        XCTAssertEqual(orders.map(\.orderID), [964])
+    }
+
+    func test_map_skips_malformed_orders_when_response_has_data_envelope() throws {
+        let response = try makeOrdersResponse(hasDataEnvelope: true) { malformedOrder in
+            malformedOrder.removeValue(forKey: "total")
+        }
+
+        let orders = try POSOrderListMapper(siteID: dummySiteID).map(response: response)
+
+        XCTAssertEqual(orders.map(\.orderID), [964])
+    }
+
+    func test_regular_order_list_mapper_still_throws_for_missing_required_fields() throws {
+        let response = try makeOrdersResponse { malformedOrder in
+            malformedOrder.removeValue(forKey: "total")
+        }
+
+        XCTAssertThrowsError(try OrderListMapper(siteID: dummySiteID).map(response: response))
+    }
+}
+
+private extension POSOrderListMapperTests {
+    func makeOrdersResponse(
+        hasDataEnvelope: Bool = false,
+        mutateMalformedOrder: (inout [String: Any]) -> Void
+    ) throws -> Data {
+        let response = try XCTUnwrap(Loader.contentsOf("orders-load-all-without-data"))
+        let sourceOrders = try XCTUnwrap(JSONSerialization.jsonObject(with: response) as? [[String: Any]])
+        let sourceOrder = try XCTUnwrap(sourceOrders.first)
+
+        var malformedOrder = sourceOrder
+        mutateMalformedOrder(&malformedOrder)
+
+        var validOrder = sourceOrder
+        validOrder["id"] = 964
+        validOrder["number"] = "964"
+
+        let orders = [malformedOrder, validOrder]
+        let payload: Any = hasDataEnvelope ? ["data": orders] : orders
+        return try JSONSerialization.data(withJSONObject: payload)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleErrorStateTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleErrorStateTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import PointOfSale
+
+struct PointOfSaleErrorStateTests {
+    @Test
+    func errorOnLoadingOrders_uses_try_again_button_text() {
+        let errorState = PointOfSaleErrorState.errorOnLoadingOrders()
+
+        #expect(errorState.buttonText == "Try again")
+    }
+
+    @Test
+    func errorOnLoadingOrdersNextPage_uses_try_again_button_text() {
+        let errorState = PointOfSaleErrorState.errorOnLoadingOrdersNextPage()
+
+        #expect(errorState.buttonText == "Try again")
+    }
+
+    @Test
+    func errorOnLoadingProducts_keeps_generic_retry_button_text() {
+        let errorState = PointOfSaleErrorState.errorOnLoadingProducts()
+
+        #expect(errorState.buttonText == "Retry")
+    }
+}

--- a/Modules/Tests/YosemiteTests/PointOfSale/OrderList/POSOrderListServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/OrderList/POSOrderListServiceTests.swift
@@ -3,7 +3,6 @@ import XCTest
 import struct NetworkingCore.PagedItems
 import struct NetworkingCore.Order
 import struct NetworkingCore.OrderItem
-import enum NetworkingCore.OrderStatusEnum
 import WooFoundation
 
 final class POSOrderListServiceTests: XCTestCase {
@@ -60,11 +59,10 @@ final class POSOrderListServiceTests: XCTestCase {
     }
 
     func test_PointOfSaleOrderServiceProtocol_provides_orders_when_store_has_orders() async throws {
-        let mockOrder = Order.fake().copy(
+        let mockOrder = makeOrder(
             orderID: 1001,
             number: "1001",
-            status: .completed,
-            total: "25.99"
+            items: [makeOrderItem()]
         )
         mockOrdersRemote.mockPagedOrdersResult = .success(PagedItems(items: [mockOrder],
                                                                      hasMorePages: false,
@@ -126,6 +124,30 @@ final class POSOrderListServiceTests: XCTestCase {
         XCTAssertEqual(mockOrdersRemote.spySearchTerm, "100")
     }
 
+    func test_providePointOfSaleOrders_when_one_order_has_invalid_total_then_skips_malformed_order_and_returns_page() async throws {
+        let malformedOrder = makeOrder(
+            orderID: 1001,
+            number: "1001",
+            total: "invalid",
+            items: [makeOrderItem()]
+        )
+        let validOrder = makeOrder(
+            orderID: 1002,
+            number: "1002",
+            items: [makeOrderItem(itemID: 2)]
+        )
+        mockOrdersRemote.mockPagedOrdersResult = .success(PagedItems(items: [malformedOrder, validOrder],
+                                                                     hasMorePages: true,
+                                                                     totalItems: 2))
+
+        let pagedOrders = try await orderProvider.providePointOfSaleOrders(pageNumber: 1)
+
+        XCTAssertEqual(pagedOrders.items.map(\.id), [1002])
+        XCTAssertTrue(pagedOrders.hasMorePages)
+        XCTAssertEqual(pagedOrders.totalItems, 2)
+        XCTAssertEqual(pagedOrders.items.first?.formattedTotal, "$25.99")
+    }
+
     func test_loadOrder_when_order_item_has_invalid_total_tax_then_throws_requestFailed() async {
         let malformedOrder = makeOrder(
             orderID: 1001,
@@ -147,8 +169,8 @@ final class POSOrderListServiceTests: XCTestCase {
 
     func test_PointOfSaleOrderServiceProtocol_returns_correct_pagination_when_more_pages_available() async throws {
         let mockOrders = [
-            Order.fake().copy(orderID: 1001, number: "1001", status: .completed, total: "25.99"),
-            Order.fake().copy(orderID: 1002, number: "1002", status: .completed, total: "15.50")
+            makeOrder(orderID: 1001, number: "1001", total: "25.99", items: [makeOrderItem()]),
+            makeOrder(orderID: 1002, number: "1002", total: "15.50", items: [makeOrderItem(itemID: 2)])
         ]
         mockOrdersRemote.mockPagedOrdersResult = .success(PagedItems(items: mockOrders,
                                                                      hasMorePages: true,
@@ -219,6 +241,8 @@ private extension POSOrderListServiceTests {
     func makeOrder(
         orderID: Int64,
         number: String,
+        total: String = "25.99",
+        totalTax: String = "2.50",
         items: [OrderItem]
     ) -> Order {
         Order.fake().copy(
@@ -227,8 +251,8 @@ private extension POSOrderListServiceTests {
             status: .completed,
             currency: "USD",
             discountTotal: "0.00",
-            total: "25.99",
-            totalTax: "2.50",
+            total: total,
+            totalTax: totalTax,
             items: items,
             refunds: [],
             fees: []

--- a/Modules/Tests/YosemiteTests/PointOfSale/OrderList/POSOrderListServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/OrderList/POSOrderListServiceTests.swift
@@ -79,7 +79,7 @@ final class POSOrderListServiceTests: XCTestCase {
         XCTAssertEqual(pagedOrders.items.first?.id, 1001)
     }
 
-    func test_providePointOfSaleOrders_when_one_order_item_has_invalid_total_tax_then_returns_page() async throws {
+    func test_providePointOfSaleOrders_when_one_order_item_has_invalid_total_tax_then_skips_malformed_order_and_returns_page() async throws {
         let malformedOrder = makeOrder(
             orderID: 1001,
             number: "1001",
@@ -91,14 +91,58 @@ final class POSOrderListServiceTests: XCTestCase {
             items: [makeOrderItem(itemID: 2)]
         )
         mockOrdersRemote.mockPagedOrdersResult = .success(PagedItems(items: [malformedOrder, validOrder],
-                                                                     hasMorePages: false,
+                                                                     hasMorePages: true,
                                                                      totalItems: 2))
 
         let pagedOrders = try await orderProvider.providePointOfSaleOrders(pageNumber: 1)
 
-        XCTAssertEqual(pagedOrders.items.map(\.id), [1001, 1002])
+        XCTAssertEqual(pagedOrders.items.map(\.id), [1002])
+        XCTAssertTrue(pagedOrders.hasMorePages)
         XCTAssertEqual(pagedOrders.totalItems, 2)
         XCTAssertEqual(pagedOrders.items.first?.lineItems.first?.totalTax, .zero)
+    }
+
+    func test_searchPointOfSaleOrders_when_one_order_item_has_invalid_total_tax_then_skips_malformed_order_and_returns_page() async throws {
+        let malformedOrder = makeOrder(
+            orderID: 1001,
+            number: "1001",
+            items: [makeOrderItem(totalTax: "")]
+        )
+        let validOrder = makeOrder(
+            orderID: 1002,
+            number: "1002",
+            items: [makeOrderItem(itemID: 2)]
+        )
+        mockOrdersRemote.mockSearchPagedOrdersResult = .success(PagedItems(items: [malformedOrder, validOrder],
+                                                                           hasMorePages: true,
+                                                                           totalItems: 2))
+
+        let pagedOrders = try await orderProvider.searchPointOfSaleOrders(searchTerm: "100", pageNumber: 1)
+
+        XCTAssertEqual(pagedOrders.items.map(\.id), [1002])
+        XCTAssertTrue(pagedOrders.hasMorePages)
+        XCTAssertEqual(pagedOrders.totalItems, 2)
+        XCTAssertTrue(mockOrdersRemote.searchPOSOrdersCalled)
+        XCTAssertEqual(mockOrdersRemote.spySearchTerm, "100")
+    }
+
+    func test_loadOrder_when_order_item_has_invalid_total_tax_then_throws_requestFailed() async {
+        let malformedOrder = makeOrder(
+            orderID: 1001,
+            number: "1001",
+            items: [makeOrderItem(totalTax: "")]
+        )
+        mockOrdersRemote.loadPOSOrderResult = .success(malformedOrder)
+
+        do {
+            _ = try await orderProvider.loadOrder(orderID: 1001)
+            XCTFail("Expected error to be thrown")
+        } catch POSOrderListServiceError.requestFailed {
+            XCTAssertTrue(mockOrdersRemote.loadPOSOrderCalled)
+            XCTAssertEqual(mockOrdersRemote.spyLoadPOSOrderID, 1001)
+        } catch {
+            XCTFail("Unexpected error occurred: \(error)")
+        }
     }
 
     func test_PointOfSaleOrderServiceProtocol_returns_correct_pagination_when_more_pages_available() async throws {

--- a/Modules/Tests/YosemiteTests/PointOfSale/OrderList/POSOrderListServiceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/OrderList/POSOrderListServiceTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import Yosemite
 import struct NetworkingCore.PagedItems
 import struct NetworkingCore.Order
+import struct NetworkingCore.OrderItem
 import enum NetworkingCore.OrderStatusEnum
 import WooFoundation
 
@@ -78,6 +79,28 @@ final class POSOrderListServiceTests: XCTestCase {
         XCTAssertEqual(pagedOrders.items.first?.id, 1001)
     }
 
+    func test_providePointOfSaleOrders_when_one_order_item_has_invalid_total_tax_then_returns_page() async throws {
+        let malformedOrder = makeOrder(
+            orderID: 1001,
+            number: "1001",
+            items: [makeOrderItem(totalTax: "")]
+        )
+        let validOrder = makeOrder(
+            orderID: 1002,
+            number: "1002",
+            items: [makeOrderItem(itemID: 2)]
+        )
+        mockOrdersRemote.mockPagedOrdersResult = .success(PagedItems(items: [malformedOrder, validOrder],
+                                                                     hasMorePages: false,
+                                                                     totalItems: 2))
+
+        let pagedOrders = try await orderProvider.providePointOfSaleOrders(pageNumber: 1)
+
+        XCTAssertEqual(pagedOrders.items.map(\.id), [1001, 1002])
+        XCTAssertEqual(pagedOrders.totalItems, 2)
+        XCTAssertEqual(pagedOrders.items.first?.lineItems.first?.totalTax, .zero)
+    }
+
     func test_PointOfSaleOrderServiceProtocol_returns_correct_pagination_when_more_pages_available() async throws {
         let mockOrders = [
             Order.fake().copy(orderID: 1001, number: "1001", status: .completed, total: "25.99"),
@@ -147,5 +170,42 @@ final class POSOrderListServiceTests: XCTestCase {
 private extension POSOrderListServiceTests {
     enum TestError: Error {
         case expectedError
+    }
+
+    func makeOrder(
+        orderID: Int64,
+        number: String,
+        items: [OrderItem]
+    ) -> Order {
+        Order.fake().copy(
+            orderID: orderID,
+            number: number,
+            status: .completed,
+            currency: "USD",
+            discountTotal: "0.00",
+            total: "25.99",
+            totalTax: "2.50",
+            items: items,
+            refunds: [],
+            fees: []
+        )
+    }
+
+    func makeOrderItem(
+        itemID: Int64 = 1,
+        totalTax: String = "0.00"
+    ) -> OrderItem {
+        OrderItem.fake().copy(
+            itemID: itemID,
+            name: "Test Item",
+            productID: 101,
+            variationID: 0,
+            quantity: 1.0,
+            price: NSDecimalNumber(string: "10.00"),
+            subtotal: "10.00",
+            total: "10.00",
+            totalTax: totalTax,
+            image: nil
+        )
     }
 }

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -92,50 +92,65 @@ struct POSOrderMapperTests {
     // MARK: - Product Line Items
 
     @Test
-    func lineItems_treat_invalid_total_tax_as_zero() throws {
+    func lineItems_throw_invalid_tax_error_when_total_tax_is_invalid() throws {
         // Given
-        let item = makeOrderItem(totalTax: "")
-        let order = makeOrder(items: [item])
+        let item = makeOrderItem(itemID: 11, totalTax: "")
+        let order = makeOrder(orderID: 42, items: [item])
 
         // When
-        let result = try sut.map(order: order)
-
-        // Then
-        let mappedItem = try #require(result.lineItems.first)
-        #expect(mappedItem.totalTax == .zero)
-        #expect(mappedItem.formattedPrice == "$10.00")
-        #expect(mappedItem.formattedTotal == "$10.00")
+        do {
+            _ = try sut.map(order: order)
+            Issue.record("Expected invalid tax error")
+        } catch POSOrderItemMappingError.invalidTaxValue(let orderID, let itemID, let value) {
+            // Then
+            #expect(orderID == 42)
+            #expect(itemID == 11)
+            #expect(value == "")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     @Test
-    func lineItems_treat_invalid_total_as_price_times_quantity() throws {
+    func lineItems_throw_total_formatting_error_when_total_is_invalid() throws {
         // Given
-        let item = makeOrderItem(quantity: 2, total: "invalid")
-        let order = makeOrder(items: [item])
+        let item = makeOrderItem(itemID: 12, total: "invalid")
+        let order = makeOrder(orderID: 43, items: [item])
 
         // When
-        let result = try sut.map(order: order)
-
-        // Then
-        let mappedItem = try #require(result.lineItems.first)
-        #expect(mappedItem.total == Decimal(20))
-        #expect(mappedItem.formattedTotal == "$20.00")
+        do {
+            _ = try sut.map(order: order)
+            Issue.record("Expected total formatting error")
+        } catch POSOrderItemMappingError.totalFormattingFailed(let orderID, let itemID, let total, let currency) {
+            // Then
+            #expect(orderID == 43)
+            #expect(itemID == 12)
+            #expect(total == "invalid")
+            #expect(currency == "USD")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     @Test
-    func lineItems_treat_invalid_price_as_zero() throws {
+    func lineItems_throw_price_formatting_error_when_price_is_invalid() throws {
         // Given
-        let item = makeOrderItem(price: NSDecimalNumber.notANumber)
-        let order = makeOrder(items: [item])
+        let item = makeOrderItem(itemID: 13, price: NSDecimalNumber.notANumber)
+        let order = makeOrder(orderID: 44, items: [item])
 
         // When
-        let result = try sut.map(order: order)
-
-        // Then
-        let mappedItem = try #require(result.lineItems.first)
-        #expect(mappedItem.price == .zero)
-        #expect(mappedItem.formattedPrice == "")
-        #expect(mappedItem.formattedTotal == "$10.00")
+        do {
+            _ = try sut.map(order: order)
+            Issue.record("Expected price formatting error")
+        } catch POSOrderItemMappingError.priceFormattingFailed(let orderID, let itemID, let price, let currency) {
+            // Then
+            #expect(orderID == 44)
+            #expect(itemID == 13)
+            #expect(price == NSDecimalNumber.notANumber)
+            #expect(currency == "USD")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
     }
 
     // MARK: - formattedNetAmount Logic Tests

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -89,6 +89,46 @@ struct POSOrderMapperTests {
         #expect(result.formattedPaymentTotal == "$25.99")
     }
 
+    // MARK: - Order Totals
+
+    @Test
+    func order_throws_total_formatting_error_when_total_is_invalid() throws {
+        // Given
+        let order = makeOrder(orderID: 45, total: "invalid")
+
+        // When
+        do {
+            _ = try sut.map(order: order)
+            Issue.record("Expected order total formatting error")
+        } catch POSOrderMappingError.totalFormattingFailed(let orderID, let total, let currency) {
+            // Then
+            #expect(orderID == 45)
+            #expect(total == "invalid")
+            #expect(currency == "USD")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func order_throws_total_tax_formatting_error_when_total_tax_is_invalid() throws {
+        // Given
+        let order = makeOrder(orderID: 46, totalTax: "invalid")
+
+        // When
+        do {
+            _ = try sut.map(order: order)
+            Issue.record("Expected order total tax formatting error")
+        } catch POSOrderMappingError.totalTaxFormattingFailed(let orderID, let totalTax, let currency) {
+            // Then
+            #expect(orderID == 46)
+            #expect(totalTax == "invalid")
+            #expect(currency == "USD")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
     // MARK: - Product Line Items
 
     @Test

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -105,7 +105,7 @@ struct POSOrderMapperTests {
             // Then
             #expect(orderID == 42)
             #expect(itemID == 11)
-            #expect(value == "")
+            #expect(value.isEmpty)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSOrderMapperTests.swift
@@ -89,6 +89,55 @@ struct POSOrderMapperTests {
         #expect(result.formattedPaymentTotal == "$25.99")
     }
 
+    // MARK: - Product Line Items
+
+    @Test
+    func lineItems_treat_invalid_total_tax_as_zero() throws {
+        // Given
+        let item = makeOrderItem(totalTax: "")
+        let order = makeOrder(items: [item])
+
+        // When
+        let result = try sut.map(order: order)
+
+        // Then
+        let mappedItem = try #require(result.lineItems.first)
+        #expect(mappedItem.totalTax == .zero)
+        #expect(mappedItem.formattedPrice == "$10.00")
+        #expect(mappedItem.formattedTotal == "$10.00")
+    }
+
+    @Test
+    func lineItems_treat_invalid_total_as_price_times_quantity() throws {
+        // Given
+        let item = makeOrderItem(quantity: 2, total: "invalid")
+        let order = makeOrder(items: [item])
+
+        // When
+        let result = try sut.map(order: order)
+
+        // Then
+        let mappedItem = try #require(result.lineItems.first)
+        #expect(mappedItem.total == Decimal(20))
+        #expect(mappedItem.formattedTotal == "$20.00")
+    }
+
+    @Test
+    func lineItems_treat_invalid_price_as_zero() throws {
+        // Given
+        let item = makeOrderItem(price: NSDecimalNumber.notANumber)
+        let order = makeOrder(items: [item])
+
+        // When
+        let result = try sut.map(order: order)
+
+        // Then
+        let mappedItem = try #require(result.lineItems.first)
+        #expect(mappedItem.price == .zero)
+        #expect(mappedItem.formattedPrice == "")
+        #expect(mappedItem.formattedTotal == "$10.00")
+    }
+
     // MARK: - formattedNetAmount Logic Tests
 
     @Test


### PR DESCRIPTION
## Description
We map the order list in Yosemite, for POS, and previously if it was malformed, the entire list wouldn't be shown. 

With this PR, we only skip orders with errors. Could be further improved by showing them with limited information or some warning label that we don't know what the tax is, but this is better than it was.

## Test Steps
Use proxyman to intercept the response to loading the order list in POS. Open orders, and set an invalid tax amount or total on a line item or the whole order, like "beans".

1. Confirm the full POS order list still loads
2. Confirm POS order search returns valid orders when one order in the remote page has malformed product-line amounts.
3. Confirm single-order loading fails when that order cannot be mapped.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.