### PR TITLE
Log catalog malformed items for support

### DIFF
--- a/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
+++ b/Modules/Sources/Networking/Remote/POSCatalogSyncRemote.swift
@@ -1,5 +1,6 @@
 // periphery:ignore:all
 import Foundation
+import CocoaLumberjackSwift
 import enum NetworkingCore.POSCatalogFileError
 
 /// Protocol for POS Catalog Sync Remote operations.
@@ -530,7 +531,7 @@ public enum POSCatalogStatus: String, Decodable {
 public enum POSCatalogItem: Decodable {
     case product(POSProduct)
     case variation(POSProductVariation)
-    /// Items with malformed data that fail to decode are skipped during parsing
+    /// Items with malformed data that fail to decode are skipped during parsing, and logged
     case unsupported
 
     private enum CodingKeys: String, CodingKey {
@@ -546,12 +547,14 @@ public enum POSCatalogItem: Decodable {
             do {
                 self = .variation(try container.decode(POSProductVariation.self, forKey: .data))
             } catch {
+                DDLogWarn("⚠️ POS catalog item skipped (type: \(type)): \(error)")
                 self = .unsupported
             }
         } else {
             do {
                 self = .product(try container.decode(POSProduct.self, forKey: .data))
             } catch {
+                DDLogWarn("⚠️ POS catalog item skipped (type: \(type)): \(error)")
                 self = .unsupported
             }
         }

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -790,6 +790,39 @@ struct POSCatalogSyncRemoteTests {
         #expect(catalog.variations.isEmpty)
     }
 
+    @Test func downloadCatalog_when_item_has_null_data_then_skips_it_without_failing() async throws {
+        // Given: an item whose `data` payload is null is a benign skip (decodeIfPresent -> nil)
+        let remote = createRemote()
+        let downloadURL = "https://example.com/catalog.json"
+        let json = """
+        [
+          {
+            "type": "simple",
+            "data": {
+              "id": 1, "sku": "valid", "global_unique_id": "", "name": "Valid Product",
+              "short_description": "", "description": "", "stock_status": "instock",
+              "manage_stock": false, "stock_quantity": null, "price": 10, "images": [],
+              "parent_id": 0, "attributes": [], "downloadable": false, "status": "publish", "type": "simple"
+            }
+          },
+          {
+            "type": "simple",
+            "data": null
+          }
+        ]
+        """
+        let mockFileURL = mockBackgroundDownloader.createMockDownloadFile(withContent: json)
+        mockBackgroundDownloader.mockSuccessfulDownload(fileURL: mockFileURL)
+
+        // When
+        let catalog = try await remote.downloadCatalog(for: sampleSiteID, downloadURL: downloadURL, allowCellular: true)
+
+        // Then: the null-data item is skipped, the valid product is parsed
+        #expect(catalog.products.count == 1)
+        #expect(catalog.products.first?.productID == 1)
+        #expect(catalog.variations.isEmpty)
+    }
+
     @Test func downloadCatalog_handles_empty_catalog() async throws {
         // Given
         let remote = createRemote()


### PR DESCRIPTION
Closes WOOMOB-2641

## Description
When the POS catalog file is parsed, items that fail to decode are silently mapped to `POSCatalogItem.unsupported` and dropped with no logging. If a merchant reports a product missing from POS, there's no trace of why. We add a simple log to help with support queries.

## Test Steps
Add snippet to `POSCatalogSyncRemote.swift` line 293

```
 _ = try? mapper.map(response: Data(#"[{"type":"simple","data":{"id":99}}]"#.utf8))
```

- Load POS > Sync catalog > Observe `POS catalog item skipped` warning in console
- Go to Help and Support > View application log > current. See warning logged:

<img width="1488" height="2266" alt="simulator_screenshot_ADC54700-C591-4C63-9926-A8151A045AD1" src="https://github.com/user-attachments/assets/4f8d14bb-0b05-4efe-ae75-a399c9b0f2a7" />
