### PR TITLE
Fix crash when starting Tracks

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Improvements to POS by downloading product catalog to the device [https://github.com/woocommerce/woocommerce-ios/pull/16958]
 - [*] Dashboard: Added option to update analytic update setting [https://github.com/woocommerce/woocommerce-ios/pull/17304]
 - [*] Fixed several crash-risk code paths in Shipping Labels, Stats, and Downloadable files [https://github.com/woocommerce/woocommerce-ios/pull/17307]
+- [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
 
 24.9
 -----

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -6,15 +6,36 @@ import protocol WooFoundation.AnalyticsProvider
 import WooFoundationCore
 
 public class TracksProvider: NSObject, AnalyticsProvider {
-    private static let contextManager = TracksContextManager()
 
-    private static let tracksService: TracksService = {
-        let tracksService = TracksService(contextManager: contextManager)!
-        tracksService.eventNamePrefix = Constants.eventNamePrefix
-        return tracksService
-    }()
+    /// `TracksServiceExecutor` ensures that we access the Tracks service on a background queue, while always creating the service on the main thread.
+    private enum TracksServiceExecutor {
+        private static let contextManager = TracksContextManager()
 
-    private static let tracksQueue = DispatchQueue(label: "com.woocommerce.TracksProvider")
+        private static let service: TracksService = {
+            let service = TracksService(contextManager: contextManager)!
+            service.eventNamePrefix = Constants.eventNamePrefix
+            return service
+        }()
+
+        private static let queue = DispatchQueue(label: "com.woocommerce.TracksProvider")
+
+        /// Keep lazy `TracksService` construction off the serialization queue while still serializing service use.
+        static func enqueue(_ operation: @escaping (TracksService) -> Void) {
+            let enqueue: (TracksService) -> Void = { tracksService in
+                queue.async {
+                    operation(tracksService)
+                }
+            }
+
+            if Thread.isMainThread {
+                enqueue(service)
+            } else {
+                DispatchQueue.main.async {
+                    enqueue(service)
+                }
+            }
+        }
+    }
 
     private static var isPOSModeActive: Bool = false
 
@@ -38,9 +59,9 @@ public extension TracksProvider {
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         let eventName = decorateEventNameForPOSIfNeeded(eventName)
-        Self.tracksQueue.async {
+        Self.TracksServiceExecutor.enqueue { tracksService in
             if let properties {
-                guard Self.tracksService.trackEventName(eventName, withCustomProperties: properties) else {
+                guard tracksService.trackEventName(eventName, withCustomProperties: properties) else {
                     return DDLogError("🔴 Error tracking \(eventName) with properties: \(properties)")
                 }
 
@@ -52,15 +73,15 @@ public extension TracksProvider {
 
                 DDLogInfo("🔵 Tracked \(eventName), properties: [\(keyValuePairs)]")
             } else {
-                Self.tracksService.trackEventName(eventName)
+                tracksService.trackEventName(eventName)
                 DDLogInfo("🔵 Tracked \(eventName)")
             }
         }
     }
 
     func clearEvents() {
-        Self.tracksQueue.async {
-            Self.tracksService.clearQueuedEvents()
+        Self.TracksServiceExecutor.enqueue { tracksService in
+            tracksService.clearQueuedEvents()
         }
     }
 
@@ -72,8 +93,8 @@ public extension TracksProvider {
             UserDefaults.standard[.defaultAnonymousID] = nil
             UserDefaults.standard[.analyticsUsername] = nil
             let anonymousUserID = ServiceLocator.stores.sessionManager.anonymousUserID
-            Self.tracksQueue.async {
-                Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousUserID)
+            Self.TracksServiceExecutor.enqueue { tracksService in
+                tracksService.switchToAnonymousUser(withAnonymousID: anonymousUserID)
             }
             return
         }
@@ -95,34 +116,34 @@ private extension TracksProvider {
             if currentAnalyticsUsername.isEmpty {
                 // No previous username logged
                 UserDefaults.standard[.analyticsUsername] = account.username
-                Self.tracksQueue.async {
-                    Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
-                                                                 userID: String(account.userID),
-                                                                 wpComToken: authToken,
-                                                                 skipAliasEventCreation: false)
+                Self.TracksServiceExecutor.enqueue { tracksService in
+                    tracksService.switchToAuthenticatedUser(withUsername: account.username,
+                                                           userID: String(account.userID),
+                                                           wpComToken: authToken,
+                                                           skipAliasEventCreation: false)
                 }
             } else if currentAnalyticsUsername == account.username {
                 // Username did not change - just make sure Tracks client has it
-                Self.tracksQueue.async {
-                    Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
-                                                                 userID: String(account.userID),
-                                                                 wpComToken: authToken,
-                                                                 skipAliasEventCreation: true)
+                Self.TracksServiceExecutor.enqueue { tracksService in
+                    tracksService.switchToAuthenticatedUser(withUsername: account.username,
+                                                           userID: String(account.userID),
+                                                           wpComToken: authToken,
+                                                           skipAliasEventCreation: true)
                 }
             } else {
                 // Username changed for some reason - switch back to anonymous first
-                Self.tracksQueue.async {
-                    Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
-                    Self.tracksService.switchToAuthenticatedUser(withUsername: account.username,
-                                                                 userID: String(account.userID),
-                                                                 wpComToken: authToken,
-                                                                 skipAliasEventCreation: false)
+                Self.TracksServiceExecutor.enqueue { tracksService in
+                    tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
+                    tracksService.switchToAuthenticatedUser(withUsername: account.username,
+                                                           userID: String(account.userID),
+                                                           wpComToken: authToken,
+                                                           skipAliasEventCreation: false)
                 }
             }
         } else {
             UserDefaults.standard[.analyticsUsername] = nil
-            Self.tracksQueue.async {
-                Self.tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
+            Self.TracksServiceExecutor.enqueue { tracksService in
+                tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
             }
         }
     }
@@ -300,9 +321,9 @@ private extension TracksProvider {
         let readUIKitAndApply = {
             let voiceOver = UIAccessibility.isVoiceOverRunning
             let isRTL = UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
-            Self.tracksQueue.async {
-                Self.tracksService.userProperties.removeAllObjects()
-                Self.tracksService.userProperties.addEntries(from: [
+            Self.TracksServiceExecutor.enqueue { tracksService in
+                tracksService.userProperties.removeAllObjects()
+                tracksService.userProperties.addEntries(from: [
                     UserProperties.platformKey: "iOS",
                     UserProperties.voiceOverKey: voiceOver,
                     UserProperties.rtlKey: isRTL


### PR DESCRIPTION
## Description
Fixes WOOMOB-3174.

We fixed a crash in 24.6 by shifting calls to `TracksService` onto a background queue (See #16944.) This significantly reduced crashes, however in 24.6 a new crash came up: bad access when starting Tracks (i.e., on launch.)

`TracksService` is created as a lazy static singleton, and it appears that initialising it on a background queue could occasionally crash. The investigation lead to [TracksService calls to reachability](https://github.com/Automattic/Automattic-Tracks-iOS/blob/c06b8d14e9c4eefcccb46627285947e7de6a4d72/Sources/Event%20Logging/TracksService.m#L100).

Previous to #16944, the service would have been created on the main thread. As a speculative fix, this PR goes back to creating the service on main, while keeping the background queue for access/general use.

## Test Steps
I couldn't repro the crash, and it's very infrequent. Testing is limited to running the app and ensuring tracks events still happen.

1. Review `TracksProvider` and confirm all direct Tracks operations go through `TracksServiceExecutor.enqueue`.
2. Confirm `TracksServiceExecutor` owns the lazy `TracksService`, context manager, and the queue, so direct service access is not exposed to `TracksProvider` call sites.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.