### PR TITLE
Fix ExPlat weak-reference crash in ABTest.start

### DIFF
--- a/Modules/Sources/Experiments/ABTest.swift
+++ b/Modules/Sources/Experiments/ABTest.swift
@@ -44,15 +44,16 @@ public extension ABTest {
     static func start(for context: ExperimentContext) async {
         let experiments = ABTest.genuineCases.filter { $0.context == context }
 
+        // Strongly capture `ExPlat.shared` so it can't be released on a background thread (when Tracks
+        // switches users) while `refresh` forms its `[weak self]`, which would crash (WOOMOB-3320).
+        guard !experiments.isEmpty, let explat = ExPlat.shared else {
+            return
+        }
+
         await withCheckedContinuation { continuation in
-            guard !experiments.isEmpty else {
-                return continuation.resume(returning: ())
-            }
+            explat.register(experiments: experiments.map { $0.rawValue })
 
-            let experimentNames = experiments.map { $0.rawValue }
-            ExPlat.shared?.register(experiments: experimentNames)
-
-            ExPlat.shared?.refresh {
+            explat.refresh {
                 continuation.resume(returning: ())
             }
         } as Void

--- a/Modules/Sources/Experiments/ABTest.swift
+++ b/Modules/Sources/Experiments/ABTest.swift
@@ -44,8 +44,7 @@ public extension ABTest {
     static func start(for context: ExperimentContext) async {
         let experiments = ABTest.genuineCases.filter { $0.context == context }
 
-        // Strongly capture `ExPlat.shared` so it can't be released on a background thread (when Tracks
-        // switches users) while `refresh` forms its `[weak self]`, which would crash (WOOMOB-3320).
+        // Strongly capture `ExPlat.shared` so it can't be released on a background thread.
         guard !experiments.isEmpty, let explat = ExPlat.shared else {
             return
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 25.0
 -----
+- [*] Fixed a crash on launch that could affect logged-in users when A/B experiments refreshed. [https://github.com/woocommerce/woocommerce-ios/pull/17408]
 - [*] Fixed an app hang on launch on stores with large REST APIs (many plugins). [https://github.com/woocommerce/woocommerce-ios/pull/17396]
 - [*] Fixed a crash that could occur when using the Connectivity Tool to troubleshoot connection issues. [https://github.com/woocommerce/woocommerce-ios/pull/17361]
 - [*] Fixed order refunds hiding duplicate product lines after one matching line was refunded. [https://github.com/woocommerce/woocommerce-ios/pull/17313]


### PR DESCRIPTION
Fixes WOOMOB-3320

## Description
Fixes a crash introduced in 24.9: `Cannot form weak reference to instance of AutomatticExperiments.ExPlat … in the process of deallocation`.

`ABTest.start` borrowed `ExPlat.shared` while calling `refresh`, whose body synchronously forms a `[weak self]`. Tracks reassigns/releases `ExPlat.shared` on a background queue during user switches (which happen on every logged-in launch), so the instance could deallocate mid-`refresh` → SIGABRT. The fix captures a strong local reference so the instance stays alive across the call, and returns early when `shared` is `nil` (also closes a latent never-resumed continuation).

The underlying unsynchronized global lives in Tracks; a durable [upstream fix](https://github.com/Automattic/Automattic-Tracks-iOS/pull/364) is proposed as a follow-up. This is the surgical app-side fix to stop the crashes now.

## Test Steps
Timing-dependent data race — not deterministically reproducible from the UI. Validated by code inspection against the Sentry stack and the affected user's logs (double logged-in analytics refresh at launch matching the crash). Smoke: launch while logged in, confirm no crash and A/B experiments still resolve.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.