### PR TITLE
[Woo POS][Phone] Render beta feature to switch between catalog options

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 import protocol Experiments.FeatureFlagService
 import struct Storage.GeneralAppSettingsStorage
 
@@ -7,7 +6,7 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
     @Published private(set) var availableFeatures: [BetaFeature] = []
     private let appSettings: GeneralAppSettingsStorage
     private let featureFlagService: FeatureFlagService
-    private let isIPad: Bool
+    private let isPOSTabVisible: () async -> Bool
 
     private let betaFeatures = BetaFeature.allCases
 
@@ -15,10 +14,10 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
 
     init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         isIPad: Bool = UIDevice.current.userInterfaceIdiom == .pad) {
+         isPOSTabVisible: @escaping () async -> Bool = BetaFeaturesConfigurationViewModel.defaultPOSTabVisibility) {
         self.appSettings = appSettings
         self.featureFlagService = featureFlagService
-        self.isIPad = isIPad
+        self.isPOSTabVisible = isPOSTabVisible
         self.appPasswordsExperimentAvailabilityChecker = ApplicationPasswordsExperimentAvailabilityChecker()
 
         setupInitialFeaturesVisibility()
@@ -27,6 +26,14 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
 
     func isOn(feature: BetaFeature) -> Binding<Bool> {
         appSettings.betaFeatureEnabledBinding(feature)
+    }
+
+    func refreshAvailableFeatures() async {
+        let fetchedAvailableFeatures = await fetchFeaturesAvailability()
+
+        await MainActor.run {
+            availableFeatures = fetchedAvailableFeatures
+        }
     }
 }
 
@@ -38,7 +45,7 @@ private extension BetaFeaturesConfigurationViewModel {
             case .applicationPasswords:
                 return appPasswordsExperimentAvailabilityChecker.isAvailable
             case .posLocalCatalog:
-                return isIPad && featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI)
+                return false
         }
     }
 
@@ -50,11 +57,7 @@ private extension BetaFeaturesConfigurationViewModel {
 
     func updateFeaturesAvailability() {
         Task {
-            let fetchedAvailableFeatures = await fetchFeaturesAvailability()
-
-            await MainActor.run {
-                availableFeatures = fetchedAvailableFeatures
-            }
+            await refreshAvailableFeatures()
         }
     }
 
@@ -69,12 +72,28 @@ private extension BetaFeaturesConfigurationViewModel {
                     results.append(feature)
                 }
             case .posLocalCatalog:
-                if isIPad && featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI) {
+                if await shouldShowPOSLocalCatalog() {
                     results.append(feature)
                 }
             }
         }
 
         return results
+    }
+
+    func shouldShowPOSLocalCatalog() async -> Bool {
+        guard featureFlagService.isFeatureFlagEnabled(.pointOfSaleCatalogAPI) else {
+            return false
+        }
+        return await isPOSTabVisible()
+    }
+}
+
+extension BetaFeaturesConfigurationViewModel {
+    static func defaultPOSTabVisibility() async -> Bool {
+        guard let site = ServiceLocator.stores.sessionManager.defaultSite else {
+            return false
+        }
+        return await POSTabVisibilityChecker(site: site).checkVisibility()
     }
 }

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import Experiments
 import Storage
 import XCTest
 @testable import WooCommerce
@@ -16,9 +17,74 @@ final class BetaFeaturesConfigurationViewModelTests: XCTestCase {
 
     func test_availableFeatures_include_viewAddOns() {
         // Given
-        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings)
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings,
+                                                           isPOSTabVisible: { false })
 
         // Then
         XCTAssertTrue(viewModel.availableFeatures.contains(.viewAddOns))
+    }
+
+    func test_availableFeatures_include_posLocalCatalog_when_catalogAPI_feature_flag_is_enabled_and_POSTab_is_visible() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleCatalogAPI] = true
+
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings,
+                                                           featureFlagService: featureFlagService,
+                                                           isPOSTabVisible: { true })
+
+        // When
+        await viewModel.refreshAvailableFeatures()
+
+        // Then
+        XCTAssertTrue(viewModel.availableFeatures.contains(.posLocalCatalog))
+    }
+
+    func test_availableFeatures_do_not_include_posLocalCatalog_when_POSTab_is_not_visible() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleCatalogAPI] = true
+
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings,
+                                                           featureFlagService: featureFlagService,
+                                                           isPOSTabVisible: { false })
+
+        // When
+        await viewModel.refreshAvailableFeatures()
+
+        // Then
+        XCTAssertFalse(viewModel.availableFeatures.contains(.posLocalCatalog))
+    }
+
+    func test_availableFeatures_do_not_include_posLocalCatalog_when_catalogAPI_feature_flag_is_disabled() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSaleCatalogAPI] = false
+        let posTabVisibility = POSTabVisibilitySpy(isVisible: true)
+
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings,
+                                                           featureFlagService: featureFlagService,
+                                                           isPOSTabVisible: posTabVisibility.checkVisibility)
+
+        // When
+        await viewModel.refreshAvailableFeatures()
+
+        // Then
+        XCTAssertFalse(viewModel.availableFeatures.contains(.posLocalCatalog))
+        XCTAssertFalse(posTabVisibility.didCheckVisibility)
+    }
+}
+
+private final class POSTabVisibilitySpy {
+    private let isVisible: Bool
+    private(set) var didCheckVisibility = false
+
+    init(isVisible: Bool) {
+        self.isVisible = isVisible
+    }
+
+    func checkVisibility() async -> Bool {
+        didCheckVisibility = true
+        return isVisible
     }
 }


### PR DESCRIPTION
Closes WOOMOB-3367

## Description
The experimental toggle for local catalog usage relied on an `.isIpad` check, which means it was not shown as an option for new Phone POS users. This PR updates the toggle to be rendred based in POS visibility, so we only render it when the device can actually use the feature (iPads or iPhones on UK + iOS26) without duplicating checks.

## Test Steps
- Load POS into an eligible and uneligible device, if the POS tab appears then the feature toggle under Menu > Settings > Experimental features should show as well. 
- For easier testing you can remove or update the requirements in `POSTabVisibilityChecker` as you see fit, ie:

```diff
+private static let minimumPhonePOSOperatingSystemVersion = OperatingSystemVersion(majorVersion: 18, minorVersion: 0, patchVersion: 0)
- private static let minimumPhonePOSOperatingSystemVersion = OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)

// Removes UK limitation:
- guard userInterfaceIdiom != .phone || countryCode == .GB else {
-  return .ineligible(reason: .unsupportedCountry(supportedCountries: [.GB]))
- }
```

| Non-POS eligible | POS eligible |
|--------|--------|
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-06-25 at 16 16 16" src="https://github.com/user-attachments/assets/b6af16ad-e8b0-41c4-8da9-1bd865517823" /> | <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - Logged wpcom a8c - 2026-06-25 at 16 13 26" src="https://github.com/user-attachments/assets/0ae62b00-5cd7-4131-92e9-1b64b6b2bf99" /> | 

