### PR TITLE
POS roles: gate settings editing and staff management; drop baseline caps

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/POSFloatingControlView.swift
@@ -16,8 +16,7 @@ struct POSFloatingControlView: View {
     /// Invoked when the Settings menu item is tapped. The host gates it on `.viewPOSSettings` before
     /// presenting the settings screen.
     private let onSettingsSelected: () -> Void
-    /// Invoked when the Orders menu item is tapped. The host gates it on `.viewOrders` before
-    /// presenting the orders screen.
+    /// Invoked when the Orders menu item is tapped.
     private let onOrdersSelected: () -> Void
     @State private var showProductRestrictionsModal: Bool = false
     @State private var showBarcodeScanningModal: Bool = false

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -112,7 +112,7 @@ struct PointOfSaleDashboardView: View {
                                    showSupport: $showSupport,
                                    showDocumentation: $showDocumentation,
                                    onSettingsSelected: requestSettingsPermission,
-                                   onOrdersSelected: requestOrdersPermission)
+                                   onOrdersSelected: presentOrders)
             .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
             .padding(.bottom, Constants.floatingControlBottomPadding)
             .trackSize(size: $floatingSize)
@@ -364,7 +364,7 @@ struct PointOfSaleDashboardView: View {
             if featureFlags.isFeatureFlagEnabled(.pointOfSaleHistoricalOrdersi1) {
                 Button {
                     analytics.track(event: WooAnalyticsEvent.PointOfSale.ordersMenuItemTapped())
-                    requestOrdersPermission()
+                    presentOrders()
                 } label: {
                     Label(Localization.phoneMenuOrders, systemImage: "text.document")
                 }
@@ -590,13 +590,6 @@ private extension PointOfSaleDashboardView {
         showOrders = true
     }
 
-    /// Opens the orders list, gated on `.viewOrders` via manager override.
-    func requestOrdersPermission() {
-        overrideHandler.gate(.viewOrders, reason: Localization.ordersOverrideDescription) { _ in
-            presentOrders()
-        }
-    }
-
     /// Opens POS settings, gated on `.viewPOSSettings` via manager override.
     func requestSettingsPermission() {
         overrideHandler.gate(.viewPOSSettings, reason: Localization.settingsOverrideDescription) { _ in
@@ -685,12 +678,6 @@ private extension PointOfSaleDashboardView {
             value: "Exiting Point of Sale requires approval",
             comment: "Message shown in the manager-override PIN prompt when a staff member without the "
                 + "exit permission tries to leave Point of Sale."
-        )
-        static let ordersOverrideDescription = NSLocalizedString(
-            "pointOfSaleDashboard.orders.overrideReason",
-            value: "Opening orders requires approval",
-            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
-                + "view-orders permission tries to open the Point of Sale orders list."
         )
         static let phoneMenuOrders = NSLocalizedString(
             "pointOfSaleDashboard.phone.menu.orders",

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 struct POSSettingsLocalCatalogDetailView: View {
     private let viewModel: POSSettingsLocalCatalogViewModel
     /// Gates an edit action on `editPOSSettings`. Defaults to running it directly (previews / no host gate).
-    private let requestEditPermission: (@escaping () -> Void) -> Void
+    private let requestEditPermission: POSPermissionRequest
 
     init(viewModel: POSSettingsLocalCatalogViewModel,
-         requestEditPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {
+         requestEditPermission: @escaping POSPermissionRequest = { $0() }) {
         self.viewModel = viewModel
         self.requestEditPermission = requestEditPermission
     }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsLocalCatalogDetailView.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 struct POSSettingsLocalCatalogDetailView: View {
     private let viewModel: POSSettingsLocalCatalogViewModel
+    /// Gates an edit action on `editPOSSettings`. Defaults to running it directly (previews / no host gate).
+    private let requestEditPermission: (@escaping () -> Void) -> Void
 
-    init(viewModel: POSSettingsLocalCatalogViewModel) {
+    init(viewModel: POSSettingsLocalCatalogViewModel,
+         requestEditPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {
         self.viewModel = viewModel
+        self.requestEditPermission = requestEditPermission
     }
 
     var body: some View {
@@ -61,17 +65,27 @@ private extension POSSettingsLocalCatalogDetailView {
 
     @ViewBuilder
     var managingDataUsage: some View {
-        @Bindable var viewModel = viewModel
         VStack(spacing: POSSpacing.none) {
             POSInformationCard {
                 POSInformationCardFieldRowWithToggle(
                     label: Localization.managingDataUsage,
                     value: Localization.allowSyncOnCellular,
                     showSeparator: false,
-                    isOn: $viewModel.allowFullSyncOnCellular
+                    isOn: cellularSyncBinding
                 )
             }
         }
+    }
+
+    /// Toggling the cellular-sync setting is an edit, so route changes through `editPOSSettings`:
+    /// the value only flips once the operator holds the cap or a manager approves the override.
+    private var cellularSyncBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.allowFullSyncOnCellular },
+            set: { newValue in
+                requestEditPermission { viewModel.allowFullSyncOnCellular = newValue }
+            }
+        )
     }
 
     @ViewBuilder
@@ -85,8 +99,10 @@ private extension POSSettingsLocalCatalogDetailView {
                     labelStyle: .bold,
                     buttonTitle: Localization.updateCatalog,
                     buttonAction: {
-                        Task {
-                            await viewModel.refreshCatalog()
+                        requestEditPermission {
+                            Task {
+                                await viewModel.refreshCatalog()
+                            }
                         }
                     },
                     buttonStyle: .primary,

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -9,7 +9,7 @@ struct POSSettingsStoreDetailView: View {
 
     let viewModel: POSSettingsStoreViewModel
     /// Gates an edit action on `editPOSSettings`. Defaults to running it directly (previews / no host gate).
-    let requestEditPermission: (@escaping () -> Void) -> Void
+    private let requestEditPermission: (@escaping () -> Void) -> Void
 
     init(viewModel: POSSettingsStoreViewModel,
          requestEditPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -8,9 +8,13 @@ struct POSSettingsStoreDetailView: View {
     @Environment(\.posAnalytics) private var analytics
 
     let viewModel: POSSettingsStoreViewModel
+    /// Gates an edit action on `editPOSSettings`. Defaults to running it directly (previews / no host gate).
+    let requestEditPermission: (@escaping () -> Void) -> Void
 
-    init(viewModel: POSSettingsStoreViewModel) {
+    init(viewModel: POSSettingsStoreViewModel,
+         requestEditPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {
         self.viewModel = viewModel
+        self.requestEditPermission = requestEditPermission
     }
 
     private var backgroundColor: Color {
@@ -107,7 +111,7 @@ struct POSSettingsStoreDetailView: View {
                 if !viewModel.receiptSettingsAdminURL.isEmpty {
                     Button {
                         analytics.track(.pointOfSaleEditReceiptTapped)
-                        showingWebView = true
+                        requestEditPermission { showingWebView = true }
                     } label: {
                         Image(systemName: "square.and.pencil")
                             .font(.posBodyLargeBold)

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsStoreDetailView.swift
@@ -9,10 +9,10 @@ struct POSSettingsStoreDetailView: View {
 
     let viewModel: POSSettingsStoreViewModel
     /// Gates an edit action on `editPOSSettings`. Defaults to running it directly (previews / no host gate).
-    private let requestEditPermission: (@escaping () -> Void) -> Void
+    private let requestEditPermission: POSPermissionRequest
 
     init(viewModel: POSSettingsStoreViewModel,
-         requestEditPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {
+         requestEditPermission: @escaping POSPermissionRequest = { $0() }) {
         self.viewModel = viewModel
         self.requestEditPermission = requestEditPermission
     }

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct POSSettingsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var selection: SidebarNavigation?
+    @State private var editOverrideHandler = POSManagerOverrideHandler()
 
     let settingsController: POSSettingsControllerProtocol
 
@@ -15,12 +16,22 @@ struct POSSettingsView: View {
                              horizontalSizeClass == .compact ?
                                 .init(state: .enabled, action: { self.selection = nil }) : nil)
         } detailPlaceholderView: {
-            POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
+            POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel,
+                                       requestEditPermission: requestEditPermission)
         } setDefaultValue: {
             if selection == nil {
                 selection = .store
             }
         }
+        .posRootModal()
+        .posManagerOverrideModal(handler: editOverrideHandler)
+    }
+
+    /// Gates an edit to POS settings on `.editPOSSettings`. When the operator holds it the edit runs
+    /// immediately; otherwise the manager-override modal is presented and the edit runs once an
+    /// authorized staff member approves.
+    func requestEditPermission(_ perform: @escaping () -> Void) {
+        editOverrideHandler.gate(.editPOSSettings, reason: Localization.editOverrideDescription, perform: { _ in perform() })
     }
 }
 
@@ -121,12 +132,14 @@ extension POSSettingsView {
     private func detailView(for selection: SidebarNavigation, navigationPath: Binding<NavigationPath>) -> some View {
         switch selection {
         case .store:
-            POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel)
+            POSSettingsStoreDetailView(viewModel: settingsController.storeViewModel,
+                                       requestEditPermission: requestEditPermission)
         case .hardware:
             POSSettingsHardwareDetailView(settingsController: settingsController, navigationPath: navigationPath)
         case .localCatalog:
             if let viewModel = settingsController.localCatalogViewModel {
-                POSSettingsLocalCatalogDetailView(viewModel: viewModel)
+                POSSettingsLocalCatalogDetailView(viewModel: viewModel,
+                                                  requestEditPermission: requestEditPermission)
             } else {
                 EmptyView()
             }
@@ -187,6 +200,13 @@ extension POSSettingsView {
             "pointOfSaleSettingsView.navigationTitle",
             value: "Settings",
             comment: "Title of the Point of Sale settings view."
+        )
+
+        static let editOverrideDescription = NSLocalizedString(
+            "pointOfSaleSettingsView.editOverrideReason",
+            value: "Changing settings requires approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "edit-settings permission tries to change a Point of Sale setting."
         )
 
         static let sidebarNavigationStoreTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -23,7 +23,8 @@ struct POSSettingsView: View {
                 selection = .store
             }
         }
-        .posRootModal()
+        // No `.posRootModal()` here — `.posFullScreenCover` already provides one for this content, and a
+        // second bound to the same `POSModalManager` would render the override modal twice.
         .posManagerOverrideModal(handler: overrideHandler)
     }
 
@@ -288,6 +289,11 @@ extension POSSettingsView {
 
 #if DEBUG
 #Preview {
+    // Production supplies these via `.posFullScreenCover`; the standalone preview provides its own root
+    // modal and managers so the override modal has somewhere to render.
     POSSettingsView(settingsController: POSSettingsPreviewController())
+        .posRootModal()
+        .environmentObject(POSModalManager())
+        .environmentObject(POSFullScreenCoverManager())
 }
 #endif

--- a/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Settings/POSSettingsView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct POSSettingsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var selection: SidebarNavigation?
-    @State private var editOverrideHandler = POSManagerOverrideHandler()
+    @State private var overrideHandler = POSManagerOverrideHandler()
 
     let settingsController: POSSettingsControllerProtocol
 
@@ -24,14 +24,21 @@ struct POSSettingsView: View {
             }
         }
         .posRootModal()
-        .posManagerOverrideModal(handler: editOverrideHandler)
+        .posManagerOverrideModal(handler: overrideHandler)
     }
 
     /// Gates an edit to POS settings on `.editPOSSettings`. When the operator holds it the edit runs
     /// immediately; otherwise the manager-override modal is presented and the edit runs once an
     /// authorized staff member approves.
     func requestEditPermission(_ perform: @escaping () -> Void) {
-        editOverrideHandler.gate(.editPOSSettings, reason: Localization.editOverrideDescription, perform: { _ in perform() })
+        overrideHandler.gate(.editPOSSettings, reason: Localization.editOverrideDescription, perform: { _ in perform() })
+    }
+
+    /// Gates opening the wp-admin staff-management web view on `.managePOSStaff`. When the operator
+    /// holds it the view opens immediately; otherwise the override modal is presented and it opens once
+    /// an authorized staff member approves.
+    func requestManageStaffPermission(_ perform: @escaping () -> Void) {
+        overrideHandler.gate(.managePOSStaff, reason: Localization.manageStaffOverrideDescription, perform: { _ in perform() })
     }
 }
 
@@ -145,7 +152,8 @@ extension POSSettingsView {
             }
         case .staff:
             if let staffSettingsService = settingsController.staffSettingsService {
-                POSStaffSettingsView(service: staffSettingsService)
+                POSStaffSettingsView(service: staffSettingsService,
+                                     requestManageStaffPermission: requestManageStaffPermission)
             } else {
                 EmptyView()
             }
@@ -207,6 +215,13 @@ extension POSSettingsView {
             value: "Changing settings requires approval",
             comment: "Message shown in the manager-override PIN prompt when a staff member without the "
                 + "edit-settings permission tries to change a Point of Sale setting."
+        )
+
+        static let manageStaffOverrideDescription = NSLocalizedString(
+            "pointOfSaleSettingsView.manageStaffOverrideReason",
+            value: "Managing staff requires approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "manage-staff permission tries to open staff management."
         )
 
         static let sidebarNavigationStoreTitle = NSLocalizedString(

--- a/Modules/Sources/PointOfSale/Roles/Models/POSCapability.swift
+++ b/Modules/Sources/PointOfSale/Roles/Models/POSCapability.swift
@@ -2,9 +2,6 @@ enum POSCapability: String, CaseIterable, Sendable {
     // POS-specific capabilities use the `woocommerce_pos_` prefix, matching the keys the staff
     // endpoint reports. Capability matching is by raw value (see `POSStaff.hasCapability`), so
     // non-`woocommerce_pos_` identifiers can be added as cases later without changing the lookup logic.
-    case processSales = "woocommerce_pos_process_sales"
-    case viewOrders = "woocommerce_pos_view_orders"
-    case applyCoupons = "woocommerce_pos_apply_coupons"
     case createCoupons = "woocommerce_pos_create_coupons"
     case issueRefunds = "woocommerce_pos_issue_refunds"
     case viewPOSSettings = "woocommerce_pos_view_settings"

--- a/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
+++ b/Modules/Sources/PointOfSale/Roles/Providers/DefaultPOSAccessSession.swift
@@ -45,7 +45,15 @@ final class DefaultPOSAccessSession: POSAccessSession {
     }
 
     func allows(_ capability: POSCapability) -> Bool {
-        currentStaff?.hasCapability(capability) == true
+        // Access is only gated when the cached staff list has PINs — the same cache-driven signal that
+        // drives the lock screen. With no PIN-backed staff, nobody signs in (so `currentStaff` is nil)
+        // and there'd be no PIN to approve an override, so gating is effectively off and everything is
+        // allowed. Without this, a roles-enabled site that hasn't set up any PINs would deny every gated
+        // action and strand the operator on an override modal no one can satisfy.
+        guard hasAnyPINs else {
+            return true
+        }
+        return currentStaff?.hasCapability(capability) == true
     }
 
     func signIn(withPIN pin: String) async throws(POSAuthError) {

--- a/Modules/Sources/PointOfSale/Roles/Views/POSManagerOverrideModal.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSManagerOverrideModal.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+/// A view-facing request to perform a capability-gated action. Called with the action to run, it either
+/// runs it immediately (the operator holds the capability) or presents the manager-override modal and runs
+/// it once an authorized staff member approves. Views default it to running the action directly, which keeps
+/// previews and ungated hosts working without a real gate.
+typealias POSPermissionRequest = (_ perform: @escaping () -> Void) -> Void
+
 private struct POSManagerOverrideModalModifier: ViewModifier {
     @Environment(\.posAccessSession) private var session
 

--- a/Modules/Sources/PointOfSale/Roles/Views/POSManagerOverrideView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSManagerOverrideView.swift
@@ -47,7 +47,9 @@ private extension POSManagerOverrideView {
         .padding(.horizontal, POSPadding.large)
         .posModalCloseButton(action: { handler.cancel() }, accessibilityLabel: Localization.close)
         .padding(POSPadding.large)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Size to content and let the modal center it, like the lock screen and the iPad layout. Filling
+        // the screen pushed the close button under the status bar (status-bar overlap, untappable).
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     func header(spacing: CGFloat) -> some View {

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -7,9 +7,18 @@ struct POSStaffSettingsView: View {
     @Environment(\.posAccessSession) private var session
 
     let service: POSStaffSettingsService
+    /// Gates opening the staff-management web view on `managePOSStaff`. Defaults to running it directly
+    /// (previews / no host gate).
+    private let requestManageStaffPermission: (@escaping () -> Void) -> Void
 
     @State private var state: LoadState = .idle
     @State private var showsManageStaff: Bool = false
+
+    init(service: POSStaffSettingsService,
+         requestManageStaffPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {
+        self.service = service
+        self.requestManageStaffPermission = requestManageStaffPermission
+    }
 
     private enum LoadState {
         case idle
@@ -38,10 +47,7 @@ struct POSStaffSettingsView: View {
                             staffListCard(staff: staff)
                         }
                     }
-                    // Managing staff happens in wp-admin and is gated server-side on `manage_woocommerce`,
-                    // which only admins/shop managers hold — so only surface the CTA when the operator
-                    // has `managePOSStaff`. There's no override: a manager can't grant it to themselves.
-                    if manageStaffURL != nil, session.allows(.managePOSStaff) {
+                    if manageStaffURL != nil {
                         manageStaffCard
                     }
                     footerText
@@ -169,7 +175,11 @@ private extension POSStaffSettingsView {
 
     var manageStaffCard: some View {
         Button {
-            showsManageStaff = true
+            // Always offered; gated on `managePOSStaff` so a staff member without it needs an
+            // authorized override before the wp-admin staff page opens (it's also gated server-side
+            // on `manage_woocommerce`). The web view authenticates as the device account, so the
+            // override authorizes opening it rather than acting as the approver.
+            requestManageStaffPermission { showsManageStaff = true }
         } label: {
             Text(Localization.manageStaffButton)
         }

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -38,7 +38,10 @@ struct POSStaffSettingsView: View {
                             staffListCard(staff: staff)
                         }
                     }
-                    if manageStaffURL != nil {
+                    // Managing staff happens in wp-admin and is gated server-side on `manage_woocommerce`,
+                    // which only admins/shop managers hold — so only surface the CTA when the operator
+                    // has `managePOSStaff`. There's no override: a manager can't grant it to themselves.
+                    if manageStaffURL != nil, session.allows(.managePOSStaff) {
                         manageStaffCard
                     }
                     footerText

--- a/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
+++ b/Modules/Sources/PointOfSale/Roles/Views/POSStaffSettingsView.swift
@@ -9,13 +9,13 @@ struct POSStaffSettingsView: View {
     let service: POSStaffSettingsService
     /// Gates opening the staff-management web view on `managePOSStaff`. Defaults to running it directly
     /// (previews / no host gate).
-    private let requestManageStaffPermission: (@escaping () -> Void) -> Void
+    private let requestManageStaffPermission: POSPermissionRequest
 
     @State private var state: LoadState = .idle
     @State private var showsManageStaff: Bool = false
 
     init(service: POSStaffSettingsService,
-         requestManageStaffPermission: @escaping (@escaping () -> Void) -> Void = { $0() }) {
+         requestManageStaffPermission: @escaping POSPermissionRequest = { $0() }) {
         self.service = service
         self.requestManageStaffPermission = requestManageStaffPermission
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -168,12 +168,25 @@ struct DefaultPOSAccessSessionTests {
         #expect(sut.session.allows(.issueRefunds) == false)
     }
 
-    @Test func test_allows_when_no_currentStaff_then_returns_false() {
-        // Given
+    @Test func test_allows_when_gated_but_not_signed_in_then_returns_false() {
+        // Given a session with PIN-backed staff (gating active) but nobody signed in
+        let cache = POSStaffCache(storage: InMemoryStaffStorage())
+        cache.save([makeStaffMember(hasPIN: true)], siteID: 123)
+        let sut = makeSUT(authenticator: MockPOSPINAuthenticator(), cache: cache)
+
+        // When / Then — gating is active and there's no current staff, so access is denied
+        #expect(sut.session.hasAnyPINs == true)
+        #expect(sut.session.allows(.issueRefunds) == false)
+    }
+
+    @Test func test_allows_when_no_pins_cached_then_returns_true() {
+        // Given a roles-enabled session with no PIN-backed staff (gating inactive)
         let sut = makeSUT(authenticator: MockPOSPINAuthenticator())
 
-        // When / Then
-        #expect(sut.session.allows(.issueRefunds) == false)
+        // When / Then — nobody can sign in and no PIN could approve an override, so gating is off
+        #expect(sut.session.hasAnyPINs == false)
+        #expect(sut.session.allows(.issueRefunds) == true)
+        #expect(sut.session.allows(.exitPOS) == true)
     }
 
     @Test func test_lock_when_called_then_persists_true_to_per_site_lock_key() {

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSAccessSessionTests.swift
@@ -451,7 +451,7 @@ private extension DefaultPOSAccessSessionTests {
         POSStaffMember(userID: userID,
                        displayName: "Staff",
                        preset: .cashier,
-                       capabilities: ["woocommerce_pos_process_sales": true],
+                       capabilities: ["woocommerce_pos_issue_refunds": true],
                        pin: hasPIN ? .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                            salt: "c2FsdA==", hash: "aGFzaA==") : nil)
     }

--- a/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/DefaultPOSPINAuthenticatorTests.swift
@@ -14,7 +14,7 @@ struct DefaultPOSPINAuthenticatorTests {
     @Test func test_authenticate_when_pin_matches_a_cached_member_then_returns_that_staff() async throws {
         // Given a cached member whose PIN hash matches "1234"
         let member = makeMember(userID: 7, displayName: "Manny", preset: .manager,
-                                capabilities: ["woocommerce_pos_process_sales": true, "woocommerce_pos_issue_refunds": true],
+                                capabilities: ["woocommerce_pos_issue_refunds": true],
                                 pin: pinDetails(forPIN: "1234"))
         let sut = makeSUT(cached: [member])
 
@@ -89,8 +89,8 @@ struct DefaultPOSPINAuthenticatorTests {
         // Given a member with a granted known cap, a denied known cap, and an unknown cap
         let member = makeMember(userID: 1,
                                 capabilities: [
-                                    "woocommerce_pos_process_sales": true,
-                                    "woocommerce_pos_issue_refunds": false,
+                                    "woocommerce_pos_issue_refunds": true,
+                                    "woocommerce_pos_create_coupons": false,
                                     "some_unknown_cap": true
                                 ],
                                 pin: pinDetails(forPIN: "1234"))
@@ -100,9 +100,9 @@ struct DefaultPOSPINAuthenticatorTests {
         let staff = try await sut.authenticate(withPIN: "1234")
 
         // Then only the granted, recognized capability survives
-        #expect(staff.capabilities == ["woocommerce_pos_process_sales"])
-        #expect(staff.hasCapability(.processSales))
-        #expect(!staff.hasCapability(.issueRefunds))
+        #expect(staff.capabilities == ["woocommerce_pos_issue_refunds"])
+        #expect(staff.hasCapability(.issueRefunds))
+        #expect(!staff.hasCapability(.createCoupons))
     }
 
     @MainActor
@@ -136,7 +136,7 @@ struct DefaultPOSPINAuthenticatorTests {
 
     @MainActor
     @Test func test_verify_when_manager_lacks_the_capability_then_throws_invalidPIN() async throws {
-        let cashier = makeMember(userID: 6, capabilities: ["woocommerce_pos_process_sales": true],
+        let cashier = makeMember(userID: 6, capabilities: [:],
                                  pin: pinDetails(forPIN: "9999"))
         let sut = makeSUT(cached: [cashier])
 
@@ -159,7 +159,7 @@ private extension DefaultPOSPINAuthenticatorTests {
     func makeMember(userID: Int64,
                     displayName: String = "User",
                     preset: POSStaffPreset = .cashier,
-                    capabilities: [String: Bool] = ["woocommerce_pos_process_sales": true],
+                    capabilities: [String: Bool] = ["woocommerce_pos_issue_refunds": true],
                     pin: POSStaffMember.PINDetails?) -> POSStaffMember {
         POSStaffMember(userID: userID, displayName: displayName, preset: preset,
                        capabilities: capabilities, pin: pin)

--- a/Modules/Tests/PointOfSaleTests/Roles/POSCapabilityTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSCapabilityTests.swift
@@ -4,9 +4,6 @@ import Testing
 struct POSCapabilityTests {
     @Test func test_rawValues_match_backend_capability_identifiers() {
         // When / Then
-        #expect(POSCapability.processSales.rawValue == "woocommerce_pos_process_sales")
-        #expect(POSCapability.viewOrders.rawValue == "woocommerce_pos_view_orders")
-        #expect(POSCapability.applyCoupons.rawValue == "woocommerce_pos_apply_coupons")
         #expect(POSCapability.createCoupons.rawValue == "woocommerce_pos_create_coupons")
         #expect(POSCapability.issueRefunds.rawValue == "woocommerce_pos_issue_refunds")
         #expect(POSCapability.viewPOSSettings.rawValue == "woocommerce_pos_view_settings")
@@ -16,11 +13,9 @@ struct POSCapabilityTests {
     }
 
     @Test func test_allCases_is_exactly_the_supported_capability_set() {
-        // When / Then
+        // Only the capabilities the client enforces are modelled; the cashier-baseline caps the server
+        // also reports (process_sales / view_orders / apply_coupons) are intentionally excluded.
         #expect(Set(POSCapability.allCases.map(\.rawValue)) == [
-            "woocommerce_pos_process_sales",
-            "woocommerce_pos_view_orders",
-            "woocommerce_pos_apply_coupons",
             "woocommerce_pos_create_coupons",
             "woocommerce_pos_issue_refunds",
             "woocommerce_pos_view_settings",

--- a/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Roles/POSRolesPersistenceTests.swift
@@ -54,7 +54,7 @@ private extension POSRolesPersistenceTests {
         POSStaffMember(userID: 1,
                        displayName: "Staff",
                        preset: .cashier,
-                       capabilities: ["woocommerce_pos_process_sales": true],
+                       capabilities: ["woocommerce_pos_issue_refunds": true],
                        pin: .init(algorithm: "pbkdf2-sha256", iterations: 1,
                                   salt: "c2FsdA==", hash: "aGFzaA=="))
     }


### PR DESCRIPTION
## Description
PR 2 of WOOMOB-3288 (POS capability gating), behind the `pointOfSaleRoles` flag. Gates two manager/admin-only settings surfaces and finalizes the baseline-cap drop:

- **`editPOSSettings`** — the receipt-settings edit, the cellular-sync toggle, and the manual catalog update now require a manager override before taking effect. Read-only and hardware/card-reader settings are untouched.
- **`managePOSStaff`** — the manage-staff CTA is always shown; tapping it requires an override before the wp-admin staff page opens. (The web view authenticates as the device account, so the override authorizes *opening* it.)
- **Removes the 3 cashier-baseline caps** (`processSales`, `viewOrders`, `applyCoupons`) from `POSCapability` — every preset holds them, so gating them never denies anyone. The server keeps reporting these keys; the client just doesn't model or gate them (the staff decoder drops keys it doesn't recognize, covered by tests). The inert `viewOrders` gate added in PR 1 is removed.

M1 enforces 6 caps: `viewPOSSettings` + `exitPOS` (PR 1, merged), `editPOSSettings` + `managePOSStaff` (this PR), `issueRefunds` (PR 3), `createCoupons` (PR 4).

### Also fixed
- **No-PIN sessions are now ungated.** With roles on but no staff PINs configured, nobody is ever prompted to sign in, so `allows()` denied every capability and *every* gated CTA (exit, settings, …) popped an override modal that no PIN could approve. Access is now gated only when the staff cache actually has PINs — the same cache-driven signal that drives the lock screen. (Also fixes the already-merged PR 1 gates.)
- **Override modal close button on phone.** The manager-approval modal filled the screen, pushing the close (✕) button under the status bar where it wasn't tappable; it now sizes to content and centers like the lock screen / iPad layout.

## Test Steps
Optional — behavior is behind `pointOfSaleRoles` and covered by unit tests. For end-to-end manual testing of the full gating flow, use the POC branch (https://github.com/woocommerce/woocommerce/pull/65913).

With the flag on and staff PINs configured:
1. As a staff member **without** `editPOSSettings`: Settings → Store, tap the receipt **edit** (pencil) → override PIN prompt; an authorized PIN opens the webview. Same for the catalog **cellular** toggle and **Update catalog**.
2. As a staff member **without** `managePOSStaff`: Settings → Staff, tap **manage staff** → override PIN prompt.
3. As an **admin** holding both → both work directly, no prompt.

- [x] I (the author) will manually test the steps above.
- [ ] I will also verify with the feature flag off and with a staff member that has no capabilities.

## Screenshots

edit settings CTA (store settings, catalog settings, staff settings) | manage staff CTA 
-- | --
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-06-30 at 12 52 15" src="https://github.com/user-attachments/assets/1d005db8-ada8-4d8d-9bf6-c1dccf5ee779" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-06-30 at 12 52 36" src="https://github.com/user-attachments/assets/b6db2862-a3f3-4f13-86ae-6954d0ec7cc0" />


