### PR TITLE
Bump min Woo version to 10.9.2 for self-driven push notifications

### DIFF
--- a/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
+++ b/WooCommerce/Classes/Notifications/WooPushNotificationSetupCoordinator.swift
@@ -68,7 +68,7 @@ final class WooPushNotificationSetupCoordinator {
 
 enum WooPluginRequirements {
     static let pluginPath = "woocommerce/woocommerce.php"
-    static let minimumVersion = "10.9.0"
+    static let minimumVersion = "10.9.2"
 }
 
 private extension WooPushNotificationSetupCoordinator {


### PR DESCRIPTION
## Description

Cherry-picks the code change from https://github.com/woocommerce/woocommerce-ios/pull/17435 into `release/25.0.1`.

This bumps the minimum required WooCommerce plugin version for self-driven push notifications from `10.9.0` to `10.9.2`.

## Test Steps

Same as https://github.com/woocommerce/woocommerce-ios/pull/17435:

1. Fire up a fresh JN site and install Woo 10.9.1 on it.
2. Install the app and login to that site.
3. Enable the FF.
4. Restart the app.
5. Note the dashboard card should appear.
6. Start the PN enablement.
7. It should fail with 10.9.1 needs update.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.