### PR TITLE
Isolate analytics opt-in state in WooAnalyticsTests

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -25,16 +25,20 @@ final class WooAnalytics: Analytics {
 
     private lazy var widgetSetupChangeTracker = WidgetSetupChangeTracker()
 
+    /// Defaults database used to persist the analytics opt-in state
+    ///
+    private let userDefaults: UserDefaults
+
     /// Check user opt-in for analytics
     ///
     var userHasOptedIn: Bool {
         get {
             let isUITesting: Bool = CommandLine.arguments.contains("-ui_testing")
-            let optedIn: Bool? = UserDefaults.standard.object(forKey: .userOptedInAnalytics)
+            let optedIn: Bool? = userDefaults.object(forKey: .userOptedInAnalytics)
             return ( optedIn ?? true ) && !isUITesting // analytics tracking on by default, but disabled for UI tests
         }
         set {
-            UserDefaults.standard.set(newValue, forKey: .userOptedInAnalytics)
+            userDefaults.set(newValue, forKey: .userOptedInAnalytics)
         }
     }
 
@@ -43,8 +47,9 @@ final class WooAnalytics: Analytics {
 
     /// Designated Initializer
     ///
-    init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker) {
+    init(analyticsProvider: AnalyticsProvider & WPAnalyticsTracker, userDefaults: UserDefaults = .standard) {
         self.analyticsProvider = analyticsProvider
+        self.userDefaults = userDefaults
         WPAnalytics.register(analyticsProvider)
     }
 }

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -24,6 +24,10 @@ class WooAnalyticsTests: XCTestCase {
     ///
     private var userDefaults: UserDefaults!
 
+    /// Suite name backing `userDefaults`, retained so the persistent domain can be cleared in tearDown.
+    ///
+    private var userDefaultsSuiteName: String!
+
     private let sampleSiteID: Int64 = 12345
 
     private let sampleSiteURL: String = "https://example.com"
@@ -39,12 +43,15 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        userDefaultsSuiteName = UUID().uuidString
+        userDefaults = UserDefaults(suiteName: userDefaultsSuiteName)!
         analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), userDefaults: userDefaults)
     }
 
     override func tearDown() {
+        userDefaults.removePersistentDomain(forName: userDefaultsSuiteName)
         userDefaults = nil
+        userDefaultsSuiteName = nil
         super.tearDown()
         ServiceLocator.setStores(originalStores)
     }

--- a/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
+++ b/WooCommerce/WooCommerceTests/System/WooAnalyticsTests.swift
@@ -20,6 +20,10 @@ class WooAnalyticsTests: XCTestCase {
 
     private var stores: MockStoresManager!
 
+    /// Isolated defaults database so tests don't depend on the host's persisted analytics opt-in state.
+    ///
+    private var userDefaults: UserDefaults!
+
     private let sampleSiteID: Int64 = 12345
 
     private let sampleSiteURL: String = "https://example.com"
@@ -35,10 +39,12 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider())
+        userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        analytics = WooAnalytics(analyticsProvider: MockAnalyticsProvider(), userDefaults: userDefaults)
     }
 
     override func tearDown() {
+        userDefaults = nil
         super.tearDown()
         ServiceLocator.setStores(originalStores)
     }
@@ -174,7 +180,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                    defaultStoreUUID: "sample_store_uuid",
                                                                    cachedWooCommerceVersion: "10.0"))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -212,7 +218,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
 
         // When
         analytics.track(.sitePickerContinueTapped, withProperties: Constants.testProperty1)
@@ -250,7 +256,7 @@ class WooAnalyticsTests: XCTestCase {
                                                                     siteID: sampleSiteID,
                                                                     url: sampleSiteURL)))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
 
         // When
         analytics.track(Event.bookingDetailAttendanceStatusUpdate(bookingStatus: .attended))
@@ -271,7 +277,7 @@ class WooAnalyticsTests: XCTestCase {
         }
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: false))
         ServiceLocator.setStores(stores)
-        analytics = WooAnalytics(analyticsProvider: testingProvider)
+        analytics = WooAnalytics(analyticsProvider: testingProvider, userDefaults: userDefaults)
 
         // When
         analytics.track(Event.bookingDetailAttendanceStatusUpdate(bookingStatus: .attended))


### PR DESCRIPTION
## Description
`WooAnalytics.userHasOptedIn` read/wrote the analytics opt-in flag directly from the process-global `UserDefaults.standard` (the `userOptedInAnalytics` key), and every `track(...)` path short-circuits when it is `false`. `WooAnalyticsTests` never isolated or reset that standard default, so a test host whose `UserDefaults.standard` had `userOptedInAnalytics = false` persisted (e.g. a developer toggled "Collect Information" off in a prior run on the same simulator) would fail the event-count assertions because no events were recorded.

This fix injects `UserDefaults` into `WooAnalytics` (defaulting to `.standard`, mirroring the existing `UpdateAnalyticsSettingUseCase` pattern) and has the tests pass a fresh per-test suite (`UserDefaults(suiteName: UUID().uuidString)`, the convention already used by `BookingsTabEligibilityCheckerTests`). A fresh suite has no `userOptedInAnalytics` value, so `optedIn ?? true` evaluates to `true` and tracking is enabled regardless of the host's real Collect Information setting.

Production behaviour is unchanged: the single construction site in `ServiceLocator` keeps the defaulted `.standard`.

Addresses WOOMOB-3206.

## Test Steps
Validate analytics events are still tracked.

1. Interact with few parts of the app
2. Head to Menu/Settings/Help & Support/View Application Log/Current
3. Scroll to bottom
4. You should see events related to the latest interactions of the app.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Internal test-isolation change, no release note needed.)