### PR TITLE
[Woo POS] Fix new order product list on iPad

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CartView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CartView.swift
@@ -136,7 +136,7 @@ private struct CartHeaderView: View {
             return .init(state: state, action: {
                 analytics.track(.pointOfSaleBackToCartTapped)
                 posModel.addMoreToCart()
-            })
+            }, accessibilityIdentifier: "pos-cart-back-button")
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -110,8 +110,11 @@ struct ItemListView: View {
     /// so it lives on the aggregate model as `editingCustomAmount` for cross-pane reach.
     @State private var isAddingCustomAmount: Bool = false
 
+    @State private var navigationResetID: Int = 0
+
     var body: some View {
         navigationContainer
+            .id(navigationResetID)
             // The phone cart button and the iPad floating control are suppressed while the
             // add-custom-amount form is pushed. Emit that request from this always-present view,
             // keyed on the push flag, so it reverts the instant the form is popped: a preference
@@ -178,6 +181,13 @@ struct ItemListView: View {
         .onChange(of: posModel.orderStage) { _, stage in
             guard stage != .building else { return }
             isAddingCustomAmount = false
+        }
+        // The left pane also owns product drill-down navigation. Only reset that navigation after a
+        // completed checkout starts a fresh empty cart. Returning to edit the current cart should
+        // preserve the merchant's place in the selector.
+        .onChange(of: posModel.orderStage) { oldStage, newStage in
+            guard oldStage == .finalizing, newStage == .building, posModel.cart.isEmpty else { return }
+            navigationResetID += 1
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderBackButton.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderBackButton.swift
@@ -22,6 +22,7 @@ struct POSPageHeaderBackButton: View {
                 .padding(.horizontal, backButtonPadding)
         }
         .disabled(configuration.state == .disabled || configuration.state == .shimmering)
+        .accessibilityIdentifier(configuration.accessibilityIdentifier ?? Constants.defaultAccessibilityIdentifier)
         .if(configuration.state == .shimmering) { view in
             view.shimmering()
         }
@@ -31,5 +32,6 @@ struct POSPageHeaderBackButton: View {
 private extension POSPageHeaderBackButton {
     enum Constants {
         static let defaultBackButtonIcon = "chevron.backward"
+        static let defaultAccessibilityIdentifier = "pos-header-back-button"
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSPageHeaderView.swift
@@ -11,11 +11,13 @@ struct POSPageHeaderBackButtonConfiguration {
     let state: State
     let action: () -> Void
     let buttonIcon: String?
+    let accessibilityIdentifier: String?
 
-    init(state: State, action: @escaping () -> Void, buttonIcon: String? = nil) {
+    init(state: State, action: @escaping () -> Void, buttonIcon: String? = nil, accessibilityIdentifier: String? = nil) {
         self.state = state
         self.action = action
         self.buttonIcon = buttonIcon
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 }
 

--- a/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
@@ -208,9 +208,11 @@ public final class POSScreen: ScreenObject {
     @discardableResult
     public func verifyReadyForNewOrder(previousProductID: Int? = nil, previousVariationID: Int? = nil) -> Self {
         let phoneCartButton = app.buttons["pos-phone-cart-button"]
+
+        XCTAssertTrue(firstProductCardGetter(app).waitForExistence(timeout: 15), "POS product list should be visible for a new order.")
+
         if phoneCartButton.waitForIsHittable(timeout: 1) {
             // Phone uses a collapsed cart button; tablet keeps the cart pane visible.
-            XCTAssertTrue(firstProductCardGetter(app).waitForExistence(timeout: 15), "POS product list should be visible for a new order.")
             XCTAssertTrue(phoneCartButton.label.contains("0"), "Phone cart button should show an empty cart for a new order.")
         } else {
             XCTAssertTrue(cartViewGetter(app).waitForExistence(timeout: 10), "POS cart should be visible for a new order.")

--- a/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
@@ -109,7 +109,7 @@ public final class POSScreen: ScreenObject {
     public func verifyVariationSelectorVisible(variationID: Int) -> Self {
         let variationButton = app.buttons["pos-variation-card-\(variationID)"]
 
-        XCTAssertTrue(variationButton.waitForExistence(timeout: 15), "POS variation selector should remain visible when returning to edit the cart.")
+        XCTAssertTrue(waitForVisibleElement(variationButton, timeout: 15), "POS variation selector should remain visible when returning to edit the cart.")
 
         return self
     }

--- a/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/POS/POSScreen.swift
@@ -96,6 +96,25 @@ public final class POSScreen: ScreenObject {
     }
 
     @discardableResult
+    public func tapBackToProductSelectorFromCheckout() -> Self {
+        let backButton = app.buttons["pos-cart-back-button"]
+
+        XCTAssertTrue(backButton.waitForIsHittable(timeout: 15), "POS cart back button should be tappable from checkout.")
+
+        backButton.tap()
+        return self
+    }
+
+    @discardableResult
+    public func verifyVariationSelectorVisible(variationID: Int) -> Self {
+        let variationButton = app.buttons["pos-variation-card-\(variationID)"]
+
+        XCTAssertTrue(variationButton.waitForExistence(timeout: 15), "POS variation selector should remain visible when returning to edit the cart.")
+
+        return self
+    }
+
+    @discardableResult
     public func tapCardReaderPayment() -> Self {
         let cardReaderButton = app.buttons["pos-card-reader-button"]
         if cardReaderButton.waitForIsHittable(timeout: 2) {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
+- [*] POS: Fixed new orders on iPad returning to the previous variation selector instead of the root product list. [https://github.com/woocommerce/woocommerce-ios/pull/17356]
 
 
 25.0

--- a/WooCommerce/WooCommerceUITests/Tests/POSTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/POSTests.swift
@@ -46,6 +46,10 @@ final class POSTests: XCTestCase {
 
     func test_POS_eligible_site_can_complete_cash_payment_and_start_new_order() throws {
         try beginTwoProductCheckout()
+            .tapBackToProductSelectorFromCheckout()
+            .verifyVariationSelectorVisible(variationID: ProductIDs.variation)
+            .tapCheckout()
+            .waitForTotalsLoaded()
             .tapCashPayment()
             .tapMarkPaymentComplete()
             .waitForPaymentSuccess()


### PR DESCRIPTION
Fixes WOOMOB-3181

## Description

Fixes an iPad/tablet POS regression where starting a new order after payment could leave the left pane on the previously selected product variation list instead of returning to the root product list.

### Regression source

This was introduced by [`fa686cd3b2006c101c49b8cb29c1111619b406fd`](https://github.com/woocommerce/woocommerce-ios/commit/fa686cd3b2006c101c49b8cb29c1111619b406fd) in [#16877](https://github.com/woocommerce/woocommerce-ios/pull/16877), which moved tablet checkout into the offset-based dashboard layout with a `NavigationStack` for payments. That layout keeps the item-list pane mounted while checkout is active, so the item-list pane private `NavigationStack` retained its variation drill-down path after payment success.

### Fix

This PR adds a scoped navigation reset only when checkout finishes and POS returns from `finalizing` to `building` with an empty cart. Returning from checkout before payment still preserves the selector state.

The UI test assertion now verifies that new orders show the root product list, and the existing cash payment flow also covers backing out of checkout before payment.

## Test Steps

1. Open Woo POS on iPad/tablet.
2. Select a product with variations.
3. Select a variation.
4. Proceed to payment and complete the order.
5. Tap **Start new order**.
6. Observe the left pane.

Before: the left pane remains on the variation selection screen.
Expected now: the left pane shows the root product list.

@jaclync also ran POS UI tests locally to ensure they pass consistently.

## Screenshots


https://github.com/user-attachments/assets/a7d13094-6650-493d-bc03-c9efff12ad18



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
