### PR TITLE
Fix ExPlat weak-reference crash in ABTest.start

### DIFF
--- a/Modules/Sources/Experiments/ABTest.swift
+++ b/Modules/Sources/Experiments/ABTest.swift
@@ -44,15 +44,16 @@ public extension ABTest {
     static func start(for context: ExperimentContext) async {
         let experiments = ABTest.genuineCases.filter { $0.context == context }
 
+        // Strongly capture `ExPlat.shared` so it can't be released on a background thread (when Tracks
+        // switches users) while `refresh` forms its `[weak self]`, which would crash (WOOMOB-3320).
+        guard !experiments.isEmpty, let explat = ExPlat.shared else {
+            return
+        }
+
         await withCheckedContinuation { continuation in
-            guard !experiments.isEmpty else {
-                return continuation.resume(returning: ())
-            }
+            explat.register(experiments: experiments.map { $0.rawValue })
 
-            let experimentNames = experiments.map { $0.rawValue }
-            ExPlat.shared?.register(experiments: experimentNames)
-
-            ExPlat.shared?.refresh {
+            explat.refresh {
                 continuation.resume(returning: ())
             }
         } as Void

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.1
 -----
+- [*] Fixed a crash on launch that could affect logged-in users when A/B experiments refreshed. [https://github.com/woocommerce/woocommerce-ios/pull/17406]
 - [*] Fixed product titles being misaligned in the Linked Products cross-sells/upsells list when a product name wrapped to multiple lines. [https://github.com/woocommerce/woocommerce-ios/pull/17353]
 - [*] Fixed crashes that could occur when opening share and action sheets on iPad. [https://github.com/woocommerce/woocommerce-ios/pull/17382]
 - [***] Phone POS available for UK-based stores [https://github.com/woocommerce/woocommerce-ios/pull/17325]


### PR DESCRIPTION
Fixes WOOMOB-3320

## Description

`ABTest.start` borrowed `ExPlat.shared` at +0 while calling `refresh`, whose body synchronously forms a `[weak self]`. Tracks reassigns/releases `ExPlat.shared` on a background queue during user switches (which happen on every logged-in launch), so the instance could deallocate mid-`refresh` → SIGABRT. The fix captures a strong local reference so the instance stays alive across the call, and returns early when `shared` is `nil` (also closes a latent never-resumed continuation).

The underlying unsynchronized global lives in Automattic-Tracks-iOS; a durable [upstream fix](https://github.com/Automattic/Automattic-Tracks-iOS/pull/364) is proposed as a follow-up. This is the surgical app-side fix to stop the crashes now.

## Test Steps
Timing-dependent data race — not deterministically reproducible from the UI. Validated by code inspection against the Sentry stack and the affected user's logs . Smoke: launch while logged in, confirm no crash and A/B experiments still resolve.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.