### PR TITLE
Remove IPP and POS support for fiscalization countries

### DIFF
--- a/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
+++ b/Modules/Sources/Yosemite/Model/Payments/CardPresentPaymentsConfiguration.swift
@@ -112,7 +112,7 @@ public struct CardPresentPaymentsConfiguration: Equatable {
                 contactlessLimitAmount: 10000,
                 minimumOperatingSystemVersionForTapToPay: Constants.sharedMinimumIosVersion
             )
-        case .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES:
+        case .FI, .IE, .LU, .NL:
             self.init(
                 countryCode: country,
                 paymentMethods: [.cardPresent],

--- a/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Eligibility/POSCountryCurrencyValidator.swift
@@ -78,7 +78,7 @@ public enum POSCountryCurrencyValidator {
     }
 
     private static let eeaEuroCountries: [CountryCode] = [
-        .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES
+        .FI, .IE, .LU, .NL
     ]
 
     /// Countries whose POS eligibility is still controlled by remote rollout

--- a/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresher.swift
+++ b/Modules/Sources/Yosemite/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresher.swift
@@ -37,14 +37,14 @@ public final class CardPresentPaymentsCountryExpansionEligibilityRefresher: @unc
     }
 
     /// Returns the remote feature flag that gates IPP for the given country, if any.
-    /// Returns `nil` for the existing supported countries (US/PR/CA/GB), which need no flag.
+    /// Returns `nil` for existing supported countries that need no flag, and countries without active IPP support.
     public static func flag(for country: CountryCode) -> RemoteFeatureFlag? {
         switch country {
         case .US, .PR, .CA, .GB:
             return nil
-        case .FR, .DE, .IE, .NL, .SG, .NZ:
+        case .IE, .NL, .SG, .NZ:
             return .inPersonPaymentsCountryExpansion
-        case .AT, .BE, .FI, .IT, .LU, .PT, .ES:
+        case .FI, .LU:
             return .inPersonPaymentsCountryExpansionEUExtended
         case .AU:
             return .inPersonPaymentsAustraliaWooPayments

--- a/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
+++ b/Modules/Tests/YosemiteTests/Model/CardPresentConfigurationTests.swift
@@ -53,11 +53,11 @@ class CardPresentConfigurationTests: XCTestCase {
 
     // MARK: - Country Expansion (RSM-637)
     //
-    // The model knows about all 13 expansion countries unconditionally; per-site exposure
+    // The model knows about expansion countries unconditionally; per-site exposure
     // is gated upstream by `CardPresentConfigurationLoader` + the eligibility cache.
 
-    func test_configuration_for_each_EEA_Euro_expansion_country() {
-        let eeaCountries: [CountryCode] = [.AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES]
+    func test_configuration_for_each_supported_EEA_Euro_expansion_country() {
+        let eeaCountries: [CountryCode] = [.FI, .IE, .LU, .NL]
         for country in eeaCountries {
             let configuration = CardPresentPaymentsConfiguration(country: country)
             XCTAssertTrue(configuration.isSupportedCountry, "Expected \(country) to be supported by the model")
@@ -73,6 +73,18 @@ class CardPresentConfigurationTests: XCTestCase {
             // €50 — Stripe Terminal contactless CVM limit for EEA-Euro countries.
             XCTAssertEqual(configuration.contactlessLimitAmount, 5000)
             XCTAssertEqual(configuration.stripeSmallestCurrencyUnitMultiplier, 100)
+        }
+    }
+
+    func test_configuration_for_fiscalization_countries_is_unsupported() {
+        let fiscalizationCountries: [CountryCode] = [.AT, .BE, .FR, .DE, .IT, .PT, .ES]
+        for country in fiscalizationCountries {
+            let configuration = CardPresentPaymentsConfiguration(country: country)
+            XCTAssertFalse(configuration.isSupportedCountry, "Expected \(country) to be unsupported by the model")
+            XCTAssertEqual(configuration.currencies, [])
+            XCTAssertEqual(configuration.paymentMethods, [])
+            XCTAssertEqual(configuration.paymentGateways, [])
+            XCTAssertEqual(configuration.supportedReaders, [])
         }
     }
 

--- a/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/Eligibility/POSCountryCurrencyValidatorTests.swift
@@ -200,6 +200,7 @@ struct POSCountryCurrencyValidatorTests {
         #expect(supportedCurrencies[.GB] == [.GBP])
         #expect(supportedCurrencies[.CA] == nil)
         #expect(supportedCurrencies[.AT] == nil)
+        #expect(supportedCurrencies[.DE] == nil)
         #expect(supportedCurrencies[.SG] == nil)
         #expect(supportedCurrencies[.NZ] == nil)
     }
@@ -219,17 +220,10 @@ struct POSCountryCurrencyValidatorTests {
     // MARK: - Validator gated-country behavior
 
     @Test(arguments: [
-        (country: CountryCode.AT, currency: CurrencyCode.EUR),
-        (country: CountryCode.BE, currency: CurrencyCode.EUR),
         (country: CountryCode.FI, currency: CurrencyCode.EUR),
-        (country: CountryCode.FR, currency: CurrencyCode.EUR),
-        (country: CountryCode.DE, currency: CurrencyCode.EUR),
         (country: CountryCode.IE, currency: CurrencyCode.EUR),
-        (country: CountryCode.IT, currency: CurrencyCode.EUR),
         (country: CountryCode.LU, currency: CurrencyCode.EUR),
         (country: CountryCode.NL, currency: CurrencyCode.EUR),
-        (country: CountryCode.PT, currency: CurrencyCode.EUR),
-        (country: CountryCode.ES, currency: CurrencyCode.EUR),
         (country: CountryCode.SG, currency: CurrencyCode.SGD),
         (country: CountryCode.NZ, currency: CurrencyCode.NZD),
         (country: CountryCode.AU, currency: CurrencyCode.AUD)
@@ -244,16 +238,16 @@ struct POSCountryCurrencyValidatorTests {
 
     @Test("Gated country with mismatched currency is ineligible when the current site country is eligible")
     func test_gated_country_with_mismatched_currency_is_ineligible() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .DE,
+        let result = POSCountryCurrencyValidator.validate(countryCode: .FI,
                                                           currencyCode: .USD,
                                                           siteID: siteID,
                                                           eligibilityService: eligibleService)
-        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .DE, supportedCurrencies: [.EUR])))
+        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .FI, supportedCurrencies: [.EUR])))
     }
 
     @Test("Gated country is unsupported when eligibility off")
     func test_gated_country_is_unsupported_when_eligibility_off() {
-        let result = POSCountryCurrencyValidator.validate(countryCode: .DE,
+        let result = POSCountryCurrencyValidator.validate(countryCode: .FI,
                                                           currencyCode: .EUR,
                                                           siteID: siteID,
                                                           eligibilityService: ineligibleService)
@@ -263,8 +257,29 @@ struct POSCountryCurrencyValidatorTests {
         }
     }
 
+    @Test(arguments: [
+        CountryCode.AT,
+        .BE,
+        .FR,
+        .DE,
+        .IT,
+        .PT,
+        .ES
+    ])
+    func fiscalization_country_is_unsupported_even_when_current_site_country_is_eligible(country: CountryCode) {
+        let result = POSCountryCurrencyValidator.validate(countryCode: country,
+                                                          currencyCode: .EUR,
+                                                          siteID: siteID,
+                                                          eligibilityService: eligibleService)
+        guard case .ineligible(let reason) = result, case .unsupportedCountry(let supportedCountries) = reason else {
+            Issue.record("Expected unsupportedCountry result, got \(result)")
+            return
+        }
+        #expect(!supportedCountries.contains(country))
+    }
+
     private let eeaEuroCountries: [CountryCode] = [
-        .AT, .BE, .FI, .FR, .DE, .IE, .IT, .LU, .NL, .PT, .ES
+        .FI, .IE, .LU, .NL
     ]
 
     // Mirrors the validator's temporary coarse gated-country set. The specific

--- a/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresherTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Payments/CardPresentPaymentsCountryExpansionEligibilityRefresherTests.swift
@@ -17,9 +17,17 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         }
     }
 
+    @Test("flag(for:) returns nil for fiscalization countries removed from support")
+    func test_flag_for_removed_fiscalization_countries() {
+        for country in [CountryCode.AT, .BE, .FR, .DE, .IT, .PT, .ES] {
+            #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: country) == nil,
+                    "Expected \(country) to require no expansion flag after support removal")
+        }
+    }
+
     @Test("flag(for:) returns inPersonPaymentsCountryExpansion for the primary group")
     func test_flag_for_primary_expansion_group() {
-        for country in [CountryCode.FR, .DE, .IE, .NL, .SG, .NZ] {
+        for country in [CountryCode.IE, .NL, .SG, .NZ] {
             #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: country)
                     == .inPersonPaymentsCountryExpansion,
                     "Expected \(country) to map to inPersonPaymentsCountryExpansion")
@@ -28,7 +36,7 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
 
     @Test("flag(for:) returns inPersonPaymentsCountryExpansionEUExtended for the EU extended group")
     func test_flag_for_eu_extended_expansion_group() {
-        for country in [CountryCode.AT, .BE, .FI, .IT, .LU, .PT, .ES] {
+        for country in [CountryCode.FI, .LU] {
             #expect(CardPresentPaymentsCountryExpansionEligibilityRefresher.flag(for: country)
                     == .inPersonPaymentsCountryExpansionEUExtended,
                     "Expected \(country) to map to inPersonPaymentsCountryExpansionEUExtended")
@@ -76,7 +84,7 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         )
 
         // When
-        await refresher.refresh(siteID: siteID, countryCode: .FR)
+        await refresher.refresh(siteID: siteID, countryCode: .NL)
 
         // Then
         #expect(service.cachedValues == [siteID: true])
@@ -112,7 +120,7 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         )
 
         // When
-        await refresher.refresh(siteID: siteID, countryCode: .ES)
+        await refresher.refresh(siteID: siteID, countryCode: .FI)
 
         // Then
         #expect(await dispatchedFlags.values == [.inPersonPaymentsCountryExpansionEUExtended])
@@ -150,8 +158,8 @@ struct CardPresentPaymentsCountryExpansionEligibilityRefresherTests {
         )
 
         // When
-        await refresher.refresh(siteID: 1, countryCode: .DE)
-        await refresher.refresh(siteID: 2, countryCode: .ES)
+        await refresher.refresh(siteID: 1, countryCode: .NL)
+        await refresher.refresh(siteID: 2, countryCode: .FI)
         await refresher.refresh(siteID: 3, countryCode: .US)
 
         // Then

--- a/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/In-Person Payments/CardPresentConfigurationLoaderTests.swift
@@ -72,9 +72,9 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertTrue(loader.configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_Spain_is_unsupported_when_expansion_ineligible() {
+    func test_configuration_for_Netherlands_is_unsupported_when_expansion_ineligible() {
         // Given
-        setupCountry(country: .es)
+        setupCountry(country: .nl)
 
         // When
         let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: ineligibleService)
@@ -83,9 +83,9 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         XCTAssertFalse(loader.configuration.isSupportedCountry)
     }
 
-    func test_configuration_for_Spain_is_supported_when_expansion_eligible() {
+    func test_configuration_for_Netherlands_is_supported_when_expansion_eligible() {
         // Given
-        setupCountry(country: .es)
+        setupCountry(country: .nl)
 
         // When
         let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
@@ -93,6 +93,17 @@ final class CardPresentConfigurationLoaderTests: XCTestCase {
         // Then
         XCTAssertTrue(loader.configuration.isSupportedCountry)
         XCTAssertEqual(loader.configuration.currencies, [.EUR])
+    }
+
+    func test_configuration_for_Spain_is_unsupported_when_expansion_eligible() {
+        // Given
+        setupCountry(country: .es)
+
+        // When
+        let loader = CardPresentConfigurationLoader(stores: stores, eligibilityService: eligibleService)
+
+        // Then
+        XCTAssertFalse(loader.configuration.isSupportedCountry)
     }
 
     func test_configuration_for_Singapore_is_supported_when_expansion_eligible() {
@@ -160,6 +171,7 @@ private extension CardPresentConfigurationLoaderTests {
         case us = "US:CA"
         case ca = "CA:NS"
         case es = "ES"
+        case nl = "NL"
         case gb = "GB"
         case sg = "SG"
         case nz = "NZ"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -464,9 +464,7 @@ struct POSTabEligibilityCheckerTests {
     // MARK: - IPP Country Expansion Gate Tests
 
     @Test(arguments: [
-        (country: Country.de, currency: CurrencyCode.EUR),
-        (country: Country.es, currency: CurrencyCode.EUR),
-        (country: Country.fr, currency: CurrencyCode.EUR),
+        (country: Country.nl, currency: CurrencyCode.EUR),
         (country: Country.sg, currency: CurrencyCode.SGD),
         (country: Country.nz, currency: CurrencyCode.NZD),
         (country: Country.au, currency: CurrencyCode.AUD)
@@ -488,8 +486,7 @@ struct POSTabEligibilityCheckerTests {
     }
 
     @Test(arguments: [
-        Country.de,
-        Country.es,
+        Country.nl,
         Country.sg,
         Country.nz,
         Country.au
@@ -511,9 +508,34 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
     }
 
+    @Test(arguments: [
+        Country.at,
+        Country.be,
+        Country.de,
+        Country.es,
+        Country.fr,
+        Country.it,
+        Country.pt
+    ])
+    fileprivate func fiscalization_country_is_ineligible_when_expansion_eligibility_is_enabled(country: Country) async throws {
+        // Given
+        setupCountry(country: country, currency: .EUR)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService,
+                                               expansionEligibilityService: eligibleExpansionService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then - falls through with `siteSettingsNotAvailable` (the unsupportedCountry path is mapped here)
+        #expect(result == .ineligible(reason: .siteSettingsNotAvailable))
+    }
+
     @Test func expansion_country_with_mismatched_currency_is_ineligible_when_expansion_eligibility_is_enabled() async throws {
-        // Given - DE store with USD currency (mismatch)
-        setupCountry(country: .de, currency: .USD)
+        // Given - NL store with USD currency (mismatch)
+        setupCountry(country: .nl, currency: .USD)
         let checker = POSTabEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
@@ -524,7 +546,7 @@ struct POSTabEligibilityCheckerTests {
         let result = await checker.checkEligibility()
 
         // Then
-        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .DE, supportedCurrencies: [.EUR])))
+        #expect(result == .ineligible(reason: .unsupportedCurrency(countryCode: .NL, supportedCurrencies: [.EUR])))
     }
 
 }
@@ -576,11 +598,16 @@ private extension POSTabEligibilityCheckerTests {
     enum Country: String {
         case us = "US:CA"
         case pr = "PR"
+        case at = "AT"
+        case be = "BE"
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
         case de = "DE"
         case fr = "FR"
+        case it = "IT"
+        case nl = "NL"
+        case pt = "PT"
         case sg = "SG"
         case nz = "NZ"
         case au = "AU"
@@ -591,6 +618,10 @@ private extension POSTabEligibilityCheckerTests {
                 return .US
             case .pr:
                 return .PR
+            case .at:
+                return .AT
+            case .be:
+                return .BE
             case .ca:
                 return .CA
             case .gb:
@@ -601,6 +632,12 @@ private extension POSTabEligibilityCheckerTests {
                 return .DE
             case .fr:
                 return .FR
+            case .it:
+                return .IT
+            case .nl:
+                return .NL
+            case .pt:
+                return .PT
             case .sg:
                 return .SG
             case .nz:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -118,8 +118,30 @@ struct POSTabVisibilityCheckerTests {
     }
 
     @Test func is_visible_for_expansion_country_when_expansion_flag_enabled_even_with_empty_cache() async throws {
-        // Given - ES (an expansion country) with an empty expansion-eligibility cache,
+        // Given - NL (an expansion country) with an empty expansion-eligibility cache,
         // and the country-expansion remote feature flag enabled.
+        let featureFlagService = MockFeatureFlagService()
+        setupCountry(country: .nl, currency: .EUR)
+        accountWhitelistedInBackend(true, expansionFlagsEnabled: true)
+        let expansionEligibilityService = MockCardPresentPaymentsCountryExpansionEligibilityService()
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              expansionEligibilityService: expansionEligibilityService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then - checkVisibility refreshes the expansion eligibility cache before validating,
+        // so NL is reported as visible without requiring a prior pre-warm.
+        #expect(result == true)
+        #expect(expansionEligibilityService.isEligible(siteID: siteID) == true)
+    }
+
+    @Test func is_invisible_for_spain_when_expansion_flag_enabled_even_with_empty_cache() async throws {
+        // Given - ES is a removed fiscalization country, even when the expansion flag is enabled.
         let featureFlagService = MockFeatureFlagService()
         setupCountry(country: .es, currency: .EUR)
         accountWhitelistedInBackend(true, expansionFlagsEnabled: true)
@@ -134,10 +156,8 @@ struct POSTabVisibilityCheckerTests {
         // When
         let result = await checker.checkVisibility()
 
-        // Then - checkVisibility refreshes the expansion eligibility cache before validating,
-        // so ES is reported as visible without requiring a prior pre-warm.
-        #expect(result == true)
-        #expect(expansionEligibilityService.isEligible(siteID: siteID) == true)
+        // Then
+        #expect(result == false)
     }
 
     @Test func is_visible_for_australia_when_au_feature_flag_enabled_even_with_empty_cache() async throws {
@@ -180,9 +200,9 @@ struct POSTabVisibilityCheckerTests {
     }
 
     @Test func is_invisible_for_expansion_country_when_expansion_flag_disabled() async throws {
-        // Given - ES (an expansion country) with the country-expansion remote feature flag disabled.
+        // Given - NL (an expansion country) with the country-expansion remote feature flag disabled.
         let featureFlagService = MockFeatureFlagService()
-        setupCountry(country: .es, currency: .EUR)
+        setupCountry(country: .nl, currency: .EUR)
         accountWhitelistedInBackend(true, expansionFlagsEnabled: false)
         let checker = POSTabVisibilityChecker(site: site,
                                               userInterfaceIdiom: .pad,
@@ -404,6 +424,7 @@ private extension POSTabVisibilityCheckerTests {
         case ca = "CA:NS"
         case gb = "GB"
         case es = "ES"
+        case nl = "NL"
         case au = "AU"
 
         var countryCode: CountryCode {
@@ -418,6 +439,8 @@ private extension POSTabVisibilityCheckerTests {
                 return .GB
             case .es:
                 return .ES
+            case .nl:
+                return .NL
             case .au:
                 return .AU
             }


### PR DESCRIPTION
## Description
Removes active IPP and POS support for Austria, Belgium, France, Germany, Italy, Portugal, and Spain from the fiscalization country matrix.

Changes:
- Leaves EEA-Euro support only for Finland, Ireland, Luxembourg, and Netherlands.
- Keeps Singapore and New Zealand support.
- Updates IPP/POS eligibility tests to assert the removed countries are unsupported even with cached expansion eligibility.

## Test Steps
- Confirm Austria, Belgium, France, Germany, Italy, Portugal, and Spain are treated as unsupported for IPP/POS

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.