### PR TITLE
[Woo POS] Add staff fetching, per-site cache, and error mapping adaptor

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -275,6 +275,7 @@ let package = Package(
                 "WooFoundation",
                 "Yosemite",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
+                .product(name: "KeychainAccess", package: "KeychainAccess"),
                 .product(name: "Shimmer", package: "SwiftUI-Shimmer"),
                 .product(name: "Kingfisher", package: "Kingfisher"),
             ],

--- a/Modules/Sources/Networking/Remote/POSStaffRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSStaffRemote.swift
@@ -1,8 +1,15 @@
 import Foundation
 
+/// Fetches the POS staff list. Conformed to by `POSStaffRemote`; callers (e.g. the app-target
+/// `POSStaffAdaptor`) depend on this abstraction so they can be unit-tested with a mock.
+///
+public protocol POSStaffRemoteProtocol {
+    func fetchStaff(siteID: Int64) async throws -> [POSStaffMember]
+}
+
 /// `POSStaff` remote endpoints.
 ///
-public final class POSStaffRemote: Remote {
+public final class POSStaffRemote: Remote, POSStaffRemoteProtocol {
 
     /// Fetches the POS staff list for the given site. Requires the device user to hold
     /// `manage_woocommerce` server-side (admin / shop_manager).

--- a/Modules/Sources/PointOfSale/Roles/Models/POSStaffFetchError.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSStaffFetchError.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Error returned by `POSStaffFetching.fetchStaff(siteID:)`. Mapped at the app-target adaptor
+/// from underlying Networking errors so the authenticator and session can branch by intent.
+///
+public enum POSStaffFetchError: Error, Equatable {
+    /// HTTP 404 / `rest_no_route`: the staff endpoint isn't registered server-side — either a feature
+    /// flag gating it is off, or the store's WooCommerce/POS version predates the endpoint. The two are
+    /// indistinguishable to the client and both degrade to no-PIN-gating mode.
+    case endpointUnavailable
+
+    /// HTTP 401/403. The device admin lacks the server-side capability required to read the
+    /// staff endpoint (currently `manage_woocommerce`). Diagnostic state; surfaced to the operator
+    /// as a generic "Reach out to your administrator" message.
+    case adminMissingCapability
+
+    /// 5xx / network timeout / connectivity. Transient. Caller falls back to the existing cache.
+    case transient(retryable: Bool)
+
+    /// Response body could not be decoded. Indicates a wire-shape mismatch with the backend.
+    case malformedResponse
+}

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
@@ -71,8 +71,9 @@ final class POSStaffCache: Sendable {
     }
 
     func lastFetched(siteID: Int64) -> Date? {
-        // Read atomically with the staff payload - a torn cache (timestamp present, payload missing)
-        // would otherwise read as "no PINs" and auto-unlock POS without a verified fetch.
+        // Require the staff payload before trusting the timestamp: a torn cache (timestamp present,
+        // payload missing) must read as "never fetched" - not silently as "no PINs", which would
+        // auto-unlock POS without a verified fetch.
         guard load(siteID: siteID) != nil else { return nil }
         guard let raw = storage.string(forKey: timestampKey(siteID: siteID)),
               let interval = TimeInterval(raw) else { return nil }

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
@@ -1,0 +1,92 @@
+import CocoaLumberjackSwift
+import Foundation
+import struct Networking.POSStaffMember
+@preconcurrency import KeychainAccess
+
+protocol POSStaffKeyValueStorage: Sendable {
+    func string(forKey key: String) -> String?
+    func setString(_ value: String?, forKey key: String)
+}
+
+struct KeychainPOSStaffStorage: POSStaffKeyValueStorage {
+    static let service = "com.woocommerce.pos.staffCache"
+
+    private let keychain: Keychain
+
+    init(service: String = KeychainPOSStaffStorage.service) {
+        self.keychain = Keychain(service: service)
+    }
+
+    func string(forKey key: String) -> String? {
+        do {
+            return try keychain.get(key)
+        } catch {
+            DDLogError("POSStaffCache keychain read failed for key=\(key): \(error)")
+            return nil
+        }
+    }
+
+    func setString(_ value: String?, forKey key: String) {
+        do {
+            if let value {
+                try keychain.set(value, key: key)
+            } else {
+                try keychain.remove(key)
+            }
+        } catch {
+            DDLogError("POSStaffCache keychain write failed for key=\(key): \(error)")
+        }
+    }
+}
+
+final class POSStaffCache: Sendable {
+    private let storage: POSStaffKeyValueStorage
+    private let now: @Sendable () -> Date
+
+    init(storage: POSStaffKeyValueStorage = KeychainPOSStaffStorage(),
+         now: @escaping @Sendable () -> Date = { Date() }) {
+        self.storage = storage
+        self.now = now
+    }
+
+    func load(siteID: Int64) -> [POSStaffMember]? {
+        guard let json = storage.string(forKey: staffKey(siteID: siteID)),
+              let data = json.data(using: .utf8),
+              let members = try? JSONDecoder().decode([POSStaffMember].self, from: data) else {
+            return nil
+        }
+        return members
+    }
+
+    func save(_ staff: [POSStaffMember], siteID: Int64) {
+        guard let data = try? JSONEncoder().encode(staff),
+              let json = String(data: data, encoding: .utf8) else { return }
+        storage.setString(json, forKey: staffKey(siteID: siteID))
+        storage.setString(String(now().timeIntervalSince1970), forKey: timestampKey(siteID: siteID))
+    }
+
+    func clear(siteID: Int64) {
+        storage.setString(nil, forKey: staffKey(siteID: siteID))
+        storage.setString(nil, forKey: timestampKey(siteID: siteID))
+    }
+
+    func hasAnyPINs(siteID: Int64) -> Bool {
+        load(siteID: siteID)?.contains(where: { $0.pin != nil }) ?? false
+    }
+
+    func lastFetched(siteID: Int64) -> Date? {
+        // Read atomically with the staff payload - a torn cache (timestamp present, payload missing)
+        // would otherwise read as "no PINs" and auto-unlock POS without a verified fetch.
+        guard load(siteID: siteID) != nil else { return nil }
+        guard let raw = storage.string(forKey: timestampKey(siteID: siteID)),
+              let interval = TimeInterval(raw) else { return nil }
+        return Date(timeIntervalSince1970: interval)
+    }
+}
+
+// MARK: - Storage keys
+
+private extension POSStaffCache {
+    func staffKey(siteID: Int64) -> String { "staff.\(siteID)" }
+    func timestampKey(siteID: Int64) -> String { "lastFetched.\(siteID)" }
+}

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
@@ -70,10 +70,6 @@ final class POSStaffCache: Sendable {
         storage.setString(nil, forKey: timestampKey(siteID: siteID))
     }
 
-    func hasAnyPINs(siteID: Int64) -> Bool {
-        load(siteID: siteID)?.contains(where: { $0.pin != nil }) ?? false
-    }
-
     func lastFetched(siteID: Int64) -> Date? {
         // Read atomically with the staff payload - a torn cache (timestamp present, payload missing)
         // would otherwise read as "no PINs" and auto-unlock POS without a verified fetch.
@@ -81,6 +77,15 @@ final class POSStaffCache: Sendable {
         guard let raw = storage.string(forKey: timestampKey(siteID: siteID)),
               let interval = TimeInterval(raw) else { return nil }
         return Date(timeIntervalSince1970: interval)
+    }
+}
+
+// MARK: - Derived queries
+
+extension POSStaffCache {
+    /// `true` when the cached staff list for the site contains at least one member with a PIN.
+    func hasAnyPINs(siteID: Int64) -> Bool {
+        load(siteID: siteID)?.contains(where: { $0.pin != nil }) ?? false
     }
 }
 

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
@@ -9,7 +9,7 @@ protocol POSStaffKeyValueStorage: Sendable {
 }
 
 struct KeychainPOSStaffStorage: POSStaffKeyValueStorage {
-    static let service = "com.woocommerce.pos.staffCache"
+    static let service = "com.automattic.woocommerce.pos.staffCache"
 
     private let keychain: Keychain
 

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
@@ -1,6 +1,6 @@
 import CocoaLumberjackSwift
 import Foundation
-import struct Networking.POSStaffMember
+import struct Yosemite.POSStaffMember
 @preconcurrency import KeychainAccess
 
 protocol POSStaffKeyValueStorage: Sendable {

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffFetching.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffFetching.swift
@@ -1,0 +1,7 @@
+import struct Networking.POSStaffMember
+
+/// Fetches the POS staff list for a site. The concrete implementation (`POSStaffAdaptor`) lives in
+/// the app target and maps Networking errors to `POSStaffFetchError`.
+public protocol POSStaffFetching: Sendable {
+    func fetchStaff(siteID: Int64) async throws(POSStaffFetchError) -> [POSStaffMember]
+}

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffFetching.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffFetching.swift
@@ -2,6 +2,6 @@ import struct Networking.POSStaffMember
 
 /// Fetches the POS staff list for a site. The concrete implementation (`POSStaffAdaptor`) lives in
 /// the app target and maps Networking errors to `POSStaffFetchError`.
-public protocol POSStaffFetching: Sendable {
+public protocol POSStaffFetching {
     func fetchStaff(siteID: Int64) async throws(POSStaffFetchError) -> [POSStaffMember]
 }

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffFetching.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffFetching.swift
@@ -1,4 +1,4 @@
-import struct Networking.POSStaffMember
+import struct Yosemite.POSStaffMember
 
 /// Fetches the POS staff list for a site. The concrete implementation (`POSStaffAdaptor`) lives in
 /// the app target and maps Networking errors to `POSStaffFetchError`.

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -101,6 +101,7 @@ public typealias Product = Networking.Product
 public typealias PushNotificationPreferences = Networking.PushNotificationPreferences
 public typealias POSProduct = Networking.POSProduct
 public typealias POSProductVariation = Networking.POSProductVariation
+public typealias POSStaffMember = Networking.POSStaffMember
 public typealias ProductAddOn = Networking.ProductAddOn
 public typealias ProductAddOnOption = Networking.ProductAddOnOption
 public typealias ProductBackordersSetting = Networking.ProductBackordersSetting

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Testing
+import struct Networking.POSStaffMember
+@testable import PointOfSale
+
+struct POSStaffCacheTests {
+
+    // MARK: - load / save round-trip
+
+    @Test func test_load_when_nothing_saved_then_returns_nil() {
+        // Given
+        let (cache, _) = makeCache()
+
+        // When
+        let loaded = cache.load(siteID: 1)
+
+        // Then
+        #expect(loaded == nil)
+    }
+
+    @Test func test_save_then_load_when_same_site_then_returns_full_member_list() {
+        // Given
+        let (cache, _) = makeCache()
+        let members = [makeMember(userID: 1, pin: makePIN()), makeMember(userID: 2, pin: nil)]
+
+        // When
+        cache.save(members, siteID: 99)
+
+        // Then
+        #expect(cache.load(siteID: 99) == members)
+    }
+
+    @Test func test_save_when_different_sites_share_a_user_id_then_each_site_keeps_its_own_record() {
+        // Given
+        // Same userID on both sites but different records — proves lookups are keyed per-site,
+        // not deduplicated by userID.
+        let (cache, _) = makeCache()
+        let siteAMembers = [makeMember(userID: 1, displayName: "Alice")]
+        let siteBMembers = [makeMember(userID: 1, displayName: "Bob")]
+
+        // When
+        cache.save(siteAMembers, siteID: 10)
+        cache.save(siteBMembers, siteID: 20)
+
+        // Then
+        #expect(cache.load(siteID: 10) == siteAMembers)
+        #expect(cache.load(siteID: 20) == siteBMembers)
+    }
+
+    // MARK: - clear
+
+    @Test func test_clear_when_site_has_cache_then_load_and_lastFetched_return_nil() {
+        // Given
+        let (cache, _) = makeCache()
+        cache.save([makeMember(userID: 1)], siteID: 1)
+
+        // When
+        cache.clear(siteID: 1)
+
+        // Then
+        #expect(cache.load(siteID: 1) == nil)
+        #expect(cache.lastFetched(siteID: 1) == nil)
+    }
+
+    @Test func test_clear_when_other_site_cached_then_only_target_site_cleared() {
+        // Given
+        let (cache, _) = makeCache()
+        cache.save([makeMember(userID: 1)], siteID: 1)
+        cache.save([makeMember(userID: 2)], siteID: 2)
+
+        // When
+        cache.clear(siteID: 1)
+
+        // Then
+        #expect(cache.load(siteID: 1) == nil)
+        #expect(cache.load(siteID: 2) == [makeMember(userID: 2)])
+    }
+
+    // MARK: - hasAnyPINs
+
+    @Test func test_hasAnyPINs_when_no_cache_then_false() {
+        // Given
+        let (cache, _) = makeCache()
+
+        // Then
+        #expect(cache.hasAnyPINs(siteID: 1) == false)
+    }
+
+    @Test func test_hasAnyPINs_when_no_member_has_pin_then_false() {
+        // Given
+        let (cache, _) = makeCache()
+        cache.save([makeMember(userID: 1, pin: nil), makeMember(userID: 2, pin: nil)], siteID: 1)
+
+        // Then
+        #expect(cache.hasAnyPINs(siteID: 1) == false)
+    }
+
+    @Test func test_hasAnyPINs_when_at_least_one_member_has_pin_then_true() {
+        // Given
+        let (cache, _) = makeCache()
+        cache.save([makeMember(userID: 1, pin: nil), makeMember(userID: 2, pin: makePIN())], siteID: 1)
+
+        // Then
+        #expect(cache.hasAnyPINs(siteID: 1) == true)
+    }
+
+    // MARK: - lastFetched
+
+    @Test func test_lastFetched_when_nothing_saved_then_nil() {
+        // Given
+        let (cache, _) = makeCache()
+
+        // Then
+        #expect(cache.lastFetched(siteID: 1) == nil)
+    }
+
+    @Test func test_lastFetched_when_saved_then_round_trips_the_timestamp() {
+        // Given
+        // Fractional seconds exercise the round-trip through the persisted string representation.
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000.5)
+        let (cache, _) = makeCache(now: { fixedNow })
+
+        // When
+        cache.save([makeMember(userID: 1)], siteID: 1)
+
+        // Then
+        #expect(cache.lastFetched(siteID: 1) == fixedNow)
+    }
+
+    @Test func test_lastFetched_when_payload_missing_but_timestamp_present_then_nil() {
+        // Given
+        // Reproduces a torn cache (timestamp written, payload lost). The staff key format is part of
+        // the on-disk persistence contract, so reaching for it directly here is intentional.
+        let (cache, storage) = makeCache()
+        cache.save([makeMember(userID: 1)], siteID: 1)
+
+        // When
+        storage.setString(nil, forKey: "staff.1")
+
+        // Then
+        #expect(cache.lastFetched(siteID: 1) == nil)
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSStaffCacheTests {
+    func makeCache(now: @escaping @Sendable () -> Date = { Date() }) -> (POSStaffCache, InMemoryPOSStaffStorage) {
+        let storage = InMemoryPOSStaffStorage()
+        return (POSStaffCache(storage: storage, now: now), storage)
+    }
+
+    func makeMember(userID: Int64,
+                    displayName: String? = nil,
+                    pin: POSStaffMember.PINDetails? = nil) -> POSStaffMember {
+        POSStaffMember(userID: userID,
+                       displayName: displayName ?? "User \(userID)",
+                       preset: "pos_cashier",
+                       capabilities: ["pos_process_payments": true],
+                       pin: pin)
+    }
+
+    func makePIN() -> POSStaffMember.PINDetails {
+        POSStaffMember.PINDetails(algorithm: "pbkdf2-sha256", iterations: 5000, salt: "c2FsdA==", hash: "aGFzaA==")
+    }
+}
+
+/// In-memory `POSStaffKeyValueStorage` stub. `@unchecked Sendable` is required because the protocol
+/// is `Sendable` while this holds mutable state; it's sound because each test owns its own instance
+/// and never shares it across tasks.
+private final class InMemoryPOSStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
+    private var store: [String: String] = [:]
+
+    func string(forKey key: String) -> String? {
+        store[key]
+    }
+
+    func setString(_ value: String?, forKey key: String) {
+        store[key] = value
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-import struct Networking.POSStaffMember
+import struct Yosemite.POSStaffMember
 @testable import PointOfSale
 
 struct POSStaffCacheTests {

--- a/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
@@ -46,7 +46,7 @@ final class POSStaffAdaptor: POSStaffFetching {
                 throw .adminMissingCapability
             case .noRestRoute:
                 throw .endpointUnavailable
-            case .unknown(let code, _, _) where code == "rest_forbidden":
+            case .unknown(let code, _, _) where Self.isAuthDenialCode(code):
                 throw .adminMissingCapability
             default:
                 throw .transient(retryable: true)

--- a/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
@@ -61,10 +61,12 @@ final class POSStaffAdaptor: POSStaffFetching {
     }
 
     private static func classify(networkError error: NetworkError) -> POSStaffFetchError {
-        if case .notFound = error, error.errorCode == "rest_no_route" {
+        // `errorCode` decodes the response body on each access, so read it once.
+        let code = error.errorCode
+        if case .notFound = error, code == "rest_no_route" {
             return .endpointUnavailable
         }
-        if let code = error.errorCode, isAuthDenialCode(code) {
+        if let code, isAuthDenialCode(code) {
             return .adminMissingCapability
         }
         if let status = error.responseCode, status == 401 || status == 403 {

--- a/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
@@ -5,14 +5,6 @@ import Networking
 import NetworkingCore
 import PointOfSale
 
-/// Test-seam wrapping `POSStaffRemote` so the adaptor can be unit-tested with a mock.
-///
-protocol POSStaffRemoteProtocol: Sendable {
-    func fetchStaff(siteID: Int64) async throws -> [POSStaffMember]
-}
-
-extension POSStaffRemote: POSStaffRemoteProtocol {}
-
 /// Concrete `POSStaffFetching` in the app target. Calls `POSStaffRemote` and maps Networking
 /// errors to the typed `POSStaffFetchError` so PointOfSale callers can branch by intent.
 ///

--- a/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
+++ b/WooCommerce/Classes/POS/Adaptors/POSStaffAdaptor.swift
@@ -1,0 +1,87 @@
+import CocoaLumberjackSwift
+import Combine
+import Foundation
+import Networking
+import NetworkingCore
+import PointOfSale
+
+/// Test-seam wrapping `POSStaffRemote` so the adaptor can be unit-tested with a mock.
+///
+protocol POSStaffRemoteProtocol: Sendable {
+    func fetchStaff(siteID: Int64) async throws -> [POSStaffMember]
+}
+
+extension POSStaffRemote: POSStaffRemoteProtocol {}
+
+/// Concrete `POSStaffFetching` in the app target. Calls `POSStaffRemote` and maps Networking
+/// errors to the typed `POSStaffFetchError` so PointOfSale callers can branch by intent.
+///
+/// HTTP 401/403, expired tokens, and `woocommerce_rest_cannot_view` map to `.adminMissingCapability`.
+final class POSStaffAdaptor: POSStaffFetching {
+    private let remote: POSStaffRemoteProtocol
+
+    init(remote: POSStaffRemoteProtocol) {
+        self.remote = remote
+    }
+
+    convenience init(network: Network) {
+        self.init(remote: POSStaffRemote(network: network))
+    }
+
+    convenience init?(credentials: Credentials?,
+                      selectedSite: AnyPublisher<JetpackSite?, Never>,
+                      appPasswordSupportState: AnyPublisher<Bool, Never>) {
+        guard let credentials else {
+            DDLogError("⛔️ Could not create POSStaffAdaptor due to not finding credentials")
+            return nil
+        }
+        let network = AlamofireNetwork(credentials: credentials,
+                                       selectedSite: selectedSite,
+                                       appPasswordSupportState: appPasswordSupportState)
+        self.init(network: network)
+    }
+
+    func fetchStaff(siteID: Int64) async throws(POSStaffFetchError) -> [POSStaffMember] {
+        do {
+            return try await remote.fetchStaff(siteID: siteID)
+        } catch let error as DecodingError {
+            DDLogError("POS staff decode failure: \(error)")
+            throw .malformedResponse
+        } catch let error as DotcomError {
+            // Reached when the request tunnels through Jetpack and DotcomValidator parses the body.
+            switch error {
+            case .unauthorized, .invalidToken:
+                throw .adminMissingCapability
+            case .noRestRoute:
+                throw .endpointUnavailable
+            case .unknown(let code, _, _) where code == "rest_forbidden":
+                throw .adminMissingCapability
+            default:
+                throw .transient(retryable: true)
+            }
+        } catch let error as NetworkError {
+            // Reached when the request goes direct via the REST path (app-password sites).
+            // The body code lives on `error.errorCode`; the HTTP status on `error.responseCode`.
+            throw Self.classify(networkError: error)
+        } catch {
+            throw .transient(retryable: true)
+        }
+    }
+
+    private static func classify(networkError error: NetworkError) -> POSStaffFetchError {
+        if case .notFound = error, error.errorCode == "rest_no_route" {
+            return .endpointUnavailable
+        }
+        if let code = error.errorCode, isAuthDenialCode(code) {
+            return .adminMissingCapability
+        }
+        if let status = error.responseCode, status == 401 || status == 403 {
+            return .adminMissingCapability
+        }
+        return .transient(retryable: true)
+    }
+
+    private static func isAuthDenialCode(_ code: String) -> Bool {
+        code.hasPrefix("woocommerce_rest_cannot") || code == "rest_forbidden"
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
@@ -57,6 +57,13 @@ struct POSStaffAdaptorTests {
                      forRemoteError: DotcomError.unknown(code: "rest_forbidden", message: nil, data: nil))
     }
 
+    @Test func test_fetchStaff_when_dotcom_unknown_woocommerce_rest_cannot_view_then_adminMissingCapability() async {
+        // The Jetpack-tunnelled path must classify a `woocommerce_rest_cannot*` denial the same as
+        // the direct REST path does, rather than letting it fall through to `.transient`.
+        await expect(.adminMissingCapability,
+                     forRemoteError: DotcomError.unknown(code: "woocommerce_rest_cannot_view", message: nil, data: nil))
+    }
+
     @Test func test_fetchStaff_when_dotcom_other_then_transient_retryable() async {
         await expect(.transient(retryable: true), forRemoteError: DotcomError.requestFailed())
     }

--- a/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 import enum Networking.NetworkError
 import enum NetworkingCore.DotcomError
-import struct Networking.POSStaffMember
+import struct Yosemite.POSStaffMember
 import protocol Networking.POSStaffRemoteProtocol
 import enum PointOfSale.POSStaffFetchError
 @testable import WooCommerce

--- a/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
@@ -68,7 +68,7 @@ struct POSStaffAdaptorTests {
                      forRemoteError: networkError(statusCode: 404, code: "rest_no_route"))
     }
 
-    @Test func test_fetchStaff_when_network_woocommerce_rest_cannot_code_then_adminMissingCapability() async {
+    @Test func test_fetchStaff_when_network_woocommerce_rest_cannot_view_then_adminMissingCapability() async {
         await expect(.adminMissingCapability,
                      forRemoteError: networkError(statusCode: 403, code: "woocommerce_rest_cannot_view"))
     }

--- a/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
@@ -3,6 +3,7 @@ import Testing
 import enum Networking.NetworkError
 import enum NetworkingCore.DotcomError
 import struct Networking.POSStaffMember
+import protocol Networking.POSStaffRemoteProtocol
 import enum PointOfSale.POSStaffFetchError
 @testable import WooCommerce
 
@@ -146,8 +147,7 @@ private extension POSStaffAdaptorTests {
 
 private struct AnonymousError: Error {}
 
-/// `@unchecked Sendable` is sound: each test owns its mock and never shares it across tasks.
-private final class MockPOSStaffRemote: POSStaffRemoteProtocol, @unchecked Sendable {
+private final class MockPOSStaffRemote: POSStaffRemoteProtocol {
     private let result: Result<[POSStaffMember], Error>
 
     init(result: Result<[POSStaffMember], Error>) {

--- a/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
@@ -1,0 +1,160 @@
+import Foundation
+import Testing
+import enum Networking.NetworkError
+import enum NetworkingCore.DotcomError
+import struct Networking.POSStaffMember
+import enum PointOfSale.POSStaffFetchError
+@testable import WooCommerce
+
+struct POSStaffAdaptorTests {
+    private let siteID: Int64 = 123
+
+    // MARK: - Success
+
+    @Test func test_fetchStaff_when_remote_succeeds_then_returns_members() async throws {
+        // Given
+        let members = [makeMember(userID: 1), makeMember(userID: 2)]
+        let sut = makeSUT(.success(members))
+
+        // When
+        let result = try await sut.fetchStaff(siteID: siteID)
+
+        // Then
+        #expect(result == members)
+    }
+
+    // MARK: - DecodingError
+
+    @Test func test_fetchStaff_when_remote_throws_decoding_error_then_malformedResponse() async {
+        // Given
+        let decodingError = DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "bad shape"))
+        let sut = makeSUT(.failure(decodingError))
+
+        // Then
+        await #expect(throws: POSStaffFetchError.malformedResponse) {
+            // When
+            _ = try await sut.fetchStaff(siteID: self.siteID)
+        }
+    }
+
+    // MARK: - DotcomError mapping (Jetpack-tunnelled path)
+
+    @Test func test_fetchStaff_when_dotcom_unauthorized_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability, forRemoteError: DotcomError.unauthorized())
+    }
+
+    @Test func test_fetchStaff_when_dotcom_invalidToken_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability, forRemoteError: DotcomError.invalidToken())
+    }
+
+    @Test func test_fetchStaff_when_dotcom_noRestRoute_then_endpointUnavailable() async {
+        await expect(.endpointUnavailable, forRemoteError: DotcomError.noRestRoute())
+    }
+
+    @Test func test_fetchStaff_when_dotcom_unknown_rest_forbidden_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability,
+                     forRemoteError: DotcomError.unknown(code: "rest_forbidden", message: nil, data: nil))
+    }
+
+    @Test func test_fetchStaff_when_dotcom_other_then_transient_retryable() async {
+        await expect(.transient(retryable: true), forRemoteError: DotcomError.requestFailed())
+    }
+
+    // MARK: - NetworkError mapping (direct REST path)
+
+    @Test func test_fetchStaff_when_network_notFound_rest_no_route_then_endpointUnavailable() async {
+        await expect(.endpointUnavailable,
+                     forRemoteError: networkError(statusCode: 404, code: "rest_no_route"))
+    }
+
+    @Test func test_fetchStaff_when_network_woocommerce_rest_cannot_code_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability,
+                     forRemoteError: networkError(statusCode: 403, code: "woocommerce_rest_cannot_view"))
+    }
+
+    @Test func test_fetchStaff_when_network_rest_forbidden_code_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability,
+                     forRemoteError: networkError(statusCode: 403, code: "rest_forbidden"))
+    }
+
+    @Test func test_fetchStaff_when_network_status_403_without_code_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability, forRemoteError: networkError(statusCode: 403))
+    }
+
+    @Test func test_fetchStaff_when_network_status_401_without_code_then_adminMissingCapability() async {
+        await expect(.adminMissingCapability, forRemoteError: networkError(statusCode: 401))
+    }
+
+    @Test func test_fetchStaff_when_network_status_500_then_transient_retryable() async {
+        await expect(.transient(retryable: true), forRemoteError: networkError(statusCode: 500))
+    }
+
+    @Test func test_fetchStaff_when_network_timeout_then_transient_retryable() async {
+        await expect(.transient(retryable: true), forRemoteError: networkError(statusCode: 408))
+    }
+
+    @Test func test_fetchStaff_when_network_notFound_without_rest_no_route_then_transient_retryable() async {
+        // A 404 that is not the `rest_no_route` body is treated as transient, not endpointUnavailable.
+        await expect(.transient(retryable: true), forRemoteError: networkError(statusCode: 404))
+    }
+
+    // MARK: - Unrecognised errors
+
+    @Test func test_fetchStaff_when_remote_throws_unknown_error_then_transient_retryable() async {
+        await expect(.transient(retryable: true), forRemoteError: AnonymousError())
+    }
+}
+
+// MARK: - Helpers
+
+private extension POSStaffAdaptorTests {
+    func makeSUT(_ result: Result<[POSStaffMember], Error>) -> POSStaffAdaptor {
+        POSStaffAdaptor(remote: MockPOSStaffRemote(result: result))
+    }
+
+    /// Asserts the adaptor maps `remoteError` thrown by the remote to `expected`.
+    func expect(_ expected: POSStaffFetchError,
+                forRemoteError remoteError: Error,
+                sourceLocation: SourceLocation = #_sourceLocation) async {
+        let sut = makeSUT(.failure(remoteError))
+        await #expect(throws: expected, sourceLocation: sourceLocation) {
+            _ = try await sut.fetchStaff(siteID: self.siteID)
+        }
+    }
+
+    func makeMember(userID: Int64) -> POSStaffMember {
+        POSStaffMember(userID: userID,
+                       displayName: "User \(userID)",
+                       preset: "pos_cashier",
+                       capabilities: ["pos_process_payments": true],
+                       pin: nil)
+    }
+
+    /// Builds a `NetworkError` whose `errorCode` resolves from a `{"code": ...}` response body.
+    func networkError(statusCode: Int, code: String? = nil) -> NetworkError {
+        let response = code.map { Data("{\"code\":\"\($0)\"}".utf8) }
+        switch statusCode {
+        case 404:
+            return .notFound(response: response)
+        case 408:
+            return .timeout(response: response)
+        default:
+            return .unacceptableStatusCode(statusCode: statusCode, response: response)
+        }
+    }
+}
+
+private struct AnonymousError: Error {}
+
+/// `@unchecked Sendable` is sound: each test owns its mock and never shares it across tasks.
+private final class MockPOSStaffRemote: POSStaffRemoteProtocol, @unchecked Sendable {
+    private let result: Result<[POSStaffMember], Error>
+
+    init(result: Result<[POSStaffMember], Error>) {
+        self.result = result
+    }
+
+    func fetchStaff(siteID: Int64) async throws -> [POSStaffMember] {
+        try result.get()
+    }
+}


### PR DESCRIPTION
## Description
Part of WOOMOB-3148 (POS Roles: staff fetch). Builds on #17322 (the `POSStaffMember` model + `POSStaffRemote`, already merged) to add the fetch/cache/error-mapping layer the PIN authenticator will consume. No app code wires this in yet, so there is no behavior change.

**Networking**
- `POSStaffRemoteProtocol` — added (co-located in `POSStaffRemote.swift`, like the other `*RemoteProtocol`s); `POSStaffRemote` conforms directly. Lets the app-target adaptor depend on an abstraction it can mock.

**PointOfSale**
- `POSStaffFetching` — protocol the authenticator will depend on, returning `[POSStaffMember]` and throwing the typed `POSStaffFetchError`.
- `POSStaffFetchError` — typed error (`endpointUnavailable` / `adminMissingCapability` / `transient(retryable:)` / `malformedResponse`) so callers can branch by intent.
- `POSStaffCache` — per-site Keychain cache of the full staff list. It stores a `lastFetched` timestamp (exposed via `lastFetched(siteID:)`) for the consumer's freshness decision — the cache itself doesn't evaluate expiry; the TTL/refetch policy lives with the consumer (the access session, in WOOMOB-3170). Also exposes a `hasAnyPINs(siteID:)` derived query.

**App target**
- `POSStaffAdaptor` — concrete `POSStaffFetching`. Calls `POSStaffRemote` and maps Networking errors (`DotcomError` for the Jetpack-tunnelled path, `NetworkError` for direct REST) to `POSStaffFetchError`.

Subsequent PR (WOOMOB-3170) adds the real PBKDF2 PIN authenticator that consumes the cache + fetcher, at which point `POSStaffFetching` becomes `Sendable` again (dropped here as there is no concurrent consumer yet).

## Test Steps
Networking-only / no UI. Verify via unit tests:

```
# Cache + derived queries (Keychain-backed)
xcodebuild -workspace WooCommerce.xcworkspace -scheme PointOfSale \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -sdk iphonesimulator \
  test -only-testing:"PointOfSaleTests/POSStaffCacheTests"

# Adaptor error mapping (Dotcom + NetworkError paths)
xcodebuild -workspace WooCommerce.xcworkspace -scheme WooCommerce \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  test -only-testing:"WooCommerceTests/POSStaffAdaptorTests"
```

`POSStaffCacheTests` covers save/load round-trip, per-site isolation, `lastFetched` timestamping, torn-cache handling, and `hasAnyPINs`. `POSStaffAdaptorTests` covers the success path plus each error mapping (decoding, unauthorized/invalid-token/forbidden → `adminMissingCapability`, no-route → `endpointUnavailable`, fallback → `transient`).

## Screenshots
N/A — no UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not user-facing — internal fetch/cache layer, not yet wired to any feature.)