### PR TITLE
[Woo POS] Add staff settings page

### DIFF
--- a/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
+++ b/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
@@ -8,7 +8,6 @@ public struct POSStaffMember: Codable, Equatable, Sendable {
     public let displayName: String
 
     /// Server-side role preset, used only for display labelling — never for permission checks.
-    /// Canonical presets are `pos_admin` / `pos_manager` / `pos_cashier`; see `POSStaffPreset`.
     public let preset: POSStaffPreset
 
     /// POS capabilities the staff member holds, keyed by the server's `pos_*` capability

--- a/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
+++ b/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
@@ -7,9 +7,9 @@ public struct POSStaffMember: Codable, Equatable, Sendable {
     public let userID: Int64
     public let displayName: String
 
-    /// Server-side preset slug, used only for display labelling — never for permission checks.
-    /// POS presets use the `pos_` prefix (e.g. `pos_cashier`, `pos_manager`, `pos_admin`).
-    public let preset: String
+    /// Server-side role preset, used only for display labelling — never for permission checks.
+    /// Canonical presets are `pos_admin` / `pos_manager` / `pos_cashier`; see `POSStaffPreset`.
+    public let preset: POSStaffPreset
 
     /// POS capabilities the staff member holds, keyed by the server's `pos_*` capability
     /// identifier. The server emits only granted entries (all values are `true` in the
@@ -20,7 +20,7 @@ public struct POSStaffMember: Codable, Equatable, Sendable {
     public let pin: PINDetails?
 
     public init(userID: Int64, displayName: String,
-                preset: String, capabilities: [String: Bool], pin: PINDetails?) {
+                preset: POSStaffPreset, capabilities: [String: Bool], pin: PINDetails?) {
         self.userID = userID
         self.displayName = displayName
         self.preset = preset

--- a/Modules/Sources/Networking/Model/POS/POSStaffPreset.swift
+++ b/Modules/Sources/Networking/Model/POS/POSStaffPreset.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// POS staff role preset from the `preset` field of `GET /wc/pos/v1/staff`. Used only for display
+/// labelling — never for permission checks.
+public enum POSStaffPreset: String, Codable, Hashable, Sendable {
+    case admin = "pos_admin"
+    case manager = "pos_manager"
+    case cashier = "pos_cashier"
+}

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
@@ -16,6 +16,9 @@ protocol POSSettingsControllerProtocol {
     var storeViewModel: POSSettingsStoreViewModel { get }
     var localCatalogViewModel: POSSettingsLocalCatalogViewModel? { get }
     var isLocalCatalogEligible: Bool { get }
+    /// Backs the read-only Staff settings screen, supplied by the host when POS roles are enabled.
+    /// `nil` keeps the Staff card hidden (roles disabled, or unconfigured previews/mocks).
+    var staffSettingsService: POSStaffSettingsService? { get }
 }
 
 @Observable final class PointOfSaleSettingsController: POSSettingsControllerProtocol {
@@ -25,6 +28,7 @@ protocol POSSettingsControllerProtocol {
     let storeViewModel: POSSettingsStoreViewModel
     let localCatalogViewModel: POSSettingsLocalCatalogViewModel?
     let isLocalCatalogEligible: Bool
+    let staffSettingsService: POSStaffSettingsService?
 
     init(siteID: Int64,
          settingsService: PointOfSaleSettingsServiceProtocol,
@@ -35,7 +39,9 @@ protocol POSSettingsControllerProtocol {
          grdbManager: GRDBManagerProtocol?,
          catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol?,
          isLocalCatalogEligible: Bool,
-         receiptSettingsAdminURL: String) {
+         receiptSettingsAdminURL: String,
+         staffSettingsService: POSStaffSettingsService? = nil) {
+        self.staffSettingsService = staffSettingsService
         self.storeViewModel = POSSettingsStoreViewModel(siteID: siteID,
                                                         settingsService: settingsService,
                                                         pluginsService: pluginsService,
@@ -93,6 +99,8 @@ final class POSSettingsPreviewController: POSSettingsControllerProtocol {
     var isLocalCatalogEligible: Bool {
         localCatalogViewModel != nil
     }
+
+    var staffSettingsService: POSStaffSettingsService?
 }
 
 final class MockPointOfSaleSettingsService: PointOfSaleSettingsServiceProtocol {

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleSettingsController.swift
@@ -16,8 +16,6 @@ protocol POSSettingsControllerProtocol {
     var storeViewModel: POSSettingsStoreViewModel { get }
     var localCatalogViewModel: POSSettingsLocalCatalogViewModel? { get }
     var isLocalCatalogEligible: Bool { get }
-    /// Backs the read-only Staff settings screen, supplied by the host when POS roles are enabled.
-    /// `nil` keeps the Staff card hidden (roles disabled, or unconfigured previews/mocks).
     var staffSettingsService: POSStaffSettingsService? { get }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -89,6 +89,7 @@ public struct PointOfSaleEntryPointView: View {
          preferredConnectionMethod: CardReaderConnectionMethod = .bluetooth,
          staffFetcher: POSStaffFetching,
          receiptPrinter: ReceiptPrinterServiceProtocol? = nil,
+         staffSettingsService: POSStaffSettingsService? = nil,
          services: POSDependencyProviding,
          itemProvider: PointOfSaleItemServiceProtocol? = nil) {
         self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
@@ -149,7 +150,8 @@ public struct PointOfSaleEntryPointView: View {
                                                                 grdbManager: grdbManager,
                                                                 catalogSyncCoordinator: catalogSyncCoordinator,
                                                                 isLocalCatalogEligible: isLocalCatalogEligible,
-                                                                receiptSettingsAdminURL: receiptSettingsAdminURL)
+                                                                receiptSettingsAdminURL: receiptSettingsAdminURL,
+                                                                staffSettingsService: staffSettingsService)
         self.collectOrderPaymentAnalyticsTracker = collectOrderPaymentAnalyticsTracker
         self.searchHistoryService = searchHistoryService
         self.popularPurchasableItemsController = PointOfSaleItemsController(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -64,6 +64,14 @@ extension POSSettingsView {
                         selection = .localCatalog
                     })
                 }
+                if isStaffSectionVisible {
+                    POSSettingsCard(title: POSSettingsView.SidebarNavigation.staff.title,
+                                        subtitle: POSSettingsView.SidebarNavigation.staff.subtitle,
+                                        isSelected: selection == .staff,
+                                        action: {
+                        selection = .staff
+                    })
+                }
                 Spacer()
 
                 helpView
@@ -87,9 +95,19 @@ extension POSSettingsView {
             } else {
                 EmptyView()
             }
+        case .staff:
+            if let staffSettingsService = settingsController.staffSettingsService {
+                POSStaffSettingsView(service: staffSettingsService)
+            } else {
+                EmptyView()
+            }
         case .help:
             POSSettingsHelpDetailView()
         }
+    }
+
+    private var isStaffSectionVisible: Bool {
+        settingsController.staffSettingsService != nil
     }
 
     @ViewBuilder
@@ -124,6 +142,7 @@ extension POSSettingsView {
         case store
         case hardware
         case localCatalog
+        case staff
         case help
 
         var id: Self { self }
@@ -133,6 +152,7 @@ extension POSSettingsView {
             case .store: return Localization.sidebarNavigationStoreTitle
             case .hardware: return Localization.sidebarNavigationHardwareTitle
             case .localCatalog: return Localization.sidebarNavigationLocalCatalogTitle
+            case .staff: return Localization.sidebarNavigationStaffTitle
             case .help: return Localization.sidebarNavigationHelpTitle
             }
         }
@@ -142,13 +162,14 @@ extension POSSettingsView {
             case .store: return Localization.sidebarNavigationStoreSubtitle
             case .hardware: return Localization.sidebarNavigationHardwareSubtitle
             case .localCatalog: return Localization.sidebarNavigationLocalCatalogSubtitle
+            case .staff: return Localization.sidebarNavigationStaffSubtitle
             case .help: return Localization.sidebarNavigationHelpSubtitle
             }
         }
 
         var icon: String? {
             switch self {
-            case .store, .hardware, .localCatalog:
+            case .store, .hardware, .localCatalog, .staff:
                 return nil
             case .help:
                 return "questionmark.circle"
@@ -203,6 +224,18 @@ extension POSSettingsView {
             "pointOfSaleSettingsView.sidebarNavigationLocalCatalogSubtitle",
             value: "Manage catalog settings",
             comment: "Description of the settings to be found within the Local catalog section."
+        )
+
+        static let sidebarNavigationStaffTitle = NSLocalizedString(
+            "pointOfSaleSettingsView.sidebarNavigationStaffTitle",
+            value: "Staff",
+            comment: "Title of the Staff section within Point of Sale settings."
+        )
+
+        static let sidebarNavigationStaffSubtitle = NSLocalizedString(
+            "pointOfSaleSettingsView.sidebarNavigationStaffSubtitle.m1",
+            value: "View staff and PIN access",
+            comment: "Description of the settings to be found within the Staff section."
         )
 
         static let sidebarNavigationHelpSubtitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -43,32 +43,32 @@ extension POSSettingsView {
 
             VStack(spacing: POSSpacing.small) {
                 POSSettingsCard(title: POSSettingsView.SidebarNavigation.store.title,
-                                    subtitle: POSSettingsView.SidebarNavigation.store.subtitle,
-                                    isSelected: selection == .store,
-                                    action: {
+                                subtitle: POSSettingsView.SidebarNavigation.store.subtitle,
+                                isSelected: selection == .store,
+                                action: {
                     analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
                     selection = .store
                 })
                 POSSettingsCard(title: POSSettingsView.SidebarNavigation.hardware.title,
-                                    subtitle: POSSettingsView.SidebarNavigation.hardware.subtitle,
-                                    isSelected: selection == .hardware,
-                                    action: {
+                                subtitle: POSSettingsView.SidebarNavigation.hardware.subtitle,
+                                isSelected: selection == .hardware,
+                                action: {
                     analytics.track(.pointOfSaleSettingsHardwareTapped)
                     selection = .hardware
                 })
                 if settingsController.isLocalCatalogEligible {
                     POSSettingsCard(title: POSSettingsView.SidebarNavigation.localCatalog.title,
-                                        subtitle: POSSettingsView.SidebarNavigation.localCatalog.subtitle,
-                                        isSelected: selection == .localCatalog,
-                                        action: {
+                                    subtitle: POSSettingsView.SidebarNavigation.localCatalog.subtitle,
+                                    isSelected: selection == .localCatalog,
+                                    action: {
                         selection = .localCatalog
                     })
                 }
                 if isStaffSectionVisible {
                     POSSettingsCard(title: POSSettingsView.SidebarNavigation.staff.title,
-                                        subtitle: POSSettingsView.SidebarNavigation.staff.subtitle,
-                                        isSelected: selection == .staff,
-                                        action: {
+                                    subtitle: POSSettingsView.SidebarNavigation.staff.subtitle,
+                                    isSelected: selection == .staff,
+                                    action: {
                         selection = .staff
                     })
                 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSStaff.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSStaff.swift
@@ -1,7 +1,9 @@
+import enum Yosemite.POSStaffPreset
+
 struct POSStaff: Equatable, Sendable {
     let userID: Int64
     let displayName: String
-    let preset: String
+    let preset: POSStaffPreset
     let capabilities: Set<String>
 
     func hasCapability(_ capability: POSCapability) -> Bool {

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 import CocoaLumberjackSwift
+import struct Yosemite.POSStaffMember
 
 @Observable
 @MainActor
@@ -99,6 +100,13 @@ final class DefaultPOSAccessSession: POSAccessSession {
             // gating reflect whatever it already holds (no cached PINs ⇒ no lock screen).
             DDLogError("POS staff refresh failed: \(error)")
         }
+        applyCacheState()
+    }
+
+    /// Refreshes gating from a staff list the caller already fetched — caches it and re-derives lock
+    /// state without a second staff fetch.
+    func refreshPINStatus(using staff: [POSStaffMember]) async {
+        cache.save(staff, siteID: siteID)
         applyCacheState()
     }
 

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -123,7 +123,7 @@ private extension DefaultPOSPINAuthenticator {
         return POSStaff(
             userID: member.userID,
             displayName: member.displayName,
-            preset: member.preset.rawValue,
+            preset: member.preset,
             capabilities: posCaps
         )
     }

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSPINAuthenticator.swift
@@ -123,7 +123,7 @@ private extension DefaultPOSPINAuthenticator {
         return POSStaff(
             userID: member.userID,
             displayName: member.displayName,
-            preset: member.preset,
+            preset: member.preset.rawValue,
             capabilities: posCaps
         )
     }

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -1,6 +1,7 @@
 #if DEBUG
 
 import Observation
+import struct Yosemite.POSStaffMember
 
 @Observable
 @MainActor
@@ -80,6 +81,7 @@ final class MockPOSAccessSession: POSAccessSession {
     }
 
     func refreshPINStatus() async {}
+    func refreshPINStatus(using staff: [POSStaffMember]) async {}
     func clearStaffCache() {}
 }
 

--- a/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/MockPOSAccessSession.swift
@@ -23,7 +23,7 @@ final class MockPOSAccessSession: POSAccessSession {
          hasAnyPINs: Bool = true,
          signInResult: Result<POSStaff, POSAuthError> = .success(
             POSStaff(userID: 1, displayName: "Maya",
-                     preset: "pos_manager", capabilities: Set(POSCapability.allCases.map(\.rawValue)))
+                     preset: .manager, capabilities: Set(POSCapability.allCases.map(\.rawValue)))
          ),
          managerApprovalResult: Result<Void, POSAuthError> = .success(()),
          checkLockoutResult: Result<Void, POSAuthError> = .success(())) {

--- a/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/POSAccessSession.swift
@@ -1,3 +1,5 @@
+import struct Yosemite.POSStaffMember
+
 @MainActor
 protocol POSAccessSession: AnyObject {
     var currentStaff: POSStaff? { get }
@@ -17,6 +19,9 @@ protocol POSAccessSession: AnyObject {
     func lock()
     func checkLockoutState() throws(POSAuthError)
     func refreshPINStatus() async
+    /// Refreshes PIN gating from an already-loaded staff list, so a caller that just fetched staff
+    /// (e.g. the staff settings screen) can sync the session without hitting the staff endpoint again.
+    func refreshPINStatus(using staff: [POSStaffMember]) async
 
     /// Clears the staff cache for the current site on a live session, dropping any in-flight
     /// refresh's write so a clear that lands mid-fetch can't resurrect stale staff. Logout — where

--- a/Modules/Sources/PointOfSale/Roles/Providers/UnrestrictedPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/UnrestrictedPOSAccessSession.swift
@@ -1,3 +1,5 @@
+import struct Yosemite.POSStaffMember
+
 @MainActor
 final class UnrestrictedPOSAccessSession: POSAccessSession {
     nonisolated init() {}
@@ -12,5 +14,6 @@ final class UnrestrictedPOSAccessSession: POSAccessSession {
     func lock() {}
     func checkLockoutState() throws(POSAuthError) {}
     func refreshPINStatus() async {}
+    func refreshPINStatus(using staff: [POSStaffMember]) async {}
     func clearStaffCache() {}
 }

--- a/Modules/Sources/PointOfSale/Roles/Services/POSStaffSettingsService.swift
+++ b/Modules/Sources/PointOfSale/Roles/Services/POSStaffSettingsService.swift
@@ -1,0 +1,33 @@
+import struct Yosemite.POSStaffMember
+
+/// Backs the staff settings screen. M1 is read-only: load the latest staff snapshot and expose the
+/// web "manage staff" URL (an authenticated wp-admin deep link, passed as a string the view
+/// resolves). M2 will extend this protocol with in-app staff/PIN management — create / update /
+/// delete staff and set / reset PIN — so the screen evolves without changing how it's injected.
+///
+/// `DefaultPOSStaffSettingsService` is the standard implementation; the app target supplies the
+/// manage-on-web URL (see `Site.posStaffManagementAdminURL`).
+public protocol POSStaffSettingsService {
+    func loadStaff() async throws -> [POSStaffMember]
+    var manageStaffURL: String { get }
+}
+
+/// Default `POSStaffSettingsService`: a stateless wrapper that loads staff through the injected
+/// `POSStaffFetching` and exposes the host-provided manage-on-web URL string. The wp-admin URL is
+/// built by the app target (see `Site.posStaffManagementAdminURL`) and passed in as data, mirroring
+/// how `receiptSettingsAdminURL` flows into POS.
+public struct DefaultPOSStaffSettingsService: POSStaffSettingsService {
+    private let staffFetcher: POSStaffFetching
+    private let siteID: Int64
+    public let manageStaffURL: String
+
+    public init(staffFetcher: POSStaffFetching, siteID: Int64, manageStaffURL: String) {
+        self.staffFetcher = staffFetcher
+        self.siteID = siteID
+        self.manageStaffURL = manageStaffURL
+    }
+
+    public func loadStaff() async throws -> [POSStaffMember] {
+        try await staffFetcher.fetchStaff(siteID: siteID)
+    }
+}

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import struct Networking.POSStaffMember
+import enum Networking.POSStaffPreset
 
 struct POSStaffSettingsView: View {
     @Environment(\.posExternalViews) private var externalViews
@@ -118,20 +119,15 @@ private extension POSStaffSettingsView {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// Maps the server preset slug (`pos_admin` / `pos_manager` / `pos_cashier`, with the older
-    /// `administrator` / `shop_manager` kept for resilience) to a display label.
-    static func displayName(for preset: String) -> String {
+    /// Maps the role preset to a display label.
+    static func displayName(for preset: POSStaffPreset) -> String {
         switch preset {
-        case "pos_admin", "administrator":
+        case .admin:
             return Localization.roleAdmin
-        case "shop_manager":
-            return Localization.roleShopManager
-        case "pos_manager":
+        case .manager:
             return Localization.rolePOSManager
-        case "pos_cashier":
+        case .cashier:
             return Localization.rolePOSCashier
-        default:
-            return preset
         }
     }
 
@@ -268,12 +264,6 @@ private enum Localization {
         comment: "Display name for the administrator role in the POS staff list."
     )
 
-    static let roleShopManager = NSLocalizedString(
-        "posStaffSettingsView.role.shopManager",
-        value: "Shop Manager",
-        comment: "Display name for the shop manager role in the POS staff list."
-    )
-
     static let rolePOSManager = NSLocalizedString(
         "posStaffSettingsView.role.posManager",
         value: "POS Manager",
@@ -313,13 +303,13 @@ private struct PreviewPOSStaffSettingsService: POSStaffSettingsService {
         [
             POSStaffMember(userID: 1,
                            displayName: "Maya Patel",
-                           preset: "pos_manager",
+                           preset: .manager,
                            capabilities: [:],
                            pin: .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                       salt: "c2FsdA==", hash: "aGFzaA==")),
             POSStaffMember(userID: 2,
                            displayName: "Sam Lee",
-                           preset: "pos_cashier",
+                           preset: .cashier,
                            capabilities: [:],
                            pin: nil)
         ]

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -1,0 +1,336 @@
+import SwiftUI
+import struct Networking.POSStaffMember
+
+struct POSStaffSettingsView: View {
+    @Environment(\.posExternalViews) private var externalViews
+    @Environment(\.posAccessSession) private var session
+
+    let service: POSStaffSettingsService
+
+    @State private var staffMembers: [POSStaffMember] = []
+    @State private var isLoading: Bool = false
+    @State private var loadError: Error?
+    @State private var hasLoadedOnce = false
+    @State private var showsManageStaff: Bool = false
+
+    var body: some View {
+        VStack(spacing: POSSpacing.none) {
+            POSPageHeaderView(title: Localization.staffTitle)
+                .foregroundColor(.posSurface)
+                .accessibilityAddTraits(.isHeader)
+
+            ScrollView {
+                VStack(spacing: POSSpacing.medium) {
+                    if isLoading {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, POSPadding.xLarge)
+                    } else if let loadError {
+                        staffLoadErrorView(error: loadError)
+                    } else if !staffMembers.isEmpty {
+                        staffListCard
+                    }
+                    manageStaffCard
+                    footerText
+                }
+                .padding(.horizontal, POSPadding.medium)
+            }
+        }
+        .background(Color.posSurface)
+        .task {
+            // Load once. Presenting the full-screen Manage staff web view makes this view
+            // disappear, so `.task` re-fires on dismiss — without this guard that would re-show
+            // (and could strand) the spinner. Post-web changes are picked up by the silent refresh
+            // in the web view's completion below.
+            guard !hasLoadedOnce else { return }
+            hasLoadedOnce = true
+            await fetchStaff()
+        }
+        .posFullScreenCover(isPresented: $showsManageStaff) {
+            if let manageStaffURL = URL(string: service.manageStaffURL) {
+                externalViews.createAuthenticatedWebView(
+                    url: manageStaffURL,
+                    title: Localization.manageStaffWebTitle,
+                    completion: {
+                        showsManageStaff = false
+                        // Silent refresh: the list is already on screen, so update it in place
+                        // without the spinner (which could otherwise stick after the cover dismiss).
+                        Task { await fetchStaff(showLoading: false) }
+                    }
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Subviews
+
+private extension POSStaffSettingsView {
+    var staffListCard: some View {
+        POSInformationCard {
+            VStack(spacing: POSSpacing.none) {
+                ForEach(Array(sortedStaffMembers.enumerated()), id: \.element.userID) { index, member in
+                    staffRow(member: member, isCurrentOperator: member.userID == currentOperatorID)
+
+                    if index < sortedStaffMembers.count - 1 {
+                        Divider()
+                            .padding(.vertical, POSPadding.small)
+                    }
+                }
+            }
+        }
+    }
+
+    var currentOperatorID: Int64? {
+        session.currentStaff?.userID
+    }
+
+    var sortedStaffMembers: [POSStaffMember] {
+        staffMembers.sorted { lhs, rhs in
+            let lhsCurrent = lhs.userID == currentOperatorID
+            let rhsCurrent = rhs.userID == currentOperatorID
+            if lhsCurrent != rhsCurrent {
+                return lhsCurrent
+            }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+    }
+
+    func staffRow(member: POSStaffMember, isCurrentOperator: Bool) -> some View {
+        HStack(alignment: .center, spacing: POSSpacing.medium) {
+            VStack(alignment: .leading, spacing: POSPadding.xSmall) {
+                Text(member.displayName)
+                    .font(.posBodyMediumBold)
+                    .foregroundStyle(Color.posOnSurface)
+                Text(Self.displayName(for: member.preset))
+                    .font(.posBodySmallRegular())
+                    .foregroundStyle(.secondary)
+                if isCurrentOperator {
+                    signedInBadge
+                }
+            }
+
+            Spacer()
+
+            pinStatusBadge(hasPIN: member.pin != nil)
+        }
+        .padding(.vertical, POSPadding.xSmall)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Maps the server preset slug (`pos_admin` / `pos_manager` / `pos_cashier`, with the older
+    /// `administrator` / `shop_manager` kept for resilience) to a display label.
+    static func displayName(for preset: String) -> String {
+        switch preset {
+        case "pos_admin", "administrator":
+            return Localization.roleAdmin
+        case "shop_manager":
+            return Localization.roleShopManager
+        case "pos_manager":
+            return Localization.rolePOSManager
+        case "pos_cashier":
+            return Localization.rolePOSCashier
+        default:
+            return preset
+        }
+    }
+
+    var signedInBadge: some View {
+        Text(Localization.signedInBadge)
+            .font(.posCaptionRegular)
+            .foregroundStyle(Color.posOnInfoLowest)
+            .padding(.horizontal, POSPadding.small)
+            .padding(.vertical, POSPadding.xSmall)
+            .background(Color.posInfoLowest)
+            .clipShape(RoundedRectangle(cornerRadius: POSCornerRadiusStyle.small.value))
+    }
+
+    /// Neutral indicator using shape (filled vs slashed) rather than colour so it reads
+    /// correctly for colourblind users and doesn't imply "No PIN" is an error — staff
+    /// PIN setup is managed on the web, so a missing one is informational, not a warning.
+    func pinStatusBadge(hasPIN: Bool) -> some View {
+        HStack(spacing: POSSpacing.small) {
+            Image(systemName: hasPIN ? "lock.fill" : "lock.slash")
+                .foregroundStyle(hasPIN ? Color.posOnSurface : Color.posOnSurfaceVariantLowest)
+            Text(hasPIN ? Localization.pinSetLabel : Localization.noPINLabel)
+                .font(.posBodySmallRegular())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    var manageStaffCard: some View {
+        Button {
+            showsManageStaff = true
+        } label: {
+            Text(Localization.manageStaffButton)
+        }
+        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        .frame(maxWidth: .infinity)
+    }
+
+    func staffLoadErrorView(error: Error) -> some View {
+        VStack(spacing: POSSpacing.medium) {
+            Text(Localization.staffLoadError)
+                .font(.posBodyMediumRegular())
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                Task { await fetchStaff() }
+            } label: {
+                Text(Localization.staffLoadRetry)
+            }
+            .buttonStyle(POSOutlinedButtonStyle(size: .compact))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, POSPadding.xLarge)
+    }
+
+    var footerText: some View {
+        Text(Localization.footer)
+            .font(.posBodyMediumRegular())
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, POSPadding.small)
+    }
+}
+
+// MARK: - Logic
+
+private extension POSStaffSettingsView {
+    /// Loads the staff list. `showLoading` drives the full-screen spinner + error state for the
+    /// initial load and retries; pass `false` for a silent in-place refresh (e.g. after returning
+    /// from the Manage staff web view), which keeps the current list visible and never strands the
+    /// spinner.
+    func fetchStaff(showLoading: Bool = true) async {
+        if showLoading {
+            isLoading = true
+            loadError = nil
+        }
+        do {
+            staffMembers = try await service.loadStaff()
+            // Keep the access session in sync so menu items like "Lock POS" pick up
+            // PIN changes made via the Manage staff web view without requiring a relaunch.
+            await session.refreshPINStatus()
+            // Clear any stale error so a successful silent refresh recovers the list.
+            loadError = nil
+        } catch {
+            if showLoading {
+                loadError = error
+            }
+        }
+        isLoading = false
+    }
+}
+
+// MARK: - Localization
+
+private enum Localization {
+    static let staffTitle = NSLocalizedString(
+        "posStaffSettingsView.staffTitle",
+        value: "Staff",
+        comment: "Navigation title for the staff settings detail view in POS settings."
+    )
+
+    static let signedInBadge = NSLocalizedString(
+        "posStaffSettingsView.signedInBadge",
+        value: "Signed in",
+        comment: "Badge label shown next to the currently signed-in staff member in the POS staff list."
+    )
+
+    static let pinSetLabel = NSLocalizedString(
+        "posStaffSettingsView.pinSetLabel",
+        value: "PIN set",
+        comment: "Status label shown next to a staff member who has a PIN configured."
+    )
+
+    static let noPINLabel = NSLocalizedString(
+        "posStaffSettingsView.noPINLabel",
+        value: "No PIN",
+        comment: "Status label shown next to a staff member who does not have a PIN configured."
+    )
+
+    static let manageStaffButton = NSLocalizedString(
+        "posStaffSettingsView.manageStaffWebButton",
+        value: "Manage staff on the web",
+        comment: "Button to open the WordPress admin staff management page in a web view."
+    )
+
+    static let manageStaffWebTitle = NSLocalizedString(
+        "posStaffSettingsView.manageStaffWebTitle",
+        value: "Manage Staff",
+        comment: "Navigation title for the web view showing WordPress admin staff management."
+    )
+
+    static let roleAdmin = NSLocalizedString(
+        "posStaffSettingsView.role.admin",
+        value: "Admin",
+        comment: "Display name for the administrator role in the POS staff list."
+    )
+
+    static let roleShopManager = NSLocalizedString(
+        "posStaffSettingsView.role.shopManager",
+        value: "Shop Manager",
+        comment: "Display name for the shop manager role in the POS staff list."
+    )
+
+    static let rolePOSManager = NSLocalizedString(
+        "posStaffSettingsView.role.posManager",
+        value: "POS Manager",
+        comment: "Display name for the POS manager role in the POS staff list."
+    )
+
+    static let rolePOSCashier = NSLocalizedString(
+        "posStaffSettingsView.role.posCashier",
+        value: "POS Cashier",
+        comment: "Display name for the POS cashier role in the POS staff list."
+    )
+
+    static let staffLoadError = NSLocalizedString(
+        "posStaffSettingsView.staffLoadError",
+        value: "Unable to load staff. Check your connection and try again.",
+        comment: "Error message shown when the staff list fails to load from the server."
+    )
+
+    static let staffLoadRetry = NSLocalizedString(
+        "posStaffSettingsView.staffLoadRetry",
+        value: "Retry",
+        comment: "Button to retry loading the staff list after a failure."
+    )
+
+    static let footer = NSLocalizedString(
+        "posStaffSettingsView.autoLockFooter",
+        value: "POS locks when you tap Lock POS from the menu, or automatically after 5 minutes of inactivity.",
+        comment: "Footer text explaining how POS locking works, including auto-lock timeout."
+    )
+}
+
+// MARK: - Preview
+
+#if DEBUG
+private struct PreviewPOSStaffSettingsService: POSStaffSettingsService {
+    func loadStaff() async throws -> [POSStaffMember] {
+        [
+            POSStaffMember(userID: 1,
+                           displayName: "Maya Patel",
+                           preset: "pos_manager",
+                           capabilities: [:],
+                           pin: .init(algorithm: "pbkdf2-sha256", iterations: 1,
+                                      salt: "c2FsdA==", hash: "aGFzaA==")),
+            POSStaffMember(userID: 2,
+                           displayName: "Sam Lee",
+                           preset: "pos_cashier",
+                           capabilities: [:],
+                           pin: nil)
+        ]
+    }
+
+    var manageStaffURL: String { "about:blank" }
+}
+
+#Preview {
+//    POSStaffSettingsView(service: PreviewPOSStaffSettingsService())
+    Text("Preview unavailable in this environment")
+
+}
+#endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
-import struct Networking.POSStaffMember
-import enum Networking.POSStaffPreset
+import struct Yosemite.POSStaffMember
+import enum Yosemite.POSStaffPreset
 
 struct POSStaffSettingsView: View {
     @Environment(\.posExternalViews) private var externalViews
@@ -8,11 +8,15 @@ struct POSStaffSettingsView: View {
 
     let service: POSStaffSettingsService
 
-    @State private var staffMembers: [POSStaffMember] = []
-    @State private var isLoading: Bool = false
-    @State private var loadError: Error?
-    @State private var hasLoadedOnce = false
+    @State private var state: LoadState = .idle
     @State private var showsManageStaff: Bool = false
+
+    private enum LoadState {
+        case idle
+        case loading
+        case loaded([POSStaffMember])
+        case failed(Error)
+    }
 
     var body: some View {
         VStack(spacing: POSSpacing.none) {
@@ -22,16 +26,21 @@ struct POSStaffSettingsView: View {
 
             ScrollView {
                 VStack(spacing: POSSpacing.medium) {
-                    if isLoading {
+                    switch state {
+                    case .idle, .loading:
                         ProgressView()
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, POSPadding.xLarge)
-                    } else if let loadError {
-                        staffLoadErrorView(error: loadError)
-                    } else if !staffMembers.isEmpty {
-                        staffListCard
+                    case .failed(let error):
+                        staffLoadErrorView(error: error)
+                    case .loaded(let staff):
+                        if !staff.isEmpty {
+                            staffListCard(staff: staff)
+                        }
                     }
-                    manageStaffCard
+                    if manageStaffURL != nil {
+                        manageStaffCard
+                    }
                     footerText
                 }
                 .padding(.horizontal, POSPadding.medium)
@@ -39,16 +48,10 @@ struct POSStaffSettingsView: View {
         }
         .background(Color.posSurface)
         .task {
-            // Load once. Presenting the full-screen Manage staff web view makes this view
-            // disappear, so `.task` re-fires on dismiss — without this guard that would re-show
-            // (and could strand) the spinner. Post-web changes are picked up by the silent refresh
-            // in the web view's completion below.
-            guard !hasLoadedOnce else { return }
-            hasLoadedOnce = true
-            await fetchStaff()
+            await loadStaffIfNeeded()
         }
         .posFullScreenCover(isPresented: $showsManageStaff) {
-            if let manageStaffURL = URL(string: service.manageStaffURL) {
+            if let manageStaffURL {
                 externalViews.createAuthenticatedWebView(
                     url: manageStaffURL,
                     title: Localization.manageStaffWebTitle,
@@ -67,13 +70,14 @@ struct POSStaffSettingsView: View {
 // MARK: - Subviews
 
 private extension POSStaffSettingsView {
-    var staffListCard: some View {
-        POSInformationCard {
+    func staffListCard(staff: [POSStaffMember]) -> some View {
+        let sortedStaff = sortedStaffMembers(staff)
+        return POSInformationCard {
             VStack(spacing: POSSpacing.none) {
-                ForEach(Array(sortedStaffMembers.enumerated()), id: \.element.userID) { index, member in
+                ForEach(Array(sortedStaff.enumerated()), id: \.element.userID) { index, member in
                     staffRow(member: member, isCurrentOperator: member.userID == currentOperatorID)
 
-                    if index < sortedStaffMembers.count - 1 {
+                    if index < sortedStaff.count - 1 {
                         Divider()
                             .padding(.vertical, POSPadding.small)
                     }
@@ -86,8 +90,8 @@ private extension POSStaffSettingsView {
         session.currentStaff?.userID
     }
 
-    var sortedStaffMembers: [POSStaffMember] {
-        staffMembers.sorted { lhs, rhs in
+    func sortedStaffMembers(_ staff: [POSStaffMember]) -> [POSStaffMember] {
+        staff.sorted { lhs, rhs in
             let lhsCurrent = lhs.userID == currentOperatorID
             let rhsCurrent = rhs.userID == currentOperatorID
             if lhsCurrent != rhsCurrent {
@@ -154,6 +158,12 @@ private extension POSStaffSettingsView {
         }
     }
 
+    /// The wp-admin staff-management URL, or `nil` when the host didn't supply a usable one. When
+    /// `nil` the manage-on-web button is hidden rather than opening an empty web view.
+    var manageStaffURL: URL? {
+        URL(string: service.manageStaffURL)
+    }
+
     var manageStaffCard: some View {
         Button {
             showsManageStaff = true
@@ -194,28 +204,36 @@ private extension POSStaffSettingsView {
 // MARK: - Logic
 
 private extension POSStaffSettingsView {
-    /// Loads the staff list. `showLoading` drives the full-screen spinner + error state for the
-    /// initial load and retries; pass `false` for a silent in-place refresh (e.g. after returning
-    /// from the Manage staff web view), which keeps the current list visible and never strands the
-    /// spinner.
+    /// Loads once on first appearance. Presenting the full-screen Manage staff web view makes this
+    /// view disappear, so `.task` re-fires on dismiss; the `.idle` guard keeps that from re-running
+    /// the initial load. Post-web changes are picked up by the silent refresh in the web view's
+    /// completion handler.
+    func loadStaffIfNeeded() async {
+        guard case .idle = state else { return }
+        await fetchStaff()
+    }
+
+    /// Loads the staff list. `showLoading` drives the spinner + error state for the initial load and
+    /// retries; pass `false` for a silent in-place refresh (e.g. after returning from the Manage
+    /// staff web view), which keeps the current list visible and never strands the spinner.
     func fetchStaff(showLoading: Bool = true) async {
         if showLoading {
-            isLoading = true
-            loadError = nil
+            state = .loading
         }
         do {
-            staffMembers = try await service.loadStaff()
-            // Keep the access session in sync so menu items like "Lock POS" pick up
-            // PIN changes made via the Manage staff web view without requiring a relaunch.
-            await session.refreshPINStatus()
-            // Clear any stale error so a successful silent refresh recovers the list.
-            loadError = nil
+            let staff = try await service.loadStaff()
+            // Keep the access session in sync so menu items like "Lock POS" pick up PIN changes made
+            // via the Manage staff web view — using the list we just fetched, so the staff endpoint
+            // isn't hit a second time.
+            await session.refreshPINStatus(using: staff)
+            state = .loaded(staff)
         } catch {
+            // Silent-refresh failures keep the current list on screen; only the initial load and
+            // retry surface the error state.
             if showLoading {
-                loadError = error
+                state = .failed(error)
             }
         }
-        isLoading = false
     }
 }
 

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -329,8 +329,6 @@ private struct PreviewPOSStaffSettingsService: POSStaffSettingsService {
 }
 
 #Preview {
-//    POSStaffSettingsView(service: PreviewPOSStaffSettingsService())
-    Text("Preview unavailable in this environment")
-
+    POSStaffSettingsView(service: PreviewPOSStaffSettingsService())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -59,7 +59,7 @@ struct POSStaffSettingsView: View {
                         showsManageStaff = false
                         // Silent refresh: the list is already on screen, so update it in place
                         // without the spinner (which could otherwise stick after the cover dismiss).
-                        Task { await fetchStaff(showLoading: false) }
+                        Task { await fetchStaff(showsLoading: false) }
                     }
                 )
             }
@@ -213,11 +213,11 @@ private extension POSStaffSettingsView {
         await fetchStaff()
     }
 
-    /// Loads the staff list. `showLoading` drives the spinner + error state for the initial load and
+    /// Loads the staff list. `showsLoading` drives the spinner + error state for the initial load and
     /// retries; pass `false` for a silent in-place refresh (e.g. after returning from the Manage
     /// staff web view), which keeps the current list visible and never strands the spinner.
-    func fetchStaff(showLoading: Bool = true) async {
-        if showLoading {
+    func fetchStaff(showsLoading: Bool = true) async {
+        if showsLoading {
             state = .loading
         }
         do {
@@ -230,7 +230,7 @@ private extension POSStaffSettingsView {
         } catch {
             // Silent-refresh failures keep the current list on screen; only the initial load and
             // retry surface the error state.
-            if showLoading {
+            if showsLoading {
                 state = .failed(error)
             }
         }

--- a/Modules/Sources/Yosemite/Model/Model.swift
+++ b/Modules/Sources/Yosemite/Model/Model.swift
@@ -105,6 +105,7 @@ public typealias QRLoginTokenHash = Networking.QRLoginTokenHash
 public typealias POSProduct = Networking.POSProduct
 public typealias POSProductVariation = Networking.POSProductVariation
 public typealias POSStaffMember = Networking.POSStaffMember
+public typealias POSStaffPreset = Networking.POSStaffPreset
 public typealias ProductAddOn = Networking.ProductAddOn
 public typealias ProductAddOnOption = Networking.ProductAddOnOption
 public typealias ProductBackordersSetting = Networking.ProductBackordersSetting

--- a/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
@@ -43,7 +43,7 @@ struct POSStaffRemoteTests {
         let manager = try #require(staff.first)
         #expect(manager.userID == 12)
         #expect(manager.displayName == "Morgan Manager")
-        #expect(manager.preset == "pos_manager")
+        #expect(manager.preset == .manager)
         #expect(manager.capabilities["pos_issue_refunds"] == true)
         #expect(manager.capabilities["pos_manage_staff"] == true)
 
@@ -67,7 +67,7 @@ struct POSStaffRemoteTests {
         #expect(staff.map { $0.userID } == [12, 34])
 
         let cashier = try #require(staff.last)
-        #expect(cashier.preset == "pos_cashier")
+        #expect(cashier.preset == .cashier)
         #expect(cashier.capabilities == ["pos_process_sales": true])
     }
 
@@ -82,7 +82,7 @@ struct POSStaffRemoteTests {
         // Then
         let admin = try #require(staff.last)
         #expect(admin.userID == 1)
-        #expect(admin.preset == "administrator")
+        #expect(admin.preset == .admin)
         #expect(admin.pin == nil)
     }
 

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff.json
@@ -41,7 +41,7 @@
         {
             "user_id": 1,
             "display_name": "Avery Admin",
-            "preset": "administrator",
+            "preset": "pos_admin",
             "capabilities": {
                 "pos_process_sales": true,
                 "pos_view_orders": true,

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSSettingsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSSettingsControllerTests.swift
@@ -107,4 +107,5 @@ final class MockPOSSettingsController: POSSettingsControllerProtocol {
                                                                               receiptSettingsAdminURL: "")
     var localCatalogViewModel: POSSettingsLocalCatalogViewModel?
     var isLocalCatalogEligible = true
+    var staffSettingsService: POSStaffSettingsService?
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -449,7 +449,7 @@ private extension DefaultPOSAccessSessionTests {
     func makeStaffMember(userID: Int64 = 1, hasPIN: Bool) -> POSStaffMember {
         POSStaffMember(userID: userID,
                        displayName: "Staff",
-                       preset: "pos_cashier",
+                       preset: .cashier,
                        capabilities: ["pos_process_sales": true],
                        pin: hasPIN ? .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                            salt: "c2FsdA==", hash: "aGFzaA==") : nil)

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import struct Yosemite.POSStaffMember
+import enum Yosemite.POSStaffPreset
 @testable import PointOfSale
 
 @MainActor
@@ -159,7 +160,7 @@ struct DefaultPOSAccessSessionTests {
 
     @Test func test_allows_when_currentStaff_lacks_capability_then_returns_false() async throws {
         // Given
-        let staff = makeStaff(preset: "pos_cashier", capabilities: [])
+        let staff = makeStaff(preset: .cashier, capabilities: [])
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator(authenticateResult: .success(staff)))
         try await sut.session.signIn(withPIN: "1234")
 
@@ -457,7 +458,7 @@ private extension DefaultPOSAccessSessionTests {
 
     func makeStaff(userID: Int64 = 1,
                    displayName: String = "Maya",
-                   preset: String = "pos_manager",
+                   preset: POSStaffPreset = .manager,
                    capabilities: Set<String> = []) -> POSStaff {
         POSStaff(userID: userID,
                  displayName: displayName,

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -24,7 +24,7 @@ struct DefaultPOSPINAuthenticatorTests {
         // Then
         #expect(staff.userID == 7)
         #expect(staff.displayName == "Manny")
-        #expect(staff.preset == "pos_manager")
+        #expect(staff.preset == .manager)
     }
 
     @MainActor

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -2,6 +2,7 @@ import CommonCrypto
 import Foundation
 import Testing
 import struct Yosemite.POSStaffMember
+import enum Yosemite.POSStaffPreset
 @testable import PointOfSale
 
 struct DefaultPOSPINAuthenticatorTests {
@@ -12,7 +13,7 @@ struct DefaultPOSPINAuthenticatorTests {
     @MainActor
     @Test func test_authenticate_when_pin_matches_a_cached_member_then_returns_that_staff() async throws {
         // Given a cached member whose PIN hash matches "1234"
-        let member = makeMember(userID: 7, displayName: "Manny", preset: "pos_manager",
+        let member = makeMember(userID: 7, displayName: "Manny", preset: .manager,
                                 capabilities: ["pos_process_sales": true, "pos_issue_refunds": true],
                                 pin: pinDetails(forPIN: "1234"))
         let sut = makeSUT(cached: [member])
@@ -124,7 +125,7 @@ struct DefaultPOSPINAuthenticatorTests {
 
     @MainActor
     @Test func test_verify_when_manager_holds_the_capability_then_does_not_throw() async throws {
-        let manager = makeMember(userID: 5, displayName: "Morgan", preset: "pos_manager",
+        let manager = makeMember(userID: 5, displayName: "Morgan", preset: .manager,
                                  capabilities: ["pos_issue_refunds": true],
                                  pin: pinDetails(forPIN: "9999"))
         let sut = makeSUT(cached: [manager])
@@ -157,7 +158,7 @@ private extension DefaultPOSPINAuthenticatorTests {
 
     func makeMember(userID: Int64,
                     displayName: String = "User",
-                    preset: String = "pos_cashier",
+                    preset: POSStaffPreset = .cashier,
                     capabilities: [String: Bool] = ["pos_process_sales": true],
                     pin: POSStaffMember.PINDetails?) -> POSStaffMember {
         POSStaffMember(userID: userID, displayName: displayName, preset: preset,

--- a/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/Mocks/MockPOSPINAuthenticator.swift
@@ -21,7 +21,7 @@ final class MockPOSPINAuthenticator: POSPINAuthenticating {
             POSStaff(
                 userID: 1,
                 displayName: "Maya",
-                preset: "pos_manager",
+                preset: .manager,
                 capabilities: Set(POSCapability.allCases.map(\.rawValue))
             )
          ),

--- a/Modules/Tests/PointOfSaleTests/Roles/POSAutoLockActivityControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSAutoLockActivityControllerTests.swift
@@ -205,7 +205,7 @@ private extension POSAutoLockActivityControllerTests {
     }
 
     func makeStaff() -> POSStaff {
-        POSStaff(userID: 1, displayName: "Maya", preset: "shop_manager", capabilities: [])
+        POSStaff(userID: 1, displayName: "Maya", preset: .manager, capabilities: [])
     }
 }
 

--- a/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSLockScreenModelTests.swift
@@ -227,7 +227,7 @@ struct POSLockScreenModelTests {
         POSStaff(
             userID: 1,
             displayName: "Maya",
-            preset: "Manager",
+            preset: .manager,
             capabilities: Set(POSCapability.allCases.map(\.rawValue))
         )
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
@@ -53,7 +53,7 @@ private extension POSRolesPersistenceTests {
     func makeStaffMemberWithPIN() -> POSStaffMember {
         POSStaffMember(userID: 1,
                        displayName: "Staff",
-                       preset: "pos_cashier",
+                       preset: .cashier,
                        capabilities: ["pos_process_sales": true],
                        pin: .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                   salt: "c2FsdA==", hash: "aGFzaA=="))

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffCacheTests.swift
@@ -155,7 +155,7 @@ private extension POSStaffCacheTests {
                     pin: POSStaffMember.PINDetails? = nil) -> POSStaffMember {
         POSStaffMember(userID: userID,
                        displayName: displayName ?? "User \(userID)",
-                       preset: "pos_cashier",
+                       preset: .cashier,
                        capabilities: ["pos_process_payments": true],
                        pin: pin)
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffTests.swift
@@ -4,7 +4,7 @@ import Testing
 struct POSStaffTests {
     @Test func test_hasCapability_when_staff_has_it_then_returns_true() {
         // Given
-        let sut = POSStaff(userID: 1, displayName: "Jane", preset: "pos_manager", capabilities: ["pos_issue_refunds"])
+        let sut = POSStaff(userID: 1, displayName: "Jane", preset: .manager, capabilities: ["pos_issue_refunds"])
 
         // When / Then
         #expect(sut.hasCapability(.issueRefunds))
@@ -12,7 +12,7 @@ struct POSStaffTests {
 
     @Test func test_hasCapability_when_staff_lacks_it_then_returns_false() {
         // Given
-        let sut = POSStaff(userID: 2, displayName: "Sam", preset: "pos_cashier", capabilities: [])
+        let sut = POSStaff(userID: 2, displayName: "Sam", preset: .cashier, capabilities: [])
 
         // When / Then
         #expect(sut.hasCapability(.issueRefunds) == false)

--- a/WooCommerce/Classes/Extensions/Site+URL.swift
+++ b/WooCommerce/Classes/Extensions/Site+URL.swift
@@ -51,6 +51,11 @@ extension Site {
         adminURL + "admin.php?page=wc-settings&tab=point-of-sale"
     }
 
+    /// Constructs the admin URL for managing POS staff.
+    var posStaffManagementAdminURL: String {
+        adminURL + "admin.php?page=wc-settings&tab=point-of-sale&section=staff"
+    }
+
     /// Returns the WooCommerce admin URL, or attempts to construct it from the site URL.
     ///
     func adminURLWithFallback() -> URL? {

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -322,6 +322,18 @@ private extension POSTabCoordinator {
                 let receiptPrinter: ReceiptPrinterServiceProtocol? = ServiceLocator.featureFlagService
                     .isFeatureFlagEnabled(.starReceiptPrinterSupport) ? ServiceLocator.posReceiptPrinterService : nil
 
+                // Present staff settings only when POS roles are enabled (nil hides the Staff card).
+                // The wp-admin URL is derived from the site, like `receiptSettingsAdminURL` above.
+                let staffSettingsService: POSStaffSettingsService?
+                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.pointOfSaleRoles) {
+                    let manageStaffURL = storesManager.sessionManager.defaultSite?.posStaffManagementAdminURL ?? ""
+                    staffSettingsService = DefaultPOSStaffSettingsService(staffFetcher: staffFetcher,
+                                                                          siteID: siteID,
+                                                                          manageStaffURL: manageStaffURL)
+                } else {
+                    staffSettingsService = nil
+                }
+
                 let posView = PointOfSaleEntryPointView(
                     siteID: siteID,
                     itemFetchStrategyFactory: createItemFetchStrategyFactory(isLocalCatalogEnabled: isLocalCatalogEligible),
@@ -362,6 +374,7 @@ private extension POSTabCoordinator {
                     preferredConnectionMethod: preferredConnectionMethod,
                     staffFetcher: staffFetcher,
                     receiptPrinter: receiptPrinter,
+                    staffSettingsService: staffSettingsService,
                     services: serviceAdaptor,
                     itemProvider: itemProvider
                 )

--- a/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSStaffAdaptorTests.swift
@@ -133,7 +133,7 @@ private extension POSStaffAdaptorTests {
     func makeMember(userID: Int64) -> POSStaffMember {
         POSStaffMember(userID: userID,
                        displayName: "User \(userID)",
-                       preset: "pos_cashier",
+                       preset: .cashier,
                        capabilities: ["pos_process_payments": true],
                        pin: nil)
     }


### PR DESCRIPTION
## Description

WOOMOB-3286. Adds the read-only **Staff** page under POS Settings (M1), behind the `pointOfSaleRoles` feature flag (off by default). The final feature will be gated behind a minimum WooCommerce version when the core work is complete.

- A **Staff** card appears in POS Settings when the host supplies a staff-settings service (i.e. POS roles enabled). It opens a read-only staff list: display name, role (Admin / POS Manager / POS Cashier), a PIN-set / No-PIN indicator, and a "Signed in" badge for the current operator.
- **"Manage staff on the web"** opens an authenticated web view to wp-admin → Settings → Point of Sale → Staff. Returning silently refreshes the list in place (and the access session, so menu items like "Lock POS" pick up PIN changes) without stranding the loading spinner.
- The screen depends on a small `POSStaffSettingsService` protocol (load staff + the manage-on-web URL string). `DefaultPOSStaffSettingsService` implements it in the PointOfSale module; the wp-admin URL is derived from the site (`Site.posStaffManagementAdminURL`) and passed in as data, mirroring how `receiptSettingsAdminURL` flows into POS. It is injected through `POSSettingsControllerProtocol`, so the dashboard view isn't touched.
- `POSStaffMember.preset` is now a typed `POSStaffPreset` enum (`pos_admin` / `pos_manager` / `pos_cashier`) instead of a raw string, so the role-to-label mapping is an exhaustive switch.

## Test Steps

🗒️ Manual testing is optional, as the POS Staff API is still WIP. The screencast is from testing on a local wp-env site.

Behind the `pointOfSaleRoles` flag and needs a site with the `/wc/pos/v1/staff` backend. 

1. In code, enable `pointOfSaleRoles` feature flag.
2. Open POS → Settings → **Staff**.
3. Verify the staff list loads (name, role, PIN status, "Signed in" badge on the current operator).
4. Tap **Manage staff on the web**, make a change in the web view, tap **Done** — the list refreshes in place without a stuck spinner.

## Screenshots


https://github.com/user-attachments/assets/cdf65121-2bb4-46c3-9a4c-c250508c946a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Not user-facing — behind `pointOfSaleRoles`, off by default.)