### PR TITLE
[Woo POS] Integrate PIN authenticator with POSAccessSession

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -85,12 +85,14 @@ public struct PointOfSaleEntryPointView: View {
          sunsetWarningChecker: POSSunsetWarningChecking? = nil,
          tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking? = nil,
          preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
+         staffFetcher: POSStaffFetching,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
         self._accessSession = State(initialValue: POSAccessSessionFactory.make(
             siteID: siteID,
-            featureFlags: services.featureFlags
+            featureFlags: services.featureFlags,
+            fetcher: staffFetcher
         ))
 
         let selectedItemProvider = itemProvider ?? PointOfSaleItemService(currencySettings: services.currency.currencySettings)
@@ -267,6 +269,8 @@ public struct PointOfSaleEntryPointView: View {
 }
 
 #if DEBUG
+import struct Yosemite.POSStaffMember
+
 #Preview {
     PointOfSaleEntryPointView(
         siteID: 1,
@@ -293,8 +297,13 @@ public struct PointOfSaleEntryPointView: View {
         catalogSyncCoordinator: nil,
         isLocalCatalogEligible: false,
         receiptSettingsAdminURL: "",
+        staffFetcher: POSPreviewStaffFetcher(),
         services: POSPreviewServices()
     )
+}
+
+private struct POSPreviewStaffFetcher: POSStaffFetching {
+    func fetchStaff(siteID: Int64) async throws(POSStaffFetchError) -> [POSStaffMember] { [] }
 }
 
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Models/POSAuthError.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSAuthError.swift
@@ -5,4 +5,5 @@ enum POSAuthError: Error, Equatable {
     case rateLimited(until: Date)
     case permanentlyLocked
     case unknown
+    case staffFetchFailed(POSStaffFetchError)
 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSLockScreenModel.swift
@@ -53,7 +53,7 @@ private extension POSLockScreenModel {
         switch error {
         case .invalidPIN: .error(kind: .invalidPIN)
         case .rateLimited(let until): .lockout(until: until)
-        case .permanentlyLocked, .unknown: .error(kind: .generic)
+        case .permanentlyLocked, .unknown, .staffFetchFailed: .error(kind: .generic)
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSLockStateKey.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSLockStateKey.swift
@@ -8,4 +8,13 @@ public enum POSLockStateKey {
     public static func key(for siteID: Int64) -> String {
         "\(baseKey).\(siteID)"
     }
+
+    /// Removes the lock-state flag for every site. Used on logout, where we don't know which sites
+    /// were visited this session, so we scan for all per-site keys under the shared base.
+    static func clearAll(in userDefaults: UserDefaults) {
+        let prefix = "\(baseKey)."
+        for key in userDefaults.dictionaryRepresentation().keys where key.hasPrefix(prefix) {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSManagerOverrideHandler.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSManagerOverrideHandler.swift
@@ -75,7 +75,7 @@ private extension POSManagerOverrideHandler {
     func state(for error: POSAuthError) -> POSPINEntryState {
         switch error {
         case .invalidPIN: .error(kind: .invalidPIN)
-        case .rateLimited, .permanentlyLocked, .unknown: .error(kind: .generic)
+        case .rateLimited, .permanentlyLocked, .unknown, .staffFetchFailed: .error(kind: .generic)
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSRolesPersistence.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSRolesPersistence.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Wipes the persisted POS roles state — the keychain staff caches and the lock-state flags for
+/// every site. Public so the app target can call it at a lifecycle boundary the POS module never
+/// sees: logout, where no `DefaultPOSAccessSession` instance is alive to clear its own cache.
+///
+/// Clears *all* sites, not just the active one: a single login can visit several stores (via
+/// site-switching without logging out), so on logout we purge everything rather than guess which
+/// stores were cached. Safe to call when POS roles are disabled or nothing was ever cached — it
+/// degrades to a no-op.
+public enum POSRolesPersistence {
+    public static func clearAll(userDefaults: UserDefaults = .standard) {
+        clearAll(staffStorage: KeychainPOSStaffStorage(), userDefaults: userDefaults)
+    }
+
+    static func clearAll(staffStorage: POSStaffKeyValueStorage, userDefaults: UserDefaults) {
+        staffStorage.removeAll()
+        POSLockStateKey.clearAll(in: userDefaults)
+    }
+}

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
@@ -35,9 +35,9 @@ final class DefaultPOSAccessSession: POSAccessSession {
         self.cache = cache
         self.fetcher = fetcher
         self.userDefaults = userDefaults
-        // Gating is cache-driven, not connection-driven: lock whenever the cached staff list has
-        // PINs — including offline, since the cache persists. Only an empty cache (never fetched,
-        // or cleared) means no gating and no lock screen.
+        // Gating is cache-driven, not connection-driven: lock whenever the cached staff list has at
+        // least one PIN — including offline, since the cache persists. No cached PINs (an empty
+        // cache, or staff that simply have no PINs) means no gating and no lock screen.
         let hasPINs = cache.hasAnyPINs(siteID: siteID)
         self.hasAnyPINs = hasPINs
         self.isLocked = hasPINs
@@ -96,7 +96,7 @@ final class DefaultPOSAccessSession: POSAccessSession {
             invalidateCache()
         } catch {
             // adminMissingCapability / transient / malformedResponse: leave the cache as-is and let
-            // gating reflect whatever it already holds. An empty cache means no lock screen.
+            // gating reflect whatever it already holds (no cached PINs ⇒ no lock screen).
             DDLogError("POS staff refresh failed: \(error)")
         }
         applyCacheState()

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
@@ -1,26 +1,46 @@
 import Foundation
 import Observation
+import CocoaLumberjackSwift
 
 @Observable
 @MainActor
 final class DefaultPOSAccessSession: POSAccessSession {
     private(set) var currentStaff: POSStaff?
-    private(set) var isLocked: Bool = true
-    private(set) var hasAnyPINs: Bool = false
+    private(set) var isLocked: Bool
+    private(set) var hasAnyPINs: Bool
 
     @ObservationIgnored private let siteID: Int64
     @ObservationIgnored private let authenticator: POSPINAuthenticating
     @ObservationIgnored private let rateLimiter: POSLocalRateLimiter
+    @ObservationIgnored private let cache: POSStaffCache
+    @ObservationIgnored private let fetcher: POSStaffFetching
     @ObservationIgnored private let userDefaults: UserDefaults
+
+    /// Counts how many times the staff cache has been invalidated (logout / site-switch / roles
+    /// disabled). An in-flight fetch captures this before awaiting and drops its write if the count
+    /// changed — so a clear that lands mid-fetch can't resurrect staff into a cache that was just
+    /// emptied. Lives on the session (not the cache) because the session owns both the fetch and the
+    /// clear, and is `@MainActor`-isolated.
+    @ObservationIgnored private var cacheInvalidationCount = 0
 
     init(siteID: Int64,
          authenticator: POSPINAuthenticating,
          rateLimiter: POSLocalRateLimiter,
+         cache: POSStaffCache,
+         fetcher: POSStaffFetching,
          userDefaults: UserDefaults = .standard) {
         self.siteID = siteID
         self.authenticator = authenticator
         self.rateLimiter = rateLimiter
+        self.cache = cache
+        self.fetcher = fetcher
         self.userDefaults = userDefaults
+        // Gating is cache-driven, not connection-driven: lock whenever the cached staff list has
+        // PINs — including offline, since the cache persists. Only an empty cache (never fetched,
+        // or cleared) means no gating and no lock screen.
+        let hasPINs = cache.hasAnyPINs(siteID: siteID)
+        self.hasAnyPINs = hasPINs
+        self.isLocked = hasPINs
     }
 
     func allows(_ capability: POSCapability) -> Bool {
@@ -31,27 +51,31 @@ final class DefaultPOSAccessSession: POSAccessSession {
         try rateLimiter.checkAllowed()
 
         do {
-            let staff = try await authenticator.authenticate(withPIN: pin)
+            let staff = try await authenticateAndRefreshOnMiss(pin)
             rateLimiter.reset()
             currentStaff = staff
             isLocked = false
-            // A successful sign-in proves at least one PIN exists.
+            // A successful sign-in proves at least one PIN exists; pre-empt refreshPINStatus.
             hasAnyPINs = true
             persistLockState(false)
-        } catch {
-            switch error {
-            case .invalidPIN:
-                rateLimiter.recordFailure()
-                throw rateLimiter.errorForCurrentState(fallback: .invalidPIN)
-            default:
-                throw error
-            }
+        } catch POSAuthError.invalidPIN {
+            // A wrong PIN counts against the rate limiter; surface the lockout state if it tripped.
+            // Any other POSAuthError (rateLimited, staffFetchFailed, …) propagates untouched.
+            rateLimiter.recordFailure()
+            throw rateLimiter.errorForCurrentState(fallback: .invalidPIN)
         }
     }
 
     func requestManagerApproval(withPIN pin: String, for capability: POSCapability) async throws(POSAuthError) {
-        // TODO: implement when the manager override flow is wired in.
-        throw .unknown
+        try rateLimiter.checkAllowed()
+        do {
+            try await verifyAndRefreshOnMiss(managerPIN: pin, authorizes: capability)
+            rateLimiter.reset()
+        } catch POSAuthError.invalidPIN {
+            // Same as signIn: a wrong PIN feeds the rate limiter; other errors propagate untouched.
+            rateLimiter.recordFailure()
+            throw rateLimiter.errorForCurrentState(fallback: .invalidPIN)
+        }
     }
 
     func lock() {
@@ -64,8 +88,93 @@ final class DefaultPOSAccessSession: POSAccessSession {
     }
 
     func refreshPINStatus() async {
-        // No-op until the session owns staff fetching and can derive PIN presence from the cached
-        // staff list. Until then, `hasAnyPINs` is set by a successful sign-in.
+        do {
+            try await fetchAndCacheStaff()
+        } catch POSStaffFetchError.endpointUnavailable {
+            // The /wc/pos/v1/staff route is absent when POS roles are disabled server-side; drop any
+            // cached staff so access degrades to no PIN gating rather than locking everyone out.
+            invalidateCache()
+        } catch {
+            // adminMissingCapability / transient / malformedResponse: leave the cache as-is and let
+            // gating reflect whatever it already holds. An empty cache means no lock screen.
+            DDLogError("POS staff refresh failed: \(error)")
+        }
+        applyCacheState()
+    }
+
+    func clearStaffCache() {
+        invalidateCache()
+        currentStaff = nil
+        applyCacheState()
+    }
+}
+
+private extension DefaultPOSAccessSession {
+    func authenticateAndRefreshOnMiss(_ pin: String) async throws(POSAuthError) -> POSStaff {
+        do {
+            return try await authenticator.authenticate(withPIN: pin)
+        } catch POSAuthError.invalidPIN {
+            // PIN absent from the (possibly stale) cache — refresh once, then retry before giving up.
+            // Any other POSAuthError propagates untouched.
+            try await refreshStaffCache()
+            return try await authenticator.authenticate(withPIN: pin)
+        }
+    }
+
+    func verifyAndRefreshOnMiss(managerPIN pin: String, authorizes capability: POSCapability) async throws(POSAuthError) {
+        do {
+            try await authenticator.verify(managerPIN: pin, authorizes: capability)
+        } catch POSAuthError.invalidPIN {
+            // Same refresh-once-then-retry as authenticate; other errors propagate untouched.
+            try await refreshStaffCache()
+            try await authenticator.verify(managerPIN: pin, authorizes: capability)
+        }
+    }
+
+    /// Refresh-on-miss helper: fetches and caches staff, surfacing any fetch failure as
+    /// `.staffFetchFailed` so the sign-in / approval flow can fail cleanly.
+    func refreshStaffCache() async throws(POSAuthError) {
+        do {
+            try await fetchAndCacheStaff()
+        } catch {
+            throw .staffFetchFailed(error)
+        }
+    }
+
+    /// Fetches the staff list and writes it to the cache, unless a `clear` (logout / site-switch)
+    /// invalidated the cache while the fetch was in flight — in which case the write is dropped so
+    /// we don't restore staff into a cache that was just emptied.
+    func fetchAndCacheStaff() async throws(POSStaffFetchError) {
+        let invalidationCountBeforeFetch = cacheInvalidationCount
+        let staff = try await fetcher.fetchStaff(siteID: siteID)
+        // Drop the write if the cache was invalidated (e.g. logout) while the fetch was in flight.
+        guard invalidationCountBeforeFetch == cacheInvalidationCount else { return }
+        cache.save(staff, siteID: siteID)
+    }
+
+    /// Empties the cache and bumps the invalidation count so any in-flight fetch's write is dropped.
+    func invalidateCache() {
+        cacheInvalidationCount &+= 1
+        cache.clear(siteID: siteID)
+    }
+}
+
+private extension DefaultPOSAccessSession {
+    /// Re-derives gating from the cache. Locks only when the cached staff list has PINs and nobody
+    /// is signed in; an empty (or PIN-free) cache unlocks, so the lock screen never shows for it.
+    func applyCacheState() {
+        hasAnyPINs = cache.hasAnyPINs(siteID: siteID)
+        if hasAnyPINs {
+            // Don't override a session that's already signed in or was manually locked.
+            if currentStaff == nil {
+                isLocked = true
+            }
+        } else {
+            isLocked = false
+        }
+        // Keep the persisted key in sync: the app target reads it on cold launch to decide whether
+        // to auto-reopen POS (see MainTabBarController.autoReopenPOSIfNeeded).
+        persistLockState(isLocked)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -22,7 +22,8 @@ final class MockPOSAccessSession: POSAccessSession {
          isLocked: Bool = false,
          hasAnyPINs: Bool = true,
          signInResult: Result<POSStaff, POSAuthError> = .success(
-            POSStaff(userID: 1, displayName: "Maya", preset: "pos_manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
+            POSStaff(userID: 1, displayName: "Maya",
+                     preset: "pos_manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
          ),
          managerApprovalResult: Result<Void, POSAuthError> = .success(()),
          checkLockoutResult: Result<Void, POSAuthError> = .success(())) {
@@ -79,6 +80,7 @@ final class MockPOSAccessSession: POSAccessSession {
     }
 
     func refreshPINStatus() async {}
+    func clearStaffCache() {}
 }
 
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
@@ -18,7 +18,8 @@ protocol POSAccessSession: AnyObject {
     func checkLockoutState() throws(POSAuthError)
     func refreshPINStatus() async
 
-    /// Wipes the persisted staff cache for the current site. Called on logout and site-switch
-    /// so stale credentials do not survive across sessions.
+    /// Clears the staff cache for the current site on a live session, dropping any in-flight
+    /// refresh's write so a clear that lands mid-fetch can't resurrect stale staff. Logout — where
+    /// no session is alive — wipes the persisted cache through `POSRolesPersistence` instead.
     func clearStaffCache()
 }

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
@@ -2,10 +2,11 @@
 protocol POSAccessSession: AnyObject {
     var currentStaff: POSStaff? { get }
     var isLocked: Bool { get }
-    /// Whether the cached staff list has at least one PIN on file — i.e. POS access is PIN-gated.
-    /// Gating is cache-driven, not connection-driven: an existing cache still locks while offline.
-    /// Only an empty cache (never fetched, or cleared on logout / when roles are disabled
-    /// server-side) reports `false` — no gating, no lock screen.
+    /// Whether the cached staff list has at least one member with a PIN — i.e. POS access is
+    /// PIN-gated. Gating is cache-driven, not connection-driven: an existing cache still locks while
+    /// offline. Reports `false` whenever no cached member has a PIN — whether the cache is empty
+    /// (never fetched, or cleared on logout / when roles are disabled server-side) or it holds staff
+    /// who simply have no PINs — meaning no gating and no lock screen.
     var hasAnyPINs: Bool { get }
 
     func allows(_ capability: POSCapability) -> Bool

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
@@ -2,12 +2,22 @@
 protocol POSAccessSession: AnyObject {
     var currentStaff: POSStaff? { get }
     var isLocked: Bool { get }
+    /// Whether the cached staff list has at least one PIN on file — i.e. POS access is PIN-gated.
+    /// Gating is cache-driven, not connection-driven: an existing cache still locks while offline.
+    /// Only an empty cache (never fetched, or cleared on logout / when roles are disabled
+    /// server-side) reports `false` — no gating, no lock screen.
     var hasAnyPINs: Bool { get }
 
     func allows(_ capability: POSCapability) -> Bool
     func signIn(withPIN pin: String) async throws(POSAuthError)
+    /// Verifies the manager PIN and confirms the approver holds `capability`; throws if the PIN is
+    /// invalid or the holder lacks it.
     func requestManagerApproval(withPIN pin: String, for capability: POSCapability) async throws(POSAuthError)
     func lock()
     func checkLockoutState() throws(POSAuthError)
     func refreshPINStatus() async
+
+    /// Wipes the persisted staff cache for the current site. Called on logout and site-switch
+    /// so stale credentials do not survive across sessions.
+    func clearStaffCache()
 }

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSessionFactory.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSessionFactory.swift
@@ -2,14 +2,19 @@ import enum Experiments.FeatureFlag
 
 @MainActor
 enum POSAccessSessionFactory {
-    static func make(siteID: Int64, featureFlags: POSFeatureFlagProviding) -> POSAccessSession {
+    static func make(siteID: Int64,
+                     featureFlags: POSFeatureFlagProviding,
+                     fetcher: POSStaffFetching) -> POSAccessSession {
         guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRoles) else {
             return UnrestrictedPOSAccessSession()
         }
+        let cache = POSStaffCache()
         return DefaultPOSAccessSession(
             siteID: siteID,
-            authenticator: DefaultPOSPINAuthenticator(cache: POSStaffCache(), siteID: siteID),
-            rateLimiter: POSLocalRateLimiter(siteID: siteID)
+            authenticator: DefaultPOSPINAuthenticator(cache: cache, siteID: siteID),
+            rateLimiter: POSLocalRateLimiter(siteID: siteID),
+            cache: cache,
+            fetcher: fetcher
         )
     }
 }

--- a/Modules/Sources/PointOfSale/Roles/Providers/UnrestrictedPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/UnrestrictedPOSAccessSession.swift
@@ -12,4 +12,5 @@ final class UnrestrictedPOSAccessSession: POSAccessSession {
     func lock() {}
     func checkLockoutState() throws(POSAuthError) {}
     func refreshPINStatus() async {}
+    func clearStaffCache() {}
 }

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffCache.swift
@@ -6,6 +6,9 @@ import struct Yosemite.POSStaffMember
 protocol POSStaffKeyValueStorage: Sendable {
     func string(forKey key: String) -> String?
     func setString(_ value: String?, forKey key: String)
+    /// Removes every entry. Each storage instance is scoped to POS staff data only (the keychain
+    /// implementation uses a dedicated service), so this never touches other state.
+    func removeAll()
 }
 
 struct KeychainPOSStaffStorage: POSStaffKeyValueStorage {
@@ -35,6 +38,16 @@ struct KeychainPOSStaffStorage: POSStaffKeyValueStorage {
             }
         } catch {
             DDLogError("POSStaffCache keychain write failed for key=\(key): \(error)")
+        }
+    }
+
+    /// Removes every cached staff entry across all sites. Scoped to this storage's dedicated keychain
+    /// service, so it never touches the app's auth credentials or any other keychain data.
+    func removeAll() {
+        do {
+            try keychain.removeAll()
+        } catch {
+            DDLogError("POSStaffCache keychain removeAll failed: \(error)")
         }
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -383,6 +383,8 @@ struct DefaultPOSAccessSessionTests {
         // Then the fetched staff must not be written back into the just-cleared cache
         #expect(sut.cache.load(siteID: 123) == nil)
         #expect(sut.session.hasAnyPINs == false)
+        // ...and the racing logout leaves POS unlocked, not stranded behind an unsatisfiable lock screen
+        #expect(sut.session.isLocked == false)
     }
 
     @Test func test_refreshPINStatus_when_fetch_fails_but_cache_has_pins_then_stays_locked() async {

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -480,10 +480,3 @@ private final class UserDefaultsTestScope {
         defaults.removePersistentDomain(forName: suiteName)
     }
 }
-
-/// In-memory staff storage so cache contents stay isolated per test (no shared keychain state).
-private final class InMemoryStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
-    private var store: [String: String] = [:]
-    func string(forKey key: String) -> String? { store[key] }
-    func setString(_ value: String?, forKey key: String) { store[key] = value }
-}

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import struct Yosemite.POSStaffMember
 @testable import PointOfSale
 
 @MainActor
@@ -7,12 +8,7 @@ import Testing
 struct DefaultPOSAccessSessionTests {
     @Test func test_signIn_when_pin_is_valid_then_sets_currentStaff_and_unlocks_and_resets_limiter() async throws {
         // Given
-        let staff = POSStaff(
-            userID: 1,
-            displayName: "Maya",
-            preset: "shop_manager",
-            capabilities: Set(POSCapability.allCases.map(\.rawValue))
-        )
+        let staff = makeStaff(capabilities: Set(POSCapability.allCases.map(\.rawValue)))
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         sut.limiter.recordFailure()
 
@@ -34,7 +30,8 @@ struct DefaultPOSAccessSessionTests {
         await #expect(throws: POSAuthError.invalidPIN) {
             try await sut.session.signIn(withPIN: "0000")
         }
-        #expect(authenticator.authenticatedPINs == ["0000"])
+        // A miss triggers one cache refresh and a single retry before giving up.
+        #expect(authenticator.authenticatedPINs == ["0000", "0000"])
         #expect(sut.session.currentStaff == nil)
     }
 
@@ -127,7 +124,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_lock_when_called_then_sets_isLocked_true_and_keeps_currentStaff() async throws {
         // Given
-        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
+        let staff = makeStaff()
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
@@ -139,9 +136,10 @@ struct DefaultPOSAccessSessionTests {
         #expect(sut.session.currentStaff == staff)
     }
 
-    @Test func test_requestManagerApproval_when_called_then_throws_unknown() async {
+    @Test func test_requestManagerApproval_when_authenticator_fails_then_throws_unknown() async {
         // Given
-        let sut = makeSUT(authenticator: MockPOSPINAuthenticator())
+        let authenticator = MockPOSPINAuthenticator(verifyResult: .failure(.unknown))
+        let sut = makeSUT(authenticator: authenticator)
 
         // When / Then
         await #expect(throws: POSAuthError.unknown) {
@@ -151,12 +149,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_allows_when_currentStaff_has_capability_then_returns_true() async throws {
         // Given
-        let staff = POSStaff(
-            userID: 1,
-            displayName: "Maya",
-            preset: "shop_manager",
-            capabilities: [POSCapability.issueRefunds.rawValue]
-        )
+        let staff = makeStaff(capabilities: [POSCapability.issueRefunds.rawValue])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
@@ -166,7 +159,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_allows_when_currentStaff_lacks_capability_then_returns_false() async throws {
         // Given
-        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "pos_cashier", capabilities: [])
+        let staff = makeStaff(preset: "pos_cashier", capabilities: [])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
@@ -195,7 +188,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_signIn_when_pin_is_valid_then_persists_false_to_per_site_lock_key() async throws {
         // Given
-        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
+        let staff = makeStaff()
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         sut.session.lock()
         #expect(sut.scope.defaults.bool(forKey: POSLockStateKey.key(for: 123)) == true)
@@ -219,16 +212,210 @@ struct DefaultPOSAccessSessionTests {
     }
 
     @Test func test_signIn_when_pin_is_valid_then_sets_hasAnyPINs_true() async throws {
-        // Given
-        let staff = POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
+        // Given an empty cache, so gating starts off
+        let staff = makeStaff()
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         #expect(sut.session.hasAnyPINs == false)
+        #expect(sut.session.isLocked == false)
 
         // When
         try await sut.session.signIn(withPIN: "1234")
 
-        // Then
+        // Then — a successful sign-in proves a PIN exists
         #expect(sut.session.hasAnyPINs == true)
+    }
+
+    // MARK: - Refresh-on-miss retry
+
+    @Test func test_signIn_when_pin_misses_stale_cache_then_refreshes_once_and_succeeds() async throws {
+        // Given an authenticator that misses on the first try (stale cache) but matches after a refresh
+        let staff = makeStaff()
+        let authenticator = MockPOSPINAuthenticator()
+        authenticator.authenticateResultSequence = [.failure(.invalidPIN), .success(staff)]
+        let fetcher = MockPOSStaffFetcher(result: .success([]))
+        let sut = makeSUT(authenticator: authenticator, fetcher: fetcher)
+
+        // When
+        try await sut.session.signIn(withPIN: "1234")
+
+        // Then — the session refreshed the cache exactly once, then signed the staff in
+        #expect(fetcher.callCount == 1)
+        #expect(authenticator.authenticatedPINs == ["1234", "1234"])
+        #expect(sut.session.currentStaff == staff)
+        #expect(sut.session.isLocked == false)
+    }
+
+    @Test func test_signIn_when_pin_misses_and_refresh_fetch_fails_then_throws_staffFetchFailed() async {
+        // Given an authenticator that always misses and a fetcher that fails the refresh
+        let authenticator = MockPOSPINAuthenticator(authenticateResult: .failure(.invalidPIN))
+        let fetcher = MockPOSStaffFetcher(result: .failure(.transient(retryable: true)))
+        let sut = makeSUT(authenticator: authenticator, fetcher: fetcher)
+
+        // When / Then — the wrapped fetch error surfaces instead of invalidPIN
+        await #expect(throws: POSAuthError.staffFetchFailed(.transient(retryable: true))) {
+            try await sut.session.signIn(withPIN: "0000")
+        }
+        #expect(fetcher.callCount == 1)
+        #expect(authenticator.authenticatedPINs == ["0000"])
+    }
+
+    @Test func test_requestManagerApproval_when_pin_misses_stale_cache_then_refreshes_once_and_succeeds() async throws {
+        // Given a verify that misses on the first try but matches after a refresh
+        let authenticator = MockPOSPINAuthenticator()
+        authenticator.verifyResultSequence = [.failure(.invalidPIN), .success(())]
+        let fetcher = MockPOSStaffFetcher(result: .success([]))
+        let sut = makeSUT(authenticator: authenticator, fetcher: fetcher)
+
+        // When
+        try await sut.session.requestManagerApproval(withPIN: "9999", for: .issueRefunds)
+
+        // Then
+        #expect(fetcher.callCount == 1)
+        #expect(authenticator.verifyCallCount == 2)
+    }
+
+    // MARK: - Cache-driven gating
+
+    @Test func test_init_when_cache_is_empty_then_not_locked() {
+        // Given / When an empty cache (cold start, offline, logged out)
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator())
+
+        // Then no gating and no lock screen
+        #expect(sut.session.hasAnyPINs == false)
+        #expect(sut.session.isLocked == false)
+    }
+
+    @Test func test_init_when_cache_has_pins_then_locked() {
+        // Given a cache already holding staff with PINs
+        let cache = POSStaffCache(storage: InMemoryStaffStorage())
+        cache.save([makeStaffMember(hasPIN: true)], siteID: 123)
+
+        // When
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), cache: cache)
+
+        // Then the session locks from the start
+        #expect(sut.session.hasAnyPINs == true)
+        #expect(sut.session.isLocked == true)
+    }
+
+    @Test func test_refreshPINStatus_when_fetch_returns_staff_with_pins_then_locks() async {
+        // Given an empty cache (starts unlocked)
+        let fetcher = MockPOSStaffFetcher(result: .success([makeStaffMember(hasPIN: true)]))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher)
+        #expect(sut.session.isLocked == false)
+
+        // When the fetch reveals PINs exist
+        await sut.session.refreshPINStatus()
+
+        // Then gating kicks in
+        #expect(sut.session.hasAnyPINs == true)
+        #expect(sut.session.isLocked == true)
+    }
+
+    @Test func test_refreshPINStatus_when_lock_state_changes_then_persists_it_for_cold_launch() async {
+        // Given an empty cache, so the persisted key starts unlocked
+        let fetcher = MockPOSStaffFetcher(result: .success([makeStaffMember(hasPIN: true)]))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher)
+        #expect(sut.scope.defaults.bool(forKey: POSLockStateKey.key(for: 123)) == false)
+
+        // When a refresh discovers PINs and the session locks
+        await sut.session.refreshPINStatus()
+
+        // Then the persisted key tracks the new lock state (read on cold launch to auto-reopen POS)
+        #expect(sut.session.isLocked == true)
+        #expect(sut.scope.defaults.bool(forKey: POSLockStateKey.key(for: 123)) == true)
+    }
+
+    @Test func test_refreshPINStatus_when_fetch_returns_staff_without_pins_then_stays_unlocked() async {
+        // Given
+        let fetcher = MockPOSStaffFetcher(result: .success([makeStaffMember(hasPIN: false)]))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher)
+
+        // When
+        await sut.session.refreshPINStatus()
+
+        // Then
+        #expect(sut.session.hasAnyPINs == false)
+        #expect(sut.session.isLocked == false)
+    }
+
+    @Test func test_refreshPINStatus_when_endpointUnavailable_then_clears_cache_and_unlocks() async {
+        // Given a cache with PINs (locked at init)
+        let cache = POSStaffCache(storage: InMemoryStaffStorage())
+        cache.save([makeStaffMember(hasPIN: true)], siteID: 123)
+        let fetcher = MockPOSStaffFetcher(result: .failure(.endpointUnavailable))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher, cache: cache)
+        #expect(sut.session.isLocked == true)
+
+        // When the staff route is gone (POS roles disabled server-side)
+        await sut.session.refreshPINStatus()
+
+        // Then degrade to no gating rather than locking everyone out
+        #expect(sut.session.hasAnyPINs == false)
+        #expect(sut.session.isLocked == false)
+    }
+
+    @Test func test_refreshPINStatus_when_fetch_fails_and_cache_empty_then_stays_unlocked() async {
+        // Given an empty cache and a failing fetch (offline cold start)
+        let fetcher = MockPOSStaffFetcher(result: .failure(.transient(retryable: true)))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher)
+        #expect(sut.session.isLocked == false)
+
+        // When
+        await sut.session.refreshPINStatus()
+
+        // Then no dead-end lock screen — empty cache means no gating
+        #expect(sut.session.hasAnyPINs == false)
+        #expect(sut.session.isLocked == false)
+    }
+
+    @Test func test_refreshPINStatus_when_cache_cleared_during_fetch_then_does_not_restore_staff() async {
+        // Given a refresh in flight whose fetch would return staff with PINs
+        let fetcher = MockPOSStaffFetcher(result: .success([makeStaffMember(hasPIN: true)]))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher)
+        // ...but a logout (cache clear) lands while that fetch is in flight
+        let session = sut.session
+        fetcher.onFetchStaff = { await session.clearStaffCache() }
+
+        // When
+        await sut.session.refreshPINStatus()
+
+        // Then the fetched staff must not be written back into the just-cleared cache
+        #expect(sut.cache.load(siteID: 123) == nil)
+        #expect(sut.session.hasAnyPINs == false)
+    }
+
+    @Test func test_refreshPINStatus_when_fetch_fails_but_cache_has_pins_then_stays_locked() async {
+        // Given an existing cache with PINs (locked at init) and a failing fetch (offline)
+        let cache = POSStaffCache(storage: InMemoryStaffStorage())
+        cache.save([makeStaffMember(hasPIN: true)], siteID: 123)
+        let fetcher = MockPOSStaffFetcher(result: .failure(.transient(retryable: true)))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), fetcher: fetcher, cache: cache)
+        #expect(sut.session.isLocked == true)
+
+        // When the refresh can't reach the server
+        await sut.session.refreshPINStatus()
+
+        // Then gating from the persisted cache is preserved — offline does not unlock
+        #expect(sut.session.hasAnyPINs == true)
+        #expect(sut.session.isLocked == true)
+    }
+
+    @Test func test_refreshPINStatus_when_signed_in_and_fetch_finds_pins_then_stays_unlocked() async throws {
+        // Given a signed-in session
+        let staff = makeStaff()
+        let fetcher = MockPOSStaffFetcher(result: .success([makeStaffMember(hasPIN: true)]))
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)),
+                          fetcher: fetcher)
+        try await sut.session.signIn(withPIN: "1234")
+        #expect(sut.session.isLocked == false)
+
+        // When a later refresh confirms PINs exist
+        await sut.session.refreshPINStatus()
+
+        // Then the active session is not re-locked
+        #expect(sut.session.isLocked == false)
+        #expect(sut.session.currentStaff == staff)
     }
 }
 
@@ -237,9 +424,12 @@ private extension DefaultPOSAccessSessionTests {
         let session: DefaultPOSAccessSession
         let limiter: POSLocalRateLimiter
         let scope: UserDefaultsTestScope
+        let cache: POSStaffCache
     }
 
     func makeSUT(authenticator: POSPINAuthenticating,
+                 fetcher: POSStaffFetching = MockPOSStaffFetcher(),
+                 cache: POSStaffCache = POSStaffCache(storage: InMemoryStaffStorage()),
                  now: @escaping () -> Date = { Date() }) -> SUT {
         let scope = UserDefaultsTestScope()
         let limiter = POSLocalRateLimiter(siteID: 123, userDefaults: scope.defaults, now: now)
@@ -247,9 +437,30 @@ private extension DefaultPOSAccessSessionTests {
             siteID: 123,
             authenticator: authenticator,
             rateLimiter: limiter,
+            cache: cache,
+            fetcher: fetcher,
             userDefaults: scope.defaults
         )
-        return SUT(session: session, limiter: limiter, scope: scope)
+        return SUT(session: session, limiter: limiter, scope: scope, cache: cache)
+    }
+
+    func makeStaffMember(userID: Int64 = 1, hasPIN: Bool) -> POSStaffMember {
+        POSStaffMember(userID: userID,
+                       displayName: "Staff",
+                       preset: "pos_cashier",
+                       capabilities: ["pos_process_sales": true],
+                       pin: hasPIN ? .init(algorithm: "pbkdf2-sha256", iterations: 1,
+                                           salt: "c2FsdA==", hash: "aGFzaA==") : nil)
+    }
+
+    func makeStaff(userID: Int64 = 1,
+                   displayName: String = "Maya",
+                   preset: String = "pos_manager",
+                   capabilities: Set<String> = []) -> POSStaff {
+        POSStaff(userID: userID,
+                 displayName: displayName,
+                 preset: preset,
+                 capabilities: capabilities)
     }
 }
 
@@ -266,4 +477,11 @@ private final class UserDefaultsTestScope {
     deinit {
         defaults.removePersistentDomain(forName: suiteName)
     }
+}
+
+/// In-memory staff storage so cache contents stay isolated per test (no shared keychain state).
+private final class InMemoryStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
+    private var store: [String: String] = [:]
+    func string(forKey key: String) -> String? { store[key] }
+    func setString(_ value: String?, forKey key: String) { store[key] = value }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -196,9 +196,3 @@ private extension DefaultPOSPINAuthenticatorTests {
                                          hash: Data(derived).base64EncodedString())
     }
 }
-
-private final class InMemoryStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
-    private var store: [String: String] = [:]
-    func string(forKey key: String) -> String? { store[key] }
-    func setString(_ value: String?, forKey key: String) { store[key] = value }
-}

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/InMemoryStaffStorage.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/InMemoryStaffStorage.swift
@@ -1,0 +1,10 @@
+@testable import PointOfSale
+
+/// In-memory `POSStaffKeyValueStorage` for tests, so `POSStaffCache` contents stay isolated per test
+/// (no shared keychain state). `@unchecked Sendable`: each test owns its instance and never shares
+/// it across tasks.
+final class InMemoryStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
+    private var store: [String: String] = [:]
+    func string(forKey key: String) -> String? { store[key] }
+    func setString(_ value: String?, forKey key: String) { store[key] = value }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/InMemoryStaffStorage.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/InMemoryStaffStorage.swift
@@ -7,4 +7,5 @@ final class InMemoryStaffStorage: POSStaffKeyValueStorage, @unchecked Sendable {
     private var store: [String: String] = [:]
     func string(forKey key: String) -> String? { store[key] }
     func setString(_ value: String?, forKey key: String) { store[key] = value }
+    func removeAll() { store.removeAll() }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
@@ -6,6 +6,14 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
     var authenticateResult: Result<POSStaff, POSAuthError>
     var verifyResult: Result<Void, POSAuthError>
 
+    /// When non-empty, the first element is dequeued on each `authenticate` call and used instead of
+    /// `authenticateResult`. Lets a test drive the session's refresh-on-miss retry: e.g. `.failure(.invalidPIN)`
+    /// then `.success(staff)`. Once exhausted, `authenticateResult` takes over.
+    var authenticateResultSequence: [Result<POSStaff, POSAuthError>] = []
+
+    /// Same as `authenticateResultSequence`, but for `verify`.
+    var verifyResultSequence: [Result<Void, POSAuthError>] = []
+
     private(set) var authenticatedPINs: [String] = []
     private(set) var verifyCallCount: Int = 0
 
@@ -13,7 +21,7 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
             POSStaff(
                 userID: 1,
                 displayName: "Maya",
-                preset: "shop_manager",
+                preset: "pos_manager",
                 capabilities: Set(POSCapability.allCases.map(\.rawValue))
             )
          ),
@@ -24,12 +32,13 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
 
     func authenticate(withPIN pin: String) async throws(POSAuthError) -> POSStaff {
         authenticatedPINs.append(pin)
-        return try authenticateResult.get()
+        let result = authenticateResultSequence.isEmpty ? authenticateResult : authenticateResultSequence.removeFirst()
+        return try result.get()
     }
 
-    func verify(managerPIN pin: String, authorizes capability: POSCapability)
-        async throws(POSAuthError) {
+    func verify(managerPIN pin: String, authorizes capability: POSCapability) async throws(POSAuthError) {
         verifyCallCount += 1
-        _ = try verifyResult.get()
+        let result = verifyResultSequence.isEmpty ? verifyResult : verifyResultSequence.removeFirst()
+        try result.get()
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSStaffFetcher.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSStaffFetcher.swift
@@ -1,0 +1,23 @@
+import Foundation
+@testable import PointOfSale
+import struct Yosemite.POSStaffMember
+
+/// Spy fetcher for tests.
+final class MockPOSStaffFetcher: POSStaffFetching {
+    var result: Result<[POSStaffMember], POSStaffFetchError>
+    private(set) var callCount = 0
+
+    /// Runs inside `fetchStaff`, before it returns, so a test can mutate the SUT mid-fetch — e.g.
+    /// simulate a logout (cache clear) landing while a staff fetch is in flight.
+    var onFetchStaff: (@Sendable () async -> Void)?
+
+    init(result: Result<[POSStaffMember], POSStaffFetchError> = .success([])) {
+        self.result = result
+    }
+
+    func fetchStaff(siteID: Int64) async throws(POSStaffFetchError) -> [POSStaffMember] {
+        callCount += 1
+        await onFetchStaff?()
+        return try result.get()
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/POSAccessSessionFactoryTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSAccessSessionFactoryTests.swift
@@ -10,7 +10,7 @@ struct POSAccessSessionFactoryTests {
         let flags = StubPOSFeatureFlagProviding(enabledFlags: [])
 
         // When
-        let session = POSAccessSessionFactory.make(siteID: 123, featureFlags: flags)
+        let session = POSAccessSessionFactory.make(siteID: 123, featureFlags: flags, fetcher: MockPOSStaffFetcher())
 
         // Then
         #expect(session is UnrestrictedPOSAccessSession)
@@ -21,7 +21,7 @@ struct POSAccessSessionFactoryTests {
         let flags = StubPOSFeatureFlagProviding(enabledFlags: [.pointOfSaleRoles])
 
         // When
-        let session = POSAccessSessionFactory.make(siteID: 123, featureFlags: flags)
+        let session = POSAccessSessionFactory.make(siteID: 123, featureFlags: flags, fetcher: MockPOSStaffFetcher())
 
         // Then
         #expect(session is DefaultPOSAccessSession)

--- a/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+import struct Yosemite.POSStaffMember
+@testable import PointOfSale
+
+@MainActor
+struct POSRolesPersistenceTests {
+    @Test func test_clearAll_wipes_staff_cache_for_every_site() {
+        // Given staff cached with PINs for several sites
+        let storage = InMemoryStaffStorage()
+        let cache = POSStaffCache(storage: storage)
+        cache.save([makeStaffMemberWithPIN()], siteID: 123)
+        cache.save([makeStaffMemberWithPIN()], siteID: 456)
+
+        // When
+        POSRolesPersistence.clearAll(staffStorage: storage, userDefaults: UserDefaultsTestScope().defaults)
+
+        // Then every site's cached staff is gone
+        #expect(cache.load(siteID: 123) == nil)
+        #expect(cache.load(siteID: 456) == nil)
+    }
+
+    @Test func test_clearAll_clears_lock_flags_for_every_site() {
+        // Given lock flags persisted for several sites
+        let scope = UserDefaultsTestScope()
+        scope.defaults.set(true, forKey: POSLockStateKey.key(for: 123))
+        scope.defaults.set(true, forKey: POSLockStateKey.key(for: 456))
+
+        // When
+        POSRolesPersistence.clearAll(staffStorage: InMemoryStaffStorage(), userDefaults: scope.defaults)
+
+        // Then no site's lock flag reads as locked
+        #expect(scope.defaults.bool(forKey: POSLockStateKey.key(for: 123)) == false)
+        #expect(scope.defaults.bool(forKey: POSLockStateKey.key(for: 456)) == false)
+    }
+
+    @Test func test_clearAll_leaves_unrelated_user_defaults_keys_untouched() {
+        // Given a POS lock flag alongside an unrelated app preference
+        let scope = UserDefaultsTestScope()
+        scope.defaults.set(true, forKey: POSLockStateKey.key(for: 123))
+        scope.defaults.set("keep", forKey: "com.woocommerce.someOtherSetting")
+
+        // When
+        POSRolesPersistence.clearAll(staffStorage: InMemoryStaffStorage(), userDefaults: scope.defaults)
+
+        // Then the lock-state prefix scan removes only the POS lock flag
+        #expect(scope.defaults.bool(forKey: POSLockStateKey.key(for: 123)) == false)
+        #expect(scope.defaults.string(forKey: "com.woocommerce.someOtherSetting") == "keep")
+    }
+}
+
+private extension POSRolesPersistenceTests {
+    func makeStaffMemberWithPIN() -> POSStaffMember {
+        POSStaffMember(userID: 1,
+                       displayName: "Staff",
+                       preset: "pos_cashier",
+                       capabilities: ["pos_process_sales": true],
+                       pin: .init(algorithm: "pbkdf2-sha256", iterations: 1,
+                                  salt: "c2FsdA==", hash: "aGFzaA=="))
+    }
+}
+
+@MainActor
+private final class UserDefaultsTestScope {
+    let defaults: UserDefaults
+    private let suiteName: String
+
+    init() {
+        suiteName = "test.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
@@ -178,4 +178,8 @@ private final class InMemoryPOSStaffStorage: POSStaffKeyValueStorage, @unchecked
     func setString(_ value: String?, forKey key: String) {
         store[key] = value
     }
+
+    func removeAll() {
+        store.removeAll()
+    }
 }

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -306,6 +306,14 @@ private extension POSTabCoordinator {
                                                                            storageManager: storageManager,
                                                                            currencySettings: currencySettings)
 
+                guard let staffFetcher = POSStaffAdaptor(credentials: credentials,
+                                                         selectedSite: defaultSitePublisher,
+                                                         appPasswordSupportState: isAppPasswordSupported) else {
+                    DDLogError("⛔️ Could not start POS: POSStaffAdaptor unavailable (missing credentials)")
+                    await hostingController.dismiss(animated: true)
+                    return
+                }
+
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: createItemFetchStrategyFactory(isLocalCatalogEnabled: isLocalCatalogEligible),
@@ -344,6 +352,7 @@ private extension POSTabCoordinator {
                     sunsetWarningChecker: sunsetWarningChecker,
                     tapToPayAvailabilityChecker: tapToPayAvailabilityChecker,
                     preferredConnectionMethod: preferredConnectionMethod,
+                    staffFetcher: staffFetcher,
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -9,6 +9,7 @@ import class WidgetKit.WidgetCenter
 import Experiments
 import WordPressAuthenticator
 import enum NetworkingCore.RequestAuthenticationMode
+import enum PointOfSale.POSRolesPersistence
 
 // MARK: - DefaultStoresManager
 //
@@ -310,6 +311,11 @@ class DefaultStoresManager: StoresManager {
                 await syncCoordinator?.stopOngoingSyncs(for: siteID)
             }
         }
+
+        // Purge all persisted POS roles state (staff caches + lock flags for every site visited this
+        // session) so a different user signing in on this device can't inherit cached staff PINs or
+        // land on a previous store's lock screen.
+        POSRolesPersistence.clearAll()
 
         sessionManager.deleteApplicationPassword(locally: true)
         sessionManager.reset()


### PR DESCRIPTION
## Description
WOOMOB-3170, part 2 of 2 (part 1 was #17331, now merged). Gives `DefaultPOSAccessSession` ownership of staff freshness and wires the real PIN authenticator in.

- **`refreshPINStatus()`** — fetches the staff list, caches it, then derives PIN gating **from the cache**. Gating is a Bool (`hasAnyPINs` = the cached staff list has PINs), and it's **cache-driven, not connection-driven**: an existing cache still locks while offline. Only an *empty* cache (never fetched, cleared on logout/site-switch, or POS roles disabled server-side) means no gating and no lock screen. An unavailable `/wc/pos/v1/staff` endpoint clears the cache and degrades to no gating rather than locking everyone out.
- **`signIn` / `requestManagerApproval`** — verify against the cache and, on a miss, **refresh the cache once and retry** before failing. This "refresh-on-miss" used to live in the authenticator; it now lives in the session, which owns fetching. A fetch failure surfaces as `.staffFetchFailed` (not counted as a PIN failure); a genuine wrong PIN records a rate-limiter failure.
- The session owns a **`cacheInvalidationCount`** so a `clear` (logout / site-switch) that lands mid-fetch drops the stale write. `POSStaffCache` is **untouched by this PR** — it stays a pure, checked-`Sendable` storage layer; the race guard is the session's responsibility.
- Lock-state changes from a refresh are **persisted to `POSLockStateKey`**, keeping the app target's cold-launch auto-reopen (`MainTabBarController.autoReopenPOSIfNeeded`) consistent with the session's actual lock state.
- `POSAuthError` gains `.staffFetchFailed`. The app target threads a `POSStaffAdaptor` fetcher through the coordinator + entry point (and dismisses the POS loader if the adaptor can't be created). `requestManagerApproval` returns `Void` for now — it will return the approver's `POSStaff` once override attribution (`_pos_override_staff_user_id`) is wired up.

## Testing
No manual test steps — the feature is behind the `pointOfSaleRoles` flag (off by default) and the `/wc/pos/v1/staff` endpoint isn't available yet, so there's no user-facing flow to exercise. CI unit coverage is sufficient: `DefaultPOSAccessSessionTests` covers refresh-on-miss retry, cache-driven gating/lock state, the clear-races-fetch guard, and lock-state persistence; `DefaultPOSPINAuthenticatorTests` / `POSStaffCacheTests` cover the verification and cache layers.

## Screenshots
N/A — no UI (behind `pointOfSaleRoles`, not yet surfaced).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not user-facing — feature-flagged, not surfaced.)