### PR TITLE
Analytics: Track horizontal size class globally

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Yosemite
 import AutomatticTracks
 import WordPressShared
@@ -42,6 +43,12 @@ public class TracksProvider: NSObject, AnalyticsProvider {
     public static func setPOSMode(_ active: Bool) {
         isPOSModeActive = active
     }
+
+    static var horizontalSizeClass: UIUserInterfaceSizeClass = .unspecified
+
+    public static func setHorizontalSizeClass(_ sizeClass: UIUserInterfaceSizeClass) {
+        horizontalSizeClass = sizeClass
+    }
 }
 
 
@@ -59,6 +66,7 @@ public extension TracksProvider {
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         let eventName = decorateEventNameForPOSIfNeeded(eventName)
+        let properties = trackWithHorizontalSizeClass(properties)
         Self.TracksServiceExecutor.enqueue { tracksService in
             if let properties {
                 guard tracksService.trackEventName(eventName, withCustomProperties: properties) else {
@@ -146,6 +154,24 @@ private extension TracksProvider {
                 tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
             }
         }
+    }
+
+    /// Adds `horizontal_size_class` to the event's properties when a concrete layout is known,
+    /// without overwriting a value the event already provides.
+    ///
+    func trackWithHorizontalSizeClass(_ properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
+        let sizeClass = Self.horizontalSizeClass
+        guard sizeClass == .compact || sizeClass == .regular else {
+            return properties
+        }
+
+        var layoutProperties = properties ?? [:]
+        guard layoutProperties[Constants.horizontalSizeClassKey] == nil else {
+            return layoutProperties
+        }
+
+        layoutProperties[Constants.horizontalSizeClassKey] = sizeClass.nameForAnalytics
+        return layoutProperties
     }
 
     private func decorateEventNameForPOSIfNeeded(_ eventName: String) -> String {
@@ -347,6 +373,7 @@ private extension TracksProvider {
 
     enum Constants {
         static let eventNamePrefix = "woocommerceios"
+        static let horizontalSizeClassKey = "horizontal_size_class"
     }
 
     enum UserProperties {

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -48,7 +48,7 @@ public class TracksProvider: NSObject, AnalyticsProvider {
 extension TracksProvider {
     /// Read on the main thread only; UIKit trait reads are main-thread bound. Off the main thread
     /// (background BGTask/push events, where layout is irrelevant) it returns `.unspecified`, which
-    /// `trackWithHorizontalSizeClass` skips.
+    /// `addHorizontalSizeClass(to:sizeClass:)` skips.
     func currentHorizontalSizeClass() -> UIUserInterfaceSizeClass {
         guard Thread.isMainThread else {
             return .unspecified
@@ -59,8 +59,8 @@ extension TracksProvider {
     /// Adds `horizontal_size_class` to the event's properties when a concrete layout is known,
     /// without overwriting a value the event already provides.
     ///
-    func trackWithHorizontalSizeClass(_ properties: [AnyHashable: Any]?,
-                                      sizeClass: UIUserInterfaceSizeClass) -> [AnyHashable: Any]? {
+    func addHorizontalSizeClass(to properties: [AnyHashable: Any]?,
+                                sizeClass: UIUserInterfaceSizeClass) -> [AnyHashable: Any]? {
         guard sizeClass == .compact || sizeClass == .regular else {
             return properties
         }
@@ -90,7 +90,7 @@ public extension TracksProvider {
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         let eventName = decorateEventNameForPOSIfNeeded(eventName)
-        let properties = trackWithHorizontalSizeClass(properties, sizeClass: currentHorizontalSizeClass())
+        let properties = addHorizontalSizeClass(to: properties, sizeClass: currentHorizontalSizeClass())
         Self.TracksServiceExecutor.enqueue { tracksService in
             if let properties {
                 guard tracksService.trackEventName(eventName, withCustomProperties: properties) else {

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -65,13 +65,13 @@ extension TracksProvider {
             return properties
         }
 
-        var layoutProperties = properties ?? [:]
-        guard layoutProperties[Constants.horizontalSizeClassKey] == nil else {
-            return layoutProperties
+        var decoratedProperties = properties ?? [:]
+        guard decoratedProperties[Constants.horizontalSizeClassKey] == nil else {
+            return decoratedProperties
         }
 
-        layoutProperties[Constants.horizontalSizeClassKey] = sizeClass.nameForAnalytics
-        return layoutProperties
+        decoratedProperties[Constants.horizontalSizeClassKey] = sizeClass.nameForAnalytics
+        return decoratedProperties
     }
 }
 

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -61,7 +61,7 @@ extension TracksProvider {
     ///
     func addHorizontalSizeClass(to properties: [AnyHashable: Any]?,
                                 sizeClass: UIUserInterfaceSizeClass) -> [AnyHashable: Any]? {
-        guard sizeClass == .compact || sizeClass == .regular else {
+        guard sizeClass != .unspecified else {
             return properties
         }
 

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -43,20 +43,24 @@ public class TracksProvider: NSObject, AnalyticsProvider {
     public static func setPOSMode(_ active: Bool) {
         isPOSModeActive = active
     }
-
-    static var horizontalSizeClass: UIUserInterfaceSizeClass = .unspecified
-
-    public static func setHorizontalSizeClass(_ sizeClass: UIUserInterfaceSizeClass) {
-        horizontalSizeClass = sizeClass
-    }
 }
 
 extension TracksProvider {
+    /// Read on the main thread only; UIKit trait reads are main-thread bound. Off the main thread
+    /// (background BGTask/push events, where layout is irrelevant) it returns `.unspecified`, which
+    /// `trackWithHorizontalSizeClass` skips.
+    func currentHorizontalSizeClass() -> UIUserInterfaceSizeClass {
+        guard Thread.isMainThread else {
+            return .unspecified
+        }
+        return UIApplication.wooKeyWindow?.traitCollection.horizontalSizeClass ?? .unspecified
+    }
+
     /// Adds `horizontal_size_class` to the event's properties when a concrete layout is known,
     /// without overwriting a value the event already provides.
     ///
     func trackWithHorizontalSizeClass(_ properties: [AnyHashable: Any]?,
-                                      sizeClass: UIUserInterfaceSizeClass = TracksProvider.horizontalSizeClass) -> [AnyHashable: Any]? {
+                                      sizeClass: UIUserInterfaceSizeClass) -> [AnyHashable: Any]? {
         guard sizeClass == .compact || sizeClass == .regular else {
             return properties
         }
@@ -86,7 +90,7 @@ public extension TracksProvider {
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         let eventName = decorateEventNameForPOSIfNeeded(eventName)
-        let properties = trackWithHorizontalSizeClass(properties)
+        let properties = trackWithHorizontalSizeClass(properties, sizeClass: currentHorizontalSizeClass())
         Self.TracksServiceExecutor.enqueue { tracksService in
             if let properties {
                 guard tracksService.trackEventName(eventName, withCustomProperties: properties) else {

--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -51,6 +51,26 @@ public class TracksProvider: NSObject, AnalyticsProvider {
     }
 }
 
+extension TracksProvider {
+    /// Adds `horizontal_size_class` to the event's properties when a concrete layout is known,
+    /// without overwriting a value the event already provides.
+    ///
+    func trackWithHorizontalSizeClass(_ properties: [AnyHashable: Any]?,
+                                      sizeClass: UIUserInterfaceSizeClass = TracksProvider.horizontalSizeClass) -> [AnyHashable: Any]? {
+        guard sizeClass == .compact || sizeClass == .regular else {
+            return properties
+        }
+
+        var layoutProperties = properties ?? [:]
+        guard layoutProperties[Constants.horizontalSizeClassKey] == nil else {
+            return layoutProperties
+        }
+
+        layoutProperties[Constants.horizontalSizeClassKey] = sizeClass.nameForAnalytics
+        return layoutProperties
+    }
+}
+
 
 // MARK: - AnalyticsProvider Conformance
 //
@@ -154,24 +174,6 @@ private extension TracksProvider {
                 tracksService.switchToAnonymousUser(withAnonymousID: anonymousID)
             }
         }
-    }
-
-    /// Adds `horizontal_size_class` to the event's properties when a concrete layout is known,
-    /// without overwriting a value the event already provides.
-    ///
-    func trackWithHorizontalSizeClass(_ properties: [AnyHashable: Any]?) -> [AnyHashable: Any]? {
-        let sizeClass = Self.horizontalSizeClass
-        guard sizeClass == .compact || sizeClass == .regular else {
-            return properties
-        }
-
-        var layoutProperties = properties ?? [:]
-        guard layoutProperties[Constants.horizontalSizeClassKey] == nil else {
-            return layoutProperties
-        }
-
-        layoutProperties[Constants.horizontalSizeClassKey] = sizeClass.nameForAnalytics
-        return layoutProperties
     }
 
     private func decorateEventNameForPOSIfNeeded(_ eventName: String) -> String {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Products.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Products.swift
@@ -1,31 +1,23 @@
-import UIKit
 import Networking
 
 extension WooAnalyticsEvent {
     enum Products {
         /// Event property keys.
         private enum Key {
-            static let horizontalSizeClass = "horizontal_size_class"
             static let productType = "product_type"
         }
 
-        static func productListSelected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productListSelected,
-                              properties: [Key.horizontalSizeClass: horizontalSizeClass.nameForAnalytics])
+        static func productListSelected() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productListSelected, properties: [:])
         }
 
-        static func productListReselected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productListReselected,
-                              properties: [Key.horizontalSizeClass: horizontalSizeClass.nameForAnalytics])
+        static func productListReselected() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productListReselected, properties: [:])
         }
 
-        static func productListProductTapped(productType: ProductType,
-                                             horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+        static func productListProductTapped(productType: ProductType) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productListProductTapped,
-                              properties: [
-                                Key.productType: productType.rawValue,
-                                Key.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
-                              ])
+                              properties: [Key.productType: productType.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+WooApp.swift
@@ -474,10 +474,9 @@ extension WooAnalyticsEvent {
             static let hasChangedData = "has_changed_data"
         }
 
-        static func loaded(hasLinkedProducts: Bool, hasMinMaxQuantityRules: Bool, horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+        static func loaded(hasLinkedProducts: Bool, hasMinMaxQuantityRules: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailLoaded, properties: ["has_linked_products": hasLinkedProducts,
-                                                                           "has_minmax_quantity_rules": hasMinMaxQuantityRules,
-                                                                           "horizontal_size_class": horizontalSizeClass.nameForAnalytics])
+                                                                           "has_minmax_quantity_rules": hasMinMaxQuantityRules])
         }
 
         /// Tracks when the merchant previews a product draft.
@@ -639,31 +638,22 @@ extension WooAnalyticsEvent {
             static let usesGiftCard = "use_gift_card"
             static let taxStatus = "tax_status"
             static let expanded = "expanded"
-            static let horizontalSizeClass = "horizontal_size_class"
             static let shippingMethod = "shipping_method"
         }
 
-        static func ordersSelected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
-            return WooAnalyticsEvent(statName: .ordersSelected,
-                                     properties: [
-                                        Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
-                                     ])
+        static func ordersSelected() -> WooAnalyticsEvent {
+            return WooAnalyticsEvent(statName: .ordersSelected, properties: [:])
         }
 
-        static func ordersReselected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
-            return WooAnalyticsEvent(statName: .ordersReselected,
-                                     properties: [
-                                        Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
-                                     ])
+        static func ordersReselected() -> WooAnalyticsEvent {
+            return WooAnalyticsEvent(statName: .ordersReselected, properties: [:])
         }
 
-        static func orderOpen(order: Order,
-                              horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+        static func orderOpen(order: Order) -> WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .orderOpen,
                                      properties: [
                                         "id": order.orderID,
-                                        "status": order.status.rawValue,
-                                        Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                                        "status": order.status.rawValue
                                      ])
         }
 
@@ -858,8 +848,7 @@ extension WooAnalyticsEvent {
                                             hasCustomerDetails: Bool,
                                             hasFees: Bool,
                                             hasShippingMethod: Bool,
-                                            products: [Product],
-                                            horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+                                            products: [Product]) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreateButtonTapped, properties: [
                 Keys.orderStatus: status.rawValue,
                 Keys.productCount: Int64(productCount),
@@ -867,8 +856,7 @@ extension WooAnalyticsEvent {
                 Keys.hasCustomerDetails: hasCustomerDetails,
                 Keys.hasFees: hasFees,
                 Keys.hasShippingMethod: hasShippingMethod,
-                Keys.productTypes: productTypes(order: order, products: products),
-                Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                Keys.productTypes: productTypes(order: order, products: products)
             ])
         }
 
@@ -879,8 +867,7 @@ extension WooAnalyticsEvent {
                                                       hasCustomerDetails: Bool,
                                                       hasFees: Bool,
                                                       hasShippingMethod: Bool,
-                                                      products: [Product],
-                                                      horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+                                                      products: [Product]) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped, properties: [
                 Keys.flow: Flow.creation.rawValue,
                 Keys.orderStatus: status.rawValue,
@@ -889,8 +876,7 @@ extension WooAnalyticsEvent {
                 Keys.hasCustomerDetails: hasCustomerDetails,
                 Keys.hasFees: hasFees,
                 Keys.hasShippingMethod: hasShippingMethod,
-                Keys.productTypes: productTypes(order: order, products: products),
-                Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                Keys.productTypes: productTypes(order: order, products: products)
             ])
         }
 
@@ -2730,11 +2716,10 @@ extension WooAnalyticsEvent {
     enum ProductsOnboarding {
         enum Keys: String {
             case type
-            case horizontalSizeClass = "horizontal_size_class"
         }
 
-        static func productListAddProductButtonTapped(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productListAddProductTapped, properties: [Keys.horizontalSizeClass.rawValue: horizontalSizeClass.nameForAnalytics])
+        static func productListAddProductButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productListAddProductTapped, properties: [:])
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -491,11 +491,9 @@ private extension MainTabBarController {
         case .myStore:
             ServiceLocator.analytics.track(.dashboardSelected)
         case .orders:
-            ServiceLocator.analytics.track(
-                event: .Orders.ordersSelected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            ServiceLocator.analytics.track(event: .Orders.ordersSelected())
         case .products:
-            ServiceLocator.analytics.track(
-                event: .Products.productListSelected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            ServiceLocator.analytics.track(event: .Products.productListSelected())
         case .bookings:
             ServiceLocator.analytics.track(Event.mainTabBookingsSelect())
         case .hubMenu:
@@ -512,11 +510,9 @@ private extension MainTabBarController {
         case .myStore:
             ServiceLocator.analytics.track(.dashboardReselected)
         case .orders:
-            ServiceLocator.analytics.track(
-                event: .Orders.ordersReselected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            ServiceLocator.analytics.track(event: .Orders.ordersReselected())
         case .products:
-            ServiceLocator.analytics.track(
-                event: .Products.productListReselected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            ServiceLocator.analytics.track(event: .Products.productListReselected())
         case .bookings:
             ServiceLocator.analytics.track(Event.mainTabBookingsReselect())
         case .hubMenu:

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -261,10 +261,7 @@ final class MainTabBarController: UITabBarController {
     }
 
     private func observeTraitChanges() {
-        TracksProvider.setHorizontalSizeClass(traitCollection.horizontalSizeClass)
-
         registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitVerticalSizeClass.self]) { (self: Self, _) in
-            TracksProvider.setHorizontalSizeClass(self.traitCollection.horizontalSizeClass)
             self.configureTabBarLayoutOnIpad()
         }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -261,7 +261,10 @@ final class MainTabBarController: UITabBarController {
     }
 
     private func observeTraitChanges() {
+        TracksProvider.setHorizontalSizeClass(traitCollection.horizontalSizeClass)
+
         registerForTraitChanges([UITraitHorizontalSizeClass.self, UITraitVerticalSizeClass.self]) { (self: Self, _) in
+            TracksProvider.setHorizontalSizeClass(self.traitCollection.horizontalSizeClass)
             self.configureTabBarLayoutOnIpad()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -2096,8 +2096,7 @@ private extension EditableOrderViewModel {
             hasCustomerDetails: hasCustomerDetails,
             hasFees: orderSynchronizer.order.fees.isNotEmpty,
             hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
-            products: Array(allProducts),
-            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            products: Array(allProducts)))
     }
 
     func trackCollectPaymentTapped() {
@@ -2110,8 +2109,7 @@ private extension EditableOrderViewModel {
             hasCustomerDetails: hasCustomerDetails,
             hasFees: orderSynchronizer.order.fees.isNotEmpty,
             hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
-            products: Array(allProducts),
-            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            products: Array(allProducts)))
     }
 
     /// Tracks an order creation success

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -810,8 +810,7 @@ extension OrderListViewController: UITableViewDelegate {
 
         selectedIndexPath = indexPath
         let order = orderDetailsViewModel.order
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order,
-                                                                                 horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
         selectedOrderID = order.orderID
         let allViewModels = allViewModels()
         let currentIndex = allViewModels.firstIndex(where: { $0.order.orderID == order.orderID })

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -172,9 +172,7 @@ final class OrdersRootViewController: UIViewController {
         let detailsViewController = OrderDetailsViewController(viewModel: viewModel)
 
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
-        analytics.track(event: .Orders.orderOpen(
-            order: order,
-            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+        analytics.track(event: .Orders.orderOpen(order: order))
     }
 
     /// Selects the order given the ID from the order list view if the order exists locally.
@@ -640,10 +638,7 @@ private extension OrdersRootViewController {
     /// Pushes an `OrderDetailsViewController` onto the navigation stack.
     ///
     private func navigateToOrderDetail(_ order: Order, onCompletion: ((Bool) -> Void)? = nil) {
-        analytics.track(event: .Orders.orderOpen(
-            order: order,
-            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass
-        ))
+        analytics.track(event: .Orders.orderOpen(order: order))
 
         ordersViewController.showOrderDetails(order, shouldScrollIfNeeded: true) { _ in
             onCompletion?(true)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -105,7 +105,7 @@ final class AddProductCoordinator: Coordinator {
     func start() {
         switch source {
         case .productsTab:
-            analytics.track(event: .ProductsOnboarding.productListAddProductButtonTapped(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+            analytics.track(event: .ProductsOnboarding.productListAddProductButtonTapped())
         default:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -717,8 +717,7 @@ extension ProductFormViewModel {
         let hasLinkedProducts = product.upsellIDs.isNotEmpty || product.crossSellIDs.isNotEmpty
         let hasMinMaxQuantityRules = product.canEditQuantityRules
         analytics.track(event: .ProductDetail.loaded(hasLinkedProducts: hasLinkedProducts,
-                                                                      hasMinMaxQuantityRules: hasMinMaxQuantityRules,
-                                                                      horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+                                                     hasMinMaxQuantityRules: hasMinMaxQuantityRules))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1309,9 +1309,7 @@ extension ProductsViewController: UITableViewDelegate {
             updatedSelectedItems()
         } else {
             ServiceLocator.analytics.track(event:
-                    .Products.productListProductTapped(
-                        productType: product.productType,
-                        horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+                    .Products.productListProductTapped(productType: product.productType))
 
             didSelectProduct(product: product)
         }

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
@@ -58,6 +58,16 @@ struct TracksProviderHorizontalSizeClassTests {
         #expect(result?[key] as? String == "regular")
     }
 
+    @Test func test_currentHorizontalSizeClass_when_off_main_thread_then_returns_unspecified() async {
+        // When (read from a detached task, guaranteed off the main thread)
+        let result = await Task.detached { [sut] in
+            sut.currentHorizontalSizeClass()
+        }.value
+
+        // Then
+        #expect(result == .unspecified)
+    }
+
     @Test func test_addHorizontalSizeClass_when_nil_properties_and_concrete_sizeClass_then_returns_only_layout() {
         // When
         let result = sut.addHorizontalSizeClass(to: nil, sizeClass: .compact)

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import UIKit
+@testable import WooCommerce
+
+struct TracksProviderHorizontalSizeClassTests {
+
+    private let sut = TracksProvider()
+    private let key = "horizontal_size_class"
+
+    @Test func test_trackWithHorizontalSizeClass_when_regular_then_adds_regular_value() {
+        // When
+        let result = sut.trackWithHorizontalSizeClass([:], sizeClass: .regular)
+
+        // Then
+        #expect(result?[key] as? String == "regular")
+    }
+
+    @Test func test_trackWithHorizontalSizeClass_when_compact_then_adds_compact_value() {
+        // When
+        let result = sut.trackWithHorizontalSizeClass([:], sizeClass: .compact)
+
+        // Then
+        #expect(result?[key] as? String == "compact")
+    }
+
+    @Test func test_trackWithHorizontalSizeClass_when_unspecified_then_does_not_add_property() {
+        // When
+        let withProperties = sut.trackWithHorizontalSizeClass(["a": 1], sizeClass: .unspecified)
+        let withoutProperties = sut.trackWithHorizontalSizeClass(nil, sizeClass: .unspecified)
+
+        // Then
+        #expect(withProperties?[key] == nil)
+        #expect(withProperties?["a"] as? Int == 1)
+        #expect(withoutProperties == nil)
+    }
+
+    @Test func test_trackWithHorizontalSizeClass_when_property_already_present_then_keeps_existing_value() {
+        // Given — an event that already carries its own horizontal_size_class (e.g. product/order factories)
+        let existing: [AnyHashable: Any] = [key: "regular"]
+
+        // When — the cached layout differs
+        let result = sut.trackWithHorizontalSizeClass(existing, sizeClass: .compact)
+
+        // Then — the event's own value wins
+        #expect(result?[key] as? String == "regular")
+    }
+
+    @Test func test_trackWithHorizontalSizeClass_preserves_other_properties() {
+        // When
+        let result = sut.trackWithHorizontalSizeClass(["products_in_cart": 2, "is_ciab": false], sizeClass: .regular)
+
+        // Then
+        #expect(result?["products_in_cart"] as? Int == 2)
+        #expect(result?["is_ciab"] as? Bool == false)
+        #expect(result?[key] as? String == "regular")
+    }
+
+    @Test func test_trackWithHorizontalSizeClass_when_nil_properties_and_concrete_sizeClass_then_returns_only_layout() {
+        // When
+        let result = sut.trackWithHorizontalSizeClass(nil, sizeClass: .compact)
+
+        // Then
+        #expect(result?.count == 1)
+        #expect(result?[key] as? String == "compact")
+    }
+
+    @Test func test_setHorizontalSizeClass_updates_cached_value() {
+        // When
+        TracksProvider.setHorizontalSizeClass(.regular)
+
+        // Then
+        #expect(TracksProvider.horizontalSizeClass == .regular)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
@@ -7,26 +7,26 @@ struct TracksProviderHorizontalSizeClassTests {
     private let sut = TracksProvider()
     private let key = "horizontal_size_class"
 
-    @Test func test_trackWithHorizontalSizeClass_when_regular_then_adds_regular_value() {
+    @Test func test_addHorizontalSizeClass_when_regular_then_adds_regular_value() {
         // When
-        let result = sut.trackWithHorizontalSizeClass([:], sizeClass: .regular)
+        let result = sut.addHorizontalSizeClass(to: [:], sizeClass: .regular)
 
         // Then
         #expect(result?[key] as? String == "regular")
     }
 
-    @Test func test_trackWithHorizontalSizeClass_when_compact_then_adds_compact_value() {
+    @Test func test_addHorizontalSizeClass_when_compact_then_adds_compact_value() {
         // When
-        let result = sut.trackWithHorizontalSizeClass([:], sizeClass: .compact)
+        let result = sut.addHorizontalSizeClass(to: [:], sizeClass: .compact)
 
         // Then
         #expect(result?[key] as? String == "compact")
     }
 
-    @Test func test_trackWithHorizontalSizeClass_when_unspecified_then_does_not_add_property() {
+    @Test func test_addHorizontalSizeClass_when_unspecified_then_does_not_add_property() {
         // When
-        let withProperties = sut.trackWithHorizontalSizeClass(["a": 1], sizeClass: .unspecified)
-        let withoutProperties = sut.trackWithHorizontalSizeClass(nil, sizeClass: .unspecified)
+        let withProperties = sut.addHorizontalSizeClass(to: ["a": 1], sizeClass: .unspecified)
+        let withoutProperties = sut.addHorizontalSizeClass(to: nil, sizeClass: .unspecified)
 
         // Then
         #expect(withProperties?[key] == nil)
@@ -34,23 +34,23 @@ struct TracksProviderHorizontalSizeClassTests {
         #expect(withoutProperties == nil)
     }
 
-    @Test func test_trackWithHorizontalSizeClass_when_property_already_present_then_keeps_existing_value() {
+    @Test func test_addHorizontalSizeClass_when_property_already_present_then_keeps_existing_value() {
         // Given — an event that already carries its own horizontal_size_class (e.g. product/order factories)
         let existing: [AnyHashable: Any] = [key: "regular"]
 
         // When — the cached layout differs
-        let result = sut.trackWithHorizontalSizeClass(existing, sizeClass: .compact)
+        let result = sut.addHorizontalSizeClass(to: existing, sizeClass: .compact)
 
         // Then — the event's own value wins
         #expect(result?[key] as? String == "regular")
     }
 
-    @Test func test_trackWithHorizontalSizeClass_preserves_other_properties() {
+    @Test func test_addHorizontalSizeClass_preserves_other_properties() {
         // Given
         let existingProperties: [AnyHashable: Any] = ["some_int_property": 2, "some_bool_property": false]
 
         // When
-        let result = sut.trackWithHorizontalSizeClass(existingProperties, sizeClass: .regular)
+        let result = sut.addHorizontalSizeClass(to: existingProperties, sizeClass: .regular)
 
         // Then
         #expect(result?["some_int_property"] as? Int == 2)
@@ -58,9 +58,9 @@ struct TracksProviderHorizontalSizeClassTests {
         #expect(result?[key] as? String == "regular")
     }
 
-    @Test func test_trackWithHorizontalSizeClass_when_nil_properties_and_concrete_sizeClass_then_returns_only_layout() {
+    @Test func test_addHorizontalSizeClass_when_nil_properties_and_concrete_sizeClass_then_returns_only_layout() {
         // When
-        let result = sut.trackWithHorizontalSizeClass(nil, sizeClass: .compact)
+        let result = sut.addHorizontalSizeClass(to: nil, sizeClass: .compact)
 
         // Then
         #expect(result?.count == 1)

--- a/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
+++ b/WooCommerce/WooCommerceTests/Analytics/TracksProviderHorizontalSizeClassTests.swift
@@ -46,12 +46,15 @@ struct TracksProviderHorizontalSizeClassTests {
     }
 
     @Test func test_trackWithHorizontalSizeClass_preserves_other_properties() {
+        // Given
+        let existingProperties: [AnyHashable: Any] = ["some_int_property": 2, "some_bool_property": false]
+
         // When
-        let result = sut.trackWithHorizontalSizeClass(["products_in_cart": 2, "is_ciab": false], sizeClass: .regular)
+        let result = sut.trackWithHorizontalSizeClass(existingProperties, sizeClass: .regular)
 
         // Then
-        #expect(result?["products_in_cart"] as? Int == 2)
-        #expect(result?["is_ciab"] as? Bool == false)
+        #expect(result?["some_int_property"] as? Int == 2)
+        #expect(result?["some_bool_property"] as? Bool == false)
         #expect(result?[key] as? String == "regular")
     }
 
@@ -62,13 +65,5 @@ struct TracksProviderHorizontalSizeClassTests {
         // Then
         #expect(result?.count == 1)
         #expect(result?[key] as? String == "compact")
-    }
-
-    @Test func test_setHorizontalSizeClass_updates_cached_value() {
-        // When
-        TracksProvider.setHorizontalSizeClass(.regular)
-
-        // Then
-        #expect(TracksProvider.horizontalSizeClass == .regular)
     }
 }


### PR DESCRIPTION
Closes WOOMOB-3318 
Follow-up from p1782363833374789-slack-CGPNUU63E

## Description
Adds `horizontal_size_class` (regular / compact) to every tracked event so we can tell how merchants use the app across screen configurations, which was previously invisible as we only had `device_info_*` and orientation in certain events.

It's stamped globally now in `TracksProvider.track(_:withProperties:)`, the single point every event funnels through, reading the size class live from the key window.

Note: There are still ~10 events that already send `horizontal_size_class`, I haven't modified these in this PR to keep scope small and not mess with legacy data. But I think we can remove them as well and rely on the global log only, since I don't recall we haven't used this for anything in particular so far. Thoughts?

## Test Steps
- iPhone: tap around (Orders, Products, a product); every event shows `horizontal_size_class: compact`.
- iPad full‑screen. Tap around, see `horizontal_size_class: regular`.
- iPad split view (> 50%). every event shows `horizontal_size_class: compact`.

```
🔵 Tracked pos_item_added_to_cart, properties: [is_wpcom_store: false, cached_woo_core_version: 10.5.3, product_type: simple, site_url: https://indiemelon.mystagingwebsite.com, is_jetpack_installed: true, source: product, item_type: product, is_jetpack_cp_connected: false, result_position: 3, source_type: list, store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, is_jetpack_connected: true, blog_id: 215063064, horizontal_size_class: compact]
```

## Screenshots
N/A
