### PR TITLE
[WOOMOB-3401] Exclude comment and blank lines from the Danger PR size warning

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -47,7 +47,12 @@ view_changes_checker.check
 
 pr_size_checker.check_diff_size(
   max_size: 300,
-  file_selector: ->(path) { !path.include?('Tests/') }
+  file_selector: ->(path) { !path.include?('Tests/') },
+  # Exclude blank lines and Swift comment lines from the size metric
+  line_selector: lambda { |line|
+    stripped = line.strip
+    !(stripped.empty? || stripped.start_with?('//', '/*', '*', '*/'))
+  }
 )
 
 # skip remaining checks if the PR is still a Draft

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 4.1'
 end
 
-gem 'danger-dangermattic', '~> 1.3'
+gem 'danger-dangermattic', '~> 1.4'
 gem 'dotenv'
 gem 'fastlane', '~> 2.237'
 gem 'fastlane-plugin-firebase_app_distribution', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       octokit (>= 4.0)
       pstore (~> 0.1)
       terminal-table (>= 1, < 5)
-    danger-dangermattic (1.3.0)
+    danger-dangermattic (1.4.0)
       danger (~> 9.5, >= 9.5.3)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.13)
@@ -379,7 +379,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  danger-dangermattic (~> 1.3)
+  danger-dangermattic (~> 1.4)
   dotenv
   fastlane (~> 2.237)
   fastlane-plugin-firebase_app_distribution (~> 1.0)


### PR DESCRIPTION
## Description

Fixes WOOMOB-3400

The Danger 300-line PR size warning counted comment and blank lines as code. Bumps `danger-dangermattic` to 1.4.0, which adds a `line_selector:` option to `check_diff_size` ([dangermattic#133](https://github.com/Automattic/dangermattic/pull/133)), and uses it to skip blank lines and `//`, `/*`, `*`, `*/` lines.

Companion to woocommerce/woocommerce-android#16225.

## Test Steps

No testing needed — the Danger check on this PR exercises the new code path.

## Screenshots

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.