### PR TITLE
Fix dead "Need more help?" links on login site-address and error dialogs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 25.1
 -----
 - [*] Fixed a crash that could occur when picking an image from the device library while editing a product. [https://github.com/woocommerce/woocommerce-ios/pull/17369]
-- [*] Login: Fixed the dead "Need more help?" link on the pre-login "Find your store address" screen so it opens Help & Support [https://github.com/woocommerce/woocommerce-ios/pull/17372]
 - [*] Login: Fixed the dead "Need more help?" links on the site-address help and login error dialogs so they open support as intended [https://github.com/woocommerce/woocommerce-ios/pull/17372]
 - [*] Shipping Labels: Clearer notice when the origin (Ship from) address is missing a phone number or email [https://github.com/woocommerce/woocommerce-ios/pull/17339]
 - [*] Add support for Liquid Glass on iOS 26 [https://github.com/woocommerce/woocommerce-ios/pull/17337]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [*] Fixed a crash that could occur when picking an image from the device library while editing a product. [https://github.com/woocommerce/woocommerce-ios/pull/17369]
 - [*] Login: Fixed the dead "Need more help?" link on the pre-login "Find your store address" screen so it opens Help & Support [https://github.com/woocommerce/woocommerce-ios/pull/17372]
+- [*] Login: Fixed the dead "Need more help?" links on the site-address help and login error dialogs so they open support as intended [https://github.com/woocommerce/woocommerce-ios/pull/17372]
 - [*] Shipping Labels: Clearer notice when the origin (Ship from) address is missing a phone number or email [https://github.com/woocommerce/woocommerce-ios/pull/17339]
 - [*] Add support for Liquid Glass on iOS 26 [https://github.com/woocommerce/woocommerce-ios/pull/17337]
 - [*] Order Creation: fixed visual issues with screen layout [https://github.com/woocommerce/woocommerce-ios/pull/17346]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.1
 -----
 - [*] Fixed a crash that could occur when picking an image from the device library while editing a product. [https://github.com/woocommerce/woocommerce-ios/pull/17369]
+- [*] Login: Fixed the dead "Need more help?" link on the pre-login "Find your store address" screen so it opens Help & Support [https://github.com/woocommerce/woocommerce-ios/pull/17372]
 - [*] Shipping Labels: Clearer notice when the origin (Ship from) address is missing a phone number or email [https://github.com/woocommerce/woocommerce-ios/pull/17339]
 - [*] Add support for Liquid Glass on iOS 26 [https://github.com/woocommerce/woocommerce-ios/pull/17337]
 - [*] Order Creation: fixed visual issues with screen layout [https://github.com/woocommerce/woocommerce-ios/pull/17346]

--- a/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -28,25 +28,17 @@ extension FancyAlertViewController {
         onDismiss: (() -> Void)? = nil) -> FancyAlertViewController {
 
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-            // Capture the presenter before dismissing. Resolving the presenter via
-            // `UIApplication.shared.delegate?.window` returns nil in this scene-based app,
-            // which previously left the button dead (the modal would just close).
+            // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
             let presenter = controller.presentingViewController
             controller.dismiss(animated: true) {
-                guard let presenter,
-                    let authDelegate = WordPressAuthenticator.shared.delegate
+                guard WordPressAuthenticator.shared.delegate?.supportEnabled == true,
+                    let presenter
                 else {
                     return
                 }
 
                 moreHelpTapped?()
-                let state = AuthenticatorAnalyticsTracker.shared.state
-                let siteAddress = loginFields.siteAddress.isEmpty ? nil : loginFields.siteAddress
-                authDelegate.presentSupport(from: presenter,
-                                            sourceTag: sourceTag,
-                                            lastStep: state.lastStep,
-                                            lastFlow: state.lastFlow,
-                                            siteURL: siteAddress)
+                WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: presenter, sourceTag: sourceTag)
             }
         }
 
@@ -126,8 +118,10 @@ extension FancyAlertViewController {
     ///
     private static func alertForGenericErrorMessage(_ message: String, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
+            // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
+            let presenter = controller.presentingViewController
             controller.dismiss(animated: true) {
-                guard let sourceViewController = UIApplication.shared.delegate?.window??.topmostPresentedViewController,
+                guard let presenter,
                     let authDelegate = WordPressAuthenticator.shared.delegate
                 else {
                     return
@@ -135,7 +129,7 @@ extension FancyAlertViewController {
 
                 let state = AuthenticatorAnalyticsTracker.shared.state
                 let siteAddress = loginFields.siteAddress.isEmpty ? nil : loginFields.siteAddress
-                authDelegate.presentSupport(from: sourceViewController,
+                authDelegate.presentSupport(from: presenter,
                                             sourceTag: sourceTag,
                                             lastStep: state.lastStep,
                                             lastFlow: state.lastFlow,
@@ -170,17 +164,16 @@ extension FancyAlertViewController {
             WPAuthenticatorLogInfo("Error Alert: Support not enabled. Hiding Help button.")
         } else {
             moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
+                // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
+                let presenter = controller.presentingViewController
                 controller.dismiss(animated: true) {
-                    // Find the topmost view controller that we can present from
-                    guard let appDelegate = UIApplication.shared.delegate,
-                        let window = appDelegate.window,
-                        let viewController = window?.topmostPresentedViewController,
+                    guard let presenter,
                         WordPressAuthenticator.shared.delegate?.supportEnabled == true
                         else {
                             return
                     }
 
-                    WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag)
+                    WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: presenter, sourceTag: sourceTag)
                 }
             }
         }
@@ -204,9 +197,10 @@ extension FancyAlertViewController {
     ///
     private static func alertForBadURL(with message: String) -> FancyAlertViewController {
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
+            // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
+            let presenter = controller.presentingViewController
             controller.dismiss(animated: true) {
-                // Find the topmost view controller that we can present from
-                guard let viewController = UIApplication.shared.delegate?.window??.topmostPresentedViewController,
+                guard let presenter,
                     let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3")
                     else {
                         return
@@ -214,7 +208,7 @@ extension FancyAlertViewController {
 
                 let safariViewController = SFSafariViewController(url: url)
                 safariViewController.modalPresentationStyle = .pageSheet
-                viewController.present(safariViewController, animated: true, completion: nil)
+                presenter.present(safariViewController, animated: true, completion: nil)
             }
         }
 

--- a/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -28,16 +28,25 @@ extension FancyAlertViewController {
         onDismiss: (() -> Void)? = nil) -> FancyAlertViewController {
 
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
+            // Capture the presenter before dismissing. Resolving the presenter via
+            // `UIApplication.shared.delegate?.window` returns nil in this scene-based app,
+            // which previously left the button dead (the modal would just close).
+            let presenter = controller.presentingViewController
             controller.dismiss(animated: true) {
-                // Find the topmost view controller that we can present from
-                guard WordPressAuthenticator.shared.delegate?.supportEnabled == true,
-                    let viewController = UIApplication.shared.delegate?.window??.topmostPresentedViewController
+                guard let presenter,
+                    let authDelegate = WordPressAuthenticator.shared.delegate
                 else {
                     return
                 }
 
                 moreHelpTapped?()
-                WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag)
+                let state = AuthenticatorAnalyticsTracker.shared.state
+                let siteAddress = loginFields.siteAddress.isEmpty ? nil : loginFields.siteAddress
+                authDelegate.presentSupport(from: presenter,
+                                            sourceTag: sourceTag,
+                                            lastStep: state.lastStep,
+                                            lastFlow: state.lastFlow,
+                                            siteURL: siteAddress)
             }
         }
 

--- a/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
+++ b/WooCommerce/WordPressAuthenticator/Extensions/FancyAlertViewController+LoginError.swift
@@ -28,12 +28,8 @@ extension FancyAlertViewController {
         onDismiss: (() -> Void)? = nil) -> FancyAlertViewController {
 
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-            // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
-            let presenter = controller.presentingViewController
-            controller.dismiss(animated: true) {
-                guard WordPressAuthenticator.shared.delegate?.supportEnabled == true,
-                    let presenter
-                else {
+            controller.dismissAndPresent { presenter in
+                guard WordPressAuthenticator.shared.delegate?.supportEnabled == true else {
                     return
                 }
 
@@ -118,12 +114,8 @@ extension FancyAlertViewController {
     ///
     private static func alertForGenericErrorMessage(_ message: String, loginFields: LoginFields, sourceTag: WordPressSupportSourceTag) -> FancyAlertViewController {
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-            // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
-            let presenter = controller.presentingViewController
-            controller.dismiss(animated: true) {
-                guard let presenter,
-                    let authDelegate = WordPressAuthenticator.shared.delegate
-                else {
+            controller.dismissAndPresent { presenter in
+                guard let authDelegate = WordPressAuthenticator.shared.delegate else {
                     return
                 }
 
@@ -164,13 +156,9 @@ extension FancyAlertViewController {
             WPAuthenticatorLogInfo("Error Alert: Support not enabled. Hiding Help button.")
         } else {
             moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-                // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
-                let presenter = controller.presentingViewController
-                controller.dismiss(animated: true) {
-                    guard let presenter,
-                        WordPressAuthenticator.shared.delegate?.supportEnabled == true
-                        else {
-                            return
+                controller.dismissAndPresent { presenter in
+                    guard WordPressAuthenticator.shared.delegate?.supportEnabled == true else {
+                        return
                     }
 
                     WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: presenter, sourceTag: sourceTag)
@@ -197,13 +185,9 @@ extension FancyAlertViewController {
     ///
     private static func alertForBadURL(with message: String) -> FancyAlertViewController {
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-            // Capture the presenter before dismissing; the legacy app-delegate window lookup is nil in this scene-based app.
-            let presenter = controller.presentingViewController
-            controller.dismiss(animated: true) {
-                guard let presenter,
-                    let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3")
-                    else {
-                        return
+            controller.dismissAndPresent { presenter in
+                guard let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3") else {
+                    return
                 }
 
                 let safariViewController = SFSafariViewController(url: url)
@@ -222,5 +206,23 @@ extension FancyAlertViewController {
                                                      titleAccessoryButton: nil,
                                                      dismissAction: nil)
         return FancyAlertViewController.controllerWithConfiguration(configuration: config)
+    }
+}
+
+private extension FancyAlertViewController {
+    /// Dismisses the alert and then runs `presentAction` with the view controller that presented it.
+    ///
+    /// The presenter is captured before dismissing because resolving it afterwards via
+    /// `UIApplication.shared.delegate?.window` returns nil in this scene-based app, which is
+    /// what previously left the "Need more help?" buttons dead (the modal would just close).
+    func dismissAndPresent(_ presentAction: @escaping (_ presenter: UIViewController) -> Void) {
+        let presenter = presentingViewController
+        dismiss(animated: true) {
+            guard let presenter else {
+                return
+            }
+
+            presentAction(presenter)
+        }
     }
 }


### PR DESCRIPTION
## Description

Fixes [WOOMOB-3284](https://linear.app/a8c/issue/WOOMOB-3284/bug-dead-need-more-help-link-on-pre-login-find-your-store-address).

### Root cause

These dialogs resolved the view controller to present from via `UIApplication.shared.delegate?.window`. WooCommerce is a scene-based app: the window lives on `SceneDelegate`, and `AppDelegate` has no `window`, so that lookup returns `nil`. The guard bailed out after the modal had already been dismissed, leaving the button dead. The same dead pattern affected all four "Need more help?" buttons in `FancyAlertViewController+LoginError.swift`.

### Fix

Capture the alert's `presentingViewController` before dismissing (these alerts are always presented modally, so it's the correct, scene-agnostic presenter) and present from it. Each of the four buttons keeps its original destination and guards unchanged.

## Test Steps

1. Launch the app logged out → **Log In** → **Enter your store address** → continue to the site-address screen.
2. Tap **Find your store address**, then **Need more help?** → the modal closes and the support flow opens (instead of nothing happening).

## Screenshots

| Before | After |
| --- | --- |
| <img width="256" height="555" alt="ScreenRecording_06-16-2026 21-17-20_1" src="https://github.com/user-attachments/assets/98335693-4a7c-4d81-abe4-a1dd382197fb" /> | <img width="256" height="554" alt="ScreenRecording_06-17-2026 14-32-56_1" src="https://github.com/user-attachments/assets/952e5f9a-cb78-4dae-8532-5e9ba9030000" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.