### PR TITLE
DNM: Add POS location stock spike

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -76,7 +76,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backgroundProductImageUpload:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .inventoryProductLabelsInPOS:
-            return false
+            return true
         case .productImageOptimizedHandling:
             return true
         case .pointOfSaleOrdersi1:

--- a/Modules/Sources/Fakes/Networking.generated.swift
+++ b/Modules/Sources/Fakes/Networking.generated.swift
@@ -783,7 +783,8 @@ extension Networking.POSProduct {
             stockQuantity: .fake(),
             stockStatusKey: .fake(),
             statusKey: .fake(),
-            variationIDs: .fake()
+            variationIDs: .fake(),
+            locationStock: []
         )
     }
 }
@@ -805,7 +806,8 @@ extension Networking.POSProductVariation {
             downloadable: .fake(),
             manageStock: .fake(),
             stockQuantity: .fake(),
-            stockStatusKey: .fake()
+            stockStatusKey: .fake(),
+            locationStock: []
         )
     }
 }

--- a/Modules/Sources/Fakes/Yosemite.generated.swift
+++ b/Modules/Sources/Fakes/Yosemite.generated.swift
@@ -67,7 +67,8 @@ extension Yosemite.POSSimpleProduct {
             bundledItems: .fake(),
             manageStock: .fake(),
             stockQuantity: .fake(),
-            stockStatusKey: .fake()
+            stockStatusKey: .fake(),
+            pointOfSaleStockQuantity: nil
         )
     }
 }

--- a/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1323,7 +1323,8 @@ extension Networking.POSProduct {
         stockQuantity: NullableCopiableProp<Decimal> = .copy,
         stockStatusKey: CopiableProp<String> = .copy,
         statusKey: CopiableProp<String> = .copy,
-        variationIDs: CopiableProp<[Int64]> = .copy
+        variationIDs: CopiableProp<[Int64]> = .copy,
+        locationStock: CopiableProp<[POSLocationStock]> = .copy
     ) -> Networking.POSProduct {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1343,6 +1344,7 @@ extension Networking.POSProduct {
         let stockStatusKey = stockStatusKey ?? self.stockStatusKey
         let statusKey = statusKey ?? self.statusKey
         let variationIDs = variationIDs ?? self.variationIDs
+        let locationStock = locationStock ?? self.locationStock
 
         return Networking.POSProduct(
             siteID: siteID,
@@ -1362,7 +1364,8 @@ extension Networking.POSProduct {
             stockQuantity: stockQuantity,
             stockStatusKey: stockStatusKey,
             statusKey: statusKey,
-            variationIDs: variationIDs
+            variationIDs: variationIDs,
+            locationStock: locationStock
         )
     }
 }
@@ -1382,7 +1385,8 @@ extension Networking.POSProductVariation {
         downloadable: CopiableProp<Bool> = .copy,
         manageStock: CopiableProp<Bool> = .copy,
         stockQuantity: NullableCopiableProp<Decimal> = .copy,
-        stockStatusKey: CopiableProp<String> = .copy
+        stockStatusKey: CopiableProp<String> = .copy,
+        locationStock: CopiableProp<[Networking.POSLocationStock]> = .copy
     ) -> Networking.POSProductVariation {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -1398,6 +1402,7 @@ extension Networking.POSProductVariation {
         let manageStock = manageStock ?? self.manageStock
         let stockQuantity = stockQuantity ?? self.stockQuantity
         let stockStatusKey = stockStatusKey ?? self.stockStatusKey
+        let locationStock = locationStock ?? self.locationStock
 
         return Networking.POSProductVariation(
             siteID: siteID,
@@ -1413,7 +1418,8 @@ extension Networking.POSProductVariation {
             downloadable: downloadable,
             manageStock: manageStock,
             stockQuantity: stockQuantity,
-            stockStatusKey: stockStatusKey
+            stockStatusKey: stockStatusKey,
+            locationStock: locationStock
         )
     }
 }

--- a/Modules/Sources/Networking/Model/POSProduct.swift
+++ b/Modules/Sources/Networking/Model/POSProduct.swift
@@ -42,6 +42,11 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
     public let manageStock: Bool
     public let stockQuantity: Decimal?
     public let stockStatusKey: String
+    public let locationStock: [POSLocationStock]
+
+    public var pointOfSaleStockQuantity: Decimal? {
+        locationStock.first { $0.slug == POSLocationStock.pointOfSaleSlug }?.quantity
+    }
 
     public let statusKey: String
 
@@ -68,7 +73,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                 stockQuantity: Decimal?,
                 stockStatusKey: String,
                 statusKey: String,
-                variationIDs: [Int64]) {
+                variationIDs: [Int64],
+                locationStock: [POSLocationStock] = []) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -91,6 +97,7 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
         self.stockStatusKey = stockStatusKey
+        self.locationStock = locationStock
 
         self.statusKey = statusKey
 
@@ -137,6 +144,7 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
         let manageStock = try container.decode(Bool.self, forKey: .manageStock)
         let stockQuantity = container.failsafeDecodeIfPresent(decimalForKey: .stockQuantity)
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
+        let locationStock = try container.decodeIfPresent([POSLocationStock].self, forKey: .locationStock) ?? []
 
         let statusKey = try container.decode(String.self, forKey: .statusKey)
 
@@ -159,7 +167,8 @@ public struct POSProduct: Codable, Equatable, GeneratedCopiable, GeneratedFakeab
                   stockQuantity: stockQuantity,
                   stockStatusKey: stockStatusKey,
                   statusKey: statusKey,
-                  variationIDs: variationIDs)
+                  variationIDs: variationIDs,
+                  locationStock: locationStock)
     }
 
     static let requestFields: [String] = {
@@ -194,5 +203,58 @@ private extension POSProduct {
         case stockStatusKey = "stock_status"
         case statusKey = "status"
         case variationIDs = "variations"
+        case locationStock = "location_stock"
+    }
+}
+
+public struct POSLocationStock: Codable, Equatable {
+    public static let pointOfSaleSlug = "pos"
+
+    public let slug: String
+    public let name: String
+    public let quantity: Decimal
+    public let stockStatusKey: String
+
+    public init(slug: String,
+                name: String,
+                quantity: Decimal,
+                stockStatusKey: String) {
+        self.slug = slug
+        self.name = name
+        self.quantity = quantity
+        self.stockStatusKey = stockStatusKey
+    }
+
+    public static func pointOfSale(quantity: Decimal) -> POSLocationStock {
+        POSLocationStock(
+            slug: pointOfSaleSlug,
+            name: "POS",
+            quantity: quantity,
+            stockStatusKey: quantity > 0 ? ProductStockStatus.inStock.rawValue : ProductStockStatus.outOfStock.rawValue
+        )
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let slug = try container.decode(String.self, forKey: .slug)
+        let name = try container.decode(String.self, forKey: .name)
+        let quantity = container.failsafeDecodeIfPresent(decimalForKey: .quantity) ?? 0
+        let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
+
+        self.init(
+            slug: slug,
+            name: name,
+            quantity: quantity,
+            stockStatusKey: stockStatusKey
+        )
+    }
+}
+
+private extension POSLocationStock {
+    enum CodingKeys: String, CodingKey {
+        case slug
+        case name
+        case quantity
+        case stockStatusKey = "stock_status"
     }
 }

--- a/Modules/Sources/Networking/Model/POSProductVariation.swift
+++ b/Modules/Sources/Networking/Model/POSProductVariation.swift
@@ -30,6 +30,11 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
     public let manageStock: Bool
     public let stockQuantity: Decimal?
     public let stockStatusKey: String
+    public let locationStock: [POSLocationStock]
+
+    public var pointOfSaleStockQuantity: Decimal? {
+        locationStock.first { $0.slug == POSLocationStock.pointOfSaleSlug }?.quantity
+    }
 
     public var stockStatus: ProductStockStatus {
         return ProductStockStatus(rawValue: stockStatusKey)
@@ -48,7 +53,8 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
                 downloadable: Bool,
                 manageStock: Bool,
                 stockQuantity: Decimal?,
-                stockStatusKey: String) {
+                stockStatusKey: String,
+                locationStock: [POSLocationStock] = []) {
         self.siteID = siteID
         self.productID = productID
         self.productVariationID = productVariationID
@@ -63,6 +69,7 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
         self.stockStatusKey = stockStatusKey
+        self.locationStock = locationStock
     }
 
     public init(from decoder: Decoder) throws {
@@ -108,6 +115,7 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
         let stockQuantity = container.failsafeDecodeIfPresent(decimalForKey: .stockQuantity)
         let typeKey = try container.decode(String.self, forKey: .typeKey)
         let stockStatusKey = try container.decode(String.self, forKey: .stockStatusKey)
+        let locationStock = try container.decodeIfPresent([POSLocationStock].self, forKey: .locationStock) ?? []
 
         self.init(siteID: siteID,
                   productID: productID,
@@ -122,7 +130,8 @@ public struct POSProductVariation: Codable, Equatable, GeneratedCopiable, Genera
                   downloadable: downloadable,
                   manageStock: manageStock,
                   stockQuantity: stockQuantity,
-                  stockStatusKey: stockStatusKey)
+                  stockStatusKey: stockStatusKey,
+                  locationStock: locationStock)
     }
 
     static let requestFields: [String] = {
@@ -154,6 +163,7 @@ private extension POSProductVariation {
         case manageStock = "manage_stock"
         case stockQuantity = "stock_quantity"
         case stockStatusKey = "stock_status"
+        case locationStock = "location_stock"
     }
 }
 

--- a/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/OrdersRemote.swift
@@ -270,6 +270,9 @@ public class OrdersRemote: Remote, OrdersRemoteProtocol {
                 if let createdViaValue = source.createdViaValue {
                     params[Order.CodingKeys.createdVia.rawValue] = createdViaValue
                 }
+                if let inventoryLocationValue = source.inventoryLocationValue {
+                    params[ParameterKeys.inventoryLocation] = inventoryLocationValue
+                }
 
                 params[ParameterKeys.decimalPlaces] = OrdersRemote.Defaults.decimalPoints
 
@@ -609,6 +612,7 @@ public extension OrdersRemote {
         static let customer = "customer"
         static let product = "product"
         static let createdVia = "created_via"
+        static let inventoryLocation = "inventory_location"
         static let decimalPlaces = "dp"
     }
 
@@ -705,6 +709,15 @@ private extension OrdersRemote.OrderCreationSource {
             return nil
         case .pointOfSale:
             return "pos-rest-api"
+        }
+    }
+
+    var inventoryLocationValue: String? {
+        switch self {
+        case .storeManagement:
+            return nil
+        case .pointOfSale:
+            return "pos"
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/SearchResultVariationCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/SearchResultVariationCardView.swift
@@ -8,9 +8,14 @@ struct SearchResultVariationCardView: View {
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.posFeatureFlags) private var featureFlags
 
     private var dimension: CGFloat {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
+    }
+
+    private var shouldShowProductLabels: Bool {
+        featureFlags.isFeatureFlagEnabled(.inventoryProductLabelsInPOS)
     }
 
     init(variation: POSVariation, parentProduct: POSVariableParentProduct) {
@@ -43,6 +48,11 @@ struct SearchResultVariationCardView: View {
                 Text(variation.formattedPrice)
                     .foregroundStyle(Constants.detailColor)
                     .font(Constants.itemDetailFont)
+
+                Text(POSStockFormatter.stockStatusLabel(for: variation))
+                    .foregroundStyle(Constants.detailColor)
+                    .font(Constants.itemDetailFont)
+                    .renderedIf(shouldShowProductLabels)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))

--- a/Modules/Sources/PointOfSale/Presentation/Item Selector/VariationCardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Item Selector/VariationCardView.swift
@@ -6,9 +6,14 @@ struct VariationCardView: View {
 
     @ScaledMetric private var scale: CGFloat = 1.0
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.posFeatureFlags) private var featureFlags
 
     private var dimension: CGFloat {
         min(Constants.productCardSize * scale, Constants.maximumProductCardSize)
+    }
+
+    private var shouldShowProductLabels: Bool {
+        featureFlags.isFeatureFlagEnabled(.inventoryProductLabelsInPOS)
     }
 
     init(variation: POSVariation) {
@@ -32,6 +37,11 @@ struct VariationCardView: View {
                 Text(variation.formattedPrice)
                     .foregroundStyle(Constants.detailColor)
                     .font(Constants.itemDetailFont)
+
+                Text(POSStockFormatter.stockStatusLabel(for: variation))
+                    .foregroundStyle(Constants.detailColor)
+                    .font(Constants.itemDetailFont)
+                    .renderedIf(shouldShowProductLabels)
             }
             .padding(.horizontal, Constants.horizontalTextPadding * (1 / scale))
             .padding(.vertical, Constants.verticalTextPadding * (1 / scale))

--- a/Modules/Sources/PointOfSale/Utils/POSStockFormatter.swift
+++ b/Modules/Sources/PointOfSale/Utils/POSStockFormatter.swift
@@ -1,20 +1,64 @@
 import Foundation
 import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
 
 struct POSStockFormatter {
     static func stockStatusLabel(for product: POSSimpleProduct) -> String {
-        switch product.manageStock {
+        stockStatusLabel(manageStock: product.manageStock,
+                         stockQuantity: product.stockQuantity,
+                         productStockStatusDescription: product.productStockStatus.description,
+                         pointOfSaleStockQuantity: product.pointOfSaleStockQuantity)
+    }
+
+    static func stockStatusLabel(for variation: POSVariation) -> String {
+        if let stock = variation.pointOfSaleStockQuantity {
+            return stockLabel(for: stock)
+        }
+
+        if variation.manageStock {
+            return stockStatusLabel(manageStock: variation.manageStock,
+                                    stockQuantity: variation.stockQuantity,
+                                    productStockStatusDescription: variation.productStockStatus.description,
+                                    pointOfSaleStockQuantity: nil)
+        }
+
+        if variation.parentPointOfSaleStockQuantity != nil || variation.parentManageStock || !variation.parentStockStatusKey.isEmpty {
+            return stockStatusLabel(manageStock: variation.parentManageStock,
+                                    stockQuantity: variation.parentStockQuantity,
+                                    productStockStatusDescription: variation.parentProductStockStatus.description,
+                                    pointOfSaleStockQuantity: variation.parentPointOfSaleStockQuantity)
+        }
+
+        return stockStatusLabel(manageStock: variation.manageStock,
+                                stockQuantity: variation.stockQuantity,
+                                productStockStatusDescription: variation.productStockStatus.description,
+                                pointOfSaleStockQuantity: nil)
+    }
+
+    private static func stockStatusLabel(manageStock: Bool,
+                                         stockQuantity: Decimal?,
+                                         productStockStatusDescription: String,
+                                         pointOfSaleStockQuantity: Decimal?) -> String {
+        if let stock = pointOfSaleStockQuantity {
+            return stockLabel(for: stock)
+        }
+
+        switch manageStock {
         case false:
-            return product.productStockStatus.description
+            return productStockStatusDescription
         case true:
-            guard let stock = product.stockQuantity else {
-                return product.productStockStatus.description
+            guard let stock = stockQuantity else {
+                return productStockStatusDescription
             }
-            if stock <= 0 {
-                return Localization.outOfStock
-            } else {
-                return String.localizedStringWithFormat(Localization.inStockWithQuantity, "\(stock)")
-            }
+            return stockLabel(for: stock)
+        }
+    }
+
+    private static func stockLabel(for stock: Decimal) -> String {
+        if stock <= 0 {
+            return Localization.outOfStock
+        } else {
+            return String.localizedStringWithFormat(Localization.inStockWithQuantity, "\(stock)")
         }
     }
 

--- a/Modules/Sources/Storage/GRDB/GRDBManager.swift
+++ b/Modules/Sources/Storage/GRDB/GRDBManager.swift
@@ -89,6 +89,10 @@ private extension GRDBManager {
             try V003AddVariationTypeKey.migrate(db)
         }
 
+        migrator.registerMigration("V004AddProductPointOfSaleStockQuantity") { db in
+            try V004AddProductPointOfSaleStockQuantity.migrate(db)
+        }
+
         try migrator.migrate(databaseConnection)
     }
 }

--- a/Modules/Sources/Storage/GRDB/Migrations/V004AddProductPointOfSaleStockQuantity.swift
+++ b/Modules/Sources/Storage/GRDB/Migrations/V004AddProductPointOfSaleStockQuantity.swift
@@ -1,0 +1,14 @@
+import Foundation
+import GRDB
+
+struct V004AddProductPointOfSaleStockQuantity {
+    static func migrate(_ db: Database) throws {
+        try db.alter(table: "product") { t in
+            t.add(column: "pointOfSaleStockQuantity", .double)
+        }
+
+        try db.alter(table: "productVariation") { t in
+            t.add(column: "pointOfSaleStockQuantity", .double)
+        }
+    }
+}

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProduct.swift
@@ -17,6 +17,7 @@ public struct PersistedProduct: Codable {
     public let manageStock: Bool
     public let stockQuantity: Decimal?
     public let stockStatusKey: String
+    public let pointOfSaleStockQuantity: Decimal?
     public let statusKey: String
 
     public init(id: Int64,
@@ -33,6 +34,7 @@ public struct PersistedProduct: Codable {
                 manageStock: Bool,
                 stockQuantity: Decimal?,
                 stockStatusKey: String,
+                pointOfSaleStockQuantity: Decimal? = nil,
                 statusKey: String) {
         self.id = id
         self.siteID = siteID
@@ -48,6 +50,7 @@ public struct PersistedProduct: Codable {
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
         self.stockStatusKey = stockStatusKey
+        self.pointOfSaleStockQuantity = pointOfSaleStockQuantity
         self.statusKey = statusKey
     }
 }
@@ -73,6 +76,7 @@ extension PersistedProduct: FetchableRecord, PersistableRecord {
         public static let manageStock = Column(CodingKeys.manageStock)
         public static let stockQuantity = Column(CodingKeys.stockQuantity)
         public static let stockStatusKey = Column(CodingKeys.stockStatusKey)
+        public static let pointOfSaleStockQuantity = Column(CodingKeys.pointOfSaleStockQuantity)
         public static let statusKey = Column(CodingKeys.statusKey)
     }
 
@@ -197,6 +201,7 @@ private extension PersistedProduct {
         case manageStock
         case stockQuantity
         case stockStatusKey
+        case pointOfSaleStockQuantity
         case statusKey
     }
 

--- a/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
+++ b/Modules/Sources/Storage/GRDB/Model/PersistedProductVariation.swift
@@ -14,6 +14,7 @@ public struct PersistedProductVariation: Codable {
     public let fullDescription: String?
     public let manageStock: Bool
     public let stockQuantity: Decimal?
+    public let pointOfSaleStockQuantity: Decimal?
     public let stockStatusKey: String
 
     public init(id: Int64,
@@ -27,6 +28,7 @@ public struct PersistedProductVariation: Codable {
                 fullDescription: String?,
                 manageStock: Bool,
                 stockQuantity: Decimal?,
+                pointOfSaleStockQuantity: Decimal? = nil,
                 stockStatusKey: String) {
         self.id = id
         self.siteID = siteID
@@ -39,6 +41,7 @@ public struct PersistedProductVariation: Codable {
         self.fullDescription = fullDescription
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
+        self.pointOfSaleStockQuantity = pointOfSaleStockQuantity
         self.stockStatusKey = stockStatusKey
     }
 }
@@ -61,6 +64,7 @@ extension PersistedProductVariation: FetchableRecord, PersistableRecord {
         public static let fullDescription = Column(CodingKeys.fullDescription)
         public static let manageStock = Column(CodingKeys.manageStock)
         public static let stockQuantity = Column(CodingKeys.stockQuantity)
+        public static let pointOfSaleStockQuantity = Column(CodingKeys.pointOfSaleStockQuantity)
         public static let stockStatusKey = Column(CodingKeys.stockStatusKey)
     }
 
@@ -142,6 +146,7 @@ extension PersistedProductVariation {
         case fullDescription
         case manageStock
         case stockQuantity
+        case pointOfSaleStockQuantity
         case stockStatusKey
     }
 }

--- a/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
+++ b/Modules/Sources/Yosemite/Model/Copiable/Models+Copiable.generated.swift
@@ -151,7 +151,8 @@ extension Yosemite.POSSimpleProduct {
         bundledItems: CopiableProp<[Networking.ProductBundleItem]> = .copy,
         manageStock: CopiableProp<Bool> = .copy,
         stockQuantity: NullableCopiableProp<Decimal> = .copy,
-        stockStatusKey: CopiableProp<String> = .copy
+        stockStatusKey: CopiableProp<String> = .copy,
+        pointOfSaleStockQuantity: NullableCopiableProp<Decimal> = .copy
     ) -> Yosemite.POSSimpleProduct {
         let id = id ?? self.id
         let name = name ?? self.name
@@ -164,6 +165,7 @@ extension Yosemite.POSSimpleProduct {
         let manageStock = manageStock ?? self.manageStock
         let stockQuantity = stockQuantity ?? self.stockQuantity
         let stockStatusKey = stockStatusKey ?? self.stockStatusKey
+        let pointOfSaleStockQuantity = pointOfSaleStockQuantity ?? self.pointOfSaleStockQuantity
 
         return Yosemite.POSSimpleProduct(
             id: id,
@@ -176,7 +178,8 @@ extension Yosemite.POSSimpleProduct {
             bundledItems: bundledItems,
             manageStock: manageStock,
             stockQuantity: stockQuantity,
-            stockStatusKey: stockStatusKey
+            stockStatusKey: stockStatusKey,
+            pointOfSaleStockQuantity: pointOfSaleStockQuantity
         )
     }
 }

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -100,6 +100,7 @@ public typealias PaymentGatewayAccount = Networking.PaymentGatewayAccount
 public typealias Product = Networking.Product
 public typealias PushNotificationPreferences = Networking.PushNotificationPreferences
 public typealias POSProduct = Networking.POSProduct
+public typealias POSLocationStock = Networking.POSLocationStock
 public typealias POSProductVariation = Networking.POSProductVariation
 public typealias ProductAddOn = Networking.ProductAddOn
 public typealias ProductAddOnOption = Networking.ProductAddOnOption

--- a/Modules/Sources/Yosemite/Model/Storage/PersistedProduct+Conversions.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/PersistedProduct+Conversions.swift
@@ -20,11 +20,14 @@ extension PersistedProduct {
             manageStock: posProduct.manageStock,
             stockQuantity: posProduct.stockQuantity,
             stockStatusKey: posProduct.stockStatusKey,
+            pointOfSaleStockQuantity: posProduct.pointOfSaleStockQuantity,
             statusKey: posProduct.statusKey
         )
     }
 
     func toPOSProduct(images: [ProductImage] = [], attributes: [ProductAttribute] = [], variationIDs: [Int64] = []) -> POSProduct {
+        let locationStock = pointOfSaleStockQuantity.map { [POSLocationStock.pointOfSale(quantity: $0)] } ?? []
+
         return POSProduct(
             siteID: siteID,
             productID: id,
@@ -43,7 +46,8 @@ extension PersistedProduct {
             stockQuantity: stockQuantity,
             stockStatusKey: stockStatusKey,
             statusKey: statusKey,
-            variationIDs: variationIDs
+            variationIDs: variationIDs,
+            locationStock: locationStock
         )
     }
 

--- a/Modules/Sources/Yosemite/Model/Storage/PersistedProductVariation+Conversions.swift
+++ b/Modules/Sources/Yosemite/Model/Storage/PersistedProductVariation+Conversions.swift
@@ -17,11 +17,14 @@ extension PersistedProductVariation {
             fullDescription: posProductVariation.fullDescription,
             manageStock: posProductVariation.manageStock,
             stockQuantity: posProductVariation.stockQuantity,
+            pointOfSaleStockQuantity: posProductVariation.pointOfSaleStockQuantity,
             stockStatusKey: posProductVariation.stockStatusKey
         )
     }
 
     func toPOSProductVariation(attributes: [ProductVariationAttribute] = [], image: ProductImage? = nil) -> POSProductVariation {
+        let locationStock = pointOfSaleStockQuantity.map { [POSLocationStock.pointOfSale(quantity: $0)] } ?? []
+
         return POSProductVariation(
             siteID: siteID,
             productID: productID,
@@ -36,7 +39,8 @@ extension PersistedProductVariation {
             downloadable: downloadable,
             manageStock: manageStock,
             stockQuantity: stockQuantity,
-            stockStatusKey: stockStatusKey
+            stockStatusKey: stockStatusKey,
+            locationStock: locationStock
         )
     }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/GRDBObservableDataSource.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/GRDBObservableDataSource.swift
@@ -196,7 +196,11 @@ public final class GRDBObservableDataSource: POSObservableDataSourceProtocol {
                         name: product.name,
                         productImageSource: nil, // Image not needed for variation name generation
                         productID: product.id,
-                        allAttributes: attributes
+                        allAttributes: attributes,
+                        manageStock: product.manageStock,
+                        stockQuantity: product.stockQuantity,
+                        stockStatusKey: product.stockStatusKey,
+                        pointOfSaleStockQuantity: product.pointOfSaleStockQuantity
                     )
                 } else {
                     updatedParentProduct = parentProduct

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSProductOrVariationResolver.swift
@@ -91,7 +91,8 @@ private extension POSProduct {
                 downloadable: downloadable,
                 manageStock: manageStock,
                 stockQuantity: stockQuantity,
-                stockStatusKey: stockStatusKey
+                stockStatusKey: stockStatusKey,
+                locationStock: locationStock
             )
         } catch {
             throw .mappingError(scannedCode: scannedCode, underlyingError: error)

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSSimpleProduct.swift
@@ -20,6 +20,7 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
     public let manageStock: Bool
     public let stockQuantity: Decimal?
     public let stockStatusKey: String
+    public let pointOfSaleStockQuantity: Decimal?
     public var productStockStatus: ProductStockStatus {
         return ProductStockStatus(rawValue: stockStatusKey)
     }
@@ -34,7 +35,8 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
                 bundledItems: [ProductBundleItem] = [],
                 manageStock: Bool,
                 stockQuantity: Decimal?,
-                stockStatusKey: String) {
+                stockStatusKey: String,
+                pointOfSaleStockQuantity: Decimal? = nil) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -44,6 +46,7 @@ public struct POSSimpleProduct: POSOrderableItem, OrderSyncProductTypeProtocol {
         self.manageStock = manageStock
         self.stockQuantity = stockQuantity
         self.stockStatusKey = stockStatusKey
+        self.pointOfSaleStockQuantity = pointOfSaleStockQuantity
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSVariableParentProduct.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSVariableParentProduct.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Networking
 
 public struct POSVariableParentProduct: Equatable, Hashable, Identifiable {
     public let id: POSItemIdentifier
@@ -6,16 +7,32 @@ public struct POSVariableParentProduct: Equatable, Hashable, Identifiable {
     public let productImageSource: String?
     public let productID: Int64
     let allAttributes: [ProductAttribute]
+    public let manageStock: Bool
+    public let stockQuantity: Decimal?
+    public let stockStatusKey: String
+    public let pointOfSaleStockQuantity: Decimal?
+
+    public var productStockStatus: ProductStockStatus {
+        return ProductStockStatus(rawValue: stockStatusKey)
+    }
 
     init(id: POSItemIdentifier,
          name: String, productImageSource: String?,
          productID: Int64,
-         allAttributes: [ProductAttribute]) {
+         allAttributes: [ProductAttribute],
+         manageStock: Bool = false,
+         stockQuantity: Decimal? = nil,
+         stockStatusKey: String = "",
+         pointOfSaleStockQuantity: Decimal? = nil) {
         self.id = id
         self.name = name
         self.productImageSource = productImageSource
         self.productID = productID
         self.allAttributes = allAttributes
+        self.manageStock = manageStock
+        self.stockQuantity = stockQuantity
+        self.stockStatusKey = stockStatusKey
+        self.pointOfSaleStockQuantity = pointOfSaleStockQuantity
     }
 
     #if DEBUG

--- a/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/POSVariation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Networking
 
 public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Hashable, Identifiable {
     // Identifiable & POSOrderableItem
@@ -17,6 +18,23 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
     // Variation specific
     public let parentProductName: String
 
+    // Stock
+    public let manageStock: Bool
+    public let stockQuantity: Decimal?
+    public let stockStatusKey: String
+    public let pointOfSaleStockQuantity: Decimal?
+    public let parentManageStock: Bool
+    public let parentStockQuantity: Decimal?
+    public let parentStockStatusKey: String
+    public let parentPointOfSaleStockQuantity: Decimal?
+
+    public var productStockStatus: ProductStockStatus {
+        return ProductStockStatus(rawValue: stockStatusKey)
+    }
+    public var parentProductStockStatus: ProductStockStatus {
+        return ProductStockStatus(rawValue: parentStockStatusKey)
+    }
+
     public init(id: POSItemIdentifier,
                 name: String,
                 formattedPrice: String,
@@ -24,7 +42,15 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
                 productImageSource: String? = nil,
                 productID: Int64,
                 variationID: Int64,
-                parentProductName: String) {
+                parentProductName: String,
+                manageStock: Bool = false,
+                stockQuantity: Decimal? = nil,
+                stockStatusKey: String = "",
+                pointOfSaleStockQuantity: Decimal? = nil,
+                parentManageStock: Bool = false,
+                parentStockQuantity: Decimal? = nil,
+                parentStockStatusKey: String = "",
+                parentPointOfSaleStockQuantity: Decimal? = nil) {
         self.id = id
         self.name = name
         self.formattedPrice = formattedPrice
@@ -33,6 +59,14 @@ public struct POSVariation: OrderSyncProductVariationTypeProtocol, Equatable, Ha
         self.productID = productID
         self.productVariationID = variationID
         self.parentProductName = parentProductName
+        self.manageStock = manageStock
+        self.stockQuantity = stockQuantity
+        self.stockStatusKey = stockStatusKey
+        self.pointOfSaleStockQuantity = pointOfSaleStockQuantity
+        self.parentManageStock = parentManageStock
+        self.parentStockQuantity = parentStockQuantity
+        self.parentStockStatusKey = parentStockStatusKey
+        self.parentPointOfSaleStockQuantity = parentPointOfSaleStockQuantity
     }
 }
 

--- a/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
+++ b/Modules/Sources/Yosemite/PointOfSale/Items/PointOfSaleItemMapper.swift
@@ -38,14 +38,19 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                                            price: product.price,
                                                            manageStock: product.manageStock,
                                                            stockQuantity: product.stockQuantity,
-                                                           stockStatusKey: product.stockStatusKey))
+                                                           stockStatusKey: product.stockStatusKey,
+                                                           pointOfSaleStockQuantity: product.pointOfSaleStockQuantity))
                 case .variable:
                     return .variableParentProduct(POSVariableParentProduct(
                         id: id,
                         name: product.name,
                         productImageSource: thumbnailSource,
                         productID: product.productID,
-                        allAttributes: product.attributesForVariations
+                        allAttributes: product.attributesForVariations,
+                        manageStock: product.manageStock,
+                        stockQuantity: product.stockQuantity,
+                        stockStatusKey: product.stockStatusKey,
+                        pointOfSaleStockQuantity: product.pointOfSaleStockQuantity
                     ))
                 default:
                     return nil
@@ -69,7 +74,15 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                  productImageSource: variation.image?.src,
                                  productID: variation.productID,
                                  variationID: variation.productVariationID,
-                                 parentProductName: parentProduct.name))
+                                 parentProductName: parentProduct.name,
+                                 manageStock: variation.manageStock,
+                                 stockQuantity: variation.stockQuantity,
+                                 stockStatusKey: variation.stockStatusKey,
+                                 pointOfSaleStockQuantity: variation.pointOfSaleStockQuantity,
+                                 parentManageStock: parentProduct.manageStock,
+                                 parentStockQuantity: parentProduct.stockQuantity,
+                                 parentStockStatusKey: parentProduct.stockStatusKey,
+                                 parentPointOfSaleStockQuantity: parentProduct.pointOfSaleStockQuantity))
         }
     }
 
@@ -87,14 +100,19 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
                                                    price: product.price,
                                                    manageStock: product.manageStock,
                                                    stockQuantity: product.stockQuantity,
-                                                   stockStatusKey: product.stockStatusKey))
+                                                   stockStatusKey: product.stockStatusKey,
+                                                   pointOfSaleStockQuantity: product.pointOfSaleStockQuantity))
         case .variable:
             return .variableParentProduct(POSVariableParentProduct(
                 id: id,
                 name: product.name,
                 productImageSource: thumbnailSource,
                 productID: product.productID,
-                allAttributes: product.attributesForVariations
+                allAttributes: product.attributesForVariations,
+                manageStock: product.manageStock,
+                stockQuantity: product.stockQuantity,
+                stockStatusKey: product.stockStatusKey,
+                pointOfSaleStockQuantity: product.pointOfSaleStockQuantity
             ))
         default:
             return nil
@@ -117,7 +135,15 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
             productImageSource: variation.image?.src,
             productID: variation.productID,
             variationID: variation.productVariationID,
-            parentProductName: parentProduct.name
+            parentProductName: parentProduct.name,
+            manageStock: variation.manageStock,
+            stockQuantity: variation.stockQuantity,
+            stockStatusKey: variation.stockStatusKey,
+            pointOfSaleStockQuantity: variation.pointOfSaleStockQuantity,
+            parentManageStock: parentProduct.manageStock,
+            parentStockQuantity: parentProduct.stockQuantity,
+            parentStockStatusKey: parentProduct.stockStatusKey,
+            parentPointOfSaleStockQuantity: parentProduct.pointOfSaleStockQuantity
         )
 
         let parentId = POSItemIdentifier(underlyingType: .product, itemID: parentProduct.productID)
@@ -127,7 +153,11 @@ final class PointOfSaleItemMapper: PointOfSaleItemMapperProtocol {
             name: parentProduct.name,
             productImageSource: thumbnailSource,
             productID: parentProduct.productID,
-            allAttributes: parentProduct.attributesForVariations
+            allAttributes: parentProduct.attributesForVariations,
+            manageStock: parentProduct.manageStock,
+            stockQuantity: parentProduct.stockQuantity,
+            stockStatusKey: parentProduct.stockStatusKey,
+            pointOfSaleStockQuantity: parentProduct.pointOfSaleStockQuantity
         )
 
         return .searchResultVariation(posVariation, parentProduct: posParentProduct)

--- a/Modules/Sources/Yosemite/Tools/POS/POSCartProductObserver.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCartProductObserver.swift
@@ -141,7 +141,11 @@ public final class POSCartProductObserver: POSCartProductObserving {
                         name: parentProduct.name,
                         productImageSource: parentProduct.images.first?.src,
                         productID: parentProduct.productID,
-                        allAttributes: parentProduct.attributes
+                        allAttributes: parentProduct.attributes,
+                        manageStock: parentProduct.manageStock,
+                        stockQuantity: parentProduct.stockQuantity,
+                        stockStatusKey: parentProduct.stockStatusKey,
+                        pointOfSaleStockQuantity: parentProduct.pointOfSaleStockQuantity
                     )
 
                     let mapped = itemMapper.mapVariationsToPOSItems(

--- a/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -844,6 +844,20 @@ final class OrdersRemoteTests: XCTestCase {
         assertEqual(received, "pos-rest-api")
     }
 
+    func test_createPOSOrder_sets_inventory_location_for_point_of_sale() async throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let order = Order.fake()
+
+        // When
+        _ = try? await remote.createPOSOrder(siteID: 123, order: order, fields: [])
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        XCTAssertEqual(request.parameters["inventory_location"] as? String, "pos")
+        XCTAssertNil(request.parameters["location"])
+    }
+
     func test_createOrder_without_source_parameter_does_not_set_created_via() throws {
         // Given
         let remote = OrdersRemote(network: network)
@@ -855,6 +869,8 @@ final class OrdersRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
         XCTAssertNil(request.parameters["created_via"])
+        XCTAssertNil(request.parameters["inventory_location"])
+        XCTAssertNil(request.parameters["location"])
     }
 
     func test_createOrder_includes_decimal_places_parameter() throws {

--- a/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSCatalogSyncRemoteTests.swift
@@ -466,6 +466,107 @@ struct POSCatalogSyncRemoteTests {
         #expect(fieldNames.contains("manage_stock"))
         #expect(fieldNames.contains("stock_quantity"))
         #expect(fieldNames.contains("stock_status"))
+        #expect(fieldNames.contains("location_stock"))
+    }
+
+    @Test func posProductVariation_decodes_location_stock_array_with_pos_entry() throws {
+        // Given
+        let json = """
+        {
+            "id": 123,
+            "parent_id": 119,
+            "attributes": [],
+            "price": "15.00",
+            "downloadable": false,
+            "manage_stock": true,
+            "stock_quantity": 9,
+            "stock_status": "instock",
+            "type": "variation",
+            "location_stock": [
+                {
+                    "slug": "warehouse",
+                    "name": "Warehouse",
+                    "quantity": 9,
+                    "stock_status": "instock"
+                },
+                {
+                    "slug": "pos",
+                    "name": "POS",
+                    "quantity": 3,
+                    "stock_status": "instock"
+                }
+            ]
+        }
+        """
+
+        // When
+        let variation = try decodePOSProductVariation(from: json)
+
+        // Then
+        #expect(variation.locationStock.count == 2)
+        #expect(variation.pointOfSaleStockQuantity == 3)
+    }
+
+    @Test func posProductVariation_decodes_location_stock_without_removed_fields() throws {
+        // Given
+        let json = """
+        {
+            "id": 123,
+            "parent_id": 119,
+            "attributes": [],
+            "price": "15.00",
+            "downloadable": false,
+            "manage_stock": true,
+            "stock_quantity": 9,
+            "stock_status": "instock",
+            "type": "variation",
+            "location_stock": [
+                {
+                    "slug": "pos",
+                    "name": "POS",
+                    "quantity": 3,
+                    "stock_status": "instock"
+                }
+            ]
+        }
+        """
+
+        // When
+        let variation = try decodePOSProductVariation(from: json)
+
+        // Then
+        #expect(variation.pointOfSaleStockQuantity == 3)
+    }
+
+    @Test func posProductVariation_without_pos_location_stock_has_nil_pos_stock_quantity() throws {
+        // Given
+        let json = """
+        {
+            "id": 123,
+            "parent_id": 119,
+            "attributes": [],
+            "price": "15.00",
+            "downloadable": false,
+            "manage_stock": true,
+            "stock_quantity": 9,
+            "stock_status": "instock",
+            "type": "variation",
+            "location_stock": [
+                {
+                    "slug": "warehouse",
+                    "name": "Warehouse",
+                    "quantity": 9,
+                    "stock_status": "instock"
+                }
+            ]
+        }
+        """
+
+        // When
+        let variation = try decodePOSProductVariation(from: json)
+
+        // Then
+        #expect(variation.pointOfSaleStockQuantity == nil)
     }
 
     // MARK: - Count Endpoints Tests
@@ -652,8 +753,12 @@ struct POSCatalogSyncRemoteTests {
 
         // Then
         let queryParametersDictionary = try #require(network.queryParametersDictionary as? [String: any Hashable])
-        #expect(queryParametersDictionary["_product_fields"] as? String == POSProduct.requestFields.joined(separator: ","))
-        #expect(queryParametersDictionary["_variation_fields"] as? String == POSProductVariation.requestFields.joined(separator: ","))
+        let productFields = try #require(queryParametersDictionary["_product_fields"] as? String)
+        let variationFields = try #require(queryParametersDictionary["_variation_fields"] as? String)
+        #expect(productFields == POSProduct.requestFields.joined(separator: ","))
+        #expect(variationFields == POSProductVariation.requestFields.joined(separator: ","))
+        #expect(productFields.split(separator: ",").contains("location_stock"))
+        #expect(variationFields.split(separator: ",").contains("location_stock"))
         #expect(queryParametersDictionary["force"] == nil)
     }
 
@@ -707,6 +812,8 @@ struct POSCatalogSyncRemoteTests {
         #expect(simpleProduct.name == "Synergistic Copper Clock")
         #expect(simpleProduct.price == "220")
         #expect(simpleProduct.stockStatusKey == "instock")
+        #expect(simpleProduct.locationStock.count == 2)
+        #expect(simpleProduct.pointOfSaleStockQuantity == 7)
         #expect(simpleProduct.images.count == 1)
         #expect(simpleProduct.images.first?.src == "https://example.com/wp-content/uploads/2025/08/img-ad.png")
 
@@ -739,6 +846,8 @@ struct POSCatalogSyncRemoteTests {
         #expect(variation.sku?.isEmpty == true)
         #expect(variation.globalUniqueID?.isEmpty == true)
         #expect(variation.price == "330.34")
+        #expect(variation.locationStock.count == 2)
+        #expect(variation.pointOfSaleStockQuantity == 4)
         #expect(variation.attributes.count == 3)
         #expect(variation.image?.src == "https://example.com/wp-content/uploads/2025/08/img-quae.png")
         #expect(variation.attributes == [
@@ -1074,6 +1183,12 @@ private extension POSCatalogSyncRemoteTests {
                              backgroundDownloader: mockBackgroundDownloader,
                              fileManager: mockFileManager,
                              backgroundDownloadStateStore: backgroundDownloadStateStore)
+    }
+
+    func decodePOSProductVariation(from json: String) throws -> POSProductVariation {
+        let decoder = JSONDecoder()
+        decoder.userInfo[.siteID] = sampleSiteID
+        return try decoder.decode(POSProductVariation.self, from: Data(json.utf8))
     }
 
     /// Loads test data from bundle response file.

--- a/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSProductsNetworkingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Networking
 @testable import NetworkingCore
@@ -195,6 +196,121 @@ struct POSProductsNetworkingTests {
         #expect(fieldNames.contains("manage_stock"))
         #expect(fieldNames.contains("stock_quantity"))
         #expect(fieldNames.contains("stock_status"))
+        #expect(fieldNames.contains("location_stock"))
+    }
+
+    @Test func posProduct_decodes_location_stock_array_with_pos_entry() throws {
+        // Given
+        let json = """
+        {
+            "id": 100,
+            "name": "POS Stock Product",
+            "type": "simple",
+            "downloadable": false,
+            "parent_id": 0,
+            "images": [],
+            "attributes": [],
+            "manage_stock": true,
+            "stock_quantity": 12,
+            "stock_status": "instock",
+            "status": "publish",
+            "variations": [],
+            "location_stock": [
+                {
+                    "slug": "warehouse",
+                    "name": "Warehouse",
+                    "quantity": 12,
+                    "stock_status": "instock"
+                },
+                {
+                    "slug": "pos",
+                    "name": "POS",
+                    "quantity": 4,
+                    "stock_status": "instock"
+                }
+            ]
+        }
+        """
+
+        // When
+        let product = try decodePOSProduct(from: json)
+
+        // Then
+        #expect(product.locationStock.count == 2)
+        let posStock = try #require(product.locationStock.first { $0.slug == "pos" })
+        #expect(posStock.name == "POS")
+        #expect(posStock.quantity == 4)
+        #expect(posStock.stockStatusKey == "instock")
+        #expect(product.pointOfSaleStockQuantity == 4)
+    }
+
+    @Test func posProduct_decodes_location_stock_without_removed_fields() throws {
+        // Given
+        let json = """
+        {
+            "id": 101,
+            "name": "Minimal Location Stock Product",
+            "type": "simple",
+            "downloadable": false,
+            "parent_id": 0,
+            "images": [],
+            "attributes": [],
+            "manage_stock": true,
+            "stock_quantity": 8,
+            "stock_status": "instock",
+            "status": "publish",
+            "variations": [],
+            "location_stock": [
+                {
+                    "slug": "pos",
+                    "name": "POS",
+                    "quantity": 0,
+                    "stock_status": "outofstock"
+                }
+            ]
+        }
+        """
+
+        // When
+        let product = try decodePOSProduct(from: json)
+
+        // Then
+        #expect(product.pointOfSaleStockQuantity == 0)
+        #expect(product.locationStock.first?.stockStatusKey == "outofstock")
+    }
+
+    @Test func posProduct_returns_nil_pointOfSaleStockQuantity_without_pos_location_stock() throws {
+        // Given
+        let json = """
+        {
+            "id": 102,
+            "name": "Warehouse Stock Product",
+            "type": "simple",
+            "downloadable": false,
+            "parent_id": 0,
+            "images": [],
+            "attributes": [],
+            "manage_stock": true,
+            "stock_quantity": 6,
+            "stock_status": "instock",
+            "status": "publish",
+            "variations": [],
+            "location_stock": [
+                {
+                    "slug": "warehouse",
+                    "name": "Warehouse",
+                    "quantity": 6,
+                    "stock_status": "instock"
+                }
+            ]
+        }
+        """
+
+        // When
+        let product = try decodePOSProduct(from: json)
+
+        // Then
+        #expect(product.pointOfSaleStockQuantity == nil)
     }
 
     @Test func loadProductsForPointOfSale_requests_only_required_fields() async throws {
@@ -353,5 +469,11 @@ struct POSProductsNetworkingTests {
         // Then
         let request = try #require(network.requestsForResponseData.first as? JetpackRequest)
         #expect(request.parameters["pos_products_only"] as? String == "true")
+    }
+
+    private func decodePOSProduct(from json: String) throws -> POSProduct {
+        let decoder = JSONDecoder()
+        decoder.userInfo[.siteID] = sampleSiteID
+        return try decoder.decode(POSProduct.self, from: Data(json.utf8))
     }
 }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-catalog-download-mixed.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-catalog-download-mixed.json
@@ -11,6 +11,20 @@
       "stock_status": "instock",
       "manage_stock": false,
       "stock_quantity": null,
+      "location_stock": [
+        {
+          "slug": "warehouse",
+          "name": "Warehouse",
+          "quantity": 22,
+          "stock_status": "instock"
+        },
+        {
+          "slug": "pos",
+          "name": "POS",
+          "quantity": 7,
+          "stock_status": "instock"
+        }
+      ],
       "price": 220,
       "images": [
         {
@@ -119,6 +133,20 @@
       "stock_status": "instock",
       "manage_stock": true,
       "stock_quantity": 69,
+      "location_stock": [
+        {
+          "slug": "warehouse",
+          "name": "Warehouse",
+          "quantity": 69,
+          "stock_status": "instock"
+        },
+        {
+          "slug": "pos",
+          "name": "POS",
+          "quantity": 4,
+          "stock_status": "instock"
+        }
+      ],
       "price": 330.34,
       "image": {
         "id": 62,

--- a/Modules/Tests/PointOfSaleTests/Presentation/POSStockFormatterTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Presentation/POSStockFormatterTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import struct Yosemite.POSSimpleProduct
+import struct Yosemite.POSVariation
 @testable import PointOfSale
 
 struct POSStockFormatterTests {
@@ -98,9 +99,49 @@ struct POSStockFormatterTests {
         #expect(stockLabel == "Out of stock")
     }
 
-    // Disabled temporarily due to failure to code freeze 22.5
-    // Context: p1748609128918879?thread_ts=1748592083.887729&cid=CC7L49W13-slack-CC7L49W13
-    @Test(.disabled()) func test_when_managestock_enabled_and_stockQuantity_is_positive_then_returns_number_in_stock_stockLabel() async throws {
+    @Test func test_when_pointOfSaleStockQuantity_is_available_then_returns_pos_stock_quantity_label() async throws {
+        // Given
+        let product = POSSimpleProduct.fake().copy(manageStock: false,
+                                                   stockQuantity: 99,
+                                                   stockStatusKey: "outofstock",
+                                                   pointOfSaleStockQuantity: 4)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: product)
+
+        // Then
+        #expect(stockLabel == "4 in stock")
+    }
+
+    @Test func test_when_pointOfSaleStockQuantity_is_zero_then_returns_out_of_stock_label() async throws {
+        // Given
+        let product = POSSimpleProduct.fake().copy(manageStock: true,
+                                                   stockQuantity: 99,
+                                                   stockStatusKey: "instock",
+                                                   pointOfSaleStockQuantity: 0)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: product)
+
+        // Then
+        #expect(stockLabel == "Out of stock")
+    }
+
+    @Test func test_when_pointOfSaleStockQuantity_is_not_available_then_falls_back_to_core_stock_quantity() async throws {
+        // Given
+        let product = POSSimpleProduct.fake().copy(manageStock: true,
+                                                   stockQuantity: 0,
+                                                   stockStatusKey: "instock",
+                                                   pointOfSaleStockQuantity: nil)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: product)
+
+        // Then
+        #expect(stockLabel == "Out of stock")
+    }
+
+    @Test func test_when_managestock_enabled_and_stockQuantity_is_positive_then_returns_number_in_stock_stockLabel() async throws {
         // Given
         let manageStockEnabled: Bool = true
         let stockQuantity: Decimal = 5
@@ -112,5 +153,147 @@ struct POSStockFormatterTests {
 
         // Then
         #expect(stockLabel == "5 in stock")
+    }
+
+    @Test func test_when_variation_pointOfSaleStockQuantity_is_available_then_returns_pos_stock_quantity_label() async throws {
+        // Given
+        let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 123),
+                                     name: "Variation",
+                                     formattedPrice: "$10.00",
+                                     price: "10.00",
+                                     productID: 456,
+                                     variationID: 123,
+                                     parentProductName: "Product",
+                                     manageStock: false,
+                                     stockQuantity: 99,
+                                     stockStatusKey: "outofstock",
+                                     pointOfSaleStockQuantity: 4)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: variation)
+
+        // Then
+        #expect(stockLabel == "4 in stock")
+    }
+
+    @Test func test_when_variation_pointOfSaleStockQuantity_is_not_available_then_falls_back_to_core_stock_quantity() async throws {
+        // Given
+        let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 123),
+                                     name: "Variation",
+                                     formattedPrice: "$10.00",
+                                     price: "10.00",
+                                     productID: 456,
+                                     variationID: 123,
+                                     parentProductName: "Product",
+                                     manageStock: true,
+                                     stockQuantity: 5,
+                                     stockStatusKey: "instock",
+                                     pointOfSaleStockQuantity: nil)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: variation)
+
+        // Then
+        #expect(stockLabel == "5 in stock")
+    }
+
+    @Test func test_when_variation_has_no_own_pos_or_core_stock_then_uses_parent_pos_stock_quantity() async throws {
+        // Given
+        let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 123),
+                                     name: "Variation",
+                                     formattedPrice: "$10.00",
+                                     price: "10.00",
+                                     productID: 456,
+                                     variationID: 123,
+                                     parentProductName: "Product",
+                                     manageStock: false,
+                                     stockQuantity: nil,
+                                     stockStatusKey: "outofstock",
+                                     pointOfSaleStockQuantity: nil,
+                                     parentManageStock: true,
+                                     parentStockQuantity: 8,
+                                     parentStockStatusKey: "instock",
+                                     parentPointOfSaleStockQuantity: 6)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: variation)
+
+        // Then
+        #expect(stockLabel == "6 in stock")
+    }
+
+    @Test func test_when_variation_has_no_own_stock_or_parent_pos_stock_then_uses_parent_core_stock_quantity() async throws {
+        // Given
+        let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 123),
+                                     name: "Variation",
+                                     formattedPrice: "$10.00",
+                                     price: "10.00",
+                                     productID: 456,
+                                     variationID: 123,
+                                     parentProductName: "Product",
+                                     manageStock: false,
+                                     stockQuantity: nil,
+                                     stockStatusKey: "outofstock",
+                                     pointOfSaleStockQuantity: nil,
+                                     parentManageStock: true,
+                                     parentStockQuantity: 8,
+                                     parentStockStatusKey: "instock",
+                                     parentPointOfSaleStockQuantity: nil)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: variation)
+
+        // Then
+        #expect(stockLabel == "8 in stock")
+    }
+
+    @Test func test_when_variation_has_own_pos_stock_then_it_overrides_parent_stock() async throws {
+        // Given
+        let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 123),
+                                     name: "Variation",
+                                     formattedPrice: "$10.00",
+                                     price: "10.00",
+                                     productID: 456,
+                                     variationID: 123,
+                                     parentProductName: "Product",
+                                     manageStock: false,
+                                     stockQuantity: nil,
+                                     stockStatusKey: "outofstock",
+                                     pointOfSaleStockQuantity: 2,
+                                     parentManageStock: true,
+                                     parentStockQuantity: 8,
+                                     parentStockStatusKey: "instock",
+                                     parentPointOfSaleStockQuantity: 6)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: variation)
+
+        // Then
+        #expect(stockLabel == "2 in stock")
+    }
+
+    @Test func test_when_variation_has_own_core_stock_then_it_overrides_parent_stock() async throws {
+        // Given
+        let variation = POSVariation(id: .init(underlyingType: .variation, itemID: 123),
+                                     name: "Variation",
+                                     formattedPrice: "$10.00",
+                                     price: "10.00",
+                                     productID: 456,
+                                     variationID: 123,
+                                     parentProductName: "Product",
+                                     manageStock: true,
+                                     stockQuantity: 3,
+                                     stockStatusKey: "instock",
+                                     pointOfSaleStockQuantity: nil,
+                                     parentManageStock: true,
+                                     parentStockQuantity: 8,
+                                     parentStockStatusKey: "instock",
+                                     parentPointOfSaleStockQuantity: 6)
+
+        // When
+        let stockLabel = POSStockFormatter.stockStatusLabel(for: variation)
+
+        // Then
+        #expect(stockLabel == "3 in stock")
     }
 }

--- a/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
+++ b/Modules/Tests/StorageTests/GRDB/GRDBManagerTests.swift
@@ -147,6 +147,28 @@ struct GRDBManagerTests {
         }
     }
 
+    // MARK: - V004 Migration Tests
+
+    struct V004MigrationTests {
+        @Test("V004 migration adds pointOfSaleStockQuantity column to product and productVariation tables")
+        func test_v004_migration_adds_pointOfSaleStockQuantity_column() throws {
+            // Given
+            let manager = try GRDBManager()
+
+            // When
+            let columns = try manager.databaseConnection.read { db in
+                (
+                    try db.columns(in: "product").map(\.name),
+                    try db.columns(in: "productVariation").map(\.name)
+                )
+            }
+
+            // Then
+            #expect(columns.0.contains("pointOfSaleStockQuantity"))
+            #expect(columns.1.contains("pointOfSaleStockQuantity"))
+        }
+    }
+
     // MARK: - CRUD Tests
 
     struct CRUDTests {

--- a/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/GRDBObservableDataSourceTests.swift
@@ -120,7 +120,13 @@ struct GRDBObservableDataSourceTests {
     @Test("Load variations for parent product")
     func test_load_variations_for_parent_product() async throws {
         // Given: Insert parent product and variations
-        let parentProduct = createPersistedProduct(id: 100, name: "Parent", type: "variable")
+        let parentProduct = createPersistedProduct(id: 100,
+                                                   name: "Parent",
+                                                   type: "variable",
+                                                   manageStock: true,
+                                                   stockQuantity: 8,
+                                                   stockStatusKey: "instock",
+                                                   pointOfSaleStockQuantity: 6)
         try await insertProducts([parentProduct])
         try await insertTestVariations(parentID: 100, count: 3)
 
@@ -141,6 +147,15 @@ struct GRDBObservableDataSourceTests {
         #expect(sut.variationItems.count == 3)
         #expect(sut.isLoadingVariations == false)
         #expect(sut.productItems.isEmpty) // Products should remain unaffected
+
+        guard case .variation(let firstVariation) = sut.variationItems.first else {
+            Issue.record("First item should be variation")
+            return
+        }
+        #expect(firstVariation.parentManageStock == true)
+        #expect(firstVariation.parentStockQuantity == 8)
+        #expect(firstVariation.parentStockStatusKey == "instock")
+        #expect(firstVariation.parentPointOfSaleStockQuantity == 6)
     }
 
     @Test("Load variations is idempotent for same parent")
@@ -767,7 +782,13 @@ struct GRDBObservableDataSourceTests {
         }
     }
 
-    private func createPersistedProduct(id: Int64, name: String, type: String) -> PersistedProduct {
+    private func createPersistedProduct(id: Int64,
+                                        name: String,
+                                        type: String,
+                                        manageStock: Bool = false,
+                                        stockQuantity: Decimal? = nil,
+                                        stockStatusKey: String = "instock",
+                                        pointOfSaleStockQuantity: Decimal? = nil) -> PersistedProduct {
         PersistedProduct(
             id: id,
             siteID: siteID,
@@ -780,9 +801,10 @@ struct GRDBObservableDataSourceTests {
             price: "10.00",
             downloadable: false,
             parentID: 0,
-            manageStock: false,
-            stockQuantity: nil,
-            stockStatusKey: "instock",
+            manageStock: manageStock,
+            stockQuantity: stockQuantity,
+            stockStatusKey: stockStatusKey,
+            pointOfSaleStockQuantity: pointOfSaleStockQuantity,
             statusKey: "publish"
         )
     }

--- a/Modules/Tests/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/POSProductOrVariationResolverTests.swift
@@ -59,19 +59,28 @@ struct POSProductOrVariationResolverTests {
             name: "Variation",
             productTypeKey: "variation",
             price: "15.00",
-            parentID: 123
+            parentID: 123,
+            locationStock: [.pointOfSale(quantity: 4)]
         )
         let parentProduct = POSProduct.fake().copy(
             productID: 123,
             name: "Parent Product",
-            productTypeKey: "variable"
+            productTypeKey: "variable",
+            manageStock: true,
+            stockQuantity: 9,
+            stockStatusKey: "instock",
+            locationStock: [.pointOfSale(quantity: 7)]
         )
         let expectedParentItem = POSItem.variableParentProduct(POSVariableParentProduct(
             id: POSItemIdentifier(underlyingType: .product, itemID: 1),
             name: "Parent Product",
             productImageSource: nil,
             productID: 123,
-            allAttributes: []
+            allAttributes: [],
+            manageStock: true,
+            stockQuantity: 9,
+            stockStatusKey: "instock",
+            pointOfSaleStockQuantity: 7
         ))
         let expectedVariationItem = POSItem.variation(POSVariation(
             id: POSItemIdentifier(underlyingType: .product, itemID: 1),
@@ -99,6 +108,8 @@ struct POSProductOrVariationResolverTests {
         #expect(mockItemMapper.mapVariationsToPOSItemsCalled)
         #expect(mockItemMapper.mockVariations.count == 1)
         #expect(mockItemMapper.mockVariations.first?.productVariationID == 456)
+        #expect(mockItemMapper.mockVariations.first?.pointOfSaleStockQuantity == 4)
+        #expect(mockItemMapper.mockParentProduct?.pointOfSaleStockQuantity == 7)
         #expect(result == expectedVariationItem)
     }
 

--- a/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemMapperTests.swift
+++ b/Modules/Tests/YosemiteTests/PointOfSale/PointOfSaleItemMapperTests.swift
@@ -54,6 +54,7 @@ struct PointOfSaleItemMapperTests {
                 #expect(mappedProduct.manageStock == product.manageStock)
                 #expect(mappedProduct.stockQuantity == product.stockQuantity)
                 #expect(mappedProduct.stockStatusKey == product.stockStatusKey)
+                #expect(mappedProduct.pointOfSaleStockQuantity == product.pointOfSaleStockQuantity)
 
             case "variable":
                 guard case let .variableParentProduct(mappedProduct) = items[index] else {
@@ -113,6 +114,105 @@ struct PointOfSaleItemMapperTests {
         }
     }
 
+    @Test("Map variation to POS item includes POS location stock quantity")
+    func mapVariationToPOSItem_includes_pos_location_stock_quantity() {
+        // Given
+        let variation = POSProductVariation.fake().copy(
+            productID: 125,
+            productVariationID: 456,
+            attributes: [ProductVariationAttribute.fake().copy(name: "Color", option: "Red")],
+            manageStock: true,
+            stockQuantity: 10,
+            stockStatusKey: "instock",
+            locationStock: [.pointOfSale(quantity: 4)]
+        )
+        let parentProduct = Self.createParentProduct()
+
+        // When
+        let items = sut.mapVariationsToPOSItems(variations: [variation], parentProduct: parentProduct)
+
+        // Then
+        guard case let .variation(mappedVariation) = items.first else {
+            Issue.record("Expected variation, but got \(String(describing: items.first))")
+            return
+        }
+        #expect(mappedVariation.manageStock == variation.manageStock)
+        #expect(mappedVariation.stockQuantity == variation.stockQuantity)
+        #expect(mappedVariation.stockStatusKey == variation.stockStatusKey)
+        #expect(mappedVariation.pointOfSaleStockQuantity == variation.pointOfSaleStockQuantity)
+    }
+
+    @Test("Map variation to POS item includes parent stock for inherited stock display")
+    func mapVariationToPOSItem_includes_parent_stock_for_inherited_stock_display() {
+        // Given
+        let variation = POSProductVariation.fake().copy(
+            productID: 125,
+            productVariationID: 456,
+            attributes: [ProductVariationAttribute.fake().copy(name: "Color", option: "Red")],
+            manageStock: false,
+            stockQuantity: nil,
+            stockStatusKey: "outofstock",
+            locationStock: []
+        )
+        let parentProduct = POSVariableParentProduct(
+            id: POSItemIdentifier(underlyingType: .product, itemID: 125),
+            name: "Parent Product",
+            productImageSource: nil,
+            productID: 125,
+            allAttributes: [ProductAttribute.fake().copy(name: "Color", options: ["Red"])],
+            manageStock: true,
+            stockQuantity: 8,
+            stockStatusKey: "instock",
+            pointOfSaleStockQuantity: 6
+        )
+
+        // When
+        let items = sut.mapVariationsToPOSItems(variations: [variation], parentProduct: parentProduct)
+
+        // Then
+        guard case let .variation(mappedVariation) = items.first else {
+            Issue.record("Expected variation, but got \(String(describing: items.first))")
+            return
+        }
+        #expect(mappedVariation.parentManageStock == parentProduct.manageStock)
+        #expect(mappedVariation.parentStockQuantity == parentProduct.stockQuantity)
+        #expect(mappedVariation.parentStockStatusKey == parentProduct.stockStatusKey)
+        #expect(mappedVariation.parentPointOfSaleStockQuantity == parentProduct.pointOfSaleStockQuantity)
+    }
+
+    @Test("Map search result variation includes POS location stock quantity")
+    func mapSearchResultVariation_includes_pos_location_stock_quantity() {
+        // Given
+        let variation = POSProductVariation.fake().copy(
+            productID: 125,
+            productVariationID: 456,
+            attributes: [ProductVariationAttribute.fake().copy(name: "Color", option: "Red")],
+            manageStock: true,
+            stockQuantity: 10,
+            stockStatusKey: "instock",
+            locationStock: [.pointOfSale(quantity: 4)]
+        )
+        let parentProduct = POSProduct.fake().copy(
+            productID: 125,
+            name: "Variable Product",
+            productTypeKey: "variable",
+            attributes: [ProductAttribute.fake().copy(name: "Color", variation: true, options: ["Red"])]
+        )
+
+        // When
+        let item = sut.mapVariationToSearchResultPOSItem(variation: variation, parentProduct: parentProduct)
+
+        // Then
+        guard case let .searchResultVariation(mappedVariation, _) = item else {
+            Issue.record("Expected search result variation, but got \(String(describing: item))")
+            return
+        }
+        #expect(mappedVariation.manageStock == variation.manageStock)
+        #expect(mappedVariation.stockQuantity == variation.stockQuantity)
+        #expect(mappedVariation.stockStatusKey == variation.stockStatusKey)
+        #expect(mappedVariation.pointOfSaleStockQuantity == variation.pointOfSaleStockQuantity)
+    }
+
     @Test("Format price correctly",
           arguments: [
             // Test valid price
@@ -136,6 +236,32 @@ struct PointOfSaleItemMapperTests {
         #expect(simpleProduct.formattedPrice == expectedPrice)
     }
 
+    @Test("Map simple product without POS location stock leaves POS stock quantity unset")
+    func mapSimpleProduct_without_pos_location_stock_leaves_pos_stock_quantity_unset() {
+        // Given
+        let product = POSProduct.fake().copy(
+            productTypeKey: "simple",
+            stockQuantity: 6,
+            locationStock: [
+                POSLocationStock(slug: "warehouse",
+                                 name: "Warehouse",
+                                 quantity: 6,
+                                 stockStatusKey: "instock")
+            ]
+        )
+
+        // When
+        let items = sut.mapProductsToPOSItems(products: [product])
+
+        // Then
+        guard case let .simpleProduct(simpleProduct) = items.first else {
+            Issue.record("Expected simple product, but got \(String(describing: items.first))")
+            return
+        }
+        #expect(simpleProduct.stockQuantity == 6)
+        #expect(simpleProduct.pointOfSaleStockQuantity == nil)
+    }
+
     // MARK: - Test Data Factory Methods
 
     private static func createSimpleProduct1() -> POSProduct {
@@ -147,7 +273,8 @@ struct PointOfSaleItemMapperTests {
             images: [.fake().copy(src: "https://example.com/image1.jpg")],
             manageStock: true,
             stockQuantity: 10,
-            stockStatusKey: "instock"
+            stockStatusKey: "instock",
+            locationStock: [.pointOfSale(quantity: 3)]
         )
     }
 

--- a/Modules/Tests/YosemiteTests/Storage/PersistedProductTests.swift
+++ b/Modules/Tests/YosemiteTests/Storage/PersistedProductTests.swift
@@ -29,7 +29,8 @@ struct PersistedProductTests {
             stockQuantity: 5,
             stockStatusKey: "instock",
             statusKey: "publish",
-            variationIDs: []
+            variationIDs: [],
+            locationStock: [.pointOfSale(quantity: 3)]
         )
 
         // When
@@ -50,6 +51,7 @@ struct PersistedProductTests {
         #expect(persisted.manageStock == posProduct.manageStock)
         #expect(persisted.stockQuantity == posProduct.stockQuantity)
         #expect(persisted.stockStatusKey == posProduct.stockStatusKey)
+        #expect(persisted.pointOfSaleStockQuantity == posProduct.pointOfSaleStockQuantity)
         #expect(persisted.statusKey == posProduct.statusKey)
     }
 
@@ -73,6 +75,7 @@ struct PersistedProductTests {
             manageStock: false,
             stockQuantity: nil,
             stockStatusKey: "outofstock",
+            pointOfSaleStockQuantity: 7,
             statusKey: "publish"
         )
 
@@ -133,6 +136,8 @@ struct PersistedProductTests {
         #expect(posProduct.manageStock == persisted.manageStock)
         #expect(posProduct.stockQuantity == persisted.stockQuantity)
         #expect(posProduct.stockStatusKey == persisted.stockStatusKey)
+        #expect(posProduct.pointOfSaleStockQuantity == persisted.pointOfSaleStockQuantity)
+        #expect(posProduct.locationStock.first?.slug == "pos")
         #expect(posProduct.statusKey == persisted.statusKey)
         #expect(posProduct.images.count == 2)
         #expect(posProduct.attributes.count == 2)
@@ -518,7 +523,8 @@ struct PersistedProductTests {
             stockQuantity: 50,
             stockStatusKey: "instock",
             statusKey: "publish",
-            variationIDs: []
+            variationIDs: [],
+            locationStock: [.pointOfSale(quantity: 9)]
         )
 
         // When saving and loading back
@@ -536,6 +542,7 @@ struct PersistedProductTests {
         #expect(loadedPOSProduct.fullDescription == posProduct.fullDescription)
         #expect(loadedPOSProduct.shortDescription == posProduct.shortDescription)
         #expect(loadedPOSProduct.sku == posProduct.sku)
+        #expect(loadedPOSProduct.pointOfSaleStockQuantity == posProduct.pointOfSaleStockQuantity)
         #expect(loadedPOSProduct.images.count == 2)
         #expect(loadedPOSProduct.attributes.count == 2)
 

--- a/Modules/Tests/YosemiteTests/Storage/PersistedProductVariationTests.swift
+++ b/Modules/Tests/YosemiteTests/Storage/PersistedProductVariationTests.swift
@@ -36,7 +36,8 @@ struct PersistedProductVariationTests {
             downloadable: false,
             manageStock: true,
             stockQuantity: 2,
-            stockStatusKey: "instock"
+            stockStatusKey: "instock",
+            locationStock: [.pointOfSale(quantity: 4)]
         )
 
         // When
@@ -53,6 +54,7 @@ struct PersistedProductVariationTests {
         #expect(persisted.fullDescription == pos.fullDescription)
         #expect(persisted.manageStock == pos.manageStock)
         #expect(persisted.stockQuantity == pos.stockQuantity)
+        #expect(persisted.pointOfSaleStockQuantity == pos.pointOfSaleStockQuantity)
         #expect(persisted.stockStatusKey == pos.stockStatusKey)
     }
 
@@ -73,6 +75,7 @@ struct PersistedProductVariationTests {
             fullDescription: "Full",
             manageStock: false,
             stockQuantity: nil,
+            pointOfSaleStockQuantity: 5,
             stockStatusKey: "outofstock"
         )
 
@@ -114,6 +117,7 @@ struct PersistedProductVariationTests {
         #expect(pos.fullDescription == persisted.fullDescription)
         #expect(pos.manageStock == persisted.manageStock)
         #expect(pos.stockQuantity == persisted.stockQuantity)
+        #expect(pos.pointOfSaleStockQuantity == persisted.pointOfSaleStockQuantity)
         #expect(pos.stockStatusKey == persisted.stockStatusKey)
         #expect(pos.attributes.count == 2)
         #expect(pos.image?.imageID == varImage.id)
@@ -564,7 +568,8 @@ struct PersistedProductVariationTests {
             downloadable: false,
             manageStock: true,
             stockQuantity: 25,
-            stockStatusKey: "instock"
+            stockStatusKey: "instock",
+            locationStock: [.pointOfSale(quantity: 8)]
         )
 
         // When saving and loading back
@@ -584,6 +589,7 @@ struct PersistedProductVariationTests {
         #expect(loadedPOSVariation.sku == posVariation.sku)
         #expect(loadedPOSVariation.price == posVariation.price)
         #expect(loadedPOSVariation.stockQuantity == posVariation.stockQuantity)
+        #expect(loadedPOSVariation.pointOfSaleStockQuantity == posVariation.pointOfSaleStockQuantity)
         #expect(loadedPOSVariation.attributes.count == 2)
         #expect(loadedPOSVariation.image != nil)
 


### PR DESCRIPTION
## Description
DO NOT MERGE: draft spike for consuming the WooCommerce Core POS-only location stock behavior.

This adds narrow POS support for `location_stock` with `slug == "pos"` on products and variations, keeps Core stock as the fallback, and sends `inventory_location=pos` for POS REST order creation only. It also updates the POS catalog persistence/display path so variations without their own POS stock can inherit parent POS/Core stock, while variation-level stock still overrides the parent.

Notes:
- This is intentionally a spike PR and may exceed the normal non-test diff guidance.
- No generic multi-location inventory UI or arbitrary location selection is introduced.
- Release notes are intentionally not added while this remains DNM spike work.

## Test Steps
- `xcodebuild -workspace WooCommerce.xcworkspace -scheme Networking -destination 'platform=iOS Simulator,id=6E32D759-B6D7-43C1-A9C9-0FC44D85C8AC' -sdk iphonesimulator test -only-testing:NetworkingTests/POSCatalogSyncRemoteTests`
- `xcodebuild -workspace WooCommerce.xcworkspace -scheme PointOfSale -destination 'platform=iOS Simulator,id=6E32D759-B6D7-43C1-A9C9-0FC44D85C8AC' -sdk iphonesimulator test -only-testing:PointOfSaleTests/POSStockFormatterTests`
- `xcodebuild -workspace WooCommerce.xcworkspace -scheme Yosemite -destination 'platform=iOS Simulator,id=6E32D759-B6D7-43C1-A9C9-0FC44D85C8AC' -sdk iphonesimulator test -only-testing:YosemiteTests/PointOfSaleItemMapperTests -only-testing:YosemiteTests/POSProductOrVariationResolverTests`
- `xcodebuild -workspace WooCommerce.xcworkspace -scheme Yosemite -destination 'platform=iOS Simulator,id=6E32D759-B6D7-43C1-A9C9-0FC44D85C8AC' -sdk iphonesimulator test -only-testing:YosemiteTests/GRDBObservableDataSourceTests`
- Previous focused runs for POS product decoding, storage migration, persistence conversion, and order remote behavior passed during the spike.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
