### PR TITLE
[WOOMOB-2578] Name missing origin phone/email in Woo Shipping label notice

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.1
 -----
+- [*] Shipping Labels: Clearer notice when the origin (Ship from) address is missing a phone number or email [https://github.com/woocommerce/woocommerce-ios/pull/17339]
 - [*] Add support for Liquid Glass on iOS 26 [https://github.com/woocommerce/woocommerce-ios/pull/17337]
 - [*] Order Creation: fixed visual issues with screen layout [https://github.com/woocommerce/woocommerce-ios/pull/17346]
 - [*] POS: Fixed discarded card reader checkout orders appearing in Orders until refresh. [https://github.com/woocommerce/woocommerce-ios/pull/17357]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -306,13 +306,13 @@ private extension WooShippingCreateLabelsView {
                 .minimumScaleFactor(0.5)
 
             if viewModel.shouldShowNotices {
-                if let originAddressUnverifiedNoticeLabel = viewModel.originAddressUnverifiedNoticeLabel {
-                    // Unverified notice for origin address
-                    verificationNotice(with: originAddressUnverifiedNoticeLabel,
+                if let originAddressNoticeLabel = viewModel.originAddressNoticeLabel {
+                    // Notice for origin address status (missing phone/email or unverified)
+                    verificationNotice(with: originAddressNoticeLabel,
                                        isVerified: false,
                                        onDismiss: {
                         withAnimation {
-                            viewModel.originAddressUnverifiedNoticeLabel = nil
+                            viewModel.originAddressNoticeLabel = nil
                         }
                     },
                                        onTap: {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -114,8 +114,9 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         }
     }
 
-    /// This property can be set to display a notice with the provided label about the origin address status.
-    @Published var originAddressUnverifiedNoticeLabel: String?
+    /// This property can be set to display a notice with the provided label about the origin address status
+    /// (e.g. a missing phone number, missing email, or an unverified address).
+    @Published var originAddressNoticeLabel: String?
 
     /// Address to ship to (customer address), formatted for display and split into separate lines to allow additional formatting.
     var destinationAddressLines: [String]? {
@@ -718,8 +719,19 @@ private extension WooShippingCreateLabelsViewModel {
             .sink { [weak self] selectedOriginAddress in
                 guard let self else { return }
                 originAddress = selectedOriginAddress?.formattedPostalAddress ?? ""
-                originAddressUnverifiedNoticeLabel = {
-                    if let selectedOriginAddress, !selectedOriginAddress.isVerified {
+                originAddressNoticeLabel = {
+                    guard let selectedOriginAddress else {
+                        return nil
+                    }
+                    // A missing phone number or email is the only origin input that reliably fails rate loading,
+                    // so surface the specific missing field before falling back to the generic unverified notice.
+                    if selectedOriginAddress.phone.isEmpty {
+                        return Localization.OriginAddress.missingPhone
+                    }
+                    if selectedOriginAddress.email.isEmpty {
+                        return Localization.OriginAddress.missingEmail
+                    }
+                    if !selectedOriginAddress.isVerified {
                         return Localization.OriginAddressStatus.unverified
                     }
                     return nil
@@ -929,6 +941,19 @@ private extension WooShippingCreateLabelsViewModel {
                 "wooShipping.createLabels.addressVerification.originUnverified",
                 value: "Origin address unverified",
                 comment: "Notice when a origin address is unverified on the shipping label creation screen"
+            )
+        }
+
+        enum OriginAddress {
+            static let missingPhone = NSLocalizedString(
+                "wooShipping.createLabels.originAddress.missingPhone",
+                value: "Phone number is required for the origin address.",
+                comment: "Notice when the origin (ship from) address is missing a phone number on the shipping label creation screen"
+            )
+            static let missingEmail = NSLocalizedString(
+                "wooShipping.createLabels.originAddress.missingEmail",
+                value: "Email is required for the origin address.",
+                comment: "Notice when the origin (ship from) address is missing an email on the shipping label creation screen"
             )
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -949,12 +949,12 @@ private extension WooShippingCreateLabelsViewModel {
         enum OriginAddress {
             static let missingPhone = NSLocalizedString(
                 "wooShipping.createLabels.originAddress.missingPhone",
-                value: "Phone number is required for the origin address.",
+                value: "Phone number is missing for the origin address.",
                 comment: "Notice when the origin (ship from) address is missing a phone number on the shipping label creation screen"
             )
             static let missingEmail = NSLocalizedString(
                 "wooShipping.createLabels.originAddress.missingEmail",
-                value: "Email is required for the origin address.",
+                value: "Email is missing for the origin address.",
                 comment: "Notice when the origin (ship from) address is missing an email on the shipping label creation screen"
             )
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -725,7 +725,9 @@ private extension WooShippingCreateLabelsViewModel {
                     }
                     // A missing phone number or email is the only origin input that reliably fails rate loading,
                     // so surface the specific missing field before falling back to the generic unverified notice.
-                    if selectedOriginAddress.phone.isEmpty {
+                    // Use the digit-based check (matching the destination phone notice) so whitespace/punctuation-only
+                    // phones, which the backend also rejects as empty, are treated as missing.
+                    if selectedOriginAddress.toWooShippingAddress().phoneDigits.isEmpty {
                         return Localization.OriginAddress.missingPhone
                     }
                     if selectedOriginAddress.email.isEmpty {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -172,8 +172,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel2.isOrderCompleted)
     }
 
-    func test_origin_unverified_state_is_correct() {
-        // Given
+    /// Builds a view model whose store returns a single origin address with the given phone/email/verification state.
+    private func makeViewModelLoadingOriginAddress(phone: String,
+                                                   email: String,
+                                                   isVerified: Bool = false) -> WooShippingCreateLabelsViewModel {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let originAddress = WooShippingOriginAddress(siteID: 123,
                                                      id: "default_address",
@@ -184,12 +186,12 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                                                      state: "NY",
                                                      postcode: "12883-1487",
                                                      country: "US",
-                                                     phone: "223-456-7890",
+                                                     phone: phone,
                                                      firstName: "JANE",
                                                      lastName: "DOE",
-                                                     email: "TEST@EXAMPLE.COM",
+                                                     email: email,
                                                      defaultAddress: true,
-                                                     isVerified: false)
+                                                     isVerified: isVerified)
         stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
             switch action {
             case .loadOriginAddresses(_, let completion):
@@ -202,12 +204,14 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                 XCTFail("Unexpected action: \(action)")
             }
         }
-        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+        return WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                shippingSettingsService: MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil),
+                                                stores: stores)
+    }
 
-        // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
-                                                         shippingSettingsService: shippingSettingsService,
-                                                         stores: stores)
+    func test_origin_unverified_state_is_correct() {
+        // Given
+        let viewModel = makeViewModelLoadingOriginAddress(phone: "223-456-7890", email: "TEST@EXAMPLE.COM")
         XCTAssertFalse(viewModel.isOriginAddressUnverified)
         XCTAssertNil(viewModel.originAddressNoticeLabel)
 
@@ -221,44 +225,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_origin_notice_shows_missing_phone_when_origin_phone_is_empty() {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let originAddress = WooShippingOriginAddress(siteID: 123,
-                                                     id: "default_address",
-                                                     company: "HEADQUARTERS",
-                                                     address1: "15 ALGONKIN ST",
-                                                     address2: "STE 100",
-                                                     city: "TICONDEROGA",
-                                                     state: "NY",
-                                                     postcode: "12883-1487",
-                                                     country: "US",
-                                                     phone: "",
-                                                     firstName: "JANE",
-                                                     lastName: "DOE",
-                                                     email: "TEST@EXAMPLE.COM",
-                                                     defaultAddress: true,
-                                                     isVerified: false)
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            switch action {
-            case .loadOriginAddresses(_, let completion):
-                completion(.success([originAddress]))
-            case .loadAccountSettings(_, let completion):
-                completion(.success(self.settings))
-            case .loadPackages, .verifyDestinationAddress:
-                break
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
-
-        // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
-                                                         shippingSettingsService: shippingSettingsService,
-                                                         stores: stores)
+        // A missing origin phone is surfaced specifically rather than the generic unverified notice.
+        let viewModel = makeViewModelLoadingOriginAddress(phone: "", email: "TEST@EXAMPLE.COM")
 
         // Then
-        // A missing origin phone is surfaced specifically rather than the generic unverified notice,
-        // so the merchant knows which field to fix.
         let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingPhone",
                                          value: "Phone number is missing for the origin address.",
                                          comment: "")
@@ -270,44 +240,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_origin_notice_shows_missing_phone_when_origin_phone_has_no_digits() {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let originAddress = WooShippingOriginAddress(siteID: 123,
-                                                     id: "default_address",
-                                                     company: "HEADQUARTERS",
-                                                     address1: "15 ALGONKIN ST",
-                                                     address2: "STE 100",
-                                                     city: "TICONDEROGA",
-                                                     state: "NY",
-                                                     postcode: "12883-1487",
-                                                     country: "US",
-                                                     phone: " - ",
-                                                     firstName: "JANE",
-                                                     lastName: "DOE",
-                                                     email: "TEST@EXAMPLE.COM",
-                                                     defaultAddress: true,
-                                                     isVerified: false)
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            switch action {
-            case .loadOriginAddresses(_, let completion):
-                completion(.success([originAddress]))
-            case .loadAccountSettings(_, let completion):
-                completion(.success(self.settings))
-            case .loadPackages, .verifyDestinationAddress:
-                break
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
-
-        // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
-                                                         shippingSettingsService: shippingSettingsService,
-                                                         stores: stores)
+        // A phone with no digits (whitespace/punctuation only) is rejected by the backend as empty.
+        let viewModel = makeViewModelLoadingOriginAddress(phone: " - ", email: "TEST@EXAMPLE.COM")
 
         // Then
-        // A phone with no digits (whitespace/punctuation only) is rejected by the backend as empty,
-        // so it must surface the missing-phone notice rather than the generic unverified one.
         let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingPhone",
                                          value: "Phone number is missing for the origin address.",
                                          comment: "")
@@ -319,43 +255,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
 
     func test_origin_notice_shows_missing_email_when_origin_email_is_empty() {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        let originAddress = WooShippingOriginAddress(siteID: 123,
-                                                     id: "default_address",
-                                                     company: "HEADQUARTERS",
-                                                     address1: "15 ALGONKIN ST",
-                                                     address2: "STE 100",
-                                                     city: "TICONDEROGA",
-                                                     state: "NY",
-                                                     postcode: "12883-1487",
-                                                     country: "US",
-                                                     phone: "223-456-7890",
-                                                     firstName: "JANE",
-                                                     lastName: "DOE",
-                                                     email: "",
-                                                     defaultAddress: true,
-                                                     isVerified: false)
-        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
-            switch action {
-            case .loadOriginAddresses(_, let completion):
-                completion(.success([originAddress]))
-            case .loadAccountSettings(_, let completion):
-                completion(.success(self.settings))
-            case .loadPackages, .verifyDestinationAddress:
-                break
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
-        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
-
-        // When
-        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
-                                                         shippingSettingsService: shippingSettingsService,
-                                                         stores: stores)
+        // A present phone with a missing email surfaces the email notice (phone check takes precedence).
+        let viewModel = makeViewModelLoadingOriginAddress(phone: "223-456-7890", email: "")
 
         // Then
-        // A present phone with a missing email surfaces the email notice (phone check takes precedence over email).
         let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingEmail",
                                          value: "Email is missing for the origin address.",
                                          comment: "")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -260,7 +260,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // A missing origin phone is surfaced specifically rather than the generic unverified notice,
         // so the merchant knows which field to fix.
         let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingPhone",
-                                         value: "Phone number is required for the origin address.",
+                                         value: "Phone number is missing for the origin address.",
                                          comment: "")
         waitUntil {
             viewModel.originAddress.isNotEmpty
@@ -309,7 +309,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // A phone with no digits (whitespace/punctuation only) is rejected by the backend as empty,
         // so it must surface the missing-phone notice rather than the generic unverified one.
         let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingPhone",
-                                         value: "Phone number is required for the origin address.",
+                                         value: "Phone number is missing for the origin address.",
                                          comment: "")
         waitUntil {
             viewModel.originAddress.isNotEmpty
@@ -357,7 +357,7 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Then
         // A present phone with a missing email surfaces the email notice (phone check takes precedence over email).
         let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingEmail",
-                                         value: "Email is required for the origin address.",
+                                         value: "Email is missing for the origin address.",
                                          comment: "")
         waitUntil {
             viewModel.originAddress.isNotEmpty

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -209,14 +209,111 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
                                                          shippingSettingsService: shippingSettingsService,
                                                          stores: stores)
         XCTAssertFalse(viewModel.isOriginAddressUnverified)
-        XCTAssertNil(viewModel.originAddressUnverifiedNoticeLabel)
+        XCTAssertNil(viewModel.originAddressNoticeLabel)
 
         // Then
         waitUntil {
             viewModel.originAddress.isNotEmpty
         }
         XCTAssertTrue(viewModel.isOriginAddressUnverified)
-        XCTAssertNotNil(viewModel.originAddressUnverifiedNoticeLabel)
+        XCTAssertNotNil(viewModel.originAddressNoticeLabel)
+    }
+
+    func test_origin_notice_shows_missing_phone_when_origin_phone_is_empty() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let originAddress = WooShippingOriginAddress(siteID: 123,
+                                                     id: "default_address",
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+
+        // Then
+        // A missing origin phone is surfaced specifically rather than the generic unverified notice,
+        // so the merchant knows which field to fix.
+        let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingPhone",
+                                         value: "Phone number is required for the origin address.",
+                                         comment: "")
+        waitUntil {
+            viewModel.originAddress.isNotEmpty
+        }
+        XCTAssertEqual(viewModel.originAddressNoticeLabel, expected)
+    }
+
+    func test_origin_notice_shows_missing_email_when_origin_email_is_empty() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let originAddress = WooShippingOriginAddress(siteID: 123,
+                                                     id: "default_address",
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: "223-456-7890",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+
+        // Then
+        // A present phone with a missing email surfaces the email notice (phone check takes precedence over email).
+        let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingEmail",
+                                         value: "Email is required for the origin address.",
+                                         comment: "")
+        waitUntil {
+            viewModel.originAddress.isNotEmpty
+        }
+        XCTAssertEqual(viewModel.originAddressNoticeLabel, expected)
     }
 
     func test_editSelectedOriginAddress_sets_addressToEdit_view_model() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -268,6 +268,55 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.originAddressNoticeLabel, expected)
     }
 
+    func test_origin_notice_shows_missing_phone_when_origin_phone_has_no_digits() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let originAddress = WooShippingOriginAddress(siteID: 123,
+                                                     id: "default_address",
+                                                     company: "HEADQUARTERS",
+                                                     address1: "15 ALGONKIN ST",
+                                                     address2: "STE 100",
+                                                     city: "TICONDEROGA",
+                                                     state: "NY",
+                                                     postcode: "12883-1487",
+                                                     country: "US",
+                                                     phone: " - ",
+                                                     firstName: "JANE",
+                                                     lastName: "DOE",
+                                                     email: "TEST@EXAMPLE.COM",
+                                                     defaultAddress: true,
+                                                     isVerified: false)
+        stores.whenReceivingAction(ofType: WooShippingAction.self) { action in
+            switch action {
+            case .loadOriginAddresses(_, let completion):
+                completion(.success([originAddress]))
+            case .loadAccountSettings(_, let completion):
+                completion(.success(self.settings))
+            case .loadPackages, .verifyDestinationAddress:
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let shippingSettingsService = MockShippingSettingsService(dimensionUnit: nil, weightUnit: nil)
+
+        // When
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         shippingSettingsService: shippingSettingsService,
+                                                         stores: stores)
+
+        // Then
+        // A phone with no digits (whitespace/punctuation only) is rejected by the backend as empty,
+        // so it must surface the missing-phone notice rather than the generic unverified one.
+        let expected = NSLocalizedString("wooShipping.createLabels.originAddress.missingPhone",
+                                         value: "Phone number is required for the origin address.",
+                                         comment: "")
+        waitUntil {
+            viewModel.originAddress.isNotEmpty
+        }
+        XCTAssertEqual(viewModel.originAddressNoticeLabel, expected)
+    }
+
     func test_origin_notice_shows_missing_email_when_origin_email_is_empty() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)


### PR DESCRIPTION
Fixes WOOMOB-2578.

## Description

When creating a Woo Shipping label, the origin "Ship from" notice now names the missing field instead of the generic "Origin address unverified":

- empty phone → "Phone number is missing for the origin address."
- empty email → "Email is missing for the origin address."
- otherwise → existing "Origin address unverified."

Derived client-side from the selected origin address (mirrors the existing destination-phone validation). Renamed `originAddressUnverifiedNoticeLabel` → `originAddressNoticeLabel`; the notice keeps its tap-to-edit action. Added unit tests.

## Test Steps

1. Log into [this site](https://mc.a8c.com/secret-store/?secret_id=14561)
2. Open order `#58`
3. Tap "Create Shipping Label"
5. The origin notice reads "Phone number is missing for the origin address." Tapping it opens the origin address editor.
6. Add a phone `4155550199 ` -> Notice is gone

## Screenshots

 | Before | After |
| --- | --- |
| <img height="600" alt="Orders 4" src="https://github.com/user-attachments/assets/2b12a73f-00cd-4f3e-a97e-551dd3bba9fb" /> | <img height="600" alt="image" src="https://github.com/user-attachments/assets/d77de771-11a1-446a-9665-bd5069f92876" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.