### PR TITLE
CIAB clean-up 3: Bookings tab, hub menu

### DIFF
--- a/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
+++ b/WooCommerce/Classes/Bookings/BookingsTabEligibilityChecker.swift
@@ -13,18 +13,15 @@ final class BookingsTabEligibilityChecker: BookingsTabEligibilityCheckerProtocol
     private let site: Site
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
-    private let ciabEligibilityChecker: CIABEligibilityCheckerProtocol
     private let userDefaults: UserDefaults
 
     init(site: Site,
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         ciabEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          userDefaults: UserDefaults = .standard) {
         self.site = site
         self.stores = stores
         self.featureFlagService = featureFlagService
-        self.ciabEligibilityChecker = ciabEligibilityChecker
         self.userDefaults = userDefaults
     }
 
@@ -46,11 +43,6 @@ final class BookingsTabEligibilityChecker: BookingsTabEligibilityCheckerProtocol
     func checkVisibility() async -> Bool {
         // Check feature flag
         guard featureFlagService.isFeatureFlagEnabled(.ciabBookings) else {
-            return false
-        }
-
-        // Check if current site is CIAB (bookings only for CIAB sites)
-        guard ciabEligibilityChecker.isSiteCIAB(site) else {
             return false
         }
 

--- a/WooCommerce/Classes/Routing/ProductDetail/ProductAdminURLProvider.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/ProductAdminURLProvider.swift
@@ -7,24 +7,10 @@ enum ProductAdminURLProvider {
     static func editURL(for product: Product, site: Site?) -> URL? {
         guard let base = site?.adminURLWithFallback() else { return nil }
 
-        /// Only use CIAB next admin URL for new booking type
-        /// Otherwise, use the default wp-admin URL
-        guard product.productType == .booking else {
-            return base.appending(path: "post.php", directoryHint: .notDirectory)
-                .appending(queryItems: [
-                    URLQueryItem(name: "post", value: product.productID.description),
-                    URLQueryItem(name: "action", value: "edit")
-                ])
-        }
-
-        let adminBase = base.appending(path: "admin.php", directoryHint: .notDirectory)
-
-        var components = URLComponents(url: adminBase, resolvingAgainstBaseURL: false)!
-        components.queryItems = [
-            URLQueryItem(name: "page", value: "next-admin"),
-            URLQueryItem(name: "p", value: "/woocommerce/services/edit/\(product.productID)")
-        ]
-
-        return components.url
+        return base.appending(path: "post.php", directoryHint: .notDirectory)
+            .appending(queryItems: [
+                URLQueryItem(name: "post", value: product.productID.description),
+                URLQueryItem(name: "action", value: "edit")
+            ])
     }
 }

--- a/WooCommerce/Classes/Routing/ProductDetail/ProductDetailNavigator.swift
+++ b/WooCommerce/Classes/Routing/ProductDetail/ProductDetailNavigator.swift
@@ -20,15 +20,12 @@ final class ProductDetailNavigator {
 
     static var shared = ProductDetailNavigator()
 
-    private let ciabChecker: CIABEligibilityCheckerProtocol
     private let coordinatorFactory: ProductDetailCoordinatorFactoryProtocol
     private let stores: StoresManager
 
-    init(ciabChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
-         coordinatorFactory: ProductDetailCoordinatorFactoryProtocol = ProductDetailCoordinatorFactory.default,
+    init(coordinatorFactory: ProductDetailCoordinatorFactoryProtocol = ProductDetailCoordinatorFactory.default,
          stores: StoresManager = ServiceLocator.stores,
     ) {
-        self.ciabChecker = ciabChecker
         self.coordinatorFactory = coordinatorFactory
         self.stores = stores
     }
@@ -68,8 +65,6 @@ final class ProductDetailNavigator {
     }
 
     private func shouldOpenInWeb(product: Product) -> Bool {
-        let isLegacyBookableType = product.productType == .legacyBooking
-        let isNewBookableType = ciabChecker.isCurrentSiteCIAB && product.productType == .booking
-        return isLegacyBookableType || isNewBookableType
+        product.productType == .legacyBooking
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -17,8 +17,6 @@ struct HubMenu: View {
 
     @ObservedObject private var viewModel: HubMenuViewModel
 
-    @State private var safariSheetURL: URL?
-
     init(viewModel: HubMenuViewModel) {
         self.viewModel = viewModel
     }
@@ -45,14 +43,6 @@ struct HubMenu: View {
         switch menu.id {
         case HubMenuViewModel.GoogleAds.id:
             googleAdsCampaignHandler()
-        case HubMenuViewModel.WoocommerceAdmin.id:
-            // On CIAB sites, open WC Admin in a Safari sheet instead of the in-app webview.
-            // The in-app webview hides the Admin navigation sidebar, which breaks WC Admin
-            // navigation on CIAB sites where the full admin experience is expected.
-            if viewModel.isCIABSite() {
-                safariSheetURL = viewModel.woocommerceAdminURL
-                return
-            }
         case HubMenuViewModel.Settings.id:
             ServiceLocator.analytics.track(.hubMenuSettingsTapped)
         case HubMenuViewModel.Blaze.id:
@@ -107,7 +97,6 @@ private extension HubMenu {
         .listStyle(.insetGrouped)
         .background(Color(.listBackground))
         .accentColor(Color(.listSelectedBackground))
-        .safariSheet(url: $safariSheetURL)
     }
 
     @ViewBuilder
@@ -138,8 +127,6 @@ private extension HubMenu {
             case .blaze:
                 BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID)
             case .wooCommerceAdmin:
-                // Note: On CIAB sites, WC Admin is opened in a Safari sheet instead (see handleTap).
-                // This in-app webview path is only used for non-CIAB sites.
                 webView(url: viewModel.woocommerceAdminURL,
                         title: HubMenuViewModel.Localization.woocommerceAdmin,
                         shouldAuthenticate: viewModel.shouldAuthenticateAdminPage)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -85,8 +85,6 @@ final class HubMenuViewModel: ObservableObject {
     private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
 
-    private let siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol
-
     private let posEligibilityService: POSEligibilityServiceProtocol
     private let bookingsEligibilityCheckerFactory: (Site) -> BookingsTabEligibilityCheckerProtocol
     private let isPad: Bool
@@ -138,7 +136,6 @@ final class HubMenuViewModel: ObservableObject {
          inboxEligibilityChecker: InboxEligibilityChecker = InboxEligibilityUseCase(),
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
          googleAdsEligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
-         siteCIABEligibilityChecker: CIABEligibilityCheckerProtocol = CIABEligibilityChecker(),
          posEligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
          bookingsEligibilityCheckerFactory: @escaping (Site) -> BookingsTabEligibilityCheckerProtocol = { site in
              BookingsTabEligibilityChecker(site: site)
@@ -156,7 +153,6 @@ final class HubMenuViewModel: ObservableObject {
         self.inboxEligibilityChecker = inboxEligibilityChecker
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.googleAdsEligibilityChecker = googleAdsEligibilityChecker
-        self.siteCIABEligibilityChecker = siteCIABEligibilityChecker
         self.posEligibilityService = posEligibilityService
         self.bookingsEligibilityCheckerFactory = bookingsEligibilityCheckerFactory
         self.isPad = isPad ?? UIDevice.isPad()
@@ -225,14 +221,6 @@ final class HubMenuViewModel: ObservableObject {
 
     func trackMenuItemTapEvent(menu: HubMenuItem) {
         analytics.track(.hubMenuOptionTapped, withProperties: [AnalyticsKeys.trackingOption: menu.trackingOption])
-    }
-
-    /// Whether the current site is a CIAB (Commerce in a Box) site.
-    /// On CIAB sites, WC Admin opens in an SFSafariViewController (Safari sheet) instead of the
-    /// in-app webview, because the in-app webview hides the Admin navigation sidebar which is
-    /// needed for full WC Admin navigation.
-    func isCIABSite() -> Bool {
-        siteCIABEligibilityChecker.isCurrentSiteCIAB
     }
 
     func createGoogleAdsCampaignCoordinator(with navigationController: UINavigationController) -> GoogleAdsCampaignCoordinator {

--- a/WooCommerce/WooCommerceTests/Bookings/BookingsTabEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/Bookings/BookingsTabEligibilityCheckerTests.swift
@@ -10,7 +10,6 @@ struct BookingsTabEligibilityCheckerTests {
     private var stores: MockStoresManager!
     private var site: Site!
     private var featureFlagService: MockFeatureFlagService!
-    private var ciabEligibilityChecker: MockCIABEligibilityChecker!
     private let siteID: Int64 = 123
 
     init() {
@@ -18,7 +17,6 @@ struct BookingsTabEligibilityCheckerTests {
         stores.updateDefaultStore(storeID: siteID)
         site = Site.fake().copy(siteID: siteID)
         featureFlagService = MockFeatureFlagService()
-        ciabEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true, mockedCIABSites: [site])
     }
 
     // MARK: - `checkInitialVisibility` Tests
@@ -30,7 +28,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -47,7 +44,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -63,7 +59,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -82,27 +77,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
-                                                    userDefaults: userDefaults)
-
-        // When
-        let result = await checker.checkVisibility()
-
-        // Then
-        #expect(result == false)
-    }
-
-    @Test func checkVisibility_returns_false_when_site_is_not_CIAB() async throws {
-        // Given
-        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
-        let featureFlagService = MockFeatureFlagService(isCIABBookingsEnabled: true)
-        let ciabEligibilityChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
-        setupStoreHasBookableProducts(hasProducts: true)
-        setupStoreHasBookings(hasBookings: true)
-        let checker = BookingsTabEligibilityChecker(site: site,
-                                                    stores: stores,
-                                                    featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -121,7 +95,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -140,7 +113,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -159,7 +131,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -179,7 +150,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -199,7 +169,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -218,7 +187,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -237,7 +205,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -256,7 +223,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When
@@ -275,7 +241,6 @@ struct BookingsTabEligibilityCheckerTests {
         let checker = BookingsTabEligibilityChecker(site: site,
                                                     stores: stores,
                                                     featureFlagService: featureFlagService,
-                                                    ciabEligibilityChecker: ciabEligibilityChecker,
                                                     userDefaults: userDefaults)
 
         // When

--- a/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductAdminURLProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductAdminURLProviderTests.swift
@@ -9,7 +9,7 @@ final class ProductAdminURLProviderTests {
     private lazy var aSite = Site.fake().copy(url: storeURL)
 
     @Test
-    func test_editURL_for_booking_product_uses_next_admin_services_path() throws {
+    func test_editURL_for_booking_product_uses_wp_admin_post_path() throws {
         // Given
         let bookingProduct = Product.fake().copy(productID: productID, productTypeKey: "bookable-service")
 
@@ -18,7 +18,7 @@ final class ProductAdminURLProviderTests {
 
         // Then
         #expect(url.absoluteString ==
-                "\(storeURL)/wp-admin/admin.php?page=next-admin&p=/woocommerce/services/edit/\(productID)")
+                "\(storeURL)/wp-admin/post.php?post=\(productID)&action=edit")
     }
 
     @Test

--- a/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductDetailNavigatorTests.swift
+++ b/WooCommerce/WooCommerceTests/Routing/ProductDetail/ProductDetailNavigatorTests.swift
@@ -11,19 +11,15 @@ final class ProductDetailNavigatorTests {
 
     // MARK: - Non-bookable products
 
-    @Test(arguments: [
-        (isCIABSite: true, product: aNonBookingProduct),
-        (isCIABSite: false, product: aNonBookingProduct),
-    ])
-    func non_bookable_product_directs_to_native_view_regardless_of_CIAB(isCIABSite: Bool, product: Product) {
+    @Test
+    func non_bookable_product_directs_to_native_view() {
         // Given
         let navigator = ProductDetailNavigator(
-            ciabChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: isCIABSite),
             coordinatorFactory: coordinatorFactory
         )
 
         // When
-        _ = navigator.makeDestination(product: product, isReadOnly: false)
+        _ = navigator.makeDestination(product: Self.aNonBookingProduct, isReadOnly: false)
 
         // Then
         #expect(coordinatorFactory.createdNativeCoordiantor)
@@ -33,26 +29,9 @@ final class ProductDetailNavigatorTests {
     // MARK: - New booking type (bookable-service)
 
     @Test
-    func new_booking_product_on_CIAB_site_directs_to_web_view() {
+    func new_booking_product_directs_to_native_view() {
         // Given
         let navigator = ProductDetailNavigator(
-            ciabChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true),
-            coordinatorFactory: coordinatorFactory
-        )
-
-        // When
-        _ = navigator.makeDestination(product: Self.aNewBookingProduct, isReadOnly: false)
-
-        // Then
-        #expect(coordinatorFactory.createdWebCoordiantor)
-        #expect(!coordinatorFactory.createdNativeCoordiantor)
-    }
-
-    @Test
-    func new_booking_product_on_non_CIAB_site_directs_to_native_view() {
-        // Given
-        let navigator = ProductDetailNavigator(
-            ciabChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false),
             coordinatorFactory: coordinatorFactory
         )
 
@@ -66,11 +45,10 @@ final class ProductDetailNavigatorTests {
 
     // MARK: - Legacy booking type
 
-    @Test(arguments: [true, false])
-    func legacy_booking_product_directs_to_web_view_regardless_of_CIAB(isCIABSite: Bool) {
+    @Test
+    func legacy_booking_product_directs_to_web_view() {
         // Given
         let navigator = ProductDetailNavigator(
-            ciabChecker: MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: isCIABSite),
             coordinatorFactory: coordinatorFactory
         )
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -767,39 +767,6 @@ final class HubMenuViewModelTests: XCTestCase {
             XCTAssertNil(eventProperties)
         }
     }
-
-
-    // MARK: - CIAB WC Admin Safari Sheet
-
-    @MainActor
-    func test_isCIABSite_when_site_is_CIAB_then_returns_true() {
-        // Given
-        let ciabChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: true)
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         siteCIABEligibilityChecker: ciabChecker)
-
-        // When
-        let result = viewModel.isCIABSite()
-
-        // Then
-        XCTAssertTrue(result)
-    }
-
-    @MainActor
-    func test_isCIABSite_when_site_is_not_CIAB_then_returns_false() {
-        // Given
-        let ciabChecker = MockCIABEligibilityChecker(mockedIsCurrentSiteCIAB: false)
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         siteCIABEligibilityChecker: ciabChecker)
-
-        // When
-        let result = viewModel.isCIABSite()
-
-        // Then
-        XCTAssertFalse(result)
-    }
 }
 
 private extension HubMenuViewModelTests {


### PR DESCRIPTION
## Description
Part 3 of removing legacy CIAB code. Bookings tab (only the CIAB eligibility path), and hub menu web view.

## Test Steps
- CI should pass
