### PR TITLE
CIAB clean-up 1: Blaze & Shipping labels

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -13,18 +13,15 @@ protocol BlazeEligibilityCheckerProtocol {
 /// Checks for Blaze eligibility for a site and its products.
 final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
     private let stores: StoresManager
-    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
 
     /// In-flight eligibility checks keyed by siteID, shared across all instances.
     /// Thread-safe because all access is on @MainActor.
     private static var inFlightChecks: [Int64: Task<Bool, Never>] = [:]
 
     init(
-        stores: StoresManager = ServiceLocator.stores,
-        siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker()
+        stores: StoresManager = ServiceLocator.stores
     ) {
         self.stores = stores
-        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
     }
 
     /// Checks if the site is eligible for Blaze.
@@ -69,8 +66,7 @@ private extension BlazeEligibilityChecker {
     func checkSiteEligibility(_ site: Site) async -> Bool {
         guard
             site.isAdmin,
-            site.canBlaze,
-            siteCIABEligibilityChecker.isFeatureSupported(.blaze, for: site)
+            site.canBlaze
         else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -104,7 +104,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
     private let defaults: UserDefaults
     private let pushNotesManager: PushNotesManager
     private let analytics: Analytics
-    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
     private let pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking
 
     private var isSelfDrivenPNEligible = false
@@ -121,7 +120,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
          defaults: UserDefaults = .standard,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          analytics: Analytics = ServiceLocator.analytics,
-         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          pushNotificationEligibilityChecker: WooPushNotificationEligibilityChecking = WooPushNotificationEligibilityCheck()) {
         self.stores = stores
         self.storageManager = storageManager
@@ -129,7 +127,6 @@ final class SettingsViewModel: SettingsViewModelOutput, SettingsViewModelActions
         self.defaults = defaults
         self.pushNotesManager = pushNotesManager
         self.analytics = analytics
-        self.ciabEligibilityChecker = ciabEligibilityChecker
         self.pushNotificationEligibilityChecker = pushNotificationEligibilityChecker
 
         /// Initialize Sites Results Controller
@@ -267,11 +264,6 @@ private extension SettingsViewModel {
             // Show the plugins section only if the user has an `admin` role for the default store site.
             //
             guard stores.sessionManager.defaultRoles.contains(.administrator) else {
-                return nil
-            }
-
-            // Hide plugins section for CIAB sites
-            guard !ciabEligibilityChecker.isCurrentSiteCIAB else {
                 return nil
             }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModel.swift
@@ -257,10 +257,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         )
     }()
 
-    /// Provides checks for CIAB
-    /// Used to determine "Split Shipments" feature availability
-    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
-
     /// Initialize the view model with or without an existing shipping label.
     init(order: Order,
          preselection: WooShippingCreateLabelSelection? = nil,
@@ -269,7 +265,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
-         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          initialNoticeDelay: RunLoop.SchedulerTimeType.Stride = .seconds(2),
          onLabelPurchase: ((Bool) -> Void)? = nil) {
         self.order = order
@@ -286,7 +281,6 @@ final class WooShippingCreateLabelsViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics
-        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         self.shippingSettingsService = shippingSettingsService
         self.weightUnit = shippingSettingsService.weightUnit ?? ""
         self.dimensionsUnit = shippingSettingsService.dimensionUnit ?? ""
@@ -568,20 +562,14 @@ extension WooShippingCreateLabelsViewModel {
         return itemsDataSource.items.map(\.quantity).reduce(0, +) > 1
     }
 
-    private var splitShipmentsFeatureAvailable: Bool {
-        return siteCIABEligibilityChecker.isFeatureSupportedForCurrentSite(.splitShipments)
-    }
-
     /// Determines if the "Edit split shipments" (pencil icon) is visible in top shipments bar.
     var editSplitShipmentsOptionVisible: Bool {
-        splitShipmentsFeatureAvailable &&
         hasMultipleProducts &&
         hasUnfulfilledShipments
     }
 
     /// Determines if the "Split Shipments" row is visible above the "Products" section
     var splitShipmentsRowVisible: Bool {
-        splitShipmentsFeatureAvailable &&
         hasMultipleProducts &&
         shipments.count == 1 &&
         canViewLabel == false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
@@ -131,53 +131,6 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         XCTAssertTrue(isEligible)
     }
 
-    @MainActor
-    func test_isEligible_is_true_when_site_is_non_ciab_and_other_requirements_met() async {
-        // Given
-        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
-        let site = mockSite(isEligibleForBlaze: true,
-                            isJetpackThePluginInstalled: false,
-                            isJetpackConnected: true)
-        let siteIsCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-        )
-        let blazeEligibilityChecker = BlazeEligibilityChecker(
-            stores: stores,
-            siteCIABEligibilityChecker: siteIsCIABChecker
-        )
-        mockPluginFetch(remotePlugin: .fake().copy(plugin: Self.pluginSlug, active: true))
-
-        // When
-        let isEligible = await blazeEligibilityChecker.isSiteEligible(site)
-
-        // Then
-        XCTAssertTrue(isEligible)
-    }
-
-    @MainActor
-    func test_isEligible_is_false_when_site_is_ciab_and_other_requirements_met() async {
-        // Given
-        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
-        let site = mockSite(isEligibleForBlaze: true,
-                            isJetpackThePluginInstalled: false,
-                            isJetpackConnected: true)
-        let siteIsCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: true,
-            mockedCIABSites: [site]
-        )
-        let blazeEligibilityChecker = BlazeEligibilityChecker(
-            stores: stores,
-            siteCIABEligibilityChecker: siteIsCIABChecker
-        )
-        mockPluginFetch(remotePlugin: .fake().copy(plugin: Self.pluginSlug, active: true))
-
-        // When
-        let isEligible = await blazeEligibilityChecker.isSiteEligible(site)
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
     // MARK: - `isProductEligible`
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -107,52 +107,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_canShowInDashboard_returns_false_if_store_is_ciab_and_other_requirements_met() async {
-        // Given
-
-        let site = Site.fake().copy(
-            siteID: sampleSiteID,
-            isJetpackThePluginInstalled: true,
-            isJetpackConnected: true,
-            canBlaze: true,
-            isAdmin: true,
-        )
-
-        stores.updateDefaultStore(site)
-
-        let siteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: true,
-            mockedCIABSites: [stores.sessionManager.defaultSite ?? .fake()]
-        )
-        let blazeEligibilityChecker = BlazeEligibilityChecker(
-            stores: stores,
-            siteCIABEligibilityChecker: siteCIABChecker
-        )
-        let sut = BlazeCampaignDashboardViewModel(
-            siteID: sampleSiteID,
-            stores: stores,
-            storageManager: storageManager,
-            blazeEligibilityChecker: blazeEligibilityChecker
-        )
-
-        mockSynchronizeProducts(
-            insertProductToStorage: .fake().copy(
-                siteID: sampleSiteID,
-                statusKey: (ProductStatus.published.rawValue)
-            )
-        )
-
-        mockSynchronizeCampaignsList()
-
-        // When
-        await sut.checkAvailability()
-
-        // Then
-        XCTAssertFalse(sut.canShowInDashboard)
-    }
-
-    @MainActor
-    func test_canShowInDashboard_returns_true_if_store_is_non_ciab_and_other_requirements_met() async {
+    func test_canShowInDashboard_returns_true_if_store_meets_blaze_requirements() async {
         // Given
         let site = Site.fake().copy(
             siteID: sampleSiteID,
@@ -164,17 +119,11 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         stores.updateDefaultStore(site)
 
-        let siteCIABChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
-        let blazeEligibilityChecker = BlazeEligibilityChecker(
-            stores: stores,
-            siteCIABEligibilityChecker: siteCIABChecker
-        )
-
         let sut = BlazeCampaignDashboardViewModel(
             siteID: sampleSiteID,
             stores: stores,
             storageManager: storageManager,
-            blazeEligibilityChecker: blazeEligibilityChecker
+            blazeEligibilityChecker: BlazeEligibilityChecker(stores: stores)
         )
 
         mockSynchronizeProducts(

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -459,27 +459,11 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.connectivity) })
     }
 
-    func test_sections_do_not_contain_plugins_when_site_is_CIAB() {
+    func test_sections_contain_plugins_when_user_is_admin() {
         // Given
         let viewModel = SettingsViewModel(
             stores: stores,
-            storageManager: storageManager,
-            ciabEligibilityChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true))
-
-        // When
-        viewModel.onViewDidLoad()
-
-        // Then
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.plugins) })
-        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.woocommerceDetails) })
-    }
-
-    func test_sections_contain_plugins_when_site_is_not_CIAB_and_user_is_admin() {
-        // Given
-        let viewModel = SettingsViewModel(
-            stores: stores,
-            storageManager: storageManager,
-            ciabEligibilityChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false))
+            storageManager: storageManager)
 
         // When
         viewModel.onViewDidLoad()
@@ -495,8 +479,7 @@ final class SettingsViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
         let viewModel = SettingsViewModel(
             stores: stores,
-            storageManager: storageManager,
-            ciabEligibilityChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false))
+            storageManager: storageManager)
 
         // When
         viewModel.onViewDidLoad()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingCreateLabelsViewModelTests.swift
@@ -1458,72 +1458,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         }
     }
 
-    func test_splitShipmentsRowVisible_is_false_when_split_shipments_feature_is_unavailable() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Is CIAB site with the `.splitShipments` disabled
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: true,
-            mockedCIABDisabledFeatures: [.splitShipments]
-        )
-
-        /// Multiple products
-        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
-        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
-
-        storageManager.insertSampleProduct(readOnlyProduct: product1)
-        storageManager.insertSampleProduct(readOnlyProduct: product2)
-
-        let order = Order.fake().copy(
-            siteID: siteID,
-            orderID: orderID,
-            items: [
-                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
-                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
-            ])
-
-        /// Single unfulfilled shipment
-        let shipments = [
-            WooShippingShipment.fake().copy(
-                siteID: siteID,
-                orderID: orderID,
-                index: "shipment_0",
-                items: [
-                    .fake().copy(id: product1.productID),
-                    .fake().copy(id: product2.productID)
-                ])
-        ]
-        insert(shipments: shipments, order: order)
-
-        // When
-        let viewModel = WooShippingCreateLabelsViewModel(
-            order: order,
-            stores: stores,
-            storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
-            initialNoticeDelay: .seconds(0)
-        )
-
-        waitUntil {
-            viewModel.state == .ready
-        }
-
-        // Then
-        XCTAssertFalse(viewModel.splitShipmentsRowVisible)
-    }
-
     func test_splitShipmentsRowVisible_is_false_when_only_single_product_item_exists() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Non-CIAB site
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-            mockedCIABDisabledFeatures: []
-        )
 
         /// Single product
         let product1 = Product.fake().copy(siteID: siteID, productID: 1)
@@ -1553,7 +1491,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             order: order,
             stores: stores,
             storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
             initialNoticeDelay: .seconds(0)
         )
 
@@ -1569,12 +1506,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Non-CIAB site
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-            mockedCIABDisabledFeatures: []
-        )
 
         /// Multiple products
         let product1 = Product.fake().copy(siteID: siteID, productID: 1)
@@ -1615,7 +1546,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             order: order,
             stores: stores,
             storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
             initialNoticeDelay: .seconds(0)
         )
 
@@ -1632,12 +1562,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .testingInstance)
         initialConfigurationForSplitShipmentsTest(stores: stores)
 
-        /// Non-CIAB site (feature available)
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-            mockedCIABDisabledFeatures: []
-        )
-
         /// Multiple products
         let product1 = Product.fake().copy(siteID: siteID, productID: 1)
         let product2 = Product.fake().copy(siteID: siteID, productID: 2)
@@ -1671,7 +1595,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             order: order,
             stores: stores,
             storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
             initialNoticeDelay: .seconds(0)
         )
 
@@ -1683,72 +1606,10 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.splitShipmentsRowVisible)
     }
 
-    func test_editSplitShipmentsOptionVisible_is_false_when_split_shipments_feature_is_unavailable() {
-        // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Is CIAB site with the `.splitShipments` disabled
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: true,
-            mockedCIABDisabledFeatures: [.splitShipments]
-        )
-
-        /// Multiple products
-        let product1 = Product.fake().copy(siteID: siteID, productID: 1)
-        let product2 = Product.fake().copy(siteID: siteID, productID: 2)
-
-        storageManager.insertSampleProduct(readOnlyProduct: product1)
-        storageManager.insertSampleProduct(readOnlyProduct: product2)
-
-        let order = Order.fake().copy(
-            siteID: siteID,
-            orderID: orderID,
-            items: [
-                OrderItem.fake().copy(productID: product1.productID, quantity: 1),
-                OrderItem.fake().copy(productID: product2.productID, quantity: 1)
-            ])
-
-        /// Single unfulfilled shipment
-        let shipments = [
-            WooShippingShipment.fake().copy(
-                siteID: siteID,
-                orderID: orderID,
-                index: "shipment_0",
-                items: [
-                    .fake().copy(id: product1.productID),
-                    .fake().copy(id: product2.productID)
-                ])
-        ]
-        insert(shipments: shipments, order: order)
-
-        // When
-        let viewModel = WooShippingCreateLabelsViewModel(
-            order: order,
-            stores: stores,
-            storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
-            initialNoticeDelay: .seconds(0)
-        )
-
-        waitUntil {
-            viewModel.state == .ready
-        }
-
-        // Then
-        XCTAssertFalse(viewModel.editSplitShipmentsOptionVisible)
-    }
-
     func test_editSplitShipmentsOptionVisible_is_false_when_only_single_product_item_exists() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Non-CIAB site (split shipments available)
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-            mockedCIABDisabledFeatures: []
-        )
 
         /// Single product
         let product1 = Product.fake().copy(siteID: siteID, productID: 1)
@@ -1778,7 +1639,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             order: order,
             stores: stores,
             storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
             initialNoticeDelay: .seconds(0)
         )
 
@@ -1794,12 +1654,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Non-CIAB site (split shipments available)
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-            mockedCIABDisabledFeatures: []
-        )
 
         /// Multiple products
         let product1 = Product.fake().copy(siteID: siteID, productID: 1)
@@ -1848,7 +1702,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             order: order,
             stores: stores,
             storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
             initialNoticeDelay: .seconds(0)
         )
 
@@ -1864,12 +1717,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         initialConfigurationForSplitShipmentsTest(stores: stores)
-
-        /// Non-CIAB site (split shipments available)
-        let mockSiteCIABChecker = MockCIABEligibilityChecker(
-            mockedIsCurrentSiteCIAB: false,
-            mockedCIABDisabledFeatures: []
-        )
 
         /// Multiple products
         let product1 = Product.fake().copy(siteID: siteID, productID: 1)
@@ -1904,7 +1751,6 @@ final class WooShippingCreateLabelsViewModelTests: XCTestCase {
             order: order,
             stores: stores,
             storageManager: storageManager,
-            siteCIABEligibilityChecker: mockSiteCIABChecker,
             initialNoticeDelay: .seconds(0)
         )
 


### PR DESCRIPTION
## Description
Part 1 of removing legacy CIAB code. This PR handles Blaze and Shipping labels paths

## Changes
  - Removed CIAB gating from BlazeEligibilityChecker.
  - Removed the stale CIAB cases from BlazeEligibilityCheckerTests.
  - Fixed the adjacent BlazeCampaignDashboardViewModelTests that still used the removed BlazeEligibilityChecker(... siteCIABEligibilityChecker:) initializer.
  - Removed CIAB gating from the Settings plugins/WooCommerce details section.
  - Removed CIAB gating from WooShipping split shipments.
  - Removed the CIAB-only negative split-shipment tests and cleaned the remaining split-shipment tests.

## Test Steps
- Spot check if anything is off in Blaze and Shipping labels eligibility.
- CI should pass

## Screenshots
N/A
