### PR TITLE
Skip unsupported-country shipping label requests

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -965,7 +965,7 @@ extension OrderDetailsViewModel {
 }
 
 private extension OrderDetailsViewModel {
-    static let shippingLabelSupportedCountries: Set<CountryCode> = [.US, .PR, .VI, .GU, .AS, .MP, .UM]
+    static let shippingLabelSupportedCountries: Set<CountryCode> = [.US, .PR, .VI, .GU, .AS, .MP, .UM, .FM, .MH]
 
     static let storeCountrySettingID = "woocommerce_default_country"
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -965,7 +965,18 @@ extension OrderDetailsViewModel {
 }
 
 private extension OrderDetailsViewModel {
-    static let shippingLabelSupportedCountries: Set<CountryCode> = [.US, .PR, .VI, .GU, .AS, .MP, .UM, .FM, .MH]
+    /// Mirrors the Woo Shipping and legacy WCShip supported store-origin countries for shipping labels.
+    static let shippingLabelSupportedCountries: Set<CountryCode> = [
+        .US, // United States.
+        .AS, // American Samoa.
+        .PR, // Puerto Rico.
+        .VI, // United States Virgin Islands.
+        .GU, // Guam.
+        .MP, // Northern Mariana Islands.
+        .UM, // United States Minor Outlying Islands.
+        .FM, // Federated States of Micronesia.
+        .MH, // Marshall Islands.
+    ]
 
     static let storeCountrySettingID = "woocommerce_default_country"
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -707,6 +707,10 @@ extension OrderDetailsViewModel {
     }
 
     @MainActor func syncShippingLabelsOrShipments() async {
+        guard storeCountrySupportsShippingLabels else {
+            return
+        }
+
         let isRevampedFlow = featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation)
         guard isRevampedFlow else {
             /// old logic for syncing labels
@@ -790,6 +794,10 @@ extension OrderDetailsViewModel {
 
     @MainActor
     func checkShippingLabelCreationEligibility() async -> Bool {
+        guard storeCountrySupportsShippingLabels else {
+            return false
+        }
+
         let isRevampedFlow = featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation)
         guard isRevampedFlow else {
             if await localRequirementsForShippingLabelsAreFulfilled() {
@@ -957,6 +965,29 @@ extension OrderDetailsViewModel {
 }
 
 private extension OrderDetailsViewModel {
+    static let shippingLabelSupportedCountries: Set<CountryCode> = [.US, .PR, .VI, .GU, .AS, .MP, .UM]
+
+    static let storeCountrySettingID = "woocommerce_default_country"
+
+    var storeCountrySupportsShippingLabels: Bool {
+        guard let countryCode = storeCountryCode else {
+            return false
+        }
+        return Self.shippingLabelSupportedCountries.contains(countryCode)
+    }
+
+    var storeCountryCode: CountryCode? {
+        let predicate = NSPredicate(format: "siteID == %lld AND settingID == %@", order.siteID, Self.storeCountrySettingID)
+        let resultsController = ResultsController<StorageSiteSetting>(storageManager: storageManager, matching: predicate, sortedBy: [])
+        try? resultsController.performFetch()
+
+        guard let countryAndState = resultsController.fetchedObjects.first?.value,
+              let country = countryAndState.components(separatedBy: ":").first?.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() else {
+            return nil
+        }
+
+        return CountryCode(rawValue: country)
+    }
 
     @MainActor func checkShippingLabelCreationEligibilityForWooShipping() async -> Bool {
         await withCheckedContinuation { continuation in

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -980,11 +980,19 @@ private extension OrderDetailsViewModel {
 
     static let storeCountrySettingID = "woocommerce_default_country"
 
+    /// Fails open when the store country is unknown (not cached yet or unparseable) so a cache miss
+    /// can never hide the feature from an eligible store — the plugin eligibility check remains the
+    /// source of truth. Only a known-unsupported country skips the shipping label requests.
     var storeCountrySupportsShippingLabels: Bool {
         guard let countryCode = storeCountryCode else {
+            DDLogInfo("Store country unknown; deferring shipping label support to the plugin eligibility check.")
+            return true
+        }
+        guard Self.shippingLabelSupportedCountries.contains(countryCode) else {
+            DDLogInfo("Skipping shipping label requests: store country \(countryCode.rawValue) does not support shipping labels.")
             return false
         }
-        return Self.shippingLabelSupportedCountries.contains(countryCode)
+        return true
     }
 
     var storeCountryCode: CountryCode? {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -965,47 +965,27 @@ extension OrderDetailsViewModel {
 }
 
 private extension OrderDetailsViewModel {
-    /// Mirrors the Woo Shipping and legacy WCShip supported store-origin countries for shipping labels.
-    static let shippingLabelSupportedCountries: Set<CountryCode> = [
-        .US, // United States.
-        .AS, // American Samoa.
-        .PR, // Puerto Rico.
-        .VI, // United States Virgin Islands.
-        .GU, // Guam.
-        .MP, // Northern Mariana Islands.
-        .UM, // United States Minor Outlying Islands.
-        .FM, // Federated States of Micronesia.
-        .MH, // Marshall Islands.
-    ]
-
-    static let storeCountrySettingID = "woocommerce_default_country"
-
     /// Fails open when the store country is unknown (not cached yet or unparseable) so a cache miss
     /// can never hide the feature from an eligible store — the plugin eligibility check remains the
     /// source of truth. Only a known-unsupported country skips the shipping label requests.
     var storeCountrySupportsShippingLabels: Bool {
-        guard let countryCode = storeCountryCode else {
+        let countryCode = storeCountryCode
+        guard countryCode != .unknown else {
             DDLogInfo("Store country unknown; deferring shipping label support to the plugin eligibility check.")
             return true
         }
-        guard Self.shippingLabelSupportedCountries.contains(countryCode) else {
+        guard USPSDomesticMailCountries.countryCodes.contains(countryCode) else {
             DDLogInfo("Skipping shipping label requests: store country \(countryCode.rawValue) does not support shipping labels.")
             return false
         }
         return true
     }
 
-    var storeCountryCode: CountryCode? {
-        let predicate = NSPredicate(format: "siteID == %lld AND settingID == %@", order.siteID, Self.storeCountrySettingID)
+    var storeCountryCode: CountryCode {
+        let predicate = NSPredicate(format: "siteID == %lld", order.siteID)
         let resultsController = ResultsController<StorageSiteSetting>(storageManager: storageManager, matching: predicate, sortedBy: [])
         try? resultsController.performFetch()
-
-        guard let countryAndState = resultsController.fetchedObjects.first?.value,
-              let country = countryAndState.components(separatedBy: ":").first?.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() else {
-            return nil
-        }
-
-        return CountryCode(rawValue: country)
+        return SiteAddress(siteSettings: resultsController.fetchedObjects).countryCode
     }
 
     @MainActor func checkShippingLabelCreationEligibilityForWooShipping() async -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewModel.swift
@@ -481,7 +481,7 @@ final class ShippingLabelFormViewModel {
     func filteredCountries(for type: ShipType) -> [Country] {
         switch type {
         case .origin:
-            return countries.filter { Constants.acceptedUSPSCountries.contains($0.code) }
+            return countries.filter { USPSDomesticMailCountries.rawCountryCodes.contains($0.code) }
         case .destination:
             return countries
         }
@@ -973,21 +973,6 @@ private extension ShippingLabelFormViewModel {
     }
 
     enum Constants {
-        /// This is hardcoded for now based on: https://git.io/JBuja.
-        /// It would be great if this can be fetched remotely.
-        ///
-        static let acceptedUSPSCountries = [
-            "US", // United States
-            "PR", // Puerto Rico
-            "VI", // Virgin Islands
-            "GU", // Guam
-            "AS", // American Samoa
-            "UM", // United States Minor Outlying Islands
-            "MH", // Marshall Islands
-            "FM", // Micronesia
-            "MP" // Northern Mariana Islands
-        ]
-
         /// Country code for US - to check for international shipment
         ///
         static let usCountryCode = "US"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/USPSDomesticMailCountries.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/USPSDomesticMailCountries.swift
@@ -1,0 +1,22 @@
+import WooFoundation
+
+/// Countries in the USPS domestic mail path — the store-origin and destination countries supported
+/// for shipping label purchase with the Woo Shipping and legacy WCShip plugins.
+/// This is hardcoded for now based on: https://git.io/JBuja.
+/// It would be great if this can be fetched remotely.
+enum USPSDomesticMailCountries {
+    static let countryCodes: Set<CountryCode> = [
+        .US, // United States
+        .PR, // Puerto Rico
+        .VI, // Virgin Islands
+        .GU, // Guam
+        .AS, // American Samoa
+        .UM, // United States Minor Outlying Islands
+        .MH, // Marshall Islands
+        .FM, // Micronesia
+        .MP // Northern Mariana Islands
+    ]
+
+    /// Raw ISO 3166-1 alpha-2 codes for call sites that compare plain string country codes.
+    static let rawCountryCodes: Set<String> = Set(countryCodes.map(\.rawValue))
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRequirements.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Customs/WooShippingCustomsRequirements.swift
@@ -34,8 +34,8 @@ struct WooShippingCustomsRequirements {
             return false
         }
 
-        return Constants.uspsDomesticMailCountries.contains(originCountry) &&
-            Constants.uspsDomesticMailCountries.contains(destinationCountry)
+        return USPSDomesticMailCountries.rawCountryCodes.contains(originCountry) &&
+            USPSDomesticMailCountries.rawCountryCodes.contains(destinationCountry)
     }
 }
 
@@ -67,17 +67,5 @@ private extension WooShippingCustomsRequirements {
         /// These US states are a special case because they represent military bases. They're considered "domestic",
         /// but they require a Customs form to ship from/to them.
         static let usMilitaryStates = ["AA", "AE", "AP"]
-
-        static let uspsDomesticMailCountries = [
-            "US", // United States
-            "PR", // Puerto Rico
-            "VI", // Virgin Islands
-            "GU", // Guam
-            "AS", // American Samoa
-            "UM", // United States Minor Outlying Islands
-            "MH", // Marshall Islands
-            "FM", // Micronesia
-            "MP"  // Northern Mariana Islands
-        ]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingAddresses/WooShippingEditAddressViewModel.swift
@@ -148,7 +148,7 @@ final class WooShippingEditAddressViewModel: ObservableObject, Identifiable {
     var countries: [Country] {
         switch addressType {
         case .origin:
-            resultsController.fetchedObjects.filter { Constants.acceptedUSPSCountries.contains($0.code) }
+            resultsController.fetchedObjects.filter { USPSDomesticMailCountries.rawCountryCodes.contains($0.code) }
         case .destination:
             resultsController.fetchedObjects
         }
@@ -740,26 +740,6 @@ extension WooShippingEditAddressViewModel {
                 return Localization.DestinationAddressUpdateError.message
             }
         }
-    }
-}
-
-// MARK: Constants
-private extension WooShippingEditAddressViewModel {
-    enum Constants {
-        /// This is hardcoded for now based on: https://git.io/JBuja.
-        /// It would be great if this can be fetched remotely.
-        ///
-        static let acceptedUSPSCountries = [
-            "US", // United States
-            "PR", // Puerto Rico
-            "VI", // Virgin Islands
-            "GU", // Guam
-            "AS", // American Samoa
-            "UM", // United States Minor Outlying Islands
-            "MH", // Marshall Islands
-            "FM", // Micronesia
-            "MP" // Northern Mariana Islands
-        ]
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -522,7 +522,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     }
 
     func test_checkShippingLabelCreationEligibility_when_store_country_is_supported_dispatches_action() async throws {
-        for storeCountry in ["US", "PR", "VI", "GU", "AS", "MP", "UM", "us", "Pr"] {
+        for storeCountry in ["US", "PR", "VI", "GU", "AS", "MP", "UM", "FM", "MH", "us", "Pr"] {
             // Given
             let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
                                                           handlesEligibilityCheck: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -80,6 +80,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_syncShippingLabels_without_a_non_virtual_product_does_not_dispatch_actions() async throws {
         // Given
+        configureDefaultStoreCountry("US")
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
@@ -93,6 +94,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_syncShippingLabels_with_legacy_extension_and_feature_flag_enabled_dispatches_actions_correctly() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6)])
+        configureDefaultStoreCountry("US")
 
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
@@ -147,6 +149,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_syncShippingLabels_with_wooShipping_extension_and_feature_flag_enabled_dispatches_actions_correctly() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6)])
+        configureDefaultStoreCountry("US")
 
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
@@ -191,6 +194,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_syncShippingLabels_with_wooShipping_extension_and_feature_flag_disabled_dispatches_actions_correctly() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6)])
+        configureDefaultStoreCountry("US")
 
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
@@ -242,10 +246,35 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(orderID, order.orderID)
     }
 
+    func test_syncShippingLabels_when_store_country_is_not_supported_does_not_dispatch_actions() async throws {
+        for storeCountry in ["FR", "DE", "BR", "IN", ""] {
+            // Given
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry)
+
+            // When
+            await viewModel.syncShippingLabelsOrShipments()
+
+            // Then
+            XCTAssertEqual(storesManager.receivedActions.count, 0, "Expected no actions for \(storeCountry)")
+        }
+    }
+
+    func test_syncShippingLabels_without_store_country_does_not_dispatch_actions() async throws {
+        // Given
+        let viewModel = configureShippingLabelContext(storeCountry: nil)
+
+        // When
+        await viewModel.syncShippingLabelsOrShipments()
+
+        // Then
+        XCTAssertEqual(storesManager.receivedActions.count, 0)
+    }
+
     // MARK: - `checkShippingLabelCreationEligibility`
 
     func test_checkShippingLabelCreationEligibility_without_a_non_virtual_product_returns_false() async throws {
         // Given
+        configureDefaultStoreCountry("US")
         storesManager.reset()
 
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
@@ -264,6 +293,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_with_a_non_virtual_product_returns_value_from_action() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
+        configureDefaultStoreCountry("US")
         let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.LegacyWCShip, siteID: order.siteID, isActive: true)
         whenFetchingSystemPlugin(thenReturn: plugin)
         whenCheckingShippingLabelCreationEligibility(thenReturn: true)
@@ -283,6 +313,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_checkShippingLabelCreationEligibility_without_a_non_virtual_product_does_not_dispatch_actions() async throws {
         // Given
+        configureDefaultStoreCountry("US")
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
 
@@ -302,6 +333,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_with_legacy_extension_and_feature_flag_enabled_dispatches_actions_correctly() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
+        configureDefaultStoreCountry("US")
 
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
@@ -358,6 +390,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_with_wooshipping_and_feature_flag_enabled_dispatches_actions_correctly() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
+        configureDefaultStoreCountry("US")
 
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
@@ -404,6 +437,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_when_feature_flag_disabled_dispatches_actions_correctly() async throws {
         // Given
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
+        configureDefaultStoreCountry("US")
 
         storesManager.reset()
         XCTAssertEqual(storesManager.receivedActions.count, 0)
@@ -455,6 +489,55 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
         XCTAssertEqual(siteID, order.siteID)
         XCTAssertEqual(orderID, order.orderID)
+    }
+
+    func test_checkShippingLabelCreationEligibility_when_store_country_is_not_supported_returns_false_without_dispatching_actions() async throws {
+        for storeCountry in ["FR", "DE", "BR", "IN", ""] {
+            // Given
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry)
+
+            // When
+            let isEligible = await viewModel.checkShippingLabelCreationEligibility()
+
+            // Then
+            XCTAssertFalse(isEligible, "Expected ineligible for \(storeCountry)")
+            XCTAssertEqual(storesManager.receivedActions.count, 0, "Expected no actions for \(storeCountry)")
+        }
+    }
+
+    func test_checkShippingLabelCreationEligibility_without_store_country_returns_false_without_dispatching_actions() async throws {
+        // Given
+        let viewModel = configureShippingLabelContext(storeCountry: nil)
+
+        // When
+        let isEligible = await viewModel.checkShippingLabelCreationEligibility()
+
+        // Then
+        XCTAssertFalse(isEligible)
+        XCTAssertEqual(storesManager.receivedActions.count, 0)
+    }
+
+    func test_checkShippingLabelCreationEligibility_when_store_country_is_supported_dispatches_action() async throws {
+        for storeCountry in ["US", "PR", "VI", "GU", "AS", "MP", "UM", "us", "Pr"] {
+            // Given
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry)
+
+            // When
+            let isEligible = await viewModel.checkShippingLabelCreationEligibility()
+
+            // Then
+            XCTAssertTrue(isEligible, "Expected eligible result from action for \(storeCountry)")
+            XCTAssertEqual(storesManager.receivedActions.count, 2, "Expected plugin fetch and eligibility check for \(storeCountry)")
+
+            let action = try XCTUnwrap(storesManager.receivedActions[1] as? WooShippingAction)
+            guard case let WooShippingAction.checkCreationEligibility(siteID, orderID, _) = action else {
+                XCTFail("Expected \(action) to be \(WooShippingAction.self)")
+                return
+            }
+
+            XCTAssertEqual(siteID, order.siteID)
+            XCTAssertEqual(orderID, order.orderID)
+        }
     }
 
     func test_there_should_not_be_edit_order_action_if_order_is_not_synced() {
@@ -758,6 +841,38 @@ private extension OrderDetailsViewModelTests {
         products.forEach { product in
             storageManager.insertSampleProduct(readOnlyProduct: product)
         }
+    }
+
+    func configureDefaultStoreCountry(_ country: String) {
+        let setting = SiteSetting.fake().copy(siteID: order.siteID,
+                                              settingID: "woocommerce_default_country",
+                                              value: country,
+                                              settingGroupKey: "general")
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+    }
+
+    func configureShippingLabelContext(storeCountry: String?) -> OrderDetailsViewModel {
+        storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+        storageManager = MockStorageManager()
+        configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
+
+        if let storeCountry {
+            configureDefaultStoreCountry(storeCountry)
+        }
+
+        let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, siteID: order.siteID, isActive: true)
+        whenFetchingSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, thenReturn: plugin)
+        whenCheckingShippingLabelCreationEligibility(thenReturn: true)
+        whenSyncingShipments(thenReturn: .success([]))
+        storesManager.reset()
+
+        let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
+        let viewModel = OrderDetailsViewModel(order: order,
+                                              stores: storesManager,
+                                              storageManager: storageManager,
+                                              featureFlagService: featureFlagService)
+        self.viewModel = viewModel
+        return viewModel
     }
 
     func whenFetchingSystemPlugin(path: String? = nil, thenReturn plugin: SystemPlugin?) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -247,7 +247,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     }
 
     func test_syncShippingLabels_when_store_country_is_not_supported_does_not_dispatch_actions() async throws {
-        for storeCountry in ["FR", "DE", "BR", "IN", ""] {
+        for storeCountry in ["FR", "DE", "BR", "IN"] {
             // Given
             let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
                                                           handlesShipmentSync: true)
@@ -260,16 +260,27 @@ final class OrderDetailsViewModelTests: XCTestCase {
         }
     }
 
-    func test_syncShippingLabels_without_store_country_does_not_dispatch_actions() async throws {
-        // Given
-        let viewModel = configureShippingLabelContext(storeCountry: nil,
-                                                      handlesShipmentSync: true)
+    func test_syncShippingLabels_when_store_country_is_unknown_dispatches_actions() async throws {
+        for storeCountry in [nil, ""] {
+            // Given
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
+                                                          handlesShipmentSync: true)
 
-        // When
-        await viewModel.syncShippingLabelsOrShipments()
+            // When
+            await viewModel.syncShippingLabelsOrShipments()
 
-        // Then
-        XCTAssertEqual(storesManager.receivedActions.count, 0)
+            // Then
+            XCTAssertEqual(storesManager.receivedActions.count, 2, "Expected fail-open plugin fetch and shipment sync for \(String(describing: storeCountry))")
+
+            let action = try XCTUnwrap(storesManager.receivedActions[1] as? WooShippingAction)
+            guard case let WooShippingAction.syncShipments(siteID, orderID, _) = action else {
+                XCTFail("Expected \(action) to be \(WooShippingAction.self)")
+                return
+            }
+
+            XCTAssertEqual(siteID, order.siteID)
+            XCTAssertEqual(orderID, order.orderID)
+        }
     }
 
     // MARK: - `checkShippingLabelCreationEligibility`
@@ -494,7 +505,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     }
 
     func test_checkShippingLabelCreationEligibility_when_store_country_is_not_supported_returns_false_without_dispatching_actions() async throws {
-        for storeCountry in ["FR", "DE", "BR", "IN", ""] {
+        for storeCountry in ["FR", "DE", "BR", "IN"] {
             // Given
             let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
                                                           handlesEligibilityCheck: true)
@@ -508,17 +519,19 @@ final class OrderDetailsViewModelTests: XCTestCase {
         }
     }
 
-    func test_checkShippingLabelCreationEligibility_without_store_country_returns_false_without_dispatching_actions() async throws {
-        // Given
-        let viewModel = configureShippingLabelContext(storeCountry: nil,
-                                                      handlesEligibilityCheck: true)
+    func test_checkShippingLabelCreationEligibility_when_store_country_is_unknown_defers_to_eligibility_check() async throws {
+        for storeCountry in [nil, ""] {
+            // Given
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
+                                                          handlesEligibilityCheck: true)
 
-        // When
-        let isEligible = await viewModel.checkShippingLabelCreationEligibility()
+            // When
+            let isEligible = await viewModel.checkShippingLabelCreationEligibility()
 
-        // Then
-        XCTAssertFalse(isEligible)
-        XCTAssertEqual(storesManager.receivedActions.count, 0)
+            // Then
+            XCTAssertTrue(isEligible, "Expected fail-open eligibility result from action for \(String(describing: storeCountry))")
+            XCTAssertEqual(storesManager.receivedActions.count, 2, "Expected plugin fetch and eligibility check for \(String(describing: storeCountry))")
+        }
     }
 
     func test_checkShippingLabelCreationEligibility_when_store_country_is_supported_dispatches_action() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -249,7 +249,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_syncShippingLabels_when_store_country_is_not_supported_does_not_dispatch_actions() async throws {
         for storeCountry in ["FR", "DE", "BR", "IN", ""] {
             // Given
-            let viewModel = configureShippingLabelContext(storeCountry: storeCountry)
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
+                                                          handlesShipmentSync: true)
 
             // When
             await viewModel.syncShippingLabelsOrShipments()
@@ -261,7 +262,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_syncShippingLabels_without_store_country_does_not_dispatch_actions() async throws {
         // Given
-        let viewModel = configureShippingLabelContext(storeCountry: nil)
+        let viewModel = configureShippingLabelContext(storeCountry: nil,
+                                                      handlesShipmentSync: true)
 
         // When
         await viewModel.syncShippingLabelsOrShipments()
@@ -494,7 +496,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_when_store_country_is_not_supported_returns_false_without_dispatching_actions() async throws {
         for storeCountry in ["FR", "DE", "BR", "IN", ""] {
             // Given
-            let viewModel = configureShippingLabelContext(storeCountry: storeCountry)
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
+                                                          handlesEligibilityCheck: true)
 
             // When
             let isEligible = await viewModel.checkShippingLabelCreationEligibility()
@@ -507,7 +510,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
 
     func test_checkShippingLabelCreationEligibility_without_store_country_returns_false_without_dispatching_actions() async throws {
         // Given
-        let viewModel = configureShippingLabelContext(storeCountry: nil)
+        let viewModel = configureShippingLabelContext(storeCountry: nil,
+                                                      handlesEligibilityCheck: true)
 
         // When
         let isEligible = await viewModel.checkShippingLabelCreationEligibility()
@@ -520,7 +524,8 @@ final class OrderDetailsViewModelTests: XCTestCase {
     func test_checkShippingLabelCreationEligibility_when_store_country_is_supported_dispatches_action() async throws {
         for storeCountry in ["US", "PR", "VI", "GU", "AS", "MP", "UM", "us", "Pr"] {
             // Given
-            let viewModel = configureShippingLabelContext(storeCountry: storeCountry)
+            let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
+                                                          handlesEligibilityCheck: true)
 
             // When
             let isEligible = await viewModel.checkShippingLabelCreationEligibility()
@@ -851,7 +856,9 @@ private extension OrderDetailsViewModelTests {
         storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
     }
 
-    func configureShippingLabelContext(storeCountry: String?) -> OrderDetailsViewModel {
+    func configureShippingLabelContext(storeCountry: String?,
+                                       handlesEligibilityCheck: Bool = false,
+                                       handlesShipmentSync: Bool = false) -> OrderDetailsViewModel {
         storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
         storageManager = MockStorageManager()
         configureOrderWithProductsInStorage(products: [.fake().copy(productID: 6, virtual: false)])
@@ -862,8 +869,12 @@ private extension OrderDetailsViewModelTests {
 
         let plugin = insertSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, siteID: order.siteID, isActive: true)
         whenFetchingSystemPlugin(path: SitePlugin.SupportedPluginPath.WooShipping, thenReturn: plugin)
-        whenCheckingShippingLabelCreationEligibility(thenReturn: true)
-        whenSyncingShipments(thenReturn: .success([]))
+        if handlesEligibilityCheck {
+            whenCheckingShippingLabelCreationEligibility(thenReturn: true)
+        }
+        if handlesShipmentSync {
+            whenSyncingShipments(thenReturn: .success([]))
+        }
         storesManager.reset()
 
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -520,7 +520,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     }
 
     func test_checkShippingLabelCreationEligibility_when_store_country_is_unknown_defers_to_eligibility_check() async throws {
-        for storeCountry in [nil, ""] {
+        for storeCountry in [nil, "", "us", "Pr"] {
             // Given
             let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
                                                           handlesEligibilityCheck: true)
@@ -535,7 +535,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
     }
 
     func test_checkShippingLabelCreationEligibility_when_store_country_is_supported_dispatches_action() async throws {
-        for storeCountry in ["US", "PR", "VI", "GU", "AS", "MP", "UM", "FM", "MH", "us", "Pr"] {
+        for storeCountry in ["US", "PR", "VI", "GU", "AS", "MP", "UM", "FM", "MH"] {
             // Given
             let viewModel = configureShippingLabelContext(storeCountry: storeCountry,
                                                           handlesEligibilityCheck: true)


### PR DESCRIPTION
Part of: WOOMOB-3404

## Description
Stores outside the shipping-label supported country set can still have Woo Shipping installed and active. Before this change, opening an order always dispatched shipping-label eligibility and label/shipment sync requests for those stores, even though the backend would never allow label creation. 
If the plugin endpoint was slow or timed out, those optional requests could keep the order details loading state active long after the core order content was ready.

This adds a local store-country gate before both shipping-label paths on order details:

- `checkShippingLabelCreationEligibility()`
- `syncShippingLabelsOrShipments()`

The guard reads the cached `woocommerce_default_country` site setting, normalizes the country code, and only allows the existing Woo Shipping / legacy WCShip flow for the supported allow-list: `US`, `PR`, `VI`, `GU`, `AS`, `MP`, `UM`, `FM`, `MH`.

We are intentionally using the hardcoded app list for both plugin paths. Woo Shipping currently uses the same USPS domestic-territory list as legacy WCShip, there are no short-term plans to expand label purchasing to new origin countries, and the plugin does not currently expose a mobile-consumable supported-country config that would let the app skip the eligibility call without keeping a local list. This keeps the order details screen from making known-unnecessary shipping-label requests while matching the current server-side support matrix.

Unsupported, missing, or invalid store countries return before plugin checks, so no label eligibility or label/shipment sync request is dispatched.

## Test Steps

1. On a non-supported-country store, for example `FR`, with Woo Shipping active, open an order with physical products.
2. Confirm order details load normally and no `/wcshipping/v1/eligibility/*` eligibility or shipment sync request is sent.
3. Confirm the shipping-label creation UI remains unavailable as before.
4. Repeat on a non-supported-country store with the legacy WCShip/WooCommerce Services plugin active.
5. Confirm no `/wc/v1/connect/label/*/creation_eligibility` or legacy label sync request is sent.
6. On a `US` store with Woo Shipping active, open an order with physical products.
7. Confirm the existing eligibility check still runs and the shipping-label creation flow appears when the backend returns eligible.
8. If available, repeat with a supported territory country code such as `PR`, `FM`, or `MH` to confirm the guard does not block the existing server-side eligibility check.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
