### PR TITLE
Downsample Order Details product thumbnails to cell size

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.0
 -----
+- [internal] Reduced memory use on Order Details by downsampling product thumbnails to the cell size instead of a large fallback. [https://github.com/woocommerce/woocommerce-ios/pull/17341]
 - [*] Fixed order refunds hiding duplicate product lines after one matching line was refunded. [https://github.com/woocommerce/woocommerce-ios/pull/17313]
 - [*] Added age-eligibility verification to comply with App Store requirements [https://github.com/woocommerce/woocommerce-ios/pull/17321]
 - [*] Fixed refunds for orders with multiple shipping lines so all shipping lines can be refunded. [https://github.com/woocommerce/woocommerce-ios/pull/17312]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
@@ -112,6 +112,9 @@ extension PickListTableViewCell {
     /// Configure a pick list cell
     ///
     func configure(item: ProductDetailsCellViewModel, imageService: ImageService) {
+        /// Make sure `productImageView` is laid out and gained bounds, so the image is
+        /// downsampled to the thumbnail size rather than the large fallback size.
+        productImageView.layoutIfNeeded()
         imageService.downloadAndCacheImageForImageView(productImageView,
                                                        with: item.imageURL?.absoluteString,
                                                        placeholder: UIImage.productPlaceholderImage.imageWithTintColor(UIColor.listIcon),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -185,6 +185,9 @@ extension ProductDetailsTableViewCell {
     /// Configure a product detail cell
     ///
     func configure(item: ProductDetailsCellViewModel, imageService: ImageService) {
+        /// Make sure `productImageView` is laid out and gained bounds, so the image is
+        /// downsampled to the thumbnail size rather than the large fallback size.
+        productImageView.layoutIfNeeded()
         imageService.downloadAndCacheImageForImageView(productImageView,
                                                        with: item.imageURL?.absoluteString,
                                                        placeholder: UIImage.productPlaceholderImage.imageWithTintColor(UIColor.listIcon),


### PR DESCRIPTION
## Description
Part of WOOMOB-420 (top WatchdogTermination / OOM crash).

Order Details product thumbnails (`ProductDetailsTableViewCell` and `PickListTableViewCell`) call `imageService.downloadAndCacheImageForImageView(_:)` before their image view has been laid out. When `productImageView.bounds` is empty at configure time, `DefaultImageService` falls back to an 800×800 `DownsamplingImageProcessor` target (~2.5 MB decoded) instead of the 44pt cell size (~70 KB decoded, ≈132×132 at 3×).

This calls `productImageView.layoutIfNeeded()` before the download so the thumbnail is downsampled to its display size. The image view is pinned to a fixed 44×44 in both XIBs, so the forced layout reliably yields real bounds. Order Details reloads frequently (status changes, app foreground), so this trims repeated memory spikes.

It applies to Order Details the same fix #15815 made for the Products list cell (`ProductsTabProductTableViewCell`), which left these two cells out.

## Test Steps
1. Open an order with several product line items (ideally on a store with large product images).
2. Confirm thumbnails render correctly — no clipping, placeholder, or aspect-ratio regressions.
3. With Xcode's view/layout inspector, select a product thumbnail and verify the underlying `UIImage` size matches the 44pt view size × screen scale (≈132×132 on a 3× device), not the original/800×800 image.
4. Repeat for the pick-list cell (orders that surface the pick list).

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.