### PR TITLE
Fix push notification setup card without site

### DIFF
--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -20,7 +20,8 @@ final class WooPushNotificationSetupCoordinator {
     func startSetup(siteAlreadyConnected: Bool,
                     pluginOutdatedVersion: String? = nil) {
         guard let site = stores.sessionManager.defaultSite else {
-            fatalError("❌ No default site found for Woo push notification setup!")
+            assertionFailure("No default site found for Woo push notification setup.")
+            return
         }
         let navigationController = WooNavigationController()
         let handler = WPComConnectionSetupHandler(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -376,10 +376,14 @@ private extension DashboardViewHostingController {
     func configureConnectWPComCard() {
         rootView.onConnectWPComSetup = { [weak self] in
             guard let self else { return }
+            guard let site = viewModel.stores.sessionManager.defaultSite,
+                  site.siteID == viewModel.siteID else {
+                return
+            }
             self.viewModel.onConnectWPComCardTapped()
             let benefitsViewModel = WPComPushNotificationsBenefitsViewModel(
-                siteID: viewModel.siteID,
-                siteURL: viewModel.stores.sessionManager.defaultSite?.url ?? "",
+                siteID: site.siteID,
+                siteURL: site.url,
                 onDismiss: {
                     self.dismiss(animated: true)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -752,9 +752,10 @@ private extension DashboardViewModel {
 
     func observeSelfDrivenPushTokenPersistence() {
         pushNotesManager.siteIDsRegisteredForWooPNsPublisher
-            .combineLatest(userDefaults.publisher(for: \.hideWPComConnectionOnDashboard))
+            .combineLatest(userDefaults.publisher(for: \.hideWPComConnectionOnDashboard),
+                           stores.sessionManager.defaultSitePublisher)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _, _ in
+            .sink { [weak self] _, _, _ in
                 guard let self else { return }
                 Task {
                     await self.updateSelfDrivenPushRegistrationStatus()
@@ -1055,10 +1056,16 @@ private extension DashboardViewModel {
         isSelfDrivenPushNotificationRegistered = registeredSiteIDs.contains(siteID)
         dismissedWPComConnectionSuggestion = userDefaults.hideWPComConnectionOnDashboard
 
+        guard let defaultSite = stores.sessionManager.defaultSite,
+              defaultSite.siteID == siteID else {
+            shouldSuggestWPComConnection = false
+            return
+        }
+
         let isEligibleForSelfDrivenPN = await pushNotificationEligibilityChecker.checkEligibility()
         shouldSuggestWPComConnection = pushNotesManager.hasStoredSiteIDsRegisteredForWooPNs &&
             registeredSiteIDs.contains(siteID) == false &&
-            (stores.isAuthenticatedWithoutWPCom || stores.sessionManager.defaultSite?.isJetpackCPConnected == true) &&
+            (stores.isAuthenticatedWithoutWPCom || defaultSite.isJetpackCPConnected) &&
             !dismissedWPComConnectionSuggestion &&
             isEligibleForSelfDrivenPN
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1085,8 +1085,11 @@ final class DashboardViewModelTests: XCTestCase {
     @MainActor
     func test_shouldSuggestWPComConnection_returns_false_when_default_site_is_unavailable_for_site_credential_login() async {
         // Given
+        let sessionManager = SessionManager.makeForTesting(authenticated: true, defaultSite: site)
+        sessionManager.defaultSite = nil
+        stores = MockStoresManager(sessionManager: sessionManager)
+        setUpBasicMocks()
         mockReloadingData()
-        stores.sessionManager.defaultSite = nil
         stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
         eligibilityChecker.isEligible = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -1083,6 +1083,45 @@ final class DashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_shouldSuggestWPComConnection_returns_false_when_default_site_is_unavailable_for_site_credential_login() async {
+        // Given
+        mockReloadingData()
+        stores.sessionManager.defaultSite = nil
+        stores.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        let eligibilityChecker = MockWooPushNotificationEligibilityChecker()
+        eligibilityChecker.isEligible = true
+        let pushNotesManager = MockPushNotificationsManager(siteIDsRegisteredForWooPNs: [],
+                                                            hasStoredSiteIDsRegisteredForWooPNs: true)
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           userDefaults: userDefaults,
+                                           pushNotesManager: pushNotesManager,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker,
+                                           pushNotificationEligibilityChecker: eligibilityChecker)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldSuggestWPComConnection)
+        XCTAssertFalse(viewModel.showOnDashboardCards.contains(.connectWPCom))
+
+        // When
+        stores.updateDefaultStore(site)
+        await until {
+            viewModel.shouldSuggestWPComConnection &&
+            viewModel.showOnDashboardCards.contains(.connectWPCom)
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.shouldSuggestWPComConnection)
+        XCTAssertTrue(viewModel.showOnDashboardCards.contains(.connectWPCom))
+    }
+
+    @MainActor
     func test_shouldSuggestWPComConnection_returns_false_when_site_is_registered_with_Woo_PN_and_not_wpcom_login() async {
         // Given
         mockReloadingData()


### PR DESCRIPTION
Fixes WOOMOB-3376, supersedes #17424

## Description
This fixes a crash in the Woo push notification setup flow when the dashboard shows the Connect WordPress.com card before `stores.sessionManager.defaultSite` is available.

The dashboard now keeps the card hidden until the matching `defaultSite` is available, recomputes the card visibility when the site is loaded, and guards the tap/setup paths as a final safety net. I've also downgraded the fatalError to an assertion

## Test Steps

1. Log in with site credentials, then force quit and enable airplane mode.
2. Launch the app, observe that the notification card isn't shown 
3. Disable airplane mode and immediately tap the card when it appears, then whatever CTA is visible
4. Confirm the setup flow opens without crashing.

N.B. These repro steps are a good way to repro the crash... but not so good for the fix because the dashboard doesn't fully reload in response to the internet connection coming back. The other check is just to force quit the app, reopen it, and observe that it takes a beat before showing the notifications card.

## Screenshots

### Before

https://github.com/user-attachments/assets/a234452c-4854-4d29-9e26-cdb43152c5ee


### After

https://github.com/user-attachments/assets/76652285-170c-485c-8af2-424eb5771258



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.