### PR TITLE
Update store listing payment country copy

### DIFF
--- a/fastlane/metadata/default/description.txt
+++ b/fastlane/metadata/default/description.txt
@@ -7,10 +7,10 @@ Create orders on the fly
 Once you have some products created, it’s simple. Choose items from your catalog, add shipping, and then fill in customer details to quickly create an order that syncs with your inventory.
 
 Take payments in person
-Collect physical payments using WooCommerce In-Person Payments and a card reader in Australia, Austria, Belgium, Canada, Finland, France, Germany, Ireland, Italy, Luxembourg, the Netherlands, New Zealand, Portugal, Singapore, Spain, the UK, and the US. Tap to Pay on iPhone is available in the UK and US. Start a new order – or find an existing one that’s pending payment – then seamlessly accept payment.
+Collect physical payments using WooCommerce In-Person Payments and a card reader in Australia, Canada, Finland, Ireland, Luxembourg, the Netherlands, New Zealand, Singapore, the UK, and the US. Tap to Pay on iPhone is available in the UK and US. Start a new order – or find an existing one that’s pending payment – then seamlessly accept payment.
 
 Go from clicks to bricks
-Turn any tablet into a powerful point of sale with WooCommerce POS. Search products, scan barcodes, apply coupons, and send email receipts, with all of your online and physical sales synced in real time. Available in the US and UK.
+Turn any tablet into a powerful point of sale with WooCommerce POS. Search products, scan barcodes, apply coupons, and send email receipts, with all of your online and physical sales synced in real time. Available in Australia, Canada, Finland, Ireland, Luxembourg, the Netherlands, New Zealand, Singapore, the UK, and the US.
 
 Get notified of every sale
 Now that you’re actively selling, never miss an order or a review. Keep yourself in the loop by enabling real-time alerts – and listen for that addictive “cha-ching” sound that comes with each new sale!


### PR DESCRIPTION
I realised we'd not updated the descriptions again after the fiscalization rollback; this fixes the App Store description.

- Updates the App Store description card-reader and POS country lists to Australia, Canada, Finland, Ireland, Luxembourg, the Netherlands, New Zealand, Singapore, the UK, and the US.

Tests:
N/A