### PR TITLE
Fix bulk update of regular price on variable products

### DIFF
--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -291,22 +291,23 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
                                         productVariations: [ProductVariation],
                                         completion: @escaping (Result<[ProductVariation], Error>) -> Void) {
 
-        do {
-            let parameters = try productVariations.map { try $0.toDictionary() }
-            let requestParameters: RequestParameterConvertibleDictionary = ["update": parameters]
-            let path = "\(Path.products)/\(productID)/variations/batch"
-            let request = JetpackRequest(wooApiVersion: .mark3,
-                                         method: .post,
-                                         siteID: siteID,
-                                         path: path,
-                                         parameters: requestParameters,
-                                         availableAsRESTRequest: true)
-            let mapper = ProductVariationsBulkUpdateMapper(siteID: siteID, productID: productID)
-
-            enqueue(request, mapper: mapper, completion: completion)
-        } catch {
-            completion(.failure(error))
+        // Bulk price update intentionally sends only id + regular_price so stale sale-price fields do not make the API reject the request.
+        // Android parity for #16084.
+        let parameters: [[String: Any]] = productVariations.map { variation in
+            ["id": variation.productVariationID,
+             "regular_price": variation.regularPrice ?? ""]
         }
+        let requestParameters: RequestParameterConvertibleDictionary = ["update": parameters]
+        let path = "\(Path.products)/\(productID)/variations/batch"
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: requestParameters,
+                                     availableAsRESTRequest: true)
+        let mapper = ProductVariationsBulkUpdateMapper(siteID: siteID, productID: productID)
+
+        enqueue(request, mapper: mapper, completion: completion)
     }
 
     /// Deletes a specific `ProductVariation`.

--- a/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
+++ b/Modules/Sources/Networking/Remote/ProductVariationsRemote.swift
@@ -293,9 +293,9 @@ public class ProductVariationsRemote: Remote, ProductVariationsRemoteProtocol {
 
         // Bulk price update intentionally sends only id + regular_price so stale sale-price fields do not make the API reject the request.
         // Android parity for #16084.
-        let parameters: [[String: Any]] = productVariations.map { variation in
-            ["id": variation.productVariationID,
-             "regular_price": variation.regularPrice ?? ""]
+        let parameters: [RequestParameterDictionary] = productVariations.map { variation in
+            ["id": .int64(variation.productVariationID),
+             "regular_price": .string(variation.regularPrice ?? "")]
         }
         let requestParameters: RequestParameterConvertibleDictionary = ["update": parameters]
         let path = "\(Path.products)/\(productID)/variations/batch"

--- a/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/ProductVariationsRemoteTests.swift
@@ -460,6 +460,49 @@ final class ProductVariationsRemoteTests: XCTestCase {
         XCTAssertEqual(updatedProductVariation, productVariations)
     }
 
+    func test_bulk_update_productVariations_sends_only_id_and_regular_price() throws {
+        // Given
+        let remote = ProductVariationsRemote(network: network)
+        let firstProductVariationID: Int64 = 2783
+        let secondProductVariationID: Int64 = 2784
+        let productVariations = [
+            sampleProductVariation(siteID: sampleSiteID, productID: sampleProductID, id: firstProductVariationID)
+                .copy(regularPrice: "5.00", salePrice: "8.00"),
+            sampleProductVariation(siteID: sampleSiteID, productID: sampleProductID, id: secondProductVariationID)
+                .copy(regularPrice: "6.00", salePrice: "9.00")
+        ]
+
+        network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)/variations/batch", filename: "product-variations-bulk-update")
+
+        // When
+        waitForExpectation { expectation in
+            remote.updateProductVariations(siteID: sampleSiteID, productID: sampleProductID, productVariations: productVariations) { _ in
+                expectation.fulfill()
+            }
+        }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let updateParam = try XCTUnwrap(request.parameters["update"] as? [[String: Any]])
+        let expectedPayloads: [(id: Int64, regularPrice: String)] = [
+            (firstProductVariationID, "5.00"),
+            (secondProductVariationID, "6.00")
+        ]
+
+        XCTAssertEqual(updateParam.count, productVariations.count)
+        for (index, expectedPayload) in expectedPayloads.enumerated() {
+            let update = updateParam[index]
+            XCTAssertEqual(Set(update.keys), Set(["id", "regular_price"]))
+            XCTAssertEqual(update["id"] as? Int64, expectedPayload.id)
+            XCTAssertEqual(update["regular_price"] as? String, expectedPayload.regularPrice)
+            XCTAssertNil(update["sale_price"])
+            XCTAssertNil(update["date_on_sale_from"])
+            XCTAssertNil(update["date_on_sale_to"])
+            XCTAssertNil(update["sku"])
+            XCTAssertNil(update["attributes"])
+        }
+    }
+
     /// Verifies that updateProductVariation properly relays Networking Layer errors.
     ///
     func testUpdateProductVariationProperlyRelaysNetwokingErrors() {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [*] Products: Fixed bulk updating the regular price of a variable product failing with "Can't update price". [https://github.com/woocommerce/woocommerce-ios/pull/17446]
 - [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/17432]
 
 


### PR DESCRIPTION
## Description

Fixes #16084.

Bulk updating the Regular price of a variable product (Products -> product -> Variations -> Bulk update -> Regular price) failed on iOS with a generic "Can't update price", while the same action worked on Android and in WP Admin.

The bulk update goes through `ProductVariationsRemote.updateProductVariations`, which built the `variations/batch` `update` payload by serializing each full `ProductVariation` via `toDictionary()`. `ProductVariation.encode(to:)` emits the entire object, so a regular-price-only bulk update also re-sent every variation's existing `sale_price` and sale dates. When a variation already had a sale price that was no longer valid against the new regular price (for example a stale sale price greater than the new regular price), the WooCommerce REST batch endpoint rejected the whole request, surfacing as "Can't update price".

This change makes the bulk update send a minimal payload containing only each variation's `id` and the edited `regular_price`, matching the WooCommerce Android client. Stale sale-price and other unrelated fields are no longer re-sent, so the endpoint no longer rejects the update. `ProductVariation.encode(to:)` is unchanged, so the single-variation update path still sends the full object.

## Test Steps

1. On a store with a variable product, set a sale price on one or more variations such that the sale price would be invalid against a new, lower regular price (e.g. variation regular price 10, sale price 8; you intend to bulk-set the regular price to 5).
2. In the app, open the product -> Variations -> Bulk update -> Regular price.
3. Enter a new regular price and tap Save.
4. Before this change the update fails with "Can't update price"; after this change the regular price is updated successfully for all variations, and the existing sale prices are left untouched.

This is a networking-layer change. A unit test (`ProductVariationsRemoteTests.test_bulk_update_productVariations_sends_only_id_and_regular_price`) verifies the batch `update` payload contains only `id` and `regular_price` and omits `sale_price`, the sale dates, `sku`, and `attributes`.

## Screenshots

Not applicable - this is a networking-layer fix with no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
