### PR TITLE
Keep dashboard card time-range picker visible on load errors

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
-- [*] Dashboard Performance and Top Performers cards: keep the time-range picker visible when a card fails to load, so a shorter range can be picked without leaving the error state. [WOOMOB-3255]
+- [*] Fixed dashboard Performance and Top Performers cards getting stuck in their error state — the time-range picker now stays visible when a card fails to load, so a shorter range can be picked without logging out. [WOOMOB-3254]
 
 25.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
-
+- [*] Dashboard Performance and Top Performers cards: keep the time-range picker visible when a card fails to load, so a shorter range can be picked without leaving the error state. [WOOMOB-3255]
 
 25.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -38,10 +38,9 @@ struct StorePerformanceView: View {
             header
                 .padding(.horizontal, Layout.padding)
 
-            if viewModel.loadingError != nil {
-                errorStateView
-                    .padding(.horizontal, Layout.padding)
-            } else if viewModel.analyticsEnabled {
+            if viewModel.analyticsEnabled {
+                // Keep the range picker visible during load errors so the merchant can switch
+                // to a shorter range without having to leave the error state.
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
@@ -49,33 +48,38 @@ struct StorePerformanceView: View {
 
                 Divider()
 
-                revenueTypeSelector
-                    .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
-                    .shimmering(active: viewModel.showRedactedState)
+                if viewModel.loadingError != nil {
+                    errorStateView
+                        .padding(.horizontal, Layout.padding)
+                } else {
+                    revenueTypeSelector
+                        .padding(.horizontal, Layout.padding)
+                        .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                        .shimmering(active: viewModel.showRedactedState)
 
-                statsView
-                    .padding(.vertical, Layout.padding)
-                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
-                    .shimmering(active: viewModel.showRedactedState)
+                    statsView
+                        .padding(.vertical, Layout.padding)
+                        .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                        .shimmering(active: viewModel.showRedactedState)
 
-                timestampView
-                    .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
-                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
-                    .shimmering(active: viewModel.showRedactedState)
+                    timestampView
+                        .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
+                        .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                        .shimmering(active: viewModel.showRedactedState)
 
-                chartView
-                    .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
-                    .shimmering(active: viewModel.showRedactedState)
+                    chartView
+                        .padding(.horizontal, Layout.padding)
+                        .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                        .shimmering(active: viewModel.showRedactedState)
 
-                Divider()
-                    .padding(.leading, Layout.padding)
+                    Divider()
+                        .padding(.leading, Layout.padding)
 
-                viewAllAnalyticsButton
-                    .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    viewAllAnalyticsButton
+                        .padding(.horizontal, Layout.padding)
+                        .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
+                        .shimmering(active: viewModel.syncingData)
+                }
             } else {
                 UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -30,15 +30,9 @@ struct TopPerformersDashboardView: View {
             if !viewModel.analyticsEnabled {
                 UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)
-            } else if viewModel.syncingError != nil {
-                DashboardCardErrorView(onRetry: {
-                    ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .topPerformers))
-                    Task {
-                        await viewModel.reloadDataIfNeeded(forceRefresh: true)
-                    }
-                })
-                .padding(.horizontal, Layout.padding)
             } else {
+                // Keep the range picker visible during load errors so the merchant can switch
+                // to a shorter range without having to leave the error state.
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.periodViewModel.redacted.header ? [.placeholder] : [])
@@ -46,23 +40,33 @@ struct TopPerformersDashboardView: View {
 
                 Divider()
 
-                topPerformersList
-
-                Divider()
-                    .padding(.leading, Layout.padding)
-
-                timestampView
-                    .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
-                    .redacted(reason: viewModel.periodViewModel.redacted.rows ? [.placeholder] : [])
-                    .shimmering(active: viewModel.periodViewModel.redacted.rows)
-
-                Divider()
-                    .padding(.leading, Layout.padding)
-
-                viewAllAnalyticsButton
+                if viewModel.syncingError != nil {
+                    DashboardCardErrorView(onRetry: {
+                        ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .topPerformers))
+                        Task {
+                            await viewModel.reloadDataIfNeeded(forceRefresh: true)
+                        }
+                    })
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.periodViewModel.redacted.actionButton ? [.placeholder] : [])
-                    .shimmering(active: viewModel.periodViewModel.redacted.actionButton)
+                } else {
+                    topPerformersList
+
+                    Divider()
+                        .padding(.leading, Layout.padding)
+
+                    timestampView
+                        .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
+                        .redacted(reason: viewModel.periodViewModel.redacted.rows ? [.placeholder] : [])
+                        .shimmering(active: viewModel.periodViewModel.redacted.rows)
+
+                    Divider()
+                        .padding(.leading, Layout.padding)
+
+                    viewAllAnalyticsButton
+                        .padding(.horizontal, Layout.padding)
+                        .redacted(reason: viewModel.periodViewModel.redacted.actionButton ? [.placeholder] : [])
+                        .shimmering(active: viewModel.periodViewModel.redacted.actionButton)
+                }
             }
         }
         .padding(.vertical, Layout.padding)


### PR DESCRIPTION
## Description

Fixes [WOOMOB-3254](https://linear.app/a8c/issue/WOOMOB-3254/ios-performance-card-stuck-in-error-state-with-no-option-to-change) — the Dashboard's **Performance** card can get stuck in its error state with no way out: when the load fails (e.g. a 30s server timeout on a large date range like _This Year_ on a high-volume store), the whole card content is swapped out for an "Unable to load data" view with only a Retry button. Retrying re-sends the same failing request, and the only workaround documented in the ticket is to log out and back in.

**Root cause.** The card's body used `if loadingError != nil → show ONLY the error view; else if analyticsEnabled → show the range picker + content`, so the picker was hidden any time there was an error.

**Fix.** Small restructure of the body so the header + time-range picker stay visible whenever analytics are enabled. The error view replaces only the content below the divider. No view-model changes are needed — `didSelectTimeRange` already calls `reloadDataIfNeeded()`, which clears `loadingError` and re-syncs, so picking a different range from the error state recovers cleanly.

**Top Performers fix included.** The same dead-end exists in the Top Performers card (`syncingError != nil` swaps out the entire content including its `timeRangeBar`). Linear only references the Performance card, but Top Performers is fixed in the same PR for consistency — on iPad's 2-column Dashboard layout, leaving only one card fixed would put the two side-by-side cards in visibly different error UIs, which would look like a bug.

**Out of scope (deliberate).**
- No "Try a shorter range" subtitle on the error view — the now-visible picker is self-explanatory; can be added in a follow-up if discoverability turns out to be an issue.
- Android parity: ticket asks us to check whether Android has the same issue — that's a separate task, not addressed here.

## Test Steps

1. Sign in to a store and let the Dashboard load.
2. Make the Performance card fail to load — easiest options:
   - Toggle Airplane Mode, then **pull-to-refresh** the Dashboard, OR
   - Switch the Performance card to a range the backend can't deliver quickly (large stores often fail on _This Year_).
3. Verify the error view appears **below a still-visible range picker** (not replacing the whole card).
4. Tap the range picker → pick a different range (e.g. _Today_).
5. Verify the error clears and the card reloads with data for the new range.
6. Repeat the same flow for the **Top Performers** card.
7. **iPad**: confirm the Dashboard's 2-column layout still looks correct in error state (Performance on one side, Top Performers on the other, range picker visible in both during error).
8. **Other states still work**:
   - Analytics-unavailable stores still show the full "Unable to display…" message (no range picker — unchanged).
   - Custom-range picker still opens correctly when tapped from the now-visible picker during error.

## Screenshots

| Before | After (iPhone) |
|---|---|
| <img src="https://github.com/user-attachments/assets/2be28c6a-cda5-450b-8aae-29235ad2b7d9" width="280" alt="Before"> | <img src="https://github.com/user-attachments/assets/9e187e45-7cda-4b8e-8edd-a8ffaa7edeeb" width="280" alt="After iPhone"> |

**iPad** — 2-column dashboard layout

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/09564a7c-8b9b-4caa-ba79-2c7509151114" width="350" alt="Before iPad"> | <img src="https://github.com/user-attachments/assets/4a9078a1-5770-449c-ab51-412d12e35fa5" width="350" alt="After iPad"> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.