### PR TITLE
[Woo POS] Stabilize POS payment async test waits

### DIFF
--- a/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSPaymentModelTests.swift
@@ -142,9 +142,9 @@ struct POSPaymentModelTests {
         let service = MockCardPresentPaymentService()
         let sut = makePaymentController(cardPresentPaymentService: service)
 
-        await withCheckedContinuation { continuation in
+        await fireOnce { fire in
             service.onCancelPaymentCalled = {
-                continuation.resume()
+                fire()
             }
             sut.startCashPayment()
 
@@ -365,9 +365,9 @@ struct POSPaymentModelTests {
         let service = MockCardPresentPaymentService()
         let sut = makePaymentController(cardPresentPaymentService: service)
 
-        await withCheckedContinuation { continuation in
+        await fireOnce { fire in
             service.onCancelPaymentCalled = {
-                continuation.resume()
+                fire()
             }
             sut.startMarkAsPaidPayment()
 
@@ -2165,8 +2165,8 @@ struct POSPaymentModelTests {
         // so wait for the SDK-level `connectReader` to be called before
         // asserting. Without this the Task hasn't been scheduled yet by the
         // time the test continues.
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             Task { @MainActor in await sut.startPayment() }
         }
 
@@ -2201,8 +2201,8 @@ struct POSPaymentModelTests {
         // spawns its own Task; wait for the SDK-level `connectReader` to
         // be called so the post-connect `lastConnectedMethod` assignment
         // has landed before we proceed.
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             sut.connectCardReader()
         }
         #expect(sut.lastConnectedMethod == .bluetooth)
@@ -2212,8 +2212,8 @@ struct POSPaymentModelTests {
         // `startPayment` sees the BT cleanup conditions (TTP preferred +
         // `lastConnectedMethod == .bluetooth` + reader still connected) and
         // disconnects before kicking the silent TTP pre-connect.
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             Task { @MainActor in await sut.startPayment() }
         }
 
@@ -2257,8 +2257,8 @@ struct POSPaymentModelTests {
             preferredConnectionMethod: .tapToPay,
             cardPaymentSelectionMode: .compact)
 
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             sut.connectCardReader()
         }
         #expect(sut.selectedCardPaymentRail == .bluetoothReader)
@@ -2283,15 +2283,15 @@ struct POSPaymentModelTests {
             preferredConnectionMethod: .tapToPay,
             cardPaymentSelectionMode: .compact)
 
-        await withCheckedContinuation { continuation in
-            service.onConnectReaderCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onConnectReaderCalled = { fire() }
             sut.connectCardReader()
         }
         #expect(sut.selectedCardPaymentRail == .bluetoothReader)
 
         // When
-        await withCheckedContinuation { continuation in
-            service.onDisconnectReaderCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onDisconnectReaderCalled = { fire() }
             sut.disconnectCardReader()
         }
 
@@ -2311,9 +2311,9 @@ struct POSPaymentModelTests {
         await sut.selectCardPaymentRail(.bluetoothReader)
 
         // When
-        await withCheckedContinuation { continuation in
+        await fireOnce { fire in
             service.onCancelPaymentCalled = {
-                continuation.resume()
+                fire()
             }
             sut.startCashPayment()
         }
@@ -2365,8 +2365,8 @@ struct POSPaymentModelTests {
             cardPaymentSelectionMode: .compact)
 
         // When
-        await withCheckedContinuation { continuation in
-            service.onCollectPaymentCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onCollectPaymentCalled = { fire() }
             Task { @MainActor in await sut.startCardPayment(with: .bluetoothReader) }
         }
 
@@ -2413,8 +2413,8 @@ struct POSPaymentModelTests {
             cardPresentPaymentService: service,
             orderProvider: orderProvider,
             preferredConnectionMethod: .bluetooth)
-        await withCheckedContinuation { continuation in
-            service.onCollectPaymentCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onCollectPaymentCalled = { fire() }
             Task { @MainActor in await sut.startPayment() }
         }
         let connectCountAfterFirst = service.connectReaderCallCount
@@ -2448,8 +2448,8 @@ struct POSPaymentModelTests {
             cardPresentPaymentService: service,
             orderProvider: orderProvider,
             preferredConnectionMethod: .bluetooth)
-        await withCheckedContinuation { continuation in
-            service.onCollectPaymentCalled = { continuation.resume() }
+        await fireOnce { fire in
+            service.onCollectPaymentCalled = { fire() }
             Task { @MainActor in await sut.startPayment() }
         }
         service.cancelPaymentCalled = false

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -669,9 +669,9 @@ struct PointOfSaleAggregateModelTests {
                 orderController: orderController)
 
             // When / Then
-            await withCheckedContinuation { continuation in
+            await fireOnce { fire in
                 cardPresentPaymentService.onCancelPaymentCalled = {
-                    continuation.resume()
+                    fire()
                 }
                 sut.startCashPayment()
 
@@ -1169,9 +1169,9 @@ struct PointOfSaleAggregateModelTests {
                 analytics: analytics)
 
             // When
-            await withCheckedContinuation { continuation in
+            await fireOnce { fire in
                 cardPresentPaymentService.onCancelReconnectionCalled = {
-                    continuation.resume()
+                    fire()
                 }
                 sut.cancelReconnection()
             }
@@ -1244,10 +1244,10 @@ struct PointOfSaleAggregateModelTests {
             barcodeScanService.errorToThrow = .notFound(scannedCode: "123456")
 
             // When & Then
-            await withCheckedContinuation { continuation in
+            await fireOnce { fire in
                 soundPlayer.onPlaySound = { sound in
                     #expect(sound == .barcodeScanFailure)
-                    continuation.resume()
+                    fire()
                 }
                 sut.barcodeScanned(.success("123456"))
             }


### PR DESCRIPTION
Attempts to mitigate flakiness around POS Payments async tests caused checked-continuation waits on mock callback hooks.

## Description

This updates POS payment-related tests to use the existing `fireOnce` helper when waiting for mock callbacks such as `onConnectReaderCalled`, `onCollectPaymentCalled`, `onDisconnectReaderCalled`, and cancellation hooks.

This was introduced initially on https://github.com/woocommerce/woocommerce-ios/pull/16984 to resolve a similar issue in other POS places, which is the usage of `withCheckedContinuation` directly causes crashes if the callback fires more than once, generally due how complicated things are: multiple task scheduling, combine usage, etc, ...

I'm assuming that here the tests only need to know that the async path fired at least once before asserting state or call counters, but any feedback if this seems a good direction or is just hiding a different problem is appreciated @joshheald 

Every time it fails, CI reported a crash around `CheckedContinuation.resume()` while attributing the failure to a synchronous `POSPaymentViewHelperTests` assertion, but those tests do not use continuations, so most likely the source comes from somewhere else  (another concurrently-running POS tests that triggers the double-resume?)

Example:
```
Unit Tests: 1 tests have failed (1 distinct assertion failure(s) in total)
  test_shouldShowDisconnectedMessage_returns_false_when_card_payment_ongoing(.disconnected, .cardPaymentSuccessful) in POSPaymentViewHelperTests
  Crash: xctest at CheckedContinuation.resume<>()
```

## Test Steps
- CI should pass

