### PR TITLE
Improve product thumbnail placeholders in orders

### DIFF
--- a/WooCommerce/Classes/Extensions/ProductImageThumbnail+Extensions.swift
+++ b/WooCommerce/Classes/Extensions/ProductImageThumbnail+Extensions.swift
@@ -1,12 +1,54 @@
 import SwiftUI
+import UIKit
 import struct WooFoundation.ProductImageThumbnail
 
-// Convenience initializer that maintains the default behavior.
-extension ProductImageThumbnail where Placeholder == Image {
+enum ProductThumbnailStyle {
+    private static let cornerRadius: CGFloat = 2
+    private static let borderWidth: CGFloat = 0.5
+    static let placeholderImage: UIImage = .productsTabProductCellPlaceholderImage
+    private static let backgroundColor: UIColor = .listForeground(modal: false)
+    private static let borderColor: UIColor = .border
+    private static let placeholderContentMode: UIView.ContentMode = .center
+    private static let imageContentMode: UIView.ContentMode = .scaleAspectFill
+}
+
+extension UIImageView {
+    func applyProductThumbnailStyle() {
+        backgroundColor = ProductThumbnailStyle.backgroundColor
+        layer.cornerRadius = ProductThumbnailStyle.cornerRadius
+        layer.borderWidth = ProductThumbnailStyle.borderWidth
+        refreshProductThumbnailBorderColor()
+        clipsToBounds = true
+    }
+
+    func removeProductThumbnailStyle() {
+        backgroundColor = nil
+        layer.cornerRadius = 0
+        layer.borderWidth = 0
+        layer.borderColor = nil
+        clipsToBounds = true
+    }
+
+    func showProductThumbnailPlaceholder() {
+        image = ProductThumbnailStyle.placeholderImage
+        contentMode = ProductThumbnailStyle.placeholderContentMode
+    }
+
+    func showProductThumbnailImage() {
+        contentMode = ProductThumbnailStyle.imageContentMode
+    }
+
+    func refreshProductThumbnailBorderColor() {
+        layer.borderColor = ProductThumbnailStyle.borderColor.cgColor
+    }
+}
+
+// Convenience initializer for the app's default product thumbnail placeholder.
+extension ProductImageThumbnail where Placeholder == ProductImageThumbnailPlaceholder {
     init(productImageURL: URL?,
          productImageSize: CGFloat,
          scale: CGFloat,
-         productImageCornerRadius: CGFloat = 0,
+         productImageCornerRadius: CGFloat = ProductThumbnailStyle.cornerRadius,
          foregroundColor: Color,
          cachesOriginalImage: Bool = false) {
         self.init(productImageURL: productImageURL,
@@ -15,7 +57,36 @@ extension ProductImageThumbnail where Placeholder == Image {
                  productImageCornerRadius: productImageCornerRadius,
                  foregroundColor: foregroundColor,
                  cachesOriginalImage: cachesOriginalImage) {
-            Image(uiImage: .productPlaceholderImage)
+            ProductImageThumbnailPlaceholder(productImageSize: productImageSize,
+                                             scale: scale,
+                                             cornerRadius: productImageCornerRadius)
         }
+    }
+}
+
+struct ProductImageThumbnailPlaceholder: View {
+    private let productImageSize: CGFloat
+    private let scale: CGFloat
+    private let cornerRadius: CGFloat
+
+    init(productImageSize: CGFloat,
+         scale: CGFloat,
+         cornerRadius: CGFloat) {
+        self.productImageSize = productImageSize
+        self.scale = scale
+        self.cornerRadius = cornerRadius
+    }
+
+    var body: some View {
+        Image(uiImage: ProductThumbnailStyle.placeholderImage)
+            .frame(width: productImageSize * scale, height: productImageSize * scale)
+            .background {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(Color(ProductThumbnailStyle.backgroundColor))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(Color(ProductThumbnailStyle.borderColor), lineWidth: ProductThumbnailStyle.borderWidth)
+            }
     }
 }

--- a/WooCommerce/Classes/Extensions/ProductImageThumbnail+Extensions.swift
+++ b/WooCommerce/Classes/Extensions/ProductImageThumbnail+Extensions.swift
@@ -3,13 +3,13 @@ import UIKit
 import struct WooFoundation.ProductImageThumbnail
 
 enum ProductThumbnailStyle {
-    private static let cornerRadius: CGFloat = 2
-    private static let borderWidth: CGFloat = 0.5
+    fileprivate static let cornerRadius: CGFloat = 2
+    fileprivate static let borderWidth: CGFloat = 0.5
     static let placeholderImage: UIImage = .productsTabProductCellPlaceholderImage
-    private static let backgroundColor: UIColor = .listForeground(modal: false)
-    private static let borderColor: UIColor = .border
-    private static let placeholderContentMode: UIView.ContentMode = .center
-    private static let imageContentMode: UIView.ContentMode = .scaleAspectFill
+    fileprivate static let backgroundColor: UIColor = .listForeground(modal: false)
+    fileprivate static let borderColor: UIColor = .border
+    fileprivate static let placeholderContentMode: UIView.ContentMode = .center
+    fileprivate static let imageContentMode: UIView.ContentMode = .scaleAspectFill
 }
 
 extension UIImageView {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -156,7 +156,6 @@ private struct CollapsibleProductRowCard: View {
                                           productImageSize: viewModel.hasParentProduct ?
                                           Layout.childProductImageSize : Layout.parentProductImageSize,
                                           scale: scale,
-                                          productImageCornerRadius: Layout.productImageCornerRadius,
                                           foregroundColor: Color(UIColor.listSmallIcon))
                     .padding(.leading, viewModel.hasParentProduct ? Layout.childLeadingPadding : 0)
                     .overlay(alignment: .topTrailing) {
@@ -415,7 +414,6 @@ private extension CollapsibleProductRowCard {
         static let borderLineWidth: CGFloat = 1
         static let parentProductImageSize: CGFloat = 56.0
         static let childProductImageSize: CGFloat = 40.0
-        static let productImageCornerRadius: CGFloat = 4.0
         static let iconSize: CGFloat = 16
         static let deleteIconSize: CGFloat = 24.0
         static let rowMinHeight: CGFloat = 40.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
@@ -22,7 +22,6 @@ struct ProductDiscountView: View {
                     ProductImageThumbnail(productImageURL: viewModel.imageURL,
                                           productImageSize: Layout.productImageSize,
                                           scale: 1,
-                                          productImageCornerRadius: Layout.frameCornerRadius,
                                           foregroundColor: Color(UIColor.listSmallIcon))
                     VStack(alignment: .leading) {
                         Text(viewModel.name)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/Product Details/PickListTableViewCell.swift
@@ -91,6 +91,7 @@ final class PickListTableViewCell: UITableViewCell {
         setupQuantityLabel()
         setupSkuLabel()
         setupAddOnViews()
+        observeInterfaceTraitChanges()
     }
 
     override func prepareForReuse() {
@@ -112,11 +113,17 @@ extension PickListTableViewCell {
     /// Configure a pick list cell
     ///
     func configure(item: ProductDetailsCellViewModel, imageService: ImageService) {
+        productImageView.applyProductThumbnailStyle()
+        productImageView.showProductThumbnailPlaceholder()
         imageService.downloadAndCacheImageForImageView(productImageView,
                                                        with: item.imageURL?.absoluteString,
-                                                       placeholder: UIImage.productPlaceholderImage.imageWithTintColor(UIColor.listIcon),
+                                                       placeholder: ProductThumbnailStyle.placeholderImage,
                                                        progressBlock: nil,
-                                                       completion: nil)
+                                                       completion: { [weak self] image, error in
+                                                           if image != nil && error == nil {
+                                                               self?.productImageView.showProductThumbnailImage()
+                                                           }
+                                                       })
         name = item.name
         quantity = item.quantity
         viewAddOnsStackView.isHidden = !item.hasAddOns
@@ -139,10 +146,8 @@ private extension PickListTableViewCell {
     }
 
     func setupImageView() {
-        productImageView.image = .productImage
-        productImageView.tintColor = .listSmallIcon
-        productImageView.contentMode = .scaleAspectFill
-        productImageView.clipsToBounds = true
+        productImageView.applyProductThumbnailStyle()
+        productImageView.showProductThumbnailPlaceholder()
     }
 
     func setupNameLabel() {
@@ -177,6 +182,16 @@ private extension PickListTableViewCell {
             self?.onViewAddOnsTouchUp?()
         }
         viewAddOnsStackView.addGestureRecognizer(tapRecognizer)
+    }
+
+    func observeInterfaceTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitUserInterfaceStyle.self,
+            UITraitAccessibilityContrast.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
+            self.productImageView.refreshProductThumbnailBorderColor()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Product List Section/ProductDetailsTableViewCell.swift
@@ -71,6 +71,7 @@ final class ProductDetailsTableViewCell: UITableViewCell {
         configureSelectionStyle()
         configureAttributesStackView()
         configureAddOnViews()
+        observeInterfaceTraitChanges()
     }
 
     override func updateConfiguration(using state: UICellConfigurationState) {
@@ -86,10 +87,8 @@ private extension ProductDetailsTableViewCell {
     }
 
     func configureProductImageView() {
-        productImageView.image = UIImage.productPlaceholderImage
-        productImageView.tintColor = .listSmallIcon
-        productImageView.contentMode = .scaleAspectFill
-        productImageView.clipsToBounds = true
+        productImageView.applyProductThumbnailStyle()
+        productImageView.showProductThumbnailPlaceholder()
     }
 
     func configureNameLabel() {
@@ -139,6 +138,16 @@ private extension ProductDetailsTableViewCell {
         selectionStyle = .none
     }
 
+    func observeInterfaceTraitChanges() {
+        let traits: [UITrait] = [
+            UITraitUserInterfaceStyle.self,
+            UITraitAccessibilityContrast.self
+        ]
+        registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
+            self.productImageView.refreshProductThumbnailBorderColor()
+        }
+    }
+
     /// Adds padding between the leading margin and the product image if the product is a child product.
     ///
     func configureChildProductPadding(isChildProduct: Bool) {
@@ -185,11 +194,17 @@ extension ProductDetailsTableViewCell {
     /// Configure a product detail cell
     ///
     func configure(item: ProductDetailsCellViewModel, imageService: ImageService) {
+        productImageView.applyProductThumbnailStyle()
+        productImageView.showProductThumbnailPlaceholder()
         imageService.downloadAndCacheImageForImageView(productImageView,
                                                        with: item.imageURL?.absoluteString,
-                                                       placeholder: UIImage.productPlaceholderImage.imageWithTintColor(UIColor.listIcon),
+                                                       placeholder: ProductThumbnailStyle.placeholderImage,
                                                        progressBlock: nil,
-                                                       completion: nil)
+                                                       completion: { [weak self] image, error in
+                                                           if image != nil && error == nil {
+                                                               self?.productImageView.showProductThumbnailImage()
+                                                           }
+                                                       })
 
         nameLabel.text = item.name
         priceLabel.text = item.total
@@ -202,7 +217,9 @@ extension ProductDetailsTableViewCell {
 
     func configure(customAmountViewModel: OrderDetailsCustomAmountCellViewModel) {
         nameLabel.text = customAmountViewModel.name
+        productImageView.removeProductThumbnailStyle()
         productImageView.image = customAmountViewModel.image
+        productImageView.showProductThumbnailImage()
         priceLabel.text = customAmountViewModel.total
         subtitleLabel.text = Localization.customAmount
         viewAddOnsStackView.isHidden = true

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -99,15 +99,15 @@ extension ProductsTabProductTableViewCell {
             /// Make sure `productImageView` is laid out and gained bounds
             productImageView.layoutIfNeeded()
 
-            productImageView.image = .productsTabProductCellPlaceholderImage
+            productImageView.image = ProductThumbnailStyle.placeholderImage
             if let productURLString = viewModel.imageUrl {
                 imageService.downloadAndCacheImageForImageView(productImageView,
                                                                with: productURLString,
-                                                               placeholder: .productsTabProductCellPlaceholderImage,
+                                                               placeholder: ProductThumbnailStyle.placeholderImage,
                                                                progressBlock: nil) { [weak self] image, error in
                                                                 let success = image != nil && error == nil
                                                                 if success {
-                                                                    self?.productImageView.contentMode = .scaleAspectFill
+                                                                    self?.productImageView.showProductThumbnailImage()
                                                                 }
                 }
             }
@@ -193,13 +193,7 @@ private extension ProductsTabProductTableViewCell {
     }
 
     func configureProductImageView() {
-
-        productImageView.backgroundColor = Colors.imageBackgroundColor
-        productImageView.tintColor = Colors.imagePlaceholderTintColor
-        productImageView.layer.cornerRadius = Constants.cornerRadius
-        productImageView.layer.borderWidth = Constants.borderWidth
-        productImageView.layer.borderColor = Colors.imageBorderColor.cgColor
-        productImageView.clipsToBounds = true
+        productImageView.applyProductThumbnailStyle()
 
         // This multiplier matches the required size(37.5pt) for a 375pt(as per designs) content view width
         let widthConstraint = productImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.1)
@@ -271,7 +265,7 @@ private extension ProductsTabProductTableViewCell {
             UITraitAccessibilityContrast.self
         ]
         registerForTraitChanges(traits) { (self: Self, _: UITraitCollection) in
-            self.productImageView.layer.borderColor = Colors.imageBorderColor.cgColor
+            self.productImageView.refreshProductThumbnailBorderColor()
         }
     }
 }
@@ -280,19 +274,11 @@ private extension ProductsTabProductTableViewCell {
 ///
 private extension ProductsTabProductTableViewCell {
     enum Constants {
-        static let cornerRadius = CGFloat(2.0)
-        static let borderWidth = CGFloat(0.5)
         static let stackViewInset = CGFloat(16)
         /// Fixed side length for the square drag-handle icon shown in draggable cells.
         static let draggableIconLength = CGFloat(40)
         static let nameLabelDefaultMinimumHeight = CGFloat(20)
         static let detailsLabelDefaultMinimumHeight = CGFloat(16)
-    }
-
-    enum Colors {
-        static let imageBorderColor = UIColor.border
-        static let imagePlaceholderTintColor = UIColor.systemColor(.systemGray2)
-        static let imageBackgroundColor = UIColor.listForeground(modal: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -50,7 +50,6 @@ struct ProductRow: View {
             ProductImageThumbnail(productImageURL: viewModel.imageURL,
                                   productImageSize: Layout.productImageSize,
                                   scale: scale,
-                                  productImageCornerRadius: Layout.cornerRadius,
                                   foregroundColor: Color(UIColor.listSmallIcon))
 
             // Product details
@@ -117,7 +116,6 @@ extension ProductRow {
 private extension ProductRow {
     enum Layout {
         static let productImageSize: CGFloat = 48.0
-        static let cornerRadius: CGFloat = 4.0
         static let checkImageSize: CGFloat = 24.0
     }
 }


### PR DESCRIPTION
## Description
Closes WOOMOB-3186

Updates product thumbnail placeholders used by order creation, Select Products, and Order Details product rows to match the Products tab styling. 

Empty product images now render as a centered icon inside the same border as on the products tab.

## Test Steps
Feel free to validate from the video...

1. Open Orders and create a New Order.
2. Tap Add Products and search for a product with no image.
3. Verify the placeholder in Select Products matches the Products tab thumbnail styling in light and dark mode.
4. Add the product and verify the order form row uses the same thumbnail styling.
5. Open an order with a product that has no image and verify the Order Details product rows use the same framed placeholder.
6. Verify products with images still render normally.

## Screenshots


https://github.com/user-attachments/assets/55660004-705c-48be-ba7e-aacd4dbb9d59


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.