### PR TITLE
Fix Connectivity Tool crash by isolating the view model to the main actor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 25.0
 -----
+- [*] Fixed a crash that could occur when using the Connectivity Tool to troubleshoot connection issues. [https://github.com/woocommerce/woocommerce-ios/pull/17361]
 - [*] Fixed order refunds hiding duplicate product lines after one matching line was refunded. [https://github.com/woocommerce/woocommerce-ios/pull/17313]
 - [*] Added age-eligibility verification to comply with App Store requirements [https://github.com/woocommerce/woocommerce-ios/pull/17321]
 - [*] Fixed refunds for orders with multiple shipping lines so all shipping lines can be refunded. [https://github.com/woocommerce/woocommerce-ios/pull/17312]

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -33,10 +33,12 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         super.viewDidLoad()
 
         // Bind cards to view
-        viewModel.$cards.sink { [weak self] cards in
-            self?.rootView.cards = cards
-        }
-        .store(in: &subscriptions)
+        viewModel.$cards
+            .receive(on: RunLoop.main)
+            .sink { [weak self] cards in
+                self?.rootView.cards = cards
+            }
+            .store(in: &subscriptions)
 
         // Bind chat button visibility
         viewModel.$showChatButton.sink { [weak self] show in

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -33,12 +33,10 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         super.viewDidLoad()
 
         // Bind cards to view
-        viewModel.$cards
-            .receive(on: RunLoop.main)
-            .sink { [weak self] cards in
-                self?.rootView.cards = cards
-            }
-            .store(in: &subscriptions)
+        viewModel.$cards.sink { [weak self] cards in
+            self?.rootView.cards = cards
+        }
+        .store(in: &subscriptions)
 
         // Bind chat button visibility
         viewModel.$showChatButton.sink { [weak self] show in

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel+Notifications.swift
@@ -143,14 +143,18 @@ extension ConnectivityToolViewModel {
         let updatedSettings = settings.copy(blogs: updatedBlogs)
 
         let action = AccountAction.updateNotificationSettings(notificationSettings: updatedSettings) { [weak self] result in
-            guard let self else { return }
-            switch result {
-            case .success:
-                DDLogInfo("Connectivity Tool: ✅ Order notifications enabled successfully")
-                self.updateCardState(for: .notifications, state: .success)
-            case .failure(let error):
-                DDLogError("Connectivity Tool: ❌ Failed to enable order notifications\n\(error)")
-                self.restoreNotificationsCardActions(settings: settings)
+            // `AccountStore` resumes this completion off the main thread, so hop back to the
+            // main actor before mutating `cards` (via `updateCardState`).
+            Task { @MainActor in
+                guard let self else { return }
+                switch result {
+                case .success:
+                    DDLogInfo("Connectivity Tool: ✅ Order notifications enabled successfully")
+                    self.updateCardState(for: .notifications, state: .success)
+                case .failure(let error):
+                    DDLogError("Connectivity Tool: ❌ Failed to enable order notifications\n\(error)")
+                    self.restoreNotificationsCardActions(settings: settings)
+                }
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -14,6 +14,7 @@ import struct Networking.SystemPlugin
 import protocol WooFoundation.Analytics
 import protocol Experiments.FeatureFlagService
 
+@MainActor
 final class ConnectivityToolViewModel {
 
     /// Cards to be rendered by the view.


### PR DESCRIPTION
Closes: WOOMOB-3175

## Description

`ConnectivityToolViewModel` runs its connectivity checks in a `Task` that isn't isolated to the main actor, so its `@Published var cards` array is appended to and subscripted on background threads (every `await` resumes on an arbitrary cooperative thread) while SwiftUI reads it on the main thread to render. `Array` isn't thread-safe, so the concurrent access corrupts the buffer and the bounds check traps — `Array._checkSubscript` / `EXC_BREAKPOINT` at `cards[cardIndex] = cards[cardIndex].updatingState(testResult)`.

This isolates the view model to the main actor (`@MainActor`), matching the already-safe `PreLoginConnectivityToolViewModel`. All `cards` access now happens on the main thread; the network calls still run off-main via `await`, so the UI isn't blocked.

**I could not reproduce the crash locally.** It's a timing-dependent data race — the background write has to coincide with a main-thread read — so it only surfaces intermittently in the field. I instead confirmed the root cause by instrumenting the view model with thread logging (every `cards` mutation ran on a background thread before the change and on the main thread after) and by matching field crash logs to the exact line.

## Test Steps

1. Open the Connectivity Tool (Menu → Settings → Troubleshoot Connection, or via an order-list connection-error banner).
2. Repeat the test connection step several times (re-run the checks / tap "Retry test") and confirm the checks complete without crashing.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
