### PR TITLE
Add tracking events for UPS and FedEx ToS

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -1415,6 +1415,7 @@ public enum WooAnalyticsStat: String {
     case wooShippingPaymentStep = "wcs_payment_step"
     case wooShippingPurchaseStep = "wcs_purchase_step"
     case wooShippingRefundRequested = "wcs_refund_requested"
+    case wooShippingCarrierTermsOfService = "wcs_carrier_tos"
 
     // MARK: Support Chat events
     case supportChatEntryPointTapped = "support_chat_entry_point_tapped"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 - [*] Fixed several crash-risk code paths in Shipping Labels, Stats, and Downloadable files [https://github.com/woocommerce/woocommerce-ios/pull/17307]
 - [*] Improved responsiveness to iPad window resizing throughout the app [https://github.com/woocommerce/woocommerce-ios/pull/17336]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
+- [internal] Added tracking events for UPS and FedEx carrier Terms of Service (shown/accepted) [https://github.com/woocommerce/woocommerce-ios/pull/17343]
 - [x] Added option to login with QR-code
 
 24.9

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
-- [internal] Added tracking events for UPS and FedEx carrier Terms of Service (shown/accepted) [https://github.com/woocommerce/woocommerce-ios/pull/17343]
+- [*] Added tracking events for UPS and FedEx carrier Terms of Service (shown/accepted) [https://github.com/woocommerce/woocommerce-ios/pull/17343]
 
 25.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
-- [*] Added tracking events for UPS and FedEx carrier Terms of Service (shown/accepted) [https://github.com/woocommerce/woocommerce-ios/pull/17343]
+
 
 25.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
-
+- [internal] Added tracking events for UPS and FedEx carrier Terms of Service (shown/accepted) [https://github.com/woocommerce/woocommerce-ios/pull/17343]
 
 25.0
 -----
@@ -16,7 +16,6 @@
 - [*] Fixed several crash-risk code paths in Shipping Labels, Stats, and Downloadable files [https://github.com/woocommerce/woocommerce-ios/pull/17307]
 - [*] Improved responsiveness to iPad window resizing throughout the app [https://github.com/woocommerce/woocommerce-ios/pull/17336]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
-- [internal] Added tracking events for UPS and FedEx carrier Terms of Service (shown/accepted) [https://github.com/woocommerce/woocommerce-ios/pull/17343]
 - [x] Added option to login with QR-code
 
 24.9

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooShipping.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooShipping.swift
@@ -5,7 +5,18 @@ extension WooAnalyticsEvent {
         private enum Keys: String {
             case type
             case state
+            case carrier
             case unfulfilledShipmentsCount = "unfulfilled_shipments_count"
+        }
+
+        enum Carrier: String {
+            case upsdap
+            case fedex
+        }
+
+        enum CarrierTermsState: String {
+            case shown
+            case accepted
         }
 
         enum AddressType: String {
@@ -97,6 +108,13 @@ extension WooAnalyticsEvent {
         /// When a shipping label refund is requested
         static func refundRequested(error: Error? = nil) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .wooShippingRefundRequested, properties: [:], error: error)
+        }
+
+        /// When the carrier Terms of Service sheet is shown, or the merchant accepts it.
+        static func carrierTermsOfService(carrier: Carrier, state: CarrierTermsState) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .wooShippingCarrierTermsOfService,
+                              properties: [Keys.carrier.rawValue: carrier.rawValue,
+                                           Keys.state.rawValue: state.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -128,6 +128,7 @@ struct WooShippingCreateLabelsView: View {
             .sheet(isPresented: $viewModel.shouldShowUPSTermsAndConditions) {
                 if let termsViewModel = viewModel.upsTermsViewModel {
                     UPSTermsView(viewModel: termsViewModel, onConfirmation: {
+                        viewModel.trackCarrierTermsAccepted(.upsdap)
                         viewModel.shouldShowUPSTermsAndConditions = false
                         Task { @MainActor in
                             await viewModel.purchaseLabel(shouldRefreshPackageAndRate: true)
@@ -139,6 +140,7 @@ struct WooShippingCreateLabelsView: View {
             }
             .sheet(isPresented: $viewModel.shouldShowFedExTermsAndConditions) {
                 FedExTermsView(viewModel: viewModel.fedExTermsViewModel, onConfirmation: {
+                    viewModel.trackCarrierTermsAccepted(.fedex)
                     viewModel.shouldShowFedExTermsAndConditions = false
                     Task { @MainActor in
                         await viewModel.purchaseLabel(shouldRefreshPackageAndRate: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -197,9 +197,21 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
 
     private(set) var paymentMethodsViewModel: ShippingLabelPaymentMethodsViewModel?
 
-    @Published var shouldShowUPSTermsAndConditions = false
+    @Published var shouldShowUPSTermsAndConditions = false {
+        didSet {
+            if shouldShowUPSTermsAndConditions {
+                analytics.track(event: .WooShipping.carrierTermsOfService(carrier: .upsdap, state: .shown))
+            }
+        }
+    }
 
-    @Published var shouldShowFedExTermsAndConditions = false
+    @Published var shouldShowFedExTermsAndConditions = false {
+        didSet {
+            if shouldShowFedExTermsAndConditions {
+                analytics.track(event: .WooShipping.carrierTermsOfService(carrier: .fedex, state: .shown))
+            }
+        }
+    }
 
     var upsTermsViewModel: UPSTermsViewModel? {
         guard let originAddress = selectedOriginAddress?.toWooShippingAddress() else {
@@ -364,6 +376,11 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
     func updateShipments(_ shipments: [Shipment]) {
         self.selectedShipmentIndex = 0
         self.shipments = shipments
+    }
+
+    /// Tracks that the merchant accepted the carrier Terms of Service.
+    func trackCarrierTermsAccepted(_ carrier: WooAnalyticsEvent.WooShipping.Carrier) {
+        analytics.track(event: .WooShipping.carrierTermsOfService(carrier: carrier, state: .accepted))
     }
 
     func didUpdateAccountSettings(_ accountSettings: ShippingLabelAccountSettings) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -2003,6 +2003,81 @@ private extension WooShippingCreateLabelsViewModelTests {
     }
 }
 
+// MARK: - Carrier Terms of Service tracking
+extension WooShippingCreateLabelsViewModelTests {
+    func test_carrier_tos_shown_event_is_tracked_when_UPS_terms_are_shown() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         stores: MockStoresManager(sessionManager: .testingInstance),
+                                                         analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+
+        // When
+        viewModel.shouldShowUPSTermsAndConditions = true
+
+        // Then
+        analyticsProvider.assertReceived(event: "wcs_carrier_tos", with: ["carrier": "upsdap", "state": "shown"])
+    }
+
+    func test_carrier_tos_shown_event_is_tracked_when_FedEx_terms_are_shown() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         stores: MockStoresManager(sessionManager: .testingInstance),
+                                                         analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+
+        // When
+        viewModel.shouldShowFedExTermsAndConditions = true
+
+        // Then
+        analyticsProvider.assertReceived(event: "wcs_carrier_tos", with: ["carrier": "fedex", "state": "shown"])
+    }
+
+    func test_carrier_tos_shown_event_is_not_tracked_when_terms_are_dismissed() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         stores: MockStoresManager(sessionManager: .testingInstance),
+                                                         analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        viewModel.shouldShowUPSTermsAndConditions = true
+        analyticsProvider.clearEvents()
+
+        // When
+        viewModel.shouldShowUPSTermsAndConditions = false
+
+        // Then
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("wcs_carrier_tos"))
+    }
+
+    func test_carrier_tos_accepted_event_is_tracked_for_UPS() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         stores: MockStoresManager(sessionManager: .testingInstance),
+                                                         analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+
+        // When
+        viewModel.trackCarrierTermsAccepted(.upsdap)
+
+        // Then
+        analyticsProvider.assertReceived(event: "wcs_carrier_tos", with: ["carrier": "upsdap", "state": "accepted"])
+    }
+
+    func test_carrier_tos_accepted_event_is_tracked_for_FedEx() {
+        // Given
+        let analyticsProvider = MockAnalyticsProvider()
+        let viewModel = WooShippingCreateLabelsViewModel(order: Order.fake(),
+                                                         stores: MockStoresManager(sessionManager: .testingInstance),
+                                                         analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+
+        // When
+        viewModel.trackCarrierTermsAccepted(.fedex)
+
+        // Then
+        analyticsProvider.assertReceived(event: "wcs_carrier_tos", with: ["carrier": "fedex", "state": "accepted"])
+    }
+}
+
 private extension WooShippingAccountSettings {
     static func fake() -> WooShippingAccountSettings {
         .init(storeOptions: .init(currencySymbol: "$", dimensionUnit: "in", weightUnit: "lbs", originCountry: "US"),


### PR DESCRIPTION
Closes: WOOMOB-2725

## Description

We weren't tracking anything when merchants see or accept the UPS/FedEx carrier Terms of Service in the Woo Shipping label flow. This adds a single `wcs_carrier_tos` event with `carrier` (`upsdap`/`fedex`) and `state` (`shown`/`accepted`) properties, following the existing `wcs_` step pattern. Android gets the matching events in woocommerce/woocommerce-android#16065 for parity.

## Test Steps

### Prerequisite

You'll need your A8C WP.COM account to be configured for shipping testing. Follow the PbTz5e-11v-p2 tutorial (You can skip the last "Pointing your Site to the Connect Staging Server" part)

1. Open any order from `#63, #64, #67, #68, #69, #70, #71`
2. Select "Create Shipping Labels"
3. Wait a bit so that the "Origin address unverified" notice shows. Tap it and verify the address.
4. Repeat address verification for the destination address.
5. Tap "Select Package"
6. Tap on carrier tab
7. Select a parcel from UPSP
8. Tap "Add Package"
9. Tap "Purchase Label"
10. TermOfService should be shown.
11. IF ToS does not show you'll either need to pick a different prefilled origin address or change the origin address.
12. Accept all and finish the purchase.
13. Menu/Settings/Help&Support/View Application Log
14. Open Current
15. Fired event should be close to the bottom. Look for 
```
🔵 Tracked: wcs_carrier_tos, Properties: {"state":"shown","carrier":"upsdap"}
🔵 Tracked: wcs_carrier_tos, Properties: {"state":"accepted","carrier":"upsdap"}
```

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.