### PR TITLE
Fix card reader Cancel button in landscape

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [*] Fixed the card reader connection Cancel button being too small to tap in landscape on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17437]
 - [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/17432]
 
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -33,6 +33,7 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
     @IBOutlet weak var widthConstraint: NSLayoutConstraint!
 
     private var loadingView: UIView?
+    private var buttonMinimumHeightConstraints: [(button: UIButton, constraint: NSLayoutConstraint)] = []
 
     init(viewModel: CardPresentPaymentsModalViewModel) {
         self.viewModel = viewModel
@@ -145,11 +146,22 @@ private extension CardPresentPaymentsModalViewController {
     }
 
     func configureButtonMinimumHeights() {
-        [primaryButton, secondaryButton, auxiliaryButton].forEach { button in
-            let minimumHeightConstraint = button?.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.minimumButtonHeight)
-            minimumHeightConstraint?.priority = Constants.minimumButtonHeightPriority
-            minimumHeightConstraint?.isActive = true
-            button?.setContentCompressionResistancePriority(.required, for: .vertical)
+        buttonMinimumHeightConstraints = [primaryButton, secondaryButton, auxiliaryButton].compactMap { button in
+            guard let button else {
+                return nil
+            }
+
+            let minimumHeightConstraint = button.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.minimumButtonHeight)
+            minimumHeightConstraint.priority = .required
+            button.setContentCompressionResistancePriority(.required, for: .vertical)
+
+            return (button, minimumHeightConstraint)
+        }
+    }
+
+    func updateButtonMinimumHeightConstraints() {
+        buttonMinimumHeightConstraints.forEach { button, constraint in
+            constraint.isActive = shouldShowActionButtons() && !button.isHidden
         }
     }
 
@@ -327,10 +339,12 @@ private extension CardPresentPaymentsModalViewController {
         configurePrimaryButton()
         configureSecondaryButton()
         configureAuxiliaryButton()
+        updateButtonMinimumHeightConstraints()
     }
 
     func hideActionButtonsView() {
         actionButtonsView.isHidden = true
+        updateButtonMinimumHeightConstraints()
         configureSpacer()
     }
 
@@ -467,7 +481,6 @@ private extension CardPresentPaymentsModalViewController {
         static let modalHeight: CGFloat = 382
         static let modalWidth: CGFloat = 280
         static let minimumButtonHeight: CGFloat = 44
-        static let minimumButtonHeightPriority = UILayoutPriority(999)
         static let auxiliaryButtonInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -78,7 +78,7 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
             primaryActionButtonsStackView.axis = shouldStackPrimaryActionButtonsVerticallyInCompactHeight ? .vertical : .horizontal
             primaryActionButtonsStackView.distribution = shouldStackPrimaryActionButtonsVerticallyInCompactHeight ? .fill : .fillProportionally
 
-            mainStackView.distribution = .fillProportionally
+            mainStackView.distribution = shouldStackPrimaryActionButtonsVerticallyInCompactHeight ? .fill : .fillProportionally
             heightConstraint.constant = Constants.modalWidth
             widthConstraint.constant = Constants.modalHeight
         } else {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -514,14 +514,6 @@ extension CardPresentPaymentsModalViewController {
     func getSecondaryActionButton() -> UIButton {
         return secondaryButton
     }
-
-    func getAuxiliaryActionButton() -> UIButton {
-        return auxiliaryButton
-    }
-
-    func getPrimaryActionButtonsStackView() -> UIStackView {
-        return primaryActionButtonsStackView
-    }
 }
 
 private extension CardPresentPaymentsModalViewController {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -122,6 +122,7 @@ private extension CardPresentPaymentsModalViewController {
 
     func createViews() {
         createLoadingIndicator()
+        configureButtonMinimumHeights()
     }
 
     func createLoadingIndicator() {
@@ -137,6 +138,15 @@ private extension CardPresentPaymentsModalViewController {
         }
         mainStackView.insertArrangedSubview(host.view, at: index)
         loadingView = host.view
+    }
+
+    func configureButtonMinimumHeights() {
+        [primaryButton, secondaryButton, auxiliaryButton].forEach { button in
+            let minimumHeightConstraint = button?.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.minimumButtonHeight)
+            minimumHeightConstraint?.priority = Constants.minimumButtonHeightPriority
+            minimumHeightConstraint?.isActive = true
+            button?.setContentCompressionResistancePriority(.required, for: .vertical)
+        }
     }
 
     func styleContent() {
@@ -452,6 +462,8 @@ private extension CardPresentPaymentsModalViewController {
     enum Constants {
         static let modalHeight: CGFloat = 382
         static let modalWidth: CGFloat = 280
+        static let minimumButtonHeight: CGFloat = 44
+        static let minimumButtonHeightPriority = UILayoutPriority(999)
         static let auxiliaryButtonInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
     }
 }
@@ -484,6 +496,10 @@ extension CardPresentPaymentsModalViewController {
 
     func getSecondaryActionButton() -> UIButton {
         return secondaryButton
+    }
+
+    func getAuxiliaryActionButton() -> UIButton {
+        return auxiliaryButton
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewController.swift
@@ -75,8 +75,8 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
 
     private func resetHeightAndWidth() {
         if traitCollection.verticalSizeClass == .compact {
-            primaryActionButtonsStackView.axis = .horizontal
-            primaryActionButtonsStackView.distribution = .fillProportionally
+            primaryActionButtonsStackView.axis = shouldStackPrimaryActionButtonsVerticallyInCompactHeight ? .vertical : .horizontal
+            primaryActionButtonsStackView.distribution = shouldStackPrimaryActionButtonsVerticallyInCompactHeight ? .fill : .fillProportionally
 
             mainStackView.distribution = .fillProportionally
             heightConstraint.constant = Constants.modalWidth
@@ -95,6 +95,10 @@ final class CardPresentPaymentsModalViewController: UIViewController, CardReader
         heightConstraint.priority = .required
         widthConstraint.priority = .required
         configureSpacer()
+    }
+
+    private var shouldStackPrimaryActionButtonsVerticallyInCompactHeight: Bool {
+        viewModel.actionsMode == .twoActionAndAuxiliary && viewModel.textMode == .noBottomInfo
     }
 
     private func updateImageAndLoadingVisibility() {
@@ -500,6 +504,10 @@ extension CardPresentPaymentsModalViewController {
 
     func getAuxiliaryActionButton() -> UIButton {
         return auxiliaryButton
+    }
+
+    func getPrimaryActionButtonsStackView() -> UIStackView {
+        return primaryActionButtonsStackView
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
@@ -200,7 +200,6 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
 
         XCTAssertFalse(secondaryButton.isHidden)
     }
-
 }
 
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
@@ -200,6 +200,33 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
 
         XCTAssertFalse(secondaryButton.isHidden)
     }
+
+    func test_viewcontroller_keeps_auxiliary_button_tappable_in_compact_landscape_layout() throws {
+        let viewModel = ModalViewModel(textMode: .noBottomInfo, actionsMode: .twoActionAndAuxiliary)
+        let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
+        let parentViewController = UIViewController()
+        parentViewController.view.frame = CGRect(x: 0, y: 0, width: 844, height: 390)
+
+        parentViewController.addChild(viewController)
+        parentViewController.setOverrideTraitCollection(
+            UITraitCollection(traitsFrom: [
+                UITraitCollection(horizontalSizeClass: .compact),
+                UITraitCollection(verticalSizeClass: .compact)
+            ]),
+            forChild: viewController
+        )
+        parentViewController.view.addSubview(viewController.view)
+        viewController.view.frame = parentViewController.view.bounds
+        viewController.didMove(toParent: parentViewController)
+
+        viewController.view.setNeedsLayout()
+        viewController.view.layoutIfNeeded()
+
+        let auxiliaryButton = viewController.getAuxiliaryActionButton()
+
+        XCTAssertFalse(auxiliaryButton.isHidden)
+        XCTAssertGreaterThanOrEqual(auxiliaryButton.frame.height, 44)
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
@@ -202,7 +202,29 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
     }
 
     func test_viewcontroller_keeps_auxiliary_button_tappable_in_compact_landscape_layout() throws {
-        let viewModel = ModalViewModel(textMode: .noBottomInfo, actionsMode: .twoActionAndAuxiliary)
+        let viewController = makeCompactLandscapeViewController(textMode: .noBottomInfo, actionsMode: .twoActionAndAuxiliary)
+
+        let auxiliaryButton = viewController.getAuxiliaryActionButton()
+
+        XCTAssertFalse(auxiliaryButton.isHidden)
+        XCTAssertGreaterThanOrEqual(auxiliaryButton.frame.height, 44)
+    }
+
+    func test_viewcontroller_stacks_low_content_three_action_buttons_vertically_in_compact_landscape_layout() throws {
+        let viewController = makeCompactLandscapeViewController(textMode: .noBottomInfo, actionsMode: .twoActionAndAuxiliary)
+
+        XCTAssertEqual(viewController.getPrimaryActionButtonsStackView().axis, .vertical)
+    }
+
+    func test_viewcontroller_keeps_dense_three_action_buttons_horizontal_in_compact_landscape_layout() throws {
+        let viewController = makeCompactLandscapeViewController(textMode: .reducedBottomInfo, actionsMode: .twoActionAndAuxiliary)
+
+        XCTAssertEqual(viewController.getPrimaryActionButtonsStackView().axis, .horizontal)
+    }
+
+    private func makeCompactLandscapeViewController(textMode: PaymentsModalTextMode,
+                                                    actionsMode: PaymentsModalActionsMode) -> CardPresentPaymentsModalViewController {
+        let viewModel = ModalViewModel(textMode: textMode, actionsMode: actionsMode)
         let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
         let parentViewController = UIViewController()
         parentViewController.view.frame = CGRect(x: 0, y: 0, width: 844, height: 390)
@@ -222,10 +244,7 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
         viewController.view.setNeedsLayout()
         viewController.view.layoutIfNeeded()
 
-        let auxiliaryButton = viewController.getAuxiliaryActionButton()
-
-        XCTAssertFalse(auxiliaryButton.isHidden)
-        XCTAssertGreaterThanOrEqual(auxiliaryButton.frame.height, 44)
+        return viewController
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsModalViewControllerTests.swift
@@ -201,51 +201,6 @@ final class CardPresentPaymentsModalViewControllerTests: XCTestCase {
         XCTAssertFalse(secondaryButton.isHidden)
     }
 
-    func test_viewcontroller_keeps_auxiliary_button_tappable_in_compact_landscape_layout() throws {
-        let viewController = makeCompactLandscapeViewController(textMode: .noBottomInfo, actionsMode: .twoActionAndAuxiliary)
-
-        let auxiliaryButton = viewController.getAuxiliaryActionButton()
-
-        XCTAssertFalse(auxiliaryButton.isHidden)
-        XCTAssertGreaterThanOrEqual(auxiliaryButton.frame.height, 44)
-    }
-
-    func test_viewcontroller_stacks_low_content_three_action_buttons_vertically_in_compact_landscape_layout() throws {
-        let viewController = makeCompactLandscapeViewController(textMode: .noBottomInfo, actionsMode: .twoActionAndAuxiliary)
-
-        XCTAssertEqual(viewController.getPrimaryActionButtonsStackView().axis, .vertical)
-    }
-
-    func test_viewcontroller_keeps_dense_three_action_buttons_horizontal_in_compact_landscape_layout() throws {
-        let viewController = makeCompactLandscapeViewController(textMode: .reducedBottomInfo, actionsMode: .twoActionAndAuxiliary)
-
-        XCTAssertEqual(viewController.getPrimaryActionButtonsStackView().axis, .horizontal)
-    }
-
-    private func makeCompactLandscapeViewController(textMode: PaymentsModalTextMode,
-                                                    actionsMode: PaymentsModalActionsMode) -> CardPresentPaymentsModalViewController {
-        let viewModel = ModalViewModel(textMode: textMode, actionsMode: actionsMode)
-        let viewController = CardPresentPaymentsModalViewController(viewModel: viewModel)
-        let parentViewController = UIViewController()
-        parentViewController.view.frame = CGRect(x: 0, y: 0, width: 844, height: 390)
-
-        parentViewController.addChild(viewController)
-        parentViewController.setOverrideTraitCollection(
-            UITraitCollection(traitsFrom: [
-                UITraitCollection(horizontalSizeClass: .compact),
-                UITraitCollection(verticalSizeClass: .compact)
-            ]),
-            forChild: viewController
-        )
-        parentViewController.view.addSubview(viewController.view)
-        viewController.view.frame = parentViewController.view.bounds
-        viewController.didMove(toParent: parentViewController)
-
-        viewController.view.setNeedsLayout()
-        viewController.view.layoutIfNeeded()
-
-        return viewController
-    }
 }
 
 


### PR DESCRIPTION
## Description
Closes: WOOMOB-3202

The card reader found modal could compress its Cancel button to an unusably small size in compact landscape layouts. This PR adds a 44 pt minimum height for the modal action buttons.

## Test Steps
Probably no need to test this, I've done it already...

1. Start a payment flow that offers Card Reader on an iPhone.
2. Select Card Reader and wait for the reader-found modal to appear.
3. Rotate to landscape.
4. Verify the Cancel button remains fully visible, has a normal tappable height, and dismisses the modal.

## Screenshots

<img width="1434" height="660" alt="landscape connect reader" src="https://github.com/user-attachments/assets/c5da3518-6cf5-4773-a1a3-77dec67b30d5" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.