### PR TITLE
 [WOOMOB-3314] Parse SiteAPI response off the main thread to fix launch hang

### DIFF
--- a/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
@@ -23,7 +23,9 @@ public class SiteAPIRemote: Remote {
                                      availableAsRESTRequest: false)
         let mapper = SiteAPIMapper(siteID: siteID)
 
-        enqueue(request, mapper: mapper, completion: completion)
+        // Parse off the main thread: the root endpoint's `routes` map can be several MB on
+        // plugin-heavy stores, and decoding it on the main thread hangs the app at launch (WOOMOB-3314).
+        enqueue(request, mapper: mapper, parseInBackground: true, completion: completion)
     }
 }
 

--- a/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
+++ b/Modules/Sources/Networking/Remote/SiteAPIRemote.swift
@@ -23,8 +23,6 @@ public class SiteAPIRemote: Remote {
                                      availableAsRESTRequest: false)
         let mapper = SiteAPIMapper(siteID: siteID)
 
-        // Parse off the main thread: the root endpoint's `routes` map can be several MB on
-        // plugin-heavy stores, and decoding it on the main thread hangs the app at launch (WOOMOB-3314).
         enqueue(request, mapper: mapper, parseInBackground: true, completion: completion)
     }
 }

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -121,7 +121,13 @@ open class Remote: NSObject {
     ///     - mapper: Mapper entity that will be used to attempt to parse the Backend's Response.
     ///     - completion: Closure to be executed upon completion.
     ///
+    /// - Parameter parseInBackground: When `true`, the response is parsed on a background queue and
+    ///   `completion` is delivered back on the main queue. Use this for endpoints whose payloads are
+    ///   large enough that parsing on the main thread would block it (e.g. the REST root route map
+    ///   fetched by `SiteAPIRemote`). Defaults to `false`, preserving the existing main-thread parsing.
+    ///   See WOOMOB-3314.
     public func enqueue<M: Mapper>(_ request: Request, mapper: M,
+                            parseInBackground: Bool = false,
                             completion: @escaping (Result<M.Output, Error>) -> Void) {
         network.responseData(for: request) { [weak self] result in
             guard let self else {
@@ -130,16 +136,39 @@ open class Remote: NSObject {
 
             switch result {
             case .success(let data):
-                do {
-                    let validator = request.responseDataValidator()
-                    try validator.validate(data: data)
-                    let parsed = try mapper.map(response: data)
-                    completion(.success(parsed))
-                } catch {
-                    self.handleResponseError(error: error, for: request)
-                    self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                    DDLogError("<> Mapping Error: \(error)")
-                    completion(.failure(error))
+                if parseInBackground {
+                    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                        guard let self else {
+                            return
+                        }
+                        do {
+                            let validator = request.responseDataValidator()
+                            try validator.validate(data: data)
+                            let parsed = try mapper.map(response: data)
+                            DispatchQueue.main.async {
+                                completion(.success(parsed))
+                            }
+                        } catch {
+                            DispatchQueue.main.async {
+                                self.handleResponseError(error: error, for: request)
+                                self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                                DDLogError("<> Mapping Error: \(error)")
+                                completion(.failure(error))
+                            }
+                        }
+                    }
+                } else {
+                    do {
+                        let validator = request.responseDataValidator()
+                        try validator.validate(data: data)
+                        let parsed = try mapper.map(response: data)
+                        completion(.success(parsed))
+                    } catch {
+                        self.handleResponseError(error: error, for: request)
+                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                        DDLogError("<> Mapping Error: \(error)")
+                        completion(.failure(error))
+                    }
                 }
             case .failure(let error):
                 completion(.failure(self.mapNetworkError(error: error, for: request)))

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -119,13 +119,8 @@ open class Remote: NSObject {
     /// - Parameters:
     ///     - request: Request that should be performed.
     ///     - mapper: Mapper entity that will be used to attempt to parse the Backend's Response.
+    ///     - parseInBackground: Parse the response off the main thread (completion still on main). Temporary; see WOOMOB-3314.
     ///     - completion: Closure to be executed upon completion.
-    ///
-    /// - Parameter parseInBackground: When `true`, the response is parsed on a background queue and
-    ///   `completion` is delivered back on the main queue. Use this for endpoints whose payloads are
-    ///   large enough that parsing on the main thread would block it (e.g. the REST root route map
-    ///   fetched by `SiteAPIRemote`). Defaults to `false`, preserving the existing main-thread parsing.
-    ///   See WOOMOB-3314.
     public func enqueue<M: Mapper>(_ request: Request, mapper: M,
                             parseInBackground: Bool = false,
                             completion: @escaping (Result<M.Output, Error>) -> Void) {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 25.0
 -----
+- [*] Fixed an app hang on launch on stores with large REST APIs (many plugins). [https://github.com/woocommerce/woocommerce-ios/pull/17396]
 - [*] Fixed a crash that could occur when using the Connectivity Tool to troubleshoot connection issues. [https://github.com/woocommerce/woocommerce-ios/pull/17361]
 - [*] Fixed order refunds hiding duplicate product lines after one matching line was refunded. [https://github.com/woocommerce/woocommerce-ios/pull/17313]
 - [*] Added age-eligibility verification to comply with App Store requirements [https://github.com/woocommerce/woocommerce-ios/pull/17321]


### PR DESCRIPTION
Fixes WOOMOB-3314

## Description

**Root cause:** `SiteAPIRemote.loadAPIInformation` parses the site root REST response on the **main thread**. `routes` was added to that request's `_fields` in #17137, which makes the response large (several MB on plugin-heavy stores), so parsing it on the main thread freezes the app at launch.

This PR moves parsing off the main thread **only for this one call** (the one returning the large payload), via an opt-in `parseInBackground` flag on `Remote.enqueue` (default `false`, so all other callers are unchanged). Moving *all* remote parsing off the main thread is a broader change and will land in a separate follow-up PR.

## Test Steps
I'll invite your wordpress.com account to the store. You must login with that.

1. **Confirm the bug:** Log into the store in the store version and confirm the hang.
2. **Confirm the fix:** Log into the store in the PR build and confirm there is no hang.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.