### PR TITLE
Remove `pointOfSaleRefundsi1` flag

### DIFF
--- a/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
+++ b/Modules/Sources/Experiments/DefaultFeatureFlagService.swift
@@ -87,8 +87,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return !buildConfig.isProduction
         case .pointOfSaleCatalogAPI:
             return true
-        case .pointOfSaleRefundsi1:
-            return true
         case .pointOfSaleRoles:
             return false
         case .pointOfSaleCustomAmounts:

--- a/Modules/Sources/Experiments/FeatureFlag.swift
+++ b/Modules/Sources/Experiments/FeatureFlag.swift
@@ -195,10 +195,6 @@ public enum FeatureFlag: Int, CaseIterable {
     ///
     case pointOfSaleCatalogAPI
 
-    /// Enables the refunds functionality within POS
-    ///
-    case pointOfSaleRefundsi1
-
     /// Enables POS staff roles and permissions (PIN access, lock screen, capability-based gating)
     ///
     case pointOfSaleRoles

--- a/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSOrderListController.swift
@@ -105,7 +105,6 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
     private let orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol
     private let refundsService: POSRefundsServiceProtocol
     private let refundSubmissionProcessor: POSRefundSubmissionProcessing
-    private let featureFlags: POSFeatureFlagProviding
     private var isProcessingRefund = false
     private var paginationTracker: AsyncPaginationTracker {
         if let existing = strategyPaginationTracker[fetchStrategy.id] {
@@ -119,20 +118,17 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
     init(orderListFetchStrategyFactory: POSOrderListFetchStrategyFactoryProtocol,
          refundsService: POSRefundsServiceProtocol,
          refundSubmissionProcessor: POSRefundSubmissionProcessing,
-         featureFlags: POSFeatureFlagProviding,
          initialState: POSOrderListState = .loading([])) {
         self.ordersViewState = initialState
         self.orderListFetchStrategyFactory = orderListFetchStrategyFactory
         self.fetchStrategy = orderListFetchStrategyFactory.defaultStrategy()
         self.refundsService = refundsService
         self.refundSubmissionProcessor = refundSubmissionProcessor
-        self.featureFlags = featureFlags
     }
 
     @MainActor
     var refundActionAvailability: RefundActionAvailability {
-        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1),
-              let order = selectedOrder,
+        guard let order = selectedOrder,
               order.status == .completed else {
             return .unavailable
         }
@@ -150,8 +146,7 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
     @MainActor
     var displayedLineItems: [POSOrderItem] {
         guard let order = selectedOrder else { return [] }
-        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1),
-              !isLoadingOrderRefunds else {
+        guard !isLoadingOrderRefunds else {
             return order.lineItems
         }
         let refundedQuantities = order.refunds.flatMap(\.items).refundedQuantitiesByItemID()
@@ -172,8 +167,7 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
     @MainActor
     var displayedCustomAmounts: [POSOrderCustomAmount] {
         guard let order = selectedOrder else { return [] }
-        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1),
-              !isLoadingOrderRefunds else {
+        guard !isLoadingOrderRefunds else {
             return order.customAmounts
         }
         let refundedItemIDs: Set<Int64> = Set(order.refunds.flatMap(\.items).compactMap(\.refundedItemID))
@@ -451,7 +445,6 @@ enum POSRefundProcessingError: LocalizedError, Equatable {
     }
 
     func loadOrderRefunds() async {
-        guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1) else { return }
         guard let order = selectedOrder, order.refunds.isNotEmpty else {
             return
         }

--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -25,7 +25,6 @@ struct POSOrderDetailsView: View {
     @Environment(\.siteTimezone) private var siteTimezone
     @Environment(POSOrderListModel.self) private var orderListModel
     @Environment(\.posAnalytics) private var analytics
-    @Environment(\.posFeatureFlags) private var featureFlags
     @Environment(\.posCurrencyProvider) private var currencyProvider
     @State private var isShowingEmailReceiptView = false
     @State private var refundSelectionState: RefundSelectionState?
@@ -36,10 +35,6 @@ struct POSOrderDetailsView: View {
 
     private var shouldShowBackButton: Bool {
         horizontalSizeClass == .compact
-    }
-
-    private var shouldShowDedicatedRefundsSection: Bool {
-        featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1)
     }
 
     private var dateFormatter: DateFormatter {
@@ -87,7 +82,7 @@ struct POSOrderDetailsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: POSSpacing.medium) {
                     let isLoadingOrderRefunds = orderListModel.ordersController.isLoadingOrderRefunds
-                    if shouldShowDedicatedRefundsSection && isLoadingOrderRefunds {
+                    if isLoadingOrderRefunds {
                         // Render skeletons for both sections while refund details load so
                         // the items don't get rearranged when filtering kicks in.
                         ghostItemsSection(rowCount: order.lineItems.count + order.customAmounts.count)
@@ -99,7 +94,7 @@ struct POSOrderDetailsView: View {
                             itemsSection(products: displayedLineItems, customAmounts: displayedCustomAmounts)
                         }
                         let refundedItems = order.refunds.flatMap { $0.items }
-                        if shouldShowDedicatedRefundsSection && !refundedItems.isEmpty {
+                        if !refundedItems.isEmpty {
                             refundedProductsSection(refundedItems)
                         }
                     }
@@ -176,7 +171,6 @@ struct POSOrderDetailsView: View {
             .posHeaderBackButtonIcon(systemName: "xmark")
         }
         .task {
-            guard shouldShowDedicatedRefundsSection else { return }
             await orderListModel.ordersController.loadOrderRefunds()
         }
         .task {
@@ -524,10 +518,6 @@ private extension POSOrderDetailsView {
         case .refunded:
             return .init(primary: email, secondary: [])
         case .completed:
-            guard featureFlags.isFeatureFlagEnabled(.pointOfSaleRefundsi1) else {
-                return .init(primary: email, secondary: [])
-            }
-
             switch orderListModel.ordersController.refundActionAvailability {
             case .available:
                 return .init(primary: .issueRefund, secondary: [email])

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -157,8 +157,7 @@ public struct PointOfSaleEntryPointView: View {
         self.posEntryPointController = POSEntryPointController(eligibilityChecker: posEligibilityChecker)
         let ordersController = POSOrderListController(orderListFetchStrategyFactory: orderListFetchStrategyFactory,
                                                       refundsService: refundsService,
-                                                      refundSubmissionProcessor: refundSubmissionProcessor,
-                                                      featureFlags: services.featureFlags)
+                                                      refundSubmissionProcessor: refundSubmissionProcessor)
         self.orderListModel = POSOrderListModel(ordersController: ordersController,
                                                 receiptSender: receiptSender,
                                                 refundSubmissionModel: refundSubmissionProcessor.stateModel)

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -385,6 +385,18 @@ final class POSOrderListControllerTests {
     }
 
     @MainActor
+    @Test func refundActionAvailability_when_completed_order_selected_then_available() async throws {
+        // Given
+        let order = makeOrder(id: 1)
+
+        // When
+        sut.selectOrder(order)
+
+        // Then
+        #expect(sut.refundActionAvailability == .available)
+    }
+
+    @MainActor
     @Test func refundActionAvailability_when_no_selected_order_then_unavailable() async throws {
         // When / Then
         #expect(sut.refundActionAvailability == .unavailable)
@@ -1690,6 +1702,29 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedCustomAmounts.first?.id == 777)
     }
 
+    @MainActor
+    @Test func test_displayedCustomAmounts_when_order_has_no_refunds_then_returns_all_custom_amounts() async throws {
+        // Given
+        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
+        let order = makeOrder(lineItems: [], customAmounts: [customAmount])
+
+        // When
+        sut.selectOrder(order)
+
+        // Then
+        #expect(sut.displayedCustomAmounts.count == 1)
+    }
+
+    @MainActor
+    @Test func test_displayedLineItems_when_no_items_refunded_then_returns_all_items() async throws {
+        // Given
+        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
+        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
+        sut.selectOrder(order)
+
+        // When/Then — all items returned regardless of refunds
+        #expect(sut.displayedLineItems.count == 2)
+    }
 }
 
 private extension POSOrderListControllerTests {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSOrderListControllerTests.swift
@@ -22,15 +22,13 @@ final class POSOrderListControllerTests {
     private let orderListService = MockPOSOrderListService()
     private let refundsService = MockPOSRefundsService()
     private lazy var fetchStrategyFactory = MockPOSOrderListFetchStrategyFactory(orderService: orderListService)
-    private lazy var featureFlags = MockFeatureFlagService()
     private lazy var currencySettingsProvider = MockCurrencySettingsProvider()
     private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettingsProvider.currencySettings)
     private lazy var refundSubmissionProcessor = MockPOSRefundSubmissionProcessor(refundsService: refundsService,
                                                                                   currencyFormatter: currencyFormatter)
     private lazy var sut = POSOrderListController(orderListFetchStrategyFactory: fetchStrategyFactory,
                                                    refundsService: refundsService,
-                                                   refundSubmissionProcessor: refundSubmissionProcessor,
-                                                   featureFlags: featureFlags)
+                                                   refundSubmissionProcessor: refundSubmissionProcessor)
 
     @Test func loadOrders_requests_first_page_after_loading_two_pages() async throws {
         try #require(sut.ordersViewState.isLoading)
@@ -387,23 +385,7 @@ final class POSOrderListControllerTests {
     }
 
     @MainActor
-    @Test func refundActionAvailability_when_feature_flag_disabled_then_unavailable() async throws {
-        // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = false
-        let order = makeOrder(id: 1) // completed by default
-
-        // When
-        sut.selectOrder(order)
-
-        // Then
-        #expect(sut.refundActionAvailability == .unavailable)
-    }
-
-    @MainActor
     @Test func refundActionAvailability_when_no_selected_order_then_unavailable() async throws {
-        // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
-
         // When / Then
         #expect(sut.refundActionAvailability == .unavailable)
     }
@@ -411,7 +393,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func refundActionAvailability_when_order_completed_then_available() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(id: 1, status: .completed)
 
         // When
@@ -424,7 +405,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func refundActionAvailability_when_order_not_completed_then_unavailable() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(id: 1, status: .processing)
 
         // When
@@ -439,7 +419,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func preloadRefundDetails_when_refund_is_available_then_preloads_without_opening_refund_flow() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(id: 1, status: .completed)
         sut.selectOrder(order)
 
@@ -458,7 +437,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func preloadRefundDetails_when_refund_is_unavailable_then_does_not_preload() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(id: 1, status: .processing)
         sut.selectOrder(order)
 
@@ -515,7 +493,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func startRefundFlow_when_item_partially_refunded_then_excludes_refunded_quantity() async throws {
         // Given: Order has 3 units of item, 1 was previously refunded
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -1, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
             isFullyRefunded: false,
@@ -537,7 +514,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func startRefundFlow_when_item_fully_refunded_then_excludes_item_entirely() async throws {
         // Given: Order has 2 units of item, both were previously refunded
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)])],
             isFullyRefunded: false,
@@ -584,7 +560,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_startRefundFlow_when_custom_amount_already_refunded_then_excludes_fee() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [POSRefund(items: [POSRefundItem(refundedItemID: 777, quantity: 0, name: "Discount Fee",
                                                      formattedPrice: "", formattedTotal: "", imageSrc: nil, isLumpSum: true)])],
@@ -662,7 +637,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func startRefundFlow_when_multiple_refunds_exist_then_aggregates_refunded_quantities() async throws {
         // Given: Order has 5 units of item, refunded across two separate refunds (2 + 2 = 4)
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [
                 POSRefund(items: [POSRefundItem(refundedItemID: 1, quantity: -2, name: "", formattedPrice: "", formattedTotal: "", imageSrc: nil)]),
@@ -1124,7 +1098,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_then_submits_refund_with_correct_order_id() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1149,7 +1122,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_then_submits_refund_with_selected_items() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1178,7 +1150,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_then_submits_refund_with_reason() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1202,7 +1173,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_successful_then_clears_selection() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1227,7 +1197,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_submission_throws_then_propagates_error() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1282,7 +1251,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_no_items_are_selected_then_throws_emptySelection() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1307,7 +1275,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_refund_is_already_in_progress_then_throws_refundAlreadyInProgress() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1345,7 +1312,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_then_converts_items_with_correct_properties() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1376,7 +1342,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_supportsAutomaticRefund_is_true_then_submits_refund_with_automatic_refund_true() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1400,7 +1365,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_supportsAutomaticRefund_is_false_then_submits_refund_with_automatic_refund_false() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1424,7 +1388,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func processRefund_when_successful_then_updates_order() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         refundsService.providePointOfSaleRefundsResultToReturn = POSRefundsResult(
             refunds: [],
             isFullyRefunded: false,
@@ -1453,7 +1416,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_loadOrderRefunds_when_order_has_refunds_then_enriches_refunds_with_items() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
@@ -1522,7 +1484,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_selectOrder_then_new_order_has_no_refunded_items() async throws {
         // Given: Load some refunded products first
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
         refundsService.loadOrderRefundsResultToReturn = [
@@ -1548,7 +1509,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_loadOrderRefunds_when_selected_order_changes_during_fetch_then_discards_stale_result() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let orderA = makeOrder(id: 1, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         let orderB = makeOrder(id: 2, refunds: [POSOrderRefund(refundID: 2, formattedTotal: "-$5.00")])
         sut.selectOrder(orderA)
@@ -1577,7 +1537,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_displayedLineItems_when_loading_refunds_then_returns_all_items() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
         let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
@@ -1597,7 +1556,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_displayedLineItems_when_refunds_loaded_then_filters_fully_refunded_items() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let items = [makePOSOrderItem(itemID: 1, quantity: 2), makePOSOrderItem(itemID: 2, quantity: 1)]
         let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
@@ -1623,7 +1581,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_displayedLineItems_when_partially_refunded_then_includes_item() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let items = [makePOSOrderItem(itemID: 1, quantity: 3)]
         let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
         sut.selectOrder(order)
@@ -1649,7 +1606,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_displayedCustomAmounts_when_fee_fully_refunded_then_filters_it_out() async throws {
         // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
         let order = makeOrder(
             lineItems: [],
@@ -1679,7 +1635,6 @@ final class POSOrderListControllerTests {
     @MainActor
     @Test func test_displayedCustomAmounts_when_other_fee_unrefunded_then_keeps_it() async throws {
         // Given - one fee refunded, another not
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let order = makeOrder(
             lineItems: [],
             customAmounts: [
@@ -1714,7 +1669,6 @@ final class POSOrderListControllerTests {
         // Given - simulates an older WooCommerce store whose refund response omits `fee_lines`,
         // so the loaded refund has no entry pointing back to the original fee id. The fee
         // can't be filtered out and stays visible (documented limitation).
-        featureFlags.isPointOfSaleRefundsi1Enabled = true
         let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
         let order = makeOrder(
             lineItems: [],
@@ -1736,31 +1690,6 @@ final class POSOrderListControllerTests {
         #expect(sut.displayedCustomAmounts.first?.id == 777)
     }
 
-    @MainActor
-    @Test func test_displayedCustomAmounts_when_feature_flag_disabled_then_returns_all_custom_amounts() async throws {
-        // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = false
-        let customAmount = makePOSOrderCustomAmount(id: 777, name: "Discount Fee")
-        let order = makeOrder(lineItems: [], customAmounts: [customAmount])
-
-        // When
-        sut.selectOrder(order)
-
-        // Then
-        #expect(sut.displayedCustomAmounts.count == 1)
-    }
-
-    @MainActor
-    @Test func test_displayedLineItems_when_feature_flag_disabled_then_returns_all_items() async throws {
-        // Given
-        featureFlags.isPointOfSaleRefundsi1Enabled = false
-        let items = [makePOSOrderItem(itemID: 1), makePOSOrderItem(itemID: 2)]
-        let order = makeOrder(lineItems: items, refunds: [POSOrderRefund(refundID: 1, formattedTotal: "-$10.00")])
-        sut.selectOrder(order)
-
-        // When/Then — all items returned regardless of refunds
-        #expect(sut.displayedLineItems.count == 2)
-    }
 }
 
 private extension POSOrderListControllerTests {
@@ -1770,8 +1699,7 @@ private extension POSOrderListControllerTests {
             orderListFetchStrategyFactory: fetchStrategyFactory,
             refundsService: refundsService,
             refundSubmissionProcessor: MockPOSRefundSubmissionProcessor(refundsService: refundsService,
-                                                                        currencyFormatter: formatter),
-            featureFlags: featureFlags
+                                                                        currencyFormatter: formatter)
         )
     }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockFeatureFlagService.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockFeatureFlagService.swift
@@ -22,7 +22,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
     var isProductImageOptimizedHandlingEnabled: Bool
     var isFeatureFlagEnabledReturnValue: [FeatureFlag: Bool] = [:]
     var isCIABBookingsEnabled: Bool
-    var isPointOfSaleRefundsi1Enabled: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -42,8 +41,7 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
          hideSitesInStorePicker: Bool = false,
          backgroundProductImageUpload: Bool = false,
          isProductImageOptimizedHandlingEnabled: Bool = false,
-         isCIABBookingsEnabled: Bool = false,
-         isPointOfSaleRefundsi1Enabled: Bool = false) {
+         isCIABBookingsEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -63,7 +61,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
         self.backgroundProductImageUpload = backgroundProductImageUpload
         self.isProductImageOptimizedHandlingEnabled = isProductImageOptimizedHandlingEnabled
         self.isCIABBookingsEnabled = isCIABBookingsEnabled
-        self.isPointOfSaleRefundsi1Enabled = isPointOfSaleRefundsi1Enabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -112,8 +109,6 @@ final class MockFeatureFlagService: POSFeatureFlagProviding {
             return isProductImageOptimizedHandlingEnabled
         case .ciabBookings:
             return isCIABBookingsEnabled
-        case .pointOfSaleRefundsi1:
-            return isPointOfSaleRefundsi1Enabled
         default:
             return false
         }


### PR DESCRIPTION
## Description
Clean-up task, removes `pointOfSaleRefundsi1` gating since refunds have been available for POS for a while now.

## Test Steps
- Navigate to POS > Orders 
- Select any completed order, see the refund flow is present and works normally.

## Screenshots

| - | - |
|--------|--------|
| <img width="1668" height="2420" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - General site - 2026-06-17 at 10 23 45" src="https://github.com/user-attachments/assets/8ec56298-edc8-4f30-8e11-1b4f3ae435db" /> | <img width="1668" height="2420" alt="Simulator Screenshot - iPad Pro 11-inch (M5) - General site - 2026-06-17 at 10 24 10" src="https://github.com/user-attachments/assets/cf85a7fa-d856-41d9-91da-83a262516db7" /> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
