### PR TITLE
Remove redundant API requests from orders pull-to-refresh and the product selector

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 25.2
 -----
+- [Internal] Remove redundant API requests from orders pull-to-refresh and the order creation product selector. [https://github.com/woocommerce/woocommerce-ios/pull/17494]
 - [*] The "Report Crashes" privacy setting is now saved to your WordPress.com account, so it persists across devices and reinstalls. [https://github.com/woocommerce/woocommerce-ios/pull/17473]
 - [*] Shipping Labels: Prevent skipping phone number validation when confirming an address by tapping too quickly. [https://github.com/woocommerce/woocommerce-ios/pull/17478]
 - [*] Fixed the card reader connection Cancel button being too small to tap in landscape on iPhone. [https://github.com/woocommerce/woocommerce-ios/pull/17437]

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -380,7 +380,6 @@ extension OrderListViewController {
         ServiceLocator.analytics.track(.ordersListPulledToRefresh)
         delegate?.orderListViewControllerWillSynchronizeOrders(self)
         NotificationCenter.default.post(name: .ordersBadgeReloadRequired, object: nil)
-        viewModel.onPullToRefresh()
         syncingCoordinator.resynchronize(reason: SyncReason.pullToRefresh.rawValue) {
             sender.endRefreshing()
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -49,21 +49,6 @@ final class OrderListViewModel {
     ///
     private var isAppActive: Bool = true
 
-    /// Checks whether the site has set up any payment method.
-    ///
-    private var hasAnyPaymentGateways: Bool {
-        storageManager.viewStorage.loadAllPaymentGateways(siteID: siteID)
-            .contains(where: { $0.enabled })
-    }
-
-    /// Checks whether the site has published any product.
-    ///
-    private var hasAnyPublishedProducts: Bool {
-        (storageManager.viewStorage.loadProducts(siteID: siteID) ?? [])
-            .map { $0.toReadOnly() }
-            .contains(where: { $0.productStatus == .published })
-    }
-
     private var isIPPSupportedCountry: Bool {
         cardPresentPaymentsConfiguration.isSupportedCountry
     }
@@ -143,24 +128,6 @@ final class OrderListViewModel {
 
         observeForegroundRemoteNotifications()
         bindTopBannerState()
-    }
-
-    /// Handles extra syncing upon pull-to-refresh.
-    func onPullToRefresh() {
-        /// syncs payment gateways
-        stores.dispatch(PaymentGatewayAction.synchronizePaymentGateways(siteID: siteID, onCompletion: { _ in }))
-
-        /// syncs first published product
-        stores.dispatch(ProductAction.synchronizeProducts(siteID: siteID,
-                                                          pageNumber: Store.Default.firstPageNumber,
-                                                          pageSize: 1,
-                                                          stockStatus: nil,
-                                                          productStatus: .published,
-                                                          productType: nil,
-                                                          productCategory: nil,
-                                                          sortOrder: .dateDescending,
-                                                          shouldDeleteStoredProductsOnFirstPage: false,
-                                                          onCompletion: { _ in }))
     }
 
     /// Starts the snapshotsProvider, logging any errors.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -803,6 +803,11 @@ private extension ProductSelectorViewModel {
             .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
 
         Publishers.CombineLatest3(searchTermPublisher, filtersPublisher, searchFilterPublisher)
+            // Skips leading emissions with the default search term and filters. Otherwise, the initial emission
+            // resyncs the first page, duplicating the sync triggered by `onLoadTrigger` on first load.
+            .drop(while: { searchTerm, filters, productSearchFilter in
+                searchTerm.isEmpty && filters == FilterProductListViewModel.Filters() && productSearchFilter == .all
+            })
             .sink { [weak self] searchTerm, filtersSubject, productSearchFilter in
                 guard let self else { return }
                 Task { @MainActor in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -221,6 +221,33 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(timesSynced, 1)
     }
 
+    @MainActor
+    func test_initial_search_and_filters_emission_does_not_duplicate_first_page_sync() async throws {
+        // Given
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 source: .orderForm(flow: .creation),
+                                                 storageManager: storageManager,
+                                                 stores: stores)
+        var timesSynced = 0
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, _, onCompletion):
+                timesSynced += 1
+                onCompletion(.success(true))
+            default:
+                XCTFail("Unsupported Action")
+            }
+        }
+
+        // When
+        viewModel.onLoadTrigger.send()
+        // Waits beyond the search debounce interval so the initial search/filters emission would have fired a resync.
+        try await Task.sleep(nanoseconds: searchDebounceTime)
+
+        // Then
+        XCTAssertEqual(timesSynced, 1)
+    }
+
     func test_entering_search_term_performs_remote_product_search() {
         // Given
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
@@ -437,7 +464,8 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.filterListViewModel.criteria, FilterProductListViewModel.Filters())
     }
 
-    func test_clearing_search_returns_full_product_list() {
+    @MainActor
+    func test_clearing_search_returns_full_product_list() async throws {
         // Given
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  source: .orderForm(flow: .creation),
@@ -445,12 +473,13 @@ final class ProductSelectorViewModelTests: XCTestCase {
                                                  stores: stores)
         let expectation = expectation(description: "Cleared product search")
         let product = Product.fake().copy(siteID: sampleSiteID, purchasable: true)
-        insert([product.copy(name: "T-shirt"), product.copy(name: "Hoodie")])
+        insert([product.copy(productID: 1, name: "T-shirt"), product.copy(productID: 2, name: "Hoodie")])
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
             switch action {
             case let .searchProducts(_, _, _, _, _, _, _, _, _, _, onCompletion):
-                self.insert(product.copy(name: "T-shirt"), withSearchTerm: "shirt")
                 onCompletion(.success(false))
+            case let .searchProductsInCache(_, _, _, onCompletion):
+                onCompletion(false)
             case let .synchronizeProducts(_, _, _, _, _, _, _, _, _, _, _, onCompletion):
                 onCompletion(.success(true))
                 expectation.fulfill()
@@ -461,8 +490,9 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // When
         viewModel.searchTerm = "shirt"
+        try await Task.sleep(nanoseconds: searchDebounceTime)
         viewModel.clearSearchAndFilters()
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        await fulfillment(of: [expectation], timeout: Constants.expectationTimeout)
 
         // Then
         XCTAssertEqual(viewModel.productRows.count, 2)


### PR DESCRIPTION
## Description

Part of [WOOMOB-420](https://linear.app/a8c/issue/WOOMOB-420) (reducing memory pressure from oversized network responses - orders and products list requests).

Two fixes from an audit of the API requests fired by the orders tab:

**1. Orders pull-to-refresh no longer syncs payment gateways and a first published product.**

`OrderListViewModel.onPullToRefresh()` dispatched `synchronizePaymentGateways` and a page-size-1 `synchronizeProducts` on every pull-to-refresh. These were added to power the create-test-order empty-state CTA, which has since been removed in WOOMOB-3317 — nothing reads this data on the pull-to-refresh path anymore. Payment gateways are still synced at session start and by the IPP cash-on-delivery settings flow, so this removes two requests per refresh with no behavior change.

**2. Opening the product selector no longer syncs the first products page twice.**

The product selector's search/filter Combine pipeline (`CombineLatest3` of search term, filters, and search-filter type) fired on subscription with the initial default values, resyncing the first page and duplicating the sync already triggered by `onLoadTrigger`. Leading emissions matching the initial state (empty search term, default filters, `.all` search filter) are now dropped. Dropping by value rather than using `dropFirst()` preserves a filter or search change that lands within the 100 ms debounce window of the first emission.

## Test Steps

Optional - feel free to also just smoke test the affected product areas in the alpha build.

Watch requests through a network proxy (e.g. Charles/Proxyman) or the device logs.

**Orders pull-to-refresh:**
1. Go to the Orders tab and pull to refresh.
2. Verify the orders list refreshes as usual, and that no `payment_gateways` request and no page-size-1 `products` request are fired (before this change, both fired on every pull).

**Product selector:**
1. Start creating an order and tap "Add Products".
2. Verify the product list loads normally, with a single first-page `products` request (before this change, it was requested twice).
3. Search for a product and apply a filter — verify results still update correctly.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.