### PR TITLE
Fix POS authenticated web view launch

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -162,7 +162,7 @@ private extension AuthenticatedWebViewController {
             view.safeBottomAnchor.constraint(equalTo: webView.bottomAnchor),
         ])
 
-        extendContentUnderSafeAreas()
+        matchWebViewBackground()
     }
 
     func configureActivityIndicator() {
@@ -173,8 +173,7 @@ private extension AuthenticatedWebViewController {
         ])
     }
 
-    func extendContentUnderSafeAreas() {
-        webView.scrollView.clipsToBounds = false
+    func matchWebViewBackground() {
         view.backgroundColor = webView.underPageBackgroundColor
     }
 
@@ -274,8 +273,7 @@ private extension AuthenticatedWebViewController {
                 .value: initialURL.absoluteString,
             ])
 
-            let queryItem = URLQueryItem(name: Constants.actionParam, value: Constants.jetpackSSOAction)
-            guard let cookie, let loginURL = URL(string: currentSite.loginURL)?.appending(queryItems: [queryItem]) else {
+            guard let cookie, let loginURL = Self.makeJetpackSSOLoginURL(from: currentSite.loginURL, redirectingTo: initialURL) else {
                 return loadContent(url: initialURL)
             }
             webView.configuration.websiteDataStore.httpCookieStore.setCookie(cookie)
@@ -357,9 +355,65 @@ extension AuthenticatedWebViewController: WKUIDelegate {
     func webViewDidClose(_ webView: WKWebView) {
         dismiss(animated: true)
     }
+
+    func webView(_ webView: WKWebView,
+                 runJavaScriptAlertPanelWithMessage message: String,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping () -> Void) {
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: Localization.ok, style: .default) { _ in
+            completionHandler()
+        })
+        presentJavaScriptDialog(alertController, fallback: completionHandler)
+    }
+
+    func webView(_ webView: WKWebView,
+                 runJavaScriptConfirmPanelWithMessage message: String,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping (Bool) -> Void) {
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: Localization.cancel, style: .cancel) { _ in
+            completionHandler(false)
+        })
+        alertController.addAction(UIAlertAction(title: Localization.ok, style: .default) { _ in
+            completionHandler(true)
+        })
+        presentJavaScriptDialog(alertController) {
+            completionHandler(false)
+        }
+    }
+
+    func webView(_ webView: WKWebView,
+                 runJavaScriptTextInputPanelWithPrompt prompt: String,
+                 defaultText: String?,
+                 initiatedByFrame frame: WKFrameInfo,
+                 completionHandler: @escaping (String?) -> Void) {
+        let alertController = UIAlertController(title: nil, message: prompt, preferredStyle: .alert)
+        alertController.addTextField { textField in
+            textField.text = defaultText
+        }
+        alertController.addAction(UIAlertAction(title: Localization.cancel, style: .cancel) { _ in
+            completionHandler(nil)
+        })
+        alertController.addAction(UIAlertAction(title: Localization.ok, style: .default) { [weak alertController] _ in
+            completionHandler(alertController?.textFields?.first?.text)
+        })
+        presentJavaScriptDialog(alertController) {
+            completionHandler(nil)
+        }
+    }
 }
 
 private extension AuthenticatedWebViewController {
+    func presentJavaScriptDialog(_ alertController: UIAlertController, fallback: @escaping () -> Void) {
+        let presentingController = topmostViewController()
+        guard presentingController.viewIfLoaded?.window != nil else {
+            fallback()
+            return
+        }
+        presentingController.present(alertController, animated: true)
+    }
+
     func presentPopupWebView(with configuration: WKWebViewConfiguration,
                              for navigationAction: WKNavigationAction) -> WKWebView? {
         guard navigationAction.targetFrame == nil else {
@@ -395,7 +449,40 @@ private extension AuthenticatedWebViewController {
     enum Constants {
         static let actionParam = "action"
         static let jetpackSSOAction = "jetpack-sso"
+        static let redirectToParam = "redirect_to"
         static let ssoRedirectCookieName = "jetpack_sso_redirect_to"
+    }
+
+    enum Localization {
+        static let ok = NSLocalizedString(
+            "authenticatedWebViewController.javascriptDialog.ok",
+            value: "OK",
+            comment: "Button to accept a JavaScript dialog in an authenticated web view."
+        )
+        static let cancel = NSLocalizedString(
+            "authenticatedWebViewController.javascriptDialog.cancel",
+            value: "Cancel",
+            comment: "Button to cancel a JavaScript dialog in an authenticated web view."
+        )
+    }
+}
+
+extension AuthenticatedWebViewController {
+    static func makeJetpackSSOLoginURL(from loginURLString: String, redirectingTo redirectURL: URL) -> URL? {
+        guard let loginURL = URL(string: loginURLString),
+              var components = URLComponents(url: loginURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        var queryItems = components.queryItems ?? []
+        queryItems.removeAll { queryItem in
+            queryItem.name == Constants.actionParam || queryItem.name == Constants.redirectToParam
+        }
+        queryItems.append(URLQueryItem(name: Constants.actionParam, value: Constants.jetpackSSOAction))
+        queryItems.append(URLQueryItem(name: Constants.redirectToParam, value: redirectURL.absoluteString))
+        components.queryItems = queryItems
+
+        return components.url
     }
 }
 

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -197,23 +197,7 @@ private extension POSTabCoordinator {
         Task { @MainActor [weak self, weak hostingController] in
             guard let self, let hostingController else { return }
 
-            // Get local catalog eligibility as bool from service
-            let isLocalCatalogEligible: Bool
-            if let service = localCatalogEligibilityService {
-                // Resolve POS eligibility before deciding the fetch strategy
-                let posState = await eligibilityChecker.checkEligibility()
-                try? await service.updatePOSEligibility(isEligible: posState == .eligible, for: siteID)
-
-                // Retry transient failures before using the value
-                let state = try await service.catalogEligibility(for: siteID)
-                if case .ineligible(reason: .catalogSizeCheckFailed) = state {
-                    try await service.refreshEligibilityState(for: siteID)
-                }
-                isLocalCatalogEligible = try await service.catalogEligibility(for: siteID) == .eligible
-            } else {
-                // Service not ready yet (rare race condition), assume ineligible
-                isLocalCatalogEligible = false
-            }
+            let isLocalCatalogEligible = await resolveLocalCatalogEligibility(for: siteID)
 
             let sunsetWarningChecker = POSSunsetWarningChecker(
                 systemStatusService: POSSystemStatusService(
@@ -386,6 +370,29 @@ private extension POSTabCoordinator {
             } else {
                 await hostingController.dismiss(animated: true)
             }
+        }
+    }
+
+    func resolveLocalCatalogEligibility(for siteID: Int64) async -> Bool {
+        guard let service = localCatalogEligibilityService else {
+            // Service not ready yet (rare race condition), assume ineligible
+            return false
+        }
+
+        do {
+            // Resolve POS eligibility before deciding the fetch strategy
+            let posState = await eligibilityChecker.checkEligibility()
+            try await service.updatePOSEligibility(isEligible: posState == .eligible, for: siteID)
+
+            // Retry transient failures before using the value
+            let state = try await service.catalogEligibility(for: siteID)
+            if case .ineligible(reason: .catalogSizeCheckFailed) = state {
+                try await service.refreshEligibilityState(for: siteID)
+            }
+            return try await service.catalogEligibility(for: siteID) == .eligible
+        } catch {
+            DDLogError("⛔️ Could not resolve POS local catalog eligibility, falling back to remote catalog: \(error)")
+            return false
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
@@ -7,23 +7,22 @@ struct WCAuthenticatedWebView: View {
     let completion: () -> Void
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             AuthenticatedWebView(isPresented: .constant(true),
                                  url: url)
-                                 .navigationTitle(title)
-                                 .navigationBarTitleDisplayMode(.inline)
-                                 .toolbar {
-                                     ToolbarItem(placement: .confirmationAction) {
-                                         Button(action: {
-                                             completion()
-                                         }, label: {
-                                             Text(Localization.done)
-                                         })
-                                     }
-                                 }
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button(action: {
+                            completion()
+                        }, label: {
+                            Text(Localization.done)
+                        })
+                    }
+                }
         }
         .wooNavigationBarStyle()
-        .navigationViewStyle(.stack)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/AuthenticatedWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/AuthenticatedWebViewModelTests.swift
@@ -89,6 +89,27 @@ struct AuthenticatedWebViewModelTests {
         #expect(authenticationFlow == .none)
     }
 
+    @Test func makeJetpackSSOLoginURL_includes_redirect_to_with_full_initial_url() throws {
+        // Given
+        let initialURL = try #require(URL(string: siteURL + "/wp-admin/admin.php?page=wc-settings&tab=point-of-sale&section=staff"))
+
+        // When
+        let loginURL = try #require(AuthenticatedWebViewController.makeJetpackSSOLoginURL(
+            from: siteURL + "/wp-login.php?foo=bar",
+            redirectingTo: initialURL
+        ))
+        let components = try #require(URLComponents(url: loginURL, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+
+        // Then
+        #expect(components.scheme == "http")
+        #expect(components.host == "example.com")
+        #expect(components.path == "/wp-login.php")
+        #expect(queryItems.first(where: { $0.name == "foo" })?.value == "bar")
+        #expect(queryItems.first(where: { $0.name == "action" })?.value == "jetpack-sso")
+        #expect(queryItems.first(where: { $0.name == "redirect_to" })?.value == initialURL.absoluteString)
+    }
+
     @Test func isAuthenticationFailure_returns_true_if_first_navigation_fails_with_error_status_code() throws {
         // Given
         let testSite = Site.fake().copy(siteID: 123, url: siteURL, hasSSOEnabled: true)


### PR DESCRIPTION
Part of: WOOMOB-3334

## Description
Fixes POS authenticated web views so post-login navigation returns to the requested admin path instead of dropping the deep-link path.

Also keeps the POS settings authenticated web view in a standard SwiftUI NavigationStack with a Done toolbar action, handles JavaScript dialogs from the embedded web view, and makes POS launch tolerate transient local-catalog eligibility failures by falling back to remote catalog rather than remaining on the loading placeholder.

## Test Steps
1. Build and launch the app on an iPad A16 iOS 26.4 simulator with an already authenticated POS test store.
2. Open POS and verify it transitions beyond the loading placeholder to the PIN screen or product grid.
3. Open a POS authenticated admin web view and verify login redirects back to the requested settings page.
4. Verify the authenticated web view navigation bar shows the title and Done action, and Done dismisses the view.
5. Run the XcodeTarget_WooCommerceTests simulator build.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to RELEASE-NOTES.txt if necessary.