### PR TITLE
[Woo POS] Add real PIN authenticator (PBKDF2, cache-only)

### DIFF
--- a/Modules/Sources/PointOfSale/Roles/Models/POSCapability.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSCapability.swift
@@ -1,8 +1,14 @@
 enum POSCapability: String, CaseIterable, Sendable {
-    // Raw values match the WordPress capability identifiers reported for a staff member.
-    case viewPOS = "view_pos"
-    case viewPOSSettings = "view_pos_settings"
-    case editPOSSettings = "edit_pos_settings"
-    case refundShopOrders = "refund_shop_orders"
-    case publishShopCoupons = "publish_shop_coupons"
+    // POS-specific capabilities use the `pos_` prefix, matching the keys the staff endpoint
+    // reports. Capability matching is by raw value (see `POSStaff.hasCapability`), so non-`pos_`
+    // identifiers can be added as cases later without changing the lookup logic.
+    case processSales = "pos_process_sales"
+    case viewOrders = "pos_view_orders"
+    case applyCoupons = "pos_apply_coupons"
+    case createCoupons = "pos_create_coupons"
+    case issueRefunds = "pos_issue_refunds"
+    case viewPOSSettings = "pos_view_settings"
+    case editPOSSettings = "pos_edit_settings"
+    case managePOSStaff = "pos_manage_staff"
+    case exitPOS = "pos_exit"
 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSStaff.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSStaff.swift
@@ -1,6 +1,7 @@
 struct POSStaff: Equatable, Sendable {
+    let userID: Int64
     let displayName: String
-    let role: String
+    let preset: String
     let capabilities: Set<String>
 
     func hasCapability(_ capability: POSCapability) -> Bool {

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import CocoaLumberjackSwift
 
 @Observable
 @MainActor
@@ -36,7 +35,7 @@ final class DefaultPOSAccessSession: POSAccessSession {
             rateLimiter.reset()
             currentStaff = staff
             isLocked = false
-            // Sign-in proves a PIN exists; pre-empt refreshPINStatus.
+            // A successful sign-in proves at least one PIN exists.
             hasAnyPINs = true
             persistLockState(false)
         } catch {
@@ -65,11 +64,8 @@ final class DefaultPOSAccessSession: POSAccessSession {
     }
 
     func refreshPINStatus() async {
-        do {
-            hasAnyPINs = try await authenticator.hasAnyPINs()
-        } catch {
-            DDLogError("Failed to refresh POS PIN status: \(error)")
-        }
+        // No-op until the session owns staff fetching and can derive PIN presence from the cached
+        // staff list. Until then, `hasAnyPINs` is set by a successful sign-in.
     }
 }
 

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -1,26 +1,125 @@
+import CocoaLumberjackSwift
+import CommonCrypto
 import Foundation
+import struct Yosemite.POSStaffMember
 
+/// Verifies a PIN against the locally cached staff list using PBKDF2-HMAC-SHA256.
+///
+/// It is a pure reader of `POSStaffCache`: keeping the cache fresh (fetching staff from the server)
+/// is the access session's responsibility, not the authenticator's. On a cache miss it simply
+/// reports `.invalidPIN`; the session decides whether to refresh and retry.
 struct DefaultPOSPINAuthenticator: POSPINAuthenticating {
-    // TODO: Replace with PBKDF2 verification against a cached staff list once the staff endpoint lands.
+    private let cache: POSStaffCache
+    private let siteID: Int64
 
-    func authenticate(withPIN pin: String) async throws(POSAuthError) -> POSStaff {
-        guard pin == "1234" else {
-            throw .invalidPIN
-        }
-        return POSStaff(
-            displayName: "Demo Manager",
-            role: "shop_manager",
-            capabilities: Set(POSCapability.allCases.map(\.rawValue))
-        )
+    init(cache: POSStaffCache, siteID: Int64) {
+        self.cache = cache
+        self.siteID = siteID
     }
 
-    func verify(managerPIN pin: String, authorizes capability: POSCapability)
-        async throws(POSAuthError) {
-        // TODO: implement when the manager override flow is wired in.
-        throw .unknown
+    func authenticate(withPIN pin: String) async throws(POSAuthError) -> POSStaff {
+        guard let match = findMatch(pin: pin) else {
+            throw .invalidPIN
+        }
+        return staff(from: match)
+    }
+
+    func verify(managerPIN pin: String, authorizes capability: POSCapability) async throws(POSAuthError) {
+        guard let match = findMatch(pin: pin), holdsCapability(match, capability) else {
+            throw .invalidPIN
+        }
     }
 
     func hasAnyPINs() async throws(POSAuthError) -> Bool {
-        true
+        cache.hasAnyPINs(siteID: siteID)
     }
+}
+
+// MARK: - Lookup helpers
+
+private extension DefaultPOSPINAuthenticator {
+    /// Returns the cached staff member whose PIN matches `pin`, or `nil` if none do.
+    func findMatch(pin: String) -> POSStaffMember? {
+        for member in cache.load(siteID: siteID) ?? [] {
+            guard let details = member.pin else { continue }
+            guard details.algorithm == Constants.supportedAlgorithm else {
+                DDLogError("POS PIN: unsupported hash algorithm '\(details.algorithm)' for staff \(member.userID); skipping")
+                continue
+            }
+            if verifyPIN(pin, against: details) {
+                return member
+            }
+        }
+        return nil
+    }
+
+    func holdsCapability(_ member: POSStaffMember, _ capability: POSCapability) -> Bool {
+        member.capabilities[capability.rawValue] == true
+    }
+}
+
+// MARK: - PBKDF2
+
+private extension DefaultPOSPINAuthenticator {
+    func verifyPIN(_ pin: String, against details: POSStaffMember.PINDetails) -> Bool {
+        guard let saltData = Data(base64Encoded: details.salt),
+              let expectedHash = Data(base64Encoded: details.hash),
+              let pinData = pin.data(using: .utf8),
+              let iterations = UInt32(exactly: details.iterations) else {
+            return false
+        }
+        var derived = [UInt8](repeating: 0, count: expectedHash.count)
+        let status = saltData.withUnsafeBytes { saltBytes -> Int32 in
+            pinData.withUnsafeBytes { pinBytes -> Int32 in
+                CCKeyDerivationPBKDF(
+                    CCPBKDFAlgorithm(kCCPBKDF2),
+                    pinBytes.baseAddress?.assumingMemoryBound(to: Int8.self),
+                    pinData.count,
+                    saltBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    saltData.count,
+                    CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                    iterations,
+                    &derived,
+                    derived.count
+                )
+            }
+        }
+        guard status == kCCSuccess else { return false }
+        return constantTimeEqual(Data(derived), expectedHash)
+    }
+
+    func constantTimeEqual(_ a: Data, _ b: Data) -> Bool {
+        guard a.count == b.count else { return false }
+        var result: UInt8 = 0
+        for i in 0..<a.count {
+            result |= a[i] ^ b[i]
+        }
+        return result == 0
+    }
+}
+
+// MARK: - POSStaff construction
+
+private extension DefaultPOSPINAuthenticator {
+    /// Builds the `POSStaff` for a verified member, keeping only the capabilities the client
+    /// recognizes — i.e. those that map to a known `POSCapability` — so unknown server-side keys
+    /// are dropped rather than carried into the app's permission checks.
+    func staff(from member: POSStaffMember) -> POSStaff {
+        let posCaps = Set(member.capabilities.compactMap { key, granted -> String? in
+            guard granted, POSCapability(rawValue: key) != nil else { return nil }
+            return key
+        })
+        return POSStaff(
+            userID: member.userID,
+            displayName: member.displayName,
+            preset: member.preset,
+            capabilities: posCaps
+        )
+    }
+}
+
+private enum Constants {
+    /// The only PIN hashing scheme the client knows how to verify. PINs tagged with anything else
+    /// are skipped (and logged) rather than silently treated as a match/mismatch.
+    static let supportedAlgorithm = "pbkdf2-sha256"
 }

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -32,14 +32,6 @@ struct DefaultPOSPINAuthenticator: POSPINAuthenticating {
             throw .invalidPIN
         }
     }
-
-    func hasAnyPINs() async throws(POSAuthError) -> Bool {
-        // Keychain read + JSON decode — kept off the calling (main) actor. The capture list pulls in
-        // just `cache` and `siteID` so the `@Sendable` closure doesn't capture the whole `self`.
-        return await Task.detached(priority: .userInitiated) { [cache, siteID] in
-            cache.hasAnyPINs(siteID: siteID)
-        }.value
-    }
 }
 
 // MARK: - Lookup helpers

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -34,10 +34,9 @@ struct DefaultPOSPINAuthenticator: POSPINAuthenticating {
     }
 
     func hasAnyPINs() async throws(POSAuthError) -> Bool {
-        let cache = self.cache
-        let siteID = self.siteID
-        // Keychain read + JSON decode — kept off the calling (main) actor.
-        return await Task.detached(priority: .userInitiated) {
+        // Keychain read + JSON decode — kept off the calling (main) actor. The capture list pulls in
+        // just `cache` and `siteID` so the `@Sendable` closure doesn't capture the whole `self`.
+        return await Task.detached(priority: .userInitiated) { [cache, siteID] in
             cache.hasAnyPINs(siteID: siteID)
         }.value
     }
@@ -49,9 +48,9 @@ private extension DefaultPOSPINAuthenticator {
     /// Returns the cached staff member whose PIN matches `pin`, or `nil` if none do. The keychain
     /// read and PBKDF2 verification run on a detached task so PIN entry never stalls the UI thread.
     func findMatch(pin: String) async -> POSStaffMember? {
-        let cache = self.cache
-        let siteID = self.siteID
-        return await Task.detached(priority: .userInitiated) {
+        // The capture list pulls in just `cache` and `siteID` so the `@Sendable` closure doesn't
+        // capture the whole `self`.
+        return await Task.detached(priority: .userInitiated) { [cache, siteID] in
             for member in cache.load(siteID: siteID) ?? [] {
                 guard let details = member.pin else { continue }
                 guard details.algorithm == Constants.supportedAlgorithm else {

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -77,12 +77,14 @@ private extension DefaultPOSPINAuthenticator {
         guard let saltData = Data(base64Encoded: details.salt),
               let expectedHash = Data(base64Encoded: details.hash),
               !expectedHash.isEmpty,
+              expectedHash.count <= Constants.maxHashByteCount,
               let pinData = pin.data(using: .utf8),
               let iterations = UInt32(exactly: details.iterations),
               iterations > 0 else {
-            // Reject empty hashes and non-positive iteration counts outright: an empty `expectedHash`
-            // would otherwise make `constantTimeEqual` return true for any PIN if PBKDF2 ever
-            // succeeded with a zero-length derivation.
+            // Reject empty/oversized hashes and non-positive iteration counts outright before
+            // touching PBKDF2. An empty `expectedHash` would otherwise make `constantTimeEqual`
+            // return true for any PIN; an oversized one (from a corrupted/tampered cache) sizes the
+            // derived-key buffer — and therefore the PBKDF2 work — proportional to it.
             return false
         }
         var derived = [UInt8](repeating: 0, count: expectedHash.count)
@@ -139,4 +141,9 @@ private enum Constants {
     /// The only PIN hashing scheme the client knows how to verify. PINs tagged with anything else
     /// are skipped (and logged) rather than silently treated as a match/mismatch.
     static let supportedAlgorithm = "pbkdf2-sha256"
+
+    /// Upper bound on the decoded PIN hash length. A PBKDF2-HMAC-SHA256 digest is 32 bytes; we keep
+    /// some headroom but reject anything larger so a corrupted/tampered cache entry can't size the
+    /// derived-key buffer — and the PBKDF2 work — to an arbitrarily large value.
+    static let maxHashByteCount = 64
 }

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -77,8 +77,13 @@ private extension DefaultPOSPINAuthenticator {
     static func verifyPIN(_ pin: String, against details: POSStaffMember.PINDetails) -> Bool {
         guard let saltData = Data(base64Encoded: details.salt),
               let expectedHash = Data(base64Encoded: details.hash),
+              !expectedHash.isEmpty,
               let pinData = pin.data(using: .utf8),
-              let iterations = UInt32(exactly: details.iterations) else {
+              let iterations = UInt32(exactly: details.iterations),
+              iterations > 0 else {
+            // Reject empty hashes and non-positive iteration counts outright: an empty `expectedHash`
+            // would otherwise make `constantTimeEqual` return true for any PIN if PBKDF2 ever
+            // succeeded with a zero-length derivation.
             return false
         }
         var derived = [UInt8](repeating: 0, count: expectedHash.count)

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -8,6 +8,9 @@ import struct Yosemite.POSStaffMember
 /// It is a pure reader of `POSStaffCache`: keeping the cache fresh (fetching staff from the server)
 /// is the access session's responsibility, not the authenticator's. On a cache miss it simply
 /// reports `.invalidPIN`; the session decides whether to refresh and retry.
+///
+/// The keychain read + PBKDF2 work runs on a detached task: PBKDF2 is intentionally CPU-heavy and the
+/// callers are `@MainActor`, so doing it inline would block the UI thread during PIN entry.
 struct DefaultPOSPINAuthenticator: POSPINAuthenticating {
     private let cache: POSStaffCache
     private let siteID: Int64
@@ -18,39 +21,49 @@ struct DefaultPOSPINAuthenticator: POSPINAuthenticating {
     }
 
     func authenticate(withPIN pin: String) async throws(POSAuthError) -> POSStaff {
-        guard let match = findMatch(pin: pin) else {
+        guard let match = await findMatch(pin: pin) else {
             throw .invalidPIN
         }
         return staff(from: match)
     }
 
     func verify(managerPIN pin: String, authorizes capability: POSCapability) async throws(POSAuthError) {
-        guard let match = findMatch(pin: pin), holdsCapability(match, capability) else {
+        guard let match = await findMatch(pin: pin), holdsCapability(match, capability) else {
             throw .invalidPIN
         }
     }
 
     func hasAnyPINs() async throws(POSAuthError) -> Bool {
-        cache.hasAnyPINs(siteID: siteID)
+        let cache = self.cache
+        let siteID = self.siteID
+        // Keychain read + JSON decode — kept off the calling (main) actor.
+        return await Task.detached(priority: .userInitiated) {
+            cache.hasAnyPINs(siteID: siteID)
+        }.value
     }
 }
 
 // MARK: - Lookup helpers
 
 private extension DefaultPOSPINAuthenticator {
-    /// Returns the cached staff member whose PIN matches `pin`, or `nil` if none do.
-    func findMatch(pin: String) -> POSStaffMember? {
-        for member in cache.load(siteID: siteID) ?? [] {
-            guard let details = member.pin else { continue }
-            guard details.algorithm == Constants.supportedAlgorithm else {
-                DDLogError("POS PIN: unsupported hash algorithm '\(details.algorithm)' for staff \(member.userID); skipping")
-                continue
+    /// Returns the cached staff member whose PIN matches `pin`, or `nil` if none do. The keychain
+    /// read and PBKDF2 verification run on a detached task so PIN entry never stalls the UI thread.
+    func findMatch(pin: String) async -> POSStaffMember? {
+        let cache = self.cache
+        let siteID = self.siteID
+        return await Task.detached(priority: .userInitiated) {
+            for member in cache.load(siteID: siteID) ?? [] {
+                guard let details = member.pin else { continue }
+                guard details.algorithm == Constants.supportedAlgorithm else {
+                    DDLogError("POS PIN: unsupported hash algorithm '\(details.algorithm)' for staff \(member.userID); skipping")
+                    continue
+                }
+                if Self.verifyPIN(pin, against: details) {
+                    return member
+                }
             }
-            if verifyPIN(pin, against: details) {
-                return member
-            }
-        }
-        return nil
+            return nil
+        }.value
     }
 
     func holdsCapability(_ member: POSStaffMember, _ capability: POSCapability) -> Bool {
@@ -61,7 +74,7 @@ private extension DefaultPOSPINAuthenticator {
 // MARK: - PBKDF2
 
 private extension DefaultPOSPINAuthenticator {
-    func verifyPIN(_ pin: String, against details: POSStaffMember.PINDetails) -> Bool {
+    static func verifyPIN(_ pin: String, against details: POSStaffMember.PINDetails) -> Bool {
         guard let saltData = Data(base64Encoded: details.salt),
               let expectedHash = Data(base64Encoded: details.hash),
               let pinData = pin.data(using: .utf8),
@@ -88,7 +101,7 @@ private extension DefaultPOSPINAuthenticator {
         return constantTimeEqual(Data(derived), expectedHash)
     }
 
-    func constantTimeEqual(_ a: Data, _ b: Data) -> Bool {
+    static func constantTimeEqual(_ a: Data, _ b: Data) -> Bool {
         guard a.count == b.count else { return false }
         var result: UInt8 = 0
         for i in 0..<a.count {

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -22,7 +22,7 @@ final class MockPOSAccessSession: POSAccessSession {
          isLocked: Bool = false,
          hasAnyPINs: Bool = true,
          signInResult: Result<POSStaff, POSAuthError> = .success(
-            POSStaff(displayName: "Maya", role: "Manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
+            POSStaff(userID: 1, displayName: "Maya", preset: "pos_manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
          ),
          managerApprovalResult: Result<Void, POSAuthError> = .success(()),
          checkLockoutResult: Result<Void, POSAuthError> = .success(())) {

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSessionFactory.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSessionFactory.swift
@@ -8,7 +8,7 @@ enum POSAccessSessionFactory {
         }
         return DefaultPOSAccessSession(
             siteID: siteID,
-            authenticator: DefaultPOSPINAuthenticator(),
+            authenticator: DefaultPOSPINAuthenticator(cache: POSStaffCache(), siteID: siteID),
             rateLimiter: POSLocalRateLimiter(siteID: siteID)
         )
     }

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSPINAuthenticating.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSPINAuthenticating.swift
@@ -1,5 +1,4 @@
 protocol POSPINAuthenticating: Sendable {
     func authenticate(withPIN pin: String) async throws(POSAuthError) -> POSStaff
     func verify(managerPIN pin: String, authorizes capability: POSCapability) async throws(POSAuthError)
-    func hasAnyPINs() async throws(POSAuthError) -> Bool
 }

--- a/Modules/Sources/PointOfSale/Roles/Views/POSManagerOverrideModal.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSManagerOverrideModal.swift
@@ -84,7 +84,7 @@ private extension POSManagerOverrideModalSizing {
 #Preview("Sample order") {
     POSManagerOverridePreview(
         session: MockPOSAccessSession(),
-        capability: .refundShopOrders,
+        capability: .issueRefunds,
         reason: "Issue a refund for Order #1043"
     )
 }
@@ -92,7 +92,7 @@ private extension POSManagerOverrideModalSizing {
 #Preview("Sample order - Invalid PIN") {
     POSManagerOverridePreview(
         session: MockPOSAccessSession(managerApprovalResult: .failure(.invalidPIN)),
-        capability: .publishShopCoupons,
+        capability: .createCoupons,
         reason: "Creating coupons requires manager approval",
         pinEntryState: .error(kind: .invalidPIN)
     )

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -139,33 +139,6 @@ struct DefaultPOSAccessSessionTests {
         #expect(sut.session.currentStaff == staff)
     }
 
-    @Test func test_refreshPINStatus_when_authenticator_succeeds_then_updates_hasAnyPINs() async {
-        // Given
-        let authenticator = MockPOSPINAuthenticator(hasAnyPINsResult: .success(true))
-        let sut = makeSUT(authenticator: authenticator)
-
-        // When
-        await sut.session.refreshPINStatus()
-
-        // Then
-        #expect(sut.session.hasAnyPINs == true)
-        #expect(authenticator.hasAnyPINsCallCount == 1)
-    }
-
-    @Test func test_refreshPINStatus_when_authenticator_fails_then_keeps_last_value() async {
-        // Given
-        let authenticator = MockPOSPINAuthenticator(hasAnyPINsResult: .success(true))
-        let sut = makeSUT(authenticator: authenticator)
-        await sut.session.refreshPINStatus()
-
-        // When
-        authenticator.hasAnyPINsResult = .failure(.unknown)
-        await sut.session.refreshPINStatus()
-
-        // Then
-        #expect(sut.session.hasAnyPINs == true)
-    }
-
     @Test func test_requestManagerApproval_when_called_then_throws_unknown() async {
         // Given
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator())

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -8,8 +8,9 @@ struct DefaultPOSAccessSessionTests {
     @Test func test_signIn_when_pin_is_valid_then_sets_currentStaff_and_unlocks_and_resets_limiter() async throws {
         // Given
         let staff = POSStaff(
+            userID: 1,
             displayName: "Maya",
-            role: "shop_manager",
+            preset: "shop_manager",
             capabilities: Set(POSCapability.allCases.map(\.rawValue))
         )
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
@@ -126,7 +127,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_lock_when_called_then_sets_isLocked_true_and_keeps_currentStaff() async throws {
         // Given
-        let staff = POSStaff(displayName: "Maya", role: "shop_manager", capabilities: [])
+        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
@@ -171,32 +172,33 @@ struct DefaultPOSAccessSessionTests {
 
         // When / Then
         await #expect(throws: POSAuthError.unknown) {
-            try await sut.session.requestManagerApproval(withPIN: "1234", for: .refundShopOrders)
+            try await sut.session.requestManagerApproval(withPIN: "1234", for: .issueRefunds)
         }
     }
 
     @Test func test_allows_when_currentStaff_has_capability_then_returns_true() async throws {
         // Given
         let staff = POSStaff(
+            userID: 1,
             displayName: "Maya",
-            role: "shop_manager",
-            capabilities: [POSCapability.refundShopOrders.rawValue]
+            preset: "shop_manager",
+            capabilities: [POSCapability.issueRefunds.rawValue]
         )
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
         // When / Then
-        #expect(sut.session.allows(.refundShopOrders) == true)
+        #expect(sut.session.allows(.issueRefunds) == true)
     }
 
     @Test func test_allows_when_currentStaff_lacks_capability_then_returns_false() async throws {
         // Given
-        let staff = POSStaff(displayName: "Maya", role: "pos_cashier", capabilities: [])
+        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "pos_cashier", capabilities: [])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
         // When / Then
-        #expect(sut.session.allows(.refundShopOrders) == false)
+        #expect(sut.session.allows(.issueRefunds) == false)
     }
 
     @Test func test_allows_when_no_currentStaff_then_returns_false() {
@@ -204,7 +206,7 @@ struct DefaultPOSAccessSessionTests {
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator())
 
         // When / Then
-        #expect(sut.session.allows(.refundShopOrders) == false)
+        #expect(sut.session.allows(.issueRefunds) == false)
     }
 
     @Test func test_lock_when_called_then_persists_true_to_per_site_lock_key() {
@@ -220,7 +222,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_signIn_when_pin_is_valid_then_persists_false_to_per_site_lock_key() async throws {
         // Given
-        let staff = POSStaff(displayName: "Maya", role: "shop_manager", capabilities: [])
+        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         sut.session.lock()
         #expect(sut.scope.defaults.bool(forKey: POSLockStateKey.key(for: 123)) == true)
@@ -245,7 +247,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_signIn_when_pin_is_valid_then_sets_hasAnyPINs_true() async throws {
         // Given
-        let staff = POSStaff(displayName: "Maya", role: "shop_manager", capabilities: [])
+        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         #expect(sut.session.hasAnyPINs == false)
 

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -143,21 +143,6 @@ struct DefaultPOSPINAuthenticatorTests {
             try await sut.verify(managerPIN: "9999", authorizes: .issueRefunds)
         }
     }
-
-    // MARK: - hasAnyPINs
-
-    @MainActor
-    @Test func test_hasAnyPINs_reflects_the_cache() async throws {
-        // Given a cache with one member that has a PIN
-        let sut = makeSUT(cached: [makeMember(userID: 1, pin: pinDetails(forPIN: "1234"))])
-
-        // Then
-        #expect(try await sut.hasAnyPINs())
-
-        // Given an empty cache
-        let empty = makeSUT()
-        #expect(try await empty.hasAnyPINs() == false)
-    }
 }
 
 // MARK: - Helpers

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -68,6 +68,22 @@ struct DefaultPOSPINAuthenticatorTests {
     }
 
     @MainActor
+    @Test func test_authenticate_rejects_members_whose_hash_exceeds_the_maximum_length() async throws {
+        // Given a cached member whose PIN hash is far larger than a real PBKDF2-SHA256 digest,
+        // simulating a corrupted or tampered cache entry
+        let oversizedHash = Data(repeating: 0, count: 1_024).base64EncodedString()
+        let details = POSStaffMember.PINDetails(algorithm: "pbkdf2-sha256", iterations: 1_000,
+                                                salt: "c2FsdC1mb3ItdGVzdHM=", hash: oversizedHash)
+        let member = makeMember(userID: 1, pin: details)
+        let sut = makeSUT(cached: [member])
+
+        // When / Then — the oversized hash is treated as invalid data rather than fed to PBKDF2
+        await #expect(throws: POSAuthError.invalidPIN) {
+            _ = try await sut.authenticate(withPIN: "1234")
+        }
+    }
+
+    @MainActor
     @Test func test_authenticate_keeps_only_known_pos_capabilities_that_are_granted() async throws {
         // Given a member with a granted known cap, a denied known cap, and an unknown cap
         let member = makeMember(userID: 1,

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -1,0 +1,200 @@
+import CommonCrypto
+import Foundation
+import Testing
+import struct Yosemite.POSStaffMember
+@testable import PointOfSale
+
+struct DefaultPOSPINAuthenticatorTests {
+    private let siteID: Int64 = 123
+
+    // MARK: - authenticate
+
+    @MainActor
+    @Test func test_authenticate_when_pin_matches_a_cached_member_then_returns_that_staff() async throws {
+        // Given a cached member whose PIN hash matches "1234"
+        let member = makeMember(userID: 7, displayName: "Manny", preset: "pos_manager",
+                                capabilities: ["pos_process_sales": true, "pos_issue_refunds": true],
+                                pin: pinDetails(forPIN: "1234"))
+        let sut = makeSUT(cached: [member])
+
+        // When
+        let staff = try await sut.authenticate(withPIN: "1234")
+
+        // Then
+        #expect(staff.userID == 7)
+        #expect(staff.displayName == "Manny")
+        #expect(staff.preset == "pos_manager")
+    }
+
+    @MainActor
+    @Test func test_authenticate_when_pin_is_wrong_then_throws_invalidPIN() async throws {
+        // Given a member with a different PIN
+        let member = makeMember(userID: 1, pin: pinDetails(forPIN: "0000"))
+        let sut = makeSUT(cached: [member])
+
+        // When / Then — no fetcher, so a miss is simply invalid (the session decides whether to refresh+retry)
+        await #expect(throws: POSAuthError.invalidPIN) {
+            _ = try await sut.authenticate(withPIN: "1234")
+        }
+    }
+
+    @MainActor
+    @Test func test_authenticate_skips_members_without_a_pin() async throws {
+        // Given one member with no PIN and one with the matching PIN
+        let noPIN = makeMember(userID: 1, pin: nil)
+        let matching = makeMember(userID: 2, pin: pinDetails(forPIN: "1234"))
+        let sut = makeSUT(cached: [noPIN, matching])
+
+        // When
+        let staff = try await sut.authenticate(withPIN: "1234")
+
+        // Then
+        #expect(staff.userID == 2)
+    }
+
+    @MainActor
+    @Test func test_authenticate_rejects_members_with_an_unsupported_algorithm() async throws {
+        // Given a member whose PIN hash would match "1234" but is tagged with an unsupported algo
+        let valid = pinDetails(forPIN: "1234")
+        let details = POSStaffMember.PINDetails(algorithm: "bcrypt", iterations: valid.iterations,
+                                                salt: valid.salt, hash: valid.hash)
+        let member = makeMember(userID: 1, pin: details)
+        let sut = makeSUT(cached: [member])
+
+        // When / Then
+        await #expect(throws: POSAuthError.invalidPIN) {
+            _ = try await sut.authenticate(withPIN: "1234")
+        }
+    }
+
+    @MainActor
+    @Test func test_authenticate_keeps_only_known_pos_capabilities_that_are_granted() async throws {
+        // Given a member with a granted known cap, a denied known cap, and an unknown cap
+        let member = makeMember(userID: 1,
+                                capabilities: [
+                                    "pos_process_sales": true,
+                                    "pos_issue_refunds": false,
+                                    "some_unknown_cap": true
+                                ],
+                                pin: pinDetails(forPIN: "1234"))
+        let sut = makeSUT(cached: [member])
+
+        // When
+        let staff = try await sut.authenticate(withPIN: "1234")
+
+        // Then only the granted, recognized capability survives
+        #expect(staff.capabilities == ["pos_process_sales"])
+        #expect(staff.hasCapability(.processSales))
+        #expect(!staff.hasCapability(.issueRefunds))
+    }
+
+    @MainActor
+    @Test func test_authenticate_when_member_has_a_valid_pin_but_no_recognized_pos_capabilities_then_returns_staff_with_none() async throws {
+        // Given a member with a matching PIN but only capabilities the client doesn't recognize
+        let member = makeMember(userID: 3,
+                                capabilities: ["some_legacy_cap": true, "another_unknown_cap": true],
+                                pin: pinDetails(forPIN: "1234"))
+        let sut = makeSUT(cached: [member])
+
+        // When
+        let staff = try await sut.authenticate(withPIN: "1234")
+
+        // Then sign-in still succeeds (the PIN is valid) but the staff carries no POS capabilities
+        #expect(staff.userID == 3)
+        #expect(staff.capabilities.isEmpty)
+    }
+
+    // MARK: - verify(managerPIN:)
+
+    @MainActor
+    @Test func test_verify_when_manager_holds_the_capability_then_does_not_throw() async throws {
+        let manager = makeMember(userID: 5, displayName: "Morgan", preset: "pos_manager",
+                                 capabilities: ["pos_issue_refunds": true],
+                                 pin: pinDetails(forPIN: "9999"))
+        let sut = makeSUT(cached: [manager])
+
+        // When / Then — succeeds without throwing
+        try await sut.verify(managerPIN: "9999", authorizes: .issueRefunds)
+    }
+
+    @MainActor
+    @Test func test_verify_when_manager_lacks_the_capability_then_throws_invalidPIN() async throws {
+        let cashier = makeMember(userID: 6, capabilities: ["pos_process_sales": true],
+                                 pin: pinDetails(forPIN: "9999"))
+        let sut = makeSUT(cached: [cashier])
+
+        await #expect(throws: POSAuthError.invalidPIN) {
+            try await sut.verify(managerPIN: "9999", authorizes: .issueRefunds)
+        }
+    }
+
+    // MARK: - hasAnyPINs
+
+    @MainActor
+    @Test func test_hasAnyPINs_reflects_the_cache() async throws {
+        // Given a cache with one member that has a PIN
+        let sut = makeSUT(cached: [makeMember(userID: 1, pin: pinDetails(forPIN: "1234"))])
+
+        // Then
+        #expect(try await sut.hasAnyPINs())
+
+        // Given an empty cache
+        let empty = makeSUT()
+        #expect(try await empty.hasAnyPINs() == false)
+    }
+}
+
+// MARK: - Helpers
+
+private extension DefaultPOSPINAuthenticatorTests {
+    @MainActor
+    func makeSUT(cached: [POSStaffMember] = []) -> DefaultPOSPINAuthenticator {
+        let cache = POSStaffCache(storage: InMemoryStaffStorage())
+        cache.save(cached, siteID: siteID)
+        return DefaultPOSPINAuthenticator(cache: cache, siteID: siteID)
+    }
+
+    func makeMember(userID: Int64,
+                    displayName: String = "User",
+                    preset: String = "pos_cashier",
+                    capabilities: [String: Bool] = ["pos_process_sales": true],
+                    pin: POSStaffMember.PINDetails?) -> POSStaffMember {
+        POSStaffMember(userID: userID, displayName: displayName, preset: preset,
+                       capabilities: capabilities, pin: pin)
+    }
+
+    /// Builds `PINDetails` whose hash is a genuine PBKDF2-HMAC-SHA256 derivation of `pin`, so the
+    /// authenticator's real verification path is exercised end to end.
+    func pinDetails(forPIN pin: String,
+                    saltBase64: String = "c2FsdC1mb3ItdGVzdHM=",
+                    iterations: Int = 1_000) -> POSStaffMember.PINDetails {
+        let salt = Data(base64Encoded: saltBase64)!
+        let pinData = pin.data(using: .utf8)!
+        var derived = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        _ = salt.withUnsafeBytes { saltBytes in
+            pinData.withUnsafeBytes { pinBytes in
+                CCKeyDerivationPBKDF(
+                    CCPBKDFAlgorithm(kCCPBKDF2),
+                    pinBytes.baseAddress?.assumingMemoryBound(to: Int8.self),
+                    pinData.count,
+                    saltBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                    salt.count,
+                    CCPseudoRandomAlgorithm(kCCPRFHmacAlgSHA256),
+                    UInt32(iterations),
+                    &derived,
+                    derived.count
+                )
+            }
+        }
+        return POSStaffMember.PINDetails(algorithm: "pbkdf2-sha256",
+                                         iterations: iterations,
+                                         salt: saltBase64,
+                                         hash: Data(derived).base64EncodedString())
+    }
+}
+
+private final class InMemoryStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
+    private var store: [String: String] = [:]
+    func string(forKey key: String) -> String? { store[key] }
+    func setString(_ value: String?, forKey key: String) { store[key] = value }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -171,8 +171,8 @@ private extension DefaultPOSPINAuthenticatorTests {
         let salt = Data(base64Encoded: saltBase64)!
         let pinData = pin.data(using: .utf8)!
         var derived = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        _ = salt.withUnsafeBytes { saltBytes in
-            pinData.withUnsafeBytes { pinBytes in
+        let status = salt.withUnsafeBytes { saltBytes -> Int32 in
+            pinData.withUnsafeBytes { pinBytes -> Int32 in
                 CCKeyDerivationPBKDF(
                     CCPBKDFAlgorithm(kCCPBKDF2),
                     pinBytes.baseAddress?.assumingMemoryBound(to: Int8.self),
@@ -186,6 +186,9 @@ private extension DefaultPOSPINAuthenticatorTests {
                 )
             }
         }
+        // Fail fast if key derivation fails — otherwise the helper would hand back an all-zero hash
+        // and the test would silently assert against meaningless data.
+        precondition(status == kCCSuccess, "PBKDF2 derivation failed in test helper (status: \(status))")
         return POSStaffMember.PINDetails(algorithm: "pbkdf2-sha256",
                                          iterations: iterations,
                                          salt: saltBase64,

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
@@ -13,8 +13,9 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
 
     init(authenticateResult: Result<POSStaff, POSAuthError> = .success(
             POSStaff(
+                userID: 1,
                 displayName: "Maya",
-                role: "shop_manager",
+                preset: "shop_manager",
                 capabilities: Set(POSCapability.allCases.map(\.rawValue))
             )
          ),

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
@@ -5,11 +5,9 @@ import Foundation
 final class MockPOSPINAuthenticator: POSPINAuthenticating {
     var authenticateResult: Result<POSStaff, POSAuthError>
     var verifyResult: Result<Void, POSAuthError>
-    var hasAnyPINsResult: Result<Bool, POSAuthError>
 
     private(set) var authenticatedPINs: [String] = []
     private(set) var verifyCallCount: Int = 0
-    private(set) var hasAnyPINsCallCount: Int = 0
 
     init(authenticateResult: Result<POSStaff, POSAuthError> = .success(
             POSStaff(
@@ -19,11 +17,9 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
                 capabilities: Set(POSCapability.allCases.map(\.rawValue))
             )
          ),
-         verifyResult: Result<Void, POSAuthError> = .success(()),
-         hasAnyPINsResult: Result<Bool, POSAuthError> = .success(true)) {
+         verifyResult: Result<Void, POSAuthError> = .success(())) {
         self.authenticateResult = authenticateResult
         self.verifyResult = verifyResult
-        self.hasAnyPINsResult = hasAnyPINsResult
     }
 
     func authenticate(withPIN pin: String) async throws(POSAuthError) -> POSStaff {
@@ -35,10 +31,5 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
         async throws(POSAuthError) {
         verifyCallCount += 1
         _ = try verifyResult.get()
-    }
-
-    func hasAnyPINs() async throws(POSAuthError) -> Bool {
-        hasAnyPINsCallCount += 1
-        return try hasAnyPINsResult.get()
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSAutoLockActivityControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSAutoLockActivityControllerTests.swift
@@ -205,7 +205,7 @@ private extension POSAutoLockActivityControllerTests {
     }
 
     func makeStaff() -> POSStaff {
-        POSStaff(displayName: "Maya", role: "shop_manager", capabilities: [])
+        POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Roles/POSCapabilityTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSCapabilityTests.swift
@@ -4,21 +4,29 @@ import Testing
 struct POSCapabilityTests {
     @Test func test_rawValues_match_backend_capability_identifiers() {
         // When / Then
-        #expect(POSCapability.viewPOS.rawValue == "view_pos")
-        #expect(POSCapability.viewPOSSettings.rawValue == "view_pos_settings")
-        #expect(POSCapability.editPOSSettings.rawValue == "edit_pos_settings")
-        #expect(POSCapability.refundShopOrders.rawValue == "refund_shop_orders")
-        #expect(POSCapability.publishShopCoupons.rawValue == "publish_shop_coupons")
+        #expect(POSCapability.processSales.rawValue == "pos_process_sales")
+        #expect(POSCapability.viewOrders.rawValue == "pos_view_orders")
+        #expect(POSCapability.applyCoupons.rawValue == "pos_apply_coupons")
+        #expect(POSCapability.createCoupons.rawValue == "pos_create_coupons")
+        #expect(POSCapability.issueRefunds.rawValue == "pos_issue_refunds")
+        #expect(POSCapability.viewPOSSettings.rawValue == "pos_view_settings")
+        #expect(POSCapability.editPOSSettings.rawValue == "pos_edit_settings")
+        #expect(POSCapability.managePOSStaff.rawValue == "pos_manage_staff")
+        #expect(POSCapability.exitPOS.rawValue == "pos_exit")
     }
 
     @Test func test_allCases_is_exactly_the_supported_capability_set() {
         // When / Then
         #expect(Set(POSCapability.allCases.map(\.rawValue)) == [
-            "view_pos",
-            "view_pos_settings",
-            "edit_pos_settings",
-            "refund_shop_orders",
-            "publish_shop_coupons"
+            "pos_process_sales",
+            "pos_view_orders",
+            "pos_apply_coupons",
+            "pos_create_coupons",
+            "pos_issue_refunds",
+            "pos_view_settings",
+            "pos_edit_settings",
+            "pos_manage_staff",
+            "pos_exit"
         ])
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
@@ -225,8 +225,9 @@ struct POSLockScreenModelTests {
 
     private func makeStaff() -> POSStaff {
         POSStaff(
+            userID: 1,
             displayName: "Maya",
-            role: "Manager",
+            preset: "Manager",
             capabilities: Set(POSCapability.allCases.map(\.rawValue))
         )
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSManagerOverrideHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSManagerOverrideHandlerTests.swift
@@ -13,12 +13,12 @@ struct POSManagerOverrideHandlerTests {
 
         // When
         sut.requestApproval(
-            for: .refundShopOrders,
+            for: .issueRefunds,
             reason: "Refunding orders requires manager approval"
         )
 
         // Then
-        #expect(sut.request?.capability == .refundShopOrders)
+        #expect(sut.request?.capability == .issueRefunds)
         #expect(sut.request?.reason == "Refunding orders requires manager approval")
         #expect(sut.pinEntryState == .idle)
     }
@@ -28,7 +28,7 @@ struct POSManagerOverrideHandlerTests {
         var loadingStateObserved = false
         let session = MockPOSAccessSession()
         let sut = POSManagerOverrideHandler(session: session)
-        sut.requestApproval(for: .publishShopCoupons, reason: "Creating coupons requires manager approval")
+        sut.requestApproval(for: .createCoupons, reason: "Creating coupons requires manager approval")
         session.onManagerApproval = {
             if sut.pinEntryState == .loading {
                 loadingStateObserved = true
@@ -72,7 +72,7 @@ struct POSManagerOverrideHandlerTests {
         // Given
         let session = MockPOSAccessSession(managerApprovalResult: .failure(.invalidPIN))
         let sut = POSManagerOverrideHandler(session: session)
-        sut.requestApproval(for: .refundShopOrders, reason: "Refunding orders requires manager approval")
+        sut.requestApproval(for: .issueRefunds, reason: "Refunding orders requires manager approval")
 
         // When
         let succeeded = await sut.submit(pin: "9999")
@@ -80,8 +80,8 @@ struct POSManagerOverrideHandlerTests {
         // Then
         #expect(succeeded == false)
         #expect(session.managerApprovalPINs == ["9999"])
-        #expect(session.managerApprovalCapabilities == [.refundShopOrders])
-        #expect(sut.request?.capability == .refundShopOrders)
+        #expect(session.managerApprovalCapabilities == [.issueRefunds])
+        #expect(sut.request?.capability == .issueRefunds)
         #expect(sut.pinEntryState == .error(kind: .invalidPIN))
     }
 
@@ -89,7 +89,7 @@ struct POSManagerOverrideHandlerTests {
         // Given
         let session = MockPOSAccessSession(managerApprovalResult: .failure(.unknown))
         let sut = POSManagerOverrideHandler(session: session)
-        sut.requestApproval(for: .publishShopCoupons, reason: "Creating coupons requires manager approval")
+        sut.requestApproval(for: .createCoupons, reason: "Creating coupons requires manager approval")
 
         // When
         let succeeded = await sut.submit(pin: "1234")
@@ -97,7 +97,7 @@ struct POSManagerOverrideHandlerTests {
         // Then
         #expect(succeeded == false)
         #expect(session.managerApprovalPINs == ["1234"])
-        #expect(sut.request?.capability == .publishShopCoupons)
+        #expect(sut.request?.capability == .createCoupons)
         #expect(sut.pinEntryState == .error(kind: .generic))
     }
 
@@ -125,7 +125,7 @@ struct POSManagerOverrideHandlerTests {
         let session = MockPOSAccessSession()
         let sut = POSManagerOverrideHandler(session: session)
         sut.requestApproval(
-            for: .refundShopOrders,
+            for: .issueRefunds,
             reason: "Refunding orders requires manager approval",
             onApproved: {
                 firstCompletionWasCalled = true
@@ -133,7 +133,7 @@ struct POSManagerOverrideHandlerTests {
         )
         session.onManagerApproval = {
             sut.requestApproval(
-                for: .publishShopCoupons,
+                for: .createCoupons,
                 reason: "Creating coupons requires manager approval",
                 onApproved: {
                     secondCompletionWasCalled = true
@@ -146,8 +146,8 @@ struct POSManagerOverrideHandlerTests {
 
         // Then
         #expect(session.managerApprovalPINs == ["1234"])
-        #expect(session.managerApprovalCapabilities == [.refundShopOrders])
-        #expect(sut.request?.capability == .publishShopCoupons)
+        #expect(session.managerApprovalCapabilities == [.issueRefunds])
+        #expect(sut.request?.capability == .createCoupons)
         #expect(sut.pinEntryState == .idle)
         #expect(firstCompletionWasCalled == false)
         #expect(secondCompletionWasCalled == false)
@@ -159,7 +159,7 @@ struct POSManagerOverrideHandlerTests {
         let session = MockPOSAccessSession()
         let sut = POSManagerOverrideHandler(session: session)
         sut.requestApproval(
-            for: .refundShopOrders,
+            for: .issueRefunds,
             reason: "Refunding orders requires manager approval",
             onApproved: {
                 completionWasCalled = true
@@ -174,7 +174,7 @@ struct POSManagerOverrideHandlerTests {
 
         // Then
         #expect(session.managerApprovalPINs == ["1234"])
-        #expect(session.managerApprovalCapabilities == [.refundShopOrders])
+        #expect(session.managerApprovalCapabilities == [.issueRefunds])
         #expect(sut.request == nil)
         #expect(sut.pinEntryState == .idle)
         #expect(completionWasCalled == false)
@@ -187,7 +187,7 @@ struct POSManagerOverrideHandlerTests {
         let session = MockPOSAccessSession()
         let sut = POSManagerOverrideHandler(session: session)
         sut.requestApproval(
-            for: .refundShopOrders,
+            for: .issueRefunds,
             reason: "Refunding orders requires manager approval",
             onApproved: {
                 firstCompletionWasCalled = true
@@ -197,7 +197,7 @@ struct POSManagerOverrideHandlerTests {
 
         // When
         sut.requestApproval(
-            for: .publishShopCoupons,
+            for: .createCoupons,
             reason: "Creating coupons requires manager approval",
             onApproved: {
                 secondCompletionWasCalled = true
@@ -210,9 +210,9 @@ struct POSManagerOverrideHandlerTests {
         #expect(sut.request == nil)
         #expect(sut.pinEntryState == .idle)
         #expect(secondRequest?.id != firstRequestID)
-        #expect(secondRequest?.capability == .publishShopCoupons)
+        #expect(secondRequest?.capability == .createCoupons)
         #expect(secondRequest?.reason == "Creating coupons requires manager approval")
-        #expect(session.managerApprovalCapabilities == [.publishShopCoupons])
+        #expect(session.managerApprovalCapabilities == [.createCoupons])
         #expect(firstCompletionWasCalled == false)
         #expect(secondCompletionWasCalled)
     }
@@ -220,14 +220,14 @@ struct POSManagerOverrideHandlerTests {
     @Test func test_submit_when_session_is_missing_then_shows_generic_error() async {
         // Given
         let sut = POSManagerOverrideHandler()
-        sut.requestApproval(for: .refundShopOrders, reason: "Refunding orders requires manager approval")
+        sut.requestApproval(for: .issueRefunds, reason: "Refunding orders requires manager approval")
 
         // When
         let succeeded = await sut.submit(pin: "1234")
 
         // Then
         #expect(succeeded == false)
-        #expect(sut.request?.capability == .refundShopOrders)
+        #expect(sut.request?.capability == .issueRefunds)
         #expect(sut.pinEntryState == .error(kind: .generic))
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffTests.swift
@@ -4,17 +4,17 @@ import Testing
 struct POSStaffTests {
     @Test func test_hasCapability_when_staff_has_it_then_returns_true() {
         // Given
-        let sut = POSStaff(displayName: "Jane", role: "pos_manager", capabilities: ["refund_shop_orders"])
+        let sut = POSStaff(userID: 1, displayName: "Jane", preset: "pos_manager", capabilities: ["pos_issue_refunds"])
 
         // When / Then
-        #expect(sut.hasCapability(.refundShopOrders))
+        #expect(sut.hasCapability(.issueRefunds))
     }
 
     @Test func test_hasCapability_when_staff_lacks_it_then_returns_false() {
         // Given
-        let sut = POSStaff(displayName: "Sam", role: "pos_cashier", capabilities: [])
+        let sut = POSStaff(userID: 2, displayName: "Sam", preset: "pos_cashier", capabilities: [])
 
         // When / Then
-        #expect(sut.hasCapability(.refundShopOrders) == false)
+        #expect(sut.hasCapability(.issueRefunds) == false)
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/UnrestrictedPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/UnrestrictedPOSAccessSessionTests.swift
@@ -29,13 +29,13 @@ struct UnrestrictedPOSAccessSessionTests {
 
         // When
         try await sut.signIn(withPIN: "1234")
-        try await sut.requestManagerApproval(withPIN: "1234", for: .refundShopOrders)
+        try await sut.requestManagerApproval(withPIN: "1234", for: .issueRefunds)
         sut.lock()
         await sut.refreshPINStatus()
 
         // Then
         #expect(sut.isLocked == false)
         #expect(sut.currentStaff == nil)
-        #expect(sut.allows(.refundShopOrders))
+        #expect(sut.allows(.issueRefunds))
     }
 }


### PR DESCRIPTION
## Description
WOOMOB-3170, part 1 of 2. Replaces the stub `DefaultPOSPINAuthenticator` with a real PBKDF2-HMAC-SHA256 verifier that checks a PIN against the cached staff list.

The authenticator is a **pure cache reader** — fetching/refreshing staff from the server is the access session's responsibility, not the authenticator's — so it takes **no fetcher** and performs no network I/O. On a cache miss it simply reports `.invalidPIN`; deciding whether to refresh-and-retry is the session's job (next PR https://github.com/woocommerce/woocommerce-ios/pull/17334).

- `DefaultPOSPINAuthenticator(cache:siteID:)` — PBKDF2 verify, constant-time compare, skips members without a PIN, validates the `pbkdf2-sha256` algorithm, and maps capabilities through `POSCapability(rawValue:)` (so only recognized identifiers survive, and non-`pos_` ones can be added later).
- `POSStaff` reshaped (`userID`/`displayName`/`preset`); `POSCapability` switched to the server's `pos_*` identifiers.
- `POSAccessSessionFactory` now constructs the real authenticator with a cache. The session itself is unchanged (still the stub) — the integration lands in part 2.

**Follow-up (part 2):** `POSAccessSession` integration — background staff refresh, `pinStatus` tri-state, degrade-on-flag-off, and refresh-on-miss retry.

## Test Steps

The PIN authenticator hasn't been integrated with the POS flow, and CI passing is sufficient.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not user-facing — feature-flagged, not surfaced.)