### PR TITLE
Fix QR-login scanner not detecting after navigating back

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
+- [Internal] QR login: fixed the scanner not detecting after navigating back from a scanned code. Feature-flagged. [https://github.com/woocommerce/woocommerce-ios/pull/17352]
 
 
 25.0

--- a/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/QRLogin/QRLoginCoordinator.swift
@@ -55,6 +55,10 @@ final class QRLoginCoordinator {
     /// deliver a second result — it must be replaced, not reused.
     private weak var prologueViewController: UIViewController?
 
+    /// Held weakly so `dropConsumedScanner()` can remove this scanner from the
+    /// stack once it has delivered a payload. (WOOMOB-3136)
+    private weak var scannerViewController: UIViewController?
+
     init(mode: Mode = .camera,
          navigationController: UINavigationController,
          parser: QRLoginPayloadParser = QRLoginPayloadParser(),
@@ -162,21 +166,6 @@ private extension QRLoginCoordinator {
         }
     }
 
-    func showScanner() {
-        analytics.trackStep(.qrScan)
-        let view = QRLoginScannerView(
-            onScannedPayload: { [weak self] payload in
-                guard let self else { return }
-                let parsed = self.parser.parse(payload)
-                self.handleScanned(payload: parsed)
-            },
-            onCancel: { [weak self] in self?.popScanner() }
-        )
-        // The scanner is full-bleed camera UI with its own in-view chrome, so it
-        // keeps the navigation bar hidden and does not use the toolbar Help item.
-        pushScreen(view, navigationBarStyle: .hidden, showsHelpButton: false)
-    }
-
     func popScanner() {
         navigationController.popViewController(animated: true)
     }
@@ -195,11 +184,36 @@ private extension QRLoginCoordinator {
     }
 }
 
+// MARK: - Scanner presentation
+
+extension QRLoginCoordinator {
+    /// Pushes the QR scanner and records it for `dropConsumedScanner()`. Internal
+    /// (not private) so navigation tests can place a scanner on the stack without
+    /// the async camera-permission flow. (WOOMOB-3136)
+    func showScanner() {
+        analytics.trackStep(.qrScan)
+        let view = QRLoginScannerView(
+            onScannedPayload: { [weak self] payload in
+                guard let self else { return }
+                let parsed = self.parser.parse(payload)
+                self.handleScanned(payload: parsed)
+            },
+            onCancel: { [weak self] in self?.popScanner() }
+        )
+        // The scanner is full-bleed camera UI with its own in-view chrome, so it
+        // keeps the navigation bar hidden and does not use the toolbar Help item.
+        scannerViewController = pushScreen(view, navigationBarStyle: .hidden, showsHelpButton: false)
+    }
+}
+
 // MARK: - Live flow
 
 private extension QRLoginCoordinator {
 
     func handleScanned(payload: QRLoginPayload) {
+        // Drop the consumed scanner so no Back/Cancel can return to it. (WOOMOB-3136)
+        dropConsumedScanner()
+
         switch payload {
         case let .selfHosted(token, siteURL):
             let strategy = SelfHostedQRLoginStrategy(token: token, siteURL: siteURL)
@@ -318,9 +332,9 @@ private extension QRLoginCoordinator {
         pushScreen(host)
     }
 
-    /// Merchant cancelled from the number-match screen. In camera mode the
-    /// merchant gets the scanner back; in deep-link mode there's no scanner to
-    /// fall back to, so popping the host view exits the QR-login surface.
+    /// Merchant cancelled from the number-match screen. In camera mode popping the
+    /// host lands on the prologue (the consumed scanner was already dropped); in
+    /// deep-link mode there's no scanner, so it exits the QR-login surface.
     func handleHostCancelled() {
         navigationController.popViewController(animated: true)
         finishIfDeepLink()
@@ -372,10 +386,8 @@ private extension QRLoginCoordinator {
     /// The merchant dismissed the magic-link auth sheet without finishing
     /// sign-in. Unwind the QR surface so they can retry.
     ///
-    /// In camera mode this unwinds to the prologue rather than the scanner: the
-    /// scanner keeps the camera live (the merchant may still be pointing at a
-    /// QR code, so it could capture another) and landing there re-enters the
-    /// scan step. Deep-link mode has no prologue, so it pops the host view and
+    /// In camera mode this pops to the prologue (the consumed scanner was already
+    /// dropped). Deep-link mode has no prologue, so it pops the host view and
     /// exits the QR surface.
     func handleMagicLinkCancelled() {
         if let prologueViewController {
@@ -384,6 +396,20 @@ private extension QRLoginCoordinator {
             navigationController.popViewController(animated: false)
         }
         finishIfDeepLink()
+    }
+
+    /// Removes the consumed scanner from the navigation stack so Back/Cancel can't
+    /// return to it — a scanner is single-use and won't deliver again. Camera mode
+    /// only; deep-link mode never pushes a scanner. (WOOMOB-3136)
+    func dropConsumedScanner() {
+        guard case .camera = mode, let scanner = scannerViewController else {
+            return
+        }
+        let remaining = navigationController.viewControllers.filter { $0 !== scanner }
+        if remaining.count != navigationController.viewControllers.count {
+            navigationController.setViewControllers(remaining, animated: false)
+        }
+        scannerViewController = nil
     }
 
     /// Fires `onFinished` exactly once so the owner can release this coordinator.

--- a/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/QRLogin/QRLoginCoordinatorTests.swift
@@ -165,6 +165,34 @@ struct QRLoginCoordinatorTests {
         #expect(nav.viewControllers.count == 2)
         #expect(spy.finishedCount == 0)
     }
+
+    @Test func camera_scan_installQR_then_drops_scanner_so_back_returns_to_prologue() {
+        // Given — a camera scanner on top of the prologue.
+        let (nav, spy, coordinator, scanner) = makeCameraCoordinatorWithScanner()
+
+        // When — an install-app QR is scanned, routing to the error screen.
+        coordinator.presentDeepLink(payload: .installQR)
+
+        // Then — the consumed scanner is dropped and the error sits on the
+        // prologue, so Back returns to the prologue, not a frozen scanner. (WOOMOB-3136)
+        #expect(nav.viewControllers.count == 2)
+        #expect(nav.viewControllers.contains { $0 === scanner } == false)
+        #expect(spy.analytics.steps.last == .qrError)
+    }
+
+    @Test func camera_scan_validQR_then_drops_scanner_so_cancel_returns_to_prologue() {
+        // Given — a camera scanner on top of the prologue.
+        let (nav, _, coordinator, scanner) = makeCameraCoordinatorWithScanner()
+
+        // When — a valid self-hosted QR is scanned, routing to the number-match host.
+        coordinator.presentDeepLink(payload: .selfHosted(token: Self.selfHostedToken,
+                                                         siteURL: URL(string: "https://example.com")!))
+
+        // Then — the consumed scanner is dropped, so cancelling the host returns
+        // to the prologue, not a frozen scanner. (WOOMOB-3136)
+        #expect(nav.viewControllers.count == 2)
+        #expect(nav.viewControllers.contains { $0 === scanner } == false)
+    }
 }
 
 // MARK: - Helpers
@@ -173,6 +201,19 @@ private extension QRLoginCoordinatorTests {
 
     /// A 64-char alphanumeric token, the minimum the self-hosted parser accepts.
     static let selfHostedToken = String(repeating: "a", count: 64)
+
+    /// Camera-mode coordinator with the prologue and a live scanner already
+    /// pushed — the starting point for the "drop the consumed scanner" tests.
+    func makeCameraCoordinatorWithScanner()
+    -> (nav: UINavigationController, spy: Spies, coordinator: QRLoginCoordinator, scanner: UIViewController?) {
+        let nav = UINavigationController()
+        let spy = Spies()
+        let coordinator = makeCoordinator(mode: .camera, navigationController: nav, spies: spy)
+        coordinator.start()
+        coordinator.showScanner()
+        #expect(nav.viewControllers.count == 2)
+        return (nav, spy, coordinator, nav.viewControllers.last)
+    }
 
     /// Bundles the injected coordinator callbacks + analytics so tests can spy
     /// on lifecycle and tracking without reaching into the coordinator.


### PR DESCRIPTION
Closes: WOOMOB-3136

## Description

In the QR Code Login flow, scanning a code and then tapping Back (from the install/invalid-code error screen) or Cancel (from the number-match screen) returned the merchant to the scanner, which no longer detected anything. A scanner is single-use — once it delivers a payload its de-dup latch is consumed and it can't deliver again — so landing back on it left a frozen camera.

`QRLoginCoordinator` now drops the consumed scanner from the navigation stack once its payload is routed (camera mode only, tracked via a `weak` reference and removed by identity). Any Back/Cancel path then lands on the prologue, where "Scan QR code" or "Scan a new code" gives a fresh scanner. This is behind the QR-login feature flag and not yet user-facing.

## Test Steps

You are gonna need to generate the QR code for login, so log in to [this](https://mc.a8c.com/secret-store/?secret_id=14583) JN site. Go to Dashbaord/WooCommerce/Thing to do next/Get mobile app.

1. Install the app.
2. Tap Log In/Help/Override Feature Flags.
3. Locate `qrCodeLogin` and enable.
4. Restart the app.
5. Log in/Scan QR Code
6. Scan the `Install App` QR code on the admin
7. Tap Back
8. Make the admin show the QR login code
9. Scan with the app
10. Note that scanning should be successful.

## Screenshots
| Before | After |
| --- | --- |
| <img width="256" height="554" alt="ScreenRecording_06-16-2026 09-38-41_1" src="https://github.com/user-attachments/assets/84a8ec94-5b74-433b-8eb8-6e89c1d516e4" /> | <img width="256" height="554" alt="ScreenRecording_06-16-2026 09-42-02_1" src="https://github.com/user-attachments/assets/09940a7b-8d8e-4bf6-9a6c-38252b500790" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.