### PR TITLE
Fix POS settings sidebar reselection

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Reusable Views/POSNavigationSplitView.swift
@@ -35,10 +35,22 @@ struct POSNavigationSplitView<Sidebar: View, Detail: View, DetailPlaceholder: Vi
         horizontalSizeClass == .regular
     }
 
+    private var sidebarSelection: Binding<SelectionValue?> {
+        Binding {
+            selection
+        } set: { newValue in
+            if let currentSelection = selection,
+               currentSelection.id == newValue?.id {
+                detailNavigationPath = NavigationPath()
+            }
+            selection = newValue
+        }
+    }
+
     var body: some View {
         GeometryReader { geometry in
             HStack(spacing: 0) {
-                sidebar($selection)
+                sidebar(sidebarSelection)
                     .frame(width: sidebarWidth(for: geometry.size.width))
 
                 NavigationStack(path: $detailNavigationPath) {

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct POSSettingsView: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.posAnalytics) private var analytics
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var selection: SidebarNavigation?
 
@@ -10,7 +8,7 @@ struct POSSettingsView: View {
 
     var body: some View {
         POSNavigationSplitView(selection: $selection) { selection in
-            listView(selection: selection)
+            POSSettingsListView(selection: selection, settingsController: settingsController)
         } detail: { selection, navigationPath in
             detailView(for: selection, navigationPath: navigationPath)
                 .environment(\.posHeaderBackButtonConfiguration,
@@ -27,59 +25,96 @@ struct POSSettingsView: View {
 }
 
 extension POSSettingsView {
-    @ViewBuilder
-    private func listView(selection: Binding<SidebarNavigation?>) -> some View {
-        VStack(alignment: .leading, spacing: POSSpacing.none) {
-            POSPageHeaderView(
-                title: Localization.navigationTitle,
-                backButtonConfiguration: .init(state: .enabled,
-                                               action: {
-                                                   analytics.track(.pointOfSaleSettingsCloseButtonTapped)
-                                                   dismiss()
-                                               }))
-            .posHeaderBackButtonIcon(systemName: "xmark")
-            .foregroundColor(.posSurface)
-            .accessibilityAddTraits(.isHeader)
+    private struct POSSettingsListView: View {
+        @Environment(\.dismiss) private var dismiss
+        @Environment(\.posAnalytics) private var analytics
+        @Binding var selection: SidebarNavigation?
 
-            VStack(spacing: POSSpacing.small) {
-                POSSettingsCard(title: POSSettingsView.SidebarNavigation.store.title,
-                                subtitle: POSSettingsView.SidebarNavigation.store.subtitle,
-                                isSelected: selection.wrappedValue == .store,
-                                action: {
-                    analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
-                    selection.wrappedValue = .store
-                })
-                POSSettingsCard(title: POSSettingsView.SidebarNavigation.hardware.title,
-                                subtitle: POSSettingsView.SidebarNavigation.hardware.subtitle,
-                                isSelected: selection.wrappedValue == .hardware,
-                                action: {
-                    analytics.track(.pointOfSaleSettingsHardwareTapped)
-                    selection.wrappedValue = .hardware
-                })
-                if settingsController.isLocalCatalogEligible {
-                    POSSettingsCard(title: POSSettingsView.SidebarNavigation.localCatalog.title,
-                                    subtitle: POSSettingsView.SidebarNavigation.localCatalog.subtitle,
-                                    isSelected: selection.wrappedValue == .localCatalog,
-                                    action: {
-                        selection.wrappedValue = .localCatalog
-                    })
-                }
-                if isStaffSectionVisible {
-                    POSSettingsCard(title: POSSettingsView.SidebarNavigation.staff.title,
-                                    subtitle: POSSettingsView.SidebarNavigation.staff.subtitle,
-                                    isSelected: selection.wrappedValue == .staff,
-                                    action: {
-                        selection.wrappedValue = .staff
-                    })
-                }
-                Spacer()
+        let settingsController: POSSettingsControllerProtocol
 
-                helpView(selection: selection)
+        var body: some View {
+            VStack(alignment: .leading, spacing: POSSpacing.none) {
+                POSPageHeaderView(
+                    title: Localization.navigationTitle,
+                    backButtonConfiguration: .init(state: .enabled,
+                                                   action: {
+                                                       analytics.track(.pointOfSaleSettingsCloseButtonTapped)
+                                                       dismiss()
+                                                   }))
+                .posHeaderBackButtonIcon(systemName: "xmark")
+                .foregroundColor(.posSurface)
+                .accessibilityAddTraits(.isHeader)
+
+                VStack(spacing: POSSpacing.small) {
+                    POSSettingsCard(title: SidebarNavigation.store.title,
+                                    subtitle: SidebarNavigation.store.subtitle,
+                                    isSelected: selection == .store,
+                                    action: {
+                        analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
+                        selection = .store
+                    })
+                    POSSettingsCard(title: SidebarNavigation.hardware.title,
+                                    subtitle: SidebarNavigation.hardware.subtitle,
+                                    isSelected: selection == .hardware,
+                                    action: {
+                        analytics.track(.pointOfSaleSettingsHardwareTapped)
+                        selection = .hardware
+                    })
+                    if settingsController.isLocalCatalogEligible {
+                        POSSettingsCard(title: SidebarNavigation.localCatalog.title,
+                                        subtitle: SidebarNavigation.localCatalog.subtitle,
+                                        isSelected: selection == .localCatalog,
+                                        action: {
+                            selection = .localCatalog
+                        })
+                    }
+                    if isStaffSectionVisible {
+                        POSSettingsCard(title: SidebarNavigation.staff.title,
+                                        subtitle: SidebarNavigation.staff.subtitle,
+                                        isSelected: selection == .staff,
+                                        action: {
+                            selection = .staff
+                        })
+                    }
+                    Spacer()
+
+                    helpView
+                }
+                .padding(.horizontal, POSPadding.medium)
             }
-            .padding(.horizontal, POSPadding.medium)
+            .background(Color.posSurfaceBright)
+            .accessibilityIdentifier("pos-settings-view")
         }
-        .background(Color.posSurfaceBright)
-        .accessibilityIdentifier("pos-settings-view")
+
+        private var isStaffSectionVisible: Bool {
+            settingsController.staffSettingsService != nil
+        }
+
+        @ViewBuilder
+        private var helpView: some View {
+            Button {
+                analytics.track(.pointOfSaleSettingsHelpTapped)
+                selection = .help
+            } label: {
+                HStack(spacing: POSSpacing.small) {
+                    if let icon = SidebarNavigation.help.icon {
+                        Image(systemName: icon)
+                            .font(.posBodyMediumBold)
+                            .foregroundStyle(Color.posOnSurface)
+                    }
+                    Text(SidebarNavigation.help.title)
+                        .font(.posBodyMediumBold)
+                        .foregroundStyle(Color.posOnSurface)
+                }
+                .padding()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(SidebarNavigation.help.title)
+        }
     }
 
     @ViewBuilder
@@ -104,36 +139,6 @@ extension POSSettingsView {
         case .help:
             POSSettingsHelpDetailView()
         }
-    }
-
-    private var isStaffSectionVisible: Bool {
-        settingsController.staffSettingsService != nil
-    }
-
-    @ViewBuilder
-    private func helpView(selection: Binding<SidebarNavigation?>) -> some View {
-        Button {
-            analytics.track(.pointOfSaleSettingsHelpTapped)
-            selection.wrappedValue = .help
-        } label: {
-            HStack(spacing: POSSpacing.small) {
-                if let icon = SidebarNavigation.help.icon {
-                    Image(systemName: icon)
-                        .font(.posBodyMediumBold)
-                        .foregroundStyle(Color.posOnSurface)
-                }
-                Text(SidebarNavigation.help.title)
-                    .font(.posBodyMediumBold)
-                    .foregroundStyle(Color.posOnSurface)
-            }
-            .padding()
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityLabel(SidebarNavigation.help.title)
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -9,8 +9,8 @@ struct POSSettingsView: View {
     let settingsController: POSSettingsControllerProtocol
 
     var body: some View {
-        POSNavigationSplitView(selection: $selection) { _ in
-            listView
+        POSNavigationSplitView(selection: $selection) { selection in
+            listView(selection: selection)
         } detail: { selection, navigationPath in
             detailView(for: selection, navigationPath: navigationPath)
                 .environment(\.posHeaderBackButtonConfiguration,
@@ -28,7 +28,7 @@ struct POSSettingsView: View {
 
 extension POSSettingsView {
     @ViewBuilder
-    private var listView: some View {
+    private func listView(selection: Binding<SidebarNavigation?>) -> some View {
         VStack(alignment: .leading, spacing: POSSpacing.none) {
             POSPageHeaderView(
                 title: Localization.navigationTitle,
@@ -44,37 +44,37 @@ extension POSSettingsView {
             VStack(spacing: POSSpacing.small) {
                 POSSettingsCard(title: POSSettingsView.SidebarNavigation.store.title,
                                 subtitle: POSSettingsView.SidebarNavigation.store.subtitle,
-                                isSelected: selection == .store,
+                                isSelected: selection.wrappedValue == .store,
                                 action: {
                     analytics.track(.pointOfSaleSettingsStoreDetailsTapped)
-                    selection = .store
+                    selection.wrappedValue = .store
                 })
                 POSSettingsCard(title: POSSettingsView.SidebarNavigation.hardware.title,
                                 subtitle: POSSettingsView.SidebarNavigation.hardware.subtitle,
-                                isSelected: selection == .hardware,
+                                isSelected: selection.wrappedValue == .hardware,
                                 action: {
                     analytics.track(.pointOfSaleSettingsHardwareTapped)
-                    selection = .hardware
+                    selection.wrappedValue = .hardware
                 })
                 if settingsController.isLocalCatalogEligible {
                     POSSettingsCard(title: POSSettingsView.SidebarNavigation.localCatalog.title,
                                     subtitle: POSSettingsView.SidebarNavigation.localCatalog.subtitle,
-                                    isSelected: selection == .localCatalog,
+                                    isSelected: selection.wrappedValue == .localCatalog,
                                     action: {
-                        selection = .localCatalog
+                        selection.wrappedValue = .localCatalog
                     })
                 }
                 if isStaffSectionVisible {
                     POSSettingsCard(title: POSSettingsView.SidebarNavigation.staff.title,
                                     subtitle: POSSettingsView.SidebarNavigation.staff.subtitle,
-                                    isSelected: selection == .staff,
+                                    isSelected: selection.wrappedValue == .staff,
                                     action: {
-                        selection = .staff
+                        selection.wrappedValue = .staff
                     })
                 }
                 Spacer()
 
-                helpView
+                helpView(selection: selection)
             }
             .padding(.horizontal, POSPadding.medium)
         }
@@ -111,10 +111,10 @@ extension POSSettingsView {
     }
 
     @ViewBuilder
-    private var helpView: some View {
+    private func helpView(selection: Binding<SidebarNavigation?>) -> some View {
         Button {
             analytics.track(.pointOfSaleSettingsHelpTapped)
-            selection = .help
+            selection.wrappedValue = .help
         } label: {
             HStack(spacing: POSSpacing.small) {
                 if let icon = SidebarNavigation.help.icon {


### PR DESCRIPTION
## Description

Fixes WOOMOB-1299

On iPad, POS settings uses a custom split view. Tapping an already-selected sidebar section did not reset the detail `NavigationStack`, so after opening a nested Hardware screen such as Barcode scanners, tapping Hardware in the sidebar left the detail stuck on the nested screen.

This routes POS settings sidebar writes through the split-view selection binding, allowing `POSNavigationSplitView` to reset the detail path when the incoming selection has the same ID as the current selection.

POS Orders note: `POSNavigationSplitView` is also used by POS Orders, but Orders ignores the split-view sidebar binding and handles row taps through `handleOrderSelection(_:)`, which returns when the tapped order is already selected. Because re-tapping the selected order never writes the same selection through the split-view binding, Orders does not get this reset behavior.

## Test Steps
1. On iPad, open POS.
2. Open Settings.
3. Select Hardware in the sidebar.
4. Open Barcode scanners.
5. Tap Hardware in the sidebar again.
6. Verify the detail pane returns to the Hardware root and the Barcode scanners detail is no longer visible.
7. Open POS Orders, select an order, tap the same selected order again, and verify Orders does not reset its detail navigation state.

## Screenshots


https://github.com/user-attachments/assets/2f1c118e-d206-4bc8-b821-bd83c2418a88



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.