### PR TITLE
[Woo POS][Local Catalog i2] Enable feature flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -92,7 +92,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .ciabBookings:
             return !buildConfig.isProduction
         case .pointOfSaleCatalogAPI:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .pointOfSaleRefundsi1:
             return true
         case .pointOfSaleRoles:


### PR DESCRIPTION
## Description
Enables `pointOfSaleCatalogAPI` for release builds

## Test Steps
- Build the app in `release` config
- Go to POS > Settings > Update catalog
- Observe in console the file-based sync strategy `local_catalog_file` is used:

```
🟣 Starting catalog request...
🔵 Tracked pos_local_catalog_sync_started, properties: [sync_type: full, sync_strategy: local_catalog_file, connection_type: wifi]
🟣 Catalog request inProgress... (attempt 1, progress: 0.0, processed: 0/-1)
🟣 Catalog generation completed after 2 poll(s)
🟣 Catalog ready for download: https://indiemelon.mystagingwebsite.com/wp-content/uploads/product-feeds/pos-catalog-feed-2026-06-09-e2e6fc4e514ff8d9775a7b96463e3588.json
🟣 Background download completed, file moved to: /Users/iamgabrielma/Library/Developer/CoreSimulator/Devices/4B6ADB99-1B27-4131-AA7F-A183F893B0BD/data/Containers/Data/Application/CE51EF44-AD9F-4061-B855-B98A7BC2AE12/tmp/pos-catalog-feed-2026-06-09-e2e6fc4e514ff8d9775a7b96463e3588.json
🟣 Catalog download completed - Time: 8.86s

🔵 Tracked pos_local_catalog_sync_completed, properties: [poll_attempts: 2, total_variations: 84, total_products: 70, sync_type: full, sync_duration_ms: 9035, sync_strategy: local_catalog_file, variations_synced: 105, generation_duration_ms: 2000, products_synced: 70]
```

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
