### PR TITLE
Fix site-credential nonce redirect handling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Order Creation: fixed visual issues with screen layout [https://github.com/woocommerce/woocommerce-ios/pull/17346]
 - [*] POS: Fixed discarded card reader checkout orders appearing in Orders until refresh. [https://github.com/woocommerce/woocommerce-ios/pull/17357]
 - [*] POS: Fixed new orders on iPad returning to the previous variation selector instead of the root product list. [https://github.com/woocommerce/woocommerce-ios/pull/17356]
+- [Internal] Improved site-credential login nonce retrieval by handling redirects explicitly, reducing HTTP 429 failures during login. [https://github.com/woocommerce/woocommerce-ios/pull/17376]
 - [Internal] QR login: fixed the scanner not detecting after navigating back from a scanned code. [https://github.com/woocommerce/woocommerce-ios/pull/17352]
 
 25.0

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -1,4 +1,6 @@
 import Foundation
+import class Networking.UserAgent
+import protocol NetworkingCore.URLSessionProtocol
 
 protocol SiteCredentialLoginProtocol {
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
@@ -111,22 +113,27 @@ enum SiteCredentialLoginError: LocalizedError {
 
 /// This use case handles site credential login without the need to use XMLRPC API.
 /// Steps for login:
-/// - Make a request to the site wp-login.php with a redirect to the nonce retrieval URL.
-/// - If the redirect succeeds with a nonce in the response, login is successful.
-/// - If the request does not redirect or the redirect fails, login fails.
+/// - Post to `wp-login.php` with a redirect target for the rest nonce endpoint.
+/// - Prevent the HTTP stack from automatically following that redirect.
+/// - Validate the redirect target and then issue an explicit nonce GET using the same cookie store.
 /// Ref: pe5sF9-1iQ-p2
 ///
 final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
     private let siteURL: String
     private let cookieJar: HTTPCookieStorage
+    private let session: URLSessionProtocol
+    private let loginSession: URLSessionProtocol
     private var successHandler: (() -> Void)?
     private var errorHandler: ((SiteCredentialLoginError) -> Void)?
-    private lazy var session = URLSession(configuration: .default)
 
     init(siteURL: String,
-         cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared) {
+         cookieJar: HTTPCookieStorage = HTTPCookieStorage.shared,
+         session: URLSessionProtocol? = nil,
+         loginSession: URLSessionProtocol? = nil) {
         self.siteURL = siteURL
         self.cookieJar = cookieJar
+        self.session = session ?? Self.makeSession(cookieJar: cookieJar)
+        self.loginSession = loginSession ?? Self.makeRedirectBlockingSession(cookieJar: cookieJar)
         super.init()
     }
 
@@ -169,7 +176,7 @@ private extension SiteCredentialLoginUseCase {
     func startLogin(with loginRequest: URLRequest) async throws {
         try await detectBasicAuthProbe()
 
-        let (data, response): (Data, URLResponse) = try await session.data(for: loginRequest)
+        let (data, response): (Data, URLResponse) = try await loginSession.data(for: loginRequest)
 
         guard let response = response as? HTTPURLResponse else {
             throw SiteCredentialLoginError.invalidLoginResponse
@@ -179,25 +186,15 @@ private extension SiteCredentialLoginUseCase {
             throw SiteCredentialLoginError.basicAuthenticationRequired
         }
 
-        /// The login request comes with a redirect header to nonce retrieval URL.
-        /// If we get a response from this URL, that means the redirect is successful.
-        /// We need to check the result of this redirect first to determine if login is successful.
-        let isNonceUrl = response.url?.absoluteString.hasSuffix(Constants.wporgNoncePath) == true
-
-        switch (isNonceUrl, response.statusCode) {
-        case (true, 200):
-            if let nonceString = String(data: data, encoding: .utf8),
-               nonceString.isValidNonce() {
-                // success!
-                return
-            } else {
+        switch response.statusCode {
+        case 300..<400:
+            guard let nonceRequest = buildNonceRequest(from: response) else {
                 throw SiteCredentialLoginError.invalidLoginResponse
             }
-        case (true, 404):
-            throw SiteCredentialLoginError.inaccessibleAdminPage
-        case (false, 404):
+            try await retrieveNonce(with: nonceRequest)
+        case 404:
             throw SiteCredentialLoginError.inaccessibleLoginPage
-        case (false, 200):
+        case 200:
             // 200 for the login URL, which means a failure
             guard let html = String(data: data, encoding: .utf8) else {
                 throw SiteCredentialLoginError.invalidLoginResponse
@@ -228,6 +225,7 @@ private extension SiteCredentialLoginUseCase {
 
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
         var parameters = [URLQueryItem]()
         parameters.append(URLQueryItem(name: "log", value: username))
@@ -243,6 +241,17 @@ private extension SiteCredentialLoginUseCase {
         return request
     }
 
+    func buildNonceRequest(from response: HTTPURLResponse) -> URLRequest? {
+        guard let nonceURL = nonceURL(from: response) else {
+            return nil
+        }
+
+        var request = URLRequest(url: nonceURL)
+        request.httpMethod = "GET"
+        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
     /// Issues a lightweight GET to detect Basic Auth without engaging URLSession auth challenge flow.
     func detectBasicAuthProbe() async throws {
         guard let loginURL = URL(string: siteURL + Constants.loginPath) else {
@@ -254,6 +263,7 @@ private extension SiteCredentialLoginUseCase {
             timeoutInterval: 8
         )
         request.httpMethod = "GET"
+        request.setValue(UserAgent.defaultUserAgent, forHTTPHeaderField: "User-Agent")
 
         let (_, response) = try await session.data(for: request)
         guard let http = response as? HTTPURLResponse else { return }
@@ -261,14 +271,79 @@ private extension SiteCredentialLoginUseCase {
             throw SiteCredentialLoginError.basicAuthenticationRequired
         }
     }
+
+    func retrieveNonce(with request: URLRequest) async throws {
+        let (data, response) = try await session.data(for: request)
+
+        guard let response = response as? HTTPURLResponse else {
+            throw SiteCredentialLoginError.invalidLoginResponse
+        }
+
+        if response.containsHTTPBasicAuthenticationChallenge {
+            throw SiteCredentialLoginError.basicAuthenticationRequired
+        }
+
+        switch response.statusCode {
+        case 200:
+            guard let nonceString = String(data: data, encoding: .utf8),
+                  nonceString.isValidNonce() else {
+                throw SiteCredentialLoginError.invalidLoginResponse
+            }
+        case 404:
+            throw SiteCredentialLoginError.inaccessibleAdminPage
+        default:
+            throw SiteCredentialLoginError.unacceptableStatusCode(code: response.statusCode)
+        }
+    }
+
+    func nonceURL(from response: HTTPURLResponse) -> URL? {
+        guard let location = response.value(forHTTPHeaderField: "Location"),
+              let resolvedURL = URL(string: location, relativeTo: response.url)?.absoluteURL,
+              resolvedURL.isExpectedRestNonceURL(for: siteURL) else {
+            return nil
+        }
+        return resolvedURL
+    }
+
+    static func makeSession(cookieJar: HTTPCookieStorage) -> URLSession {
+        URLSession(configuration: makeSessionConfiguration(cookieJar: cookieJar))
+    }
+
+    static func makeRedirectBlockingSession(cookieJar: HTTPCookieStorage) -> URLSession {
+        return URLSession(configuration: makeSessionConfiguration(cookieJar: cookieJar),
+                          delegate: RedirectBlockingURLSessionDelegate(),
+                          delegateQueue: nil)
+    }
 }
 
 extension SiteCredentialLoginUseCase {
+    static func makeSessionConfiguration(cookieJar: HTTPCookieStorage,
+                                         baseConfiguration: URLSessionConfiguration = .default) -> URLSessionConfiguration {
+        let configuration = baseConfiguration
+        configuration.httpCookieStorage = cookieJar
+        configuration.httpShouldSetCookies = true
+        // This login flow depends on handling the redirect itself and should not be intercepted by debug URLProtocol handlers.
+        configuration.protocolClasses = []
+        return configuration
+    }
+
     enum Constants {
         static let loginPath = "/wp-login.php"
         static let adminPath = "/wp-admin"
         static let wporgNoncePath = "/admin-ajax.php?action=rest-nonce"
+        static let wporgNonceEndpointPath = adminPath + "/admin-ajax.php"
+        static let restNonceActionParameter = "action"
+        static let restNonceAction = "rest-nonce"
         static let captchaText = "captcha"
+    }
+}
+
+private final class RedirectBlockingURLSessionDelegate: NSObject, URLSessionTaskDelegate {
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest) async -> URLRequest? {
+        nil
     }
 }
 
@@ -283,6 +358,72 @@ extension HTTPURLResponse {
         }
         return value(forHTTPHeaderField: "WWW-Authenticate")?
             .localizedCaseInsensitiveContains("basic") == true
+    }
+}
+
+private extension URL {
+    func isExpectedRestNonceURL(for siteURLString: String) -> Bool {
+        guard let resolvedComponents = URLComponents(url: self, resolvingAgainstBaseURL: true),
+              let siteURL = URL(string: siteURLString),
+              let siteComponents = URLComponents(url: siteURL, resolvingAgainstBaseURL: true),
+              resolvedComponents.isRestNonceURL else {
+            return false
+        }
+
+        return resolvedComponents.isOnExpectedSite(as: siteComponents)
+    }
+}
+
+private extension URLComponents {
+    var isRestNonceURL: Bool {
+        let action = queryItems?.first(where: { $0.name == SiteCredentialLoginUseCase.Constants.restNonceActionParameter })?.value
+        return path.hasSuffix(SiteCredentialLoginUseCase.Constants.wporgNonceEndpointPath) &&
+            action == SiteCredentialLoginUseCase.Constants.restNonceAction
+    }
+
+    func isOnExpectedSite(as siteComponents: URLComponents) -> Bool {
+        guard let scheme = scheme?.lowercased(),
+              let siteScheme = siteComponents.scheme?.lowercased(),
+              let host = host?.lowercased(),
+              let siteHost = siteComponents.host?.lowercased() else {
+            return false
+        }
+
+        if scheme == siteScheme {
+            return host == siteHost && effectivePort == siteComponents.effectivePort
+        }
+
+        return isHTTPSUpgrade(from: siteComponents, redirectScheme: scheme, redirectHost: host, siteHost: siteHost)
+    }
+
+    var effectivePort: Int? {
+        if let port {
+            return port
+        }
+
+        switch scheme?.lowercased() {
+        case "http":
+            return 80
+        case "https":
+            return 443
+        default:
+            return nil
+        }
+    }
+
+    func isHTTPSUpgrade(from siteComponents: URLComponents,
+                        redirectScheme: String,
+                        redirectHost: String,
+                        siteHost: String) -> Bool {
+        guard siteComponents.scheme?.lowercased() == "http",
+              redirectScheme == "https",
+              redirectHost == siteHost else {
+            return false
+        }
+
+        let usesDefaultUpgradePorts = (siteComponents.port == nil || siteComponents.port == 80) &&
+            (port == nil || port == 443)
+        return usesDefaultUpgradePorts || siteComponents.port == port
     }
 }
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -137,6 +137,10 @@ final class SiteCredentialLoginUseCase: NSObject, SiteCredentialLoginProtocol {
         super.init()
     }
 
+    deinit {
+        (loginSession as? URLSession)?.finishTasksAndInvalidate()
+    }
+
     func setupHandlers(onLoginSuccess: @escaping () -> Void,
                        onLoginFailure: @escaping (SiteCredentialLoginError) -> Void) {
         self.successHandler = onLoginSuccess

--- a/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/SiteCredentialLoginUseCaseTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import class Networking.UserAgent
 @testable import WooCommerce
 
 final class SiteCredentialLoginUseCaseTests: XCTestCase {
@@ -17,6 +18,229 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertEqual(cookieJar.cookies?.isEmpty, true)
+    }
+
+    func test_sessionConfiguration_when_customURLProtocolIsPresent_then_removesProtocolClasses() {
+        // Given
+        let cookieJar = MockCookieJar()
+        let baseConfiguration = URLSessionConfiguration.default
+        baseConfiguration.protocolClasses = [SiteCredentialLoginTestURLProtocol.self]
+
+        // When
+        let configuration = SiteCredentialLoginUseCase.makeSessionConfiguration(
+            cookieJar: cookieJar,
+            baseConfiguration: baseConfiguration
+        )
+
+        // Then
+        XCTAssertTrue(configuration.httpCookieStorage === cookieJar)
+        XCTAssertEqual(configuration.httpShouldSetCookies, true)
+        XCTAssertEqual(configuration.protocolClasses?.isEmpty, true)
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_absoluteSameOrigin_then_nonceRequestSucceeds() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath]
+        )
+        session.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath,
+            data: Data("validnonce".utf8)
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(loginSession.lastRequest?.httpMethod, "POST")
+        XCTAssertEqual(session.requestCount, 2)
+        XCTAssertEqual(
+            session.receivedRequests.last?.url?.absoluteString,
+            siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        )
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_relative_then_resolves_and_sets_userAgent_headers() async throws {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath]
+        )
+        session.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath,
+            data: Data("validnonce".utf8)
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.first?.value(forHTTPHeaderField: "User-Agent"), UserAgent.defaultUserAgent)
+        XCTAssertEqual(loginSession.lastRequest?.value(forHTTPHeaderField: "User-Agent"), UserAgent.defaultUserAgent)
+        XCTAssertEqual(
+            session.receivedRequests.last?.value(forHTTPHeaderField: "User-Agent"),
+            UserAgent.defaultUserAgent
+        )
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_subdirectoryRestNonce_then_nonceRequestSucceeds() async {
+        // Given
+        let siteURL = "https://test.com/blog"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        let nonceURL = siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": nonceURL]
+        )
+        session.simulateResponse(for: nonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.last?.url?.absoluteString, nonceURL)
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_httpsUpgrade_then_nonceRequestSucceeds() async {
+        // Given
+        let siteURL = "http://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        let secureNonceURL = "https://test.com" + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": secureNonceURL]
+        )
+        session.simulateResponse(for: secureNonceURL, data: Data("validnonce".utf8))
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        XCTAssertNoThrow(try result.get())
+        XCTAssertEqual(session.receivedRequests.last?.url?.absoluteString, secureNonceURL)
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_not_restNonce_then_returns_invalidLoginResponse() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": siteURL + SiteCredentialLoginUseCase.Constants.adminPath]
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_crossOriginRestNonce_then_returns_invalidLoginResponse() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": "https://example-attacker.test/wp-admin/admin-ajax.php?action=rest-nonce"]
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+    }
+
+    func test_handleLogin_when_loginRedirectLocation_is_sameHostDifferentPortRestNonce_then_returns_invalidLoginResponse() async {
+        // Given
+        let siteURL = "https://test.com:8080"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": "https://test.com:9090/wp-admin/admin-ajax.php?action=rest-nonce"]
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .invalidLoginResponse)
+    }
+
+    func test_handleLogin_when_manualNonceRequest_returns_notFound_then_returns_inaccessibleAdminPage() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath]
+        )
+        session.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath,
+            statusCode: 404
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .inaccessibleAdminPage)
+    }
+
+    func test_handleLogin_when_manualNonceRequest_returns_rateLimited_then_returns_unacceptableStatusCode() async {
+        // Given
+        let siteURL = "https://test.com"
+        let session = MockURLSession()
+        let loginSession = MockURLSession()
+        session.simulateResponse(for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath)
+        loginSession.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.loginPath,
+            statusCode: 302,
+            headerFields: ["Location": siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath]
+        )
+        session.simulateResponse(
+            for: siteURL + SiteCredentialLoginUseCase.Constants.adminPath + SiteCredentialLoginUseCase.Constants.wporgNoncePath,
+            statusCode: 429
+        )
+
+        // When
+        let result = await performLogin(siteURL: siteURL, session: session, loginSession: loginSession)
+
+        // Then
+        assertFailure(result, matches: .unacceptableStatusCode(code: 429))
     }
 
     func test_basicAuthenticationChallenge_is_detected_from_response_headers() throws {
@@ -42,8 +266,43 @@ final class SiteCredentialLoginUseCaseTests: XCTestCase {
     }
 }
 
+private final class SiteCredentialLoginTestURLProtocol: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        false
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {}
+
+    override func stopLoading() {}
+}
+
 // MARK: - Helpers
 private extension SiteCredentialLoginUseCaseTests {
+    func performLogin(siteURL: String,
+                      session: MockURLSession,
+                      loginSession: MockURLSession) async -> Result<Void, SiteCredentialLoginError> {
+        let useCase = SiteCredentialLoginUseCase(
+            siteURL: siteURL,
+            cookieJar: MockCookieJar(),
+            session: session,
+            loginSession: loginSession
+        )
+
+        return await withCheckedContinuation { continuation in
+            useCase.setupHandlers(onLoginSuccess: {
+                continuation.resume(returning: .success(()))
+            }, onLoginFailure: { error in
+                continuation.resume(returning: .failure(error))
+            })
+
+            useCase.handleLogin(username: "test", password: "secret")
+        }
+    }
+
     func makeHTTPURLResponse(statusCode: Int, headers: [String: String]) -> HTTPURLResponse? {
         HTTPURLResponse(
             url: URL(string: "https://example.com")!,
@@ -51,5 +310,25 @@ private extension SiteCredentialLoginUseCaseTests {
             httpVersion: nil,
             headerFields: headers
         )
+    }
+
+    func assertFailure(_ result: Result<Void, SiteCredentialLoginError>,
+                       matches expectedError: SiteCredentialLoginError,
+                       file: StaticString = #filePath,
+                       line: UInt = #line) {
+        guard case .failure(let actualError) = result else {
+            XCTFail("Expected failure result", file: file, line: line)
+            return
+        }
+
+        switch (actualError, expectedError) {
+        case (.invalidLoginResponse, .invalidLoginResponse),
+             (.inaccessibleAdminPage, .inaccessibleAdminPage):
+            break
+        case let (.unacceptableStatusCode(actualCode), .unacceptableStatusCode(expectedCode)):
+            XCTAssertEqual(actualCode, expectedCode, file: file, line: line)
+        default:
+            XCTFail("Unexpected error: \(actualError)", file: file, line: line)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockURLSession.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockURLSession.swift
@@ -6,10 +6,12 @@ final class MockURLSession: URLSessionProtocol {
     var errors: [String: Error] = [:]
 
     private(set) var lastRequest: URLRequest?
+    private(set) var receivedRequests: [URLRequest] = []
     private(set) var requestCount = 0
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
         lastRequest = request
+        receivedRequests.append(request)
         requestCount += 1
 
         let key = request.url?.absoluteString ?? ""


### PR DESCRIPTION
## Description

**Problem:** Site-credential login for self-hosted / Jurassic Ninja / Atomic / WP Cloud stores fails intermittently. `URLSession` auto-follows the `wp-login.php` POST straight to `wp-admin/admin-ajax.php?action=rest-nonce`, so the implicit nonce GET can land on a `429` or unexpected-response path before post-login REST work runs.

**Solution:** Mirror Android/FluxC's no-redirect nonce login at the HTTP layer. We POST on a redirect-blocking `URLSession`, validate the 3xx `Location`, then issue an explicit nonce GET on a session sharing the same cookie jar. The two steps are now independent, so nonce failures are classified deliberately instead of being hidden inside redirect-following.

**Why this is not a revert of [#16262](https://github.com/woocommerce/woocommerce-ios/pull/16262):** The earlier manual redirect flow, later removed in `12269c0a615d2bdff446f2401da806b74226b967`, called `task.cancel()` from the redirect delegate and swallowed the resulting `NSURLErrorCancelled(-999)` on a second async path. This version returns `nil` without cancelling, lets `data(for:)` complete with the 3xx response, then handles the redirect linearly in `startLogin`. No cancel race, no `-999` handling, and no delegate re-entry during the nonce GET.

**Redirect validation:** The resolved `Location` must hit the rest-nonce endpoint and stay on the site's origin (scheme + host + effective port). A narrow same-host `http` to `https` carve-out keeps the common upgrade case working, matching the Android scheme-upgrade behavior added in [woocommerce-android#15846](https://github.com/woocommerce/woocommerce-android/pull/15846).

**`protocolClasses = []`:** A custom/debug `URLProtocol` such as Wormholy can follow the redirect internally and bypass our delegate, making the POST arrive as a terminal `200`. We clear `protocolClasses` on these auth-only sessions to prevent that. This strips only custom interceptors, not built-in HTTP/HTTPS handling, and is scoped to this login flow. **(This also could explain why we needed #16262 in the first place, as the redirect was called twice before)**

No analytics changes, no temporary logging, and no credentials, cookies, passwords, or full response bodies are logged.

## Test Steps
1. Use a `jurassic.ninja` site as the primary test candidate. It has been the best environment for reproducing the failure on `trunk` and confirming the resolution on this branch.
2. On `trunk`, log in to that site with site credentials a few times from a clean install to confirm the intermittent failure can reproduce.
3. On this branch, repeat the same clean site-credential login attempts and confirm login succeeds consistently and reaches the store home screen.
4. Spot-check edge cases if available: a subdirectory install (`example.com/blog`), an `http://` site that canonicalizes to `https://`, wrong password, and HTTP Basic Auth.
5. With a debug HTTP interceptor such as Wormholy enabled, confirm login still succeeds.

Verified locally: targeted `SiteCredentialLoginUseCaseTests`, WooCommerce build, and `3/3` clean Jurassic Ninja logins on an iPhone 17 simulator.

## Screenshots
N/A — HTTP-layer change, no UI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
