### PR TITLE
[Woo POS][Phone] Gate phone POS rollout to `.GB` country code

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -59,8 +59,12 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     /// Used for the initial state check when a site instance hasn't been loaded but a `siteID` is available
     static func checkInitialVisibility(
         for siteID: Int64,
+        userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
         eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService()
     ) -> Bool {
+        guard userInterfaceIdiom != .phone else {
+            return false
+        }
         return eligibilityService.loadCachedPOSTabVisibility(siteID: siteID) ?? false
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -49,7 +49,10 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
 
     /// Checks the initial visibility of the POS tab without dependance on network requests.
     func checkInitialVisibility() -> Bool {
-        eligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) ?? false
+        guard userInterfaceIdiom != .phone else {
+            return false
+        }
+        return eligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) ?? false
     }
 
     /// Checks the initial visibility without the `POSTabVisibilityChecker` instance
@@ -106,6 +109,10 @@ private extension POSTabVisibilityChecker {
         // Conditions that can change if site settings are synced during the lifetime.
         let countryCode = SiteAddress(siteSettings: siteSettings).countryCode
         let currencyCode = CurrencySettings(siteSettings: siteSettings).currencyCode
+
+        guard userInterfaceIdiom != .phone || countryCode == .GB else {
+            return .ineligible(reason: .unsupportedCountry(supportedCountries: [.GB]))
+        }
 
         // Refresh the per-site IPP country expansion eligibility cache (RSM-637) before
         // validating, so the country/currency check reflects the latest remote feature

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -386,6 +386,7 @@ final class MainTabBarController: UITabBarController {
     private func setupConditionalTabsInitialVisibility(for siteID: Int64) {
         let isPOSTabVisible = POSTabVisibilityChecker.checkInitialVisibility(
             for: siteID,
+            userInterfaceIdiom: isPad ? .pad : .phone,
             eligibilityService: posEligibilityService
         )
         let isBookingsFeatureAvailable = BookingsTabEligibilityChecker.checkInitialVisibility(

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -641,7 +641,9 @@ final class MainTabBarControllerTests: XCTestCase {
             MainTabBarController(coder: coder,
                                  stores: stores,
                                  posTabVisibilityCheckerFactory: { site in
-                                     POSTabVisibilityChecker(site: site, eligibilityService: mockPOSEligibilityService)
+                                     POSTabVisibilityChecker(site: site,
+                                                            userInterfaceIdiom: .pad,
+                                                            eligibilityService: mockPOSEligibilityService)
                                  },
                                  posEligibilityService: mockPOSEligibilityService,
                                  bookingsEligibilityCheckerFactory: { site in

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -587,7 +587,7 @@ final class MainTabBarControllerTests: XCTestCase {
         assertEqual(true, analyticsProvider.receivedProperties[safe: indexOfEvent]?["is_visible"] as? Bool)
     }
 
-    func test_initial_tabs_visibility_is_set_from_cache() throws {
+    func test_initial_tabs_visibility_on_phone_ignores_cached_pos_visibility() throws {
         // Given
         let siteID: Int64 = 1126
         let mockPOSEligibilityService = MockPOSEligibilityService()
@@ -603,7 +603,8 @@ final class MainTabBarControllerTests: XCTestCase {
             return MainTabBarController(coder: coder,
                                         stores: stores,
                                         posEligibilityService: mockPOSEligibilityService,
-                                        userDefaults: userDefaults)
+                                        userDefaults: userDefaults,
+                                        isPad: false)
         }) else {
             XCTFail("Failed to instantiate MainTabBarController")
             return
@@ -614,8 +615,8 @@ final class MainTabBarControllerTests: XCTestCase {
         XCTAssertNotNil(tabBarController.view) // This triggers viewDidLoad
 
         // Then
-        let expectedTabs: [WooTab] = [.myStore, .orders, .products, .bookings, .pointOfSale, .hubMenu]
-        let visibleTabs = WooTab.visibleTabs(isPOSTabVisible: true, isBookingsTabVisible: true)
+        let expectedTabs: [WooTab] = [.myStore, .orders, .products, .bookings, .hubMenu]
+        let visibleTabs = WooTab.visibleTabs(isPOSTabVisible: false, isBookingsTabVisible: true)
         XCTAssertEqual(tabBarController.viewControllers?.count, expectedTabs.count)
         XCTAssertEqual(visibleTabs, expectedTabs)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -642,8 +642,8 @@ final class MainTabBarControllerTests: XCTestCase {
                                  stores: stores,
                                  posTabVisibilityCheckerFactory: { site in
                                      POSTabVisibilityChecker(site: site,
-                                                            userInterfaceIdiom: .pad,
-                                                            eligibilityService: mockPOSEligibilityService)
+                                                             userInterfaceIdiom: .pad,
+                                                             eligibilityService: mockPOSEligibilityService)
                                  },
                                  posEligibilityService: mockPOSEligibilityService,
                                  bookingsEligibilityCheckerFactory: { site in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -289,11 +289,12 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == false)
     }
 
-    @Test func is_visible_when_device_is_phone_and_phonePrototype_flag_enabled_for_uk_store() async throws {
+    @Test(arguments: phoneSupportedCountries)
+    func is_visible_when_device_is_phone_and_phonePrototype_flag_enabled_for_supported_country(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
         featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
-        setupCountry(country: .gb, currency: .GBP)
+        setupCountry(country: country, currency: currency)
         accountWhitelistedInBackend(true)
         let checker = POSTabVisibilityChecker(site: site,
                                               userInterfaceIdiom: .phone,
@@ -313,7 +314,7 @@ struct POSTabVisibilityCheckerTests {
         (country: Country.pr, currency: CurrencyCode.USD),
         (country: Country.ca, currency: CurrencyCode.CAD)
     ])
-    fileprivate func is_invisible_when_device_is_phone_and_store_is_supported_non_uk_country(country: Country, currency: CurrencyCode) async throws {
+    func is_invisible_when_device_is_phone_and_store_is_supported_non_uk_country(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
         featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
@@ -351,10 +352,11 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == false)
     }
 
-    @Test func is_invisible_when_device_is_phone_and_phonePrototype_flag_disabled_for_uk_store() async throws {
+    @Test(arguments: phoneSupportedCountries)
+    func is_invisible_when_device_is_phone_and_phonePrototype_flag_disabled_for_supported_country(country: Country, currency: CurrencyCode) async throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
-        setupCountry(country: .gb, currency: .GBP)
+        setupCountry(country: country, currency: currency)
         accountWhitelistedInBackend(true)
         let checker = POSTabVisibilityChecker(site: site,
                                               userInterfaceIdiom: .phone,
@@ -464,7 +466,11 @@ struct POSTabVisibilityCheckerTests {
     }
 }
 
-private extension POSTabVisibilityCheckerTests {
+extension POSTabVisibilityCheckerTests {
+    nonisolated static let phoneSupportedCountries: [(country: Country, currency: CurrencyCode)] = [
+        (country: .gb, currency: .GBP)
+    ]
+
     func setupCountry(country: Country, currency: CurrencyCode = .USD) {
         let countrySetting = mockCountrySetting(country: country)
         let currencySetting = mockCurrencySetting(currency: currency)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -289,11 +289,11 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == false)
     }
 
-    @Test func is_visible_when_device_is_phone_and_phonePrototype_flag_enabled() async throws {
+    @Test func is_visible_when_device_is_phone_and_phonePrototype_flag_enabled_for_uk_store() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService()
         featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
-        setupCountry(country: .us)
+        setupCountry(country: .gb, currency: .GBP)
         accountWhitelistedInBackend(true)
         let checker = POSTabVisibilityChecker(site: site,
                                               userInterfaceIdiom: .phone,
@@ -306,6 +306,67 @@ struct POSTabVisibilityCheckerTests {
 
         // Then
         #expect(result == true)
+    }
+
+    @Test(arguments: [
+        (country: Country.us, currency: CurrencyCode.USD),
+        (country: Country.pr, currency: CurrencyCode.USD),
+        (country: Country.ca, currency: CurrencyCode.CAD)
+    ])
+    fileprivate func is_invisible_when_device_is_phone_and_store_is_supported_non_uk_country(country: Country, currency: CurrencyCode) async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
+        setupCountry(country: country, currency: currency)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func is_invisible_when_device_is_phone_and_store_is_expansion_country() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
+        setupCountry(country: .nl, currency: .EUR)
+        accountWhitelistedInBackend(true, expansionFlagsEnabled: true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func is_invisible_when_device_is_phone_and_phonePrototype_flag_disabled_for_uk_store() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        setupCountry(country: .gb, currency: .GBP)
+        accountWhitelistedInBackend(true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              siteSettings: siteSettings,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
     }
 
     @Test func checkVisibility_returns_expected_result_after_site_settings_available() async throws {
@@ -344,7 +405,10 @@ struct POSTabVisibilityCheckerTests {
 
     @Test func checkInitialVisibility_returns_true_when_cached_tab_visibility_is_enabled() async throws {
         // Given
-        let checker = POSTabVisibilityChecker(site: site, eligibilityService: eligibilityService, stores: stores)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores)
         setupPOSTabVisibility(siteID: siteID, isVisible: true)
 
         // When
@@ -356,7 +420,10 @@ struct POSTabVisibilityCheckerTests {
 
     @Test func checkInitialVisibility_returns_false_when_cached_tab_visibility_is_disabled() async throws {
         // Given
-        let checker = POSTabVisibilityChecker(site: site, eligibilityService: eligibilityService, stores: stores)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores)
         setupPOSTabVisibility(siteID: siteID, isVisible: false)
 
         // When
@@ -368,8 +435,26 @@ struct POSTabVisibilityCheckerTests {
 
     @Test func checkInitialVisibility_returns_false_when_cached_tab_visibility_is_unavailable() async throws {
         // Given
-        let checker = POSTabVisibilityChecker(site: site, eligibilityService: eligibilityService, stores: stores)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores)
         setupPOSTabVisibility(siteID: siteID, isVisible: nil)
+
+        // When
+        let result = checker.checkInitialVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func checkInitialVisibility_returns_false_on_phone_when_cached_tab_visibility_is_enabled() async throws {
+        // Given
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores)
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
 
         // When
         let result = checker.checkInitialVisibility()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -464,6 +464,32 @@ struct POSTabVisibilityCheckerTests {
         // Then
         #expect(result == false)
     }
+
+    @Test func static_checkInitialVisibility_returns_true_on_iPad_when_cached_tab_visibility_is_enabled() async throws {
+        // Given
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+
+        // When
+        let result = POSTabVisibilityChecker.checkInitialVisibility(for: siteID,
+                                                                    userInterfaceIdiom: .pad,
+                                                                    eligibilityService: eligibilityService)
+
+        // Then
+        #expect(result == true)
+    }
+
+    @Test func static_checkInitialVisibility_returns_false_on_phone_when_cached_tab_visibility_is_enabled() async throws {
+        // Given
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+
+        // When
+        let result = POSTabVisibilityChecker.checkInitialVisibility(for: siteID,
+                                                                    userInterfaceIdiom: .phone,
+                                                                    eligibilityService: eligibilityService)
+
+        // Then
+        #expect(result == false)
+    }
 }
 
 extension POSTabVisibilityCheckerTests {


### PR DESCRIPTION
Closes WOOMOB-3208
Ref: pdfdoF-95s-p2

## Description
Gates Phone POS only for `GB` stores as part to the initial rollout.

## Test Steps
Load a GB store and a non-GB store in phone, note that the POS tab appears/doesn't.

I haven't touched any store sync/cache mechanism to not add temporary complexity to the system, there's no need really. By changing the store country, then fully switching stores and back in the app generally is enough to see the POS tab (or hide it).

## Screenshots
| Non-GB | GB |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-06-15 at 14 24 47" src="https://github.com/user-attachments/assets/2c52bda3-11e9-46f5-abab-55ef150514bf" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-06-15 at 14 26 25" src="https://github.com/user-attachments/assets/c149d183-cdf6-428e-9ab4-0f0ff1f741cd" /> | 