### PR TITLE
Fix duplicate initial coupon and popular product requests when opening POS

### DIFF
--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -185,7 +185,12 @@ struct PointOfSaleDashboardView: View {
         .ignoresSafeArea(dashboardIgnoredSafeAreaRegions)
         .onAppear {
             trackTimeForInitialLoadingState()
-            loadItemsWhenEligible()
+            // Only load here when eligibility resolved before the dashboard appeared, as the
+            // `eligibilityState` `onChange` above won't fire for that earlier transition.
+            // Otherwise the `onChange` owns the load, so we don't fetch everything twice.
+            if case .eligible = posModel.entryPointController.eligibilityState {
+                loadItemsWhenEligible()
+            }
         }
         .onChange(of: viewState) { oldValue, newValue in
             if newValue == .content && oldValue != newValue {

--- a/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
+++ b/Modules/Sources/PointOfSale/Presentation/PointOfSaleDashboardView.swift
@@ -178,19 +178,15 @@ struct PointOfSaleDashboardView: View {
             showSettings = false
             showOrders = false
         }
-        .onChange(of: posModel.entryPointController.eligibilityState) { oldValue, newValue in
-            guard case .eligible = newValue, oldValue != newValue else { return }
-            loadItemsWhenEligible()
+        // Runs at appear and again on each eligibility change, so the initial load happens
+        // exactly once when eligibility resolves to eligible — whether that's before or after
+        // the dashboard appears — and again after an ineligible → eligible recovery.
+        .task(id: posModel.entryPointController.eligibilityState) {
+            await loadItemsWhenEligible()
         }
         .ignoresSafeArea(dashboardIgnoredSafeAreaRegions)
         .onAppear {
             trackTimeForInitialLoadingState()
-            // Only load here when eligibility resolved before the dashboard appeared, as the
-            // `eligibilityState` `onChange` above won't fire for that earlier transition.
-            // Otherwise the `onChange` owns the load, so we don't fetch everything twice.
-            if case .eligible = posModel.entryPointController.eligibilityState {
-                loadItemsWhenEligible()
-            }
         }
         .onChange(of: viewState) { oldValue, newValue in
             if newValue == .content && oldValue != newValue {
@@ -595,12 +591,12 @@ private extension PointOfSaleDashboardView {
         }
     }
 
-    func loadItemsWhenEligible() {
-        Task { @MainActor in
-            await posModel.purchasableItemsController.loadItems(base: .root)
-            await posModel.couponsController.loadItems(base: .root)
-            await posModel.popularPurchasableItemsController.loadItems(base: .root)
-        }
+    @MainActor
+    func loadItemsWhenEligible() async {
+        guard case .eligible = posModel.entryPointController.eligibilityState else { return }
+        await posModel.purchasableItemsController.loadItems(base: .root)
+        await posModel.couponsController.loadItems(base: .root)
+        await posModel.popularPurchasableItemsController.loadItems(base: .root)
     }
 
     func presentOrders() {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [Internal] POS: Fix duplicated coupon and popular product requests when opening the POS tab. [https://github.com/woocommerce/woocommerce-ios/pull/17493]
 - [*] The "Report Crashes" privacy setting is now saved to your WordPress.com account, so it persists across devices and reinstalls. [https://github.com/woocommerce/woocommerce-ios/pull/17473]
 - [*] Shipping Labels: Prevent skipping phone number validation when confirming an address by tapping too quickly. [https://github.com/woocommerce/woocommerce-ios/pull/17478]
 - [*] Fixed the card reader connection Cancel button being too small to tap in landscape on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17437]


### PR DESCRIPTION
## Description

Opening the POS tab fired the initial item loads twice, duplicating the coupons first-page request and the popular products request on every POS entry (part of a broader API-request audit of POS entry, which found 9 requests on tab tap, including these two pairs of duplicates).

`PointOfSaleDashboardView` triggered `loadItemsWhenEligible()` from two places:

1. `.onAppear`, unconditionally — firing while eligibility was usually still unresolved.
2. `.onChange(of: posModel.entryPointController.eligibilityState)`, when eligibility resolves to `.eligible` a couple of seconds later.

Since eligibility typically resolves shortly *after* the dashboard appears, both paths ran, and `AsyncPaginationTracker.resync` has no guard against repeated first-page syncs.

Some history: before f614aa12c0 the function was `loadItemsIfEligible()` with the eligibility guard *inside*, making the two triggers mutually exclusive. That commit dropped the guard (while fixing the case where eligibility resolves before the dashboard appears, e.g. with mocked data), which is what introduced the double fetch.

This PR consolidates both triggers into a single `.task(id: eligibilityState)` and restores the guard inside `loadItemsWhenEligible()`. The task runs at appear and re-runs on each eligibility change, so the initial load happens exactly once when eligibility resolves to `.eligible` — whether that's before or after the dashboard appears — and items are freshly reloaded after an ineligible → eligible recovery (e.g. regaining connectivity), matching the previous `.onChange` behavior.

This is safe for the loading UI: while `eligibilityState` is `nil`, `PointOfSaleDashboardViewHelper.determineViewState` returns `.loading` regardless of the items container state, so fetching only after eligibility resolves doesn't delay anything visible.

## Test Steps

1. Run the app through a network proxy (e.g. Charles/Proxyman), or watch the device logs for `wc/v3/coupons` and `wc/v3/products` requests.
2. Log in to a POS-eligible store on iPad and tap the POS tab.
3. Verify there is exactly **one** `wc/v3/coupons` (page=1, per_page=25) request and **one** popular products request (`orderby=popularity`, per_page=10) during POS startup. Before this change there were two of each.
4. Verify the item list and coupons tab still load their content normally, and pull-to-refresh still works.
5. Recovery path: enter POS with the POS feature switch disabled (or offline), confirm the ineligible screen, then resolve the issue and tap the refresh CTA — items should load normally once eligible.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.