### PR TITLE
[POS Receipts Printing] Add Print receipt button to the payment success screen

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -55,6 +55,7 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
         messageType: .processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()),
         animation: .init(namespace: namespace))
     .environment(model.paymentModel)
+    .environment(model)
 }
 #endif
 

--- a/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSalePaymentSuccessView.swift
@@ -11,6 +11,7 @@ struct PointOfSalePaymentSuccessView: View {
     @State private var isViewLoaded: Bool = false
     @AccessibilityFocusState private var isTitleFocused: Bool
     @Environment(\.posNavigationRouter) private var router
+    @Environment(PointOfSaleAggregateModel.self) private var posModel
 
     private var isBarcodeScanningEnabled: Bool {
         onSuccessScreenBarcodeScanned != nil && !router.isNavigated
@@ -83,7 +84,8 @@ struct PointOfSalePaymentSuccessView: View {
                 // iPad: buttons take half the screen width (count:2 span:1).
                 // Phone: half the screen width is ~190pt, too narrow for "New order" /
                 // "Email receipt" — let them span the container minus standard insets instead.
-                PaymentsActionButtons(successAction: successAction)
+                PaymentsActionButtons(successAction: successAction,
+                                      showsPrintReceipt: posModel.receiptPrinter != nil)
                     .if(horizontalSizeClass != .compact) { view in
                         view.containerRelativeFrame(.horizontal, count: 2, span: 1, spacing: POSSpacing.none)
                     }
@@ -119,6 +121,9 @@ private extension PointOfSalePaymentSuccessView {
 
 #if DEBUG
 #Preview {
+    let model = POSPreviewHelpers.makePreviewAggregateModel(
+        receiptPrinter: POSReceiptPrinterPreviewService()
+    )
     PointOfSalePaymentSuccessView(
         viewModel: PointOfSalePaymentSuccessViewModel(formattedOrderTotal: "$3.00",
                                                       paymentMethod: .card),
@@ -126,5 +131,6 @@ private extension PointOfSalePaymentSuccessView {
         successAction: PaymentFlowAction(title: "New order", action: {}, analyticsEvent: nil),
         onSuccessScreenBarcodeScanned: nil
     )
+    .environment(model)
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
@@ -2,20 +2,44 @@ import SwiftUI
 
 struct PaymentsActionButtons: View {
     let successAction: PaymentFlowAction
+    let showsPrintReceipt: Bool
     @Environment(\.posAnalytics) private var analytics
     @Environment(\.posNavigationRouter) private var router
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         ZStack {
             VStack {
                 successButton
-                sendReceiptButton
+                receiptButtons
             }
         }
+    }
+
+    /// Email and Print sit side by side on regular width, and stack on compact width or at
+    /// accessibility text sizes, where two buttons in a row would be too cramped.
+    private var usesSideBySideReceiptButtons: Bool {
+        showsPrintReceipt && horizontalSizeClass != .compact && !dynamicTypeSize.isAccessibilitySize
     }
 }
 
 private extension PaymentsActionButtons {
+    @ViewBuilder
+    var receiptButtons: some View {
+        if usesSideBySideReceiptButtons {
+            HStack(spacing: Constants.receiptButtonRowSpacing) {
+                sendReceiptButton
+                printReceiptButton
+            }
+        } else {
+            sendReceiptButton
+            if showsPrintReceipt {
+                printReceiptButton
+            }
+        }
+    }
+
     var sendReceiptButton: some View {
         Button(action: {
             analytics.track(.receiptEmailTapped)
@@ -26,6 +50,18 @@ private extension PaymentsActionButtons {
             }
         })
         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        .frame(maxWidth: .infinity)
+    }
+
+    var printReceiptButton: some View {
+        Button(action: {}, label: {
+            HStack(spacing: Constants.buttonSpacing) {
+                Text(Localization.printReceipt)
+            }
+        })
+        .buttonStyle(POSOutlinedButtonStyle(size: .normal))
+        .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("pos-print-receipt-button")
     }
 
     var successButton: some View {
@@ -48,6 +84,7 @@ private extension PaymentsActionButtons {
 private extension PaymentsActionButtons {
     enum Constants {
         static let buttonSpacing: CGFloat = POSSpacing.medium
+        static let receiptButtonRowSpacing: CGFloat = POSSpacing.small
     }
 
     enum Localization {
@@ -55,15 +92,32 @@ private extension PaymentsActionButtons {
             "pos.totalsView.button.sendReceipt",
             value: "Email receipt",
             comment: "Button title for the receipt button")
+
+        static let printReceipt = NSLocalizedString(
+            "pos.paymentSuccess.button.printReceipt",
+            value: "Print receipt",
+            comment: "Button title on the Point of Sale payment success screen for printing a receipt for the completed order.")
     }
 }
 
 #if DEBUG
-#Preview {
+#Preview("Regular width") {
     PaymentsActionButtons(
         successAction: PaymentFlowAction(
             title: "New order",
             action: {},
-            analyticsEvent: nil))
+            analyticsEvent: nil),
+        showsPrintReceipt: true)
+    .environment(\.horizontalSizeClass, .regular)
+}
+
+#Preview("Compact width") {
+    PaymentsActionButtons(
+        successAction: PaymentFlowAction(
+            title: "New order",
+            action: {},
+            analyticsEvent: nil),
+        showsPrintReceipt: true)
+    .environment(\.horizontalSizeClass, .compact)
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
@@ -25,18 +25,20 @@ struct PaymentsActionButtons: View {
 }
 
 private extension PaymentsActionButtons {
-    @ViewBuilder
     var receiptButtons: some View {
-        if usesSideBySideReceiptButtons {
-            HStack(spacing: Constants.receiptButtonRowSpacing) {
-                sendReceiptButton
-                printReceiptButton
-            }
-        } else {
+        receiptButtonLayout {
             sendReceiptButton
             if showsPrintReceipt {
                 printReceiptButton
             }
+        }
+    }
+
+    var receiptButtonLayout: AnyLayout {
+        if usesSideBySideReceiptButtons {
+            AnyLayout(HStackLayout(spacing: Constants.receiptButtonRowSpacing))
+        } else {
+            AnyLayout(VStackLayout(spacing: Constants.receiptButtonRowSpacing))
         }
     }
 
@@ -51,7 +53,6 @@ private extension PaymentsActionButtons {
         })
         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("pos-email-receipt-button")
     }
 
     var printReceiptButton: some View {
@@ -62,7 +63,6 @@ private extension PaymentsActionButtons {
         })
         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("pos-print-receipt-button")
     }
 
     var successButton: some View {

--- a/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PaymentButtons.swift
@@ -51,6 +51,7 @@ private extension PaymentsActionButtons {
         })
         .buttonStyle(POSOutlinedButtonStyle(size: .normal))
         .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("pos-email-receipt-button")
     }
 
     var printReceiptButton: some View {


### PR DESCRIPTION
## Description
Part of the iOS Receipt Printing stack (PR 6/8, WOOMOB-3195). Stacked on WOOMOB-3194 (PR 5) — **base is `WOOMOB-3194-pos-printer-setup-ui`, not `trunk`**. Although this works on phone, we will review the whole project there at the end.

Adds a **Print receipt** secondary button to the POS payment success screen, completing the decided "direct buttons" layout:

- **New order** — full-width filled primary (unchanged).
- **Email receipt** + **Print receipt** — two outlined secondary buttons, laid **side by side on regular width (iPad)** and **stacked on compact width (iPhone) / accessibility text sizes**, where a two-up row would be too cramped.

### Intentionally deferred
The Print button's **tap action is empty for now**. 

## Test Steps

No need for manual testing, adding test steps as documentation.

Requires an internal build with `.starReceiptPrinterSupport` enabled (alpha / local developer).
1. Open POS and take a payment to reach the payment success screen.
2. Confirm three buttons: **New order** (primary), **Email receipt**, **Print receipt**.
3. On **iPad**: Email and Print appear **side by side** under New order.
5. With the flag **off** (default): only **New order** + **Email receipt** show — no Print button.
6. Tapping **Print receipt** currently does nothing (expected — behavior is in the next PR).
7. **Email receipt** still works as before.

No user-facing change yet (feature-flagged off), so no `RELEASE-NOTES.txt` entry.

## Screenshots
<img width="1180" height="820" alt="My Store 35" src="https://github.com/user-attachments/assets/f59215f0-e54f-4e95-9502-bf7280d3b1cd" />



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.