### PR TITLE
[WOOMOB-3200] Disable swipe-to-dismiss on the Analytics date range selector

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 - [*] POS: Fixed discarded card reader checkout orders appearing in Orders until refresh. [https://github.com/woocommerce/woocommerce-ios/pull/17357]
 - [*] POS: Fixed new orders on iPad returning to the previous variation selector instead of the root product list. [https://github.com/woocommerce/woocommerce-ios/pull/17356]
 - [Internal] QR login: fixed the scanner not detecting after navigating back from a scanned code. [https://github.com/woocommerce/woocommerce-ios/pull/17352]
-- [*] Analytics: the date range selector can no longer be dismissed by swiping it away; tap Done to close it. [https://github.com/woocommerce/woocommerce-ios/pull/PR_NUMBER]
+- [*] Analytics: the date range selector can no longer be dismissed by swiping it away; tap Done to close it. [https://github.com/woocommerce/woocommerce-ios/pull/17373]
 
 25.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] POS: Fixed discarded card reader checkout orders appearing in Orders until refresh. [https://github.com/woocommerce/woocommerce-ios/pull/17357]
 - [*] POS: Fixed new orders on iPad returning to the previous variation selector instead of the root product list. [https://github.com/woocommerce/woocommerce-ios/pull/17356]
 - [Internal] QR login: fixed the scanner not detecting after navigating back from a scanned code. [https://github.com/woocommerce/woocommerce-ios/pull/17352]
+- [*] Analytics: the date range selector can no longer be dismissed by swiping it away; tap Done to close it. [https://github.com/woocommerce/woocommerce-ios/pull/PR_NUMBER]
 
 25.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -46,6 +46,7 @@ struct AnalyticsTimeRangeCard: View {
                     }
                 }
                 .wooNavigationBarStyle()
+                .interactiveDismissDisabled()
                 .sheet(isPresented: $showCustomRangeSelectionView) {
                     RangedDatePicker(startDate: selectionType.startDate, endDate: selectionType.endDate) { start, end in
                         showTimeRangeSelectionView = false // Dismiss the initial sheet for a smooth transition


### PR DESCRIPTION
Closes: WOOMOB-3200

## Description

On iPad the Analytics Hub date range selector is presented as a form sheet, which can be dismissed with a downward drag. Selecting an option (e.g. "Yesterday") applies it immediately through the selection binding, so dragging the sheet away without tapping **Done** still applied the change — making it look like Done was required when it wasn't, and changing the range when the user only meant to back out.

This adds `.interactiveDismissDisabled()` to the selector sheet so it can no longer be dismissed by a swipe; **Done** becomes the only way to close it. Mirrors the existing pattern used for the "Customize analytics" sheet in `AnalyticsHubView`. Selection behavior is unchanged — tapping a range still applies it.

## Test Steps

1. On an **iPad**, open **My Store** → **View all store analytics**.
2. Open the **Date Range** selector from the Analytics header.
3. Select a different range (e.g. **Yesterday**), then try to dismiss the popover with a downward drag → confirm it stays open.
4. Tap **Done** → confirm the selector closes and the header/metrics reflect the selected range.

## Screenshots

<img width="640" height="447" alt="ScreenRecording_06-17-2026 15-09-58_1" src="https://github.com/user-attachments/assets/edfd16ef-baba-4161-b941-786d457aef89" />
---
- [x] I have considered if this change warrants user-facing release notes and have added them to \`RELEASE-NOTES.txt\` if necessary.