### PR TITLE
Fix Saved packages tab rows not being tappable

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Dashboard: Added option to update analytic update setting [https://github.com/woocommerce/woocommerce-ios/pull/17304]
 - [*] Fixed several crash-risk code paths in Shipping Labels, Stats, and Downloadable files [https://github.com/woocommerce/woocommerce-ios/pull/17307]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
+- [*] Fixed tapping a row in the Saved packages tab when creating a shipping label [PR_URL]
 
 24.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 - [*] Dashboard: Added option to update analytic update setting [https://github.com/woocommerce/woocommerce-ios/pull/17304]
 - [*] Fixed several crash-risk code paths in Shipping Labels, Stats, and Downloadable files [https://github.com/woocommerce/woocommerce-ios/pull/17307]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
-- [*] Fixed tapping a row in the Saved packages tab when creating a shipping label [PR_URL]
+- [*] Fixed tapping a row in the Saved packages tab when creating a shipping label [https://github.com/woocommerce/woocommerce-ios/pull/17333]
 
 24.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooSavedPackagesSelectionView.swift
@@ -283,15 +283,21 @@ private extension WooSavedPackagesSelectionView {
 
     func packagesRows(for packages: [any WooShippingPackageDataRepresentable]) -> some View {
         ForEach(packages, id: \.id) { package in
-            WooShippingPackageOptionView(
-                isSelected: viewModel.selectedSavedPackageId == package.id,
-                package: package,
-                showTopDivider: false,
-                showSource: true,
-                tapAction: {
-                    viewModel.selectedSavedPackageId = viewModel.selectedSavedPackageId == package.id ? nil : package.id
-                }
-            )
+            // Wrapped in a `Button` rather than relying on the option view's own `onTapGesture`
+            // because a custom tap gesture inside a `List` row is swallowed by `.swipeActions`,
+            // leaving the row unselectable (see WOOMOB-2980).
+            Button {
+                viewModel.selectedSavedPackageId = viewModel.selectedSavedPackageId == package.id ? nil : package.id
+            } label: {
+                WooShippingPackageOptionView(
+                    isSelected: viewModel.selectedSavedPackageId == package.id,
+                    package: package,
+                    showTopDivider: false,
+                    showSource: true,
+                    tapAction: nil
+                )
+            }
+            .buttonStyle(.plain)
             .id(package.id)
             .alignmentGuide(.listRowSeparatorLeading) { _ in
                 return 16

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Package and Rate Selection/WooShippingPackageOptionView.swift
@@ -11,7 +11,7 @@ struct WooShippingPackageOptionView: View {
     var package: WooShippingPackageDataRepresentable
     var showTopDivider: Bool
     var showSource: Bool
-    var tapAction: () -> Void
+    var tapAction: (() -> Void)?
     var starAction: (() -> Void)?
     var starred: Bool?
 
@@ -48,8 +48,10 @@ struct WooShippingPackageOptionView: View {
                 Spacer()
             }
             .contentShape(Rectangle())
-            .onTapGesture {
-                tapAction()
+            .if(tapAction != nil) { view in
+                view.onTapGesture {
+                    tapAction?()
+                }
             }
             .padding(Constants.contentPadding)
             if let starAction, let starred {


### PR DESCRIPTION
## Description

In **Order Detail → Create a shipping label → Select a package → Saved tab**, only the checkbox of each row responded to taps — tapping the row body did nothing. The **Custom** and **Carrier** tabs work as expected.

The shared `WooShippingPackageOptionView` already makes the whole row tappable via an inner `.onTapGesture`. The Saved tab is the only call site that also attaches `.swipeActions` (for swipe-to-delete), and a custom tap gesture inside a `List` row gets swallowed by `.swipeActions` — so the row body became unselectable. The Carrier tab works because it has no swipe actions.

### Fix
- Wrap the Saved row in a `Button` (with `.buttonStyle(.plain)`), which reliably receives the full-row tap and coexists with `.swipeActions`.
- Make `WooShippingPackageOptionView.tapAction` optional, so when a caller owns the tap (the Saved tab) the option view no longer installs a competing gesture. Carrier and the read-only selected-package summary are unchanged.

Scoped to the Saved tab; Custom and Carrier are untouched.

> [!NOTE]
> The Linear issue WOOMOB-2980 is labeled **Android**, but the flow and code map directly onto iOS and the same structural cause (swipeActions only on the Saved rows) is present here. Flagging in case iOS was not originally intended to be in scope.

## Test Steps
1. Open an order → **Create shipping label** → **Select a package** → **Saved** tab (you need at least one saved package).
2. Tap anywhere on a package row (the name, dimensions, or empty space), not just the checkbox.
3. **Expected:** the row selects/deselects and the bottom button enables.
4. Swipe a row left → **delete** still works.
5. Regression: confirm the **Carrier** tab rows and their star button still work, and the **Custom** tab is unaffected.

## Screenshots
_To add: before/after screen recording of the Saved tab._

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)