### PR TITLE
Update minimum required WooCommerce plugin version to 10.9.2 for self-driven push notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.1
 -----
+- [Internal] Self-driven push notifications now require WooCommerce 10.9.2 or newer.
 - [*] Order creation product search: the Products/SKU filter now appears below the search bar while you're searching, making SKU search easier to find. [https://github.com/woocommerce/woocommerce-ios/pull/17375]
 - [Internal] Parse all network responses off the main thread to keep the UI responsive on large payloads. [https://github.com/woocommerce/woocommerce-ios/pull/17402]
 - [*] Payments: the balance summary now shows Total balance (available + pending funds) and Available funds [https://github.com/woocommerce/woocommerce-ios/pull/17404]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 
 25.1
 -----
-- [Internal] Self-driven push notifications now require WooCommerce 10.9.2 or newer.
+- [Internal] Self-driven push notifications now require WooCommerce 10.9.2 or newer. [https://github.com/woocommerce/woocommerce-ios/pull/17435]
 - [*] Order creation product search: the Products/SKU filter now appears below the search bar while you're searching, making SKU search easier to find. [https://github.com/woocommerce/woocommerce-ios/pull/17375]
 - [Internal] Parse all network responses off the main thread to keep the UI responsive on large payloads. [https://github.com/woocommerce/woocommerce-ios/pull/17402]
 - [*] Payments: the balance summary now shows Total balance (available + pending funds) and Available funds [https://github.com/woocommerce/woocommerce-ios/pull/17404]

--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -68,7 +68,7 @@ final class WooPushNotificationSetupCoordinator {
 
 enum WooPluginRequirements {
     static let pluginPath = "woocommerce/woocommerce.php"
-    static let minimumVersion = "10.9.0"
+    static let minimumVersion = "10.9.2"
 }
 
 private extension WooPushNotificationSetupCoordinator {


### PR DESCRIPTION
### Description

This bumps the minimum required WooCommerce plugin version for self-driven push notifications from `10.9.0` to `10.9.2`.

### Test Steps

1. Fire up a fresh JN site and install Woo 10.9.1 on it.
2. Install the app and login to that site.
3. Enable the FF.
4. Restart the app.
5. Note the dashboard card should appear.
6. Start the PN enablement
7. It should fail with 10.9.1 needs update.

## Screenshots
<img height="600" alt="image" src="https://github.com/user-attachments/assets/10d4e840-5308-4d30-9491-ccdcc209f683" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.