### PR TITLE
Update Automattic Tracks to 4.3.1

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e1e44a3374272cf4704a4ec421d71800bc3709e46abc34864c576591f25de250",
+  "originHash" : "697851aad485df38d9401e4f7e2b179bfc80515ffbaa0ba850bd595c8429130c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS.git",
       "state" : {
-        "revision" : "b017a3510c4214f628305686dfd301ee19d7afe6",
-        "version" : "4.2.1"
+        "revision" : "cdc9348b2804af0b70a06d125fd4236d5c6f7f39",
+        "version" : "4.3.1"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -98,7 +98,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms", exact: "1.0.4"),
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift.git", from: "1.1.5"),
-        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "4.2.0"),
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS.git", from: "4.3.1"),
         .package(url: "https://github.com/Automattic/Gridicons-iOS", revision: "c904cb73e26e86463a78e1335c6f4fd54a9e9223"),
         .package(url: "https://github.com/Automattic/ScreenObject", from: "0.3.0"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 25.2
 -----
-- [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/PENDING]
+- [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/17432]
 
 
 25.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/PENDING]
 
 
 25.1


### PR DESCRIPTION
Closes WOOMOB-3366.

## Description
Updates the [Automattic-Tracks-iOS](https://github.com/Automattic/Automattic-Tracks-iOS) dependency from 4.2.1 to [4.3.1](https://github.com/Automattic/Automattic-Tracks-iOS/releases/tag/4.3.1).

Changes pulled in (4.2.1 → 4.3.1):
- **4.3.1** — Made `ExPlat.shared` lifecycle thread-safe to fix a crash.
- **4.3.0** — Track whether Lockdown Mode is enabled as a device property; library can now be used in tvOS targets.

No Tracks API changes were required on our side, this is a version bump only.

## Test Steps
- CI should be green

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
