### PR TITLE
[WOOMOB-3199] Fix tab bar remaining visible on pushed Help & Support screens

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 - [Internal] QR login: fixed the scanner not detecting after navigating back from a scanned code. [https://github.com/woocommerce/woocommerce-ios/pull/17352]
 - [*] Application Logs: added a search field to filter log lines. [https://github.com/woocommerce/woocommerce-ios/pull/17374]
 - [*] Analytics: the date range selector can no longer be dismissed by swiping it away; tap Done to close it. [https://github.com/woocommerce/woocommerce-ios/pull/17373]
+- [*] Help & Support: Fixed the main tab bar remaining visible on the System Status Report and other Help & Support screens. [https://github.com/woocommerce/woocommerce-ios/pull/17395]
 
 25.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -3,7 +3,7 @@ import Combine
 
 /// Connectivity Tool Hosting Controller
 ///
-final class ConnectivityToolViewController: UIHostingController<ConnectivityTool> {
+final class ConnectivityToolViewController: TabBarHidingHostingController<ConnectivityTool> {
 
     /// ConnectivityTool view model
     ///
@@ -25,7 +25,6 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         viewModel = ConnectivityToolViewModel()
         let view = ConnectivityTool(cards: viewModel.cards)
         super.init(rootView: view)
-        self.hidesBottomBarWhenPushed = true
         self.title = NSLocalizedString("Troubleshoot Connection", comment: "Screen title for the connectivity tool")
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -446,7 +446,6 @@ private extension HelpAndSupportViewController {
             return
         }
         let controller = SystemStatusReportHostingController(siteID: siteID)
-        controller.hidesBottomBarWhenPushed = true
         controller.setDismissAction { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// Hosting Controller for the Support Form.
 ///
-final class SupportFormHostingController: UIHostingController<SupportForm> {
+final class SupportFormHostingController: TabBarHidingHostingController<SupportForm> {
 
     /// Custom notice presenter,
     ///
@@ -18,7 +18,6 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
         rootView.onDismiss = { [weak self] in
             self?.dismissView()
         }
-        hidesBottomBarWhenPushed = true
     }
 
     dynamic required init?(coder aDecoder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Hosting controller wrapper for `SystemStatusReportView`
 ///
-final class SystemStatusReportHostingController: UIHostingController<SystemStatusReportView> {
+final class SystemStatusReportHostingController: TabBarHidingHostingController<SystemStatusReportView> {
 
     init(siteID: Int64) {
         let viewModel = SystemStatusReportViewModel(siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TabBarHidingHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TabBarHidingHostingController.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UIKit
+
+/// A `UIHostingController` base that hides the main tab bar while the screen is on screen.
+///
+/// `hidesBottomBarWhenPushed` (set here in `init`) only hides the tab bar for screens pushed onto a
+/// navigation controller that is a direct child of the tab bar controller. Screens pushed inside a
+/// SwiftUI `NavigationStack` (e.g. the Menu tab) live in a navigation controller that is not such a
+/// direct child, so the flag is silently ignored and the tab bar stays visible (WOOMOB-3199). To cover
+/// that case this base also hides the ancestor tab bar manually while the screen is shown and restores
+/// its previous visibility when it leaves the navigation stack. Subclass this instead of
+/// `UIHostingController` (and don't set `hidesBottomBarWhenPushed` again — it's set here).
+class TabBarHidingHostingController<Content: View>: UIHostingController<Content> {
+
+    /// The tab bar's visibility before this screen hid it, captured on the way in so it can be restored
+    /// on the way out. `nil` while this controller is not managing the tab bar.
+    private var tabBarWasHiddenBeforeAppearing: Bool?
+
+    override init(rootView: Content) {
+        super.init(rootView: rootView)
+        hidesBottomBarWhenPushed = true
+    }
+
+    dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        guard let tabBar = tabBarController?.tabBar else {
+            return
+        }
+        // Capture the prior visibility only on the way in, so re-appearing after a child is popped
+        // (the chat/connectivity flows push children) doesn't overwrite it with the hidden state.
+        if tabBarWasHiddenBeforeAppearing == nil {
+            tabBarWasHiddenBeforeAppearing = tabBar.isHidden
+        }
+        setAncestorTabBar(hidden: true)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        // Only restore when actually leaving the stack — not when a child screen is pushed on top of us.
+        guard let previousValue = tabBarWasHiddenBeforeAppearing,
+              isMovingFromParent || isBeingDismissed else {
+            return
+        }
+
+        // Restore the tab bar's previous visibility, keeping it hidden if an interactive pop is cancelled.
+        guard let transitionCoordinator else {
+            setAncestorTabBar(hidden: previousValue)
+            tabBarWasHiddenBeforeAppearing = nil
+            return
+        }
+        transitionCoordinator.animate(alongsideTransition: { [weak self] _ in
+            self?.setAncestorTabBar(hidden: previousValue)
+        }, completion: { [weak self] context in
+            guard let self else {
+                return
+            }
+            if context.isCancelled {
+                self.setAncestorTabBar(hidden: true)
+            } else {
+                self.tabBarWasHiddenBeforeAppearing = nil
+            }
+        })
+    }
+
+    private func setAncestorTabBar(hidden: Bool) {
+        guard let tabBar = tabBarController?.tabBar, tabBar.isHidden != hidden else {
+            return
+        }
+        tabBar.isHidden = hidden
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/SupportChat/SupportChatHostingController.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// Hosting controller for the AI support chat view.
 ///
-final class SupportChatHostingController: UIHostingController<SupportChatView> {
+final class SupportChatHostingController: TabBarHidingHostingController<SupportChatView> {
 
     private let viewModel: SupportChatViewModel
 
@@ -15,8 +15,6 @@ final class SupportChatHostingController: UIHostingController<SupportChatView> {
         self.viewModel = viewModel
         let view = SupportChatView(viewModel: viewModel)
         super.init(rootView: view)
-
-        self.hidesBottomBarWhenPushed = true
 
         viewModel.onStartJetpackSetup = { [weak self] in
             self?.startJetpackSetup()


### PR DESCRIPTION
Closes: WOOMOB-3199

## Description

Drilling into **Menu → Settings → Help & Support** and opening any of its detail screens — **System Status Report**, **Contact Support** (Support Form), **AI chat** (Support Chat), or **Troubleshoot Connection** (Connectivity tool) — left the main tab bar visible at the bottom, even though each screen set `hidesBottomBarWhenPushed = true`.

**Root cause:** `hidesBottomBarWhenPushed` only hides the tab bar for a controller pushed onto a navigation controller that is a *direct child* of the `UITabBarController`. The Menu tab hosts a SwiftUI `NavigationStack`, and these screens are pushed onto that stack's internal navigation controller — which is nested below the Menu's own navigation controller, not a direct child of the tab bar. So UIKit silently ignores the flag and the bar stays put (WOOMOB-3199).

**Fix:** Extracted the behaviour into a shared `TabBarHidingHostingController` base class and adopted it on all four Help & Support detail controllers (their individual `hidesBottomBarWhenPushed` lines are removed — the base sets it in one place). The base:
- keeps `hidesBottomBarWhenPushed`, so the standard mechanism still works wherever it can — these screens are also pushed from non-nested places (e.g. Orders/Products) where the flag correctly resizes the content;
- additionally hides the ancestor tab bar manually (`tabBar.isHidden`) while the screen is on screen — covering the nested `NavigationStack` case — and restores its previous visibility when the screen leaves;
- handles the edge cases: keeps the bar hidden if an interactive swipe-back is cancelled, and does not reveal it when one of these screens pushes a child (the chat/connectivity flows push an escalation flow on top).

Net effect: the tab bar is hidden on every Help & Support detail screen and restored when navigating back, in both the nested Menu context and the screens' other (non-nested) entry points.

## Test Steps

1. Open **Menu → Settings → Help & Support → System Status Report**.
2. Confirm the bottom tab bar is **hidden** on the screen, and that it **reappears** when you tap back.
3. Repeat for **Contact Support** (Support Form) and **Settings → Troubleshoot Connection** (Connectivity tool) — tab bar hidden on the pushed screen, restored on back.

## Screenshots

| Screen | Before | After |
| --- | --- | --- |
| Status report | <img width="1170" height="2532" alt="1-SystemStatusReport-BEFORE" src="https://github.com/user-attachments/assets/4ce6f624-2531-48b1-aa36-38598e2f7182" /> | <img width="1170" height="2532" alt="1-SystemStatusReport-AFTER" src="https://github.com/user-attachments/assets/917f0701-6eec-49f3-b2b2-ee09ded16f44" /> |
| Support | <img width="1170" height="2532" alt="2-ContactSupport-BEFORE" src="https://github.com/user-attachments/assets/e7202f61-4a17-48d4-9d5b-3e110345cf00" /> | <img width="1170" height="2532" alt="2-ContactSupport-AFTER" src="https://github.com/user-attachments/assets/3929db74-dab4-471b-83fa-c485d86f1d57" /> |
| Troubleshoot | <img width="1170" height="2532" alt="3-TroubleshootConnection-BEFORE" src="https://github.com/user-attachments/assets/ab7191d8-959b-43eb-9bd1-c79207540805" /> | <img width="1170" height="2532" alt="3-TroubleshootConnection-AFTER" src="https://github.com/user-attachments/assets/bcbec2a4-d92a-4788-be13-4f2e2f45abb5" /> |
---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


