### PR TITLE
[Woo POS] Add staff remote and model for /wc/pos/v1/staff

### DIFF
--- a/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
+++ b/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
@@ -29,16 +29,23 @@ public struct POSStaffMember: Codable, Equatable, Sendable {
     }
 
     public struct PINDetails: Codable, Equatable, Sendable {
-        public let algo: String
+        public let algorithm: String
         public let iterations: Int
-        public let salt: String  // base64
-        public let hash: String  // base64
+        public let salt: String
+        public let hash: String
 
-        public init(algo: String, iterations: Int, salt: String, hash: String) {
-            self.algo = algo
+        public init(algorithm: String, iterations: Int, salt: String, hash: String) {
+            self.algorithm = algorithm
             self.iterations = iterations
             self.salt = salt
             self.hash = hash
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case algorithm = "algo"
+            case iterations
+            case salt
+            case hash
         }
     }
 

--- a/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
+++ b/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// One row of the `GET /wc/pos/v1/staff` response. Carries the WordPress user record
+/// the iOS client caches and validates PIN entry against locally.
+///
+public struct POSStaffMember: Codable, Equatable, Sendable {
+    public let userID: Int64
+    public let displayName: String
+
+    /// Server-side preset slug, used only for display labelling — never for permission checks.
+    /// POS presets use the `pos_` prefix (e.g. `pos_cashier`, `pos_manager`, `pos_admin`).
+    public let preset: String
+
+    /// POS capabilities the staff member holds, keyed by the server's `pos_*` capability
+    /// identifier. The server emits only granted entries (all values are `true` in the
+    /// current preset bundles). Treated as opaque strings at this layer.
+    public let capabilities: [String: Bool]
+
+    /// `nil` when the user has not set a PIN.
+    public let pin: PINDetails?
+
+    public init(userID: Int64, displayName: String,
+                preset: String, capabilities: [String: Bool], pin: PINDetails?) {
+        self.userID = userID
+        self.displayName = displayName
+        self.preset = preset
+        self.capabilities = capabilities
+        self.pin = pin
+    }
+
+    public struct PINDetails: Codable, Equatable, Sendable {
+        public let algo: String
+        public let iterations: Int
+        public let salt: String  // base64
+        public let hash: String  // base64
+
+        public init(algo: String, iterations: Int, salt: String, hash: String) {
+            self.algo = algo
+            self.iterations = iterations
+            self.salt = salt
+            self.hash = hash
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case userID = "user_id"
+        case displayName = "display_name"
+        case preset
+        case capabilities
+        case pin
+    }
+}

--- a/Modules/Sources/Networking/Remote/POSStaffRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSStaffRemote.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// `POSStaff` remote endpoints.
+///
+public final class POSStaffRemote: Remote {
+
+    /// Fetches the POS staff list for the given site. Requires the device user to hold
+    /// `manage_woocommerce` server-side (admin / shop_manager).
+    ///
+    public func fetchStaff(siteID: Int64) async throws -> [POSStaffMember] {
+        let request = JetpackRequest(
+            wooApiVersion: .wcPosV1,
+            method: .get,
+            siteID: siteID,
+            path: Path.staff,
+            availableAsRESTRequest: true
+        )
+        let mapper = ListMapper<POSStaffMember>(siteID: siteID)
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+private extension POSStaffRemote {
+    enum Path {
+        static let staff = "staff"
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Testing
+@testable import Networking
+@testable import NetworkingCore
+
+struct POSStaffRemoteTests {
+    /// Mock network to inject responses and capture issued requests.
+    private let network = MockNetwork()
+
+    private let sampleSiteID: Int64 = 1234
+
+    // MARK: - Request shape
+
+    @Test func fetchStaff_issues_a_get_to_the_wc_pos_v1_staff_endpoint() async throws {
+        // Given
+        let remote = POSStaffRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "staff", filename: "pos-staff")
+
+        // When
+        _ = try await remote.fetchStaff(siteID: sampleSiteID)
+
+        // Then
+        let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
+        #expect(request.wooApiVersion == .wcPosV1)
+        #expect(request.method == .get)
+        #expect(request.siteID == sampleSiteID)
+        #expect(request.path == "staff")
+    }
+
+    // MARK: - Response parsing
+
+    @Test func fetchStaff_parses_members_from_a_data_envelope_response() async throws {
+        // Given
+        let remote = POSStaffRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "staff", filename: "pos-staff")
+
+        // When
+        let staff = try await remote.fetchStaff(siteID: sampleSiteID)
+
+        // Then
+        #expect(staff.count == 3)
+
+        let manager = try #require(staff.first)
+        #expect(manager.userID == 12)
+        #expect(manager.displayName == "Morgan Manager")
+        #expect(manager.preset == "pos_manager")
+        #expect(manager.capabilities["pos_issue_refunds"] == true)
+        #expect(manager.capabilities["pos_manage_staff"] == true)
+
+        let pin = try #require(manager.pin)
+        #expect(pin.algo == "pbkdf2-sha256")
+        #expect(pin.iterations == 100000)
+        #expect(pin.salt == "RkFLRS1URVNULVNBTFQtbm90LWEtcmVhbC1waW4tbWFuYWdlcg==")
+        #expect(pin.hash == "RkFLRS1URVNULUhBU0gtbm90LWEtcmVhbC1waW4tbWFuYWdlcg==")
+    }
+
+    @Test func fetchStaff_parses_members_from_a_flat_array_response() async throws {
+        // Given a direct REST response that is not wrapped in a `data` envelope
+        let remote = POSStaffRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "staff", filename: "pos-staff-without-data-envelope")
+
+        // When
+        let staff = try await remote.fetchStaff(siteID: sampleSiteID)
+
+        // Then
+        #expect(staff.count == 2)
+        #expect(staff.map { $0.userID } == [12, 34])
+
+        let cashier = try #require(staff.last)
+        #expect(cashier.preset == "pos_cashier")
+        #expect(cashier.capabilities == ["pos_process_sales": true])
+    }
+
+    @Test func fetchStaff_decodes_a_nil_pin_for_a_member_without_a_pin() async throws {
+        // Given a response whose last member has `"pin": null`
+        let remote = POSStaffRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "staff", filename: "pos-staff")
+
+        // When
+        let staff = try await remote.fetchStaff(siteID: sampleSiteID)
+
+        // Then
+        let admin = try #require(staff.last)
+        #expect(admin.userID == 1)
+        #expect(admin.preset == "administrator")
+        #expect(admin.pin == nil)
+    }
+
+    @Test func fetchStaff_returns_an_empty_list_for_an_empty_response() async throws {
+        // Given
+        let remote = POSStaffRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "staff", filename: "empty-data-array")
+
+        // When
+        let staff = try await remote.fetchStaff(siteID: sampleSiteID)
+
+        // Then
+        #expect(staff.isEmpty)
+    }
+
+    // MARK: - Error handling
+
+    @Test func fetchStaff_relays_networking_errors() async throws {
+        // Given no simulated response, so the network reports a not-found error
+        let remote = POSStaffRemote(network: network)
+
+        // When / Then
+        await #expect(throws: NetworkError.notFound()) {
+            _ = try await remote.fetchStaff(siteID: sampleSiteID)
+        }
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
@@ -48,7 +48,7 @@ struct POSStaffRemoteTests {
         #expect(manager.capabilities["pos_manage_staff"] == true)
 
         let pin = try #require(manager.pin)
-        #expect(pin.algo == "pbkdf2-sha256")
+        #expect(pin.algorithm == "pbkdf2-sha256")
         #expect(pin.iterations == 100000)
         #expect(pin.salt == "RkFLRS1URVNULVNBTFQtbm90LWEtcmVhbC1waW4tbWFuYWdlcg==")
         #expect(pin.hash == "RkFLRS1URVNULUhBU0gtbm90LWEtcmVhbC1waW4tbWFuYWdlcg==")

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff-without-data-envelope.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff-without-data-envelope.json
@@ -1,0 +1,27 @@
+[
+    {
+        "user_id": 12,
+        "display_name": "Morgan Manager",
+        "preset": "pos_manager",
+        "capabilities": {
+            "pos_process_sales": true,
+            "pos_view_orders": true,
+            "pos_issue_refunds": true
+        },
+        "pin": {
+            "algo": "pbkdf2-sha256",
+            "iterations": 100000,
+            "salt": "RkFLRS1URVNULVNBTFQtbm90LWEtcmVhbC1waW4tbWFuYWdlcg==",
+            "hash": "RkFLRS1URVNULUhBU0gtbm90LWEtcmVhbC1waW4tbWFuYWdlcg=="
+        }
+    },
+    {
+        "user_id": 34,
+        "display_name": "Casey Cashier",
+        "preset": "pos_cashier",
+        "capabilities": {
+            "pos_process_sales": true
+        },
+        "pin": null
+    }
+]

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff.json
@@ -1,0 +1,59 @@
+{
+    "data": [
+        {
+            "user_id": 12,
+            "display_name": "Morgan Manager",
+            "preset": "pos_manager",
+            "capabilities": {
+                "pos_process_sales": true,
+                "pos_view_orders": true,
+                "pos_apply_coupons": true,
+                "pos_create_coupons": true,
+                "pos_issue_refunds": true,
+                "pos_view_settings": true,
+                "pos_edit_settings": true,
+                "pos_manage_staff": true,
+                "pos_exit": true
+            },
+            "pin": {
+                "algo": "pbkdf2-sha256",
+                "iterations": 100000,
+                "salt": "RkFLRS1URVNULVNBTFQtbm90LWEtcmVhbC1waW4tbWFuYWdlcg==",
+                "hash": "RkFLRS1URVNULUhBU0gtbm90LWEtcmVhbC1waW4tbWFuYWdlcg=="
+            }
+        },
+        {
+            "user_id": 34,
+            "display_name": "Casey Cashier",
+            "preset": "pos_cashier",
+            "capabilities": {
+                "pos_process_sales": true,
+                "pos_view_orders": true,
+                "pos_apply_coupons": true
+            },
+            "pin": {
+                "algo": "pbkdf2-sha256",
+                "iterations": 100000,
+                "salt": "RkFLRS1URVNULVNBTFQtbm90LWEtcmVhbC1waW4tY2FzaGllcg==",
+                "hash": "RkFLRS1URVNULUhBU0gtbm90LWEtcmVhbC1waW4tY2FzaGllcg=="
+            }
+        },
+        {
+            "user_id": 1,
+            "display_name": "Avery Admin",
+            "preset": "administrator",
+            "capabilities": {
+                "pos_process_sales": true,
+                "pos_view_orders": true,
+                "pos_apply_coupons": true,
+                "pos_create_coupons": true,
+                "pos_issue_refunds": true,
+                "pos_view_settings": true,
+                "pos_edit_settings": true,
+                "pos_manage_staff": true,
+                "pos_exit": true
+            },
+            "pin": null
+        }
+    ]
+}


### PR DESCRIPTION
## Description
Part of WOOMOB-3148 (POS Roles: staff fetch).

First slice of the POS roles & permissions (local staff) work, extracted from a larger branch for reviewability. This PR adds only the **Networking layer** for the staff endpoint — no app code calls it yet, so there is no behavior change.

- `POSStaffMember` — model for one row of the `GET /wc/pos/v1/staff` response: the WordPress user record (`userID`, `displayName`, opaque `preset` slug, granted `capabilities`) plus optional PIN hash details (`PINDetails`: `algo` / `iterations` / `salt` / `hash`). `pin` is `nil` when the user hasn't set one.
- `POSStaffRemote` — fetches the staff list, mapping the response via `ListMapper<POSStaffMember>` (handles both the Jetpack `data`-envelope and direct-array REST shapes).

Subsequent PRs will add the staff cache, local PIN authentication (WOOMOB-3170), and the UI integration that consume this.

## Test Steps

This is a networking-only addition with no UI. Just CI passing is sufficient.

`POSStaffRemoteTests` covers: request shape (GET, `wc/pos/v1`, `staff` path, siteID), parsing from the `data`-envelope and flat-array responses, `nil` PIN decoding, empty list, and networking-error relay. The JSON fixtures use self-evidently fake PIN salt/hash placeholders (they decode to `FAKE-TEST-...`), not real staff data.

## Screenshots
N/A — no UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not user-facing — internal networking layer, not yet wired to any feature.)