### PR TITLE
Fix push notification source for Woo-driven notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 25.2
 -----
 - [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/17432]
+- [Internal] Fix `push_notification_source` being logged as `wpcom` instead of `woo_driven` for Woo-driven notifications. [https://github.com/woocommerce/woocommerce-ios/pull/17463]
 
 
 25.1

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -548,7 +548,7 @@ extension PushNotificationsManager {
     @MainActor
     func handleRemoteNotificationInTheBackground(userInfo: [AnyHashable: Any]) async -> UIBackgroundFetchResult {
         guard applicationState == .background, // Proceeds only if the app is in background.
-              let _ = userInfo[APNSKey.identifier] // Ensures that we are only processing a remote notification.
+              userInfo[APNSKey.type] != nil // Ensures that we are only processing a remote notification.
         else {
             return .noData
         }
@@ -1039,8 +1039,10 @@ private extension PushNotificationsManager {
     func trackNotification(with userInfo: [AnyHashable: Any]) {
         var properties = [String: Any]()
 
-        // Determine notification source - Woo driven PNs don't have `note_id` in the payload
-        let isWooDriven = userInfo[APNSKey.identifier] == nil
+        // Determine notification source - Woo driven PNs don't have `note_id` in the payload.
+        // The value may be absent, Swift `nil`, or `NSNull`, so resolve it via `string(forKey:)`,
+        // which normalizes all of those to `nil`.
+        let isWooDriven = userInfo.string(forKey: APNSKey.identifier) == nil
         properties[AnalyticKey.source] = isWooDriven ? NotificationSource.wooDriven : NotificationSource.wpcom
 
         // Set identifier based on source

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1536,6 +1536,29 @@ final class PushNotificationsManagerTests: XCTestCase {
         )
     }
 
+    func test_handleNotificationInTheForeground_when_note_id_is_NSNull_then_tracks_with_woo_driven_source() async throws {
+        // Given — the backend sends `note_id` as NSNull (not omitted) for Woo-driven notifications,
+        // which must still be classified as woo_driven rather than wpcom.
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        application.applicationState = .active
+        let payload = notificationPayload(nullNoteID: true, type: .storeOrder, title: Sample.defaultTitle)
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let notification = try XCTUnwrap(MockNotification(userInfo: payload))
+        _ = await manager.handleNotificationInTheForeground(notification)
+
+        // Then
+        analyticsProvider.assertReceived(
+            event: "push_notification_received",
+            with: [
+                "push_notification_source": "woo_driven",
+                "push_notification_type": "store_order"
+            ]
+        )
+    }
+
     func test_handleNotificationInTheForeground_when_notification_from_same_site_then_tracks_fromSelectedSite_true() async throws {
         // Given
         let siteID: Int64 = 134
@@ -1914,6 +1937,26 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertEqual(emittedBackgroundNotifications.count, 1)
         XCTAssertEqual(emittedBackgroundNotifications.first?.kind, .storeOrder)
     }
+
+    func test_handleRemoteNotificationInTheBackground_when_woo_driven_notification_without_note_id_then_emits_notification() async throws {
+        // Given — the background handler must classify a notification as remote from its `type` key,
+        // not the presence of `note_id`. A Woo-driven notification whose `note_id` is missing must
+        // still be processed, not dropped.
+        application.applicationState = .background
+        manager = makeManager()
+
+        var emittedBackgroundNotifications: [WooCommerce.PushNotification] = []
+        manager.backgroundNotifications.sink { emittedBackgroundNotifications.append($0) }.store(in: &subscriptions)
+
+        let payload = notificationPayload(noteID: nil, type: .storeOrder, title: Sample.defaultTitle)
+
+        // When
+        _ = await manager.handleRemoteNotificationInTheBackground(userInfo: payload)
+
+        // Then
+        XCTAssertEqual(emittedBackgroundNotifications.count, 1)
+        XCTAssertEqual(emittedBackgroundNotifications.first?.kind, .storeOrder)
+    }
 }
 
 
@@ -1976,8 +2019,12 @@ private extension PushNotificationsManagerTests {
 
     /// Returns a Sample Notification Payload
     ///
+    /// - Parameter nullNoteID: When `true`, includes `note_id` as `NSNull` to mimic the Woo-driven
+    ///   payload shape sent by the backend (key present with a null value, not omitted).
+    ///
     func notificationPayload(badgeCount: Int = 0,
                              noteID: Int64? = 1234,
+                             nullNoteID: Bool = false,
                              type: Note.Kind = .comment,
                              siteID: Int64 = 134,
                              title: String = Sample.defaultTitle,
@@ -1995,7 +2042,9 @@ private extension PushNotificationsManagerTests {
             "type": type.rawValue,
             "blog": siteID
         ]
-        if let noteID {
+        if nullNoteID {
+            payload["note_id"] = NSNull()
+        } else if let noteID {
             payload["note_id"] = noteID
         }
         return payload
@@ -2062,6 +2111,8 @@ private extension PushNotificationsManagerTests {
         return [
             "blog": siteID,
             "note_full_data": base64Encoded,
+            // The backend sends `note_id` as null (not omitted) for Woo-driven notifications.
+            "note_id": NSNull(),
             "aps": [
                 "category": "store_order",
                 "badge": 1,


### PR DESCRIPTION
Fixes: WOOMOB-3373

## Description

The `push_notification_source` property on `push_notification_alert_pressed` and `push_notification_received` was logged as `wpcom` for Woo-driven notifications. The payload's `note_id` arrives as `NSNull` (not Swift `nil`), so the `== nil` check failed. Resolved via `string(forKey:)`, which normalizes absent/`nil`/`NSNull` to `nil`.

While here, the background handler now detects remote notifications from the `type` key instead of `note_id` presence — a 2018 check that only worked for Woo-driven notifications by coincidence (`NSNull` being non-nil).

## Test Steps

Sending PNs to PR builds is broken now, so we'd need to build and run on a device. But the unit tests should cover this case.

1. Build on device.
2. Enable the woo FF.
3. Restart the app.
4. Put app in the background
5. Create an order
6. Validate in Applicaiton Logs `push_notificaiton_store: woo_driven`

## Screenshots
<img height="600" alt="image" src="https://github.com/user-attachments/assets/b18baf13-e1a3-400e-ba19-cf402e3768bb" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.