### PR TITLE
Support plugin-version context for remote feature flags

### DIFF
--- a/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
+++ b/Modules/Sources/Networking/Remote/FeatureFlagRemote.swift
@@ -3,17 +3,26 @@ import Foundation
 /// Protocol for `FeatureFlagsRemote` mainly used for mocking.
 ///
 public protocol FeatureFlagRemoteProtocol {
-    func loadAllFeatureFlags() async throws -> [RemoteFeatureFlag: Bool]
+    func loadAllFeatureFlags(activePluginVersions: [String: String]) async throws -> [RemoteFeatureFlag: Bool]
+}
+
+public extension FeatureFlagRemoteProtocol {
+    func loadAllFeatureFlags() async throws -> [RemoteFeatureFlag: Bool] {
+        try await loadAllFeatureFlags(activePluginVersions: [:])
+    }
 }
 
 /// Feature Flags: Remote Endpoints
 ///
 public class FeatureFlagRemote: Remote, FeatureFlagRemoteProtocol {
-    public func loadAllFeatureFlags() async throws -> [RemoteFeatureFlag: Bool] {
-        let parameters: [String: String] = [
-            ParameterKeys.platform: "ios",
-            ParameterKeys.marketingVersion: Bundle.main.marketingVersion,
+    public func loadAllFeatureFlags(activePluginVersions: [String: String] = [:]) async throws -> [RemoteFeatureFlag: Bool] {
+        var parameters: RequestParameterDictionary = [
+            ParameterKeys.platform: .string("ios"),
+            ParameterKeys.marketingVersion: .string(Bundle.main.marketingVersion),
         ]
+        activePluginVersions.forEach { plugin, version in
+            parameters[ParameterKeys.activePluginVersion(plugin: plugin)] = .string(version)
+        }
 
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: Paths.lookup, parameters: parameters)
         let valuesByFeatureFlagString: [String: Bool] = try await enqueue(request)
@@ -91,5 +100,9 @@ private extension FeatureFlagRemote {
     enum ParameterKeys {
         static let platform = "platform"
         static let marketingVersion = "marketing_version"
+
+        static func activePluginVersion(plugin: String) -> String {
+            "active_plugin_versions[\(plugin)]"
+        }
     }
 }

--- a/Modules/Sources/Yosemite/Actions/FeatureFlagAction.swift
+++ b/Modules/Sources/Yosemite/Actions/FeatureFlagAction.swift
@@ -4,4 +4,5 @@ import Foundation
 ///
 public enum FeatureFlagAction: Action {
     case isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag, defaultValue: Bool, useCache: Bool = true, completion: (Bool) -> Void)
+    case refreshRemoteFeatureFlags(siteID: Int64?, activePluginVersions: [String: String], completion: (Result<Void, Error>) -> Void)
 }

--- a/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
+++ b/Modules/Sources/Yosemite/Model/Mocks/MockStoresManager.swift
@@ -171,6 +171,8 @@ public class MockStoresManager: StoresManager {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         default:
             let message = "⚠️ [MockStoresManager] Unhandled action type: \(action.identifier) \(String(describing: action))"

--- a/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
+++ b/Modules/Sources/Yosemite/Stores/FeatureFlagStore.swift
@@ -5,8 +5,10 @@ import Storage
 public final class FeatureFlagStore: Store {
     private let remote: FeatureFlagRemoteProtocol
     private let overrideStore: RemoteFeatureFlagOverrideStore?
-    private var cachedFeatureFlags: [RemoteFeatureFlag: Bool]?
-    private var cacheTimestamp: Date?
+    private let currentSiteIDProvider: @MainActor () -> Int64?
+    private let activePluginVersionsProvider: @MainActor (Int64?) -> [String: String]
+    private var cachedFeatureFlagsByContext: [FeatureFlagContext: CacheEntry] = [:]
+    private var activePluginVersionsBySite: [SiteContext: [String: String]] = [:]
     private let cacheMaxAge: TimeInterval
     private let currentDate: () -> Date
 
@@ -16,11 +18,15 @@ public final class FeatureFlagStore: Store {
          remote: FeatureFlagRemoteProtocol,
          overrideStore: RemoteFeatureFlagOverrideStore? = nil,
          cacheMaxAge: TimeInterval = 24 * 60 * 60,
-         currentDate: @escaping () -> Date = { Date() }) {
+         currentDate: @escaping () -> Date = { Date() },
+         currentSiteIDProvider: @escaping @MainActor () -> Int64? = { nil },
+         activePluginVersionsProvider: @escaping @MainActor (Int64?) -> [String: String] = { _ in [:] }) {
         self.remote = remote
         self.cacheMaxAge = cacheMaxAge
         self.currentDate = currentDate
         self.overrideStore = overrideStore
+        self.currentSiteIDProvider = currentSiteIDProvider
+        self.activePluginVersionsProvider = activePluginVersionsProvider
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 
@@ -37,12 +43,16 @@ public final class FeatureFlagStore: Store {
     public convenience init(dispatcher: Dispatcher,
                             storageManager: StorageManagerType,
                             network: Network,
-                            overrideStore: RemoteFeatureFlagOverrideStore?) {
+                            overrideStore: RemoteFeatureFlagOverrideStore?,
+                            currentSiteIDProvider: @escaping @MainActor () -> Int64? = { nil },
+                            activePluginVersionsProvider: @escaping @MainActor (Int64?) -> [String: String] = { _ in [:] }) {
         self.init(dispatcher: dispatcher,
                   storageManager: storageManager,
                   network: network,
                   remote: FeatureFlagRemote(network: network),
-                  overrideStore: overrideStore)
+                  overrideStore: overrideStore,
+                  currentSiteIDProvider: currentSiteIDProvider,
+                  activePluginVersionsProvider: activePluginVersionsProvider)
     }
 
     // MARK: - Actions
@@ -66,6 +76,8 @@ public final class FeatureFlagStore: Store {
         switch action {
         case let .isRemoteFeatureFlagEnabled(featureFlag, defaultValue, useCache, completion):
             isRemoteFeatureFlagEnabled(featureFlag, defaultValue: defaultValue, useCache: useCache, completion: completion)
+        case let .refreshRemoteFeatureFlags(siteID, activePluginVersions, completion):
+            refreshRemoteFeatureFlags(siteID: siteID, activePluginVersions: activePluginVersions, completion: completion)
         }
     }
 }
@@ -73,9 +85,8 @@ public final class FeatureFlagStore: Store {
 // MARK: - Services
 //
 private extension FeatureFlagStore {
-    var isCacheExpired: Bool {
-        guard let cacheTimestamp else { return true }
-        return currentDate().timeIntervalSince(cacheTimestamp) >= cacheMaxAge
+    func isCacheExpired(_ entry: CacheEntry) -> Bool {
+        currentDate().timeIntervalSince(entry.timestamp) >= cacheMaxAge
     }
 
     func isRemoteFeatureFlagEnabled(_ featureFlag: RemoteFeatureFlag,
@@ -88,25 +99,95 @@ private extension FeatureFlagStore {
             return
         }
 
-        if useCache, let cachedFlags = cachedFeatureFlags, !isCacheExpired {
-            completion(cachedFlags[featureFlag] ?? defaultValue)
-            return
-        }
-
         Task { @MainActor in
+            let context = currentContext()
+
+            if useCache, let entry = cachedFeatureFlagsByContext[context], !isCacheExpired(entry) {
+                completion(entry.featureFlags[featureFlag] ?? defaultValue)
+                return
+            }
+
             do {
-                let featureFlags = try await remote.loadAllFeatureFlags()
-                await MainActor.run {
-                    self.cachedFeatureFlags = featureFlags
-                    self.cacheTimestamp = self.currentDate()
-                    completion(featureFlags[featureFlag] ?? defaultValue)
-                }
+                let featureFlags = try await remote.loadAllFeatureFlags(activePluginVersions: context.activePluginVersionsDictionary)
+                cachedFeatureFlagsByContext[context] = CacheEntry(featureFlags: featureFlags, timestamp: currentDate())
+                completion(featureFlags[featureFlag] ?? defaultValue)
             } catch {
                 DDLogError("⛔️ FeatureFlagStore: Failed to load feature flags with error: \(error)")
-                await MainActor.run {
-                    completion(defaultValue)
-                }
+                completion(defaultValue)
             }
         }
+    }
+
+    func refreshRemoteFeatureFlags(siteID: Int64?,
+                                   activePluginVersions: [String: String],
+                                   completion: @escaping (Result<Void, Error>) -> Void) {
+        Task { @MainActor in
+            let siteContext = SiteContext(siteID: siteID)
+            activePluginVersionsBySite[siteContext] = activePluginVersions
+            let context = FeatureFlagContext(siteContext: siteContext, activePluginVersions: activePluginVersions)
+
+            do {
+                let featureFlags = try await remote.loadAllFeatureFlags(activePluginVersions: activePluginVersions)
+                cachedFeatureFlagsByContext[context] = CacheEntry(featureFlags: featureFlags, timestamp: currentDate())
+                completion(.success(()))
+            } catch {
+                DDLogError("⛔️ FeatureFlagStore: Failed to refresh feature flags with error: \(error)")
+                completion(.failure(error))
+            }
+        }
+    }
+
+    @MainActor
+    func currentContext() -> FeatureFlagContext {
+        let siteID = currentSiteIDProvider()
+        let siteContext = SiteContext(siteID: siteID)
+        let activePluginVersions = activePluginVersionsBySite[siteContext] ?? activePluginVersionsProvider(siteID)
+        return FeatureFlagContext(siteContext: siteContext, activePluginVersions: activePluginVersions)
+    }
+}
+
+private struct CacheEntry {
+    let featureFlags: [RemoteFeatureFlag: Bool]
+    let timestamp: Date
+}
+
+private enum SiteContext: Hashable {
+    case noSite
+    case site(Int64)
+
+    init(siteID: Int64?) {
+        if let siteID {
+            self = .site(siteID)
+        } else {
+            self = .noSite
+        }
+    }
+}
+
+private struct FeatureFlagContext: Hashable {
+    let siteContext: SiteContext
+    let activePluginVersions: [PluginVersion]
+
+    init(siteContext: SiteContext, activePluginVersions: [String: String]) {
+        self.siteContext = siteContext
+        self.activePluginVersions = activePluginVersions
+            .map { PluginVersion(plugin: $0.key, version: $0.value) }
+            .sorted()
+    }
+
+    var activePluginVersionsDictionary: [String: String] {
+        Dictionary(uniqueKeysWithValues: activePluginVersions.map { ($0.plugin, $0.version) })
+    }
+}
+
+private struct PluginVersion: Hashable, Comparable {
+    let plugin: String
+    let version: String
+
+    static func < (lhs: PluginVersion, rhs: PluginVersion) -> Bool {
+        if lhs.plugin == rhs.plugin {
+            return lhs.version < rhs.version
+        }
+        return lhs.plugin < rhs.plugin
     }
 }

--- a/Modules/Sources/Yosemite/Tools/Plugins/ActivePluginVersionsProvider.swift
+++ b/Modules/Sources/Yosemite/Tools/Plugins/ActivePluginVersionsProvider.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public protocol ActivePluginVersionsProviding {
+    @MainActor
+    func activePluginVersions(siteID: Int64?) -> [String: String]
+}
+
+public final class WooCommerceActivePluginVersionsProvider: ActivePluginVersionsProviding {
+    public static let wooCommercePluginPath = "woocommerce/woocommerce.php"
+
+    private let pluginsService: PluginsServiceProtocol
+
+    public init(pluginsService: PluginsServiceProtocol) {
+        self.pluginsService = pluginsService
+    }
+
+    @MainActor
+    public func activePluginVersions(siteID: Int64?) -> [String: String] {
+        guard let siteID,
+              let plugin = pluginsService.loadPluginInStorage(siteID: siteID, plugin: .wooCommerce, isActive: true) else {
+            return [:]
+        }
+
+        return Self.activePluginVersions(from: [plugin])
+    }
+
+    public static func activePluginVersions(from systemPlugins: [SystemPlugin]) -> [String: String] {
+        guard let plugin = systemPlugins.first(where: { plugin in
+            plugin.plugin == wooCommercePluginPath && plugin.active && plugin.version.isEmpty == false
+        }) else {
+            return [:]
+        }
+
+        return [wooCommercePluginPath: plugin.version]
+    }
+}

--- a/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
+++ b/Modules/Tests/NetworkingTests/Remote/FeatureFlagRemoteTests.swift
@@ -37,6 +37,32 @@ final class FeatureFlagRemoteTests: XCTestCase {
         ])
     }
 
+    func test_loadAllFeatureFlags_with_active_plugin_versions_sends_bracketed_query_parameters() async throws {
+        // Given
+        let remote = FeatureFlagRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "feature-flags-load-all")
+
+        // When
+        _ = try await remote.loadAllFeatureFlags(activePluginVersions: ["woocommerce/woocommerce.php": "10.9.2"])
+
+        // Then
+        let queryItems = try requestQueryItems()
+        XCTAssertEqual(queryItems["active_plugin_versions[woocommerce/woocommerce.php]"], "10.9.2")
+    }
+
+    func test_loadAllFeatureFlags_without_active_plugin_versions_does_not_send_plugin_parameters() async throws {
+        // Given
+        let remote = FeatureFlagRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "mobile/feature-flags", filename: "feature-flags-load-all")
+
+        // When
+        _ = try await remote.loadAllFeatureFlags()
+
+        // Then
+        let queryItems = try requestQueryItems()
+        XCTAssertNil(queryItems["active_plugin_versions[woocommerce/woocommerce.php]"])
+    }
+
     func test_loadAllFeatureFlags_returns_empty_dictionary_when_response_does_not_include_known_flags() async throws {
         // Given
         let remote = FeatureFlagRemote(network: network)
@@ -104,5 +130,12 @@ final class FeatureFlagRemoteTests: XCTestCase {
 
         // Then
         XCTAssertNil(flag)
+    }
+
+    private func requestQueryItems() throws -> [String: String] {
+        let request = try XCTUnwrap(network.requestsForResponseData.first)
+        let url = try XCTUnwrap(try request.asURLRequest().url)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        return Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
     }
 }

--- a/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockFeatureFlagRemote.swift
+++ b/Modules/Tests/YosemiteTests/Mocks/Networking/Remote/MockFeatureFlagRemote.swift
@@ -10,6 +10,8 @@ final class MockFeatureFlagRemote {
     /// The number of times `loadAllFeatureFlags` has been called.
     private(set) var loadAllFeatureFlagsCallCount = 0
 
+    private(set) var activePluginVersions = [[String: String]]()
+
     /// Returns the value when `loadAllFeatureFlags` is called.
     func whenLoadingAllFeatureFlags(thenReturn result: Result<[RemoteFeatureFlag: Bool], Error>) {
         loadAllFeatureFlagsResult = result
@@ -17,8 +19,9 @@ final class MockFeatureFlagRemote {
 }
 
 extension MockFeatureFlagRemote: FeatureFlagRemoteProtocol {
-    func loadAllFeatureFlags() async throws -> [RemoteFeatureFlag: Bool] {
+    func loadAllFeatureFlags(activePluginVersions: [String: String]) async throws -> [RemoteFeatureFlag: Bool] {
         loadAllFeatureFlagsCallCount += 1
+        self.activePluginVersions.append(activePluginVersions)
         guard let result = loadAllFeatureFlagsResult else {
             XCTFail("Could not find result for loading all feature flags.")
             throw NetworkError.notFound()

--- a/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
+++ b/Modules/Tests/YosemiteTests/Stores/FeatureFlagStoreTests.swift
@@ -16,6 +16,8 @@ final class FeatureFlagStoreTests: XCTestCase {
     private var remote: MockFeatureFlagRemote!
     private var store: FeatureFlagStore!
     private var currentDate: Date!
+    private var currentSiteID: Int64?
+    private var activePluginVersions: [String: String]!
 
     override func setUp() {
         super.setUp()
@@ -24,11 +26,15 @@ final class FeatureFlagStoreTests: XCTestCase {
         network = MockNetwork()
         remote = MockFeatureFlagRemote()
         currentDate = Date()
+        currentSiteID = nil
+        activePluginVersions = [:]
         store = FeatureFlagStore(dispatcher: dispatcher,
                                  storageManager: storageManager,
                                  network: network,
                                  remote: remote,
-                                 currentDate: { self.currentDate })
+                                 currentDate: { self.currentDate },
+                                 currentSiteIDProvider: { self.currentSiteID },
+                                 activePluginVersionsProvider: { _ in self.activePluginVersions })
     }
 
     override func tearDown() {
@@ -38,6 +44,8 @@ final class FeatureFlagStoreTests: XCTestCase {
         storageManager = nil
         dispatcher = nil
         currentDate = nil
+        currentSiteID = nil
+        activePluginVersions = nil
         super.tearDown()
     }
 
@@ -159,6 +167,96 @@ final class FeatureFlagStoreTests: XCTestCase {
         // Then - should fetch from remote and return the new value (false)
         XCTAssertFalse(isEnabled)
         XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_site_changes_does_not_return_previous_site_cached_value() throws {
+        // Given
+        currentSiteID = 1
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+        let firstSiteValue = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
+                    promise(result)
+                })
+        }
+        XCTAssertTrue(firstSiteValue)
+
+        // When
+        currentSiteID = 2
+        remote.whenLoadingAllFeatureFlags(thenReturn: .failure(NetworkError.timeout()))
+        let secondSiteValue = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then
+        XCTAssertFalse(secondSiteValue)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
+    }
+
+    func test_isRemoteFeatureFlagEnabled_when_active_plugin_versions_change_uses_separate_cache_context() throws {
+        // Given
+        currentSiteID = 1
+        activePluginVersions = ["woocommerce/woocommerce.php": "10.9.2"]
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+        let firstVersionValue = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: false, useCache: true) { result in
+                    promise(result)
+                })
+        }
+        XCTAssertTrue(firstVersionValue)
+
+        // When
+        activePluginVersions = ["woocommerce/woocommerce.php": "9.9.0"]
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+        let secondVersionValue = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: true, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then
+        XCTAssertFalse(secondVersionValue)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 2)
+        XCTAssertEqual(remote.activePluginVersions, [
+            ["woocommerce/woocommerce.php": "10.9.2"],
+            ["woocommerce/woocommerce.php": "9.9.0"]
+        ])
+    }
+
+    func test_refreshRemoteFeatureFlags_with_empty_plugin_versions_keeps_selected_site_context_empty_for_lazy_reads() throws {
+        // Given
+        currentSiteID = 1
+        activePluginVersions = ["woocommerce/woocommerce.php": "10.9.2"]
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: false]))
+
+        waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .refreshRemoteFeatureFlags(siteID: 1, activePluginVersions: [:]) { result in
+                    if case let .failure(error) = result {
+                        XCTFail("Expected refresh to succeed, received \(error)")
+                    }
+                    promise(())
+                })
+        }
+
+        // When
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+        let isEnabled = waitFor { promise in
+            self.store.onAction(FeatureFlagAction
+                .isRemoteFeatureFlagEnabled(.storeCreationCompleteNotification, defaultValue: true, useCache: true) { result in
+                    promise(result)
+                })
+        }
+
+        // Then
+        XCTAssertFalse(isEnabled)
+        XCTAssertEqual(remote.loadAllFeatureFlagsCallCount, 1)
+        XCTAssertEqual(remote.activePluginVersions, [[:]])
     }
 
     func test_isRemoteFeatureFlagEnabled_when_cache_is_not_expired_returns_cached_value() throws {

--- a/Modules/Tests/YosemiteTests/Tools/Plugins/ActivePluginVersionsProviderTests.swift
+++ b/Modules/Tests/YosemiteTests/Tools/Plugins/ActivePluginVersionsProviderTests.swift
@@ -1,0 +1,48 @@
+import Testing
+@testable import Yosemite
+
+struct ActivePluginVersionsProviderTests {
+    @Test func activePluginVersions_returns_woocommerce_version_when_active_woocommerce_plugin_has_non_empty_version() {
+        // Given
+        let plugin = SystemPlugin.fake().copy(plugin: "woocommerce/woocommerce.php", version: "10.9.2", active: true)
+
+        // When
+        let versions = WooCommerceActivePluginVersionsProvider.activePluginVersions(from: [plugin])
+
+        // Then
+        #expect(versions == ["woocommerce/woocommerce.php": "10.9.2"])
+    }
+
+    @Test func activePluginVersions_returns_empty_when_woocommerce_plugin_is_inactive() {
+        // Given
+        let plugin = SystemPlugin.fake().copy(plugin: "woocommerce/woocommerce.php", version: "10.9.2", active: false)
+
+        // When
+        let versions = WooCommerceActivePluginVersionsProvider.activePluginVersions(from: [plugin])
+
+        // Then
+        #expect(versions == [:])
+    }
+
+    @Test func activePluginVersions_returns_empty_when_woocommerce_plugin_is_missing() {
+        // Given
+        let plugin = SystemPlugin.fake().copy(plugin: "jetpack/jetpack.php", version: "14.0", active: true)
+
+        // When
+        let versions = WooCommerceActivePluginVersionsProvider.activePluginVersions(from: [plugin])
+
+        // Then
+        #expect(versions == [:])
+    }
+
+    @Test func activePluginVersions_returns_empty_when_woocommerce_plugin_version_is_blank() {
+        // Given
+        let plugin = SystemPlugin.fake().copy(plugin: "woocommerce/woocommerce.php", version: "", active: true)
+
+        // When
+        let versions = WooCommerceActivePluginVersionsProvider.activePluginVersions(from: [plugin])
+
+        // Then
+        #expect(versions == [:])
+    }
+}

--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -63,6 +63,9 @@ class AuthenticatedState: StoresManagerState {
             selectedSite: site,
             appPasswordSupportState: appPasswordSupportState.eraseToAnyPublisher()
         )
+        let activePluginVersionsProvider = WooCommerceActivePluginVersionsProvider(
+            pluginsService: PluginsService(storageManager: storageManager)
+        )
 
         var services: [ActionsProcessor] = [
             AppSettingsStore(dispatcher: dispatcher,
@@ -78,7 +81,11 @@ class AuthenticatedState: StoresManagerState {
             FeatureFlagStore(dispatcher: dispatcher,
                             storageManager: storageManager,
                             network: network,
-                            overrideStore: ServiceLocator.remoteFeatureFlagOverrideStore),
+                            overrideStore: ServiceLocator.remoteFeatureFlagOverrideStore,
+                            currentSiteIDProvider: { sessionManager.defaultStoreID },
+                            activePluginVersionsProvider: { siteID in
+                                activePluginVersionsProvider.activePluginVersions(siteID: siteID)
+                            }),
             InboxNotesStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             JetpackSettingsStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
             JustInTimeMessageStore(dispatcher: dispatcher, storageManager: storageManager, network: network),

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -861,9 +861,10 @@ private extension DefaultStoresManager {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 async let orderStatuses = retrieveOrderStatus(with: siteID)
-                async let systemInformation = fetchSystemInformationAndRetryIfFails(siteID: siteID)
+                let systemInformation = await fetchSystemInformationAndRetryIfFails(siteID: siteID)
+                await refreshRemoteFeatureFlags(siteID: siteID, systemInformation: systemInformation)
 
-                trackSnapshotIfNeeded(siteID: siteID, orderStatuses: await orderStatuses, systemPlugins: await systemInformation?.systemPlugins)
+                trackSnapshotIfNeeded(siteID: siteID, orderStatuses: await orderStatuses, systemPlugins: systemInformation?.systemPlugins)
 
                 // Batch 3 (after batch 2 completes): Non-essential data.
                 synchronizePaymentGateways(siteID: siteID)
@@ -1040,6 +1041,24 @@ private extension DefaultStoresManager {
             trackedEligibleSites.remove(siteID)
         }
         ServiceLocator.analytics.track(.jetpackSiteFlaggedUnsupportedForAppPasswords, withProperties: properties)
+    }
+}
+
+
+extension DefaultStoresManager {
+    /// Refreshes remote feature flags for the selected site context after the latest system information sync attempt.
+    @MainActor
+    func refreshRemoteFeatureFlags(siteID: Int64, systemInformation: SystemInformation?) async {
+        let activePluginVersions = WooCommerceActivePluginVersionsProvider.activePluginVersions(from: systemInformation?.systemPlugins ?? [])
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            dispatch(FeatureFlagAction.refreshRemoteFeatureFlags(siteID: siteID, activePluginVersions: activePluginVersions) { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Failed to refresh remote feature flags for siteID: \(siteID). Error: \(error)")
+                }
+                continuation.resume()
+            })
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/AIAssistant/AIAssistantEligibilityCheckerTests.swift
@@ -114,6 +114,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -136,6 +138,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -158,6 +162,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -187,6 +193,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)
@@ -215,6 +223,8 @@ struct AIAssistantEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let sut = makeSUT(flagService: flagService, stores: stores)

--- a/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockStoresManager.swift
@@ -58,8 +58,11 @@ final class MockStoresManager: DefaultStoresManager {
         switch action {
         case let action as FeatureFlagAction:
             // Mirror `FeatureFlagStore`: with no remote override configured, resolve to the local default.
-            if case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion) = action {
+            switch action {
+            case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
                 completion(defaultValue)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         default:
             break

--- a/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/LocalNotificationSchedulerTests.swift
@@ -25,6 +25,8 @@ final class LocalNotificationSchedulerTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is enabled.
                 completion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 
@@ -45,6 +47,8 @@ final class LocalNotificationSchedulerTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is disabled.
                 completion(false)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 
@@ -78,6 +82,8 @@ final class LocalNotificationSchedulerTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 // Remote feature flag is enabled.
                 completion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -2035,6 +2035,8 @@ private extension PushNotificationsManagerTests {
             case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(isEnabled)
                 onCompletion?()
+            case .refreshRemoteFeatureFlags(_, _, let completion):
+                completion(.success(()))
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/WooPushNotificationEligibilityCheckTests.swift
@@ -65,6 +65,8 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
                 capturedDefaultValue = defaultValue
                 completion(defaultValue)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 
@@ -88,6 +90,8 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(featureFlag, _, _, completion):
                 capturedFeatureFlag = featureFlag
                 completion(false)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 
@@ -111,6 +115,8 @@ final class WooPushNotificationEligibilityCheckTests: XCTestCase {
             case let .isRemoteFeatureFlagEnabled(_, _, useCache, completion):
                 capturedUseCache = useCache
                 completion(false)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 
@@ -146,6 +152,8 @@ private extension WooPushNotificationEligibilityCheckTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(isEnabled)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Feature Announcement Cards/ClientSideBannerProviderTests.swift
@@ -40,6 +40,8 @@ final class ClientSideBannerProviderTests: XCTestCase {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, onCompletion):
                 onCompletion(false)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
 
@@ -239,6 +241,8 @@ final class ClientSideBannerProviderTests: XCTestCase {
                 } else {
                     onCompletion(false)
                 }
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/ApplicationPasswordsExperimentAvailabilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/ApplicationPasswordsExperimentAvailabilityCheckerTests.swift
@@ -67,6 +67,8 @@ final class ApplicationPasswordsExperimentAvailabilityCheckerTests: XCTestCase {
             switch action {
             case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(true)
+            case .refreshRemoteFeatureFlags(_, _, let completion):
+                completion(.success(()))
             }
         }
 
@@ -98,6 +100,8 @@ final class ApplicationPasswordsExperimentAvailabilityCheckerTests: XCTestCase {
             switch action {
             case .isRemoteFeatureFlagEnabled(_, _, _, let completion):
                 completion(false)
+            case .refreshRemoteFeatureFlags(_, _, let completion):
+                completion(.success(()))
             }
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -572,6 +572,8 @@ extension POSTabVisibilityCheckerTests {
                 default:
                     completion(false)
                 }
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/ARParcelFittingEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/ARParcelFittingEligibilityCheckerTests.swift
@@ -29,6 +29,8 @@ struct ARParcelFittingEligibilityCheckerTests {
                 switch action {
                 case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                     completion(remoteFF)
+                case let .refreshRemoteFeatureFlags(_, _, completion):
+                    completion(.success(()))
                 }
             }
             let featureFlagService = MockFeatureFlagService()
@@ -58,6 +60,8 @@ struct ARParcelFittingEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(true)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let featureFlagService = MockFeatureFlagService()
@@ -129,6 +133,8 @@ struct ARParcelFittingEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 completion(false)
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let featureFlagService = MockFeatureFlagService()
@@ -163,6 +169,8 @@ struct ARParcelFittingEligibilityCheckerTests {
             switch action {
             case let .isRemoteFeatureFlagEnabled(_, _, _, completion):
                 Task { completion(true) }
+            case let .refreshRemoteFeatureFlags(_, _, completion):
+                completion(.success(()))
             }
         }
         let featureFlagService = MockFeatureFlagService()

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -241,6 +241,59 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertEqual(sessionManager.defaultStoreID, 456, "Store ID should be updated to the new store")
     }
 
+    @MainActor
+    func test_refreshRemoteFeatureFlags_dispatches_active_woocommerce_plugin_version_from_system_information() async {
+        // Given
+        let manager = MockStoresManager(sessionManager: SessionManager.testingInstance)
+        let siteID: Int64 = 134
+        let systemInformation = SystemInformation(systemPlugins: [
+            SystemPlugin.fake().copy(siteID: siteID, plugin: "woocommerce/woocommerce.php", version: "10.9.2", active: true),
+            SystemPlugin.fake().copy(siteID: siteID, plugin: "jetpack/jetpack.php", version: "14.0", active: true)
+        ])
+        var capturedSiteID: Int64?
+        var capturedActivePluginVersions: [String: String]?
+        manager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .refreshRemoteFeatureFlags(siteID, activePluginVersions, completion):
+                capturedSiteID = siteID
+                capturedActivePluginVersions = activePluginVersions
+                completion(.success(()))
+            case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
+                completion(defaultValue)
+            }
+        }
+
+        // When
+        await manager.refreshRemoteFeatureFlags(siteID: siteID, systemInformation: systemInformation)
+
+        // Then
+        XCTAssertEqual(capturedSiteID, siteID)
+        XCTAssertEqual(capturedActivePluginVersions, ["woocommerce/woocommerce.php": "10.9.2"])
+    }
+
+    @MainActor
+    func test_refreshRemoteFeatureFlags_dispatches_empty_plugin_versions_when_system_information_sync_failed() async {
+        // Given
+        let manager = MockStoresManager(sessionManager: SessionManager.testingInstance)
+        let siteID: Int64 = 134
+        var capturedActivePluginVersions: [String: String]?
+        manager.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
+            switch action {
+            case let .refreshRemoteFeatureFlags(_, activePluginVersions, completion):
+                capturedActivePluginVersions = activePluginVersions
+                completion(.success(()))
+            case let .isRemoteFeatureFlagEnabled(_, defaultValue, _, completion):
+                completion(defaultValue)
+            }
+        }
+
+        // When
+        await manager.refreshRemoteFeatureFlags(siteID: siteID, systemInformation: nil)
+
+        // Then
+        XCTAssertEqual(capturedActivePluginVersions, [:])
+    }
+
     /// Verifies that `authenticate(username: authToken:)` persists the Credentials in the Keychain Storage.
     ///
     func testAuthenticatePersistsDefaultCredentialsInKeychain() {


### PR DESCRIPTION
## Description
Adds client-reported WooCommerce active plugin version context to WPCOM mobile remote feature flag requests and scopes the in-memory cache by selected site plus plugin-version fingerprint.

Why:
- WPCOM mobile feature flags can now evaluate optional active_plugin_versions query parameters.
- The client reports only the allowlisted WooCommerce plugin version as compatibility context.
- Remote feature flags are site-dependent, so cached values must not leak across selected sites.

What changed:
- Extends FeatureFlagRemote.loadAllFeatureFlags(activePluginVersions:) while keeping no-plugin calls source-compatible.
- Serializes bracketed query params like active_plugin_versions[woocommerce/woocommerce.php]=10.9.2.
- Adds a Yosemite provider that reports only active WooCommerce with a non-empty version.
- Scopes the in-memory remote feature flag cache by no-site/site context plus sorted plugin-version fingerprint.
- Refreshes remote feature flags after system information sync during login/default-site restoration and default-site switches.
- Uses an empty plugin map when system information sync fails.

## Test Steps
Run the app and:
1. Select or log in to a WooCommerce site with WooCommerce core active.
2. Confirm the app syncs plugins before fetching WPCOM mobile remote feature flags.
3. Confirm the feature flag request includes only `active_plugin_versions[woocommerce/woocommerce.php]` when WooCommerce core is active with a non-blank version.
4. Switch to another selected site and confirm remote feature flag values are reloaded for that site context with the correct version of WooCommerce. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.

Notes:
- Does not add site_id to the WPCOM feature-flags endpoint.
- Does not add production feature flag definitions.