### PR TITLE
POS roles: gate coupon creation on createCoupons

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/ItemListView.swift
@@ -102,6 +102,7 @@ struct ItemListView: View {
     }
 
     @State private var showCouponCreationModal: Bool = false
+    @State private var couponOverrideHandler = POSManagerOverrideHandler()
 
     /// Drives the navigation push to `AddCustomAmountView` from the entry row in the products list.
     ///
@@ -161,6 +162,7 @@ struct ItemListView: View {
                 await posModel.couponsController.refreshItems(base: .root)
             }
         })
+        .posManagerOverrideModal(handler: couponOverrideHandler)
         .barcodeScanning(enabled: isBarcodeScanningEnabled) { scannedCode in
             posModel.barcodeScanned(scannedCode)
         }
@@ -434,7 +436,7 @@ private extension ItemListView {
                                     canCreateCoupon: isAddingCouponAllowed,
                                     onCreateCoupon: {
                                         analytics.track(.pointOfSaleCouponsCreateTapped)
-                                        showCouponCreationModal = true
+                                        requestCouponCreationPermission()
                                     }
                                 )
                             )
@@ -484,10 +486,19 @@ private extension ItemListView {
     private var createCouponButton: some View {
         POSPageHeaderActionButton(systemName: "plus") {
             analytics.track(.pointOfSaleCouponsCreateTapped)
-            showCouponCreationModal = true
+            requestCouponCreationPermission()
         }
         .renderedIf(isAddingCouponAllowed)
         .transition(.opacity.combined(with: .scale))
+    }
+
+    /// Gates coupon creation on `.createCoupons`. When the operator already holds it, the creation
+    /// sheet opens immediately; otherwise the manager-override modal is presented and it opens once an
+    /// authorized staff member approves.
+    private func requestCouponCreationPermission() {
+        couponOverrideHandler.gate(.createCoupons, reason: Localization.couponOverrideDescription) { _ in
+            showCouponCreationModal = true
+        }
     }
 
     @ViewBuilder
@@ -507,7 +518,7 @@ private extension ItemListView {
                 viewModel: POSListEmptyViewModel(
                     itemListType: selectedItemListType,
                     baseItem: .root)) {
-                showCouponCreationModal = true
+                requestCouponCreationPermission()
             }
         }
     }
@@ -593,6 +604,13 @@ private extension ItemListView {
             "pos.itemlistview.couponsTitle",
             value: "Coupons",
             comment: "Title of the button at the top of Point of Sale to switch to Coupons list."
+        )
+
+        static let couponOverrideDescription = NSLocalizedString(
+            "pos.itemlistview.couponOverrideReason",
+            value: "Creating coupons requires approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "create-coupons permission tries to create a coupon."
         )
 
         static let sunsetWarningTitle = NSLocalizedString(


### PR DESCRIPTION
## Description
Part of WOOMOB-3288 (POS capability gating), behind the `pointOfSaleRoles` flag. Gates **coupon creation** on `woocommerce_pos_create_coupons`.

The three create-coupon entry points — the header `+` button, the phone overflow "create coupon" accessory, and the empty-state CTA — now route through the manager-override handler (`ItemListView.requestCouponCreationPermission()`). When the operator already holds `createCoupons` the creation sheet opens immediately; otherwise the "Approval required" PIN modal is presented and it opens once an authorized staff member approves.

**Gating only** — no staff attribution (`X-WC-POS-*` headers) is sent on the create request yet; that's deferred to the attribution work.

## Test Steps
Optional — behind `pointOfSaleRoles`, and the gate is covered by `POSManagerOverrideHandlerTests`.

With the flag on and staff PINs configured, on the Coupons tab:
1. As a staff member **without** `createCoupons` (e.g. a cashier), tap **create coupon** (header `+`, the phone menu entry, or the empty-state button) → the "Approval required" PIN modal appears; an authorized PIN opens the creation sheet.
2. As a staff member who **holds** `createCoupons` → the creation sheet opens directly, no prompt.

- [ ] I will manually test the steps above.
- [ ] I will also verify with the feature flag off and with a staff member that has no capabilities.

## Screenshots
N/A