### PR TITLE
Beta Fix: Fix iPad dashboard notification card height

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/WPComPushNotificationsBenefits/ConnectWPComCard.swift
@@ -12,7 +12,7 @@ struct ConnectWPComCard: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     var body: some View {
-        HStack {
+        HStack(alignment: .top) {
             Image(uiImage: .connectWPComImage)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
@@ -25,17 +25,15 @@ struct ConnectWPComCard: View {
                     .font(.callout)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            VStack {
-                Menu {
-                    Button(Localization.hideButton) {
-                        hideAction()
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .foregroundStyle(Color.secondary)
-                        .padding(.leading, Layout.padding)
+            Menu {
+                Button(Localization.hideButton) {
+                    hideAction()
                 }
-                Spacer()
+            } label: {
+                Image(systemName: "ellipsis")
+                    .foregroundStyle(Color.secondary)
+                    .padding(.leading, Layout.padding)
+                    .padding(.vertical, Layout.hideIconVerticalPadding)
             }
         }
         .padding(Layout.padding)
@@ -52,6 +50,7 @@ struct ConnectWPComCard: View {
 private extension ConnectWPComCard {
     enum Layout {
         static let padding: CGFloat = 16
+        static let hideIconVerticalPadding: CGFloat = 8
         static let iconHeight: CGFloat = 35
         static let cornerSize = CGSize(width: 8.0, height: 8.0)
     }


### PR DESCRIPTION
## Description
Fixes the new notification card on the dashboard, which was growing too tall in the iPad two-column layout.

The `...` button previously sat inside a VStack with a spacer, which made the card grow taller when the grid had space – i.e. when the left column was shorter than the right. 

The fix is to keep the button top-aligned without a spacer

## Test Steps
1. Use an iPad or iPad simulator with a site credential login store that shows the dashboard notification card reading "Never miss a new order".
2. Open the dashboard in the two-column iPad layout.
3. Confirm the notification card keeps a compact height instead of stretching too tall.
4. Confirm the ellipsis button is vertically aligned consistently with other dashboard card menu buttons.
5. Check that in the phone layout, it still works correctly

## Screenshots

### Before
<img width="1180" height="820" alt="broken notification card height" src="https://github.com/user-attachments/assets/f0fa2838-f1e2-429a-abb6-b37f4548f23b" />


### After
<img width="1180" height="820" alt="fixed notification card height" src="https://github.com/user-attachments/assets/4e36778b-afcc-4c8d-82a8-12292be0066c" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.