### PR TITLE
[WOOMOB-3372] Allow skipping overdue Stripe requirements in IPP onboarding

### DIFF
--- a/Modules/Sources/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Modules/Sources/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -58,7 +58,8 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case stripeAccountPendingRequirement(plugin: CardPresentPaymentsPlugin, deadline: Date?)
 
-    /// There are some overdue requirements on the connected Stripe account. Connecting to a reader or accepting payments is not supported in this state.
+    /// There are some overdue requirements on the connected Stripe account. Payments might not work until the requirements are addressed,
+    /// but the merchant can choose to skip this step and attempt to connect to a reader and accept payments anyway.
     ///
     case stripeAccountOverdueRequirement(plugin: CardPresentPaymentsPlugin)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -34,9 +34,14 @@ protocol CardPresentPaymentsOnboardingUseCaseProtocol {
     func updateState()
 
     /// Pending requirements can be skipped so the merchant can continue to collect payments.
-    /// Eventually, these become overdue requirements, which cannot be skipped
+    /// Eventually, these become overdue requirements, which can also be skipped (see `skipOverdueRequirements()`).
     ///
     func skipPendingRequirements()
+
+    /// Overdue requirements can also be skipped so the merchant can continue to collect payments, understanding
+    /// that some transactions may be declined until the requirement is resolved.
+    ///
+    func skipOverdueRequirements()
 
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin)
 
@@ -61,6 +66,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     private var preferredPluginLocal: CardPresentPaymentsPlugin?
     private var wasCashOnDeliveryStepSkipped: Bool = false
     private var pendingRequirementsStepSkipped: Bool = false
+    private var overdueRequirementsStepSkipped: Bool = false
 
     @Published private(set) var state: CardPresentPaymentOnboardingState = .loading
 
@@ -99,6 +105,11 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
 
     func skipPendingRequirements() {
         pendingRequirementsStepSkipped = true
+        refresh()
+    }
+
+    func skipOverdueRequirements() {
+        overdueRequirementsStepSkipped = true
         refresh()
     }
 
@@ -399,7 +410,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         guard !isStripeAccountUnderReview(account: account) else {
             return .stripeAccountUnderReview(plugin: plugin)
         }
-        guard !isStripeAccountOverdueRequirements(account: account) else {
+        guard !shouldShowOverdueRequirements(account: account) else {
             logMissingRequirements(for: account)
             return .stripeAccountOverdueRequirement(plugin: plugin)
         }
@@ -421,8 +432,9 @@ private extension CardPresentPaymentsOnboardingUseCase {
         let setAccount = CardPresentPaymentAction.use(paymentGatewayAccount: account)
         stores.dispatch(setAccount)
 
-        // Also reset the skipped pending requirements step, so that it can be shown again in the next flow
+        // Also reset the skipped pending/overdue requirements steps, so that they can be shown again in the next flow
         pendingRequirementsStepSkipped = false
+        overdueRequirementsStepSkipped = false
         return .completed(plugin: CardPresentPaymentsPluginState(plugin: plugin))
     }
 
@@ -513,6 +525,10 @@ private extension CardPresentPaymentsOnboardingUseCase {
 
     func isStripeAccountOverdueRequirements(account: PaymentGatewayAccount) -> Bool {
         account.wcpayStatus == .restricted && account.hasOverdueRequirements
+    }
+
+    func shouldShowOverdueRequirements(account: PaymentGatewayAccount) -> Bool {
+        isStripeAccountOverdueRequirements(account: account) && !overdueRequirementsStepSkipped
     }
 
     func isStripeAccountRejected(account: PaymentGatewayAccount) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -39,7 +39,9 @@ protocol CardPresentPaymentsOnboardingUseCaseProtocol {
     func skipPendingRequirements()
 
     /// Overdue requirements can also be skipped so the merchant can continue to collect payments, understanding
-    /// that some transactions may be declined until the requirement is resolved.
+    /// that some transactions may be declined until the requirement is resolved. This also skips any pending
+    /// requirements, so the merchant only has to skip once even if the account reports the same item as both
+    /// pending and overdue.
     ///
     func skipOverdueRequirements()
 
@@ -110,6 +112,9 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
 
     func skipOverdueRequirements() {
         overdueRequirementsStepSkipped = true
+        // An account with overdue requirements often has the same items listed as pending too (e.g. a payout
+        // requirement moves from currently_due to past_due). Skip both so the merchant isn't asked to skip twice.
+        pendingRequirementsStepSkipped = true
         refresh()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -576,7 +576,7 @@ private extension CardPresentPaymentsOnboardingUseCase {
         account.wcpayStatus == .enabled ||
         account.wcpayStatus == .restrictedSoon ||
         account.wcpayStatus == .pendingVerification ||
-        (account.wcpayStatus == .restricted && overdueRequirementsStepSkipped)
+        (account.wcpayStatus == .restricted && (overdueRequirementsStepSkipped || pendingRequirementsStepSkipped))
     }
 
     func isNetworkError(_ error: Error) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -570,7 +570,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
         account.wcpayStatus == .complete ||
         account.wcpayStatus == .enabled ||
         account.wcpayStatus == .restrictedSoon ||
-        account.wcpayStatus == .pendingVerification
+        account.wcpayStatus == .pendingVerification ||
+        (account.wcpayStatus == .restricted && overdueRequirementsStepSkipped)
     }
 
     func isNetworkError(_ error: Error) -> Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewController.swift
@@ -69,6 +69,7 @@ struct CardPresentPaymentsOnboardingView: View {
             case .stripeAccountOverdueRequirement(let plugin):
                 InPersonPaymentsStripeAccountOverdue(analyticReason: viewModel.state.reasonForAnalytics,
                                                      onRefresh: viewModel.refresh,
+                                                     onSkip: viewModel.skipOverdueRequirements,
                                                      plugin: plugin)
             case .stripeAccountPendingRequirement(let plugin, let deadline):
                 InPersonPaymentsStripeAccountPending(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingViewModel.swift
@@ -80,6 +80,13 @@ final class CardPresentPaymentsOnboardingViewModel: ObservableObject, PaymentSet
         useCase.skipPendingRequirements()
     }
 
+    /// Skips the Overdue Requirements step when the user taps `Skip`
+    ///
+    func skipOverdueRequirements() {
+        trackSkipped(state: useCase.state, remindLater: false)
+        useCase.skipOverdueRequirements()
+    }
+
     /// Selects the plugin to use as a payment gateway when there are multiple available
     ///
     func selectPlugin(_ plugin: CardPresentPaymentsPlugin) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -4,6 +4,7 @@ import enum Yosemite.CardPresentPaymentsPlugin
 struct InPersonPaymentsStripeAccountOverdue: View {
     let analyticReason: String
     let onRefresh: () -> Void
+    let onSkip: () -> Void
     let plugin: CardPresentPaymentsPlugin
     @State private var presentedSetupURL: URL? = nil
 
@@ -27,10 +28,10 @@ struct InPersonPaymentsStripeAccountOverdue: View {
                                                                                 presentedSetupURL = setupURL
                                                                                 trackPluginSetupTappedEvent()
                                                                             }),
-            secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.secondaryButtonTitle,
+            secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.skipButtonTitle,
                                                                                      analyticReason: analyticReason,
                                                                                      plugin: plugin,
-                                                                                     action: onRefresh)
+                                                                                     action: onSkip)
         )
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)
      }
@@ -56,35 +57,34 @@ private extension InPersonPaymentsStripeAccountOverdue {
 
 private enum Localization {
      static let title = NSLocalizedString(
-         "In‑Person Payments is currently unavailable",
-         comment: """
-                  Title for the error screen when the Stripe account is restricted because there are overdue requirements.
-                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
-                  If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
-                  """
+         "cardPresentPayments.onboarding.stripeAccountOverdue.title",
+         value: "Overdue requirements on your account",
+         comment: "Title for the error screen when the Stripe account is restricted because there are overdue requirements."
      )
 
      static let message = NSLocalizedString(
-         "You have at least one overdue requirement on your account. Please take care of that to resume In‑Person Payments.",
-         comment: """
-                  Error message when WooPayments is not supported because the Stripe account has overdue requirements
-                  The hyphen in "In‑Person" is a non-breaking hyphen (U+2011).
-                  If your translation of that term also happens to contains a hyphen, please be sure to use the non-breaking hyphen character for it
-                  """
+         "cardPresentPayments.onboarding.stripeAccountOverdue.message",
+         value: "You have at least one overdue requirement. You can skip and keep taking payments, but if the " +
+         "requirement is blocking your account, some transactions may be declined until you resolve it.",
+         comment: "Error message when the Stripe account has overdue requirements, explaining that the merchant can " +
+         "skip and continue taking payments, with a caution that some transactions may be declined if the " +
+         "account is actually blocked."
      )
 
     static let primaryButtonTitle = NSLocalizedString(
         "Resolve Now",
         comment: "Button to open a web view and resolve pending plugin requirements before using it.")
 
-    static let secondaryButtonTitle = NSLocalizedString(
-        "Refresh",
-        comment: "Button to refresh the state of the in-person payments setup.")
+    static let skipButtonTitle = NSLocalizedString(
+        "cardPresentPayments.onboarding.stripeAccountOverdue.skipButton",
+        value: "Skip",
+        comment: "Button to skip the overdue-requirements onboarding step and continue accepting In-Person Payments."
+    )
  }
 
 
 struct InPersonPaymentsStripeAccountOverdue_Previews: PreviewProvider {
     static var previews: some View {
-        InPersonPaymentsStripeAccountOverdue(analyticReason: "", onRefresh: { }, plugin: .stripe)
+        InPersonPaymentsStripeAccountOverdue(analyticReason: "", onRefresh: { }, onSkip: { }, plugin: .stripe)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -72,8 +72,10 @@ private enum Localization {
      )
 
     static let primaryButtonTitle = NSLocalizedString(
-        "Resolve Now",
-        comment: "Button to open a web view and resolve pending plugin requirements before using it.")
+        "cardPresentPayments.onboarding.stripeAccountOverdue.resolveButton",
+        value: "Resolve Now",
+        comment: "Button to open a web view and resolve overdue requirements before continuing with In-Person Payments."
+    )
 
     static let skipButtonTitle = NSLocalizedString(
         "cardPresentPayments.onboarding.stripeAccountOverdue.skipButton",

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -976,6 +976,25 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .stripeAccountOverdueRequirement(plugin: .wcPay))
     }
 
+    func test_onboarding_when_account_is_restricted_with_overdue_requirements_skipped_for_wcpay_plugin_returns_complete() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restricted, hasOverdueRequirements: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+
+        useCase.skipOverdueRequirements()
+        useCase.updateState()
+
+        let state = useCase.state
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
+    }
+
     func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -890,6 +890,25 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
     }
 
+    func test_onboarding_when_account_is_restricted_with_pending_requirements_skipped_for_wcpay_plugin_returns_complete() {
+        // Given
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: .restricted, hasPendingRequirements: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+
+        useCase.skipPendingRequirements()
+        useCase.updateState()
+
+        let state = useCase.state
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
+    }
+
     func test_onboarding_returns_complete_when_account_status_is_enabled_using_wcpay_plugin() {
         // Given
         let accountStatus: WCPayAccountStatusEnum = .enabled

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -995,6 +995,31 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
     }
 
+    func test_onboarding_when_account_has_both_overdue_and_pending_requirements_skipped_once_for_wcpay_plugin_returns_complete() {
+        // Given
+        // An account can report the same item as both pending and overdue at once (e.g. a payout requirement
+        // moves from currently_due to past_due while remaining in both lists). Skipping overdue should be
+        // enough on its own; the merchant shouldn't have to skip a second time for the pending screen.
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self,
+                                   status: .restricted,
+                                   hasPendingRequirements: true,
+                                   hasOverdueRequirements: true)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+
+        useCase.skipOverdueRequirements()
+        useCase.updateState()
+
+        let state = useCase.state
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
+    }
+
     func test_onboarding_returns_review_when_account_is_restricted_with_no_requirements_for_wcpay_plugin() {
         // Given
         setupCountry(country: .us)

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/MockCardPresentPaymentsOnboardingUseCase.swift
@@ -33,6 +33,11 @@ final class MockCardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboard
         skipPendingRequirementsWasCalled = true
     }
 
+    var skipOverdueRequirementsWasCalled = false
+    func skipOverdueRequirements() {
+        skipOverdueRequirementsWasCalled = true
+    }
+
     var selectPluginWasCalled = false
     var spySelectedPlugin: CardPresentPaymentsPlugin? = nil
     func selectPlugin(_ selectedPlugin: CardPresentPaymentsPlugin) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the Linear issue this PR addresses. -->
<!-- Part of: # -> use this if your PR is one of many related to one issue -->

## Description

Fixes WOOMOB-3372

Accounts with overdue Stripe requirements were fully blocked from in-person payments, even though many can still charge — Stripe only disables `charges_enabled` once an account is truly deactivated. We already let merchants skip *pending* requirements for the same reason; this extends the same skip to overdue, mirroring the Android fix. Worst case if an account really can't charge: Stripe rejects the payment at collection time, same as today, just discovered later.

One skip covers both pending and overdue: accounts can report the same item in both lists at once (the real bug report did), so skipping overdue also skips pending — no second confirmation needed.

## Test Steps

1. Get an account into `restricted` status with overdue requirements (optionally pending too), or mock the onboarding state to `.stripeAccountOverdueRequirement`.
2. Start card reader / In-Person Payments from Order Creation, POS, or the Payments menu.
3. Confirm the overdue screen offers Skip alongside "Resolve Now".
4. Tap Skip once and confirm the flow proceeds — even when the account also has pending requirements.

## Screenshots

P.S. The padding/margin issue on the onboarding error is reported as separate issue in Linear.

<img  height="450" alt="Simulator Screenshot - iPhone 17 - 2026-07-07 at 16 48 10" src="https://github.com/user-attachments/assets/93033443-4d92-4e9b-93cb-7fbaaedcf529" />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
