### PR TITLE
[TEMP] DO NOT MERGE: Build warning guard edge case testing round 2

### DIFF
--- a/Modules/Sources/Yosemite/Stores/OrderStore.swift
+++ b/Modules/Sources/Yosemite/Stores/OrderStore.swift
@@ -17,6 +17,7 @@ public class OrderStore: Store {
     /// Registers for supported Actions.
     ///
     override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        let temporaryUnusedLetTestValue = 1
         dispatcher.register(processor: self, for: OrderAction.self)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -175,8 +175,14 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         }
     }
 
+    @available(*, deprecated, message: "temporary warning guard test")
+    private func temporaryDeprecatedTestFunction() {}
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        var temporaryNeverMutatedTestValue = 2
+        _ = temporaryNeverMutatedTestValue
+        temporaryDeprecatedTestFunction()
         createDataSource()
 
         registerUserActivity()


### PR DESCRIPTION
## Description
Throwaway draft PR (successor to #17479, which cannot be reopened after its branch was recreated) to further verify the build warning guard from #17456 on a non-trunk base:

1. **Run A**: three distinct warning types (unused `let`, `var` never mutated, deprecated-API call) against a merge base one commit behind the base tip → expect 3 new warnings, baseline `rebuilt` at `b333e003b3`.
2. **Run B**: traded warnings — fix a base-branch warning, keep one new warning (net 0) → expect comment persists with 1 exact addition and baseline served from cache (merge base unchanged).
3. **Run C**: rebase onto the base tip → merge base changes → expect baseline `rebuilt` at `73c5ecb806`.

Do not merge — will be closed once verified.

## Test Steps
Observe the wpmobilebot warning comment after each push.

## Screenshots
N/A

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.