### PR TITLE
[WOOMOB-3446] Prevent skipping phone validation when creating a shipping label

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [*] Shipping Labels: Prevent skipping phone number validation when confirming an address by tapping too quickly. [https://github.com/woocommerce/woocommerce-ios/pull/17478]
 - [*] Fixed the card reader connection Cancel button being too small to tap in landscape on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17437]
 - [Internal] Updated Automattic Tracks to 4.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/17432]
 - [Internal] Fix `push_notification_source` being logged as `wpcom` instead of `woo_driven` for Woo-driven notifications. [https://github.com/woocommerce/woocommerce-ios/pull/17463]

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressView.swift
@@ -211,7 +211,7 @@ struct WooShippingEditAddressView: View {
 
                 Button(Localization.Button.label(for: viewModel.status)) {
                     actionType = .validateOrConfirm
-                    switch viewModel.status {
+                    switch viewModel.validatedStatus() {
                     case .verified:
                         dismiss()
                     case .unverified:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -529,6 +529,13 @@ extension WooShippingEditAddressViewModel {
         allFields.forEach { $0.validateField() }
     }
 
+    /// Re-validates all fields immediately (bypassing the per-field debounce) and returns the status.
+    /// Used on the confirm tap so a fast tap can't skip local validation. See WOOMOB-3446.
+    func validatedStatus() -> WooShippingAddressStatus {
+        validateAddress()
+        return status
+    }
+
     /// Validate the address field with the given type.
     func validate(_ field: WooShippingAddressFieldType) {
         allFields.first { $0.type == field }?.validateField()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/WooShipping Create Shipping Labels/WooShippingEditAddressViewModelTests.swift
@@ -743,6 +743,32 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.status, .unverified)
     }
 
+    // MARK: - validatedStatus (WOOMOB-3446)
+
+    func test_validatedStatus_when_phone_edited_to_empty_within_debounce_then_returns_missingInformation() {
+        // Given a valid, verified US address (default 1s field validation debounce).
+        let viewModel = makeValidVerifiedUSViewModel()
+        XCTAssertEqual(viewModel.status, .verified)
+
+        // When the phone is cleared and confirmed immediately, before the debounce fires the field
+        // error is not yet set, so `status` is still stale and would allow the user to proceed.
+        viewModel.phone.value = ""
+        XCTAssertEqual(viewModel.status, .unverified, "Within the debounce window the stale status still allows confirming")
+
+        // Then re-validating on confirm surfaces the missing phone synchronously and blocks proceeding.
+        XCTAssertEqual(viewModel.validatedStatus(), .missingInformation)
+        XCTAssertEqual(viewModel.status, .missingInformation)
+    }
+
+    func test_validatedStatus_when_address_is_valid_and_verified_then_returns_verified() {
+        // Given a valid, verified US address with no edits.
+        let viewModel = makeValidVerifiedUSViewModel()
+
+        // When re-validating on confirm.
+        // Then a valid address is not falsely blocked.
+        XCTAssertEqual(viewModel.validatedStatus(), .verified)
+    }
+
     @MainActor
     func test_isLoading_set_during_and_after_remote_validation() async {
         // Given
@@ -1643,6 +1669,31 @@ final class WooShippingEditAddressViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(receivedIsVerified, "updateDestinationAddress should be called with isVerified: false when withoutVerification is true")
+    }
+}
+
+private extension WooShippingEditAddressViewModelTests {
+    /// Builds a view model for a valid, remotely verified US origin address, so a single invalid edit
+    /// (e.g. clearing the phone) is what turns it invalid. Uses the default field validation debounce.
+    func makeValidVerifiedUSViewModel() -> WooShippingEditAddressViewModel {
+        let storageManager = MockStorageManager()
+        let countries = [Country(code: "US", name: "United States", states: [StateOfACountry(code: "NY", name: "New York")])]
+        storageManager.insertSampleCountries(readOnlyCountries: countries)
+        return WooShippingEditAddressViewModel(type: .origin,
+                                               id: "default_address",
+                                               name: "JANE DOE",
+                                               company: "HEADQUARTERS",
+                                               country: "US",
+                                               address: "15 ALGONKIN ST STE 100",
+                                               city: "TICONDEROGA",
+                                               state: "NY",
+                                               postalCode: "12883-1487",
+                                               email: "TEST@EXAMPLE.COM",
+                                               phone: "1-234-456-7890",
+                                               isDefaultAddress: true,
+                                               showCompanyField: true,
+                                               isVerified: true,
+                                               storageManager: storageManager)
     }
 }
 


### PR DESCRIPTION
Fixes: WOOMOB-3446

## Description

When editing a Woo Shipping label address, you could bypass local field validation (e.g. an empty or invalid phone) by tapping **Validate & Save** within ~1s of typing. Each field's validation is debounced 1s (`WooShippingAddressField`), and the confirm button's gate (`viewModel.status` via `isValid`) was wired to that same debounced signal — so for up to 1s `status` stayed stale (`.unverified` instead of `.missingInformation`) and a fast tap slipped through.

The fix re-validates synchronously on tap:

- **`WooShippingEditAddressViewModel.validatedStatus()`** — calls `validateAddress()` (no debounce) and returns the resulting `status`.
- **`WooShippingEditAddressView`**'s **Validate & Save** action switches on `validatedStatus()` instead of `viewModel.status`.

The debounce is unchanged (still handles the typing UX); it's just no longer what gates the button. Covers origin + destination, all fields.

## Test Steps

<details><summary><code>review-woomob-3446.sh</code></summary>

```bash
#!/bin/bash
#
# Prepares a Jurassic Ninja site to review WOOMOB-3446
# (possible to skip phone validation when creating a shipping label).
#
# You bring your OWN throwaway JN site — nothing is shared. This script only
# configures the site: it installs WooCommerce + the new WooCommerce Shipping
# plugin, sets a US store address, creates one weighted SIMPLE product and one
# US->US processing order to create a label from, and disables the Jetpack
# modules that block the app's application-password login.
#
# It does NOT (and cannot) connect the store to the Woo Shipping Connect Server:
# that needs Jetpack connected in a browser with your WP.com account. The script
# prints that one manual step at the end. Building / installing / launching the
# app is up to you.
#
# 1) Create a plain JN site (the default — Jetpack is already installed). The
#    script installs WooCommerce for you.
#      • JN web UI: create a site, or
#      • ContextA8C:  /context-a8c:jurassic-ninja-create
#    From the site's welcome page copy the DOMAIN and the admin PASSWORD.
#
# 2) Run it:
#      ./review-woomob-3446.sh <domain> <admin-password>
#
# Requires: expect (bundled on macOS).
set -euo pipefail

DOMAIN="${1:-}"
JN_PASSWORD="${2:-}"

if [[ -z "$DOMAIN" || -z "$JN_PASSWORD" ]]; then
  echo "Usage: ./review-woomob-3446.sh <jn-domain> <admin-password>"
  echo "  e.g. ./review-woomob-3446.sh funny-dino.jurassic.ninja aBc123..."
  exit 1
fi
DOMAIN="${DOMAIN#https://}"; DOMAIN="${DOMAIN#http://}"; DOMAIN="${DOMAIN%%/*}"

ADMIN_USER="demo"        # JN admin (user 1)

printf '\n\033[1;34m▸ Configuring %s for the WOOMOB-3446 review\033[0m\n' "$DOMAIN"

# Wake the site — atomic JN sites sleep when idle, and SSH/wp-cli then returns empty output or hangs.
# Poll until the REST API responds (booting the PHP/DB tier) before we SSH in.
printf '▸ Waking the site'
for i in $(seq 1 15); do
  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "https://${DOMAIN}/wp-json/" 2>/dev/null || true)
  if [ "$code" = "200" ]; then printf ' awake.\n'; break; fi
  printf '.'; sleep 5
done
curl -s -o /dev/null --max-time 15 "https://${DOMAIN}/?auto_login" 2>/dev/null || true

# Idempotent: install WooCommerce + WooCommerce Shipping, set a US store address, ensure a weighted
# SIMPLE product and one US->US processing order exist, and disable the Jetpack modules that block the
# app's application-password login.
REMOTE_SCRIPT=$(cat <<'REMOTE'
set -e
# WooCommerce (idempotent).
wp plugin is-active woocommerce >/dev/null 2>&1 || wp plugin install woocommerce --activate >/dev/null 2>&1 || { echo "WC_INSTALL_FAILED"; exit 1; }
# WooCommerce Shipping — the NEW plugin the revamped label flow requires (>= 1.0.5).
# It sometimes installs inactive, so activate explicitly.
wp plugin is-active woocommerce-shipping >/dev/null 2>&1 || wp plugin install woocommerce-shipping --activate >/dev/null 2>&1 || { echo "WCSHIPPING_INSTALL_FAILED"; exit 1; }
wp plugin activate woocommerce-shipping >/dev/null 2>&1 || true

# US store base address — the Woo Shipping origin address is auto-created from this on Connect.
wp option update woocommerce_store_address "60 29th Street #343" >/dev/null
wp option update woocommerce_store_city "San Francisco" >/dev/null
wp option update woocommerce_store_postcode "94110" >/dev/null
wp option update woocommerce_default_country "US:CA" >/dev/null
wp option update woocommerce_currency "USD" >/dev/null

# A physical SIMPLE product with a weight (orders need a weighted product to be label-eligible).
SKU="woomob-3446-review"
PID=$(wp --user=1 wc product list --sku="$SKU" --field=id 2>/dev/null | head -1)
if [ -z "$PID" ]; then
  PID=$(wp --user=1 wc product create --name="WOOMOB-3446 Review Product" --type=simple --regular_price=20 --weight=2 --sku="$SKU" --porcelain)
fi

# One clean US->US processing order to create a label from (idempotent via a stored option).
OID=$(wp option get woomob_3446_order_id 2>/dev/null || true)
if [ -z "$OID" ] || ! wp --user=1 wc shop_order get "$OID" --field=id >/dev/null 2>&1; then
  OID=$(wp --user=1 wc shop_order create --status=processing --customer_id=0 \
    --billing='{"first_name":"Jane","last_name":"Doe","address_1":"15 Algonkin St","city":"Ticonderoga","state":"NY","postcode":"12883","country":"US","email":"jane@example.com","phone":"4155550199"}' \
    --shipping='{"first_name":"Jane","last_name":"Doe","address_1":"15 Algonkin St","city":"Ticonderoga","state":"NY","postcode":"12883","country":"US","phone":"4155550199"}' \
    --line_items='[{"product_id":'"$PID"',"quantity":1}]' --porcelain)
  wp option update woomob_3446_order_id "$OID" >/dev/null
fi

# Make the app login painless (leave the admin password untouched).
wp jetpack module deactivate account-protection >/dev/null 2>&1 || true
wp jetpack module deactivate protect >/dev/null 2>&1 || true
wp cache flush >/dev/null 2>&1 || true

echo "REVIEW_ORDER=${OID}"
echo "REVIEW_DONE"
REMOTE
)

B64=$(printf '%s' "$REMOTE_SCRIPT" | base64 | tr -d '\n')
OUTPUT=$(expect <<EOF 2>&1 | sed -e 's/\r$//'
set timeout 180
spawn ssh -o StrictHostKeyChecking=no -o PreferredAuthentications=password -o PubkeyAuthentication=no ${DOMAIN}@sftp.wp.com "echo ${B64} | base64 --decode | bash"
expect {
  "assword:" { send "${JN_PASSWORD}\r"; exp_continue }
  eof
}
EOF
)

if ! grep -q "REVIEW_DONE" <<<"$OUTPUT"; then
  echo "$OUTPUT" | grep -iE "error|denied|refused|_FAILED" || echo "$OUTPUT"
  echo "❌ Site configuration failed — check the domain and admin password."
  exit 1
fi
OID=$(grep "REVIEW_ORDER=" <<<"$OUTPUT" | tail -1 | cut -d= -f2 | tr -d '[:space:]')

cat <<STEPS

✅ ${DOMAIN} is configured: WooCommerce + WooCommerce Shipping, a weighted product, and one
   processing order #${OID}.

⚠️  ONE manual step remains — the app only shows "Create Shipping Label" once the store is linked to
   the Woo Shipping Connect Server. That needs a browser + your WP.com account, so it can't be
   scripted:

   1. Open  https://${ADMIN_USER}:<the admin password>@${DOMAIN}/wp-admin/  (or the site's ?auto_login link).
   2. If Jetpack isn't connected yet: Jetpack → "Set up / Connect" → approve with your WP.com account.
   3. WooCommerce → Settings → Shipping → "WooCommerce Shipping" → finish setup / accept the Terms of
      Service. This links the Connect Server; the origin address is auto-created from the US store
      address set above.

Then build & run this PR's app (the revamped label flow is on by default) and, in the app:

   4. Log in to ${DOMAIN}. It's a Jetpack site, so use your WP.com account (the site appears in the
      store picker), OR store-address → "Sign in with store credentials" with an APPLICATION PASSWORD.
   5. Orders → open order #${OID} → "Create Shipping Label".
   6. Tap the "Ship to" (or "Ship from") address to edit it.
   7. Clear the phone number (or type an invalid one like 123) and IMMEDIATELY tap "Validate & Save"
      — within ~1s, before the field shows its inline error.

   Expected on this branch (fixed): the tap surfaces "Please provide a valid phone number.", the
   status reads "Missing information", and the save is blocked.
   On trunk (buggy): the same fast tap proceeds and skips the phone validation.

STEPS
```

</details>

1. **Create a new plain JN site.** Copy the **domain** and admin **password** from the welcome page.
2. **Run the script:**
   ```bash
   ./review-woomob-3446.sh <domain> <admin-password>
   ```
3. **Do the one manual step it prints:** open the site's `?auto_login`, connect Jetpack, then WooCommerce → Settings → Shipping → **WooCommerce Shipping** → accept the Terms of Service. (This links the Connect Server so the app shows the label option.)
4. **Build & run this branch**, log in to the site, open the seeded order → **Create Shipping Label**.
5. Tap the **Ship to** (or **Ship from**) address → clear the phone (or type `123`) → **immediately** tap **Validate & Save** (within ~1s, before the field shows its inline error).
6. shows "Please provide a valid phone number.", status reads **Missing information**, and the save is blocked.
7. Enter a valid phone → **Validate & Save** proceeds normally.

## Screenshots

<img width="256" height="554" alt="ScreenRecording_07-06-2026 13-55-11_1" src="https://github.com/user-attachments/assets/ca89f9e5-1aae-4c11-adc8-93297815899a" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

