### PR TITLE
Track Woo push token deletion results

### DIFF
--- a/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
+++ b/Modules/Sources/WooFoundationCore/Analytics/WooAnalyticsStat.swift
@@ -633,6 +633,8 @@ public enum WooAnalyticsStat: String {
 
     case wooPushTokenRegisterSuccess = "woo_push_token_register_success"
     case wooPushTokenRegisterError = "woo_push_token_register_error"
+    case wooPushTokenDeleteSuccess = "woo_push_token_delete_success"
+    case wooPushTokenDeleteError = "woo_push_token_delete_error"
     case wpcomDeviceDisablePushNotificationsSuccess = "wpcom_device_disable_push_notifications_success"
     case wpcomDeviceDisablePushNotificationsError = "wpcom_device_disable_push_notifications_error"
 
@@ -1455,10 +1457,11 @@ extension WooAnalyticsStat {
              .loginWhatIsJetpackHelpScreenViewed, .loginWhatIsJetpackHelpScreenOkButtonTapped,
              .loginWhatIsJetpackHelpScreenLearnMoreButtonTapped, .watchConnectingOpened, .watchStoreDataSynced:
             return false
-        // Per-site push token registration events attribute properties to the target site via a factory,
-        // so opt out of the default-site enrichment that would otherwise overwrite `blog_id` / `site_url`
-        // with the currently selected site.
-        case .wooPushTokenRegisterSuccess, .wooPushTokenRegisterError:
+        // Per-site push token registration/deletion events attribute properties to the target site via a
+        // factory, so opt out of the default-site enrichment that would otherwise overwrite `blog_id` /
+        // `site_url` with the currently selected site.
+        case .wooPushTokenRegisterSuccess, .wooPushTokenRegisterError,
+             .wooPushTokenDeleteSuccess, .wooPushTokenDeleteError:
             return false
         default:
             return true

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 
 25.1
 -----
+- [Internal] Track Woo push token deletion results (woo_push_token_delete_success/error). [https://github.com/woocommerce/woocommerce-ios/pull/17477]
 - [*] Order creation product search: the Products/SKU filter now appears below the search bar while you're searching, making SKU search easier to find. [https://github.com/woocommerce/woocommerce-ios/pull/17375]
 - [Internal] Parse all network responses off the main thread to keep the UI responsive on large payloads. [https://github.com/woocommerce/woocommerce-ios/pull/17402]
 - [*] Payments: the balance summary now shows Total balance (available + pending funds) and Available funds [https://github.com/woocommerce/woocommerce-ios/pull/17404]

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+PushNotifications.swift
@@ -21,6 +21,23 @@ extension WooAnalyticsEvent {
                               error: error)
         }
 
+        /// Tracked when the self-driven push token is successfully deleted for a specific target site.
+        /// Emits the target site's analytics properties so per-site dashboards attribute the event to the
+        /// correct site instead of the currently selected one.
+        static func wooPushTokenDeleteSuccess(targetSite: Site?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .wooPushTokenDeleteSuccess,
+                              properties: properties(for: targetSite))
+        }
+
+        /// Tracked when the self-driven push token deletion fails for a specific target site.
+        /// Emits the target site's analytics properties so per-site dashboards attribute the event to the
+        /// correct site instead of the currently selected one.
+        static func wooPushTokenDeleteError(targetSite: Site?, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .wooPushTokenDeleteError,
+                              properties: properties(for: targetSite),
+                              error: error)
+        }
+
         /// Combines the target site's analytics properties with session-level fields (`store_id`,
         /// `cached_woo_core_version`) that the default-site enrichment would normally attach.
         /// These events opt out of that enrichment to protect the target-site attribution, so the

--- a/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/EditStoreList/EditStoreListViewModel.swift
@@ -172,9 +172,17 @@ private extension EditStoreListViewModel {
                     ))
                 }
                 pushNotificationManager.unmarkSiteAsRegisteredForWooPNs(siteID)
+                analytics.track(event: .PushNotifications.wooPushTokenDeleteSuccess(targetSite: targetSite(for: siteID)))
             } catch {
                 DDLogError("⛔️ Failed to unregister site \(siteID) from self-driven push notifications: \(error)")
+                analytics.track(event: .PushNotifications.wooPushTokenDeleteError(targetSite: targetSite(for: siteID), error: error))
             }
         }
+    }
+
+    /// Hidden sites are always drawn from `availableSites`, so the target site for analytics
+    /// attribution can be resolved locally without a storage lookup.
+    func targetSite(for siteID: Int64) -> Site? {
+        availableSites.first { $0.siteID == siteID }
     }
 }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -315,6 +315,35 @@ extension PushNotificationsManager {
         }
     }
 
+    /// Unregisters the currently selected site's self-driven push token, tracking the deletion result.
+    ///
+    func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {
+        guard let siteID,
+              let tokenID = registrationState.wooPushNotificationToken,
+              let tokenIDInt = Int64(tokenID) else {
+            return completion(.success(()))
+        }
+        stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
+            siteID: siteID,
+            tokenID: tokenIDInt,
+            // The target siteID is the currently selected site, so REST fallback via
+            // `RequestConverter` is safe and preserved for site-credentials users who have no
+            // Jetpack tunnel available.
+            availableAsRESTRequest: true,
+            onCompletion: { [weak self] result in
+                if let self {
+                    switch result {
+                    case .success:
+                        analytics.track(event: .PushNotifications.wooPushTokenDeleteSuccess(targetSite: loadTargetSite(siteID: siteID)))
+                    case .failure(let error):
+                        analytics.track(event: .PushNotifications.wooPushTokenDeleteError(targetSite: loadTargetSite(siteID: siteID), error: error))
+                    }
+                }
+                completion(result)
+            }
+        ))
+    }
+
 
     /// Resets the Badge Count.
     ///
@@ -1009,23 +1038,6 @@ private extension PushNotificationsManager {
                 analytics.track(.wpcomDeviceDisablePushNotificationsError, withError: error)
             }
         }))
-    }
-
-    func unregisterFromWooPushNotificationsIfPossible(completion: @escaping (Result<Void, Error>) -> Void) {
-        guard let siteID,
-              let tokenID = registrationState.wooPushNotificationToken,
-              let tokenIDInt = Int64(tokenID) else {
-            return completion(.success(()))
-        }
-        stores.dispatch(NotificationAction.unregisterFromSelfDrivenPushNotifications(
-            siteID: siteID,
-            tokenID: tokenIDInt,
-            // The target siteID is the currently selected site, so REST fallback via
-            // `RequestConverter` is safe and preserved for site-credentials users who have no
-            // Jetpack tunnel available.
-            availableAsRESTRequest: true,
-            onCompletion: completion
-        ))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/EditStoreListViewModelTests.swift
@@ -398,6 +398,90 @@ struct EditStoreListViewModelTests {
         #expect(notificationManager.unmarkedSiteIDs == [site1.siteID])
     }
 
+    @MainActor
+    @Test func saveChanges_when_self_driven_unregistration_succeeds_then_tracks_delete_success_with_target_site_properties() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager(
+            wooPushNotificationToken: "99",
+            siteIDsRegisteredForWooPNs: [site1.siteID]
+        )
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .unregisterFromSelfDrivenPushNotifications(_, _, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               analytics: analytics,
+                                               onCompletion: {})
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then — the event attributes properties to the hidden site, not the selected one.
+        let successIndex = try #require(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_delete_success"))
+        let successProperties = analyticsProvider.receivedProperties[successIndex]
+        #expect(successProperties["blog_id"] as? Int64 == site1.siteID)
+        #expect(analyticsProvider.receivedEvents.contains("woo_push_token_delete_error") == false)
+    }
+
+    @MainActor
+    @Test func saveChanges_when_self_driven_unregistration_fails_then_tracks_delete_error_with_error_properties() async throws {
+        // Given
+        let userDefaults = UserDefaults(suiteName: UUID().uuidString)!
+        let notificationManager = MockPushNotificationsManager(
+            wooPushNotificationToken: "99",
+            siteIDsRegisteredForWooPNs: [site1.siteID]
+        )
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .unregisterFromSelfDrivenPushNotifications(_, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "test", code: 500)))
+            default:
+                break
+            }
+        }
+
+        let viewModel = EditStoreListViewModel(availableSites: [site1, site2],
+                                               displayedSites: [site1, site2],
+                                               currentlySelectedSite: nil,
+                                               stores: stores,
+                                               pushNotificationManager: notificationManager,
+                                               userDefaults: userDefaults,
+                                               analytics: analytics,
+                                               onCompletion: {})
+
+        // When
+        viewModel.toggleSelection(site1)
+        await viewModel.saveChanges()
+
+        // Then — the event carries the hidden site's identifier plus the generic error fields.
+        let errorIndex = try #require(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_delete_error"))
+        let errorProperties = analyticsProvider.receivedProperties[errorIndex]
+        #expect(errorProperties["blog_id"] as? Int64 == site1.siteID)
+        #expect(errorProperties["error_domain"] as? String == "test")
+        #expect(errorProperties["error_code"] as? String == "500")
+        #expect(analyticsProvider.receivedEvents.contains("woo_push_token_delete_success") == false)
+    }
+
     // MARK: - Self-driven push notification registration for newly enabled sites
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationsManagerTests.swift
@@ -1365,6 +1365,107 @@ final class PushNotificationsManagerTests: XCTestCase {
         XCTAssertEqual(successProperties["is_jetpack_connected"] as? Bool, false)
     }
 
+    // MARK: - Self-driven push token deletion analytics
+
+    func test_unregisterFromWooPushNotificationsIfPossible_when_unregistration_succeeds_then_tracks_delete_success_with_target_site_properties() async throws {
+        // Given — selected site 100 is stored with distinct properties and a Woo push token is registered.
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        defaults.set("1100", forKey: PushNotificationSharedConstants.UserDefaultsKeys.wooPushNotificationToken)
+
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: 100, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true)
+        ])
+
+        manager = makeManager(analytics: analytics)
+
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .unregisterFromSelfDrivenPushNotifications(_, _, _, onCompletion) = action {
+                onCompletion(.success(()))
+            }
+        }
+
+        // When
+        let completionExpectation = expectation(description: "Unregistration completed")
+        manager.unregisterFromWooPushNotificationsIfPossible { _ in
+            completionExpectation.fulfill()
+        }
+        await fulfillment(of: [completionExpectation], timeout: 1.0)
+
+        // Then — the event carries the target site's identifiers and capability flags.
+        let successIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_delete_success"),
+                                         "Expected a woo_push_token_delete_success event")
+        let successProperties = analyticsProvider.receivedProperties[successIndex]
+        XCTAssertEqual(successProperties["blog_id"] as? Int64, 100)
+        XCTAssertEqual(successProperties["site_url"] as? String, "https://alpha.example")
+        XCTAssertEqual(successProperties["is_wpcom_store"] as? Bool, true)
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("woo_push_token_delete_error"))
+    }
+
+    func test_unregisterFromWooPushNotificationsIfPossible_when_unregistration_fails_then_tracks_delete_error_with_error_properties() async throws {
+        // Given — same setup as the success case, but the unregistration action fails.
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+        defaults.set("1100", forKey: PushNotificationSharedConstants.UserDefaultsKeys.wooPushNotificationToken)
+
+        await insertSitesIntoStorageWithCapabilities([
+            (siteID: 100, url: "https://alpha.example", isWPCom: true, isJetpackInstalled: true, isJetpackConnected: true)
+        ])
+
+        manager = makeManager(analytics: analytics)
+
+        storesManager.whenReceivingAction(ofType: NotificationAction.self) { action in
+            if case let .unregisterFromSelfDrivenPushNotifications(_, _, _, onCompletion) = action {
+                onCompletion(.failure(NSError(domain: "test", code: 500)))
+            }
+        }
+
+        // When
+        let completionExpectation = expectation(description: "Unregistration completed")
+        manager.unregisterFromWooPushNotificationsIfPossible { _ in
+            completionExpectation.fulfill()
+        }
+        await fulfillment(of: [completionExpectation], timeout: 1.0)
+
+        // Then — the event carries the target site's identifiers plus the generic error fields.
+        let errorIndex = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "woo_push_token_delete_error"),
+                                       "Expected a woo_push_token_delete_error event")
+        let errorProperties = analyticsProvider.receivedProperties[errorIndex]
+        XCTAssertEqual(errorProperties["blog_id"] as? Int64, 100)
+        XCTAssertEqual(errorProperties["site_url"] as? String, "https://alpha.example")
+        XCTAssertEqual(errorProperties["error_domain"] as? String, "test")
+        XCTAssertEqual(errorProperties["error_code"] as? String, "500")
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("woo_push_token_delete_success"))
+    }
+
+    func test_unregisterFromWooPushNotificationsIfPossible_when_no_token_is_stored_then_completes_without_tracking() async {
+        // Given — a selected site but no Woo push token, so there is nothing to delete.
+        let analyticsProvider = MockAnalyticsProvider()
+        let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)
+        storesManager.sessionManager.setStoreId(100)
+
+        manager = makeManager(analytics: analytics)
+
+        // When
+        let completionExpectation = expectation(description: "Unregistration completed")
+        manager.unregisterFromWooPushNotificationsIfPossible { result in
+            if case .failure = result {
+                XCTFail("Expected success when there is no token to delete")
+            }
+            completionExpectation.fulfill()
+        }
+        await fulfillment(of: [completionExpectation], timeout: 1.0)
+
+        // Then — no deletion happened, so no delete events should be tracked.
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("woo_push_token_delete_success"))
+        XCTAssertFalse(analyticsProvider.receivedEvents.contains("woo_push_token_delete_error"))
+    }
+
     func test_registerDeviceToken_when_site_returns_notFound_then_unmarks_that_site() async {
         // Given
         storesManager.authenticate(credentials: SessionSettings.wpcomCredentials)


### PR DESCRIPTION
## Description

Woo Core push token deletion is only visible in device logs today, so there is no Tracks visibility into how many devices get unregistered (which made the recent flag rollback hard to assess, see the Android counterpart below). This adds `woo_push_token_delete_success` / `woo_push_token_delete_error`, mirroring the existing `woo_push_token_register_success` / `woo_push_token_register_error` events.

iOS counterpart of woocommerce/woocommerce-android#16184, with the same event names and error fields.

Tracking covers both call sites that dispatch `NotificationAction.unregisterFromSelfDrivenPushNotifications`:
- `PushNotificationsManager.unregisterFromWooPushNotificationsIfPossible` (logging out)
- `EditStoreListViewModel.unregisterHiddenSitesFromSelfDrivenPushNotifications` (hiding a store via Edit Stores)

Like the register events, the delete events attribute `blog_id` / `site_url` / capability flags to the **target** site rather than the currently selected one, so they are excluded from the default-site property enrichment in `shouldSendSiteProperties`.

Note: `unregisterFromWooPushNotificationsIfPossible` moved from a private extension to the internal one so the deletion analytics can be unit-tested directly; behavior is unchanged.

## Test Steps

1. With self-driven push notifications enabled and a store registered for Woo push notifications, log out, or hide a registered store via Store Picker → Edit Stores.
2. Verify in the Xcode console (Tracks debug output) that `woocommerce_woo_push_token_delete_success` is tracked with the target site's `blog_id`, or `woocommerce_woo_push_token_delete_error` with `error_code` / `error_domain` when the request fails.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.