### PR TITLE
Fix relatively lower risk build warnings

### DIFF
--- a/Modules/Sources/Codegen/Sourcery/Copiable/Models+Copiable.swifttemplate
+++ b/Modules/Sources/Codegen/Sourcery/Copiable/Models+Copiable.swifttemplate
@@ -129,10 +129,13 @@ let modulesToGenerateImports: [String] = {
     // Targeted imports like "enum Foo.Bar" are redundant when "Foo" is already imported.
     let broadModules = Set(allModules.filter { !$0.contains(" ") && !$0.contains(".") })
 
+    let currentModule = matchingTypes.first?.module
+
     return allModules.filter { entry in
         guard entry.contains(" ") || entry.contains(".") else { return true }
         let path = entry.contains(" ") ? entry.split(separator: " ").last.map(String.init) ?? entry : entry
         let baseModule = path.split(separator: ".").first.map(String.init) ?? path
+        guard baseModule != currentModule else { return false }
         return !broadModules.contains(baseModule)
     }
 }()

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -6,12 +6,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
     public func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
         let buildConfig = BuildConfiguration.current
 
-        /// Whether this is a UI test run.
-        ///
-        /// This can be used to enable/disable a feature flag specifically for UI testing.
-        ///
-        let isUITesting = CommandLine.arguments.contains("-ui_testing")
-
         switch featureFlag {
         case .inbox:
             return true

--- a/Modules/Sources/Fakes/Hardware.generated.swift
+++ b/Modules/Sources/Fakes/Hardware.generated.swift
@@ -40,6 +40,7 @@ extension Hardware.CardPresentTransactionDetails {
             expYear: .fake(),
             cardholderName: .fake(),
             brand: .fake(),
+            availableNetworks: .fake(),
             generatedCard: .fake(),
             receipt: .fake(),
             emvAuthData: .fake(),
@@ -82,7 +83,7 @@ extension Hardware.PaymentIntent {
             currency: .fake(),
             metadata: .fake(),
             charges: .fake(),
-            collectedPaymentMethod: nil
+            collectedPaymentMethod: .fake()
         )
     }
 }

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -1758,7 +1758,8 @@ extension Networking.SiteAPI {
         .init(
             siteID: .fake(),
             namespaces: .fake(),
-            applicationPasswordAvailable: .fake()
+            applicationPasswordAvailable: .fake(),
+            routes: .fake()
         )
     }
 }

--- a/Modules/Sources/Networking/Network/BackgroundDownloadService.swift
+++ b/Modules/Sources/Networking/Network/BackgroundDownloadService.swift
@@ -50,7 +50,7 @@ extension BackgroundDownloadService: BackgroundDownloadProtocol {
         setBackgroundCompletionHandler(completionHandler)
 
         // Create session with same identifier - this reconnects to the existing download
-        let session = createBackgroundSession(identifier: sessionIdentifier, allowCellular: allowCellular)
+        _ = createBackgroundSession(identifier: sessionIdentifier, allowCellular: allowCellular)
 
         // Wait for delegate callbacks to complete
         return try? await withCheckedThrowingContinuation { continuation in

--- a/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/NetworkingCore/Model/Copiable/Models+Copiable.generated.swift
@@ -2,7 +2,6 @@
 // DO NOT EDIT
 import Codegen
 import Foundation
-import struct NetworkingCore.JetpackSite
 
 // swiftlint:disable line_length
 

--- a/Modules/Sources/NetworkingCore/Model/Site.swift
+++ b/Modules/Sources/NetworkingCore/Model/Site.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Codegen
-import struct NetworkingCore.JetpackSite
 
 /// Represents a WordPress.com Site.
 ///

--- a/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
+++ b/Modules/Sources/NetworkingCore/Network/WordPressOrgNetwork.swift
@@ -54,7 +54,7 @@ public final class WordPressOrgNetwork: Network {
                 case .failure(let error):
                     DDLogWarn("⚠️ Error requesting \(request.urlRequest?.url?.absoluteString ?? ""): \(error.localizedDescription)")
                     do {
-                        try self.validateResponse(response.data)
+                        try Self.validateResponse(response.data)
                         continuation.resume(throwing: error)
                     } catch {
                         continuation.resume(throwing: error)
@@ -79,7 +79,7 @@ public final class WordPressOrgNetwork: Network {
             .validate()
             .responseData { response in
                 do {
-                    try self.validateResponse(response.data)
+                    try Self.validateResponse(response.data)
                     completion(response.value, response.networkingError)
                 } catch {
                     completion(nil, error)
@@ -102,7 +102,7 @@ public final class WordPressOrgNetwork: Network {
             .validate()
             .responseData { response in
                 do {
-                    try self.validateResponse(response.data)
+                    try Self.validateResponse(response.data)
                     completion(response.result.mapError { $0 })
                 } catch {
                     completion(.failure(error))
@@ -115,7 +115,7 @@ public final class WordPressOrgNetwork: Network {
         let sessionRequest = alamofireSession.request(request).validate()
         let response = await sessionRequest.serializingData().response
         do {
-            try validateResponse(response.data)
+            try Self.validateResponse(response.data)
             switch response.result {
                 case .success(let data):
                     return (data, response.response?.headers.dictionary)
@@ -141,7 +141,7 @@ public final class WordPressOrgNetwork: Network {
             guard let self else { return }
             self.alamofireSession.request(request).validate().responseData { response in
                 do {
-                    try self.validateResponse(response.data)
+                    try Self.validateResponse(response.data)
                     let result: Result<Data, Error> = response.result.mapError { $0 }
                     promise(Swift.Result.success(result))
                 } catch {
@@ -159,7 +159,7 @@ public final class WordPressOrgNetwork: Network {
             .upload(multipartFormData: multipartFormData, with: request)
             .responseData() { response in
                 do {
-                    try self.validateResponse(response.data)
+                    try Self.validateResponse(response.data)
                     completion(response.value, response.error)
                 } catch {
                     completion(nil, error)
@@ -190,7 +190,7 @@ private extension WordPressOrgNetwork {
 
     /// Validates whether the REST API request failed with an invalid cookie nonce.
     ///
-    func validateResponse(_ data: Data?) throws {
+    static func validateResponse(_ data: Data?) throws {
         if let data,
            let error = try? JSONDecoder().decode(ErrorResponse.self, from: data),
            error.code == "rest_cookie_invalid_nonce" {

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -676,7 +676,7 @@ public extension OrdersRemote {
         return try await enqueue(request, mapper: mapper)
     }
 
-    public func loadPOSOrders(siteID: Int64, orderIDs: [Int64]) async throws -> [Order] {
+    func loadPOSOrders(siteID: Int64, orderIDs: [Int64]) async throws -> [Order] {
         guard !orderIDs.isEmpty else { return [] }
         let parameters: [String: Any] = [
             ParameterKeys.include: Set(orderIDs).map(String.init).joined(separator: ","),

--- a/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSPaymentModel.swift
@@ -225,8 +225,8 @@ extension POSPaymentModel {
     /// — but threaded through with the explicit method so the eventual collect
     /// targets the reader that's actually coming up.
     func startPaymentWithMethod(_ method: CardReaderConnectionMethod) async {
-        DDLogInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus), "
-                  + "currentPaymentMethod: \(String(describing: currentPaymentMethod))")
+        logInfo("🃏 [CardPayment] startPaymentWithMethod \(method) — status: \(cardReaderConnectionStatus), " +
+                "currentPaymentMethod: \(String(describing: currentPaymentMethod))")
 
         // Same-method re-entry guard. Two different shapes:
         // - BT: card state moves out of `.idle` during collection, so the
@@ -886,9 +886,9 @@ extension POSPaymentModel {
     /// For cash, scan-to-pay, and mark-as-paid, restores session event subscriptions without
     /// activating the reader. If the QR was on screen, resumes polling.
     func activate() async {
-        DDLogInfo("▶️ [Session] activate called — isActive: \(isActive), " +
-                  "activeMethod: \(paymentState.activePaymentMethod), card: \(paymentState.card), " +
-                  "cash: \(paymentState.cash), scanToPay: \(paymentState.scanToPay)")
+        logInfo("▶️ [Session] activate called — isActive: \(isActive), " +
+                "activeMethod: \(paymentState.activePaymentMethod), card: \(paymentState.card), " +
+                "cash: \(paymentState.cash), scanToPay: \(paymentState.scanToPay)")
         guard !isActive else { return }
         if paymentState.activePaymentMethod == .card {
             await startPayment()
@@ -995,8 +995,8 @@ extension POSPaymentModel {
                             // runs blind to events. Log the cancellables count
                             // here so a "no events firing after reconnect"
                             // bug is one Bartleby search away from the cause.
-                            DDLogDebug("🃏 [CardPayment] BT auto-resume re-kick — "
-                                       + "paymentSessionCancellables.count: \(self.paymentSessionCancellables.count)")
+                            logDebug("🃏 [CardPayment] BT auto-resume re-kick — " +
+                                     "paymentSessionCancellables.count: \(self.paymentSessionCancellables.count)")
                             await self.startPayment()
                         }
                     case .cancellingConnection, .disconnecting, .reconnecting:
@@ -1257,8 +1257,8 @@ private extension POSPaymentModel {
                 guard let self else { return }
                 if paymentState.cash != .idle {
                     if cardPaymentState.requiresCashExit {
-                        DDLogWarn("💵 [CashPayment] committed card event \(cardPaymentState) during cash flow " +
-                                  "- transitioning to card view")
+                        logWarn("💵 [CashPayment] committed card event \(cardPaymentState) during cash flow " +
+                                "- transitioning to card view")
                         paymentState.cash = .idle
                     } else {
                         DDLogInfo("💵 [CashPayment] ignoring non-committed card event \(cardPaymentState) during cash flow")
@@ -1267,8 +1267,8 @@ private extension POSPaymentModel {
                 }
                 if paymentState.scanToPay != .idle {
                     if cardPaymentState.requiresCashExit {
-                        DDLogWarn("📲 [ScanToPay] committed card event \(cardPaymentState) during scan-to-pay flow " +
-                                  "- transitioning to card view")
+                        logWarn("📲 [ScanToPay] committed card event \(cardPaymentState) during scan-to-pay flow " +
+                                "- transitioning to card view")
                         stopScanToPayPolling()
                         paymentState.scanToPay = .idle
                         scanToPayURL = nil
@@ -1280,8 +1280,8 @@ private extension POSPaymentModel {
                 }
                 if paymentState.markAsPaid != .idle {
                     if cardPaymentState.requiresCashExit {
-                        DDLogWarn("🪙 [MarkAsPaid] committed card event \(cardPaymentState) during mark-as-paid flow " +
-                                  "- transitioning to card view")
+                        logWarn("🪙 [MarkAsPaid] committed card event \(cardPaymentState) during mark-as-paid flow " +
+                                "- transitioning to card view")
                         paymentState.markAsPaid = .idle
                     } else {
                         // Verbose: the merchant can sit on the confirmation alert for a while;
@@ -1290,10 +1290,10 @@ private extension POSPaymentModel {
                         return
                     }
                 }
-                DDLogInfo("🃏 [CardPayment] subscription setting card state: \(cardPaymentState), " +
-                          "current cash state: \(paymentState.cash), " +
-                          "current scanToPay state: \(paymentState.scanToPay), " +
-                          "current markAsPaid state: \(paymentState.markAsPaid)")
+                logInfo("🃏 [CardPayment] subscription setting card state: \(cardPaymentState), " +
+                        "current cash state: \(paymentState.cash), " +
+                        "current scanToPay state: \(paymentState.scanToPay), " +
+                        "current markAsPaid state: \(paymentState.markAsPaid)")
                 paymentState.card = cardPaymentState
                 // Don't auto-clear `currentPaymentMethod` on `.idle` — Stripe
                 // emits `.idle` mid-cancel of a BT scan (before the merchant
@@ -1380,6 +1380,20 @@ extension POSPaymentModel {
         resetCardReaderObservation()
         paymentSessionCancellables.removeAll()
         cancellables.forEach { $0.cancel() }
+    }
+}
+
+private extension POSPaymentModel {
+    func logInfo(_ message: String) {
+        DDLogInfo(DDLogMessageFormat(stringLiteral: message))
+    }
+
+    func logWarn(_ message: String) {
+        DDLogWarn(DDLogMessageFormat(stringLiteral: message))
+    }
+
+    func logDebug(_ message: String) {
+        DDLogDebug(DDLogMessageFormat(stringLiteral: message))
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderListView.swift
@@ -99,11 +99,11 @@ struct POSOrderListView: View {
                     }
                 }
             case (.error(let errorState), true):
-                POSListErrorView(error: errorState) {
+                POSListErrorView(error: errorState, onAction: {
                     Task { @MainActor in
                         await orderListModel.ordersController.loadOrders()
                     }
-                }
+                })
             default:
                 listView
             }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrdersView.swift
@@ -106,11 +106,11 @@ struct POSOrdersView: View {
         ZStack {
             VStack {
                 Spacer()
-                POSListErrorView(error: error) {
+                POSListErrorView(error: error, onAction: {
                     Task { @MainActor in
                         await orderListModel.ordersController.loadOrders()
                     }
-                }
+                })
                 Spacer()
             }
 

--- a/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/Refund/POSRefundModalContentView.swift
@@ -510,7 +510,13 @@ private extension CardPresentPaymentEventDetails {
         case .updateFailedNonRetryable:
             return "updateFailedNonRetryable"
         case .updateFailedLowBattery(let batteryLevel, _, _):
-            return "updateFailedLowBattery-\(batteryLevel)"
+            let batteryLevelDescription: String
+            if let batteryLevel {
+                batteryLevelDescription = "\(batteryLevel)"
+            } else {
+                batteryLevelDescription = "nil"
+            }
+            return "updateFailedLowBattery-\(batteryLevelDescription)"
         case .connectionSuccess:
             return "connectionSuccess"
         case .locationRequestPreAlert:

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSTotalsSectionView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSTotalsSectionView.swift
@@ -46,7 +46,7 @@ struct POSTotalsSectionView: View {
                 titleFont: .posBodyLargeBold
             )
 
-            if let paidAmount {
+            if paidAmount != nil {
                 sectionDivider
                 paidAmountRow
 

--- a/Scripts/build-phases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/build-phases/LintAppLocalizedStringsUsage.swift
@@ -270,7 +270,7 @@ enum LintResult { case ok, skipped, violationsFound([(line: Int, col: Int)]) }
 /// Lint a given file for usages of `NSLocalizedString` instead of `AppLocalizedString`
 func lint(fileAt url: URL, targetName: String) throws -> LintResult {
     guard ["m", "swift"].contains(url.pathExtension) else { return .skipped }
-    let content = try String(contentsOf: url)
+    let content = try String(contentsOf: url, encoding: .utf8)
     var lineNo = 0
     var violations: [(line: Int, col: Int)] = []
     content.enumerateLines { line, _ in

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -841,7 +841,7 @@ private extension StorePickerViewController {
                         self?.dismiss()
                     }
                 } else {
-                    let underlyingError = (error as? RoleEligibilityError)?.underlyingError ?? error
+                    let underlyingError = error.underlyingError ?? error
                     let isPermissionError = underlyingError is DotcomError
                     self.displayUnknownErrorModal(isPermissionError: isPermissionError)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsReportLink.swift
@@ -43,12 +43,11 @@ private extension AnalyticsReportLink {
     }
 }
 
-#Preview {
+#Preview(traits: .sizeThatFitsLayout) {
     AnalyticsReportLink(showingWebReport: .constant(false),
                         reportViewModel: .init(reportType: .revenue,
                                                period: .today,
                                                webViewTitle: "Revenue Report",
                                                reportURL: URL(string: "https://woocommerce.com/")!,
                                                usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()))
-        .previewLayout(.sizeThatFits)
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -558,7 +558,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
     }
 
     func isNetworkError(_ error: Error) -> Bool {
-        if let afError = error as? AFError {
+        if error is AFError {
             return true
         } else {
             return (error as NSError).domain == NSURLErrorDomain

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
@@ -60,7 +60,7 @@ struct ProductDiscountView: View {
                     HStack {
                         Text(Localization.priceAfterDiscountLabel)
                         Spacer()
-                        if let price = viewModel.totalPricePreDiscount {
+                        if viewModel.totalPricePreDiscount != nil {
                             Text(discountDetailsViewModel.formattedPriceAfterDiscount)
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/ShipmentDetails/WooShippingShipmentDetailsViewModel.swift
@@ -391,7 +391,7 @@ private extension WooShippingShipmentDetailsViewModel {
             .combineLatest($selectedPackage, $shippingService)
             .combineLatest($customsForm, $hazmatCategory)
             .sink { [weak self] input in
-                let ((weight, selectedPackage, shippingService), customsForm, hazmatCategory) = input
+                let ((weight, selectedPackage, shippingService), _, hazmatCategory) = input
                 guard let self, let selectedPackage, let shippingService else { return }
                 let package = buildSelectedPackage(selectedPackage,
                                                    weight: Double(weight) ?? 0,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingAddPackageViewModel.swift
@@ -291,7 +291,7 @@ final class WooShippingAddPackageViewModel: ObservableObject {
     // star/unstar packages
     func starUnstarPackage(_ packageID: String, carrierID: String) {
         let isStarring = !starredCarriersPackages.contains(packageID)
-        _ = withAnimation(starAnimation) {
+        withAnimation(starAnimation) {
             if isStarring {
                 starredCarriersPackages.insert(packageID)
             } else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -494,7 +494,8 @@ private extension PaymentMethodsViewModel {
     }
 
     private func updatePaymentGateway() {
-        CardPresentPaymentAction.loadActivePaymentGatewayExtension { paymentGateway in
+        // Preserve the existing no-op behavior while silencing the unused-result warning.
+        _ = CardPresentPaymentAction.loadActivePaymentGatewayExtension { paymentGateway in
             self.cardPaymentGateway = paymentGateway
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -493,13 +493,6 @@ private extension PaymentMethodsViewModel {
         stores.dispatch(action)
     }
 
-    private func updatePaymentGateway() {
-        // Preserve the existing no-op behavior while silencing the unused-result warning.
-        _ = CardPresentPaymentAction.loadActivePaymentGatewayExtension { paymentGateway in
-            self.cardPaymentGateway = paymentGateway
-        }
-    }
-
     func updateOrderAsynchronously() {
         let action = OrderAction.retrieveOrder(siteID: siteID, orderID: orderID) { _, _  in }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -254,7 +254,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
     /// Label showing secondary product details. Can include product type (if the row is configurable), and SKU (if available).
     ///
     var secondaryProductDetailsLabel: String {
-        if case .unsupported(let reason) = selectedState {
+        if case .unsupported = selectedState {
             return ""
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -195,7 +195,7 @@ struct ProductSelectorView: View {
 
     private func updateSyncApproach(for horizontalSizeClass: UserInterfaceSizeClass?) {
         guard let horizontalSizeClass,
-              let presentationStyle else {
+              presentationStyle != nil else {
             return
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -19,8 +19,6 @@
 		3F0904092D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; };
 		3F0904152D26A40800D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */; };
-		3F09A3FE2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3F0BFD682F85E1CD001182F9 /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0BFD642F85E1C4001182F9 /* ApiCredentials.swift */; };
 		3F0BFD692F85E1D4001182F9 /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0BFD662F85E1C4001182F9 /* ApiCredentials.swift */; };
 		3F1FA84228B60125009E246C /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F1FA84128B60125009E246C /* WidgetKit.framework */; };
@@ -177,7 +175,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3F09A3FE2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */,
 				3F0904152D26A40800D8ACCE /* WordPressAuthenticator.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -197,7 +194,6 @@
 		315E14F32698DA24000AD5FF /* PassKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PassKit.framework; path = System/Library/Frameworks/PassKit.framework; sourceTree = SDKROOT; };
 		3F0904012D26A40700D8ACCE /* WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F0904082D26A40800D8ACCE /* WordPressAuthenticatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressAuthenticatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F0BFD622F85DF6E001182F9 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3F0BFD642F85E1C4001182F9 /* ApiCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiCredentials.swift; sourceTree = DERIVED_FILE_DIR; };
 		3F0BFD662F85E1C4001182F9 /* ApiCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiCredentials.swift; sourceTree = DERIVED_FILE_DIR; };
@@ -577,7 +573,6 @@
 			files = (
 				5744BEB1248FE44D000A6FE2 /* SwiftUI.framework in Frameworks */,
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
-				3F09A3FD2D243D3F00D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 				3F2B4AEE2DDC31A200E5E49C /* XcodeTarget_WooCommerce in Frameworks */,
 				3F0904142D26A40800D8ACCE /* WordPressAuthenticator.framework in Frameworks */,
 			);
@@ -653,7 +648,6 @@
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3F09A3FC2D243D3F00D8ACCE /* WordPressAuthenticator.framework */,
 				26B0FDE12BFFBAC500A0D937 /* Contacts.framework */,
 				263E641F2BEB419B0059D84B /* NetworkingWatchOS.framework */,
 				200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1199,6 +1199,7 @@
 		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
## Why

I noticed some build warnings in a WIP branch only when I opened the file in Xcode, as they were buried in a long list of warnings in the build output that I usually only read upon errors and then filter by errors. This PR contains the smaller lower-risk build-warning fixes, while ones that need more targeted review and testing will be worked on separately. I'm also hoping to add a CI task to detect build warnings increase and post a comment in a PR (non-blocking).

## Description

| Commit | Build warning it addresses | How |
|---|---|---|
| [a3ae75b](https://github.com/woocommerce/woocommerce-ios/commit/a3ae75b551e4c6cb48e59838c5364312f5a3e8d1) | Assorted small warnings: unused locals/casts/bindings, ignored results, deprecated preview layout API. | Removes dead locals, replaces unused bindings with boolean checks or `_`, makes ignored results explicit, and uses `#Preview(traits:)`. |
| [7785cc4](https://github.com/woocommerce/woocommerce-ios/commit/7785cc4fa837ccb6b9c81350dda9b7608d9ff729) | Generated same-module import warnings, e.g. `import struct NetworkingCore.JetpackSite`. | Updates the Copiable Sourcery template to drop targeted imports whose base module is the generated file's module, then updates generated output. |
| [c1ce4ab](https://github.com/woocommerce/woocommerce-ios/commit/c1ce4abce0e88c45e1c3df3f50f9641085694cab) | Swift 6 warning from capturing non-Sendable `WordPressOrgNetwork` in response closures. | Makes stateless `validateResponse` static and calls it through `Self`. |
| [999747c](https://github.com/woocommerce/woocommerce-ios/commit/999747c3d436512e996c3ebb5c70e45e6b64898d) | Redundant access-control warning on `loadPOSOrders`. | Removes `public` because the method is already inside a public extension. |
| [e65317e](https://github.com/woocommerce/woocommerce-ios/commit/e65317e79aceeda6f3ff0c8175589e17841076ed) | Deprecated backward trailing-closure matching in POS order list error views. | Labels the retry closure as `onAction` at the call sites. |
| [2ee08c5](https://github.com/woocommerce/woocommerce-ios/commit/2ee08c5bd5d84cd98f2e5308eff37804b05c6bd1) | Deprecated CocoaLumberjack `DDLogInfo`/`DDLogWarn`/`DDLogDebug` overloads. | Routes string-built log messages through helpers that construct `DDLogMessageFormat`. |
| [41b6c06](https://github.com/woocommerce/woocommerce-ios/commit/41b6c065b4d041bcf988a064b833e8aea6d219f8) | Warning about implicit Optional debug-description interpolation. | Explicitly formats the optional battery level, using `nil` for the missing case. |
| [ab55c37](https://github.com/woocommerce/woocommerce-ios/commit/ab55c376331ee3d09cea784fe29e3a147f4f7038) | macOS 15 deprecation: `String(contentsOf:)`. | Reads source files with explicit `.utf8` via `String(contentsOf:encoding:)`. Note: This is safe because the linter only reads .swift and .m source files, which are UTF-8/ASCII in this repo. The old API used implicit encoding detection, but that behavior is deprecated and unnecessary here; using explicit .utf8 matches Xcode/source-file conventions and removes the macOS 15 build warning without changing lint logic. |
| [c9713b7](https://github.com/woocommerce/woocommerce-ios/commit/c9713b77a8c6c4c939d5a7cfdb09c2a8a335fad1) | Xcode warning: duplicate `WordPressAuthenticator.framework` build/embed entry. | Removes the duplicate framework build file, embed entry, and file reference. |
| [876a215](https://github.com/woocommerce/woocommerce-ios/commit/876a2153834095483041ba4cdc86adb8c06b301f) | Xcode warning: SwiftLint run script always runs because it has no outputs. | Marks the SwiftLint phase `alwaysOutOfDate` because it is intentionally always-run. |

Current size after the rewrite: `25 files changed, 71 insertions, 59 deletions`.

## Test Steps

Feel free to skip testing for this PR or do a quick smoke testing of the app.
I manually tested:
- Run `rake generate` and verify no diffs
- Test POS and verify `🃏 [CardPayment]` logs appear
- Smoke test the app


## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.