### PR TITLE
[TEMP] DO NOT MERGE: Verify build warning guard against non-trunk base

### DIFF
--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -17,6 +17,7 @@ public class OrderStore: Store {
     /// Registers for supported Actions.
     ///
     override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        let temporaryBaseBranchTestWarningValue = 1
         dispatcher.register(processor: self, for: OrderAction.self)
     }
 


### PR DESCRIPTION
## Description
Throwaway draft PR to verify the build warning guard from #17456 handles a non-trunk base branch: the warning baseline should be computed from the merge base with `codex/build-warning-increase-guard` (which already carries one intentional test warning), so only the single new warning added here should be flagged.

Do not merge — this PR will be closed once the guard comment is verified.

## Test Steps
1. Wait for CI to run the Build Warning Count step.
2. Verify the PR comment reports exactly **1 new build warning** (`OrderStore.swift`) against baseline base `codex/build-warning-increase-guard`, not `trunk`.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.