### PR TITLE
[Woo POS] Handle offline POS entry state

### DIFF
--- a/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSaleIneligibleUI.swift
+++ b/Modules/Sources/PointOfSale/Analytics/WooAnalyticsEvent+PointOfSaleIneligibleUI.swift
@@ -24,6 +24,8 @@ extension WooAnalyticsEvent {
 private extension POSIneligibleReason {
     var analyticsValue: String {
         switch self {
+        case .noInternetConnection:
+            return "no_internet_connection"
         case .unsupportedCurrency:
             return "store_currency"
         case .unsupportedWooCommerceVersion:

--- a/Modules/Sources/PointOfSale/Extensions/Error+Connectivity.swift
+++ b/Modules/Sources/PointOfSale/Extensions/Error+Connectivity.swift
@@ -2,7 +2,7 @@ import Foundation
 import enum Alamofire.AFError
 import enum Networking.BackgroundDownloadError
 
-extension Error {
+public extension Error {
     var isConnectivityError: Bool {
         if let backgroundDownloadError = self as? BackgroundDownloadError {
             switch backgroundDownloadError {

--- a/Modules/Sources/PointOfSale/Models/POSConnectivityErrorNotice.swift
+++ b/Modules/Sources/PointOfSale/Models/POSConnectivityErrorNotice.swift
@@ -8,7 +8,7 @@ enum POSConnectivityErrorNotice {
     )
 
     static let subtitle = NSLocalizedString(
-        "pos.itemList.connectivityErrorSubtitle",
+        "pos.connectivity.subtitle",
         value: "Please check your internet connection and try again.",
         comment: "Subtitle appearing on error screens when there is a network connectivity error."
     )

--- a/Modules/Sources/PointOfSale/Models/POSConnectivityErrorNotice.swift
+++ b/Modules/Sources/PointOfSale/Models/POSConnectivityErrorNotice.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum POSConnectivityErrorNotice {
+    static let title = NSLocalizedString(
+        "pos.connectivity.title",
+        value: "No internet connection",
+        comment: "Title shown when Point of Sale has no internet connection"
+    )
+
+    static let subtitle = NSLocalizedString(
+        "pos.itemList.connectivityErrorSubtitle",
+        value: "Please check your internet connection and try again.",
+        comment: "Subtitle appearing on error screens when there is a network connectivity error."
+    )
+}

--- a/Modules/Sources/PointOfSale/Models/POSIneligibleReason.swift
+++ b/Modules/Sources/PointOfSale/Models/POSIneligibleReason.swift
@@ -4,6 +4,7 @@ import enum WooFoundation.CurrencyCode
 
 /// Represents the reasons why a site may be ineligible for POS.
 public enum POSIneligibleReason: Equatable {
+    case noInternetConnection
     case unsupportedWooCommerceVersion(minimumVersion: String)
     case siteSettingsNotAvailable
     case wooCommercePluginNotFound

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleErrorState.swift
@@ -140,7 +140,7 @@ struct PointOfSaleErrorState: Equatable {
         }
 
         if let error, error.isConnectivityError {
-            return Constants.connectivityErrorSubtitle
+            return POSConnectivityErrorNotice.subtitle
         }
 
         return Constants.genericErrorSubtitle
@@ -224,11 +224,6 @@ struct PointOfSaleErrorState: Equatable {
             "pos.itemList.failedToRefreshCouponsTitle.2",
             value: "Unable to refresh coupons",
             comment: "Title appearing on the coupon list screen when there's an error refreshing coupons."
-        )
-        static let connectivityErrorSubtitle = NSLocalizedString(
-            "pos.itemList.connectivityErrorSubtitle",
-            value: "Please check your internet connection and try again.",
-            comment: "Subtitle appearing on error screens when there is a network connectivity error."
         )
         static let catalogBlockedTitle = NSLocalizedString(
             "pos.itemList.catalogBlockedTitle",

--- a/Modules/Sources/PointOfSale/Presentation/POSIneligibleView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSIneligibleView.swift
@@ -39,7 +39,7 @@ struct POSIneligibleView: View {
                         .frame(height: POSSpacing.medium)
 
                     VStack(spacing: POSSpacing.small) {
-                        Text(Localization.title)
+                        Text(title)
                             .font(POSFontStyle.posHeadingBold.font())
                             .multilineTextAlignment(.center)
                             .foregroundColor(Color.posOnSurface)
@@ -120,6 +120,8 @@ struct POSIneligibleView: View {
 
     private var suggestionText: String {
         switch reason {
+        case .noInternetConnection:
+            return POSConnectivityErrorNotice.subtitle
         case let .unsupportedWooCommerceVersion(minimumVersion):
             let format = NSLocalizedString("pos.ineligible.suggestion.unsupportedWooCommerceVersion",
                                      value: "Your WooCommerce version is not supported. " +
@@ -161,6 +163,15 @@ struct POSIneligibleView: View {
                                      comment: "Suggestion for self deallocated: relaunch")
         }
     }
+
+    private var title: String {
+        switch reason {
+        case .noInternetConnection:
+            return POSConnectivityErrorNotice.title
+        default:
+            return Localization.title
+        }
+    }
 }
 
 private extension POSIneligibleView {
@@ -188,7 +199,8 @@ private extension POSIneligibleReason {
                 value: "Enable POS feature",
                 comment: "Button title to enable the POS feature switch and refresh POS eligibility check"
             )
-        case .unsupportedWooCommerceVersion,
+        case .noInternetConnection,
+                .unsupportedWooCommerceVersion,
                 .siteSettingsNotAvailable,
                 .wooCommercePluginNotFound,
                 .unsupportedCurrency,
@@ -203,6 +215,13 @@ private extension POSIneligibleReason {
 }
 
 #if DEBUG
+
+#Preview("No internet connection") {
+    POSIneligibleView(
+        reason: .noInternetConnection,
+        onRefresh: {}
+    )
+}
 
 #Preview("Unsupported currency") {
     POSIneligibleView(

--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSConnectivityView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSConnectivityView.swift
@@ -32,7 +32,7 @@ struct POSConnectivityView: View {
                 .foregroundColor(Color.posOnSecondaryContainer)
                 .font(.posBodySmallBold())
 
-            Text(Localization.title)
+            Text(POSConnectivityErrorNotice.title)
                 .foregroundColor(Color.posOnSecondaryContainer)
                 .font(.posBodySmallBold())
         }
@@ -58,14 +58,6 @@ private extension POSConnectivityView {
         static let horizontalPadding: CGFloat = POSPadding.large
         static let verticalPadding: CGFloat = POSPadding.small
         static let connectivityAnimationDuration: CGFloat = 1.0
-    }
-
-    enum Localization {
-        static let title = NSLocalizedString(
-            "pos.connectivity.title",
-            value: "No internet connection",
-            comment: "Title shown on a toast view that appears when there's no internet connection"
-        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -16,8 +16,10 @@ import class Yosemite.POSSiteSettingService
 import class Yosemite.SiteAddress
 import enum Networking.SiteSettingsFeature
 import class WooFoundation.VersionHelpers
+import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
+import enum PointOfSale.POSEligibilityState
+import enum PointOfSale.POSIneligibleReason
 import protocol WooFoundation.ConnectivityObserver
-import PointOfSale
 import enum Yosemite.POSCountryCurrencyValidator
 import protocol Yosemite.CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
 import class Yosemite.CardPresentPaymentsCountryExpansionEligibilityService

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabEligibilityChecker.swift
@@ -16,9 +16,8 @@ import class Yosemite.POSSiteSettingService
 import class Yosemite.SiteAddress
 import enum Networking.SiteSettingsFeature
 import class WooFoundation.VersionHelpers
-import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
-import enum PointOfSale.POSEligibilityState
-import enum PointOfSale.POSIneligibleReason
+import protocol WooFoundation.ConnectivityObserver
+import PointOfSale
 import enum Yosemite.POSCountryCurrencyValidator
 import protocol Yosemite.CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
 import class Yosemite.CardPresentPaymentsCountryExpansionEligibilityService
@@ -31,16 +30,19 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     private let siteSettingService: POSSiteSettingServiceProtocol
     private let appPasswordSupportState: ApplicationPasswordsExperimentState
     private let expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
+    private let connectivityObserver: ConnectivityObserver
 
     init(siteID: Int64,
          siteSettings: SelectedSiteSettingsProtocol = ServiceLocator.selectedSiteSettings,
          stores: StoresManager = ServiceLocator.stores,
          systemStatusService: POSSystemStatusServiceProtocol? = nil,
          siteSettingService: POSSiteSettingServiceProtocol? = nil,
+         connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
          expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService()) {
         self.siteID = siteID
         self.siteSettings = siteSettings
         self.stores = stores
+        self.connectivityObserver = connectivityObserver
         self.expansionEligibilityService = expansionEligibilityService
         self.appPasswordSupportState = ApplicationPasswordsExperimentState()
 
@@ -65,6 +67,10 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
         // Bypass eligibility checks for screenshot tests
         if ProcessConfiguration.shouldBypassPOSEligibilityChecks {
             return .eligible
+        }
+
+        guard connectivityObserver.currentStatus != .notReachable else {
+            return .ineligible(reason: .noInternetConnection)
         }
 
         async let siteSettingsEligibility = checkSiteSettingsEligibility()
@@ -94,9 +100,12 @@ final class POSTabEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
             } catch POSTabEligibilityCheckerError.selfDeallocated {
                 return .ineligible(reason: .selfDeallocated)
             } catch {
+                if error.isConnectivityError {
+                    return .ineligible(reason: .noInternetConnection)
+                }
                 throw error
             }
-        case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound:
+        case .unsupportedWooCommerceVersion, .wooCommercePluginNotFound, .noInternetConnection:
             return await checkEligibility()
         case .featureSwitchDisabled:
             _ = try await siteSettingService.setFeature(siteID: siteID, feature: .pointOfSale, enabled: true)
@@ -128,6 +137,9 @@ private extension POSTabEligibilityChecker {
                 return isFeatureSwitchEnabled ? .eligible : .ineligible(reason: .featureSwitchDisabled)
             }
         } catch {
+            if error.isConnectivityError {
+                return .ineligible(reason: .noInternetConnection)
+            }
             return .ineligible(reason: .wooCommercePluginNotFound)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -60,10 +60,7 @@ struct POSTabEligibilityCheckerTests {
         ].publisher.eraseToAnyPublisher()
 
         setupWooCommerceVersion("9.6.0")
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -82,10 +79,7 @@ struct POSTabEligibilityCheckerTests {
         siteSettings.mockSettingsStream = settingsSubject.eraseToAnyPublisher()
 
         setupWooCommerceVersion("9.6.0")
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When - Call checkEligibility before site settings are available
         async let eligibilityTask = checker.checkEligibility()
@@ -111,10 +105,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_eligible_when_all_conditions_satisfied(country: Country, currency: CurrencyCode) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -129,11 +120,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_ineligible_when_country_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               expansionEligibilityService: ineligibleExpansionService)
+        let checker = makeEligibilityChecker(expansionEligibilityService: ineligibleExpansionService)
 
         // When
         let result = await checker.checkEligibility()
@@ -154,9 +141,7 @@ struct POSTabEligibilityCheckerTests {
                                                                   expectedSupportedCurrencies: [CurrencyCode]) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -169,10 +154,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("9.5.0")
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -185,10 +167,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("10.0.0", featureSwitchEnabled: true)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -201,10 +180,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("10.0.0", featureSwitchEnabled: false)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -217,10 +193,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("9.9.9", featureSwitchEnabled: false)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -233,11 +206,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         let offlineConnectivityObserver = MockConnectivityObserver()
         offlineConnectivityObserver.setStatus(.notReachable)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               connectivityObserver: offlineConnectivityObserver)
+        let checker = makeEligibilityChecker(connectivityObserver: offlineConnectivityObserver)
 
         // When
         let result = await checker.checkEligibility()
@@ -250,10 +219,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         mockSystemStatusService.resultToReturn = .failure(URLError(.notConnectedToInternet))
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -266,10 +232,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         mockSystemStatusService.resultToReturn = .failure(NSError(domain: "test", code: 500))
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = await checker.checkEligibility()
@@ -302,10 +265,7 @@ struct POSTabEligibilityCheckerTests {
             }
         }
 
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -335,9 +295,7 @@ struct POSTabEligibilityCheckerTests {
             }
         }
 
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores)
+        let checker = makeEligibilityChecker()
 
         // When & Then - Should throw the generic error
         #expect(syncCalled == false) // Not called yet
@@ -363,9 +321,7 @@ struct POSTabEligibilityCheckerTests {
             }
         }
 
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: .siteSettingsNotAvailable)
@@ -380,11 +336,7 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: .us, currency: .USD)
         setupWooCommerceVersion("10.0.0", featureSwitchEnabled: true)
 
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               siteSettingService: mockSiteSettingService)
+        let checker = makeEligibilityChecker(siteSettingService: mockSiteSettingService)
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: .featureSwitchDisabled)
@@ -398,10 +350,7 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: .us, currency: .USD)
         setupWooCommerceVersion("9.6.0", featureSwitchEnabled: true)
 
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: .selfDeallocated)
@@ -415,10 +364,7 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: .us, currency: .USD)
         setupWooCommerceVersion("9.6.0", featureSwitchEnabled: true)
 
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: .noInternetConnection)
@@ -439,10 +385,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -461,10 +404,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: true))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -482,10 +422,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -504,10 +441,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -526,10 +460,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -547,10 +478,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .failure(NSError(domain: "test", code: 500))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService)
+        let checker = makeEligibilityChecker()
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
@@ -570,11 +498,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_eligible_when_expansion_eligibility_is_enabled(country: Country, currency: CurrencyCode) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               expansionEligibilityService: eligibleExpansionService)
+        let checker = makeEligibilityChecker(expansionEligibilityService: eligibleExpansionService)
 
         // When
         let result = await checker.checkEligibility()
@@ -593,11 +517,7 @@ struct POSTabEligibilityCheckerTests {
         // Given - currencies that would be valid if eligibility were enabled
         let currency: CurrencyCode = country == .sg ? .SGD : (country == .nz ? .NZD : (country == .au ? .AUD : .EUR))
         setupCountry(country: country, currency: currency)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               expansionEligibilityService: ineligibleExpansionService)
+        let checker = makeEligibilityChecker(expansionEligibilityService: ineligibleExpansionService)
 
         // When
         let result = await checker.checkEligibility()
@@ -618,11 +538,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func fiscalization_country_is_ineligible_when_expansion_eligibility_is_enabled(country: Country) async throws {
         // Given
         setupCountry(country: country, currency: .EUR)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               expansionEligibilityService: eligibleExpansionService)
+        let checker = makeEligibilityChecker(expansionEligibilityService: eligibleExpansionService)
 
         // When
         let result = await checker.checkEligibility()
@@ -634,11 +550,7 @@ struct POSTabEligibilityCheckerTests {
     @Test func expansion_country_with_mismatched_currency_is_ineligible_when_expansion_eligibility_is_enabled() async throws {
         // Given - NL store with USD currency (mismatch)
         setupCountry(country: .nl, currency: .USD)
-        let checker = makeEligibilityChecker(siteID: siteID,
-                                               siteSettings: siteSettings,
-                                               stores: stores,
-                                               systemStatusService: mockSystemStatusService,
-                                               expansionEligibilityService: eligibleExpansionService)
+        let checker = makeEligibilityChecker(expansionEligibilityService: eligibleExpansionService)
 
         // When
         let result = await checker.checkEligibility()
@@ -668,19 +580,15 @@ private final class StubCardPresentExpansionEligibilityService: CardPresentPayme
 
 private extension POSTabEligibilityCheckerTests {
     func makeEligibilityChecker(
-        siteID: Int64? = nil,
-        siteSettings: SelectedSiteSettingsProtocol? = nil,
-        stores: StoresManager? = nil,
-        systemStatusService: POSSystemStatusServiceProtocol? = nil,
         siteSettingService: POSSiteSettingServiceProtocol? = nil,
         connectivityObserver: ConnectivityObserver? = nil,
         expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol =
             CardPresentPaymentsCountryExpansionEligibilityService()
     ) -> POSTabEligibilityChecker {
-        POSTabEligibilityChecker(siteID: siteID ?? self.siteID,
-                                 siteSettings: siteSettings ?? self.siteSettings,
-                                 stores: stores ?? self.stores,
-                                 systemStatusService: systemStatusService ?? mockSystemStatusService,
+        POSTabEligibilityChecker(siteID: siteID,
+                                 siteSettings: siteSettings,
+                                 stores: stores,
+                                 systemStatusService: mockSystemStatusService,
                                  siteSettingService: siteSettingService,
                                  connectivityObserver: connectivityObserver ?? self.connectivityObserver,
                                  expansionEligibilityService: expansionEligibilityService)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -15,6 +15,7 @@ struct POSTabEligibilityCheckerTests {
     private var eligibilityService: MockPOSEligibilityService!
     private var mockSystemStatusService: MockPOSSystemStatusService!
     private var mockSiteSettingService: MockPOSSiteSettingService!
+    private var connectivityObserver: MockConnectivityObserver!
     private let site = Site.fake().copy(siteID: 2)
     private var siteID: Int64 { site.siteID }
     private let ineligibleExpansionService = StubCardPresentExpansionEligibilityService(isEligible: false)
@@ -28,6 +29,9 @@ struct POSTabEligibilityCheckerTests {
         siteSettings = MockSelectedSiteSettings()
         mockSystemStatusService = MockPOSSystemStatusService()
         mockSiteSettingService = MockPOSSiteSettingService()
+        connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.reachable(type: .ethernetOrWiFi))
+        ServiceLocator.setConnectivityObserver(connectivityObserver)
         setupWooCommerceVersion()
     }
 
@@ -226,6 +230,55 @@ struct POSTabEligibilityCheckerTests {
         #expect(result == .eligible)
     }
 
+    @Test func checkEligibility_returns_noInternetConnection_when_connectivity_is_not_reachable() async throws {
+        // Given
+        let offlineConnectivityObserver = MockConnectivityObserver()
+        offlineConnectivityObserver.setStatus(.notReachable)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService,
+                                               connectivityObserver: offlineConnectivityObserver)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .noInternetConnection))
+    }
+
+    @Test func checkEligibility_returns_noInternetConnection_when_system_status_request_fails_with_connectivity_error() async throws {
+        // Given
+        mockSystemStatusService.resultToReturn = .failure(URLError(.notConnectedToInternet))
+        setupCountry(country: .us, currency: .USD)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .noInternetConnection))
+    }
+
+    @Test func checkEligibility_returns_wooCommercePluginNotFound_when_system_status_request_fails_with_generic_error() async throws {
+        // Given
+        mockSystemStatusService.resultToReturn = .failure(NSError(domain: "test", code: 500))
+        setupCountry(country: .us, currency: .USD)
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService)
+
+        // When
+        let result = await checker.checkEligibility()
+
+        // Then
+        #expect(result == .ineligible(reason: .wooCommercePluginNotFound))
+    }
+
     // MARK: - `refreshEligibility` Tests
 
     @Test(arguments: [
@@ -277,7 +330,7 @@ struct POSTabEligibilityCheckerTests {
             switch action {
             case .synchronizeGeneralSiteSettings(_, let completion):
                 syncCalled = true
-                completion(NSError(domain: "test", code: 500)) // Network error
+                completion(NSError(domain: "test", code: 500)) // Generic error
             default:
                 break
             }
@@ -287,12 +340,40 @@ struct POSTabEligibilityCheckerTests {
                                                siteSettings: siteSettings,
                                                stores: stores)
 
-        // When & Then - Should throw the network error
+        // When & Then - Should throw the generic error
         #expect(syncCalled == false) // Not called yet
         await #expect(throws: NSError.self) {
             try await checker.refreshEligibility(ineligibleReason: ineligibleReason)
         }
         #expect(syncCalled == true) // Called during the attempt
+    }
+
+    @Test func refreshEligibility_returns_noInternetConnection_when_site_settings_sync_fails_with_connectivity_error() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.6.0")
+
+        var syncCalled = false
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case .synchronizeGeneralSiteSettings(_, let completion):
+                syncCalled = true
+                completion(URLError(.notConnectedToInternet))
+            default:
+                break
+            }
+        }
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .siteSettingsNotAvailable)
+
+        // Then
+        #expect(syncCalled == true)
+        #expect(result == .ineligible(reason: .noInternetConnection))
     }
 
     @Test func refreshEligibility_checks_eligibility_for_featureSwitchDisabled() async throws {
@@ -325,6 +406,23 @@ struct POSTabEligibilityCheckerTests {
 
         // When
         let result = try await checker.refreshEligibility(ineligibleReason: .selfDeallocated)
+
+        // Then - Should check eligibility again (now eligible)
+        #expect(result == .eligible)
+    }
+
+    @Test func refreshEligibility_rechecks_eligibility_for_noInternetConnection() async throws {
+        // Given
+        setupCountry(country: .us, currency: .USD)
+        setupWooCommerceVersion("9.6.0", featureSwitchEnabled: true)
+
+        let checker = POSTabEligibilityChecker(siteID: siteID,
+                                               siteSettings: siteSettings,
+                                               stores: stores,
+                                               systemStatusService: mockSystemStatusService)
+
+        // When
+        let result = try await checker.refreshEligibility(ineligibleReason: .noInternetConnection)
 
         // Then - Should check eligibility again (now eligible)
         #expect(result == .eligible)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabEligibilityCheckerTests.swift
@@ -31,7 +31,6 @@ struct POSTabEligibilityCheckerTests {
         mockSiteSettingService = MockPOSSiteSettingService()
         connectivityObserver = MockConnectivityObserver()
         connectivityObserver.setStatus(.reachable(type: .ethernetOrWiFi))
-        ServiceLocator.setConnectivityObserver(connectivityObserver)
         setupWooCommerceVersion()
     }
 
@@ -61,7 +60,7 @@ struct POSTabEligibilityCheckerTests {
         ].publisher.eraseToAnyPublisher()
 
         setupWooCommerceVersion("9.6.0")
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -83,7 +82,7 @@ struct POSTabEligibilityCheckerTests {
         siteSettings.mockSettingsStream = settingsSubject.eraseToAnyPublisher()
 
         setupWooCommerceVersion("9.6.0")
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -112,7 +111,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_eligible_when_all_conditions_satisfied(country: Country, currency: CurrencyCode) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -130,7 +129,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_ineligible_when_country_is_not_supported(country: Country, currency: CurrencyCode) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -155,7 +154,7 @@ struct POSTabEligibilityCheckerTests {
                                                                   expectedSupportedCurrencies: [CurrencyCode]) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores)
 
@@ -170,7 +169,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("9.5.0")
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -186,7 +185,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("10.0.0", featureSwitchEnabled: true)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -202,7 +201,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("10.0.0", featureSwitchEnabled: false)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -218,7 +217,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         setupCountry(country: .us)
         setupWooCommerceVersion("9.9.9", featureSwitchEnabled: false)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -234,7 +233,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         let offlineConnectivityObserver = MockConnectivityObserver()
         offlineConnectivityObserver.setStatus(.notReachable)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -251,7 +250,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         mockSystemStatusService.resultToReturn = .failure(URLError(.notConnectedToInternet))
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -267,7 +266,7 @@ struct POSTabEligibilityCheckerTests {
         // Given
         mockSystemStatusService.resultToReturn = .failure(NSError(domain: "test", code: 500))
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -303,7 +302,7 @@ struct POSTabEligibilityCheckerTests {
             }
         }
 
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -336,7 +335,7 @@ struct POSTabEligibilityCheckerTests {
             }
         }
 
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores)
 
@@ -364,7 +363,7 @@ struct POSTabEligibilityCheckerTests {
             }
         }
 
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores)
 
@@ -381,7 +380,7 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: .us, currency: .USD)
         setupWooCommerceVersion("10.0.0", featureSwitchEnabled: true)
 
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -399,7 +398,7 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: .us, currency: .USD)
         setupWooCommerceVersion("9.6.0", featureSwitchEnabled: true)
 
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -416,7 +415,7 @@ struct POSTabEligibilityCheckerTests {
         setupCountry(country: .us, currency: .USD)
         setupWooCommerceVersion("9.6.0", featureSwitchEnabled: true)
 
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -440,7 +439,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -462,7 +461,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: true))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -483,7 +482,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: nil, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -505,7 +504,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -527,7 +526,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .success(POSPluginAndFeatureInfo(wcPlugin: wcPlugin, featureValue: nil))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -548,7 +547,7 @@ struct POSTabEligibilityCheckerTests {
         mockSystemStatusService.resultToReturn = .failure(NSError(domain: "test", code: 500))
 
         setupCountry(country: .us, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService)
@@ -571,7 +570,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func is_eligible_when_expansion_eligibility_is_enabled(country: Country, currency: CurrencyCode) async throws {
         // Given
         setupCountry(country: country, currency: currency)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -594,7 +593,7 @@ struct POSTabEligibilityCheckerTests {
         // Given - currencies that would be valid if eligibility were enabled
         let currency: CurrencyCode = country == .sg ? .SGD : (country == .nz ? .NZD : (country == .au ? .AUD : .EUR))
         setupCountry(country: country, currency: currency)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -619,7 +618,7 @@ struct POSTabEligibilityCheckerTests {
     fileprivate func fiscalization_country_is_ineligible_when_expansion_eligibility_is_enabled(country: Country) async throws {
         // Given
         setupCountry(country: country, currency: .EUR)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -635,7 +634,7 @@ struct POSTabEligibilityCheckerTests {
     @Test func expansion_country_with_mismatched_currency_is_ineligible_when_expansion_eligibility_is_enabled() async throws {
         // Given - NL store with USD currency (mismatch)
         setupCountry(country: .nl, currency: .USD)
-        let checker = POSTabEligibilityChecker(siteID: siteID,
+        let checker = makeEligibilityChecker(siteID: siteID,
                                                siteSettings: siteSettings,
                                                stores: stores,
                                                systemStatusService: mockSystemStatusService,
@@ -668,6 +667,25 @@ private final class StubCardPresentExpansionEligibilityService: CardPresentPayme
 }
 
 private extension POSTabEligibilityCheckerTests {
+    func makeEligibilityChecker(
+        siteID: Int64? = nil,
+        siteSettings: SelectedSiteSettingsProtocol? = nil,
+        stores: StoresManager? = nil,
+        systemStatusService: POSSystemStatusServiceProtocol? = nil,
+        siteSettingService: POSSiteSettingServiceProtocol? = nil,
+        connectivityObserver: ConnectivityObserver? = nil,
+        expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol =
+            CardPresentPaymentsCountryExpansionEligibilityService()
+    ) -> POSTabEligibilityChecker {
+        POSTabEligibilityChecker(siteID: siteID ?? self.siteID,
+                                 siteSettings: siteSettings ?? self.siteSettings,
+                                 stores: stores ?? self.stores,
+                                 systemStatusService: systemStatusService ?? mockSystemStatusService,
+                                 siteSettingService: siteSettingService,
+                                 connectivityObserver: connectivityObserver ?? self.connectivityObserver,
+                                 expansionEligibilityService: expansionEligibilityService)
+    }
+
     func setupCountry(country: Country, currency: CurrencyCode = .USD) {
         let countrySetting = mockCountrySetting(country: country)
         let currencySetting = mockCurrencySetting(currency: currency)


### PR DESCRIPTION
Fixes WOOMOB-1821

## Description

Improves the POS entry experience when the device has no network connection.

- Checks connectivity before running POS eligibility work and returns the POS no-internet state immediately.
- Maps connectivity failures from the system status request to the same POS no-internet state.

Android references and parity notes:
- This PR follows Android’s general retryable POS offline/error pattern, but it is not an exact Android POS entry behavior match. Feel free to suggest other copy.
- With Android local catalog enabled, POS can continue even when it's offline. If the app has to run a blocking catalog sync and that sync fails, it shows `Unable to sync` / `We are unable to sync your product catalog. Please check your internet connection and retry.` with Retry / Exit POS actions. See the [catalog sync failure copy](https://github.com/woocommerce/woocommerce-android/blob/c985031fce85eacf4302962cc3f850e6f43bddbf/WooCommerce/src/main/res/values/strings.xml#L3846-L3850) and [splash error rendering](https://github.com/woocommerce/woocommerce-android/blob/c985031fce85eacf4302962cc3f850e6f43bddbf/WooCommerce/src/main/kotlin/com/woocommerce/android/ui/woopos/splash/WooPosSplashScreen.kt#L172-L211). This is a behavior difference between platforms before this PR. IMO we can update the behavior when we support offline mode properly.

Android screenshot:

<img width="2560" height="1600" alt="Screenshot_1782334676" src="https://github.com/user-attachments/assets/d4a276fb-7ea1-4d63-b895-016028d53ed2" />


## Test Steps
🗒️ Testing is optional for reviewers, I manually tested the PR.

1. Launch the app with a POS-eligible store, disable network before opening POS, and open POS.
2. Confirm the ineligible screen shows `No internet connection` with retry affordance.
3. Re-enable network and use retry to confirm POS eligibility can be checked again.

## Screenshots

before | after
-- | --
<img width="2388" height="1668" alt=" No internet connection - before PNG" src="https://github.com/user-attachments/assets/a902c28f-deb3-4a3e-8a26-6dbb11ad5f54" /> | <img width="2388" height="1668" alt=" No internet connectice PNG" src="https://github.com/user-attachments/assets/a8ddd3b9-d8c4-483a-8097-df272a3e7f94" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.