### PR TITLE
Restore WPCom push notifications when self-driven push registrations go stale

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -637,6 +637,8 @@ public enum WooAnalyticsStat: String {
     case wooPushTokenDeleteError = "woo_push_token_delete_error"
     case wpcomDeviceDisablePushNotificationsSuccess = "wpcom_device_disable_push_notifications_success"
     case wpcomDeviceDisablePushNotificationsError = "wpcom_device_disable_push_notifications_error"
+    case wpcomDeviceEnablePushNotificationsSuccess = "wpcom_device_enable_push_notifications_success"
+    case wpcomDeviceEnablePushNotificationsError = "wpcom_device_enable_push_notifications_error"
 
     case pushNotificationsCardView = "push_notifications_card_view"
     case settingsPushNotificationsButtonTap = "settings_push_notifications_button_tap"

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 25.1
 -----
 - [Internal] Track Woo push token deletion results (woo_push_token_delete_success/error). [https://github.com/woocommerce/woocommerce-ios/pull/17477]
+- [Internal] Push notifications: restore WordPress.com notifications for stores whose self-driven push registration went stale after the feature was turned off. [https://github.com/woocommerce/woocommerce-ios/pull/17472]
 - [*] Order creation product search: the Products/SKU filter now appears below the search bar while you're searching, making SKU search easier to find. [https://github.com/woocommerce/woocommerce-ios/pull/17375]
 - [Internal] Parse all network responses off the main thread to keep the UI responsive on large payloads. [https://github.com/woocommerce/woocommerce-ios/pull/17402]
 - [*] Payments: the balance summary now shows Total balance (available + pending funds) and Available funds [https://github.com/woocommerce/woocommerce-ios/pull/17404]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 25.1
 -----
 - [Internal] Track Woo push token deletion results (woo_push_token_delete_success/error). [https://github.com/woocommerce/woocommerce-ios/pull/17477]
-- [Internal] Push notifications: restore WordPress.com notifications for stores whose self-driven push registration went stale after the feature was turned off. [https://github.com/woocommerce/woocommerce-ios/pull/17472]
 - [Internal] Push notifications: migrate stores back to WordPress.com notifications when the self-driven push feature is turned off. [https://github.com/woocommerce/woocommerce-ios/pull/17472]
 - [*] Order creation product search: the Products/SKU filter now appears below the search bar while you're searching, making SKU search easier to find. [https://github.com/woocommerce/woocommerce-ios/pull/17375]
 - [Internal] Parse all network responses off the main thread to keep the UI responsive on large payloads. [https://github.com/woocommerce/woocommerce-ios/pull/17402]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 -----
 - [Internal] Track Woo push token deletion results (woo_push_token_delete_success/error). [https://github.com/woocommerce/woocommerce-ios/pull/17477]
 - [Internal] Push notifications: restore WordPress.com notifications for stores whose self-driven push registration went stale after the feature was turned off. [https://github.com/woocommerce/woocommerce-ios/pull/17472]
+- [Internal] Push notifications: migrate stores back to WordPress.com notifications when the self-driven push feature is turned off. [https://github.com/woocommerce/woocommerce-ios/pull/17472]
 - [*] Order creation product search: the Products/SKU filter now appears below the search bar while you're searching, making SKU search easier to find. [https://github.com/woocommerce/woocommerce-ios/pull/17375]
 - [Internal] Parse all network responses off the main thread to keep the UI responsive on large payloads. [https://github.com/woocommerce/woocommerce-ios/pull/17402]
 - [*] Payments: the balance summary now shows Total balance (available + pending funds) and Available funds [https://github.com/woocommerce/woocommerce-ios/pull/17404]

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -427,16 +427,7 @@ extension PushNotificationsManager {
             }
         }
 
-        // With self-driven push OFF, a token rotation makes the Woo registrations stale (their
-        // records hold the dead token). The fallback below detects that through the STORED token,
-        // so persisting the new one is deferred until the fallback completes — a failed attempt
-        // then retries on the next launch.
-        let staleWooFallbackPending = !selfDrivenPushNotificationEnabled
-            && deviceTokenChanged
-            && registrationState.siteIDsRegisteredForWooPNs.isNotEmpty
-        if !staleWooFallbackPending {
-            registrationState.applyNewDeviceToken(newToken)
-        }
+        registrationState.applyNewDeviceToken(newToken)
 
         // The awaited flow handles its own registration,
         // so skip the existing path below.
@@ -464,36 +455,37 @@ extension PushNotificationsManager {
             disableWPComPushNotificationsIfNeeded(siteIDs: registrationState.siteIDsRegisteredForWooPNs, deviceID: deviceID)
         }
 
-        // Self-driven OFF: runs only when the device token rotated — the Woo registrations then
-        // hold a dead token, so re-enabling the WPCom PNs we disabled cannot double-send. Local
-        // state and the new token are persisted only after the re-enable succeeds, so a transient
-        // failure retries on the next launch.
-        func fallBackToWPComPushNotificationsIfWooIsStale() {
-            guard staleWooFallbackPending else {
+        // Self-driven OFF: migrates prior Woo push registrations back to WPCom. Sites with a
+        // working WPCom fallback (visible + full Jetpack) are re-enabled on WPCom first and
+        // unregistered from their store only once that succeeds — a failure leaves them on Woo
+        // push and the migration retries on the next launch. Sites without a fallback (hidden,
+        // Jetpack CP, or a site-credentials session) are unregistered unconditionally.
+        func migrateWooPushRegistrationsToWPComIfNeeded() {
+            let wooRegisteredSites = registrationState.siteIDsRegisteredForWooPNs
+            guard wooRegisteredSites.isNotEmpty else {
                 registerForWPComPushNotificationsIfPossible()
                 return
             }
-            let staleWooSites = registrationState.siteIDsRegisteredForWooPNs
-            let completeFallback = { [weak self] in
-                guard let self else { return }
-                self.registrationState.applyNewDeviceToken(newToken)
-                self.registrationState.clearWooRegistration()
-            }
-            // Site-credential users have no WPCom PNs to re-enable; just drop the stale local state.
-            if stores.isAuthenticatedWithoutWPCom {
-                completeFallback()
+            let fallbackSites: [Int64] = {
+                guard !stores.isAuthenticatedWithoutWPCom else { return [] }
+                return wooRegisteredSites.filter { siteID in
+                    guard !UserDefaults.standard.hiddenStoreIDs.contains(siteID),
+                          let site = loadTargetSite(siteID: siteID) else {
+                        return false
+                    }
+                    return site.isJetpackConnected && site.isJetpackThePluginInstalled
+                }
+            }()
+            deleteWooPushRegistrations(for: wooRegisteredSites.filter { !fallbackSites.contains($0) })
+            guard fallbackSites.isNotEmpty else {
+                registerForWPComPushNotificationsIfPossible()
                 return
             }
-            // Don't re-enable WPCom PNs for stores the user has hidden.
-            let visibleStaleSites = staleWooSites.filter { !UserDefaults.standard.hiddenStoreIDs.contains($0) }
             registerForWPComPushNotificationsIfPossible { [weak self] deviceID in
                 guard let self else { return }
-                guard visibleStaleSites.isNotEmpty else {
-                    return completeFallback()
-                }
-                self.enableWPComPushNotifications(siteIDs: visibleStaleSites, deviceID: deviceID) { success in
+                self.enableWPComPushNotifications(siteIDs: fallbackSites, deviceID: deviceID) { success in
                     if success {
-                        completeFallback()
+                        self.deleteWooPushRegistrations(for: fallbackSites)
                     }
                 }
             }
@@ -517,7 +509,7 @@ extension PushNotificationsManager {
                 }
             }
         } else {
-            fallBackToWPComPushNotificationsIfWooIsStale()
+            migrateWooPushRegistrationsToWPComIfNeeded()
         }
     }
 
@@ -1130,6 +1122,73 @@ private extension PushNotificationsManager {
                 DispatchQueue.main.async(execute: handleResult)
             }
         }))
+    }
+
+    /// Deletes the store-side Woo push token records for the given sites, unmarking each site
+    /// only after its delete succeeds so a failed site retries on the next launch.
+    ///
+    /// Registration returns a per-site record ID but only the last one is kept locally. The
+    /// store's create endpoint upserts by device UUID/token and returns the existing record's
+    /// ID, so re-registering first recovers the ID to delete.
+    func deleteWooPushRegistrations(for siteIDs: [Int64]) {
+        guard siteIDs.isNotEmpty else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            for siteID in siteIDs {
+                do {
+                    let tokenID = try await upsertWooPushTokenRecord(siteID: siteID)
+                    try await deleteWooPushTokenRecord(siteID: siteID, tokenID: tokenID)
+                    registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
+                    DDLogInfo("📱 Woo push token deleted for site \(siteID)")
+                } catch {
+                    if case .notFound = error as? NetworkError {
+                        // The route or record is gone (plugin downgraded or feature disabled) —
+                        // there is nothing left to delete.
+                        registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
+                    }
+                    DDLogError("⛔️ Unable to delete Woo push token for site \(siteID): \(error)")
+                }
+            }
+            if registrationState.siteIDsRegisteredForWooPNs.isEmpty {
+                registrationState.clearWooRegistration()
+            }
+        }
+    }
+
+    /// Dispatched directly rather than through the registration flow so the upsert doesn't
+    /// re-mark the site or overwrite the stored record ID.
+    @MainActor
+    private func upsertWooPushTokenRecord(siteID: Int64) async throws -> Int64 {
+        guard let deviceToken = registrationState.deviceToken else {
+            throw PushNotificationError.missingDeviceToken
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(NotificationAction.registerDeviceForSelfDrivenPushNotifications(
+                siteID: siteID,
+                device: APNSDevice(deviceToken: deviceToken),
+                applicationID: WooConstants.pushApplicationID,
+                deviceLocale: Locale.current.languageRegionIdentifier ?? Locale.current.identifier,
+                appVersion: Bundle.main.version,
+                // REST fallback routes to the selected site's URL, so it is only safe when the
+                // target is the selected site; cross-site calls go through the Jetpack tunnel.
+                availableAsRESTRequest: siteID == self.siteID
+            ) { result in
+                continuation.resume(with: result)
+            })
+        }
+    }
+
+    @MainActor
+    private func deleteWooPushTokenRecord(siteID: Int64, tokenID: Int64) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
+                siteID: siteID,
+                tokenID: tokenID,
+                availableAsRESTRequest: siteID == self.siteID
+            ) { result in
+                continuation.resume(with: result)
+            })
+        }
     }
 }
 

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -1139,6 +1139,7 @@ private extension PushNotificationsManager {
                     let tokenID = try await upsertWooPushTokenRecord(siteID: siteID)
                     try await deleteWooPushTokenRecord(siteID: siteID, tokenID: tokenID)
                     registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
+                    analytics.track(event: .PushNotifications.wooPushTokenDeleteSuccess(targetSite: loadTargetSite(siteID: siteID)))
                     DDLogInfo("📱 Woo push token deleted for site \(siteID)")
                 } catch {
                     if case .notFound = error as? NetworkError {
@@ -1146,6 +1147,7 @@ private extension PushNotificationsManager {
                         // there is nothing left to delete.
                         registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
                     }
+                    analytics.track(event: .PushNotifications.wooPushTokenDeleteError(targetSite: loadTargetSite(siteID: siteID), error: error))
                     DDLogError("⛔️ Unable to delete Woo push token for site \(siteID): \(error)")
                 }
             }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -411,17 +411,32 @@ extension PushNotificationsManager {
             return
         }
         let newToken = tokenData.hexString
+        let deviceTokenChanged: Bool = {
+            guard let existingToken = registrationState.deviceToken else {
+                return false
+            }
+            return existingToken != newToken
+        }()
 
-        // When the device token changes, clear registered site IDs so all sites
-        // re-register with the new token.
-        if let existingToken = registrationState.deviceToken, existingToken != newToken {
+        // When the device token changes while self-driven push is ON, clear registered site IDs so
+        // all sites re-register with the new token.
+        if selfDrivenPushNotificationEnabled, deviceTokenChanged {
             DDLogDebug("📱 Device token changed — clearing registered site IDs for re-registration")
             for siteID in registrationState.siteIDsRegisteredForWooPNs {
                 registrationState.unmarkSiteAsRegisteredForWooPNs(siteID)
             }
         }
 
-        registrationState.applyNewDeviceToken(newToken)
+        // With self-driven push OFF, a token rotation makes the Woo registrations stale (their
+        // records hold the dead token). The fallback below detects that through the STORED token,
+        // so persisting the new one is deferred until the fallback completes — a failed attempt
+        // then retries on the next launch.
+        let staleWooFallbackPending = !selfDrivenPushNotificationEnabled
+            && deviceTokenChanged
+            && registrationState.siteIDsRegisteredForWooPNs.isNotEmpty
+        if !staleWooFallbackPending {
+            registrationState.applyNewDeviceToken(newToken)
+        }
 
         // The awaited flow handles its own registration,
         // so skip the existing path below.
@@ -429,7 +444,7 @@ extension PushNotificationsManager {
             return
         }
 
-        func registerForWPComPushNotificationsIfPossible() {
+        func registerForWPComPushNotificationsIfPossible(onRegistered: ((String) -> Void)? = nil) {
             if stores.isAuthenticatedWithoutWPCom { return }
             // Register in the Dotcom's Infrastructure
             registerDotcomDevice(with: newToken) { device, error in
@@ -440,7 +455,47 @@ extension PushNotificationsManager {
 
                 DDLogVerbose("📱 Successfully registered Device ID \(deviceID) for Push Notifications")
                 self.registrationState.deviceID = deviceID
-                self.disableWPComPushNotificationsIfNeeded(siteIDs: self.registrationState.siteIDsRegisteredForWooPNs, deviceID: deviceID)
+                onRegistered?(deviceID)
+            }
+        }
+
+        // Disables WPCom PNs for the sites registered for Woo-driven PNs (self-driven ON).
+        func disableWPComForRegisteredWooSites(deviceID: String) {
+            disableWPComPushNotificationsIfNeeded(siteIDs: registrationState.siteIDsRegisteredForWooPNs, deviceID: deviceID)
+        }
+
+        // Self-driven OFF: runs only when the device token rotated — the Woo registrations then
+        // hold a dead token, so re-enabling the WPCom PNs we disabled cannot double-send. Local
+        // state and the new token are persisted only after the re-enable succeeds, so a transient
+        // failure retries on the next launch.
+        func fallBackToWPComPushNotificationsIfWooIsStale() {
+            guard staleWooFallbackPending else {
+                registerForWPComPushNotificationsIfPossible()
+                return
+            }
+            let staleWooSites = registrationState.siteIDsRegisteredForWooPNs
+            let completeFallback = { [weak self] in
+                guard let self else { return }
+                self.registrationState.applyNewDeviceToken(newToken)
+                self.registrationState.clearWooRegistration()
+            }
+            // Site-credential users have no WPCom PNs to re-enable; just drop the stale local state.
+            if stores.isAuthenticatedWithoutWPCom {
+                completeFallback()
+                return
+            }
+            // Don't re-enable WPCom PNs for stores the user has hidden.
+            let visibleStaleSites = staleWooSites.filter { !UserDefaults.standard.hiddenStoreIDs.contains($0) }
+            registerForWPComPushNotificationsIfPossible { [weak self] deviceID in
+                guard let self else { return }
+                guard visibleStaleSites.isNotEmpty else {
+                    return completeFallback()
+                }
+                self.enableWPComPushNotifications(siteIDs: visibleStaleSites, deviceID: deviceID) { success in
+                    if success {
+                        completeFallback()
+                    }
+                }
             }
         }
 
@@ -452,20 +507,17 @@ extension PushNotificationsManager {
                     try await registerSelfDrivenPushNotificationsForAllSites(with: newToken)
                     // Disable WPCom PNs for successfully registered sites
                     if let deviceID = registrationState.deviceID {
-                        disableWPComPushNotificationsIfNeeded(
-                            siteIDs: registrationState.siteIDsRegisteredForWooPNs,
-                            deviceID: deviceID
-                        )
+                        disableWPComForRegisteredWooSites(deviceID: deviceID)
                     } else {
                         // Register with WPCom to get deviceID for disabling
-                        registerForWPComPushNotificationsIfPossible()
+                        registerForWPComPushNotificationsIfPossible(onRegistered: disableWPComForRegisteredWooSites)
                     }
                 } catch {
-                    registerForWPComPushNotificationsIfPossible()
+                    registerForWPComPushNotificationsIfPossible(onRegistered: disableWPComForRegisteredWooSites)
                 }
             }
         } else {
-            registerForWPComPushNotificationsIfPossible()
+            fallBackToWPComPushNotificationsIfWooIsStale()
         }
     }
 
@@ -1036,6 +1088,46 @@ private extension PushNotificationsManager {
                 analytics.track(.wpcomDeviceDisablePushNotificationsSuccess)
             case .failure(let error):
                 analytics.track(.wpcomDeviceDisablePushNotificationsError, withError: error)
+            }
+        }))
+    }
+
+    /// Re-enables mobile push notifications for the given site IDs, when falling back to
+    /// WPCom-driven notifications after self-driven push is turned off.
+    ///
+    /// - Note: re-enables both `newComment` and `storeOrder` — any custom WPCom preference was
+    ///   already lost when we disabled them on Woo registration.
+    ///
+    func enableWPComPushNotifications(siteIDs: [Int64], deviceID: String?, onCompletion: @escaping (Bool) -> Void) {
+        guard let deviceID, let deviceIDInt = Int64(deviceID),
+              siteIDs.isNotEmpty,
+              !configuration.storesManager.isAuthenticatedWithoutWPCom else {
+            return onCompletion(false)
+        }
+        let updatedBlogs = siteIDs.map {
+            NotificationSettings.Blog(blogID: $0, devices: [
+                .init(deviceID: deviceIDInt, newComment: true, storeOrder: true)
+            ])
+        }
+        let siteSettings = NotificationSettings(blogs: updatedBlogs)
+        stores.dispatch(AccountAction.updateNotificationSettings(notificationSettings: siteSettings, onCompletion: { [weak self] result in
+            // `AccountStore` invokes this completion off the main thread; hop back before touching
+            // state and dispatching the follow-up teardown action (the Dispatcher is main-thread only).
+            let handleResult = {
+                guard let self else { return onCompletion(false) }
+                switch result {
+                case .success:
+                    self.analytics.track(.wpcomDeviceEnablePushNotificationsSuccess)
+                    onCompletion(true)
+                case .failure(let error):
+                    self.analytics.track(.wpcomDeviceEnablePushNotificationsError, withError: error)
+                    onCompletion(false)
+                }
+            }
+            if Thread.isMainThread {
+                handleResult()
+            } else {
+                DispatchQueue.main.async(execute: handleResult)
             }
         }))
     }

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -777,6 +777,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         assertDeletedWooPushToken(siteID: 99)
         assertWooRegistrationCleared()
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("wpcom_device_enable_push_notifications_success"))
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("woo_push_token_delete_success"))
     }
 
     func test_registerDeviceToken_when_FF_off_and_reenable_fails_then_keeps_fallback_site_on_woo_push() async {
@@ -858,7 +859,7 @@ final class PushNotificationsManagerTests: XCTestCase {
 
     func test_registerDeviceToken_when_FF_off_and_woo_delete_fails_then_keeps_site_marked_for_retry() async {
         // Given
-        manager = await makeMigrationScenario()
+        manager = await makeMigrationScenario(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
         stubUpdateNotificationSettings(result: .success(()))
         stubFallbackWooActions(unregisterResult: .failure(NSError(domain: "test", code: 1)))
 
@@ -867,10 +868,11 @@ final class PushNotificationsManagerTests: XCTestCase {
         await until { self.dispatchedUnregisterWooPushToken }
 
         // Then — the store still holds a live registration: the site stays marked so the delete
-        // retries on the next launch.
+        // retries on the next launch, and the failure is visible in Tracks.
         try? await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
         XCTAssertEqual(manager.wooPushNotificationToken, "555")
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("woo_push_token_delete_error"))
     }
 
     func test_registerDeviceToken_when_self_driven_gate_enabled_and_self_driven_token_registration_fails_falls_back_to_wpcom() async {

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -752,6 +752,146 @@ final class PushNotificationsManagerTests: XCTestCase {
         }))
     }
 
+    // MARK: - Self-driven OFF: fall back to WPCom for stale Woo registrations
+    //
+    // When the FF resolves to OFF and the device token has rotated, the Woo registrations hold a
+    // dead token and cannot deliver, so `registerDeviceToken` registers the current token with
+    // WPCom, re-enables the WPCom notifications we disabled while Woo-driven was active, and
+    // clears the local Woo state. The new token is persisted only when the fallback completes, so
+    // a failure retries next launch. With an unchanged token nothing changes — the Woo system
+    // keeps delivering alone. One test per scenario:
+    //   1. rotated token: register + re-enable + state cleared + analytics
+    //   2. unchanged token: no-op — Woo keeps delivering, WPCom stays disabled
+    //   3. re-enable fails: state AND old token kept so the next launch retries
+    //   4. no prior Woo registration: plain WPCom register, no settings changes
+    //   5. site-credential user: no WPCom to re-enable, stale local state still cleared
+    //   6. hidden store: excluded from the re-enable, still cleared
+
+    func test_registerDeviceToken_when_FF_off_and_token_rotated_then_reenables_wpcom_and_clears_woo_state() async {
+        // Given — a site registered while the FF was ON, and a device token that rotated since.
+        seedPriorWooRegistration()
+        seedStoredDeviceToken("an-old-device-token")
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        stubUpdateNotificationSettings(result: .success(()))
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+
+        // Then — the current token is registered with WPCom, notifications are re-enabled,
+        // the local Woo state is cleared, and the new token is persisted.
+        XCTAssertTrue(dispatchedRegisterDotcomDevice)
+        assertReenabledWPComPushNotifications()
+        assertWooRegistrationCleared()
+        XCTAssertEqual(storedDeviceToken, sampleTokenData.hexString)
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("wpcom_device_enable_push_notifications_success"))
+    }
+
+    func test_registerDeviceToken_when_FF_off_and_token_unchanged_then_keeps_woo_registration() async {
+        // Given — a Woo-registered site whose stored token matches the current one: the Woo system
+        // still delivers, so falling back would double-send. Nothing must change.
+        seedPriorWooRegistration()
+        seedStoredDeviceToken(sampleTokenData.hexString)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff()
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+
+        // Then — no settings changes and the Woo registration stays.
+        XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
+        XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
+        XCTAssertEqual(manager.wooPushNotificationToken, "555")
+    }
+
+    func test_registerDeviceToken_when_FF_off_and_reenable_fails_then_keeps_woo_state_and_old_token_for_retry() async {
+        // Given
+        seedPriorWooRegistration()
+        seedStoredDeviceToken("an-old-device-token")
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        stubUpdateNotificationSettings(result: .failure(NSError(domain: "test", code: 1)))
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+
+        // Then — the re-enable failed: the Woo state AND the old stored token are kept, so the
+        // rotation is detected again on the next launch and the fallback retries.
+        XCTAssertEqual(manager.wooPushNotificationToken, "555")
+        XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
+        XCTAssertEqual(storedDeviceToken, "an-old-device-token")
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("wpcom_device_enable_push_notifications_error"))
+    }
+
+    func test_registerDeviceToken_when_FF_off_with_no_prior_woo_registration_then_registers_wpcom_without_settings_changes() async {
+        // Given — never used Woo-driven PNs.
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff()
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+
+        // Then — plain WPCom registration, no notification-settings toggling at all.
+        XCTAssertTrue(dispatchedRegisterDotcomDevice)
+        XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
+    }
+
+    func test_registerDeviceToken_when_FF_off_and_site_credentials_user_then_clears_stale_woo_state_without_wpcom_calls() async {
+        // Given — a site-credential (no WPCom) user with a prior Woo registration and a rotated token.
+        seedPriorWooRegistration()
+        seedStoredDeviceToken("an-old-device-token")
+        storesManager.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff()
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+
+        // Then — the stale local state is cleared; there is no WPCom to register or re-enable.
+        assertWooRegistrationCleared()
+        XCTAssertEqual(storedDeviceToken, sampleTokenData.hexString)
+        XCTAssertFalse(dispatchedRegisterDotcomDevice)
+        XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
+    }
+
+    func test_registerDeviceToken_when_FF_off_and_a_stale_site_is_hidden_then_skips_its_wpcom_reenable() async {
+        // Given — two Woo-registered sites with a rotated token; the user has hidden store 100.
+        seedPriorWooRegistration(siteIDs: "99,100")
+        seedStoredDeviceToken("an-old-device-token")
+        UserDefaults.standard.saveHiddenStoreIDs([100])
+        addTeardownBlock {
+            UserDefaults.standard.saveHiddenStoreIDs([])
+        }
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff()
+        stubUpdateNotificationSettings(result: .success(()))
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+
+        // Then — WPCom is re-enabled for the visible site only, and the local state is cleared.
+        assertReenabledWPComPushNotifications(blogID: 99)
+        let accountActions = storesManager.receivedActions.compactMap { $0 as? AccountAction }
+        XCTAssertFalse(accountActions.contains(where: {
+            if case let .updateNotificationSettings(settings, _) = $0 {
+                return settings.blogs.contains(where: { $0.blogID == 100 })
+            }
+            return false
+        }), "Hidden store must not have its WPCom notifications re-enabled")
+        assertWooRegistrationCleared()
+    }
+
     func test_registerDeviceToken_when_self_driven_gate_enabled_and_self_driven_token_registration_fails_falls_back_to_wpcom() async {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
@@ -2021,6 +2161,87 @@ final class PushNotificationsManagerTests: XCTestCase {
 // MARK: - Private Methods
 //
 private extension PushNotificationsManagerTests {
+    /// Seeds the local state left behind by a prior Woo-driven (FF ON) registration.
+    func seedPriorWooRegistration(siteIDs: String = "99", tokenID: String = "555", deviceID: String = "456") {
+        defaults.set(siteIDs, forKey: PushNotificationSharedConstants.UserDefaultsKeys.siteIDsRegisteredForWooPushNotifications)
+        defaults.set(tokenID, forKey: PushNotificationSharedConstants.UserDefaultsKeys.wooPushNotificationToken)
+        defaults.set(deviceID, forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceID)
+    }
+
+    /// Seeds the persisted APNS device token — differing from `sampleTokenData` to simulate a rotation.
+    func seedStoredDeviceToken(_ token: String) {
+        defaults.set(token, forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
+    }
+
+    var storedDeviceToken: String? {
+        defaults.string(forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
+    }
+
+    /// Creates a manager whose self-driven eligibility resolves to `false`, awaiting the resolution.
+    /// Seed any prior Woo state via `seedPriorWooRegistration()` before calling this.
+    func makeFallbackManagerWithFFOff(analytics: Analytics = ServiceLocator.analytics) async -> PushNotificationsManager {
+        let eligibilityExpectation = expectation(description: "Eligibility check completed")
+        eligibilityExpectation.assertForOverFulfill = false
+        mockRemoteFeatureFlagAction(isEnabled: false, onCompletion: { eligibilityExpectation.fulfill() })
+        let manager = makeManager(featureFlagService: MockFeatureFlagService(selfDrivenPushToken: false), analytics: analytics)
+        await fulfillment(of: [eligibilityExpectation], timeout: 1.0)
+        return manager
+    }
+
+    func stubUpdateNotificationSettings(result: Result<Void, Error>) {
+        storesManager.whenReceivingAction(ofType: AccountAction.self) { action in
+            if case let .updateNotificationSettings(_, onCompletion) = action {
+                onCompletion(result)
+            }
+        }
+    }
+
+    /// Stubs the fallback's NotificationActions: WPCom device registration succeeds with
+    /// deviceID "456" and self-driven unregistration succeeds.
+    func stubFallbackWooActions() {
+        guard let device = try? JSONDecoder().decode(DotcomDevice.self, from: Data(#"{"ID": "456"}"#.utf8)) else {
+            return XCTFail("Failed to decode DotcomDevice")
+        }
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .registerDevice(_, _, _, onCompletion) = action {
+                onCompletion(device, nil)
+            }
+        }
+    }
+
+    var sampleTokenData: Data {
+        Data(Sample.deviceToken.utf8)
+    }
+
+    var dispatchedRegisterDotcomDevice: Bool {
+        storesManager.receivedActions.compactMap { $0 as? NotificationAction }.contains {
+            if case .registerDevice = $0 { return true }
+            return false
+        }
+    }
+
+    /// Asserts an `updateNotificationSettings` action re-enabled WPCom PNs (newComment/storeOrder true).
+    func assertReenabledWPComPushNotifications(blogID: Int64 = 99,
+                                               deviceID: Int64 = 456,
+                                               file: StaticString = #filePath,
+                                               line: UInt = #line) {
+        let reenabled = storesManager.receivedActions.compactMap { $0 as? AccountAction }.contains {
+            guard case let .updateNotificationSettings(settings, _) = $0,
+                  let device = settings.blogs.first(where: { $0.blogID == blogID })?
+                      .devices.first(where: { $0.deviceID == deviceID }) else {
+                return false
+            }
+            return device.newComment == true && device.storeOrder == true
+        }
+        XCTAssertTrue(reenabled, "Expected WPCom PNs re-enabled for blog \(blogID)", file: file, line: line)
+    }
+
+    /// Asserts the local Woo registration state was cleared.
+    func assertWooRegistrationCleared(file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertNil(manager.wooPushNotificationToken, file: file, line: line)
+        XCTAssertTrue(manager.siteIDsRegisteredForWooPNs.isEmpty, file: file, line: line)
+    }
+
     func makeManager(featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
                      storageManager: MockStorageManager? = nil,
                      pluginVersionCheckerFactory: PluginVersionCheckerFactoryProtocol? = nil,

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1,5 +1,6 @@
 import Combine
 import Experiments
+import TestKit
 import XCTest
 import Yosemite
 import YosemiteTestHelpers
@@ -752,25 +753,29 @@ final class PushNotificationsManagerTests: XCTestCase {
         }))
     }
 
-    // MARK: - Self-driven OFF: fall back to WPCom for stale Woo registrations
+    // MARK: - Self-driven OFF: migrate Woo push registrations back to WPCom
     //
-    // When the FF resolves to OFF and the device token has rotated, the Woo registrations hold a
-    // dead token and cannot deliver, so `registerDeviceToken` registers the current token with
-    // WPCom, re-enables the WPCom notifications we disabled while Woo-driven was active, and
-    // clears the local Woo state. The new token is persisted only when the fallback completes, so
-    // a failure retries next launch. With an unchanged token nothing changes — the Woo system
-    // keeps delivering alone. One test per scenario:
-    //   1. rotated token: register + re-enable + state cleared + analytics
-    //   2. unchanged token: no-op — Woo keeps delivering, WPCom stays disabled
-    //   3. re-enable fails: state AND old token kept so the next launch retries
-    //   4. no prior Woo registration: plain WPCom register, no settings changes
-    //   5. site-credential user: no WPCom to re-enable, stale local state still cleared
-    //   6. hidden store: excluded from the re-enable, still cleared
+    // When the FF resolves to OFF, any prior Woo push registration is migrated back to WPCom on
+    // the next launch — regardless of whether the device token changed. Sites with a working
+    // WPCom fallback (visible + full Jetpack) are re-enabled on WPCom first and unregistered
+    // from their store only once that succeeds; sites without a fallback (hidden, Jetpack CP,
+    // or a site-credentials session) are unregistered unconditionally. The store-side delete
+    // recovers each site's record ID by re-registering first (the create endpoint upserts).
+    // One test per scenario:
+    //   1. fallback site: WPCom re-enabled, Woo record deleted, state cleared (token unchanged)
+    //   2. re-enable fails: fallback site stays on Woo push so the next launch retries
+    //   3. no prior Woo registration: plain WPCom register, no settings changes
+    //   4. site-credentials user: Woo record deleted without any WPCom calls
+    //   5. hidden site: deleted without WPCom re-enable (visible sibling still re-enabled)
+    //   6. Jetpack CP site: deleted without WPCom re-enable (WPCom can't deliver to it)
+    //   7. store-side delete fails: site stays marked so the delete retries next launch
 
-    func test_registerDeviceToken_when_FF_off_and_token_rotated_then_reenables_wpcom_and_clears_woo_state() async {
-        // Given — a site registered while the FF was ON, and a device token that rotated since.
+    func test_registerDeviceToken_when_FF_off_with_prior_woo_registration_then_reenables_wpcom_and_deletes_woo_registration() async {
+        // Given — a visible full-Jetpack site registered while the FF was ON. The device token is
+        // unchanged: the migration must not wait for a rotation.
         seedPriorWooRegistration()
-        seedStoredDeviceToken("an-old-device-token")
+        seedStoredDeviceToken(sampleTokenData.hexString)
+        await insertSitesIntoStorageWithCapabilities([(99, "https://example.com", true, true, true)])
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
         manager = await makeFallbackManagerWithFFOff(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
@@ -779,39 +784,21 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         // When
         manager.registerDeviceToken(with: sampleTokenData)
+        await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
 
-        // Then — the current token is registered with WPCom, notifications are re-enabled,
-        // the local Woo state is cleared, and the new token is persisted.
+        // Then — WPCom is re-enabled first, then the store-side Woo record is deleted and the
+        // local state is cleared.
         XCTAssertTrue(dispatchedRegisterDotcomDevice)
         assertReenabledWPComPushNotifications()
+        assertDeletedWooPushToken(siteID: 99)
         assertWooRegistrationCleared()
-        XCTAssertEqual(storedDeviceToken, sampleTokenData.hexString)
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("wpcom_device_enable_push_notifications_success"))
     }
 
-    func test_registerDeviceToken_when_FF_off_and_token_unchanged_then_keeps_woo_registration() async {
-        // Given — a Woo-registered site whose stored token matches the current one: the Woo system
-        // still delivers, so falling back would double-send. Nothing must change.
-        seedPriorWooRegistration()
-        seedStoredDeviceToken(sampleTokenData.hexString)
-        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff()
-        stubFallbackWooActions()
-
-        // When
-        manager.registerDeviceToken(with: sampleTokenData)
-
-        // Then — no settings changes and the Woo registration stays.
-        XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
-        XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
-        XCTAssertEqual(manager.wooPushNotificationToken, "555")
-    }
-
-    func test_registerDeviceToken_when_FF_off_and_reenable_fails_then_keeps_woo_state_and_old_token_for_retry() async {
+    func test_registerDeviceToken_when_FF_off_and_reenable_fails_then_keeps_fallback_site_on_woo_push() async {
         // Given
         seedPriorWooRegistration()
-        seedStoredDeviceToken("an-old-device-token")
+        await insertSitesIntoStorageWithCapabilities([(99, "https://example.com", true, true, true)])
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
         storesManager.sessionManager.setStoreId(99)
         manager = await makeFallbackManagerWithFFOff(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
@@ -821,11 +808,11 @@ final class PushNotificationsManagerTests: XCTestCase {
         // When
         manager.registerDeviceToken(with: sampleTokenData)
 
-        // Then — the re-enable failed: the Woo state AND the old stored token are kept, so the
-        // rotation is detected again on the next launch and the fallback retries.
-        XCTAssertEqual(manager.wooPushNotificationToken, "555")
+        // Then — WPCom did not take over, so the site stays registered with Woo push (which still
+        // delivers) and its store-side record is kept; the next launch retries the migration.
+        XCTAssertFalse(dispatchedUnregisterWooPushToken)
         XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
-        XCTAssertEqual(storedDeviceToken, "an-old-device-token")
+        XCTAssertEqual(manager.wooPushNotificationToken, "555")
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("wpcom_device_enable_push_notifications_error"))
     }
 
@@ -842,12 +829,12 @@ final class PushNotificationsManagerTests: XCTestCase {
         // Then — plain WPCom registration, no notification-settings toggling at all.
         XCTAssertTrue(dispatchedRegisterDotcomDevice)
         XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
+        XCTAssertFalse(dispatchedUnregisterWooPushToken)
     }
 
-    func test_registerDeviceToken_when_FF_off_and_site_credentials_user_then_clears_stale_woo_state_without_wpcom_calls() async {
-        // Given — a site-credential (no WPCom) user with a prior Woo registration and a rotated token.
+    func test_registerDeviceToken_when_FF_off_and_site_credentials_user_then_deletes_woo_registration_without_wpcom_calls() async {
+        // Given — a site-credential (no WPCom) user with a prior Woo registration.
         seedPriorWooRegistration()
-        seedStoredDeviceToken("an-old-device-token")
         storesManager.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
         storesManager.sessionManager.setStoreId(99)
         manager = await makeFallbackManagerWithFFOff()
@@ -855,18 +842,23 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         // When
         manager.registerDeviceToken(with: sampleTokenData)
+        await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
 
-        // Then — the stale local state is cleared; there is no WPCom to register or re-enable.
+        // Then — there is no WPCom fallback, so the Woo registration is deleted unconditionally
+        // and no WPCom call is made.
+        assertDeletedWooPushToken(siteID: 99)
         assertWooRegistrationCleared()
-        XCTAssertEqual(storedDeviceToken, sampleTokenData.hexString)
         XCTAssertFalse(dispatchedRegisterDotcomDevice)
         XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
     }
 
-    func test_registerDeviceToken_when_FF_off_and_a_stale_site_is_hidden_then_skips_its_wpcom_reenable() async {
-        // Given — two Woo-registered sites with a rotated token; the user has hidden store 100.
+    func test_registerDeviceToken_when_FF_off_and_a_site_is_hidden_then_deletes_it_without_wpcom_reenable() async {
+        // Given — two Woo-registered full-Jetpack sites; the user has hidden store 100.
         seedPriorWooRegistration(siteIDs: "99,100")
-        seedStoredDeviceToken("an-old-device-token")
+        await insertSitesIntoStorageWithCapabilities([
+            (99, "https://example.com", true, true, true),
+            (100, "https://hidden.example.com", true, true, true)
+        ])
         UserDefaults.standard.saveHiddenStoreIDs([100])
         addTeardownBlock {
             UserDefaults.standard.saveHiddenStoreIDs([])
@@ -879,17 +871,62 @@ final class PushNotificationsManagerTests: XCTestCase {
 
         // When
         manager.registerDeviceToken(with: sampleTokenData)
+        await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
 
-        // Then — WPCom is re-enabled for the visible site only, and the local state is cleared.
+        // Then — WPCom is re-enabled for the visible site only; both sites' Woo records are
+        // deleted and the local state is cleared.
         assertReenabledWPComPushNotifications(blogID: 99)
-        let accountActions = storesManager.receivedActions.compactMap { $0 as? AccountAction }
-        XCTAssertFalse(accountActions.contains(where: {
-            if case let .updateNotificationSettings(settings, _) = $0 {
-                return settings.blogs.contains(where: { $0.blogID == 100 })
-            }
-            return false
-        }), "Hidden store must not have its WPCom notifications re-enabled")
+        assertNotReenabledWPComPushNotifications(blogID: 100)
+        assertDeletedWooPushToken(siteID: 99)
+        assertDeletedWooPushToken(siteID: 100)
         assertWooRegistrationCleared()
+    }
+
+    func test_registerDeviceToken_when_FF_off_and_a_site_is_jetpack_cp_then_deletes_it_without_wpcom_reenable() async {
+        // Given — site 100 is connected via the Jetpack Connection Package (no Jetpack plugin),
+        // so WPCom cannot deliver push notifications to it.
+        seedPriorWooRegistration(siteIDs: "99,100")
+        await insertSitesIntoStorageWithCapabilities([
+            (99, "https://example.com", true, true, true),
+            (100, "https://jcp.example.com", false, false, true)
+        ])
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff()
+        stubUpdateNotificationSettings(result: .success(()))
+        stubFallbackWooActions()
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+        await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
+
+        // Then — the JCP site gets no WPCom settings write; both Woo records are deleted.
+        assertReenabledWPComPushNotifications(blogID: 99)
+        assertNotReenabledWPComPushNotifications(blogID: 100)
+        assertDeletedWooPushToken(siteID: 99)
+        assertDeletedWooPushToken(siteID: 100)
+        assertWooRegistrationCleared()
+    }
+
+    func test_registerDeviceToken_when_FF_off_and_woo_delete_fails_then_keeps_site_marked_for_retry() async {
+        // Given
+        seedPriorWooRegistration()
+        await insertSitesIntoStorageWithCapabilities([(99, "https://example.com", true, true, true)])
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(99)
+        manager = await makeFallbackManagerWithFFOff()
+        stubUpdateNotificationSettings(result: .success(()))
+        stubFallbackWooActions(unregisterResult: .failure(NSError(domain: "test", code: 1)))
+
+        // When
+        manager.registerDeviceToken(with: sampleTokenData)
+        await until { self.dispatchedUnregisterWooPushToken }
+
+        // Then — the store still holds a live registration, so the site stays marked and the
+        // delete retries on the next launch.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
+        XCTAssertEqual(manager.wooPushNotificationToken, "555")
     }
 
     func test_registerDeviceToken_when_self_driven_gate_enabled_and_self_driven_token_registration_fails_falls_back_to_wpcom() async {
@@ -2173,10 +2210,6 @@ private extension PushNotificationsManagerTests {
         defaults.set(token, forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
     }
 
-    var storedDeviceToken: String? {
-        defaults.string(forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
-    }
-
     /// Creates a manager whose self-driven eligibility resolves to `false`, awaiting the resolution.
     /// Seed any prior Woo state via `seedPriorWooRegistration()` before calling this.
     func makeFallbackManagerWithFFOff(analytics: Analytics = ServiceLocator.analytics) async -> PushNotificationsManager {
@@ -2196,15 +2229,23 @@ private extension PushNotificationsManagerTests {
         }
     }
 
-    /// Stubs the fallback's NotificationActions: WPCom device registration succeeds with
-    /// deviceID "456" and self-driven unregistration succeeds.
-    func stubFallbackWooActions() {
+    /// Stubs the migration's NotificationActions: WPCom device registration succeeds with
+    /// deviceID "456", the Woo upsert returns record ID `siteID + 1000`, and the store-side
+    /// delete completes with `unregisterResult`.
+    func stubFallbackWooActions(unregisterResult: Result<Void, Error> = .success(())) {
         guard let device = try? JSONDecoder().decode(DotcomDevice.self, from: Data(#"{"ID": "456"}"#.utf8)) else {
             return XCTFail("Failed to decode DotcomDevice")
         }
         storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
-            if case let .registerDevice(_, _, _, onCompletion) = action {
+            switch action {
+            case let .registerDevice(_, _, _, onCompletion):
                 onCompletion(device, nil)
+            case let .registerDeviceForSelfDrivenPushNotifications(siteID, _, _, _, _, _, onCompletion):
+                onCompletion(.success(siteID + 1000))
+            case let .unregisterFromSelfDrivenPushNotifications(_, _, _, onCompletion):
+                onCompletion(unregisterResult)
+            default:
+                break
             }
         }
     }
@@ -2218,6 +2259,36 @@ private extension PushNotificationsManagerTests {
             if case .registerDevice = $0 { return true }
             return false
         }
+    }
+
+    var dispatchedUnregisterWooPushToken: Bool {
+        storesManager.receivedActions.compactMap { $0 as? NotificationAction }.contains {
+            if case .unregisterFromSelfDrivenPushNotifications = $0 { return true }
+            return false
+        }
+    }
+
+    /// Asserts the store-side Woo record was deleted for the site, with the record ID recovered
+    /// through the upsert (which `stubFallbackWooActions` answers with `siteID + 1000`).
+    func assertDeletedWooPushToken(siteID: Int64, file: StaticString = #filePath, line: UInt = #line) {
+        let deleted = storesManager.receivedActions.compactMap { $0 as? NotificationAction }.contains {
+            if case let .unregisterFromSelfDrivenPushNotifications(actionSiteID, tokenID, _, _) = $0 {
+                return actionSiteID == siteID && tokenID == siteID + 1000
+            }
+            return false
+        }
+        XCTAssertTrue(deleted, "Expected Woo push token delete for site \(siteID)", file: file, line: line)
+    }
+
+    /// Asserts no `updateNotificationSettings` action touched the given blog.
+    func assertNotReenabledWPComPushNotifications(blogID: Int64, file: StaticString = #filePath, line: UInt = #line) {
+        let touched = storesManager.receivedActions.compactMap { $0 as? AccountAction }.contains {
+            if case let .updateNotificationSettings(settings, _) = $0 {
+                return settings.blogs.contains(where: { $0.blogID == blogID })
+            }
+            return false
+        }
+        XCTAssertFalse(touched, "Blog \(blogID) must not have its WPCom notifications re-enabled", file: file, line: line)
     }
 
     /// Asserts an `updateNotificationSettings` action re-enabled WPCom PNs (newComment/storeOrder true).

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -755,30 +755,16 @@ final class PushNotificationsManagerTests: XCTestCase {
 
     // MARK: - Self-driven OFF: migrate Woo push registrations back to WPCom
     //
-    // When the FF resolves to OFF, any prior Woo push registration is migrated back to WPCom on
-    // the next launch — regardless of whether the device token changed. Sites with a working
-    // WPCom fallback (visible + full Jetpack) are re-enabled on WPCom first and unregistered
-    // from their store only once that succeeds; sites without a fallback (hidden, Jetpack CP,
-    // or a site-credentials session) are unregistered unconditionally. The store-side delete
-    // recovers each site's record ID by re-registering first (the create endpoint upserts).
-    // One test per scenario:
-    //   1. fallback site: WPCom re-enabled, Woo record deleted, state cleared (token unchanged)
-    //   2. re-enable fails: fallback site stays on Woo push so the next launch retries
-    //   3. no prior Woo registration: plain WPCom register, no settings changes
-    //   4. site-credentials user: Woo record deleted without any WPCom calls
-    //   5. hidden site: deleted without WPCom re-enable (visible sibling still re-enabled)
-    //   6. Jetpack CP site: deleted without WPCom re-enable (WPCom can't deliver to it)
-    //   7. store-side delete fails: site stays marked so the delete retries next launch
+    // Sites with a WPCom fallback (visible + full Jetpack) are re-enabled on WPCom first and
+    // unregistered from their store only once that succeeds; sites without one (hidden,
+    // Jetpack CP, site-credentials) are unregistered unconditionally. The store-side record ID
+    // is recovered by re-registering (the create endpoint upserts) before deleting.
 
     func test_registerDeviceToken_when_FF_off_with_prior_woo_registration_then_reenables_wpcom_and_deletes_woo_registration() async {
-        // Given — a visible full-Jetpack site registered while the FF was ON. The device token is
-        // unchanged: the migration must not wait for a rotation.
-        seedPriorWooRegistration()
+        // Given — a fallback-capable site registered while the FF was ON; the device token is
+        // unchanged, so the migration must not wait for a rotation.
+        manager = await makeMigrationScenario(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
         seedStoredDeviceToken(sampleTokenData.hexString)
-        await insertSitesIntoStorageWithCapabilities([(99, "https://example.com", true, true, true)])
-        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
         stubUpdateNotificationSettings(result: .success(()))
         stubFallbackWooActions()
 
@@ -786,9 +772,7 @@ final class PushNotificationsManagerTests: XCTestCase {
         manager.registerDeviceToken(with: sampleTokenData)
         await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
 
-        // Then — WPCom is re-enabled first, then the store-side Woo record is deleted and the
-        // local state is cleared.
-        XCTAssertTrue(dispatchedRegisterDotcomDevice)
+        // Then — WPCom re-enabled first, then the Woo record deleted and the local state cleared.
         assertReenabledWPComPushNotifications()
         assertDeletedWooPushToken(siteID: 99)
         assertWooRegistrationCleared()
@@ -797,19 +781,15 @@ final class PushNotificationsManagerTests: XCTestCase {
 
     func test_registerDeviceToken_when_FF_off_and_reenable_fails_then_keeps_fallback_site_on_woo_push() async {
         // Given
-        seedPriorWooRegistration()
-        await insertSitesIntoStorageWithCapabilities([(99, "https://example.com", true, true, true)])
-        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
+        manager = await makeMigrationScenario(analytics: WooAnalytics(analyticsProvider: analyticsProvider))
         stubUpdateNotificationSettings(result: .failure(NSError(domain: "test", code: 1)))
         stubFallbackWooActions()
 
         // When
         manager.registerDeviceToken(with: sampleTokenData)
 
-        // Then — WPCom did not take over, so the site stays registered with Woo push (which still
-        // delivers) and its store-side record is kept; the next launch retries the migration.
+        // Then — WPCom did not take over: the site stays on Woo push (which still delivers) and
+        // its store-side record is kept, so the next launch retries the migration.
         XCTAssertFalse(dispatchedUnregisterWooPushToken)
         XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
         XCTAssertEqual(manager.wooPushNotificationToken, "555")
@@ -826,46 +806,41 @@ final class PushNotificationsManagerTests: XCTestCase {
         // When
         manager.registerDeviceToken(with: sampleTokenData)
 
-        // Then — plain WPCom registration, no notification-settings toggling at all.
+        // Then — plain WPCom registration, no settings writes, no Woo deletes.
         XCTAssertTrue(dispatchedRegisterDotcomDevice)
-        XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
+        XCTAssertTrue(blogIDsWithWPComSettingsWrites.isEmpty)
         XCTAssertFalse(dispatchedUnregisterWooPushToken)
     }
 
     func test_registerDeviceToken_when_FF_off_and_site_credentials_user_then_deletes_woo_registration_without_wpcom_calls() async {
-        // Given — a site-credential (no WPCom) user with a prior Woo registration.
-        seedPriorWooRegistration()
-        storesManager.authenticate(credentials: SessionSettings.applicationPasswordCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff()
+        // Given
+        manager = await makeMigrationScenario(credentials: SessionSettings.applicationPasswordCredentials)
         stubFallbackWooActions()
 
         // When
         manager.registerDeviceToken(with: sampleTokenData)
         await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
 
-        // Then — there is no WPCom fallback, so the Woo registration is deleted unconditionally
-        // and no WPCom call is made.
+        // Then — no WPCom fallback exists: the Woo registration is deleted unconditionally and
+        // no WPCom call is made.
         assertDeletedWooPushToken(siteID: 99)
         assertWooRegistrationCleared()
         XCTAssertFalse(dispatchedRegisterDotcomDevice)
-        XCTAssertTrue(storesManager.receivedActions.compactMap { $0 as? AccountAction }.isEmpty)
+        XCTAssertTrue(blogIDsWithWPComSettingsWrites.isEmpty)
     }
 
-    func test_registerDeviceToken_when_FF_off_and_a_site_is_hidden_then_deletes_it_without_wpcom_reenable() async {
-        // Given — two Woo-registered full-Jetpack sites; the user has hidden store 100.
-        seedPriorWooRegistration(siteIDs: "99,100")
-        await insertSitesIntoStorageWithCapabilities([
+    func test_registerDeviceToken_when_FF_off_then_hidden_and_jetpack_cp_sites_are_deleted_without_wpcom_reenable() async {
+        // Given — 99 is fallback-capable, 100 is hidden, 101 is Jetpack CP (no Jetpack plugin,
+        // WPCom can't deliver to it).
+        manager = await makeMigrationScenario(registeredSiteIDs: "99,100,101", sites: [
             (99, "https://example.com", true, true, true),
-            (100, "https://hidden.example.com", true, true, true)
+            (100, "https://hidden.example.com", true, true, true),
+            (101, "https://jcp.example.com", false, false, true)
         ])
         UserDefaults.standard.saveHiddenStoreIDs([100])
         addTeardownBlock {
             UserDefaults.standard.saveHiddenStoreIDs([])
         }
-        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff()
         stubUpdateNotificationSettings(result: .success(()))
         stubFallbackWooActions()
 
@@ -873,48 +848,17 @@ final class PushNotificationsManagerTests: XCTestCase {
         manager.registerDeviceToken(with: sampleTokenData)
         await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
 
-        // Then — WPCom is re-enabled for the visible site only; both sites' Woo records are
-        // deleted and the local state is cleared.
+        // Then — only the fallback-capable site gets a WPCom settings write; all three Woo
+        // records are deleted and the local state is cleared.
         assertReenabledWPComPushNotifications(blogID: 99)
-        assertNotReenabledWPComPushNotifications(blogID: 100)
-        assertDeletedWooPushToken(siteID: 99)
-        assertDeletedWooPushToken(siteID: 100)
-        assertWooRegistrationCleared()
-    }
-
-    func test_registerDeviceToken_when_FF_off_and_a_site_is_jetpack_cp_then_deletes_it_without_wpcom_reenable() async {
-        // Given — site 100 is connected via the Jetpack Connection Package (no Jetpack plugin),
-        // so WPCom cannot deliver push notifications to it.
-        seedPriorWooRegistration(siteIDs: "99,100")
-        await insertSitesIntoStorageWithCapabilities([
-            (99, "https://example.com", true, true, true),
-            (100, "https://jcp.example.com", false, false, true)
-        ])
-        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff()
-        stubUpdateNotificationSettings(result: .success(()))
-        stubFallbackWooActions()
-
-        // When
-        manager.registerDeviceToken(with: sampleTokenData)
-        await until { self.manager.siteIDsRegisteredForWooPNs.isEmpty }
-
-        // Then — the JCP site gets no WPCom settings write; both Woo records are deleted.
-        assertReenabledWPComPushNotifications(blogID: 99)
-        assertNotReenabledWPComPushNotifications(blogID: 100)
-        assertDeletedWooPushToken(siteID: 99)
-        assertDeletedWooPushToken(siteID: 100)
+        XCTAssertEqual(blogIDsWithWPComSettingsWrites, [99])
+        [Int64(99), 100, 101].forEach { assertDeletedWooPushToken(siteID: $0) }
         assertWooRegistrationCleared()
     }
 
     func test_registerDeviceToken_when_FF_off_and_woo_delete_fails_then_keeps_site_marked_for_retry() async {
         // Given
-        seedPriorWooRegistration()
-        await insertSitesIntoStorageWithCapabilities([(99, "https://example.com", true, true, true)])
-        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
-        storesManager.sessionManager.setStoreId(99)
-        manager = await makeFallbackManagerWithFFOff()
+        manager = await makeMigrationScenario()
         stubUpdateNotificationSettings(result: .success(()))
         stubFallbackWooActions(unregisterResult: .failure(NSError(domain: "test", code: 1)))
 
@@ -922,8 +866,8 @@ final class PushNotificationsManagerTests: XCTestCase {
         manager.registerDeviceToken(with: sampleTokenData)
         await until { self.dispatchedUnregisterWooPushToken }
 
-        // Then — the store still holds a live registration, so the site stays marked and the
-        // delete retries on the next launch.
+        // Then — the store still holds a live registration: the site stays marked so the delete
+        // retries on the next launch.
         try? await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertEqual(manager.siteIDsRegisteredForWooPNs, [99])
         XCTAssertEqual(manager.wooPushNotificationToken, "555")
@@ -2210,6 +2154,21 @@ private extension PushNotificationsManagerTests {
         defaults.set(token, forKey: PushNotificationSharedConstants.UserDefaultsKeys.deviceToken)
     }
 
+    /// Sets up an FF-off migration scenario: a prior Woo registration for `registeredSiteIDs`,
+    /// the given sites in storage, an authenticated session on store 99, and an FF-off manager.
+    func makeMigrationScenario(
+        registeredSiteIDs: String = "99",
+        sites: [(siteID: Int64, url: String, isWPCom: Bool, isJetpackInstalled: Bool, isJetpackConnected: Bool)] = [(99, "https://example.com", true, true, true)],
+        credentials: Credentials = SessionSettings.wpcomCredentials,
+        analytics: Analytics = ServiceLocator.analytics
+    ) async -> PushNotificationsManager {
+        seedPriorWooRegistration(siteIDs: registeredSiteIDs)
+        await insertSitesIntoStorageWithCapabilities(sites)
+        storesManager.authenticate(credentials: credentials)
+        storesManager.sessionManager.setStoreId(99)
+        return await makeFallbackManagerWithFFOff(analytics: analytics)
+    }
+
     /// Creates a manager whose self-driven eligibility resolves to `false`, awaiting the resolution.
     /// Seed any prior Woo state via `seedPriorWooRegistration()` before calling this.
     func makeFallbackManagerWithFFOff(analytics: Analytics = ServiceLocator.analytics) async -> PushNotificationsManager {
@@ -2268,6 +2227,14 @@ private extension PushNotificationsManagerTests {
         }
     }
 
+    /// Blog IDs touched by any `updateNotificationSettings` action.
+    var blogIDsWithWPComSettingsWrites: [Int64] {
+        storesManager.receivedActions.compactMap { $0 as? AccountAction }.flatMap { action -> [Int64] in
+            guard case let .updateNotificationSettings(settings, _) = action else { return [] }
+            return settings.blogs.map(\.blogID)
+        }
+    }
+
     /// Asserts the store-side Woo record was deleted for the site, with the record ID recovered
     /// through the upsert (which `stubFallbackWooActions` answers with `siteID + 1000`).
     func assertDeletedWooPushToken(siteID: Int64, file: StaticString = #filePath, line: UInt = #line) {
@@ -2278,17 +2245,6 @@ private extension PushNotificationsManagerTests {
             return false
         }
         XCTAssertTrue(deleted, "Expected Woo push token delete for site \(siteID)", file: file, line: line)
-    }
-
-    /// Asserts no `updateNotificationSettings` action touched the given blog.
-    func assertNotReenabledWPComPushNotifications(blogID: Int64, file: StaticString = #filePath, line: UInt = #line) {
-        let touched = storesManager.receivedActions.compactMap { $0 as? AccountAction }.contains {
-            if case let .updateNotificationSettings(settings, _) = $0 {
-                return settings.blogs.contains(where: { $0.blogID == blogID })
-            }
-            return false
-        }
-        XCTAssertFalse(touched, "Blog \(blogID) must not have its WPCom notifications re-enabled", file: file, line: line)
     }
 
     /// Asserts an `updateNotificationSettings` action re-enabled WPCom PNs (newComment/storeOrder true).


### PR DESCRIPTION
Fixes WOOMOB-3399. Supersedes #17465.

## Description

The self-driven push notification feature flag was one-way. Registering a site with the Woo push system disables its WPCom notifications, but turning the flag off never re-enabled them — so after a rollback, affected merchants could end up without order notifications, permanently after a device-token rotation.

This mirrors the Android fix (woocommerce/woocommerce-android#16183). When the flag resolves to off, `registerDeviceToken` migrates any prior Woo push registrations back to WPCom on the next launch — no waiting for a token rotation:

- Sites with a working WPCom fallback (visible + full Jetpack connection) are re-enabled on WPCom first, and unregistered from Woo Core only once that succeeds. On failure they stay on Woo push and the migration retries on the next launch.
- Sites without a fallback (hidden stores, Jetpack CP sites, site-credentials sessions) are unregistered from Woo Core unconditionally — WPCom can't deliver to them, so there's nothing to re-enable.
- Each site's local state is cleared only after its store-side delete succeeds, so a failed delete retries on the next launch.

One iOS-specific deviation from Android: Android stores a Woo token record ID per site, iOS only keeps the last one. Instead of migrating the local storage, the migration recovers each site's record ID through Woo Core's create endpoint, which upserts by device UUID/token and returns the existing record's ID — then deletes it.

Two smaller things: `wpcom_device_enable_push_notifications_*` events mirror the existing disable pair, and the migration's store-side deletes emit the `woo_push_token_delete_*` events from #17477 (both same as Android — a persistent delete failure is the one state that can double-send, so it should be visible in Tracks). And the re-enable completion hops back to the main thread before dispatching — `AccountStore` invokes it from a background task, which tripped the Dispatcher's main-thread assertion in an on-simulator end-to-end run of the flow.

## Test Steps

You'll need a device and build the branch locally to verify this.

1. Fire up a fresh JN site with WooCommerce 10.9.2+ and log in to it with your WPCOM account.
2. Enable the woo FF, restart the app and complete the PN setup.
3. Create an order → the Woo-driven push arrives.
4. Disable the FF and restart the app.
5. Validate in Application Logs that `wpcom_device_enable_push_notifications_success` was tracked and the Woo token delete ran (`Woo push token deleted for site …`).
6. Create an order → a single push arrives (WPCom-driven now, no duplicate).
7. Restart the app again → no further migration activity in the logs.

## Screenshots

N/A — no UI changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

