### PR TITLE
Fix Last Order card customer name alignment for long names

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrderDashboardRow.swift
@@ -36,6 +36,8 @@ struct LastOrderDashboardRow: View {
                         }
                         Text(data.customerName)
                             .bodyStyle()
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
                     Spacer()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrderDashboardRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrderDashboardRowViewModelTests.swift
@@ -68,6 +68,47 @@ struct LastOrderDashboardRowViewModelTests {
         #expect(viewModel.fulfillmentBadgeText == nil)
     }
 
+    // MARK: - customerName
+
+    @Test
+    func test_customerName_when_billing_name_present_then_returns_full_name() {
+        // Given
+        let address = Address.fake().copy(firstName: "Jane", lastName: "Doe")
+        let order = Order.fake().copy(billingAddress: address)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.customerName == address.fullName)
+        #expect(viewModel.customerName != "Guest")
+    }
+
+    @Test
+    func test_customerName_when_no_billing_address_then_returns_guest() {
+        // Given
+        let order = Order.fake().copy(billingAddress: nil)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.customerName == "Guest")
+    }
+
+    @Test
+    func test_customerName_when_billing_name_empty_then_returns_guest() {
+        // Given
+        let address = Address.fake().copy(firstName: "", lastName: "")
+        let order = Order.fake().copy(billingAddress: address)
+
+        // When
+        let viewModel = LastOrderDashboardRowViewModel(order: order)
+
+        // Then
+        #expect(viewModel.customerName == "Guest")
+    }
+
     // MARK: - isFulfillmentStatusRequired
 
     @Test


### PR DESCRIPTION
## Description
On the My Store dashboard, the "Last order" card left-aligns short customer names but center-aligns names long enough to wrap onto more than one line. That makes the name inconsistent with the order number and date above it, which always stay left-aligned. The cause is that the name `Text` in `LastOrderDashboardRow.swift` had no width or alignment of its own, so a wrapped multi-line `Text` defaulted to center alignment inside the leading-aligned `VStack`. This change pins that `Text` to the leading edge with `.multilineTextAlignment(.leading)` and `.frame(maxWidth: .infinity, alignment: .leading)`, so the name is always left-aligned regardless of length.

## Test Steps
1. Open the My Store dashboard on a narrow-width device (a non-iPad iPhone, in portrait).
2. View the "Last order" card for a store whose most recent order has a long customer name that wraps to two or more lines.
3. Confirm the name is left-aligned, lined up with the order number and date above it.
4. Confirm a short single-line name is still left-aligned and unchanged.

## Screenshots
<!-- Before/after screenshots to be added. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Fixes #14630
