### PR TITLE
Detect unknown_blog response and reset selected site

### DIFF
--- a/Modules/Sources/APIMocks/Resources/mappings/jetpack-blogs/wc/orders/orders_search_unknown_blog.json
+++ b/Modules/Sources/APIMocks/Resources/mappings/jetpack-blogs/wc/orders/orders_search_unknown_blog.json
@@ -1,0 +1,21 @@
+{
+    "priority": 1,
+    "request": {
+        "method": "GET",
+        "urlPathPattern": "/rest/v1.1/jetpack-blogs/[0-9]+/rest-api/",
+        "queryParameters": {
+            "path": { "contains": "/wc/v3/orders" },
+            "query": { "contains": "unknownblog" }
+        }
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "error": "unknown_blog",
+            "message": "Unknown blog"
+        },
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+}

--- a/Modules/Sources/NetworkingCore/Model/DotcomError.swift
+++ b/Modules/Sources/NetworkingCore/Model/DotcomError.swift
@@ -32,6 +32,14 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
     ///
     case jetpackNotConnected(data: [String: AnyDecodable]? = nil)
 
+    /// WordPress.com no longer recognises the site ID sent by the app.
+    ///
+    /// Caused by stale selected-site state, a Jetpack disconnect, or site deletion.
+    /// Every subsequent request for the same site fails the same way until the
+    /// selected site is reset.
+    ///
+    case unknownBlog(data: [String: AnyDecodable]? = nil)
+
     /// Unknown: Represents an unmapped remote error. Capisce?
     ///
     case unknown(code: String, message: String?, data: [String: AnyDecodable]?)
@@ -75,6 +83,8 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
         case Constants.unknownToken,
             Constants.invalidBlog where message == ErrorMessages.jetpackNotConnected:
             self = .jetpackNotConnected(data: data)
+        case Constants.unknownBlog:
+            self = .unknownBlog(data: data)
         default:
             self = .unknown(code: error, message: message, data: data)
         }
@@ -90,6 +100,7 @@ public enum DotcomError: Error, Decodable, Equatable, GeneratedFakeable {
         static let noRestRoute      = "rest_no_route"
         static let restTermInvalid  = "woocommerce_rest_term_invalid"
         static let unknownToken     = "unknown_token"
+        static let unknownBlog      = "unknown_blog"
     }
 
     /// Coding Keys
@@ -135,6 +146,8 @@ extension DotcomError: CustomStringConvertible {
             return NSLocalizedString("Dotcom Resource does not exist", comment: "WordPress.com error thrown when a requested resource does not exist remotely.")
         case .jetpackNotConnected:
             return NSLocalizedString("Jetpack Not Connected", comment: "WordPress.com error thrown when Jetpack is not connected.")
+        case .unknownBlog:
+            return NSLocalizedString("Dotcom Unknown Blog", comment: "WordPress.com error thrown when the site ID is no longer recognized.")
         case .unknown(let code, let message, _):
             let theMessage = message ?? String()
             let messageFormat = NSLocalizedString(
@@ -157,6 +170,7 @@ public func ==(lhs: DotcomError, rhs: DotcomError) -> Bool {
         (.requestFailed, .requestFailed),
         (.noRestRoute, .noRestRoute),
         (.jetpackNotConnected, .jetpackNotConnected),
+        (.unknownBlog, .unknownBlog),
         (.noStatsPermission, .noStatsPermission),
         (.statsModuleDisabled, .statsModuleDisabled),
         (.resourceDoesNotExist, .resourceDoesNotExist):

--- a/Modules/Sources/NetworkingCore/Remote/Remote.swift
+++ b/Modules/Sources/NetworkingCore/Remote/Remote.swift
@@ -297,6 +297,8 @@ private extension Remote {
             publishJetpackTimeoutNotification(error: dotcomError)
         case .invalidToken:
             publishInvalidTokenNotification(error: dotcomError)
+        case .unknownBlog:
+            publishUnknownBlogNotification(error: dotcomError)
         default:
             break
         }
@@ -349,6 +351,12 @@ private extension Remote {
     ///
     private func publishInvalidTokenNotification(error: DotcomError) {
         NotificationCenter.default.post(name: .RemoteDidReceiveInvalidTokenError, object: error, userInfo: nil)
+    }
+
+    /// Publishes an `Unknown Blog` Notification.
+    ///
+    private func publishUnknownBlogNotification(error: DotcomError) {
+        NotificationCenter.default.post(name: .RemoteDidReceiveUnknownBlogError, object: error, userInfo: nil)
     }
 
     /// Publishes a `JSON Parsing Error` Notification.
@@ -471,6 +479,10 @@ public extension NSNotification.Name {
     /// Posted whenever an Invalid Token Error is received.
     ///
     static let RemoteDidReceiveInvalidTokenError = NSNotification.Name(rawValue: "RemoteDidReceiveInvalidTokenError")
+
+    /// Posted whenever an Unknown Blog Error is received, indicating the selected site ID is no longer recognized.
+    ///
+    static let RemoteDidReceiveUnknownBlogError = NSNotification.Name(rawValue: "RemoteDidReceiveUnknownBlogError")
 
     /// Posted whenever a Jetpack Timeout is received.
     ///

--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -246,6 +246,9 @@ public enum WooAnalyticsStat: String {
     case sitePickerListSavingSuccess = "site_picker_list_saving_success"
     case sitePickerListSavingFailure = "site_picker_list_saving_failure"
 
+    /// Tracked when the selected site is reset because WPCom returned an `unknown_blog` error.
+    case selectedSiteResetDueToUnknownBlog = "selected_site_reset_due_to_unknown_blog"
+
     // MARK: Site creation
     //
     case siteCreated = "login_woocommerce_site_created"

--- a/Modules/Sources/Yosemite/Base/StoresManager.swift
+++ b/Modules/Sources/Yosemite/Base/StoresManager.swift
@@ -98,6 +98,10 @@ public protocol StoresManager {
     ///
     func listenToWPCOMInvalidWPCOMTokenNotification()
 
+    /// Resets the selected store upon receiving `RemoteDidReceiveUnknownBlogError` notification
+    ///
+    func listenToUnknownBlogNotification()
+
     /// Whether the stores should attempt to authenticate the current site 's admin page
     /// on web view using the current credentials.
     ///

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -261,6 +261,10 @@ public class MockStoresManager: StoresManager {
         // no-op
     }
 
+    public func listenToUnknownBlogNotification() {
+        // no-op
+    }
+
     public func shouldAuthenticateAdminPage(for site: Site) -> Bool {
         return false
     }

--- a/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/RemoteTests.swift
@@ -187,6 +187,26 @@ final class RemoteTests: XCTestCase {
         await fulfillment(of: [expectationForNotification], timeout: Constants.expectationTimeout)
     }
 
+    /// Verifies that `enqueue:` posts a `RemoteDidReceiveUnknownBlogError` Notification whenever the backend returns an
+    /// `unknown_blog` error.
+    ///
+    func test_enqueue_posts_unknown_blog_notification_when_the_response_contains_unknown_blog_error() async throws {
+        let network = MockNetwork()
+        let remote = Remote(network: network)
+
+        let expectationForNotification = expectation(forNotification: .RemoteDidReceiveUnknownBlogError, object: nil, handler: nil)
+        network.simulateResponse(requestUrlSuffix: "something", filename: "unknown_blog_error")
+
+        do {
+            let _: String = try await remote.enqueue(request)
+        } catch {
+            let error = try XCTUnwrap(error as? DotcomError)
+            XCTAssertEqual(error, .unknownBlog())
+        }
+
+        await fulfillment(of: [expectationForNotification], timeout: Constants.expectationTimeout)
+    }
+
     /// Verifies that `enqueue:mapper:` posts a `RemoteDidReceiveJetpackTimeoutError` Notification whenever the backend returns a
     /// Request Timeout error.
     ///

--- a/Modules/Tests/NetworkingTests/Validators/DotcomValidatorTests.swift
+++ b/Modules/Tests/NetworkingTests/Validators/DotcomValidatorTests.swift
@@ -55,6 +55,22 @@ class DotcomValidatorTests: XCTestCase {
         }
     }
 
+    /// Verifies that the DotcomValidator successfully extracts the `unknownBlog` Dotcom Error contained within a `Data` instance.
+    ///
+    func testUnknownBlogErrorIsProperlyExtractedFromData() {
+        guard let payloadAsData = Loader.contentsOf("unknown_blog_error", extension: "json")
+            else {
+            return XCTFail()
+        }
+
+        XCTAssertThrowsError(try DotcomValidator().validate(data: payloadAsData)) { error in
+            guard let dotcomError = error as? DotcomError else {
+                return XCTFail()
+            }
+            XCTAssertEqual(dotcomError, .unknownBlog())
+        }
+    }
+
     /// Verifies that the DotcomValidator successfully extracts the `statsModuleDisabled` Dotcom Error contained within a `Data` instance.
     ///
     func testStatsModuleDisabledErrorIsProperlyExtractedFromData() {

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/unknown_blog_error.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/unknown_blog_error.json
@@ -1,0 +1,4 @@
+{
+	"error":"unknown_blog",
+	"message":"Unknown blog"
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [***] Phone POS available for UK-based stores [https://github.com/woocommerce/woocommerce-ios/pull/17325]
 - [*] Login: show the specific reason when signing in fails with a blocked WordPress.com account, instead of an incorrect-password message. [https://github.com/woocommerce/woocommerce-ios/pull/17378]
 - [*] Removed the misleading "test" wording from the place-an-order flow and clarified that processing fees aren't refundable. [https://github.com/woocommerce/woocommerce-ios/pull/17359]
+- [*] Login: Recover automatically when a selected store can no longer be reached (e.g. disconnected or removed) by returning you to the store picker instead of failing silently. [https://github.com/woocommerce/woocommerce-ios/pull/17401]
 - [*] Fixed a crash that could occur when picking an image from the device library while editing a product. [https://github.com/woocommerce/woocommerce-ios/pull/17369]
 - [*] Login: Fixed the dead "Need more help?" links on the site-address help and login error dialogs so they open support as intended [https://github.com/woocommerce/woocommerce-ios/pull/17372]
 - [*] Shipping Labels: Clearer notice when the origin (Ship from) address is missing a phone number or email [https://github.com/woocommerce/woocommerce-ios/pull/17339]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -223,6 +223,13 @@ extension WooAnalyticsEvent {
     static func ordersListLoadError(_ error: Error) -> WooAnalyticsEvent {
         WooAnalyticsEvent(statName: .ordersListLoadError, properties: [:], error: error)
     }
+
+    /// Tracked when the selected site is reset because WPCom returned an `unknown_blog` error,
+    /// routing the user to the store picker.
+    ///
+    static func selectedSiteResetDueToUnknownBlog() -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .selectedSiteResetDueToUnknownBlog, properties: [:])
+    }
 }
 
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -419,6 +419,7 @@ extension AppDelegate {
         let stores = ServiceLocator.stores
         if stores.isAuthenticatedWithoutWPCom == false {
             stores.listenToWPCOMInvalidWPCOMTokenNotification()
+            stores.listenToUnknownBlogNotification()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/AppCoordinator.swift
@@ -316,11 +316,18 @@ private extension AppCoordinator {
     /// check for errors and display store picker if none exists.
     ///
     func displayLoggedInStateWithoutDefaultStore() {
-        // Store picker is only displayed by `AppCoordinator` on launch, when the window's root is uninitialized.
-        // In other cases when the app is authenticated but there is no default store ID, the store picker is shown by authentication UI.
-        guard window.rootViewController == nil else {
+        // The store picker is displayed by `AppCoordinator` on launch (window root uninitialized) and when an
+        // in-session store reset occurs (window root is the logged-in tab UI, e.g. after an `unknown_blog`
+        // response clears the selected site). In other cases when the app is authenticated but there is no
+        // default store ID — such as mid-login — the store picker is shown by the authentication UI instead.
+        guard window.rootViewController == nil || window.rootViewController === tabBarController else {
             return
         }
+
+        // Dismiss anything presented on the current root before re-rooting. `tabBarController` is retained
+        // for the app's lifetime, so a modal left presented on it during an in-session reset would otherwise
+        // reappear when the user returns to it after re-selecting a store.
+        window.rootViewController?.dismiss(animated: false)
 
         /// If authenticating with site credentials only is incomplete,
         /// show the prologue screen to force the user to log in again.

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -35,6 +35,10 @@ class DefaultStoresManager: StoresManager {
     ///
     private var invalidWPCOMTokenNotificationObserver: NSObjectProtocol?
 
+    /// Observes unknown blog notification
+    ///
+    private var unknownBlogNotificationObserver: NSObjectProtocol?
+
     /// NotificationCenter
     ///
     private let notificationCenter: NotificationCenter
@@ -207,9 +211,10 @@ class DefaultStoresManager: StoresManager {
 
         if case .wpcom = credentials {
             listenToWPCOMInvalidWPCOMTokenNotification()
+            listenToUnknownBlogNotification()
             startObservingNetworkNotifications()
         } else {
-            invalidWPCOMTokenNotificationObserver = nil
+            removeAuthenticationFailureObservers()
             stopObservingNetworkNotifications()
         }
 
@@ -219,11 +224,51 @@ class DefaultStoresManager: StoresManager {
     /// De-authenticates upon receiving `RemoteDidReceiveInvalidTokenError` notification
     ///
     func listenToWPCOMInvalidWPCOMTokenNotification() {
+        // Block-based observers are only unregistered via `removeObserver`; reassigning the token
+        // would otherwise leave the previous registration live (this method can be called more than once).
+        if let invalidWPCOMTokenNotificationObserver {
+            notificationCenter.removeObserver(invalidWPCOMTokenNotificationObserver)
+        }
         invalidWPCOMTokenNotificationObserver = notificationCenter.addObserver(forName: .RemoteDidReceiveInvalidTokenError,
                                                                                object: nil,
                                                                                queue: .main) { [weak self] _ in
             _ = self?.deauthenticate()
         }
+    }
+
+    /// Resets the selected store upon receiving `RemoteDidReceiveUnknownBlogError` notification.
+    ///
+    /// WPCom no longer recognizes the selected site ID, so we clear it and route the user
+    /// to the store picker while keeping them authenticated.
+    ///
+    func listenToUnknownBlogNotification() {
+        // Block-based observers are only unregistered via `removeObserver`; reassigning the token
+        // would otherwise leave the previous registration live (this method can be called more than once).
+        if let unknownBlogNotificationObserver {
+            notificationCenter.removeObserver(unknownBlogNotificationObserver)
+        }
+        unknownBlogNotificationObserver = notificationCenter.addObserver(forName: .RemoteDidReceiveUnknownBlogError,
+                                                                         object: nil,
+                                                                         queue: .main) { [weak self] _ in
+            self?.resetSelectedStore()
+        }
+    }
+
+    /// Unregisters the WPCOM authentication-failure observers (invalid token and unknown blog).
+    ///
+    /// Block-based observers must be removed via `removeObserver`; setting the token to `nil` alone
+    /// leaves the registration live and firing.
+    ///
+    private func removeAuthenticationFailureObservers() {
+        if let invalidWPCOMTokenNotificationObserver {
+            notificationCenter.removeObserver(invalidWPCOMTokenNotificationObserver)
+        }
+        invalidWPCOMTokenNotificationObserver = nil
+
+        if let unknownBlogNotificationObserver {
+            notificationCenter.removeObserver(unknownBlogNotificationObserver)
+        }
+        unknownBlogNotificationObserver = nil
     }
 
     /// Synchronizes all of the Session's Entities.
@@ -261,6 +306,33 @@ class DefaultStoresManager: StoresManager {
         ZendeskProvider.shared.reset()
     }
 
+    /// Resets the selected store while remaining authenticated, routing the user to the store picker.
+    ///
+    /// Triggered when WPCom returns an `unknown_blog` error, meaning the persisted site ID is no
+    /// longer recognized (stale state, Jetpack disconnect, or site deletion). Clearing
+    /// `defaultStoreID` makes `needsDefaultStore` emit `true`, which the `AppCoordinator` observes
+    /// to present the store picker.
+    ///
+    func resetSelectedStore() {
+        // Guard against repeated resets: many in-flight requests can fail with `unknown_blog`
+        // simultaneously, each posting a notification. Once the store is cleared, ignore the rest.
+        guard let siteID = sessionManager.defaultStoreID else {
+            return
+        }
+
+        ServiceLocator.analytics.track(event: .selectedSiteResetDueToUnknownBlog())
+
+        // Stop any ongoing catalog sync tasks for the site before clearing it.
+        Task {
+            await posCatalogSyncCoordinator?.stopOngoingSyncs(for: siteID)
+        }
+
+        removeDefaultStore()
+
+        sessionManager.defaultStoreID = nil
+        sessionManager.defaultSite = nil
+    }
+
     /// Fully deauthenticates the user, if needed.
     ///
     /// This handles the scenario where `DefaultStoresManager` can't be initialized
@@ -292,7 +364,7 @@ class DefaultStoresManager: StoresManager {
             _ = currentState
         }
 
-        invalidWPCOMTokenNotificationObserver = nil
+        removeAuthenticationFailureObservers()
         stopObservingNetworkNotifications()
         trackedEligibleSites.removeAll()
 

--- a/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/AppCoordinatorTests.swift
@@ -206,6 +206,34 @@ final class AppCoordinatorTests: XCTestCase {
         assertThat(window.rootViewController, isAnInstanceOf: MainTabBarController.self)
     }
 
+    func test_resetting_selected_site_while_on_tabbar_presents_store_picker() throws {
+        // Given
+        // App is logged in with a selected site, so the root is the main tab bar.
+        stores.authenticate(credentials: SessionSettings.wpcomCredentials)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            guard case let AppSettingsAction.loadEligibilityErrorInfo(completion) = action else {
+                return
+            }
+            // any failure except `.insufficientRole` will be treated as having an eligible status.
+            completion(.failure(SampleError.first))
+        }
+        let site = Site.fake().copy(siteID: 134, isWooCommerceActive: true)
+        storageManager.insertSampleSite(readOnlySite: site)
+        sessionManager.defaultStoreID = 134
+        let appCoordinator = makeCoordinator(window: window, stores: stores, authenticationManager: authenticationManager)
+        appCoordinator.start()
+        assertThat(window.rootViewController, isAnInstanceOf: MainTabBarController.self)
+
+        // When
+        // The selected site is reset while the app is running, e.g. after an `unknown_blog` response.
+        sessionManager.defaultStoreID = nil
+
+        // Then
+        // The store picker is presented and the user stays logged in (not deauthenticated).
+        let storePickerNavigationController = try XCTUnwrap(window.rootViewController?.presentedViewController as? UINavigationController)
+        assertThat(storePickerNavigationController.topViewController, isAnInstanceOf: StorePickerViewController.self)
+    }
+
     func test_starting_app_logged_in_with_wporg_credentials_and_selected_site_stays_on_tabbar() throws {
         // Given
         stores.authenticate(credentials: SessionSettings.wporgCredentials)

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -539,6 +539,27 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertEqual(isLoggedInValues, [false, true, false])
     }
 
+    /// Verifies that the selected store is reset—while keeping the user authenticated—upon receiving an unknown blog error notification.
+    ///
+    func test_it_resets_selected_store_and_stays_authenticated_upon_receiving_unknown_blog_error_notification() {
+        // Given
+        let sessionManager = SessionManager.testingInstance
+        let manager = DefaultStoresManager(sessionManager: sessionManager,
+                                           notificationCenter: MockNotificationCenter.testingInstance)
+        manager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        manager.updateDefaultStore(storeID: 123)
+        XCTAssertEqual(sessionManager.defaultStoreID, 123)
+
+        // When
+        let error = DotcomError.unknownBlog()
+        MockNotificationCenter.testingInstance.post(name: .RemoteDidReceiveUnknownBlogError, object: error, userInfo: nil)
+
+        // Then
+        XCTAssertNil(sessionManager.defaultStoreID, "Selected store should be cleared")
+        XCTAssertTrue(manager.isAuthenticated, "User should remain authenticated")
+        XCTAssertTrue(manager.needsDefaultStore, "Should route to the store picker")
+    }
+
     /// Verifies that default store is reset when initialized in an unexpected state: deauthenticated state with default store set.
     ///
     func test_it_resets_default_store_when_initialized_with_deauthenticated_state_and_default_store_set() {


### PR DESCRIPTION
Closes: WOOMOB-3295

## Description

When WPCom returns an `unknown_blog` error, the site ID the app sent is no longer recognized (stale selected-site state, a Jetpack disconnect, or site deletion), and every subsequent request for that site keeps failing the same way with no recovery.

This detects the error, clears the selected store, and routes the user to the store picker — **without logging them out**. It mirrors the existing invalid-token handling.

Key changes:
- **`DotcomError.unknownBlog`** maps the `"unknown_blog"` code; **`Remote`** posts a new `RemoteDidReceiveUnknownBlogError` notification.
- **`DefaultStoresManager`** observes it (registered in `authenticate` and, for restored sessions, via `AppDelegate`) and resets the selected store while staying authenticated.
- **`AppCoordinator`** re-roots to the store picker for an in-session reset (previously only done at launch); any modal on the tab bar is dismissed first.
- Tracks `selected_site_reset_due_to_unknown_blog` to size the iOS cohort (the issue calls this out).

## Test Steps

`unknown_blog` can't be produced on demand against a real store, so it's mocked: the committed WireMock mapping `orders_search_unknown_blog.json` returns the `unknown_blog` response whenever an **order search** contains the magic term `unknownblog`. Normal flows are unaffected.

### One-click setup

Save the script below as `review-woomob-3295.sh` in the repo root, then run it (`./review-woomob-3295.sh`, or `--skip-build` to reuse your last build). It builds the app, starts the mock server, and launches the app on a simulator — logged out and pointed at the mock.

<details><summary><code>review-woomob-3295.sh</code></summary>

```bash
#!/bin/bash
#
# One-click review setup for WOOMOB-3295 (unknown_blog → reset selected site).
# Builds the app, starts the WireMock mock, and launches the app on a simulator
# pointed at the mock, logged out. Then you just log in and run one order search.
#
# Usage:
#   ./review-woomob-3295.sh            # build + launch
#   ./review-woomob-3295.sh --skip-build
#
# Run from the repo root.
set -euo pipefail

SKIP_BUILD=0
[[ "${1:-}" == "--skip-build" ]] && SKIP_BUILD=1

WORKSPACE="WooCommerce.xcworkspace"
SCHEME="WooCommerce"
BUNDLE_ID="com.automattic.woocommerce"
MOCK_PORT=8282

step() { printf '\n\033[1;34m▸ %s\033[0m\n' "$1"; }

# 1. Resolve a simulator (prefer a booted one, else boot an iPhone).
step "Resolving simulator"
UDID="$(xcrun simctl list devices booted | grep -oE '[0-9A-F-]{36}' | head -1 || true)"
if [[ -z "$UDID" ]]; then
  UDID="$(xcrun simctl list devices available | grep -oE 'iPhone [0-9][^(]*\(([0-9A-F-]{36})\)' | grep -oE '[0-9A-F-]{36}' | head -1)"
  echo "Booting $UDID"
  xcrun simctl boot "$UDID"
fi
open -a Simulator
echo "Using simulator: $UDID"

# 2. Start the WireMock mock server if not already up.
step "Starting WireMock mock server (:$MOCK_PORT)"
if curl -s "http://localhost:$MOCK_PORT/__admin/" >/dev/null 2>&1; then
  echo "Already running."
else
  command -v java >/dev/null || { echo "Java required (brew install openjdk)"; exit 1; }
  ./API-Mocks/scripts/start.sh "$MOCK_PORT" >/tmp/woomob3295-wiremock.log 2>&1 &
  for _ in $(seq 1 20); do curl -s "http://localhost:$MOCK_PORT/__admin/" >/dev/null 2>&1 && break; sleep 1; done
  echo "Started."
fi

# 3. Build (unless skipped) and locate the .app.
if [[ "$SKIP_BUILD" == "0" ]]; then
  step "Building $SCHEME (this can take a few minutes)"
  xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
    -destination "platform=iOS Simulator,id=$UDID" build >/tmp/woomob3295-build.log 2>&1 \
    || { echo "Build failed — see /tmp/woomob3295-build.log"; exit 1; }
fi
PRODUCTS_DIR="$(xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" \
  -destination "platform=iOS Simulator,id=$UDID" -showBuildSettings 2>/dev/null \
  | awk -F'= ' '/ BUILT_PRODUCTS_DIR =/{print $2; exit}')"
APP="$PRODUCTS_DIR/$SCHEME.app"
[[ -d "$APP" ]] || { echo "Built app not found at $APP — run without --skip-build first."; exit 1; }

# 4. Install + launch logged out, pointed at the mock.
step "Installing & launching against the mock (logged out)"
xcrun simctl install "$UDID" "$APP"
xcrun simctl terminate "$UDID" "$BUNDLE_ID" 2>/dev/null || true
xcrun simctl launch "$UDID" "$BUNDLE_ID" mocked-wpcom-api logout-at-launch >/dev/null

cat <<'STEPS'

✅ Ready. In the app:
   1. Log In → store address: yourwoosite.com → Continue
   2. Email t@wp.com → Continue → Password pw → Continue → 2FA 123456 → Continue
      → you land on "My store".
   3. Orders tab → search → type:  unknownblog
   → Expect: the selected store is cleared and you are returned to the STORE
     PICKER, still logged in.

To stop the mock: ./API-Mocks/scripts/stop.sh 8282
STEPS
```

</details>

Then, in the app:

1. **Log In** → store address `yourwoosite.com` → **Continue**.
2. Email `t@wp.com` → **Continue** → password `pw` → **Continue** → 2FA `123456` → **Continue**. You land on **My store**.
3. Open the **Orders** tab → tap search → type **`unknownblog`**.
4. Confirm the app clears the selected store and returns you to the **store picker**, still logged in.

Screenshots
<img width="295" height="640" alt="Simulator Screen Recording - iPhone 16 Pro - 2026-06-22 at 13 19 38" src="https://github.com/user-attachments/assets/209951d6-b51d-4c34-8ab4-1d4e4859b494" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
