### PR TITLE
Fix WPMediaPicker crash: pushing the same media picker twice

### DIFF
--- a/Modules/Sources/WPMediaPicker/WPNavigationMediaPickerViewController.m
+++ b/Modules/Sources/WPMediaPicker/WPNavigationMediaPickerViewController.m
@@ -206,7 +206,14 @@ static NSString *const ArrowDown = @"\u25be";
 {
     [self.mediaPicker setGroup:group];
     self.mediaPicker.title = group.name;
-    [self.internalNavigationController pushViewController:self.mediaPicker animated:YES];
+
+    // Defensive code to address the crash https://github.com/wordpress-mobile/WordPress-iOS/issues/20890.
+    // `UITableView/didSelectRowAt` can be called twice under certain circumstances, which would push the same
+    // `mediaPicker` instance more than once and crash. Adapted from the (unmerged, upstream-archived) fix in
+    // https://github.com/wordpress-mobile/MediaPicker-iOS/pull/411.
+    if (self.internalNavigationController.topViewController != self.mediaPicker) {
+        [self.internalNavigationController pushViewController:self.mediaPicker animated:YES];
+    }
 }
 
 - (void)mediaGroupPickerViewControllerDidCancel:(WPMediaGroupPickerViewController *)picker

--- a/Modules/Sources/WPMediaPicker/WPNavigationMediaPickerViewController.m
+++ b/Modules/Sources/WPMediaPicker/WPNavigationMediaPickerViewController.m
@@ -207,10 +207,13 @@ static NSString *const ArrowDown = @"\u25be";
     [self.mediaPicker setGroup:group];
     self.mediaPicker.title = group.name;
 
-    // Defensive code to address the crash https://github.com/wordpress-mobile/WordPress-iOS/issues/20890.
-    // `UITableView/didSelectRowAt` can be called twice under certain circumstances, which would push the same
-    // `mediaPicker` instance more than once and crash. Adapted from the (unmerged, upstream-archived) fix in
-    // https://github.com/wordpress-mobile/MediaPicker-iOS/pull/411.
+    // Defensive guard against the "pushed the same view controller instance more than once" crash
+    // (WordPress-iOS#20890): `UITableView/didSelectRowAt` can fire twice under certain circumstances, which
+    // pushes the same `mediaPicker` instance again and crashes.
+    //
+    // This is the interim guard upstream authored (MediaPicker-iOS#411) and proposed to ship (WordPress-iOS#21105),
+    // but abandoned in favour of replacing this device picker with Apple's PHPickerViewController (WordPress-iOS#21190).
+    // We are not migrating, so we adopt their interim guard here. MediaPicker-iOS is archived; no release carries it.
     if (self.internalNavigationController.topViewController != self.mediaPicker) {
         [self.internalNavigationController pushViewController:self.mediaPicker animated:YES];
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.1
 -----
+- [*] Fixed a crash that could occur when picking an image from the device library while editing a product. [https://github.com/woocommerce/woocommerce-ios/pull/17369]
 - [*] Shipping Labels: Clearer notice when the origin (Ship from) address is missing a phone number or email [https://github.com/woocommerce/woocommerce-ios/pull/17339]
 - [*] Add support for Liquid Glass on iOS 26 [https://github.com/woocommerce/woocommerce-ios/pull/17337]
 - [*] Order Creation: fixed visual issues with screen layout [https://github.com/woocommerce/woocommerce-ios/pull/17346]


### PR DESCRIPTION
Closes: WOOMOB-3282

## Description

Editing a product, tapping the image area → **Add images** → **Choose from device** and selecting an album can crash with `NSInvalidArgumentException: <UINavigationController…> is pushing the same view controller instance (<WPMediaPickerViewController…>) more than once`.

The album list (`WPMediaGroupPickerViewController`) is the root of the device picker's internal navigation controller. Picking an album calls `mediaGroupPickerViewController:didPickGroup:`, which unconditionally does `[self.internalNavigationController pushViewController:self.mediaPicker animated:YES]`. `UITableView`'s `didSelectRowAt` can fire twice for a single selection under certain circumstances (a pending selection re-flushed during a `CATransaction` commit — e.g. on foreground), so `didPickGroup:` runs twice and pushes the same `mediaPicker` instance onto the stack twice, which UIKit traps on.

The fix guards the push: only push `mediaPicker` when it isn't already the top view controller. This is the exact interim guard upstream authored in [MediaPicker-iOS#411](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/411) and proposed to ship in [WordPress-iOS#21105](https://github.com/wordpress-mobile/WordPress-iOS/pull/21105) — both closed unmerged, because upstream instead replaced this device picker with Apple's `PHPickerViewController` ([WordPress-iOS#21190](https://github.com/wordpress-mobile/WordPress-iOS/issues/21190)). We aren't doing that migration, so we adopt their guard directly in our vendored copy (MediaPicker-iOS is archived; no release carries it). Only the device-library path is affected — the WordPress Media Library picker sets `showGroupSelector = false` and has no album list.

**I could not reproduce the crash locally.** Upstream couldn't either ("there are no reliable ways to reproduce the crash" — [#21105](https://github.com/wordpress-mobile/WordPress-iOS/pull/21105)); it's an intermittent UIKit double-callback. I confirmed the root cause from the field instead: all three crash logs end on the same breadcrumb — `product_image_settings_add_images_source_tapped` with `source: device`, right after an `application_opened` — and the Sentry stack maps to the exact unguarded push (`WPNavigationMediaPickerViewController.m:209`) via `_userSelectRowAtPendingSelectionIndexPath → notifySelectionOfGroup → didPickGroup:`.

## Test Steps

There's no reliable way to trigger the crash; these steps verify album navigation still works with the guard in place.

1. Open any store with at least one product.
2. Open a product → tap the image area → **Add images** → **Choose from device**.
3. Select an album → confirm it opens.
4. Go back, select another album → confirm it opens.
5. Pick an image and confirm it's added to the product.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
