### PR TITLE
POS roles: gate navigation actions (settings, orders, exit) via manager override

### DIFF
--- a/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
+++ b/Modules/Sources/Networking/Model/POS/POSStaffMember.swift
@@ -10,8 +10,8 @@ public struct POSStaffMember: Codable, Equatable, Sendable {
     /// Server-side role preset, used only for display labelling — never for permission checks.
     public let preset: POSStaffPreset
 
-    /// POS capabilities the staff member holds, keyed by the server's `pos_*` capability
-    /// identifier. The server emits only granted entries (all values are `true` in the
+    /// POS capabilities the staff member holds, keyed by the server's `woocommerce_pos_*`
+    /// capability identifier. The server emits only granted entries (all values are `true` in the
     /// current preset bundles). Treated as opaque strings at this layer.
     public let capabilities: [String: Bool]
 

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -110,7 +110,7 @@ private extension POSFloatingControlView {
                 }
             }
 
-            if isRolesEnabled {
+            if canLockPOS {
                 Button {
                     session.lock()
                 } label: {
@@ -131,6 +131,13 @@ private extension POSFloatingControlView {
 
     private var isRolesEnabled: Bool {
         featureFlags.isFeatureFlagEnabled(.pointOfSaleRoles)
+    }
+
+    /// Only offer Lock POS when access is actually PIN-gated — i.e. some staff member has a PIN to
+    /// unlock with. Without this, locking a session that has no PINs (roles on, but `/staff` returned
+    /// nobody PIN-backed) would strand the operator on a lock screen that no PIN can dismiss.
+    private var canLockPOS: Bool {
+        isRolesEnabled && session.hasAnyPINs
     }
 }
 

--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -4,26 +4,33 @@ import struct WooFoundation.WooAnalyticsEvent
 struct POSFloatingControlView: View {
     @Environment(\.posBackgroundAppearance) var backgroundAppearance
     @Environment(\.posFeatureFlags) private var featureFlags
+    @Environment(\.posAccessSession) private var session
     @Environment(\.posAnalytics) private var analytics
     @Environment(PointOfSaleAggregateModel.self) private var posModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Binding private var showExitPOSModal: Bool
     @Binding private var showSupport: Bool
     @Binding private var showDocumentation: Bool
-    @Binding private var showSettings: Bool
+    /// Invoked when the Exit POS menu item is tapped. The host gates it on `.exitPOS` before
+    /// presenting the exit confirmation.
+    private let onExitSelected: () -> Void
+    /// Invoked when the Settings menu item is tapped. The host gates it on `.viewPOSSettings` before
+    /// presenting the settings screen.
+    private let onSettingsSelected: () -> Void
+    /// Invoked when the Orders menu item is tapped. The host gates it on `.viewOrders` before
+    /// presenting the orders screen.
     private let onOrdersSelected: () -> Void
     @State private var showProductRestrictionsModal: Bool = false
     @State private var showBarcodeScanningModal: Bool = false
 
-    init(showExitPOSModal: Binding<Bool>,
+    init(onExitSelected: @escaping () -> Void,
          showSupport: Binding<Bool>,
          showDocumentation: Binding<Bool>,
-         showSettings: Binding<Bool>,
+         onSettingsSelected: @escaping () -> Void,
          onOrdersSelected: @escaping () -> Void) {
-        self._showExitPOSModal = showExitPOSModal
+        self.onExitSelected = onExitSelected
         self._showSupport = showSupport
         self._showDocumentation = showDocumentation
-        self._showSettings = showSettings
+        self.onSettingsSelected = onSettingsSelected
         self.onOrdersSelected = onOrdersSelected
     }
 
@@ -71,7 +78,7 @@ private extension POSFloatingControlView {
     @ViewBuilder private func menuOptions() -> some View {
         Button {
             analytics.track(.pointOfSaleExitMenuItemTapped)
-            showExitPOSModal = true
+            onExitSelected()
         } label: {
             Label(
                 title: { Text(Localization.exitPointOfSale) },
@@ -82,7 +89,7 @@ private extension POSFloatingControlView {
         if horizontalSizeClass == .regular || isPhoneLayout {
             Button {
                 analytics.track(.pointOfSaleSettingsMenuItemTapped)
-                showSettings = true
+                onSettingsSelected()
             } label: {
                 Label(
                     title: { Text(Localization.settings) },
@@ -102,12 +109,28 @@ private extension POSFloatingControlView {
                     )
                 }
             }
+
+            if isRolesEnabled {
+                Button {
+                    session.lock()
+                } label: {
+                    Label(
+                        title: { Text(Localization.lockPOS) },
+                        icon: { Image(systemName: "lock") }
+                    )
+                }
+                .accessibilityIdentifier("pos-lock-menu-item")
+            }
         }
     }
 
     private var isPhoneLayout: Bool {
         horizontalSizeClass == .compact &&
         featureFlags.isFeatureFlagEnabled(.pointOfSalePhonePrototype)
+    }
+
+    private var isRolesEnabled: Bool {
+        featureFlags.isFeatureFlagEnabled(.pointOfSaleRoles)
     }
 }
 
@@ -150,6 +173,12 @@ private extension POSFloatingControlView {
             comment: "The title of the menu button to access Point of Sale historical orders, shown in a fullscreen view."
         )
 
+        static let lockPOS = NSLocalizedString(
+            "pointOfSale.floatingButtons.lock.button.title",
+            value: "Lock POS",
+            comment: "The title of the menu button to lock Point of Sale, requiring PIN entry to continue."
+        )
+
         static let exitPointOfSale = NSLocalizedString(
             "pointOfSale.floatingButtons.exit.button.title",
             value: "Exit POS",
@@ -168,10 +197,10 @@ private extension POSFloatingControlView {
 #if DEBUG
 
 #Preview("Reader Disconnected") {
-    POSFloatingControlView(showExitPOSModal: .constant(false),
+    POSFloatingControlView(onExitSelected: {},
                            showSupport: .constant(false),
                            showDocumentation: .constant(false),
-                           showSettings: .constant(false),
+                           onSettingsSelected: {},
                            onOrdersSelected: {})
         .environment(\.posBackgroundAppearance, .primary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())
@@ -183,20 +212,20 @@ private extension POSFloatingControlView {
     let posModel = POSPreviewHelpers.makePreviewAggregateModel(
         cardPresentPaymentService: paymentService
     )
-    return POSFloatingControlView(showExitPOSModal: .constant(false),
+    return POSFloatingControlView(onExitSelected: {},
                                   showSupport: .constant(false),
                                   showDocumentation: .constant(false),
-                                  showSettings: .constant(false),
+                                  onSettingsSelected: {},
                                   onOrdersSelected: {})
         .environment(\.posBackgroundAppearance, .primary)
         .environment(posModel)
 }
 
 #Preview("Secondary/disabled Background") {
-    POSFloatingControlView(showExitPOSModal: .constant(false),
+    POSFloatingControlView(onExitSelected: {},
                            showSupport: .constant(false),
                            showDocumentation: .constant(false),
-                           showSettings: .constant(false),
+                           onSettingsSelected: {},
                            onOrdersSelected: {})
         .environment(\.posBackgroundAppearance, .secondary)
         .environment(POSPreviewHelpers.makePreviewAggregateModel())

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -590,37 +590,30 @@ private extension PointOfSaleDashboardView {
         showOrders = true
     }
 
-    /// Gates opening the orders screen on `.viewOrders`. When the operator already holds it
-    /// (e.g. a manager/admin) orders open immediately; otherwise the manager-override modal is
-    /// presented and orders open once an authorized staff member approves.
+    /// Opens the orders list, gated on `.viewOrders` via manager override.
     func requestOrdersPermission() {
-        overrideHandler.gate(.viewOrders, reason: Localization.ordersOverrideDescription) {
+        overrideHandler.gate(.viewOrders, reason: Localization.ordersOverrideDescription) { _ in
             presentOrders()
         }
     }
 
-    /// Gates opening the settings screen on `.viewPOSSettings`. When the operator already holds it
-    /// (e.g. a manager/admin) settings opens immediately; otherwise the manager-override modal is
-    /// presented and settings opens once an authorized staff member approves.
+    /// Opens POS settings, gated on `.viewPOSSettings` via manager override.
     func requestSettingsPermission() {
-        overrideHandler.gate(.viewPOSSettings, reason: Localization.settingsOverrideDescription) {
+        overrideHandler.gate(.viewPOSSettings, reason: Localization.settingsOverrideDescription) { _ in
             showSettings = true
         }
     }
 
-    /// Gates leaving POS on `.exitPOS`. Cashiers and managers both need a manager/admin override to
-    /// exit (only admins hold it); once authorized, the existing exit confirmation is presented.
+    /// Presents the exit confirmation, gated on `.exitPOS` via manager override.
     func requestExitPermission() {
-        guard !session.allows(.exitPOS) else {
-            // The operator already holds `.exitPOS` (admin): no override modal is shown, so the
-            // confirmation can present immediately.
-            showExitPOSModal = true
-            return
-        }
-        overrideHandler.requestApproval(for: .exitPOS, reason: Localization.exitOverrideDescription) {
-            // The override modal and the exit confirmation share the single POS modal manager. Present
-            // the confirmation only after the override modal has finished dismissing — otherwise the two
-            // transitions collide on the shared manager and neither shows, dropping the operator back into
+        overrideHandler.gate(.exitPOS, reason: Localization.exitOverrideDescription) { viaOverride in
+            guard viaOverride else {
+                showExitPOSModal = true
+                return
+            }
+            // The override modal and the exit confirmation share the single POS modal manager, so
+            // present the confirmation only after the override modal has finished dismissing —
+            // presenting both together collides on the shared manager and drops the operator back into
             // POS. Mirrors the cart-sheet → barcode-cover handoff in `phoneCartSheetView`.
             DispatchQueue.main.asyncAfter(deadline: .now() + Constants.exitOverrideHandoffDelay) {
                 showExitPOSModal = true

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -676,19 +676,19 @@ private extension PointOfSaleDashboardView {
         )
         static let settingsOverrideDescription = NSLocalizedString(
             "pointOfSaleDashboard.settings.overrideReason",
-            value: "Opening settings requires manager approval",
+            value: "Opening settings requires approval",
             comment: "Message shown in the manager-override PIN prompt when a staff member without the "
                 + "view-settings permission tries to open Point of Sale settings."
         )
         static let exitOverrideDescription = NSLocalizedString(
             "pointOfSaleDashboard.exit.overrideReason",
-            value: "Exiting Point of Sale requires manager approval",
+            value: "Exiting Point of Sale requires approval",
             comment: "Message shown in the manager-override PIN prompt when a staff member without the "
                 + "exit permission tries to leave Point of Sale."
         )
         static let ordersOverrideDescription = NSLocalizedString(
             "pointOfSaleDashboard.orders.overrideReason",
-            value: "Opening orders requires manager approval",
+            value: "Opening orders requires approval",
             comment: "Message shown in the manager-override PIN prompt when a staff member without the "
                 + "view-orders permission tries to open the Point of Sale orders list."
         )

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -16,6 +16,7 @@ struct PointOfSaleDashboardView: View {
     @State private var showSupport: Bool = false
     @State private var showDocumentation: Bool = false
     @State private var showSettings: Bool = false
+    @State private var overrideHandler = POSManagerOverrideHandler()
     @State private var waitingTimeTracker: WaitingTimeTracker?
 
     @State private var navigationPath: [POSNavigationDestination] = []
@@ -107,11 +108,11 @@ struct PointOfSaleDashboardView: View {
                     .accessibilitySortPriority(2)
             }
 
-            POSFloatingControlView(showExitPOSModal: $showExitPOSModal,
+            POSFloatingControlView(onExitSelected: requestExitPermission,
                                    showSupport: $showSupport,
                                    showDocumentation: $showDocumentation,
-                                   showSettings: $showSettings,
-                                   onOrdersSelected: presentOrders)
+                                   onSettingsSelected: requestSettingsPermission,
+                                   onOrdersSelected: requestOrdersPermission)
             .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
@@ -147,6 +148,7 @@ struct PointOfSaleDashboardView: View {
             .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
         }
         .posRootModal()
+        .posManagerOverrideModal(handler: overrideHandler)
         .posSheet(isPresented: $showSupport) {
             supportForm
                 .interactiveDismissDisabled(true)
@@ -347,14 +349,14 @@ struct PointOfSaleDashboardView: View {
             }
             Button {
                 analytics.track(.pointOfSaleExitMenuItemTapped)
-                showExitPOSModal = true
+                requestExitPermission()
             } label: {
                 Label(Localization.phoneMenuExit, systemImage: "rectangle.portrait.and.arrow.forward")
             }
             .accessibilityIdentifier("pos-exit-menu-item")
             Button {
                 analytics.track(.pointOfSaleSettingsMenuItemTapped)
-                showSettings = true
+                requestSettingsPermission()
             } label: {
                 Label(Localization.phoneMenuSettings, systemImage: "gearshape")
             }
@@ -362,7 +364,7 @@ struct PointOfSaleDashboardView: View {
             if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
                 Button {
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
-                    presentOrders()
+                    requestOrdersPermission()
                 } label: {
                     Label(Localization.phoneMenuOrders, systemImage: "text.document")
                 }
@@ -587,6 +589,44 @@ private extension PointOfSaleDashboardView {
         posModel.cancelInFlightCheckout()
         showOrders = true
     }
+
+    /// Gates opening the orders screen on `.viewOrders`. When the operator already holds it
+    /// (e.g. a manager/admin) orders open immediately; otherwise the manager-override modal is
+    /// presented and orders open once an authorized staff member approves.
+    func requestOrdersPermission() {
+        overrideHandler.gate(.viewOrders, reason: Localization.ordersOverrideDescription) {
+            presentOrders()
+        }
+    }
+
+    /// Gates opening the settings screen on `.viewPOSSettings`. When the operator already holds it
+    /// (e.g. a manager/admin) settings opens immediately; otherwise the manager-override modal is
+    /// presented and settings opens once an authorized staff member approves.
+    func requestSettingsPermission() {
+        overrideHandler.gate(.viewPOSSettings, reason: Localization.settingsOverrideDescription) {
+            showSettings = true
+        }
+    }
+
+    /// Gates leaving POS on `.exitPOS`. Cashiers and managers both need a manager/admin override to
+    /// exit (only admins hold it); once authorized, the existing exit confirmation is presented.
+    func requestExitPermission() {
+        guard !session.allows(.exitPOS) else {
+            // The operator already holds `.exitPOS` (admin): no override modal is shown, so the
+            // confirmation can present immediately.
+            showExitPOSModal = true
+            return
+        }
+        overrideHandler.requestApproval(for: .exitPOS, reason: Localization.exitOverrideDescription) {
+            // The override modal and the exit confirmation share the single POS modal manager. Present
+            // the confirmation only after the override modal has finished dismissing — otherwise the two
+            // transitions collide on the shared manager and neither shows, dropping the operator back into
+            // POS. Mirrors the cart-sheet → barcode-cover handoff in `phoneCartSheetView`.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.exitOverrideHandoffDelay) {
+                showExitPOSModal = true
+            }
+        }
+    }
 }
 
 struct FloatingControlAreaSizeKey: EnvironmentKey {
@@ -609,6 +649,9 @@ private extension PointOfSaleDashboardView {
         static let floatingControlHorizontalOffset: CGFloat = POSPadding.medium
         static let floatingControlVerticalOffset: CGFloat = 0
         static let exitPOSSheetMaxWidth: CGFloat = 900.0
+        // Slightly longer than the 0.25s POS modal transition so the override modal fully dismisses
+        // before the exit confirmation presents on the shared modal manager.
+        static let exitOverrideHandoffDelay: TimeInterval = 0.3
         static let supportTag = "origin:point-of-sale"
     }
 
@@ -637,6 +680,24 @@ private extension PointOfSaleDashboardView {
             "pointOfSaleDashboard.phone.menu.settings",
             value: "Settings",
             comment: "Phone-only overflow menu item to open Point of Sale settings."
+        )
+        static let settingsOverrideDescription = NSLocalizedString(
+            "pointOfSaleDashboard.settings.overrideReason",
+            value: "Opening settings requires manager approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "view-settings permission tries to open Point of Sale settings."
+        )
+        static let exitOverrideDescription = NSLocalizedString(
+            "pointOfSaleDashboard.exit.overrideReason",
+            value: "Exiting Point of Sale requires manager approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "exit permission tries to leave Point of Sale."
+        )
+        static let ordersOverrideDescription = NSLocalizedString(
+            "pointOfSaleDashboard.orders.overrideReason",
+            value: "Opening orders requires manager approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "view-orders permission tries to open the Point of Sale orders list."
         )
         static let phoneMenuOrders = NSLocalizedString(
             "pointOfSaleDashboard.phone.menu.orders",

--- a/Modules/Sources/PointOfSale/Roles/Models/POSCapability.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSCapability.swift
@@ -1,14 +1,14 @@
 enum POSCapability: String, CaseIterable, Sendable {
-    // POS-specific capabilities use the `pos_` prefix, matching the keys the staff endpoint
-    // reports. Capability matching is by raw value (see `POSStaff.hasCapability`), so non-`pos_`
-    // identifiers can be added as cases later without changing the lookup logic.
-    case processSales = "pos_process_sales"
-    case viewOrders = "pos_view_orders"
-    case applyCoupons = "pos_apply_coupons"
-    case createCoupons = "pos_create_coupons"
-    case issueRefunds = "pos_issue_refunds"
-    case viewPOSSettings = "pos_view_settings"
-    case editPOSSettings = "pos_edit_settings"
-    case managePOSStaff = "pos_manage_staff"
-    case exitPOS = "pos_exit"
+    // POS-specific capabilities use the `woocommerce_pos_` prefix, matching the keys the staff
+    // endpoint reports. Capability matching is by raw value (see `POSStaff.hasCapability`), so
+    // non-`woocommerce_pos_` identifiers can be added as cases later without changing the lookup logic.
+    case processSales = "woocommerce_pos_process_sales"
+    case viewOrders = "woocommerce_pos_view_orders"
+    case applyCoupons = "woocommerce_pos_apply_coupons"
+    case createCoupons = "woocommerce_pos_create_coupons"
+    case issueRefunds = "woocommerce_pos_issue_refunds"
+    case viewPOSSettings = "woocommerce_pos_view_settings"
+    case editPOSSettings = "woocommerce_pos_edit_settings"
+    case managePOSStaff = "woocommerce_pos_manage_staff"
+    case exitPOS = "woocommerce_pos_exit"
 }

--- a/Modules/Sources/PointOfSale/Roles/Models/POSManagerOverrideHandler.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSManagerOverrideHandler.swift
@@ -34,6 +34,21 @@ final class POSManagerOverrideHandler {
         self.onApproved = onApproved
     }
 
+    /// Gates `capability`: runs `perform` immediately when the configured session already grants it,
+    /// otherwise presents the override modal and runs `perform` once an authorized staff member
+    /// approves. No-ops until the handler has been configured with a session (the override modal
+    /// configures it on appear).
+    func gate(_ capability: POSCapability, reason: String, perform: @escaping () -> Void) {
+        guard let session else {
+            return
+        }
+        if session.allows(capability) {
+            perform()
+        } else {
+            requestApproval(for: capability, reason: reason, onApproved: perform)
+        }
+    }
+
     @discardableResult
     func submit(pin: String) async -> Bool {
         guard let request, let session else {

--- a/Modules/Sources/PointOfSale/Roles/Models/POSManagerOverrideHandler.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSManagerOverrideHandler.swift
@@ -34,18 +34,22 @@ final class POSManagerOverrideHandler {
         self.onApproved = onApproved
     }
 
-    /// Gates `capability`: runs `perform` immediately when the configured session already grants it,
-    /// otherwise presents the override modal and runs `perform` once an authorized staff member
-    /// approves. No-ops until the handler has been configured with a session (the override modal
-    /// configures it on appear).
-    func gate(_ capability: POSCapability, reason: String, perform: @escaping () -> Void) {
+    /// Gates `capability`: runs `perform` immediately when the configured session already grants it —
+    /// including when POS roles are off, where an unrestricted session grants everything — otherwise
+    /// presents the override modal and runs `perform` once an authorized staff member approves.
+    /// `viaOverride` is `true` only on the approval path, so a caller can defer work that must wait for
+    /// the override modal to dismiss. No-ops until the handler has been configured with a session (the
+    /// override modal configures it on appear).
+    func gate(_ capability: POSCapability, reason: String, perform: @escaping (_ viaOverride: Bool) -> Void) {
         guard let session else {
             return
         }
         if session.allows(capability) {
-            perform()
+            perform(false)
         } else {
-            requestApproval(for: capability, reason: reason, onApproved: perform)
+            requestApproval(for: capability, reason: reason) {
+                perform(true)
+            }
         }
     }
 

--- a/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/POSStaffRemoteTests.swift
@@ -44,8 +44,8 @@ struct POSStaffRemoteTests {
         #expect(manager.userID == 12)
         #expect(manager.displayName == "Morgan Manager")
         #expect(manager.preset == .manager)
-        #expect(manager.capabilities["pos_issue_refunds"] == true)
-        #expect(manager.capabilities["pos_manage_staff"] == true)
+        #expect(manager.capabilities["woocommerce_pos_issue_refunds"] == true)
+        #expect(manager.capabilities["woocommerce_pos_manage_staff"] == true)
 
         let pin = try #require(manager.pin)
         #expect(pin.algorithm == "pbkdf2-sha256")
@@ -68,7 +68,7 @@ struct POSStaffRemoteTests {
 
         let cashier = try #require(staff.last)
         #expect(cashier.preset == .cashier)
-        #expect(cashier.capabilities == ["pos_process_sales": true])
+        #expect(cashier.capabilities == ["woocommerce_pos_process_sales": true])
     }
 
     @Test func fetchStaff_decodes_a_nil_pin_for_a_member_without_a_pin() async throws {

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff-without-data-envelope.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff-without-data-envelope.json
@@ -4,9 +4,9 @@
         "display_name": "Morgan Manager",
         "preset": "pos_manager",
         "capabilities": {
-            "pos_process_sales": true,
-            "pos_view_orders": true,
-            "pos_issue_refunds": true
+            "woocommerce_pos_process_sales": true,
+            "woocommerce_pos_view_orders": true,
+            "woocommerce_pos_issue_refunds": true
         },
         "pin": {
             "algo": "pbkdf2-sha256",
@@ -20,7 +20,7 @@
         "display_name": "Casey Cashier",
         "preset": "pos_cashier",
         "capabilities": {
-            "pos_process_sales": true
+            "woocommerce_pos_process_sales": true
         },
         "pin": null
     }

--- a/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff.json
+++ b/Modules/Tests/NetworkingTestsResponsesFixtures/Responses/pos-staff.json
@@ -5,15 +5,15 @@
             "display_name": "Morgan Manager",
             "preset": "pos_manager",
             "capabilities": {
-                "pos_process_sales": true,
-                "pos_view_orders": true,
-                "pos_apply_coupons": true,
-                "pos_create_coupons": true,
-                "pos_issue_refunds": true,
-                "pos_view_settings": true,
-                "pos_edit_settings": true,
-                "pos_manage_staff": true,
-                "pos_exit": true
+                "woocommerce_pos_process_sales": true,
+                "woocommerce_pos_view_orders": true,
+                "woocommerce_pos_apply_coupons": true,
+                "woocommerce_pos_create_coupons": true,
+                "woocommerce_pos_issue_refunds": true,
+                "woocommerce_pos_view_settings": true,
+                "woocommerce_pos_edit_settings": true,
+                "woocommerce_pos_manage_staff": true,
+                "woocommerce_pos_exit": true
             },
             "pin": {
                 "algo": "pbkdf2-sha256",
@@ -27,9 +27,9 @@
             "display_name": "Casey Cashier",
             "preset": "pos_cashier",
             "capabilities": {
-                "pos_process_sales": true,
-                "pos_view_orders": true,
-                "pos_apply_coupons": true
+                "woocommerce_pos_process_sales": true,
+                "woocommerce_pos_view_orders": true,
+                "woocommerce_pos_apply_coupons": true
             },
             "pin": {
                 "algo": "pbkdf2-sha256",
@@ -43,15 +43,15 @@
             "display_name": "Avery Admin",
             "preset": "pos_admin",
             "capabilities": {
-                "pos_process_sales": true,
-                "pos_view_orders": true,
-                "pos_apply_coupons": true,
-                "pos_create_coupons": true,
-                "pos_issue_refunds": true,
-                "pos_view_settings": true,
-                "pos_edit_settings": true,
-                "pos_manage_staff": true,
-                "pos_exit": true
+                "woocommerce_pos_process_sales": true,
+                "woocommerce_pos_view_orders": true,
+                "woocommerce_pos_apply_coupons": true,
+                "woocommerce_pos_create_coupons": true,
+                "woocommerce_pos_issue_refunds": true,
+                "woocommerce_pos_view_settings": true,
+                "woocommerce_pos_edit_settings": true,
+                "woocommerce_pos_manage_staff": true,
+                "woocommerce_pos_exit": true
             },
             "pin": null
         }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -451,7 +451,7 @@ private extension DefaultPOSAccessSessionTests {
         POSStaffMember(userID: userID,
                        displayName: "Staff",
                        preset: .cashier,
-                       capabilities: ["pos_process_sales": true],
+                       capabilities: ["woocommerce_pos_process_sales": true],
                        pin: hasPIN ? .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                            salt: "c2FsdA==", hash: "aGFzaA==") : nil)
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -14,7 +14,7 @@ struct DefaultPOSPINAuthenticatorTests {
     @Test func test_authenticate_when_pin_matches_a_cached_member_then_returns_that_staff() async throws {
         // Given a cached member whose PIN hash matches "1234"
         let member = makeMember(userID: 7, displayName: "Manny", preset: .manager,
-                                capabilities: ["pos_process_sales": true, "pos_issue_refunds": true],
+                                capabilities: ["woocommerce_pos_process_sales": true, "woocommerce_pos_issue_refunds": true],
                                 pin: pinDetails(forPIN: "1234"))
         let sut = makeSUT(cached: [member])
 
@@ -89,8 +89,8 @@ struct DefaultPOSPINAuthenticatorTests {
         // Given a member with a granted known cap, a denied known cap, and an unknown cap
         let member = makeMember(userID: 1,
                                 capabilities: [
-                                    "pos_process_sales": true,
-                                    "pos_issue_refunds": false,
+                                    "woocommerce_pos_process_sales": true,
+                                    "woocommerce_pos_issue_refunds": false,
                                     "some_unknown_cap": true
                                 ],
                                 pin: pinDetails(forPIN: "1234"))
@@ -100,7 +100,7 @@ struct DefaultPOSPINAuthenticatorTests {
         let staff = try await sut.authenticate(withPIN: "1234")
 
         // Then only the granted, recognized capability survives
-        #expect(staff.capabilities == ["pos_process_sales"])
+        #expect(staff.capabilities == ["woocommerce_pos_process_sales"])
         #expect(staff.hasCapability(.processSales))
         #expect(!staff.hasCapability(.issueRefunds))
     }
@@ -126,7 +126,7 @@ struct DefaultPOSPINAuthenticatorTests {
     @MainActor
     @Test func test_verify_when_manager_holds_the_capability_then_does_not_throw() async throws {
         let manager = makeMember(userID: 5, displayName: "Morgan", preset: .manager,
-                                 capabilities: ["pos_issue_refunds": true],
+                                 capabilities: ["woocommerce_pos_issue_refunds": true],
                                  pin: pinDetails(forPIN: "9999"))
         let sut = makeSUT(cached: [manager])
 
@@ -136,7 +136,7 @@ struct DefaultPOSPINAuthenticatorTests {
 
     @MainActor
     @Test func test_verify_when_manager_lacks_the_capability_then_throws_invalidPIN() async throws {
-        let cashier = makeMember(userID: 6, capabilities: ["pos_process_sales": true],
+        let cashier = makeMember(userID: 6, capabilities: ["woocommerce_pos_process_sales": true],
                                  pin: pinDetails(forPIN: "9999"))
         let sut = makeSUT(cached: [cashier])
 
@@ -159,7 +159,7 @@ private extension DefaultPOSPINAuthenticatorTests {
     func makeMember(userID: Int64,
                     displayName: String = "User",
                     preset: POSStaffPreset = .cashier,
-                    capabilities: [String: Bool] = ["pos_process_sales": true],
+                    capabilities: [String: Bool] = ["woocommerce_pos_process_sales": true],
                     pin: POSStaffMember.PINDetails?) -> POSStaffMember {
         POSStaffMember(userID: userID, displayName: displayName, preset: preset,
                        capabilities: capabilities, pin: pin)

--- a/Modules/Tests/PointOfSaleTests/Roles/POSCapabilityTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSCapabilityTests.swift
@@ -4,29 +4,29 @@ import Testing
 struct POSCapabilityTests {
     @Test func test_rawValues_match_backend_capability_identifiers() {
         // When / Then
-        #expect(POSCapability.processSales.rawValue == "pos_process_sales")
-        #expect(POSCapability.viewOrders.rawValue == "pos_view_orders")
-        #expect(POSCapability.applyCoupons.rawValue == "pos_apply_coupons")
-        #expect(POSCapability.createCoupons.rawValue == "pos_create_coupons")
-        #expect(POSCapability.issueRefunds.rawValue == "pos_issue_refunds")
-        #expect(POSCapability.viewPOSSettings.rawValue == "pos_view_settings")
-        #expect(POSCapability.editPOSSettings.rawValue == "pos_edit_settings")
-        #expect(POSCapability.managePOSStaff.rawValue == "pos_manage_staff")
-        #expect(POSCapability.exitPOS.rawValue == "pos_exit")
+        #expect(POSCapability.processSales.rawValue == "woocommerce_pos_process_sales")
+        #expect(POSCapability.viewOrders.rawValue == "woocommerce_pos_view_orders")
+        #expect(POSCapability.applyCoupons.rawValue == "woocommerce_pos_apply_coupons")
+        #expect(POSCapability.createCoupons.rawValue == "woocommerce_pos_create_coupons")
+        #expect(POSCapability.issueRefunds.rawValue == "woocommerce_pos_issue_refunds")
+        #expect(POSCapability.viewPOSSettings.rawValue == "woocommerce_pos_view_settings")
+        #expect(POSCapability.editPOSSettings.rawValue == "woocommerce_pos_edit_settings")
+        #expect(POSCapability.managePOSStaff.rawValue == "woocommerce_pos_manage_staff")
+        #expect(POSCapability.exitPOS.rawValue == "woocommerce_pos_exit")
     }
 
     @Test func test_allCases_is_exactly_the_supported_capability_set() {
         // When / Then
         #expect(Set(POSCapability.allCases.map(\.rawValue)) == [
-            "pos_process_sales",
-            "pos_view_orders",
-            "pos_apply_coupons",
-            "pos_create_coupons",
-            "pos_issue_refunds",
-            "pos_view_settings",
-            "pos_edit_settings",
-            "pos_manage_staff",
-            "pos_exit"
+            "woocommerce_pos_process_sales",
+            "woocommerce_pos_view_orders",
+            "woocommerce_pos_apply_coupons",
+            "woocommerce_pos_create_coupons",
+            "woocommerce_pos_issue_refunds",
+            "woocommerce_pos_view_settings",
+            "woocommerce_pos_edit_settings",
+            "woocommerce_pos_manage_staff",
+            "woocommerce_pos_exit"
         ])
     }
 }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSManagerOverrideHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSManagerOverrideHandlerTests.swift
@@ -29,14 +29,17 @@ struct POSManagerOverrideHandlerTests {
                                capabilities: [POSCapability.viewPOSSettings.rawValue])
         let sut = POSManagerOverrideHandler(session: MockPOSAccessSession(currentStaff: manager))
         var performCount = 0
+        var capturedViaOverride: Bool?
 
         // When
-        sut.gate(.viewPOSSettings, reason: "Opening settings requires manager approval") {
+        sut.gate(.viewPOSSettings, reason: "Opening settings requires manager approval") { viaOverride in
             performCount += 1
+            capturedViaOverride = viaOverride
         }
 
-        // Then it runs directly and presents no modal
+        // Then it runs directly, flags no override, and presents no modal
         #expect(performCount == 1)
+        #expect(capturedViaOverride == false)
         #expect(sut.request == nil)
     }
 
@@ -45,10 +48,12 @@ struct POSManagerOverrideHandlerTests {
         let cashier = POSStaff(userID: 1, displayName: "Cassie", preset: .cashier, capabilities: [])
         let sut = POSManagerOverrideHandler(session: MockPOSAccessSession(currentStaff: cashier))
         var performCount = 0
+        var capturedViaOverride: Bool?
 
         // When the gate is requested for a capability the operator lacks
-        sut.gate(.viewPOSSettings, reason: "Opening settings requires manager approval") {
+        sut.gate(.viewPOSSettings, reason: "Opening settings requires manager approval") { viaOverride in
             performCount += 1
+            capturedViaOverride = viaOverride
         }
 
         // Then the override modal is presented and the action has not run yet
@@ -58,8 +63,9 @@ struct POSManagerOverrideHandlerTests {
         // When an authorized manager approves
         await sut.submit(pin: "1234")
 
-        // Then the action runs
+        // Then the action runs and flags that it came through the override
         #expect(performCount == 1)
+        #expect(capturedViaOverride == true)
     }
 
     @Test func test_submit_when_started_then_sets_loading_state() async {

--- a/Modules/Tests/PointOfSaleTests/Roles/POSManagerOverrideHandlerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSManagerOverrideHandlerTests.swift
@@ -23,6 +23,45 @@ struct POSManagerOverrideHandlerTests {
         #expect(sut.pinEntryState == .idle)
     }
 
+    @Test func test_gate_when_session_grants_capability_then_performs_immediately_without_override() {
+        // Given an operator who already holds the capability
+        let manager = POSStaff(userID: 1, displayName: "Manny", preset: .manager,
+                               capabilities: [POSCapability.viewPOSSettings.rawValue])
+        let sut = POSManagerOverrideHandler(session: MockPOSAccessSession(currentStaff: manager))
+        var performCount = 0
+
+        // When
+        sut.gate(.viewPOSSettings, reason: "Opening settings requires manager approval") {
+            performCount += 1
+        }
+
+        // Then it runs directly and presents no modal
+        #expect(performCount == 1)
+        #expect(sut.request == nil)
+    }
+
+    @Test func test_gate_when_session_denies_capability_then_presents_override_and_performs_on_approval() async {
+        // Given an operator who lacks the capability
+        let cashier = POSStaff(userID: 1, displayName: "Cassie", preset: .cashier, capabilities: [])
+        let sut = POSManagerOverrideHandler(session: MockPOSAccessSession(currentStaff: cashier))
+        var performCount = 0
+
+        // When the gate is requested for a capability the operator lacks
+        sut.gate(.viewPOSSettings, reason: "Opening settings requires manager approval") {
+            performCount += 1
+        }
+
+        // Then the override modal is presented and the action has not run yet
+        #expect(sut.request?.capability == .viewPOSSettings)
+        #expect(performCount == 0)
+
+        // When an authorized manager approves
+        await sut.submit(pin: "1234")
+
+        // Then the action runs
+        #expect(performCount == 1)
+    }
+
     @Test func test_submit_when_started_then_sets_loading_state() async {
         // Given
         var loadingStateObserved = false

--- a/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
@@ -54,7 +54,7 @@ private extension POSRolesPersistenceTests {
         POSStaffMember(userID: 1,
                        displayName: "Staff",
                        preset: .cashier,
-                       capabilities: ["pos_process_sales": true],
+                       capabilities: ["woocommerce_pos_process_sales": true],
                        pin: .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                   salt: "c2FsdA==", hash: "aGFzaA=="))
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/POSStaffTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSStaffTests.swift
@@ -4,7 +4,7 @@ import Testing
 struct POSStaffTests {
     @Test func test_hasCapability_when_staff_has_it_then_returns_true() {
         // Given
-        let sut = POSStaff(userID: 1, displayName: "Jane", preset: .manager, capabilities: ["pos_issue_refunds"])
+        let sut = POSStaff(userID: 1, displayName: "Jane", preset: .manager, capabilities: ["woocommerce_pos_issue_refunds"])
 
         // When / Then
         #expect(sut.hasCapability(.issueRefunds))


### PR DESCRIPTION
## Description
First PR of WOOMOB-3288 (POS capability gating). Wires the POS "navigation" capabilities into the Point of Sale dashboard so opening **Settings**, opening the **Orders** list, and **exiting** POS are gated on the operator's capabilities:

- `woocommerce_pos_view_settings` → open Settings
- `woocommerce_pos_view_orders` → open Orders
- `woocommerce_pos_exit` → exit POS

When the signed-in operator lacks the capability, the action presents the manager-override modal (PIN prompt) and proceeds only once an authorized staff member approves. When the operator already holds it — or when POS roles are off (an unrestricted session grants everything) — the action runs immediately. All three route through a single `POSManagerOverrideHandler.gate(_:reason:perform:)` entry point.

Also included:
- Renames the POS capability identifiers from `pos_*` to `woocommerce_pos_*` to match the server v3 contract (enum + staff JSON fixtures + roles/Networking test assertions). Role presets (`pos_cashier`/`pos_manager`/`pos_admin`) are unchanged.
- Adds the roles-only **Lock POS** floating-control menu item, which locks the session back to the PIN screen.

Behind the `pointOfSaleRoles` feature flag. Subsequent PRs gate the remaining capabilities (refunds, coupons, settings editing, manage staff, etc.).

## Test Steps
Manual testing is **optional** — the behavior is covered by unit tests and is behind the `pointOfSaleRoles` flag.

To verify manually, with `pointOfSaleRoles` enabled on a store that has staff with PINs configured ([this POC branch](feature/pos-staff-and-attribution-v3)):
1. Sign in to POS as a **cashier** (holds process-sales, view-orders, apply-coupons; lacks view-settings and exit):
   - Tap **Orders** → opens directly (cashiers hold view-orders, so no prompt).
   - Tap **Settings** → the "Approval required" PIN modal appears. An authorized staff member's PIN opens Settings; a wrong PIN shakes and stays put.
   - Tap **Exit POS** → PIN modal appears (only admins hold exit); proceeds after an authorized PIN.
   - Tap **Lock POS** → returns to the PIN lock screen.
2. Sign in as a **manager/admin** who holds the caps → Orders, Settings, and Exit open immediately with no prompt.

- [x] I (the author) will manually test the steps above.
- [x] I will also verify the behavior with the feature flag off and with a staff member that has no capabilities.

## Screenshots


https://github.com/user-attachments/assets/47678e0c-00f8-4d83-bd2b-b66c885c4953


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. (Behind the `pointOfSaleRoles` feature flag — no release note needed.)

