### PR TITLE
[WOOMOB-3199] Fix tab bar remaining visible on the System Status Report screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 - [Internal] QR login: fixed the scanner not detecting after navigating back from a scanned code. [https://github.com/woocommerce/woocommerce-ios/pull/17352]
 - [*] Application Logs: added a search field to filter log lines. [https://github.com/woocommerce/woocommerce-ios/pull/17374]
 - [*] Analytics: the date range selector can no longer be dismissed by swiping it away; tap Done to close it. [https://github.com/woocommerce/woocommerce-ios/pull/17373]
+- [*] Help & Support: Fixed the main tab bar remaining visible on the System Status Report screen. [https://github.com/woocommerce/woocommerce-ios/pull/17394]
 
 25.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -446,7 +446,6 @@ private extension HelpAndSupportViewController {
             return
         }
         let controller = SystemStatusReportHostingController(siteID: siteID)
-        controller.hidesBottomBarWhenPushed = true
         controller.setDismissAction { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -19,6 +19,39 @@ final class SystemStatusReportHostingController: UIHostingController<SystemStatu
     func setDismissAction(_ dismissAction: @escaping () -> Void) {
         rootView.dismissAction = dismissAction
     }
+
+    // This screen is pushed inside the Menu tab's SwiftUI `NavigationStack`, whose navigation controller
+    // is not a direct child of the tab bar controller, so `hidesBottomBarWhenPushed` is ignored and the
+    // tab bar stays visible (WOOMOB-3199). Hide the ancestor tab bar manually while on screen and
+    // restore it when leaving.
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setAncestorTabBarHidden(true)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        // Restore the tab bar when leaving, but keep it hidden if an interactive pop is cancelled.
+        guard let transitionCoordinator else {
+            setAncestorTabBarHidden(false)
+            return
+        }
+        transitionCoordinator.animate(alongsideTransition: { [weak self] _ in
+            self?.setAncestorTabBarHidden(false)
+        }, completion: { [weak self] context in
+            if context.isCancelled {
+                self?.setAncestorTabBarHidden(true)
+            }
+        })
+    }
+
+    private func setAncestorTabBarHidden(_ hidden: Bool) {
+        guard let tabBar = tabBarController?.tabBar, tabBar.isHidden != hidden else {
+            return
+        }
+        tabBar.isHidden = hidden
+    }
 }
 
 /// Displays system status report


### PR DESCRIPTION
Closes: WOOMOB-3199

## Description

Navigating **Menu → Settings → Help & Support → System Status Report** left the main tab bar visible at the bottom of the System Status Report screen, even though it sets `hidesBottomBarWhenPushed = true`. The flag is silently ignored because the screen is pushed inside the Menu tab's SwiftUI `NavigationStack`, whose navigation controller is not a direct child of the tab bar controller — so UIKit never hides the bar.

`SystemStatusReportHostingController` now hides the ancestor tab bar while the screen is on screen and restores it when leaving (keeping it hidden if an interactive pop is cancelled). The now-dead `hidesBottomBarWhenPushed` at the call site is removed.

## Test Steps

1. Open **Menu → Settings → Help & Support → System Status Report**.
2. Confirm the bottom tab bar is **hidden** on the System Status Report screen.
3. Tap back → confirm the tab bar reappears on Help & Support.

## Screenshots

| Before | After |
| --- | --- |
| <img height="600" alt="1-BEFORE-tab-bar-visible-SSR" src="https://github.com/user-attachments/assets/63869697-921c-43a4-b6e8-8029e575c39a" /> | <img height="600" alt="2-AFTER-tab-bar-hidden-SSR" src="https://github.com/user-attachments/assets/47a2af00-45f6-4b89-ac65-bb358317fe6e" /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
