### PR TITLE
Add StarXpand SDK dependency and receipt-printing feature flag

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ec9cd3ba0557d92d70422d7b171708735229ff51688dc59b98efa29e1a14843a",
+  "originHash" : "e1e44a3374272cf4704a4ec421d71800bc3709e46abc34864c576591f25de250",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -240,6 +240,15 @@
       "state" : {
         "revision" : "990135f0881e56ac6b39404de0f5b0cd0dcf2131",
         "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "starxpand-sdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/star-micronics/StarXpand-SDK-iOS",
+      "state" : {
+        "revision" : "37ead35af06789f03ffb34cbf08557be519edfd3",
+        "version" : "2.12.1"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -119,6 +119,7 @@ let package = Package(
         .package(url: "https://github.com/Quick/Nimble.git", from: "13.0.0"),
         .package(url: "https://github.com/simibac/ConfettiSwiftUI.git", from: "1.0.0"),
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.3.0"),
+        .package(url: "https://github.com/star-micronics/StarXpand-SDK-iOS", from: "2.10.0"),
         .package(url: "https://github.com/stripe/stripe-terminal-ios", from: "5.1.1"),
         .package(url: "https://github.com/SVProgressHUD/SVProgressHUD", from: "2.2.5"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", revision: "d741e3cfaa74c99ef092e5fddb87d4314b63e3ed"),
@@ -156,7 +157,8 @@ let package = Package(
             dependencies: [
                 "Codegen",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
-                .product(name: "StripeTerminal", package: "stripe-terminal-ios")
+                .product(name: "StripeTerminal", package: "stripe-terminal-ios"),
+                .product(name: "StarIO10", package: "StarXpand-SDK-iOS")
             ],
             resources: [.process("Resources")]
         ),

--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -123,6 +123,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .smarterNotifications:
             return true
+        case .starReceiptPrinterSupport:
+            return false
         default:
             return true
         }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -267,4 +267,11 @@ public enum FeatureFlag: Int, CaseIterable {
     /// Enables smarter (AI-powered) push notifications.
     ///
     case smarterNotifications
+
+    /// Enables Star Micronics receipt printer support in Point of Sale.
+    /// Gates the whole receipt-printing feature (SDK, printer setup, and printing from
+    /// the order-complete screen) while it lands across stacked PRs. Off by default until
+    /// the stack is ready to enable for internal builds.
+    ///
+    case starReceiptPrinterSupport
 }

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -269,9 +269,10 @@ public enum FeatureFlag: Int, CaseIterable {
     case smarterNotifications
 
     /// Enables Star Micronics receipt printer support in Point of Sale.
-    /// Gates the whole receipt-printing feature (SDK, printer setup, and printing from
-    /// the order-complete screen) while it lands across stacked PRs. Off by default until
-    /// the stack is ready to enable for internal builds.
+    /// Gates the feature's runtime behavior (printer setup and printing from the
+    /// order-complete screen) while it lands across stacked PRs. The StarIO10 SDK is
+    /// linked unconditionally; this flag only controls whether the feature is reachable.
+    /// Off by default until the stack is ready to enable for internal builds.
     ///
     case starReceiptPrinterSupport
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,7 +13,7 @@
 - [*] Improved responsiveness to iPad window resizing throughout the app [https://github.com/woocommerce/woocommerce-ios/pull/17336]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
 - [x] Added option to login with QR-code
-- [Internal] Add Star Micronics StarXpand SDK and POS receipt-printing feature flag (off by default) [PR_URL]
+- [Internal] Add Star Micronics StarXpand SDK and POS receipt-printing feature flag (off by default) [https://github.com/woocommerce/woocommerce-ios/pull/17347]
 
 24.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,7 +13,6 @@
 - [*] Improved responsiveness to iPad window resizing throughout the app [https://github.com/woocommerce/woocommerce-ios/pull/17336]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
 - [x] Added option to login with QR-code
-- [Internal] Add Star Micronics StarXpand SDK and POS receipt-printing feature flag (off by default) [https://github.com/woocommerce/woocommerce-ios/pull/17347]
 
 24.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 - [*] Improved responsiveness to iPad window resizing throughout the app [https://github.com/woocommerce/woocommerce-ios/pull/17336]
 - [internal] Speculatively fixed occasional crash on launch when creating TracksService [https://github.com/woocommerce/woocommerce-ios/pull/17328]
 - [x] Added option to login with QR-code
+- [Internal] Add Star Micronics StarXpand SDK and POS receipt-printing feature flag (off by default) [PR_URL]
 
 24.9
 -----


### PR DESCRIPTION
## Description
First PR of the **Woo POS: Receipts Printing** stack (WOOMOB-3190).

Groundwork only — no behavior change:
- Adds the Star Micronics StarXpand SDK (`StarIO10`) to the **Hardware** module in `Modules/Package.swift`, alongside the existing Stripe Terminal card-reader SDK (same pattern, same module). Resolved to 2.12.1 via `from: "2.10.0"`.
- Adds the `starReceiptPrinterSupport` feature flag, **off in every build**. The flag is flipped on for internal builds at the end of the stack.

No UI, no Yosemite, no app-target `.xcodeproj` changes — the SDK is consumed through the Hardware module, so the app project is untouched.

Tests: none for this PR — it only adds a dependency and an off flag; meaningful test coverage starts later in the stack.

## Test Steps
This PR has no user-facing behavior. To verify:
1. Build the `WooCommerce` workspace — it compiles and `StarIO10` resolves/links into `Hardware`.
2. Confirm `starReceiptPrinterSupport` returns `false` in all build configs (nothing is gated on it yet).

## Screenshots
N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.