### PR TITLE
POS roles: gate the refund flow on issueRefunds

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/Orders/POSOrderDetailsView.swift
@@ -32,6 +32,7 @@ struct POSOrderDetailsView: View {
     @State private var refundFlowPreparationID: UUID?
     @State private var currentRefundReason: String?
     @State private var selectedRefundForDetail: POSOrderRefund?
+    @State private var refundOverrideHandler = POSManagerOverrideHandler()
 
     private var shouldShowBackButton: Bool {
         horizontalSizeClass == .compact
@@ -170,6 +171,7 @@ struct POSOrderDetailsView: View {
             }
             .posHeaderBackButtonIcon(systemName: "xmark")
         }
+        .posManagerOverrideModal(handler: refundOverrideHandler)
         .task {
             await orderListModel.ordersController.loadOrderRefunds()
         }
@@ -502,7 +504,16 @@ private extension POSOrderDetailsView {
                 isShowingEmailReceiptView = true
             }
         case .issueRefund:
-            return { initiateRefundFlow() }
+            return { requestRefundPermission() }
+        }
+    }
+
+    /// Gates the refund flow on `.issueRefunds`. When the operator already holds it the flow starts
+    /// immediately; otherwise the manager-override modal is presented and the flow starts once an
+    /// authorized staff member approves.
+    func requestRefundPermission() {
+        refundOverrideHandler.gate(.issueRefunds, reason: Localization.refundOverrideDescription(order.number)) { _ in
+            initiateRefundFlow()
         }
     }
 
@@ -768,6 +779,16 @@ private enum Localization {
             value: "Issue refund",
             comment: "Primary action button to start issuing a refund on the order details view"
         )
+
+    static func refundOverrideDescription(_ orderNumber: String) -> String {
+        let format = NSLocalizedString(
+            "pos.orderDetailsView.refundOverride.description",
+            value: "Refunding Order #%1$@ requires approval",
+            comment: "Message shown in the manager-override PIN prompt when a staff member without the "
+                + "issue-refunds permission tries to start a refund. %1$@ is the order number."
+        )
+        return String(format: format, orderNumber)
+    }
 
     static let issueRefundAccessibilityHint = NSLocalizedString(
         "pos.orderDetailsView.issueRefundAction.accessibilityHint",


### PR DESCRIPTION
## Description
Part of WOOMOB-3288 (POS capability gating), behind the `pointOfSaleRoles` flag. Gates the **refund flow** on `woocommerce_pos_issue_refunds`.

The "Issue refund" action on the order-details screen now routes through the manager-override handler (`POSOrderDetailsView.requestRefundPermission()`). When the operator already holds `issueRefunds` the flow starts immediately; otherwise the "Approval required" PIN modal is presented and the flow starts once an authorized staff member approves.

**Gating only** — no staff attribution (`X-WC-POS-*` headers) is sent on the refund request yet; that's deferred to the attribution work.

> ⚠️ **Needs a runtime check before un-drafting.** This adds `.posManagerOverrideModal` to `POSOrderDetailsView`, which was implicated in a "View details" (refund detail) regression seen on the larger POC branch. This PR is the *minimal* version (no attribution, no refund-session/auto-start changes), so it may not reproduce — but please confirm the refunds **"View details"** CTA still opens the refund detail on this branch. If it breaks, the override-modal ↔ refund-detail-modal interaction needs sorting first.

## Test Steps
With `pointOfSaleRoles` on and staff PINs configured, open an order's details:
1. As a staff member **without** `issueRefunds` (e.g. a cashier), tap **Issue refund** → the "Approval required" PIN modal appears; an authorized PIN starts the refund flow.
2. As a staff member who **holds** `issueRefunds` → the refund flow starts directly.
3. **Regression check:** on an order that has refunds, tap **View details** on a refund → the refund detail should still open.

- [ ] I will manually test the steps above (incl. the View details regression check).
- [ ] I will also verify with the feature flag off and with a staff member that has no capabilities.

## Screenshots
N/A