### PR TITLE
[Woo POS] Prevent storing auto-draft orders

### DIFF
--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -292,7 +292,7 @@ private extension OrderStore {
             }
 
             guard order.status != .autoDraft else {
-                self?.deleteStoredOrder(siteID: siteID, orderID: order.orderID) {
+                self?.deleteStoredOrder(siteID: siteID, orderID: orderID) {
                     onCompletion(order, nil)
                 }
                 return

--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -291,6 +291,13 @@ private extension OrderStore {
                 return
             }
 
+            guard order.status != .autoDraft else {
+                self?.deleteStoredOrder(siteID: siteID, orderID: order.orderID) {
+                    onCompletion(order, nil)
+                }
+                return
+            }
+
             self?.upsertStoredOrdersInBackground(readOnlyOrders: [order]) {
                 onCompletion(order, nil)
             }

--- a/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
@@ -500,9 +500,10 @@ final class OrderStoreTests: XCTestCase {
     func test_retrieveOrderRemotely_deletes_existing_stored_order_when_remote_order_is_autoDraft() throws {
         // Given
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order-auto-draft-status")
+        let requestedOrderID = sampleOrderID + 1
+        network.simulateResponse(requestUrlSuffix: "orders/\(requestedOrderID)", filename: "order-auto-draft-status")
 
-        let existingOrder = sampleOrder().copy(status: .autoDraft)
+        let existingOrder = sampleOrder().copy(orderID: requestedOrderID, status: .autoDraft)
         storageManager.insertSampleOrder(readOnlyOrder: existingOrder)
         viewStorage.saveIfNeeded()
 
@@ -510,7 +511,7 @@ final class OrderStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            orderStore.onAction(OrderAction.retrieveOrderRemotely(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+            orderStore.onAction(OrderAction.retrieveOrderRemotely(siteID: self.sampleSiteID, orderID: requestedOrderID) { result in
                 promise(result)
             })
         }
@@ -518,7 +519,7 @@ final class OrderStoreTests: XCTestCase {
         // Then
         let retrievedOrder = try XCTUnwrap(result.get())
         XCTAssertEqual(retrievedOrder.status, .autoDraft)
-        XCTAssertNil(viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderID))
+        XCTAssertNil(viewStorage.loadOrder(siteID: sampleSiteID, orderID: requestedOrderID))
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
     }
 

--- a/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/OrderStoreTests.swift
@@ -497,6 +497,31 @@ final class OrderStoreTests: XCTestCase {
         XCTAssertEqual(storedOrder?.toReadOnly(), remoteOrder)
     }
 
+    func test_retrieveOrderRemotely_deletes_existing_stored_order_when_remote_order_is_autoDraft() throws {
+        // Given
+        let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order-auto-draft-status")
+
+        let existingOrder = sampleOrder().copy(status: .autoDraft)
+        storageManager.insertSampleOrder(readOnlyOrder: existingOrder)
+        viewStorage.saveIfNeeded()
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
+
+        // When
+        let result = waitFor { promise in
+            orderStore.onAction(OrderAction.retrieveOrderRemotely(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        let retrievedOrder = try XCTUnwrap(result.get())
+        XCTAssertEqual(retrievedOrder.status, .autoDraft)
+        XCTAssertNil(viewStorage.loadOrder(siteID: sampleSiteID, orderID: sampleOrderID))
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
+    }
+
     func test_retrieveOrderRemotely_does_not_return_existing_order_in_storage_and_replaces_order_in_storage() throws {
         // Given
         let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 25.1
 -----
+- [*] POS: Fixed discarded card reader checkout orders appearing in Orders until refresh. [https://github.com/woocommerce/woocommerce-ios/pull/17357]
 
 
 25.0


### PR DESCRIPTION
Fixes: WOOMOB-88

## Description
`auto-draft` orders are temporary POS/order-creation working orders. Internal context confirms they should not appear in mobile Orders storage/UI, while `checkout-draft` is a separate status with a separate decision.

The POS card-present flow refreshes the order through `OrderAction.retrieveOrderRemotely` before collecting payment. That remote retrieval path was still upserting `auto-draft` responses into Yosemite order storage, so leaving POS during card payment could leave the temporary order visible in Orders until refresh.

This change makes remote order loading skip local upsert for `auto-draft` responses, delete any locally stored order for the requested order ID, and still return the remote order to the caller.

Relevant refs:
- P2: pdfdoF-5OU-p2#comment-7023 - POS auto-drafts are not supposed to be visible in the app Orders UI.
- P2: pdfdoF-6WZ-p2#comment-8118 - card payment order check suspected as the path that stores the temporary order.
- P2: pdfdoF-86X-p2 - documents `checkout-draft` as separate from `auto-draft`, and notes backend hides `auto-draft` by default.
- Slack: p1757672241057529-slack-C070SJRA8DP - confirms `auto-draft` orders are not returned/visible by default and distinguishes them from `checkout-draft`.

## Test Steps
1. Use a store where POS is available and connect a card reader.
2. Open POS.
3. Add products to the cart.
4. Tap Checkout.
5. Connect to a reader if needed. Wait until the card reader payment screen is ready to accept a card.
6. Open the POS menu and exit POS.
7. Open the Orders tab --> the POS `auto-draft` order should not be visible in Orders and no pull-to-refresh is needed to clear it. Before this PR, I can reproduce the issue where the auto-draft order appears in the Orders list until pull-to-refresh.

## Screenshots


https://github.com/user-attachments/assets/8fd529f2-1df2-4401-940f-01b4d0371b94



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.