### PR TITLE
Fix scroll indicator and main actor warnings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewModel.swift
@@ -20,7 +20,7 @@ final class PrivacyBannerViewModel: ObservableObject {
 
     /// Completion handler.
     ///
-    @MainActor private let onCompletion: (Result<Destination, PrivacyBannerViewModel.Error>) -> ()
+    private let onCompletion: @MainActor (Result<Destination, PrivacyBannerViewModel.Error>) -> ()
 
     /// Stores & Session.
     ///
@@ -32,7 +32,7 @@ final class PrivacyBannerViewModel: ObservableObject {
 
     init(analytics: Analytics = ServiceLocator.analytics,
          stores: StoresManager = ServiceLocator.stores,
-         onCompletion: @escaping (Result<Destination, PrivacyBannerViewModel.Error>) -> ()) {
+         onCompletion: @escaping @MainActor (Result<Destination, PrivacyBannerViewModel.Error>) -> ()) {
         self.analyticsEnabled = analytics.userHasOptedIn
         self.stores = stores
         self.analytics = analytics

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -144,7 +144,7 @@ final class HubMenuViewModel: ObservableObject {
              BookingsTabEligibilityChecker(site: site)
          },
          // Injected for mocking in tests.
-         isPad: Bool = UIDevice.isPad(),
+         isPad: Bool? = nil,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.credentials = stores.sessionManager.defaultCredentials
@@ -159,7 +159,7 @@ final class HubMenuViewModel: ObservableObject {
         self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         self.posEligibilityService = posEligibilityService
         self.bookingsEligibilityCheckerFactory = bookingsEligibilityCheckerFactory
-        self.isPad = isPad
+        self.isPad = isPad ?? UIDevice.isPad()
         self.cardPresentPaymentsOnboarding = CardPresentPaymentsOnboardingUseCase()
         self.analytics = analytics
         observeSiteForUIUpdates()

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -195,7 +195,7 @@ final class MainTabBarController: UITabBarController {
           bookingsEligibilityCheckerFactory: ((Site) -> BookingsTabEligibilityCheckerProtocol)? = nil,
           userDefaults: UserDefaults = .standard,
           // Injected for mocking in tests.
-          isPad: Bool = UIDevice.isPad()) {
+          isPad: Bool? = nil) {
         self.featureFlagService = featureFlagService
         self.noticePresenter = noticePresenter
         self.productImageUploader = productImageUploader
@@ -209,7 +209,7 @@ final class MainTabBarController: UITabBarController {
             BookingsTabEligibilityChecker(site: site)
         }
         self.userDefaults = userDefaults
-        self.isPad = isPad
+        self.isPad = isPad ?? UIDevice.isPad()
         super.init(coder: coder)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -443,9 +443,9 @@ private extension OrdersRootViewController {
             }
         }
 
-        var scrollIndicatorInsets = tableView.scrollIndicatorInsets
-        scrollIndicatorInsets.top = height
-        tableView.scrollIndicatorInsets = scrollIndicatorInsets
+        var verticalScrollIndicatorInsets = tableView.verticalScrollIndicatorInsets
+        verticalScrollIndicatorInsets.top = height
+        tableView.verticalScrollIndicatorInsets = verticalScrollIndicatorInsets
     }
 
     func configureLiquidGlassTabBarUnderlap() {

--- a/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/AI/ProductSharingMessageGenerationViewModel.swift
@@ -40,7 +40,7 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
     private let productName: String
     private let productDescription: String
     private let stores: StoresManager
-    private let isPad: Bool
+    private let isPad: Bool?
     private let analytics: Analytics
     private let delayBeforeDismissingFeedbackBanner: TimeInterval
 
@@ -56,7 +56,7 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
          url: String,
          productName: String,
          productDescription: String,
-         isPad: Bool = UIDevice.isPad(),
+         isPad: Bool? = nil,
          delayBeforeDismissingFeedbackBanner: TimeInterval = 0.5,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
@@ -96,8 +96,9 @@ final class ProductSharingMessageGenerationViewModel: ObservableObject {
         generationInProgress = false
     }
 
+    @MainActor
     func didTapShare() {
-        if isPad {
+        if isPad ?? UIDevice.isPad() {
             isSharePopoverPresented = true
         } else {
             isShareSheetPresented = true

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/FirstProductCreated/FirstProductCreatedViewModel.swift
@@ -3,6 +3,7 @@ import UIKit
 import Yosemite
 import protocol WooFoundation.Analytics
 
+@MainActor
 final class FirstProductCreatedViewModel: ObservableObject {
     @Published var isSharePopoverPresented = false
     @Published var isShareSheetPresented = false
@@ -21,7 +22,7 @@ final class FirstProductCreatedViewModel: ObservableObject {
     init(productURL: URL,
          productName: String,
          showShareProductButton: Bool,
-         isPad: Bool = UIDevice.isPad(),
+         isPad: Bool? = nil,
          eligibilityChecker: ShareProductAIEligibilityChecker = DefaultShareProductAIEligibilityChecker(),
          analytics: Analytics = ServiceLocator.analytics) {
         self.productURL = productURL
@@ -32,7 +33,7 @@ final class FirstProductCreatedViewModel: ObservableObject {
         self.canGenerateShareProductMessageUsingAI = eligibilityChecker.canGenerateShareProductMessageUsingAI
 
         self.analytics = analytics
-        self.isPad = isPad
+        self.isPad = isPad ?? UIDevice.isPad()
         self.shareSheet = ShareSheet(activityItems: [productName, productURL])
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -917,9 +917,9 @@ private extension ProductsViewController {
             }
         }
 
-        var scrollIndicatorInsets = tableView.scrollIndicatorInsets
-        scrollIndicatorInsets.top = height
-        tableView.scrollIndicatorInsets = scrollIndicatorInsets
+        var verticalScrollIndicatorInsets = tableView.verticalScrollIndicatorInsets
+        verticalScrollIndicatorInsets.top = height
+        tableView.verticalScrollIndicatorInsets = verticalScrollIndicatorInsets
     }
 
     private func updateLiquidGlassHeaderVisibility() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/FirstProductCreatedViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import WooCommerce
 import TestKit
 
+@MainActor
 final class FirstProductCreatedViewModelTests: XCTestCase {
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!


### PR DESCRIPTION
## Description
Fix a small batch of Xcode warnings:

- Replace deprecated `scrollIndicatorInsets` getter usage with `verticalScrollIndicatorInsets`.
- Move `UIDevice.isPad()` defaults out of nonisolated default arguments.
- Preserve main-actor UI contracts for privacy/product sharing view models while keeping isolation scope narrow.

## Test Steps

On Products and Orders, check that scroll indicators behave as expected.

CI passing unit tests

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.