### PR TITLE
Clarify Tap to Pay trial payment copy

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewController.swift
@@ -178,9 +178,10 @@ private enum Localization {
     )
 
     static let hintThree = NSLocalizedString(
-        "Try a payment using your own card (and refund it when you're done.)",
+        "setUpTapToPayInformation.tryPayment.hint",
+        value: "Try a live payment using your own card (and refund it when you're done; processing fees apply.)",
         comment: "Settings > Set up Tap to Pay on iPhone > Information > Hint to try out payments " +
-        "using their own card"
+        "using their own card, which creates a live transaction and incurs processing fees"
     )
 
     static let setUpButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -163,15 +163,17 @@ private enum Constants {
 private extension SetUpTapToPayPaymentPromptView {
     enum Localization {
         static let setUpTryPaymentPromptTitle = NSLocalizedString(
-            "Would you like to try a payment",
+            "setUpTapToPayPaymentPrompt.title",
+            value: "Would you like to try a payment?",
             comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Inform user that " +
             "Tap to Pay on iPhone is ready"
         )
 
         static let setUpTryPaymentPromptDescription = NSLocalizedString(
-            "Try a %1$@ payment with your debit or credit card. You can refund the payment when you’re done.",
+            "setUpTapToPayPaymentPrompt.description",
+            value: "Try a %1$@ live payment with your debit or credit card. You can refund the payment when you're done; processing fees apply.",
             comment: "Settings > Set up Tap to Pay on iPhone > Try a Payment > Description. %1$@ will be replaced " +
-            "with the amount of the trial payment, in the store's currency."
+            "with the amount of the trial payment, in the store's currency. The trial payment is a live transaction and incurs processing fees."
         )
 
         static let tryAPaymentButton = NSLocalizedString(


### PR DESCRIPTION
WOOMOB-2727

## Description
Clarifies the Tap to Pay text, so merchants understand the optional "Try a payment" is a live transaction, and processing fees apply.

## Test Steps
Just string changes, it's fine not to test.

1. Start the Tap to Pay on iPhone setup flow.
2. On the setup information screen, confirm the try-payment hint mentions a live payment and processing fees.
3. Complete setup and confirm the try-payment prompt title includes a question mark.
4. Confirm the prompt body describes a live payment and says processing fees apply.

## Screenshots

<img width="660" height="1434" alt="Try a payment wording changes" src="https://github.com/user-attachments/assets/fc6264b5-e10a-4b84-8500-a979c0151395" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
