### PR TITLE
Align POS offline entry with local catalog

### DIFF
--- a/Modules/Sources/PointOfSale/Controllers/POSEntryPointController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/POSEntryPointController.swift
@@ -11,8 +11,14 @@ public protocol POSEntryPointEligibilityCheckerProtocol {
     private(set) var eligibilityState: POSEligibilityState?
     private let posEligibilityChecker: POSEntryPointEligibilityCheckerProtocol
 
-    init(eligibilityChecker: POSEntryPointEligibilityCheckerProtocol) {
+    init(eligibilityChecker: POSEntryPointEligibilityCheckerProtocol,
+         initialEligibilityState: POSEligibilityState? = nil) {
         self.posEligibilityChecker = eligibilityChecker
+        self.eligibilityState = initialEligibilityState
+
+        guard initialEligibilityState == nil else {
+            return
+        }
 
         Task { @MainActor in
             eligibilityState = await posEligibilityChecker.checkEligibility()

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -9,7 +9,6 @@ import class Yosemite.GRDBObservableDataSource
 import protocol Storage.GRDBManagerProtocol
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
 import enum Yosemite.POSCatalogSyncError
-import enum Yosemite.POSCatalogSyncState
 
 /// Controller that wraps an observable data source for POS items
 /// Uses computed state based on data source observations for automatic UI updates
@@ -177,11 +176,14 @@ private extension PointOfSaleObservableItemsController {
     var initialSyncResult: Result<Void, Error>? {
         switch catalogSyncCoordinator.fullSyncStateModel.state[siteID] {
         case .initialSyncFailed(_, let error):
-            if hasUsableLocalCatalogCache == nil { return nil }
-            if hasUsableLocalCatalogCache == true { return .success(()) }
+            guard let hasUsableLocalCatalogCache else { return nil }
+            return hasUsableLocalCatalogCache ? .success(()) : .failure(error)
+        case .syncFailed(_, let error):
+            // A subsequent sync failure is only critical when there's no usable local data to fall back on.
+            if hasUsableLocalCatalogCache == true || !dataSource.productItems.isEmpty {
+                return .success(())
+            }
             return .failure(error)
-        case .syncFailed:
-            return .success(())
         case .syncCompleted:
             return .success(())
         default:
@@ -253,17 +255,8 @@ private extension PointOfSaleObservableItemsController {
         }
     }
 
-    func hasUsableLocalCatalog() async -> Bool {
-        let syncState = await catalogSyncCoordinator.loadLastFullSyncState(for: siteID)
-        if syncState.hasCompletedFullSync {
-            return true
-        }
-
-        return await catalogSyncCoordinator.hoursSinceLastSync(for: siteID) != nil
-    }
-
     func updateUsableLocalCatalogCache() async -> Bool {
-        let hasUsableLocalCatalog = await hasUsableLocalCatalog()
+        let hasUsableLocalCatalog = await catalogSyncCoordinator.hasUsableLocalCatalog(for: siteID)
         hasUsableLocalCatalogCache = hasUsableLocalCatalog
         return hasUsableLocalCatalog
     }
@@ -347,23 +340,6 @@ private extension PointOfSaleObservableItemsController {
         Task { @MainActor in
             // Ensure last full sync state is loaded with initial value.
             _ = await updateUsableLocalCatalogCache()
-        }
-    }
-}
-
-private extension POSCatalogSyncState {
-    var hasCompletedFullSync: Bool {
-        switch self {
-        case .syncCompleted:
-            return true
-        case .initialSyncStarted,
-                .syncStarted,
-                .initialSyncProgress,
-                .syncProgress,
-                .initialSyncFailed,
-                .syncFailed,
-                .syncNeverDone:
-            return false
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
+++ b/Modules/Sources/PointOfSale/Controllers/PointOfSaleObservableItemsController.swift
@@ -9,6 +9,7 @@ import class Yosemite.GRDBObservableDataSource
 import protocol Storage.GRDBManagerProtocol
 import protocol Yosemite.POSCatalogSyncCoordinatorProtocol
 import enum Yosemite.POSCatalogSyncError
+import enum Yosemite.POSCatalogSyncState
 
 /// Controller that wraps an observable data source for POS items
 /// Uses computed state based on data source observations for automatic UI updates
@@ -25,6 +26,8 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
 
     // Track current parent for variation state mapping
     private var currentParentItem: POSItem?
+
+    private var hasUsableLocalCatalogCache: Bool?
 
     var itemsViewState: ItemsViewState {
         ItemsViewState(
@@ -48,7 +51,7 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
         )
         self.catalogSyncCoordinator = catalogSyncCoordinator
 
-        preloadloadLastFullSyncState()
+        preloadLastFullSyncState()
     }
 
     // periphery:ignore - used by tests
@@ -59,13 +62,14 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
         self.dataSource = dataSource
         self.catalogSyncCoordinator = catalogSyncCoordinator
 
-        preloadloadLastFullSyncState()
+        preloadLastFullSyncState()
     }
 
     func loadItems(base: ItemListBaseItem) async {
         switch base {
         case .root:
-            if await shouldReload(for: base) {
+            let hasUsableLocalCatalog = await updateUsableLocalCatalogCache()
+            if await shouldReload(for: base, hasUsableLocalCatalog: hasUsableLocalCatalog) {
                 await reloadItems(base: base)
             } else if shouldRefresh(for: base) {
                 await refreshItems(base: base)
@@ -120,10 +124,10 @@ final class PointOfSaleObservableItemsController: PointOfSaleItemsControllerProt
             case .syncAlreadyInProgress, .requestCancelled:
                 refreshState = .idle
             default:
-                refreshState = .error(error)
+                refreshState = await updateUsableLocalCatalogCache() ? .idle : .error(error)
             }
         } catch {
-            refreshState = .error(error)
+            refreshState = await updateUsableLocalCatalogCache() ? .idle : .error(error)
         }
     }
 
@@ -173,10 +177,11 @@ private extension PointOfSaleObservableItemsController {
     var initialSyncResult: Result<Void, Error>? {
         switch catalogSyncCoordinator.fullSyncStateModel.state[siteID] {
         case .initialSyncFailed(_, let error):
+            if hasUsableLocalCatalogCache == nil { return nil }
+            if hasUsableLocalCatalogCache == true { return .success(()) }
             return .failure(error)
-        case .syncFailed(_, let error):
-            // If there's no catalog data, treat subsequent sync failures as critical
-            return dataSource.productItems.isEmpty ? .failure(error) : .success(())
+        case .syncFailed:
+            return .success(())
         case .syncCompleted:
             return .success(())
         default:
@@ -213,8 +218,12 @@ private extension PointOfSaleObservableItemsController {
 }
 
 private extension PointOfSaleObservableItemsController {
-    func shouldReload(for type: ItemListBaseItem) async -> Bool {
+    func shouldReload(for type: ItemListBaseItem, hasUsableLocalCatalog: Bool) async -> Bool {
         guard case .root = type else {
+            return false
+        }
+
+        guard !hasUsableLocalCatalog else {
             return false
         }
 
@@ -242,6 +251,21 @@ private extension PointOfSaleObservableItemsController {
         case .parent:
             return loadingState.variationsLoaded && dataSource.variationItems.isEmpty
         }
+    }
+
+    func hasUsableLocalCatalog() async -> Bool {
+        let syncState = await catalogSyncCoordinator.loadLastFullSyncState(for: siteID)
+        if syncState.hasCompletedFullSync {
+            return true
+        }
+
+        return await catalogSyncCoordinator.hoursSinceLastSync(for: siteID) != nil
+    }
+
+    func updateUsableLocalCatalogCache() async -> Bool {
+        let hasUsableLocalCatalog = await hasUsableLocalCatalog()
+        hasUsableLocalCatalogCache = hasUsableLocalCatalog
+        return hasUsableLocalCatalog
     }
 
     /// Computes the item list state based on current conditions
@@ -319,10 +343,27 @@ private extension PointOfSaleObservableItemsController {
 }
 
 private extension PointOfSaleObservableItemsController {
-    func preloadloadLastFullSyncState() {
+    func preloadLastFullSyncState() {
         Task { @MainActor in
-            /// Ensure last full sync state is loaded with initial value
-            _ = await catalogSyncCoordinator.loadLastFullSyncState(for: siteID)
+            // Ensure last full sync state is loaded with initial value.
+            _ = await updateUsableLocalCatalogCache()
+        }
+    }
+}
+
+private extension POSCatalogSyncState {
+    var hasCompletedFullSync: Bool {
+        switch self {
+        case .syncCompleted:
+            return true
+        case .initialSyncStarted,
+                .syncStarted,
+                .initialSyncProgress,
+                .syncProgress,
+                .initialSyncFailed,
+                .syncFailed,
+                .syncNeverDone:
+            return false
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -726,7 +726,42 @@ private extension PointOfSaleAggregateModel {
     private func performInitialSyncIfNeeded() {
         guard let catalogSyncCoordinator else { return }
         Task {
-            try? await catalogSyncCoordinator.performSmartSync(for: siteID, isBackgroundSync: false)
+            let hasLocalCatalog = await hasUsableLocalCatalog(siteID: siteID, catalogSyncCoordinator: catalogSyncCoordinator)
+            guard !hasLocalCatalog else {
+                return
+            }
+
+            do {
+                try await catalogSyncCoordinator.performSmartSync(for: siteID, isBackgroundSync: false)
+            } catch {
+                await catalogSyncCoordinator.fullSyncStateModel.updateState(.initialSyncFailed(siteID: siteID, error: error), for: siteID)
+            }
+        }
+    }
+
+    func hasUsableLocalCatalog(siteID: Int64, catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol) async -> Bool {
+        let syncState = await catalogSyncCoordinator.loadLastFullSyncState(for: siteID)
+        if syncState.hasCompletedFullSync {
+            return true
+        }
+
+        return await catalogSyncCoordinator.hoursSinceLastSync(for: siteID) != nil
+    }
+}
+
+private extension POSCatalogSyncState {
+    var hasCompletedFullSync: Bool {
+        switch self {
+        case .syncCompleted:
+            return true
+        case .initialSyncStarted,
+                .syncStarted,
+                .initialSyncProgress,
+                .syncProgress,
+                .initialSyncFailed,
+                .syncFailed,
+                .syncNeverDone:
+            return false
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
+++ b/Modules/Sources/PointOfSale/Models/PointOfSaleAggregateModel.swift
@@ -726,42 +726,16 @@ private extension PointOfSaleAggregateModel {
     private func performInitialSyncIfNeeded() {
         guard let catalogSyncCoordinator else { return }
         Task {
-            let hasLocalCatalog = await hasUsableLocalCatalog(siteID: siteID, catalogSyncCoordinator: catalogSyncCoordinator)
-            guard !hasLocalCatalog else {
-                return
-            }
-
             do {
+                // Smart sync self-limits by max age, so entry with a fresh catalog is a no-op.
                 try await catalogSyncCoordinator.performSmartSync(for: siteID, isBackgroundSync: false)
             } catch {
+                // A failed sync only blocks POS entry when there's no usable local catalog to fall back on.
+                guard await !catalogSyncCoordinator.hasUsableLocalCatalog(for: siteID) else {
+                    return
+                }
                 await catalogSyncCoordinator.fullSyncStateModel.updateState(.initialSyncFailed(siteID: siteID, error: error), for: siteID)
             }
-        }
-    }
-
-    func hasUsableLocalCatalog(siteID: Int64, catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol) async -> Bool {
-        let syncState = await catalogSyncCoordinator.loadLastFullSyncState(for: siteID)
-        if syncState.hasCompletedFullSync {
-            return true
-        }
-
-        return await catalogSyncCoordinator.hoursSinceLastSync(for: siteID) != nil
-    }
-}
-
-private extension POSCatalogSyncState {
-    var hasCompletedFullSync: Bool {
-        switch self {
-        case .syncCompleted:
-            return true
-        case .initialSyncStarted,
-                .syncStarted,
-                .initialSyncProgress,
-                .syncProgress,
-                .initialSyncFailed,
-                .syncFailed,
-                .syncNeverDone:
-            return false
         }
     }
 }

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -593,8 +593,14 @@ private extension PointOfSaleDashboardView {
     func loadItemsWhenEligible() {
         Task { @MainActor in
             await posModel.purchasableItemsController.loadItems(base: .root)
-            await posModel.couponsController.loadItems(base: .root)
+        }
+
+        Task { @MainActor in
             await posModel.popularPurchasableItemsController.loadItems(base: .root)
+        }
+
+        Task { @MainActor in
+            await posModel.couponsController.loadItems(base: .root)
         }
     }
 

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleEntryPointView.swift
@@ -162,7 +162,10 @@ public struct PointOfSaleEntryPointView: View {
         )
         self.barcodeScanService = barcodeScanService
         self.receiptSender = receiptSender
-        self.posEntryPointController = POSEntryPointController(eligibilityChecker: posEligibilityChecker)
+        self.posEntryPointController = POSEntryPointController(
+            eligibilityChecker: posEligibilityChecker,
+            initialEligibilityState: isLocalCatalogEligible ? .eligible : nil
+        )
         let ordersController = POSOrderListController(orderListFetchStrategyFactory: orderListFetchStrategyFactory,
                                                       refundsService: refundsService,
                                                       refundSubmissionProcessor: refundSubmissionProcessor)

--- a/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
+++ b/Modules/Sources/Yosemite/Tools/POS/POSCatalogSyncCoordinator.swift
@@ -94,6 +94,18 @@ public extension POSCatalogSyncCoordinatorProtocol {
         let oneHour: TimeInterval = 60 * 60
         try await performSmartSync(for: siteID, fullSyncMaxAge: twentyFourHours, incrementalSyncMaxAge: oneHour, isBackgroundSync: isBackgroundSync)
     }
+
+    /// Whether the site has local catalog data from a previously completed full sync,
+    /// usable for POS entry even when later syncs fail or the device is offline.
+    func hasUsableLocalCatalog(for siteID: Int64) async -> Bool {
+        if case .syncCompleted = await loadLastFullSyncState(for: siteID) {
+            return true
+        }
+
+        // A sync date exists whenever a full sync completed at some point,
+        // even if the latest sync attempt failed.
+        return await hoursSinceLastSync(for: siteID) != nil
+    }
 }
 
 public enum POSCatalogSyncError: Error, Equatable {

--- a/Modules/Tests/PointOfSaleTests/Controllers/POSEntryPointControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/POSEntryPointControllerTests.swift
@@ -36,4 +36,20 @@ struct POSEntryPointControllerTests {
         // Then
         #expect(controller.eligibilityState == .eligible)
     }
+
+    @Test func eligibilityState_uses_initial_state_without_checking_eligibility() async throws {
+        // Given
+        let mockEligibilityChecker = MockPOSEligibilityChecker()
+        mockEligibilityChecker.eligibility = .ineligible(reason: .noInternetConnection)
+
+        // When
+        let controller = POSEntryPointController(
+            eligibilityChecker: mockEligibilityChecker,
+            initialEligibilityState: .eligible
+        )
+
+        // Then
+        #expect(controller.eligibilityState == .eligible)
+        #expect(mockEligibilityChecker.checkEligibilityCallCount == 0)
+    }
 }

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -592,7 +592,7 @@ final class PointOfSaleObservableItemsControllerTests {
         #expect(sut.itemsViewState.itemsStack.root == .loaded(mockItems, hasMoreItems: false))
     }
 
-    @Test func test_syncFailed_with_empty_catalog_shows_content() async {
+    @Test func test_syncFailed_with_empty_catalog_and_no_previous_full_sync_shows_error() async {
         // Given
         let dataSource = MockPOSObservableDataSource()
         let coordinator = MockPOSCatalogSyncCoordinator()
@@ -608,7 +608,32 @@ final class PointOfSaleObservableItemsControllerTests {
         let containerState = sut.itemsViewState.containerState
 
         // Then
-        #expect(containerState == .content)
+        guard case .error(let errorState) = containerState else {
+            Issue.record("Expected error state when catalog is empty with no previous full sync")
+            return
+        }
+        #expect(errorState.errorType == .initialCatalogSyncError)
+    }
+
+    @Test func test_syncFailed_with_empty_catalog_and_previous_full_sync_shows_content() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let coordinator = MockPOSCatalogSyncCoordinator()
+        let siteID: Int64 = 123
+        let sut = PointOfSaleObservableItemsController(siteID: siteID, dataSource: dataSource, catalogSyncCoordinator: coordinator)
+
+        dataSource.productItems = []
+        dataSource.isLoadingProducts = false
+        let testError = NSError(domain: "test.sync", code: 500)
+        coordinator.fullSyncStateModel.state[siteID] = .syncFailed(siteID: siteID, error: testError)
+        coordinator.hoursSinceLastSyncResult = 1
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .empty)
     }
 
     @Test func test_syncFailed_with_existing_catalog_shows_content() async {
@@ -657,7 +682,7 @@ final class PointOfSaleObservableItemsControllerTests {
         #expect(coordinator.performSmartSyncSiteID == siteID)
     }
 
-    @Test func test_no_reload_after_syncFailed_with_empty_catalog() async {
+    @Test func test_reload_items_after_syncFailed_with_empty_catalog_and_no_previous_full_sync() async {
         // Given
         let dataSource = MockPOSObservableDataSource()
         let coordinator = MockPOSCatalogSyncCoordinator()
@@ -670,11 +695,12 @@ final class PointOfSaleObservableItemsControllerTests {
         coordinator.fullSyncStateModel.state[siteID] = .syncFailed(siteID: siteID, error: testError)
         coordinator.performSmartSyncResult = .success(())
 
-        // When: Load items after a subsequent sync failure
+        // When: Load items (should trigger reload because there's no usable local catalog)
         await sut.loadItems(base: .root)
 
-        // Then: Should not retry sync before the cached catalog has a chance to load
-        #expect(coordinator.performSmartSyncInvocationCount == 0)
+        // Then: Should have called performSmartSync
+        #expect(coordinator.performSmartSyncInvocationCount == 1)
+        #expect(coordinator.performSmartSyncSiteID == siteID)
     }
 
     @Test func test_no_reload_after_syncFailed_with_existing_catalog() async {

--- a/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Controllers/PointOfSaleObservableItemsControllerTests.swift
@@ -371,6 +371,54 @@ final class PointOfSaleObservableItemsControllerTests {
         #expect(sut.itemsViewState.itemsStack.root == .loaded([mockProduct], hasMoreItems: false))
     }
 
+    @Test func test_refresh_error_with_previous_full_sync_keeps_empty_products_content() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let coordinator = MockPOSCatalogSyncCoordinator()
+        let siteID: Int64 = 123
+        let sut = PointOfSaleObservableItemsController(siteID: siteID, dataSource: dataSource, catalogSyncCoordinator: coordinator)
+
+        dataSource.productItems = []
+        dataSource.isLoadingProducts = false
+        let testError = NSError(domain: "test.error", code: 500)
+        coordinator.fullSyncStateModel.state[siteID] = .syncFailed(siteID: siteID, error: testError)
+        coordinator.hoursSinceLastSyncResult = 1
+        await sut.loadItems(base: .root)
+
+        // When
+        coordinator.performIncrementalSyncResult = .failure(testError)
+        await sut.refreshItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .empty)
+    }
+
+    @Test func test_refresh_error_with_previous_full_sync_keeps_loaded_products_content() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let coordinator = MockPOSCatalogSyncCoordinator()
+        let siteID: Int64 = 123
+        let sut = PointOfSaleObservableItemsController(siteID: siteID, dataSource: dataSource, catalogSyncCoordinator: coordinator)
+
+        let mockItems = [makeSimpleProduct(productID: 1), makeSimpleProduct(productID: 2)]
+        dataSource.productItems = mockItems
+        dataSource.isLoadingProducts = false
+        dataSource.hasMoreProducts = false
+        let testError = NSError(domain: "test.error", code: 500)
+        coordinator.fullSyncStateModel.state[siteID] = .syncFailed(siteID: siteID, error: testError)
+        coordinator.hoursSinceLastSyncResult = 1
+        await sut.loadItems(base: .root)
+
+        // When
+        coordinator.performIncrementalSyncResult = .failure(testError)
+        await sut.refreshItems(base: .root)
+
+        // Then
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .loaded(mockItems, hasMoreItems: false))
+    }
+
     @Test func test_load_products_retries_refresh_when_error_exists() async {
         // Given
         let dataSource = MockPOSObservableDataSource()
@@ -510,6 +558,7 @@ final class PointOfSaleObservableItemsControllerTests {
         coordinator.fullSyncStateModel.state[siteID] = .initialSyncFailed(siteID: siteID, error: testError)
 
         // When
+        await sut.loadItems(base: .root)
         let containerState = sut.itemsViewState.containerState
 
         // Then
@@ -520,7 +569,30 @@ final class PointOfSaleObservableItemsControllerTests {
         #expect(errorState.errorType == .initialCatalogSyncError)
     }
 
-    @Test func test_syncFailed_with_empty_catalog_shows_error() async {
+    @Test func test_initialSyncFailed_with_previous_full_sync_shows_content() async {
+        // Given
+        let dataSource = MockPOSObservableDataSource()
+        let coordinator = MockPOSCatalogSyncCoordinator()
+        let siteID: Int64 = 123
+        let sut = PointOfSaleObservableItemsController(siteID: siteID, dataSource: dataSource, catalogSyncCoordinator: coordinator)
+
+        let mockItems = [makeSimpleProduct(productID: 1), makeSimpleProduct(productID: 2)]
+        dataSource.productItems = mockItems
+        dataSource.isLoadingProducts = false
+        let testError = NSError(domain: "test.sync", code: 500)
+        coordinator.fullSyncStateModel.state[siteID] = .initialSyncFailed(siteID: siteID, error: testError)
+        coordinator.hoursSinceLastSyncResult = 1
+
+        // When
+        await sut.loadItems(base: .root)
+
+        // Then
+        #expect(coordinator.performSmartSyncInvocationCount == 0)
+        #expect(sut.itemsViewState.containerState == .content)
+        #expect(sut.itemsViewState.itemsStack.root == .loaded(mockItems, hasMoreItems: false))
+    }
+
+    @Test func test_syncFailed_with_empty_catalog_shows_content() async {
         // Given
         let dataSource = MockPOSObservableDataSource()
         let coordinator = MockPOSCatalogSyncCoordinator()
@@ -536,11 +608,7 @@ final class PointOfSaleObservableItemsControllerTests {
         let containerState = sut.itemsViewState.containerState
 
         // Then
-        guard case .error(let errorState) = containerState else {
-            Issue.record("Expected error state when catalog is empty")
-            return
-        }
-        #expect(errorState.errorType == .initialCatalogSyncError)
+        #expect(containerState == .content)
     }
 
     @Test func test_syncFailed_with_existing_catalog_shows_content() async {
@@ -589,7 +657,7 @@ final class PointOfSaleObservableItemsControllerTests {
         #expect(coordinator.performSmartSyncSiteID == siteID)
     }
 
-    @Test func test_reload_items_after_syncFailed_with_empty_catalog() async {
+    @Test func test_no_reload_after_syncFailed_with_empty_catalog() async {
         // Given
         let dataSource = MockPOSObservableDataSource()
         let coordinator = MockPOSCatalogSyncCoordinator()
@@ -602,12 +670,11 @@ final class PointOfSaleObservableItemsControllerTests {
         coordinator.fullSyncStateModel.state[siteID] = .syncFailed(siteID: siteID, error: testError)
         coordinator.performSmartSyncResult = .success(())
 
-        // When: Load items (should trigger reload because catalog is empty)
+        // When: Load items after a subsequent sync failure
         await sut.loadItems(base: .root)
 
-        // Then: Should have called performSmartSync
-        #expect(coordinator.performSmartSyncInvocationCount == 1)
-        #expect(coordinator.performSmartSyncSiteID == siteID)
+        // Then: Should not retry sync before the cached catalog has a chance to load
+        #expect(coordinator.performSmartSyncInvocationCount == 0)
     }
 
     @Test func test_no_reload_after_syncFailed_with_existing_catalog() async {

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
@@ -18,6 +18,7 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     var performSmartSyncFullSyncMaxAge: TimeInterval?
     var performSmartSyncIncrementalSyncMaxAge: TimeInterval?
     var performSmartSyncResult: Result<Void, Error> = .success(())
+    var onPerformSmartSyncCalled: (() -> Void)?
 
     var onPerformFullSyncCalled: (() -> Void)?
 
@@ -54,6 +55,7 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
         performSmartSyncSiteID = siteID
         performSmartSyncFullSyncMaxAge = fullSyncMaxAge
         performSmartSyncIncrementalSyncMaxAge = incrementalSyncMaxAge
+        onPerformSmartSyncCalled?()
 
         switch performSmartSyncResult {
         case .success:
@@ -64,8 +66,14 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     }
 
     let fullSyncStateModel = POSCatalogSyncStateModel()
+    var loadLastFullSyncStateInvocationCount = 0
+    var loadLastFullSyncStateSiteID: Int64?
+    var onLoadLastFullSyncStateCalled: (() -> Void)?
 
     func loadLastFullSyncState(for siteID: Int64) async -> POSCatalogSyncState {
+        loadLastFullSyncStateInvocationCount += 1
+        loadLastFullSyncStateSiteID = siteID
+        onLoadLastFullSyncStateCalled?()
         return await fullSyncStateModel.state[siteID] ?? .syncNeverDone(siteID: siteID)
     }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSCatalogSyncCoordinator.swift
@@ -86,8 +86,10 @@ final class MockPOSCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
     }
 
     var hoursSinceLastSyncResult: Int? = nil
+    var onHoursSinceLastSyncCalled: (() -> Void)?
 
     func hoursSinceLastSync(for siteID: Int64) async -> Int? {
+        onHoursSinceLastSyncCalled?()
         return hoursSinceLastSyncResult
     }
 

--- a/Modules/Tests/PointOfSaleTests/Mocks/MockPOSEligibilityChecker.swift
+++ b/Modules/Tests/PointOfSaleTests/Mocks/MockPOSEligibilityChecker.swift
@@ -5,6 +5,7 @@ final class MockPOSEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     var initialVisibility: Bool = false
     var visibility: Bool = false
     var eligibility: POSEligibilityState = .eligible
+    private(set) var checkEligibilityCallCount = 0
 
     func checkInitialVisibility() -> Bool {
         initialVisibility
@@ -17,7 +18,8 @@ final class MockPOSEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
 
     @MainActor
     func checkEligibility() async -> POSEligibilityState {
-        eligibility
+        checkEligibilityCallCount += 1
+        return eligibility
     }
 
     func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -1303,56 +1303,7 @@ struct PointOfSaleAggregateModelTests {
     }
 
     @MainActor struct InitialCatalogSyncTests {
-        @Test func init_when_full_sync_is_completed_then_does_not_start_smart_sync() async {
-            // Given
-            let siteID: Int64 = 123
-            let coordinator = MockPOSCatalogSyncCoordinator()
-            coordinator.fullSyncStateModel.updateState(.syncCompleted(siteID: siteID), for: siteID)
-            var sut: PointOfSaleAggregateModel?
-
-            // When
-            await fireOnce { fire in
-                coordinator.onLoadLastFullSyncStateCalled = { fire() }
-                sut = makePointOfSaleAggregateModel(siteID: siteID,
-                                                    catalogSyncCoordinator: coordinator,
-                                                    isLocalCatalogEligible: true)
-            }
-            coordinator.onLoadLastFullSyncStateCalled = nil
-            await Task.yield()
-
-            // Then
-            withExtendedLifetime(sut) {}
-            #expect(coordinator.loadLastFullSyncStateInvocationCount == 1)
-            #expect(coordinator.loadLastFullSyncStateSiteID == siteID)
-            #expect(coordinator.performSmartSyncInvocationCount == 0)
-        }
-
-        @Test func init_when_previous_full_sync_exists_and_latest_sync_failed_then_does_not_start_smart_sync() async {
-            // Given
-            let siteID: Int64 = 123
-            let coordinator = MockPOSCatalogSyncCoordinator()
-            coordinator.fullSyncStateModel.updateState(.syncFailed(siteID: siteID, error: NSError(domain: "test", code: 1)), for: siteID)
-            coordinator.hoursSinceLastSyncResult = 1
-            var sut: PointOfSaleAggregateModel?
-
-            // When
-            await fireOnce { fire in
-                coordinator.onLoadLastFullSyncStateCalled = { fire() }
-                sut = makePointOfSaleAggregateModel(siteID: siteID,
-                                                    catalogSyncCoordinator: coordinator,
-                                                    isLocalCatalogEligible: true)
-            }
-            coordinator.onLoadLastFullSyncStateCalled = nil
-            await Task.yield()
-
-            // Then
-            withExtendedLifetime(sut) {}
-            #expect(coordinator.loadLastFullSyncStateInvocationCount == 1)
-            #expect(coordinator.loadLastFullSyncStateSiteID == siteID)
-            #expect(coordinator.performSmartSyncInvocationCount == 0)
-        }
-
-        @Test func init_when_full_sync_has_never_completed_then_starts_smart_sync() async {
+        @Test func init_then_starts_smart_sync() async {
             // Given
             let siteID: Int64 = 123
             let coordinator = MockPOSCatalogSyncCoordinator()
@@ -1369,10 +1320,35 @@ struct PointOfSaleAggregateModelTests {
 
             // Then
             withExtendedLifetime(sut) {}
-            #expect(coordinator.loadLastFullSyncStateInvocationCount == 1)
-            #expect(coordinator.loadLastFullSyncStateSiteID == siteID)
             #expect(coordinator.performSmartSyncInvocationCount == 1)
             #expect(coordinator.performSmartSyncSiteID == siteID)
+        }
+
+        @Test func init_when_smart_sync_fails_with_previous_full_sync_then_keeps_sync_state() async {
+            // Given
+            let siteID: Int64 = 123
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            let previousError = NSError(domain: "test", code: 1)
+            coordinator.fullSyncStateModel.updateState(.syncFailed(siteID: siteID, error: previousError), for: siteID)
+            coordinator.hoursSinceLastSyncResult = 1
+            coordinator.performSmartSyncResult = .failure(URLError(.notConnectedToInternet))
+            var sut: PointOfSaleAggregateModel?
+
+            // When
+            await fireOnce { fire in
+                coordinator.onHoursSinceLastSyncCalled = { fire() }
+                sut = makePointOfSaleAggregateModel(siteID: siteID,
+                                                    catalogSyncCoordinator: coordinator,
+                                                    isLocalCatalogEligible: true)
+            }
+            coordinator.onHoursSinceLastSyncCalled = nil
+            await Task.yield()
+            await Task.yield()
+
+            // Then: the previous full sync makes the catalog usable, so the failure is not marked as initial sync failure
+            withExtendedLifetime(sut) {}
+            #expect(coordinator.performSmartSyncInvocationCount == 1)
+            #expect(coordinator.fullSyncStateModel.state[siteID] == .syncFailed(siteID: siteID, error: previousError))
         }
 
         @Test func init_when_initial_smart_sync_fails_then_updates_initial_sync_failed_state() async {
@@ -1385,13 +1361,16 @@ struct PointOfSaleAggregateModelTests {
 
             // When
             await fireOnce { fire in
-                coordinator.onPerformSmartSyncCalled = { fire() }
+                coordinator.onHoursSinceLastSyncCalled = { fire() }
                 sut = makePointOfSaleAggregateModel(siteID: siteID,
                                                     catalogSyncCoordinator: coordinator,
                                                     isLocalCatalogEligible: true)
             }
-            coordinator.onPerformSmartSyncCalled = nil
-            await Task.yield()
+            coordinator.onHoursSinceLastSyncCalled = nil
+            // Wait for the state update that follows the usable-catalog check.
+            for _ in 0..<100 where coordinator.fullSyncStateModel.state[siteID] == nil {
+                await Task.yield()
+            }
 
             // Then
             withExtendedLifetime(sut) {}

--- a/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
+++ b/Modules/Tests/PointOfSaleTests/Models/PointOfSaleAggregateModelTests.swift
@@ -1302,6 +1302,104 @@ struct PointOfSaleAggregateModelTests {
         }
     }
 
+    @MainActor struct InitialCatalogSyncTests {
+        @Test func init_when_full_sync_is_completed_then_does_not_start_smart_sync() async {
+            // Given
+            let siteID: Int64 = 123
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            coordinator.fullSyncStateModel.updateState(.syncCompleted(siteID: siteID), for: siteID)
+            var sut: PointOfSaleAggregateModel?
+
+            // When
+            await fireOnce { fire in
+                coordinator.onLoadLastFullSyncStateCalled = { fire() }
+                sut = makePointOfSaleAggregateModel(siteID: siteID,
+                                                    catalogSyncCoordinator: coordinator,
+                                                    isLocalCatalogEligible: true)
+            }
+            coordinator.onLoadLastFullSyncStateCalled = nil
+            await Task.yield()
+
+            // Then
+            withExtendedLifetime(sut) {}
+            #expect(coordinator.loadLastFullSyncStateInvocationCount == 1)
+            #expect(coordinator.loadLastFullSyncStateSiteID == siteID)
+            #expect(coordinator.performSmartSyncInvocationCount == 0)
+        }
+
+        @Test func init_when_previous_full_sync_exists_and_latest_sync_failed_then_does_not_start_smart_sync() async {
+            // Given
+            let siteID: Int64 = 123
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            coordinator.fullSyncStateModel.updateState(.syncFailed(siteID: siteID, error: NSError(domain: "test", code: 1)), for: siteID)
+            coordinator.hoursSinceLastSyncResult = 1
+            var sut: PointOfSaleAggregateModel?
+
+            // When
+            await fireOnce { fire in
+                coordinator.onLoadLastFullSyncStateCalled = { fire() }
+                sut = makePointOfSaleAggregateModel(siteID: siteID,
+                                                    catalogSyncCoordinator: coordinator,
+                                                    isLocalCatalogEligible: true)
+            }
+            coordinator.onLoadLastFullSyncStateCalled = nil
+            await Task.yield()
+
+            // Then
+            withExtendedLifetime(sut) {}
+            #expect(coordinator.loadLastFullSyncStateInvocationCount == 1)
+            #expect(coordinator.loadLastFullSyncStateSiteID == siteID)
+            #expect(coordinator.performSmartSyncInvocationCount == 0)
+        }
+
+        @Test func init_when_full_sync_has_never_completed_then_starts_smart_sync() async {
+            // Given
+            let siteID: Int64 = 123
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            var sut: PointOfSaleAggregateModel?
+
+            // When
+            await fireOnce { fire in
+                coordinator.onPerformSmartSyncCalled = { fire() }
+                sut = makePointOfSaleAggregateModel(siteID: siteID,
+                                                    catalogSyncCoordinator: coordinator,
+                                                    isLocalCatalogEligible: true)
+            }
+            coordinator.onPerformSmartSyncCalled = nil
+
+            // Then
+            withExtendedLifetime(sut) {}
+            #expect(coordinator.loadLastFullSyncStateInvocationCount == 1)
+            #expect(coordinator.loadLastFullSyncStateSiteID == siteID)
+            #expect(coordinator.performSmartSyncInvocationCount == 1)
+            #expect(coordinator.performSmartSyncSiteID == siteID)
+        }
+
+        @Test func init_when_initial_smart_sync_fails_then_updates_initial_sync_failed_state() async {
+            // Given
+            let siteID: Int64 = 123
+            let coordinator = MockPOSCatalogSyncCoordinator()
+            let error = URLError(.notConnectedToInternet)
+            coordinator.performSmartSyncResult = .failure(error)
+            var sut: PointOfSaleAggregateModel?
+
+            // When
+            await fireOnce { fire in
+                coordinator.onPerformSmartSyncCalled = { fire() }
+                sut = makePointOfSaleAggregateModel(siteID: siteID,
+                                                    catalogSyncCoordinator: coordinator,
+                                                    isLocalCatalogEligible: true)
+            }
+            coordinator.onPerformSmartSyncCalled = nil
+            await Task.yield()
+
+            // Then
+            withExtendedLifetime(sut) {}
+            #expect(coordinator.performSmartSyncInvocationCount == 1)
+            #expect(coordinator.fullSyncStateModel.state[siteID] == .initialSyncFailed(siteID: siteID, error: error))
+        }
+    }
+
     @MainActor struct StaleSyncWarningTests {
         @Test func checkStaleSyncStatus_when_called_concurrently_then_tracks_shown_event_once() async {
             // Given

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [*] Point of Sale: POS now opens offline from the locally synced catalog when the tab was previously visible and a full catalog sync has completed. [https://github.com/woocommerce/woocommerce-ios/pull/17492]
 - [*] The "Report Crashes" privacy setting is now saved to your WordPress.com account, so it persists across devices and reinstalls. [https://github.com/woocommerce/woocommerce-ios/pull/17473]
 - [*] Shipping Labels: Prevent skipping phone number validation when confirming an address by tapping too quickly. [https://github.com/woocommerce/woocommerce-ios/pull/17478]
 - [*] Fixed the card reader connection Cancel button being too small to tap in landscape on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17437]

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -4,6 +4,8 @@ import SwiftUI
 import Yosemite
 import Combine
 import class WooFoundation.CurrencySettings
+import enum WooFoundation.ConnectivityStatus
+import protocol WooFoundation.ConnectivityObserver
 import WooFoundationCore
 import protocol Storage.GRDBManagerProtocol
 import protocol Storage.StorageManagerType
@@ -42,6 +44,9 @@ final class POSTabCoordinator {
     private let currencySettings: CurrencySettings
     private let pushNotesManager: PushNotesManager
     private let eligibilityChecker: POSEntryPointEligibilityCheckerProtocol
+    private let eligibilityService: POSEligibilityServiceProtocol
+    private let connectivityObserver: ConnectivityObserver
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
 
     private lazy var posSyncDispatcher = ForegroundPOSCatalogSyncDispatcher()
 
@@ -119,6 +124,9 @@ final class POSTabCoordinator {
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          pushNotesManager: PushNotesManager = ServiceLocator.pushNotesManager,
          eligibilityChecker: POSEntryPointEligibilityCheckerProtocol,
+         eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
+         connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
+         userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
          localCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol?) {
         self.siteID = siteID
         self.storesManager = storesManager
@@ -136,6 +144,9 @@ final class POSTabCoordinator {
         self.currencySettings = currencySettings
         self.pushNotesManager = pushNotesManager
         self.eligibilityChecker = eligibilityChecker
+        self.eligibilityService = eligibilityService
+        self.connectivityObserver = connectivityObserver
+        self.userInterfaceIdiom = userInterfaceIdiom
         self.localCatalogEligibilityService = localCatalogEligibilityService
 
         tabContainerController.wrappedController = POSTabViewController()
@@ -151,6 +162,11 @@ final class POSTabCoordinator {
             guard isPOSTabVisible else {
                 try await catalogEligibilityService.updatePOSEligibility(isEligible: false,
                                                                          for: siteID)
+                await posSyncDispatcher.stop()
+                return
+            }
+
+            guard connectivityObserver.currentStatus.isReachable else {
                 await posSyncDispatcher.stop()
                 return
             }
@@ -197,23 +213,7 @@ private extension POSTabCoordinator {
         Task { @MainActor [weak self, weak hostingController] in
             guard let self, let hostingController else { return }
 
-            // Get local catalog eligibility as bool from service
-            let isLocalCatalogEligible: Bool
-            if let service = localCatalogEligibilityService {
-                // Resolve POS eligibility before deciding the fetch strategy
-                let posState = await eligibilityChecker.checkEligibility()
-                try? await service.updatePOSEligibility(isEligible: posState == .eligible, for: siteID)
-
-                // Retry transient failures before using the value
-                let state = try await service.catalogEligibility(for: siteID)
-                if case .ineligible(reason: .catalogSizeCheckFailed) = state {
-                    try await service.refreshEligibilityState(for: siteID)
-                }
-                isLocalCatalogEligible = try await service.catalogEligibility(for: siteID) == .eligible
-            } else {
-                // Service not ready yet (rare race condition), assume ineligible
-                isLocalCatalogEligible = false
-            }
+            let isLocalCatalogEligible = await resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
 
             let sunsetWarningChecker = POSSunsetWarningChecker(
                 systemStatusService: POSSystemStatusService(
@@ -253,7 +253,7 @@ private extension POSTabCoordinator {
 
             // Only initialize local catalog infrastructure if eligible
             let grdbManager: GRDBManagerProtocol? = isLocalCatalogEligible ? ServiceLocator.grdbManager : nil
-            let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = isLocalCatalogEligible ? ServiceLocator.posCatalogSyncCoordinator : nil
+            let catalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol? = isLocalCatalogEligible ? storesManager.posCatalogSyncCoordinator : nil
 
             // Create appropriate barcode scan service based on local catalog eligibility
             // Will use local GRDB-based scanning if eligible and infrastructure is available,
@@ -289,22 +289,14 @@ private extension POSTabCoordinator {
 
                 let receiptSettingsAdminURL = storesManager.sessionManager.defaultSite?.receiptSettingsAdminURL ?? ""
 
-                // Resolve TTP eligibility once, up front, so we can hand the right
-                // preferred method down to POSPaymentModel. The same checker is also
-                // passed in for the availability controller that drives the buttons /
-                // hero, but POSPaymentModel needs the answer synchronously to know
-                // whether to skip the BT auto-collect on checkout entry.
                 let tapToPayAvailabilityChecker = POSTapToPayAvailabilityChecker(
                     siteID: siteID,
                     eligibilityService: POSEligibilityService()
                 )
-                let preferredConnectionMethod: CardReaderConnectionMethod
-                switch await tapToPayAvailabilityChecker.checkAvailability() {
-                case .available:
-                    preferredConnectionMethod = .tapToPay
-                case .unknown, .unavailable:
-                    preferredConnectionMethod = .bluetooth
-                }
+                let preferredConnectionMethod = await preferredConnectionMethodForPOSEntry(
+                    isLocalCatalogEligible: isLocalCatalogEligible,
+                    tapToPayAvailabilityChecker: tapToPayAvailabilityChecker
+                )
 
                 let refundSubmissionProcessor = POSRefundSubmissionAdaptor(orderService: orderService,
                                                                            stores: storesManager,
@@ -386,6 +378,115 @@ private extension POSTabCoordinator {
             } else {
                 await hostingController.dismiss(animated: true)
             }
+        }
+    }
+}
+
+extension POSTabCoordinator {
+    func resolveLocalCatalogAvailabilityForPOSEntry(siteID: Int64) async -> Bool {
+        if await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID) {
+            return true
+        }
+
+        guard let service = localCatalogEligibilityService else {
+            return false
+        }
+
+        guard connectivityObserver.currentStatus.isReachable else { return false }
+
+        do {
+            let posState = await eligibilityChecker.checkEligibility()
+            guard case .eligible = posState else {
+                return false
+            }
+
+            try await service.updatePOSEligibility(isEligible: true, for: siteID)
+
+            let state = try await service.catalogEligibility(for: siteID)
+            if state == .eligible {
+                return true
+            }
+
+            if case .ineligible(reason: .catalogSizeCheckFailed) = state {
+                if await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID) {
+                    return true
+                }
+                _ = try await service.refreshEligibilityState(for: siteID)
+                return try await service.catalogEligibility(for: siteID) == .eligible
+            }
+
+            return false
+        } catch {
+            return await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID)
+        }
+    }
+
+    func cachedLocalCatalogPOSEntryIsAvailable(siteID: Int64) async -> Bool {
+        guard storesManager.posCatalogSyncCoordinator != nil,
+              eligibilityService.loadCachedPOSTabVisibility(siteID: siteID) == true,
+              await localCatalogHasPreviousFullSync(siteID: siteID) else {
+            return false
+        }
+
+        return true
+    }
+
+    func preferredConnectionMethodForPOSEntry(isLocalCatalogEligible: Bool,
+                                             tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking) async -> CardReaderConnectionMethod {
+        guard !(isLocalCatalogEligible && !connectivityObserver.currentStatus.isReachable) else {
+            return .bluetooth
+        }
+
+        guard userInterfaceIdiom == .phone else {
+            return .bluetooth
+        }
+
+        switch await tapToPayAvailabilityChecker.checkAvailability() {
+        case .available:
+            return .tapToPay
+        case .unknown, .unavailable:
+            return .bluetooth
+        }
+    }
+
+    private func localCatalogHasPreviousFullSync(siteID: Int64) async -> Bool {
+        guard let posCatalogSyncCoordinator = storesManager.posCatalogSyncCoordinator else {
+            return false
+        }
+
+        let syncState = await posCatalogSyncCoordinator.loadLastFullSyncState(for: siteID)
+        if syncState.hasCompletedFullSync {
+            return true
+        }
+
+        return await posCatalogSyncCoordinator.hoursSinceLastSync(for: siteID) != nil
+    }
+}
+
+private extension ConnectivityStatus {
+    var isReachable: Bool {
+        switch self {
+        case .reachable:
+            return true
+        case .unknown, .notReachable:
+            return false
+        }
+    }
+}
+
+private extension POSCatalogSyncState {
+    var hasCompletedFullSync: Bool {
+        switch self {
+        case .syncCompleted:
+            return true
+        case .initialSyncStarted,
+                .syncStarted,
+                .initialSyncProgress,
+                .syncProgress,
+                .initialSyncFailed,
+                .syncFailed,
+                .syncNeverDone:
+            return false
         }
     }
 }

--- a/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
+++ b/WooCommerce/Classes/POS/TabBar/POSTabCoordinator.swift
@@ -166,8 +166,11 @@ final class POSTabCoordinator {
                 return
             }
 
-            guard connectivityObserver.currentStatus.isReachable else {
-                await posSyncDispatcher.stop()
+            // Offline: keep the cached eligibility untouched. Keep foreground syncs scheduled
+            // for stores that already qualify for local-catalog POS entry, so catalog syncing
+            // resumes automatically once connectivity returns.
+            if case .notReachable = connectivityObserver.currentStatus {
+                await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID) ? posSyncDispatcher.start() : posSyncDispatcher.stop()
                 return
             }
 
@@ -384,59 +387,64 @@ private extension POSTabCoordinator {
 
 extension POSTabCoordinator {
     func resolveLocalCatalogAvailabilityForPOSEntry(siteID: Int64) async -> Bool {
+        // A cached POS tab visibility plus a previously synced catalog is enough to enter
+        // local-catalog POS without waiting on remote eligibility checks.
         if await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID) {
             return true
         }
 
         guard let service = localCatalogEligibilityService else {
+            // Service not ready yet (rare race condition), assume ineligible
             return false
         }
 
-        guard connectivityObserver.currentStatus.isReachable else { return false }
+        // Without a cached local-catalog entry, offline remote checks would fail anyway.
+        if case .notReachable = connectivityObserver.currentStatus {
+            return false
+        }
 
         do {
+            // Resolve POS eligibility before deciding the fetch strategy
             let posState = await eligibilityChecker.checkEligibility()
-            guard case .eligible = posState else {
+            let isPOSEligible = posState == .eligible
+            try await service.updatePOSEligibility(isEligible: isPOSEligible, for: siteID)
+            guard isPOSEligible else {
                 return false
             }
 
-            try await service.updatePOSEligibility(isEligible: true, for: siteID)
-
             let state = try await service.catalogEligibility(for: siteID)
-            if state == .eligible {
-                return true
-            }
-
             if case .ineligible(reason: .catalogSizeCheckFailed) = state {
-                if await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID) {
-                    return true
-                }
+                // Retry transient failures before using the value
                 _ = try await service.refreshEligibilityState(for: siteID)
                 return try await service.catalogEligibility(for: siteID) == .eligible
             }
 
-            return false
+            return state == .eligible
         } catch {
-            return await cachedLocalCatalogPOSEntryIsAvailable(siteID: siteID)
+            DDLogError("⛔️ Failed to resolve local catalog availability for POS entry: \(error)")
+            return false
         }
     }
 
     func cachedLocalCatalogPOSEntryIsAvailable(siteID: Int64) async -> Bool {
-        guard storesManager.posCatalogSyncCoordinator != nil,
-              eligibilityService.loadCachedPOSTabVisibility(siteID: siteID) == true,
-              await localCatalogHasPreviousFullSync(siteID: siteID) else {
+        guard let posCatalogSyncCoordinator = storesManager.posCatalogSyncCoordinator,
+              eligibilityService.loadCachedPOSTabVisibility(siteID: siteID) == true else {
             return false
         }
 
-        return true
+        return await posCatalogSyncCoordinator.hasUsableLocalCatalog(for: siteID)
     }
 
+    /// Resolves TTP availability once, up front, because POSPaymentModel needs the answer
+    /// synchronously to know whether to skip the BT auto-collect on checkout entry.
     func preferredConnectionMethodForPOSEntry(isLocalCatalogEligible: Bool,
-                                             tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking) async -> CardReaderConnectionMethod {
-        guard !(isLocalCatalogEligible && !connectivityObserver.currentStatus.isReachable) else {
+                                              tapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking) async -> CardReaderConnectionMethod {
+        // Offline local-catalog entry can't validate Tap to Pay availability remotely.
+        if isLocalCatalogEligible, case .notReachable = connectivityObserver.currentStatus {
             return .bluetooth
         }
 
+        // Tap to Pay requires an iPhone, so skip the availability check on other devices.
         guard userInterfaceIdiom == .phone else {
             return .bluetooth
         }
@@ -448,49 +456,7 @@ extension POSTabCoordinator {
             return .bluetooth
         }
     }
-
-    private func localCatalogHasPreviousFullSync(siteID: Int64) async -> Bool {
-        guard let posCatalogSyncCoordinator = storesManager.posCatalogSyncCoordinator else {
-            return false
-        }
-
-        let syncState = await posCatalogSyncCoordinator.loadLastFullSyncState(for: siteID)
-        if syncState.hasCompletedFullSync {
-            return true
-        }
-
-        return await posCatalogSyncCoordinator.hoursSinceLastSync(for: siteID) != nil
-    }
 }
-
-private extension ConnectivityStatus {
-    var isReachable: Bool {
-        switch self {
-        case .reachable:
-            return true
-        case .unknown, .notReachable:
-            return false
-        }
-    }
-}
-
-private extension POSCatalogSyncState {
-    var hasCompletedFullSync: Bool {
-        switch self {
-        case .syncCompleted:
-            return true
-        case .initialSyncStarted,
-                .syncStarted,
-                .initialSyncProgress,
-                .syncProgress,
-                .initialSyncFailed,
-                .syncFailed,
-                .syncNeverDone:
-            return false
-        }
-    }
-}
-
 
 struct POSPresentationRootView: View {
     let posView: PointOfSaleEntryPointView?

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -95,7 +95,10 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         guard userInterfaceIdiom != .phone || isPhoneOperatingSystemEligible else {
             return false
         }
-        guard case .reachable = connectivityObserver.currentStatus else {
+        // Offline: fall back to the cached visibility instead of remote checks that would fail.
+        // Unknown connectivity (e.g. before the first path update at cold start) proceeds with
+        // the full check so a fresh online launch is not stuck with stale cached visibility.
+        if case .notReachable = connectivityObserver.currentStatus {
             return cachedPOSTabVisibility()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSTabVisibilityChecker.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import class WooFoundation.CurrencySettings
+import protocol WooFoundation.ConnectivityObserver
 import enum WooFoundation.CountryCode
 import enum WooFoundation.CurrencyCode
 import protocol Experiments.FeatureFlagService
@@ -26,6 +27,7 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
     private let expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol
     private let expansionEligibilityRefresher: CardPresentPaymentsCountryExpansionEligibilityRefresher
     private let isOperatingSystemAtLeast: (OperatingSystemVersion) -> Bool
+    private let connectivityObserver: ConnectivityObserver
 
     private static let minimumPhonePOSOperatingSystemVersion = OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0)
 
@@ -35,6 +37,7 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
          eligibilityService: POSEligibilityServiceProtocol = POSEligibilityService(),
          stores: StoresManager = ServiceLocator.stores,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         connectivityObserver: ConnectivityObserver = ServiceLocator.connectivityObserver,
          expansionEligibilityService: CardPresentPaymentsCountryExpansionEligibilityServiceProtocol = CardPresentPaymentsCountryExpansionEligibilityService(),
          expansionEligibilityRefresher: CardPresentPaymentsCountryExpansionEligibilityRefresher? = nil,
          isOperatingSystemAtLeast: @escaping (OperatingSystemVersion) -> Bool = ProcessInfo.processInfo.isOperatingSystemAtLeast) {
@@ -46,6 +49,7 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         self.featureFlagService = featureFlagService
         self.expansionEligibilityService = expansionEligibilityService
         self.isOperatingSystemAtLeast = isOperatingSystemAtLeast
+        self.connectivityObserver = connectivityObserver
         self.expansionEligibilityRefresher = expansionEligibilityRefresher ?? CardPresentPaymentsCountryExpansionEligibilityRefresher(
             eligibilityService: expansionEligibilityService,
             remoteFeatureFlagProvider: CardPresentPaymentsCountryExpansionEligibilityRefresher.makeRemoteFeatureFlagProvider(stores: stores)
@@ -91,6 +95,9 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
         guard userInterfaceIdiom != .phone || isPhoneOperatingSystemEligible else {
             return false
         }
+        guard case .reachable = connectivityObserver.currentStatus else {
+            return cachedPOSTabVisibility()
+        }
 
         async let siteSettingsEligibility = waitAndCheckSiteSettingsEligibility()
         async let featureFlagEligibility = checkRemoteFeatureEligibility()
@@ -107,6 +114,10 @@ final class POSTabVisibilityChecker: POSTabVisibilityCheckerProtocol {
 
     private var isPhoneOperatingSystemEligible: Bool {
         isOperatingSystemAtLeast(Self.minimumPhonePOSOperatingSystemVersion)
+    }
+
+    private func cachedPOSTabVisibility() -> Bool {
+        eligibilityService.loadCachedPOSTabVisibility(siteID: site.siteID) ?? false
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockPOSEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPOSEligibilityChecker.swift
@@ -6,10 +6,12 @@ import protocol PointOfSale.POSEntryPointEligibilityCheckerProtocol
 
 final class MockPOSEligibilityChecker: POSEntryPointEligibilityCheckerProtocol {
     var eligibility: POSEligibilityState = .eligible
+    private(set) var checkEligibilityCallCount = 0
 
     @MainActor
     func checkEligibility() async -> POSEligibilityState {
-        eligibility
+        checkEligibilityCallCount += 1
+        return eligibility
     }
 
     func refreshEligibility(ineligibleReason: POSIneligibleReason) async throws -> POSEligibilityState {

--- a/WooCommerce/WooCommerceTests/POS/POSTabCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSTabCoordinatorTests.swift
@@ -1,0 +1,302 @@
+import Foundation
+import PointOfSale
+import Testing
+import UIKit
+import WooFoundation
+import Yosemite
+@testable import WooCommerce
+
+@MainActor
+struct POSTabCoordinatorTests {
+    private let siteID: Int64 = 123
+
+    @Test func resolveLocalCatalogAvailability_uses_completed_full_sync_when_cached_tab_is_visible() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachePOSTabVisibility(siteID: siteID, isVisible: true)
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncCompleted(siteID: siteID))
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .ineligible(reason: .noInternetConnection)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 0)
+    }
+
+    @Test func resolveLocalCatalogAvailability_uses_previous_full_sync_when_latest_sync_failed() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachePOSTabVisibility(siteID: siteID, isVisible: true)
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(
+            syncState: .syncFailed(siteID: siteID, error: NSError(domain: "test", code: 0)),
+            hoursSinceLastSyncResult: 1
+        )
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .ineligible(reason: .noInternetConnection)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 0)
+    }
+
+    @Test func resolveLocalCatalogAvailability_returns_false_when_cached_tab_is_visible_but_catalog_never_synced() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachePOSTabVisibility(siteID: siteID, isVisible: true)
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncNeverDone(siteID: siteID))
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .ineligible(reason: .noInternetConnection)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 1)
+    }
+
+    @Test func resolveLocalCatalogAvailability_does_not_check_remote_eligibility_when_offline_and_catalog_never_synced() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachePOSTabVisibility(siteID: siteID, isVisible: true)
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncNeverDone(siteID: siteID))
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator,
+                          connectivityObserver: connectivityObserver)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 0)
+    }
+
+    @Test func resolveLocalCatalogAvailability_returns_false_when_cached_tab_is_not_visible() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachePOSTabVisibility(siteID: siteID, isVisible: false)
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncCompleted(siteID: siteID))
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .ineligible(reason: .noInternetConnection)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 1)
+    }
+
+    @Test func resolveLocalCatalogAvailability_uses_online_eligibility_when_cached_local_catalog_entry_is_unavailable() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncNeverDone(siteID: siteID))
+        let localCatalogEligibilityService = MockPOSTabLocalCatalogEligibilityService(eligibilityState: .eligible)
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .eligible
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator,
+                          localCatalogEligibilityService: localCatalogEligibilityService)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 1)
+        #expect(await localCatalogEligibilityService.updatePOSEligibilityCallCount == 1)
+    }
+
+    @Test func updatePOSEligibility_does_not_refresh_local_catalog_ineligibility_when_offline() async throws {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .ineligible(reason: .noInternetConnection)
+        let localCatalogEligibilityService = MockPOSTabLocalCatalogEligibilityService()
+        let sut = makeSUT(eligibilityChecker: eligibilityChecker,
+                          localCatalogEligibilityService: localCatalogEligibilityService,
+                          connectivityObserver: connectivityObserver)
+
+        // When
+        sut.updatePOSEligibility(isPOSTabVisible: true)
+        await Task.yield()
+        await Task.yield()
+
+        // Then
+        #expect(eligibilityChecker.checkEligibilityCallCount == 0)
+        #expect(await localCatalogEligibilityService.updatePOSEligibilityCallCount == 0)
+    }
+
+    @Test func preferredConnectionMethod_returns_bluetooth_without_checking_tap_to_pay_for_offline_local_catalog_entry() async throws {
+        // Given
+        let tapToPayChecker = MockPOSTabTapToPayAvailabilityChecker(result: .available)
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        let sut = makeSUT(connectivityObserver: connectivityObserver,
+                          userInterfaceIdiom: .phone)
+
+        // When
+        let result = await sut.preferredConnectionMethodForPOSEntry(isLocalCatalogEligible: true,
+                                                                    tapToPayAvailabilityChecker: tapToPayChecker)
+
+        // Then
+        #expect(result == .bluetooth)
+        #expect(tapToPayChecker.checkAvailabilityCallCount == 0)
+    }
+
+    @Test func preferredConnectionMethod_checks_tap_to_pay_for_online_local_catalog_entry_on_phone() async throws {
+        // Given
+        let tapToPayChecker = MockPOSTabTapToPayAvailabilityChecker(result: .available)
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.reachable(type: .ethernetOrWiFi))
+        let sut = makeSUT(connectivityObserver: connectivityObserver,
+                          userInterfaceIdiom: .phone)
+
+        // When
+        let result = await sut.preferredConnectionMethodForPOSEntry(isLocalCatalogEligible: true,
+                                                                    tapToPayAvailabilityChecker: tapToPayChecker)
+
+        // Then
+        #expect(result == .tapToPay)
+        #expect(tapToPayChecker.checkAvailabilityCallCount == 1)
+    }
+
+    @Test func preferredConnectionMethod_returns_bluetooth_without_checking_tap_to_pay_on_ipad() async throws {
+        // Given
+        let tapToPayChecker = MockPOSTabTapToPayAvailabilityChecker(result: .available)
+        let sut = makeSUT(userInterfaceIdiom: .pad)
+
+        // When
+        let result = await sut.preferredConnectionMethodForPOSEntry(isLocalCatalogEligible: false,
+                                                                    tapToPayAvailabilityChecker: tapToPayChecker)
+
+        // Then
+        #expect(result == .bluetooth)
+        #expect(tapToPayChecker.checkAvailabilityCallCount == 0)
+    }
+}
+
+private extension POSTabCoordinatorTests {
+    func makeSUT(eligibilityService: MockPOSEligibilityService = MockPOSEligibilityService(),
+                 eligibilityChecker: MockPOSEligibilityChecker = MockPOSEligibilityChecker(),
+                 catalogSyncCoordinator: MockPOSTabCatalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncCompleted(siteID: 123)),
+                 localCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol? = MockPOSTabLocalCatalogEligibilityService(),
+                 connectivityObserver: MockConnectivityObserver = MockConnectivityObserver(),
+                 userInterfaceIdiom: UIUserInterfaceIdiom = .pad) -> POSTabCoordinator {
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(siteID: siteID)))
+        stores.updateDefaultStore(storeID: siteID)
+        stores.testPOSCatalogSyncCoordinator = catalogSyncCoordinator
+        if case .unknown = connectivityObserver.currentStatus {
+            connectivityObserver.setStatus(.reachable(type: .ethernetOrWiFi))
+        }
+
+        return POSTabCoordinator(
+            siteID: siteID,
+            tabContainerController: TabContainerController(),
+            viewControllerToPresent: UIViewController(),
+            storesManager: stores,
+            eligibilityChecker: eligibilityChecker,
+            eligibilityService: eligibilityService,
+            connectivityObserver: connectivityObserver,
+            userInterfaceIdiom: userInterfaceIdiom,
+            localCatalogEligibilityService: localCatalogEligibilityService
+        )
+    }
+}
+
+private final class MockPOSTabTapToPayAvailabilityChecker: POSTapToPayAvailabilityChecking {
+    private let result: POSTapToPayAvailabilityState
+    private(set) var checkAvailabilityCallCount = 0
+
+    init(result: POSTapToPayAvailabilityState) {
+        self.result = result
+    }
+
+    func checkAvailability() async -> POSTapToPayAvailabilityState {
+        checkAvailabilityCallCount += 1
+        return result
+    }
+}
+
+private actor MockPOSTabLocalCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol {
+    private let eligibilityState: POSLocalCatalogEligibilityState
+    private(set) var updatePOSEligibilityCallCount = 0
+
+    init(eligibilityState: POSLocalCatalogEligibilityState = .eligible) {
+        self.eligibilityState = eligibilityState
+    }
+
+    func catalogEligibility(for siteID: Int64) async -> POSLocalCatalogEligibilityState {
+        eligibilityState
+    }
+
+    func updatePOSEligibility(isEligible: Bool, for siteID: Int64) async {
+        updatePOSEligibilityCallCount += 1
+    }
+
+    func refreshEligibilityState(for siteID: Int64) async -> POSLocalCatalogEligibilityState {
+        eligibilityState
+    }
+}
+
+private final class MockPOSTabCatalogSyncCoordinator: POSCatalogSyncCoordinatorProtocol {
+    let fullSyncStateModel = POSCatalogSyncStateModel()
+    private let syncState: POSCatalogSyncState
+    private let hoursSinceLastSyncResult: Int?
+
+    init(syncState: POSCatalogSyncState, hoursSinceLastSyncResult: Int? = nil) {
+        self.syncState = syncState
+        self.hoursSinceLastSyncResult = hoursSinceLastSyncResult
+    }
+
+    func performFullSyncIfApplicable(for siteID: Int64, maxAge: TimeInterval, regenerateCatalog: Bool, isBackgroundSync: Bool) async throws {}
+
+    func performIncrementalSyncIfApplicable(for siteID: Int64, maxAge: TimeInterval) async throws {}
+
+    func performSmartSync(for siteID: Int64, fullSyncMaxAge: TimeInterval, incrementalSyncMaxAge: TimeInterval, isBackgroundSync: Bool) async throws {}
+
+    func loadLastFullSyncState(for siteID: Int64) async -> POSCatalogSyncState {
+        syncState
+    }
+
+    func isSyncStale(for siteID: Int64, maxDays: Int) async -> Bool {
+        false
+    }
+
+    func hoursSinceLastSync(for siteID: Int64) async -> Int? {
+        hoursSinceLastSyncResult
+    }
+
+    func stopOngoingSyncs(for siteID: Int64) async {}
+
+    func processBackgroundDownload(fileURL: URL, siteID: Int64, snapshotDate: Date) async throws {}
+
+    func deleteProductsFromCatalog(_ productIDs: [Int64], variationIDs: [Int64], siteID: Int64) async throws {}
+
+    func startBackgroundFTSRebuildIfNeeded(for siteID: Int64) async {}
+}

--- a/WooCommerce/WooCommerceTests/POS/POSTabCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/POSTabCoordinatorTests.swift
@@ -131,6 +131,47 @@ struct POSTabCoordinatorTests {
         #expect(await localCatalogEligibilityService.updatePOSEligibilityCallCount == 1)
     }
 
+    @Test func resolveLocalCatalogAvailability_uses_cached_entry_when_offline() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        eligibilityService.cachePOSTabVisibility(siteID: siteID, isVisible: true)
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncCompleted(siteID: siteID))
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator,
+                          connectivityObserver: connectivityObserver)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == true)
+        #expect(eligibilityChecker.checkEligibilityCallCount == 0)
+    }
+
+    @Test func resolveLocalCatalogAvailability_persists_ineligibility_when_online_and_pos_ineligible() async throws {
+        // Given
+        let eligibilityService = MockPOSEligibilityService()
+        let catalogSyncCoordinator = MockPOSTabCatalogSyncCoordinator(syncState: .syncNeverDone(siteID: siteID))
+        let localCatalogEligibilityService = MockPOSTabLocalCatalogEligibilityService(eligibilityState: .eligible)
+        let eligibilityChecker = MockPOSEligibilityChecker()
+        eligibilityChecker.eligibility = .ineligible(reason: .wooCommercePluginNotFound)
+        let sut = makeSUT(eligibilityService: eligibilityService,
+                          eligibilityChecker: eligibilityChecker,
+                          catalogSyncCoordinator: catalogSyncCoordinator,
+                          localCatalogEligibilityService: localCatalogEligibilityService)
+
+        // When
+        let result = await sut.resolveLocalCatalogAvailabilityForPOSEntry(siteID: siteID)
+
+        // Then
+        #expect(result == false)
+        #expect(await localCatalogEligibilityService.spyUpdatedPOSEligibilities == [false])
+    }
+
     @Test func updatePOSEligibility_does_not_refresh_local_catalog_ineligibility_when_offline() async throws {
         // Given
         let connectivityObserver = MockConnectivityObserver()
@@ -246,6 +287,7 @@ private final class MockPOSTabTapToPayAvailabilityChecker: POSTapToPayAvailabili
 private actor MockPOSTabLocalCatalogEligibilityService: POSLocalCatalogEligibilityServiceProtocol {
     private let eligibilityState: POSLocalCatalogEligibilityState
     private(set) var updatePOSEligibilityCallCount = 0
+    private(set) var spyUpdatedPOSEligibilities: [Bool] = []
 
     init(eligibilityState: POSLocalCatalogEligibilityState = .eligible) {
         self.eligibilityState = eligibilityState
@@ -257,6 +299,7 @@ private actor MockPOSTabLocalCatalogEligibilityService: POSLocalCatalogEligibili
 
     func updatePOSEligibility(isEligible: Bool, for siteID: Int64) async {
         updatePOSEligibilityCallCount += 1
+        spyUpdatedPOSEligibilities.append(isEligible)
     }
 
     func refreshEligibilityState(for siteID: Int64) async -> POSLocalCatalogEligibilityState {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -255,6 +255,129 @@ struct POSTabVisibilityCheckerTests {
         #expect(result == false)
     }
 
+    @Test func checkVisibility_returns_cached_visibility_when_offline_and_cached_visible() async throws {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores,
+                                              connectivityObserver: connectivityObserver)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+        #expect(stores.receivedActions.contains { $0 is FeatureFlagAction } == false)
+    }
+
+    @Test func checkVisibility_returns_cached_visibility_when_offline_and_cached_hidden() async throws {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        setupPOSTabVisibility(siteID: siteID, isVisible: false)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores,
+                                              connectivityObserver: connectivityObserver)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+        #expect(stores.receivedActions.contains { $0 is FeatureFlagAction } == false)
+    }
+
+    @Test func checkVisibility_returns_cached_visibility_when_connectivity_is_unknown_and_cached_visible() async throws {
+        // Given
+        let connectivityObserver = MockConnectivityObserver()
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .pad,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores,
+                                              connectivityObserver: connectivityObserver)
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+        #expect(stores.receivedActions.contains { $0 is FeatureFlagAction } == false)
+    }
+
+    @Test func checkVisibility_returns_cached_visibility_on_phone_when_offline_and_phone_gates_pass() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              connectivityObserver: connectivityObserver,
+                                              isOperatingSystemAtLeast: { _ in true })
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == true)
+        #expect(stores.receivedActions.contains { $0 is FeatureFlagAction } == false)
+    }
+
+    @Test func checkVisibility_returns_false_on_phone_when_offline_and_phone_prototype_is_disabled() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = false
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              connectivityObserver: connectivityObserver,
+                                              isOperatingSystemAtLeast: { _ in true })
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
+    @Test func checkVisibility_returns_false_on_phone_when_offline_and_operating_system_is_below_iOS_26() async throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService()
+        featureFlagService.isFeatureFlagEnabledReturnValue[.pointOfSalePhonePrototype] = true
+        let connectivityObserver = MockConnectivityObserver()
+        connectivityObserver.setStatus(.notReachable)
+        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+        let checker = POSTabVisibilityChecker(site: site,
+                                              userInterfaceIdiom: .phone,
+                                              eligibilityService: eligibilityService,
+                                              stores: stores,
+                                              featureFlagService: featureFlagService,
+                                              connectivityObserver: connectivityObserver,
+                                              isOperatingSystemAtLeast: { _ in false })
+
+        // When
+        let result = await checker.checkVisibility()
+
+        // Then
+        #expect(result == false)
+    }
+
     @Test func checkVisibility_skips_settings_from_initialLoad() async throws {
         // Given
         let featureFlagService = MockFeatureFlagService()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSTabVisibilityCheckerTests.swift
@@ -293,12 +293,16 @@ struct POSTabVisibilityCheckerTests {
         #expect(stores.receivedActions.contains { $0 is FeatureFlagAction } == false)
     }
 
-    @Test func checkVisibility_returns_cached_visibility_when_connectivity_is_unknown_and_cached_visible() async throws {
-        // Given
+    @Test func checkVisibility_performs_full_check_when_connectivity_is_unknown() async throws {
+        // Given: connectivity is unknown (e.g. before the first path update at cold start),
+        // remote checks pass while the cached visibility is hidden
         let connectivityObserver = MockConnectivityObserver()
-        setupPOSTabVisibility(siteID: siteID, isVisible: true)
+        setupCountry(country: .us)
+        accountWhitelistedInBackend(true)
+        setupPOSTabVisibility(siteID: siteID, isVisible: false)
         let checker = POSTabVisibilityChecker(site: site,
                                               userInterfaceIdiom: .pad,
+                                              siteSettings: siteSettings,
                                               eligibilityService: eligibilityService,
                                               stores: stores,
                                               connectivityObserver: connectivityObserver)
@@ -306,9 +310,9 @@ struct POSTabVisibilityCheckerTests {
         // When
         let result = await checker.checkVisibility()
 
-        // Then
+        // Then: the full check ran instead of falling back to the cached value
         #expect(result == true)
-        #expect(stores.receivedActions.contains { $0 is FeatureFlagAction } == false)
+        #expect(stores.receivedActions.contains { $0 is FeatureFlagAction })
     }
 
     @Test func checkVisibility_returns_cached_visibility_on_phone_when_offline_and_phone_gates_pass() async throws {


### PR DESCRIPTION
WOOMOB-3374

## Description
Android allows entering POS offline when the POS tab was already visible and the POS local catalog has completed a full sync. iOS was still going through remote eligibility/sync paths in a few places, which could make POS entry slow online and leave offline tab taps stuck on the item-list-not-loaded state.

This PR:

- Keeps cached POS tab visibility usable while offline. Unknown connectivity (e.g. before the first path update at cold start) still proceeds with the full remote check, so a fresh online launch is never stuck with stale cached visibility.
- Lets the POS coordinator enter local-catalog POS from cached visibility plus a previous full sync, without waiting on remote eligibility, and seeds the POS entry controller as eligible for that path.
- Still kicks off a fire-and-forget smart sync on POS entry (it self-limits by max age), but a sync failure only surfaces as an initial-sync error when there is no usable local catalog to fall back on. Sync failures with no usable local data keep the error + retry behavior.
- Keeps the foreground sync dispatcher runnable when the app starts offline, so catalog syncing resumes automatically once connectivity returns.
- Persists POS ineligibility from the entry path when the online eligibility check returns a definite negative (matching Android, offline/indeterminate results never downgrade cached eligibility).
- Starts products, popular items, and coupons loading independently so auxiliary failures do not block the main item grid.
- Consolidates the usable-local-catalog check into a single `POSCatalogSyncCoordinatorProtocol` extension (`hasUsableLocalCatalog(for:)`) shared by the items controller, aggregate model, and tab coordinator.

## Test Steps
Automated checks (iPhone 16 Pro simulator):

- `PointOfSaleTests`: `PointOfSaleObservableItemsControllerTests`, `PointOfSaleAggregateModelTests`, `POSEntryPointControllerTests` — 118 tests, 0 failures
- `WooCommerceTests`: `POSTabCoordinatorTests`, `POSTabVisibilityCheckerTests` — 42 tests, 0 failures
- SwiftLint clean

Manual validation:

1. On a POS-eligible store, go online and complete POS local catalog full sync.
2. Confirm the POS tab is visible.
3. Disable network connectivity.
4. Tap the POS tab.
5. Confirm POS opens promptly from the tab and does not wait on remote eligibility.
6. Confirm the item grid/list loads from the local catalog and does not show the item-list-not-loaded error.
7. Confirm product search/scan can use local catalog data where applicable.
8. Confirm offline payment connection setup prefers Bluetooth rather than Tap to Pay.
9. As a negative check, use a store/device state with no previous full POS catalog sync, go offline, and confirm it does not enter usable local-catalog POS (the item list shows the sync error with retry).
10. Re-enable connectivity and confirm POS still opens and sync can resume.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
